### PR TITLE
ci: add saga_nimbee auth token to CodeArtifact registry config

### DIFF
--- a/.github/workflows/publish-all-packages.yml
+++ b/.github/workflows/publish-all-packages.yml
@@ -98,6 +98,7 @@ jobs:
       - name: Configure CodeArtifact registry
         run: |
           pnpm config set //saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/:_authToken $CODEARTIFACT_AUTH_TOKEN
+          pnpm config set //saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_nimbee/:_authToken $CODEARTIFACT_AUTH_TOKEN
 
       - name: Get pnpm store directory
         shell: bash
@@ -246,6 +247,7 @@ jobs:
       - name: Configure CodeArtifact registry
         run: |
           pnpm config set //saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/:_authToken $CODEARTIFACT_AUTH_TOKEN
+          pnpm config set //saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_nimbee/:_authToken $CODEARTIFACT_AUTH_TOKEN
 
       - name: Get pnpm store directory
         shell: bash
@@ -340,6 +342,7 @@ jobs:
       - name: Configure CodeArtifact registry
         run: |
           pnpm config set //saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/:_authToken $CODEARTIFACT_AUTH_TOKEN
+          pnpm config set //saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_nimbee/:_authToken $CODEARTIFACT_AUTH_TOKEN
 
       - name: Get pnpm store directory
         shell: bash
@@ -434,6 +437,7 @@ jobs:
       - name: Configure CodeArtifact registry
         run: |
           pnpm config set //saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/:_authToken $CODEARTIFACT_AUTH_TOKEN
+          pnpm config set //saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_nimbee/:_authToken $CODEARTIFACT_AUTH_TOKEN
 
       - name: Get pnpm store directory
         shell: bash
@@ -528,6 +532,7 @@ jobs:
       - name: Configure CodeArtifact registry
         run: |
           pnpm config set //saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/:_authToken $CODEARTIFACT_AUTH_TOKEN
+          pnpm config set //saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_nimbee/:_authToken $CODEARTIFACT_AUTH_TOKEN
 
       - name: Get pnpm store directory
         shell: bash
@@ -673,6 +678,7 @@ jobs:
       - name: Configure CodeArtifact registry
         run: |
           pnpm config set //saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/:_authToken $CODEARTIFACT_AUTH_TOKEN
+          pnpm config set //saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_nimbee/:_authToken $CODEARTIFACT_AUTH_TOKEN
 
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/publish-codeartifact.yml
+++ b/.github/workflows/publish-codeartifact.yml
@@ -98,6 +98,7 @@ jobs:
       - name: Configure CodeArtifact registry
         run: |
           pnpm config set //saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/:_authToken $CODEARTIFACT_AUTH_TOKEN
+          pnpm config set //saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_nimbee/:_authToken $CODEARTIFACT_AUTH_TOKEN
 
       - name: Get pnpm store directory
         shell: bash
@@ -232,6 +233,7 @@ jobs:
       - name: Configure CodeArtifact registry
         run: |
           pnpm config set //saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/:_authToken $CODEARTIFACT_AUTH_TOKEN
+          pnpm config set //saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_nimbee/:_authToken $CODEARTIFACT_AUTH_TOKEN
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
saga_js uses saga_nimbee as an upstream — tarballs for some packages (e.g. `@inversifyjs/common`) are served directly from saga_nimbee's URL, requiring its own auth token entry. Same domain token, additional registry path.