### PR TITLE
fix: cross-repo-link.sh disable_link destroyed package.json

### DIFF
--- a/scripts/cross-repo-link.sh
+++ b/scripts/cross-repo-link.sh
@@ -177,9 +177,9 @@ disable_link() {
     # Get all package names from config and remove them from overrides
     local packages=$(jq -r '.packages | keys[]' "$CONFIG_FILE")
 
-    local jq_filter=".pnpm.overrides"
+    local jq_filter="."
     for pkg in $packages; do
-        jq_filter="$jq_filter | del(.[\"$pkg\"])"
+        jq_filter="$jq_filter | del(.pnpm.overrides[\"$pkg\"])"
     done
 
     jq "$jq_filter" "$PACKAGE_JSON" > "$PACKAGE_JSON.tmp"


### PR DESCRIPTION
## Summary

- The `disable_link()` function in `cross-repo-link.sh` used a jq filter that extracted only `.pnpm.overrides` as the entire file output, wiping all other fields (name, scripts, devDependencies, engines, etc.)
- Fixed by changing the filter from `.pnpm.overrides | del(.[...])` to `. | del(.pnpm.overrides[...])` so it modifies overrides in place within the full document

## Test plan

- [ ] Run `pnpm soa:link:on` in a consuming repo (thrive/coach), verify package.json gains link overrides
- [ ] Run `pnpm soa:link:off`, verify only link overrides are removed and all other fields are preserved