### PR TITLE
fix: add --passWithNoTests to rabbitmq test script

### DIFF
--- a/packages/node/rabbitmq/package.json
+++ b/packages/node/rabbitmq/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "test": "vitest run",
+    "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
No test files exist yet in `packages/node/rabbitmq`; vitest exits 1 without this flag, failing the publish workflow's test job.