### PR TITLE
fix: replace global registry hijack with scoped token auth

### DIFF
--- a/docs/cicd-package-publishing.md
+++ b/docs/cicd-package-publishing.md
@@ -122,16 +122,19 @@ Add to your project's `.npmrc`:
 ### Authenticate with CodeArtifact
 
 ```bash
-# Get auth token (valid 12 hours)
+# Easiest: run co:login from any repo that has it
+pnpm co:login
+
+# Or manually (valid 12 hours):
 export CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token \
   --domain saga \
   --domain-owner 531314149529 \
   --query authorizationToken \
   --output text)
-
-# Configure npm
 npm config set //saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/:_authToken=$CODEARTIFACT_AUTH_TOKEN
 ```
+
+> **Note:** Do NOT use `aws codeartifact login --tool npm` — it hijacks the default registry in `~/.npmrc`. See [CODEARTIFACT_SETUP.md](./CODEARTIFACT_SETUP.md#troubleshooting) for details.
 
 ### Install packages
 ```bash

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "ci:check:all": "node scripts/local-ci-checks.js all",
     "ci:check:changed": "node scripts/local-ci-checks.js",
     "quick:check": "node scripts/quick-check.js",
+    "preinstall": "npm run co:login || true",
     "co:login": "export CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain saga --domain-owner 531314149529 --query authorizationToken --output text) && npm config set //saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/:_authToken=$CODEARTIFACT_AUTH_TOKEN && echo '✅ CodeArtifact auth token configured'",
     "co:whoami": "npm whoami --registry=https://saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/"
   },


### PR DESCRIPTION
## Summary

- **morning-auth.sh**: Replace 3 `aws codeartifact login --tool npm` calls with single `get-authorization-token` + scoped `npm config set`. Removes `pushd/popd`. Auto-cleans stale default registry entries from `~/.npmrc`.
- **package.json**: Add `preinstall` hook so `pnpm install` auto-authenticates with CodeArtifact
- **docs**: Update CODEARTIFACT_SETUP.md, package-registry-quickstart.md, cicd-package-publishing.md with warnings against `codeartifact login`, new preinstall hooks section, and stale registry troubleshooting

## Why

`aws codeartifact login --tool npm` overwrites the **default registry** in `~/.npmrc` to point at CodeArtifact. This breaks `pnpm install` for any public npm package (lodash, express, etc.). The fix uses scoped `_authToken` entries that only affect `@saga-ed` package resolution.

## Test plan

- [ ] Run `morning-auth.sh` → verify `~/.npmrc` has NO `registry=...codeartifact` line
- [ ] Run `pnpm install` → both @saga-ed and public packages resolve
- [ ] Run `pnpm co:whoami` → shows authenticated user

Related PRs: saga-ed/thrive, saga-ed/coach, hipponot/nimbee (same auth pattern)