### PR TITLE
Add saga-tools Claude plugin marketplace

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,12 +1,4 @@
 {
-    "extraKnownMarketplaces": {
-        "saga-tools": {
-            "source": {
-                "source": "github",
-                "repo": "saga-ed/claude-plugins"
-            }
-        }
-    },
     "enabledPlugins": {
         "system-review@saga-tools": true,
         "documentation-system@saga-tools": true


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` with `extraKnownMarketplaces` pointing to `saga-ed/claude-plugins`
- Developers are auto-prompted to install shared plugins (e.g. `system-review`) when trusting the project
- First plugin available: `/system-review` — systematic multi-agent codebase review

## Test plan
- [ ] Open Claude Code in soa, verify marketplace prompt appears on trust
- [ ] Run `/plugin install system-review@saga-tools` and confirm it installs
- [ ] Run `/system-review` and verify it starts the review workflow