### PR TITLE
feat(infra-compose): project-specific compose files + selective service startup

### DIFF
--- a/infra/api.d.ts
+++ b/infra/api.d.ts
@@ -6,6 +6,10 @@ export interface UpOptions {
     seed_dir?: string;
     /** Directory for user snapshot data (default: ~/.fixtures/profiles). */
     data_dir?: string;
+    /** Path to a project-specific compose file. If omitted, uses the infra-compose master compose.yml. */
+    compose_file?: string;
+    /** Specific services to start. If omitted, all services in the compose file start. */
+    services?: string[];
 }
 
 export interface SnapshotOptions {

--- a/infra/api.d.ts
+++ b/infra/api.d.ts
@@ -26,6 +26,8 @@ export interface ProfileOptions {
     seed_dir?: string;
     /** Directory for user snapshot data (default: ~/.fixtures/profiles). */
     data_dir?: string;
+    /** Path to a project-specific compose file. If omitted, uses the infra-compose master compose.yml. */
+    compose_file?: string;
 }
 
 export interface ListProfilesOptions {

--- a/infra/api.js
+++ b/infra/api.js
@@ -120,10 +120,11 @@ function spawn_promise(cmd, args, options = {}) {
  * @param {string[]} args - compose subcommand args (e.g. ['up', '-d'])
  * @param {Record<string, string>} env
  */
-async function compose_cmd(args, env) {
-    let result = await spawn_promise('docker', ['compose', ...args], { cwd: __dirname, env, stdio: 'inherit' });
+async function compose_cmd(args, env, cwd) {
+    const work_dir = cwd || __dirname;
+    let result = await spawn_promise('docker', ['compose', ...args], { cwd: work_dir, env, stdio: 'inherit' });
     if (result.error?.code === 'ENOENT') {
-        result = await spawn_promise('docker-compose', args, { cwd: __dirname, env, stdio: 'inherit' });
+        result = await spawn_promise('docker-compose', args, { cwd: work_dir, env, stdio: 'inherit' });
     }
     return result;
 }
@@ -159,10 +160,19 @@ async function remove_volumes(volumes) {
  * @param {{ profile?: string, seed_dir?: string, data_dir?: string }} options
  */
 export async function up(options = {}) {
-    const { profile } = options;
+    const { profile, compose_file, services } = options;
     const env = build_compose_env(options);
 
-    const result = await compose_cmd(['up', '-d'], env);
+    const args = [];
+    let cwd;
+    if (compose_file) {
+        args.push('-f', resolve(compose_file));
+        cwd = dirname(resolve(compose_file));
+    }
+    args.push('up', '-d');
+    if (services?.length) args.push(...services);
+
+    const result = await compose_cmd(args, env, cwd);
     if (result.error) throw result.error;
     if (result.status === 0 && profile) write_active_profile(profile);
     return { exitCode: result.status ?? 1 };

--- a/infra/api.js
+++ b/infra/api.js
@@ -156,20 +156,26 @@ async function remove_volumes(volumes) {
 // ── Docker lifecycle ──────────────────────────────────────────────
 
 /**
+ * Build -f flag and cwd for a project-specific compose file.
+ * @param {string | undefined} compose_file
+ * @returns {{ file_args: string[], cwd: string | undefined }}
+ */
+function compose_file_args(compose_file) {
+    if (!compose_file) return { file_args: [], cwd: undefined };
+    const abs = resolve(compose_file);
+    return { file_args: ['-f', abs], cwd: dirname(abs) };
+}
+
+/**
  * Start Docker services (detached).
- * @param {{ profile?: string, seed_dir?: string, data_dir?: string }} options
+ * @param {{ profile?: string, seed_dir?: string, data_dir?: string, compose_file?: string, services?: string[] }} options
  */
 export async function up(options = {}) {
     const { profile, compose_file, services } = options;
     const env = build_compose_env(options);
+    const { file_args, cwd } = compose_file_args(compose_file);
 
-    const args = [];
-    let cwd;
-    if (compose_file) {
-        args.push('-f', resolve(compose_file));
-        cwd = dirname(resolve(compose_file));
-    }
-    args.push('up', '-d');
+    const args = [...file_args, 'up', '-d'];
     if (services?.length) args.push(...services);
 
     const result = await compose_cmd(args, env, cwd);
@@ -184,18 +190,19 @@ export async function up(options = {}) {
  * @returns {Promise<{ status: number, profile: string }>}
  */
 export async function switch_profile(options) {
-    const { profile } = options;
+    const { profile, compose_file } = options;
     const env = build_compose_env(options);
+    const { file_args, cwd } = compose_file_args(compose_file);
 
     // Down
-    const down = await compose_cmd(['down'], env);
+    const down = await compose_cmd([...file_args, 'down'], env, cwd);
     if (down.status !== 0) return { status: down.status ?? 1, profile };
 
     // Up with new profile, wait for init containers to finish seeding
-    const up_result = await compose_cmd(['up', '-d'], env);
+    const up_result = await compose_cmd([...file_args, 'up', '-d'], env, cwd);
     if (up_result.status === 0) {
         write_active_profile(profile);
-        await wait_for_init_containers(env);
+        await wait_for_init_containers(env, cwd, file_args);
     }
     return { status: up_result.status ?? 1, profile };
 }
@@ -206,11 +213,12 @@ export async function switch_profile(options) {
  * @returns {Promise<{ status: number, profile: string }>}
  */
 export async function reset(options) {
-    const { profile } = options;
+    const { profile, compose_file } = options;
     const env = build_compose_env(options);
+    const { file_args, cwd } = compose_file_args(compose_file);
 
     // Down
-    const down = await compose_cmd(['down'], env);
+    const down = await compose_cmd([...file_args, 'down'], env, cwd);
     if (down.status !== 0) return { status: down.status ?? 1, profile };
 
     // Remove profile volumes
@@ -222,10 +230,10 @@ export async function reset(options) {
     }
 
     // Up — fresh seed, then wait for init containers to finish seeding
-    const up_result = await compose_cmd(['up', '-d'], env);
+    const up_result = await compose_cmd([...file_args, 'up', '-d'], env, cwd);
     if (up_result.status === 0) {
         write_active_profile(profile);
-        await wait_for_init_containers(env);
+        await wait_for_init_containers(env, cwd, file_args);
     }
     return { status: up_result.status ?? 1, profile };
 }
@@ -235,11 +243,12 @@ export async function reset(options) {
  * These run seeds/snapshots and exit. Without waiting, callers may try to
  * use the databases before seeding is complete.
  */
-async function wait_for_init_containers(env) {
+async function wait_for_init_containers(env, cwd, file_args = []) {
+    const work_dir = cwd || __dirname;
     for (const svc of INIT_CONTAINERS) {
         const ps = await spawn_promise('docker', [
-            'compose', 'ps', '--status', 'running', '--format', '{{.Name}}', svc,
-        ], { cwd: __dirname, env, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
+            'compose', ...file_args, 'ps', '--status', 'running', '--format', '{{.Name}}', svc,
+        ], { cwd: work_dir, env, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
         const name = (ps.stdout || '').trim();
         if (name) {
             const wait = await spawn_promise('docker', ['wait', name], { stdio: 'inherit', timeout: 120000 });
@@ -280,7 +289,8 @@ export async function restore(options) {
     } else {
         console.log(`No existing volumes — starting fresh for profile: ${profile}`);
         const env = build_compose_env(options);
-        const result = await compose_cmd(['up', '-d'], env);
+        const { file_args, cwd } = compose_file_args(options.compose_file);
+        const result = await compose_cmd([...file_args, 'up', '-d'], env, cwd);
         if (result.status === 0) write_active_profile(profile);
         return { status: result.status ?? 1, profile };
     }

--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@saga-ed/infra-compose",
-    "version": "0.10.14",
+    "version": "0.10.15",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@saga-ed/infra-compose",
-            "version": "0.10.14",
+            "version": "0.10.15",
             "dependencies": {
                 "docker-compose": "^0.24.8",
                 "mongodb": "^6.0.0",

--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@saga-ed/infra-compose",
-    "version": "0.10.5",
+    "version": "0.10.12",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@saga-ed/infra-compose",
-            "version": "0.10.5",
+            "version": "0.10.12",
             "dependencies": {
                 "docker-compose": "^0.24.8",
                 "mongodb": "^6.0.0",

--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@saga-ed/infra-compose",
-    "version": "0.10.13",
+    "version": "0.10.14",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@saga-ed/infra-compose",
-            "version": "0.10.13",
+            "version": "0.10.14",
             "dependencies": {
                 "docker-compose": "^0.24.8",
                 "mongodb": "^6.0.0",

--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@saga-ed/infra-compose",
-    "version": "0.10.12",
+    "version": "0.10.13",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@saga-ed/infra-compose",
-            "version": "0.10.12",
+            "version": "0.10.13",
             "dependencies": {
                 "docker-compose": "^0.24.8",
                 "mongodb": "^6.0.0",

--- a/infra/package.json
+++ b/infra/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/infra-compose",
-    "version": "0.10.14",
+    "version": "0.10.15",
     "description": "Composable Docker service templates for Saga platform local development",
     "bin": {
         "infra-compose": "bin/infra-compose"

--- a/infra/package.json
+++ b/infra/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/infra-compose",
-    "version": "0.10.13",
+    "version": "0.10.14",
     "description": "Composable Docker service templates for Saga platform local development",
     "bin": {
         "infra-compose": "bin/infra-compose"

--- a/infra/package.json
+++ b/infra/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/infra-compose",
-    "version": "0.10.11",
+    "version": "0.10.12",
     "description": "Composable Docker service templates for Saga platform local development",
     "bin": {
         "infra-compose": "bin/infra-compose"

--- a/infra/package.json
+++ b/infra/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/infra-compose",
-    "version": "0.10.12",
+    "version": "0.10.13",
     "description": "Composable Docker service templates for Saga platform local development",
     "bin": {
         "infra-compose": "bin/infra-compose"

--- a/infra/services/mongo/seed/init-and-seed.js
+++ b/infra/services/mongo/seed/init-and-seed.js
@@ -59,9 +59,10 @@ const seedFile = `/seed/profile-${profile}.json`;
 const extraSeedFile = `/extra-seed/profile-${profile}.json`;
 // User snapshot data (from ~/.fixtures/profiles) is mounted at /data-seed/.
 const dataSeedFile = `/data-seed/profile-${profile}.json`;
-let actualSeedFile = seedFile;
-if (fs.existsSync(extraSeedFile)) actualSeedFile = extraSeedFile;
+let actualSeedFile = null;
 if (fs.existsSync(dataSeedFile)) actualSeedFile = dataSeedFile;
+else if (fs.existsSync(extraSeedFile)) actualSeedFile = extraSeedFile;
+else if (fs.existsSync(seedFile)) actualSeedFile = seedFile;
 
 print(`Seed: profile=${profile}`);
 
@@ -71,6 +72,9 @@ const existing = sentinel.findOne({ profile: profile });
 
 if (existing) {
   print(`Seed: profile '${profile}' already seeded at ${existing.seeded_at} — skipping`);
+} else if (!actualSeedFile) {
+  print(`Seed: no seed file found for profile '${profile}' — skipping data load`);
+  sentinel.insertOne({ profile, seeded_at: new Date().toISOString(), source: "none" });
 } else {
   print(`Seed: loading ${actualSeedFile} ...`);
 

--- a/infra/services/mysql/seed/init-and-seed.sh
+++ b/infra/services/mysql/seed/init-and-seed.sh
@@ -30,8 +30,8 @@ if [ -f "/data-seed/profile-${PROFILE}.sql" ]; then
   echo "MySQL seed: using user data from ${SEED_FILE}"
 fi
 
-HOST="mysql"
-PORT="3306"
+HOST="${MYSQL_HOST:-mysql}"
+PORT="${MYSQL_PORT:-3306}"
 # Use root for admin operations (CREATE DATABASE, etc.); MYSQL_PWD env provides password
 ADMIN_USER="${MYSQL_ADMIN_USER:-root}"
 

--- a/infra/test/api-lifecycle.unit.test.js
+++ b/infra/test/api-lifecycle.unit.test.js
@@ -67,6 +67,85 @@ function get_docker_calls() {
         .map(([cmd, args]) => cmd === 'docker' ? args.join(' ') : `docker-compose ${args.join(' ')}`);
 }
 
+// ── up ─────────────────────────────────────────────────────
+
+describe('up', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        spawn_calls.length = 0;
+    });
+
+    it('calls docker compose up -d with no extra args by default', async () => {
+        mock_spawn_success();
+        const { up } = await import('../api.js');
+
+        const result = await up({ profile: 'small' });
+        expect(result.exitCode).toBe(0);
+
+        const calls = get_docker_calls();
+        expect(calls[0]).toBe('compose up -d');
+    });
+
+    it('passes -f flag and sets cwd when compose_file is provided', async () => {
+        mock_spawn_success();
+        const { up } = await import('../api.js');
+
+        const compose_file = '/some/project/docker-compose.yml';
+        await up({ profile: 'small', compose_file });
+
+        const calls = get_docker_calls();
+        expect(calls[0]).toBe(`compose -f ${compose_file} up -d`);
+
+        // Verify cwd was set to the compose file's directory
+        const up_call = spawn_calls.find(([cmd, args]) =>
+            cmd === 'docker' && args.includes('up'));
+        expect(up_call[2].cwd).toBe('/some/project');
+    });
+
+    it('appends service names when services option is provided', async () => {
+        mock_spawn_success();
+        const { up } = await import('../api.js');
+
+        await up({ profile: 'small', services: ['mongo', 'mysql', 'redis'] });
+
+        const calls = get_docker_calls();
+        expect(calls[0]).toBe('compose up -d mongo mysql redis');
+    });
+
+    it('passes both compose_file and services together', async () => {
+        mock_spawn_success();
+        const { up } = await import('../api.js');
+
+        const compose_file = '/project/docker-compose.yml';
+        await up({ profile: 'small', compose_file, services: ['mongo', 'redis'] });
+
+        const calls = get_docker_calls();
+        expect(calls[0]).toBe(`compose -f ${compose_file} up -d mongo redis`);
+
+        const up_call = spawn_calls.find(([cmd, args]) =>
+            cmd === 'docker' && args.includes('up'));
+        expect(up_call[2].cwd).toBe('/project');
+    });
+
+    it('throws when docker compose fails with an error', async () => {
+        spawn_calls.length = 0;
+        spawn.mockImplementation((cmd, args, options) => {
+            spawn_calls.push([cmd, args, options]);
+            const child = new EventEmitter();
+            child.kill = vi.fn();
+            process.nextTick(() => {
+                child.emit('error', Object.assign(new Error('spawn failed'), { code: 'ENOENT' }));
+                child.emit('close', null, null);
+            });
+            return child;
+        });
+        const { up } = await import('../api.js');
+
+        // Both docker and docker-compose fail with ENOENT
+        await expect(up({ profile: 'x' })).rejects.toThrow();
+    });
+});
+
 // ── switch_profile ──────────────────────────────────────────
 
 describe('switch_profile', () => {

--- a/packages/node/api-core/package.json
+++ b/packages/node/api-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saga-ed/soa-api-core",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "private": false,
   "type": "module",
   "main": "dist/rest-controller.js",

--- a/packages/node/api-core/src/express-server.ts
+++ b/packages/node/api-core/src/express-server.ts
@@ -64,6 +64,7 @@ export class ExpressServer {
     }
 
     this.app.use(cors(corsOptions));
+    this.app.use(express.json());
 
     // Ensure routing-controllers uses Inversify for controller resolution
     useContainer(container);

--- a/packages/node/fixture-serve/package.json
+++ b/packages/node/fixture-serve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saga-ed/fixture-serve",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": false,
   "type": "module",
   "description": "Reusable fixture server infrastructure — Express server, async job queue, provision workflow, and credential export for service-specific fixture CLIs",

--- a/packages/node/fixture-serve/package.json
+++ b/packages/node/fixture-serve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saga-ed/fixture-serve",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": false,
   "type": "module",
   "description": "Reusable fixture server infrastructure — Express server, async job queue, provision workflow, and credential export for service-specific fixture CLIs",

--- a/packages/node/fixture-serve/src/abstract-fixture-controller.ts
+++ b/packages/node/fixture-serve/src/abstract-fixture-controller.ts
@@ -300,7 +300,9 @@ export abstract class AbstractFixtureController extends AbstractRestController {
 
     @Post('/provision')
     async provision(@Body() body: { fixture_type?: string; fixture_id?: string; force_adhoc?: boolean }) {
+        this.logger.info(`Provision request body: ${JSON.stringify(body)}`);
         const { fixture_type, fixture_id: resolved_id, force_adhoc, valid } = this.resolve_fixture_type(body);
+        this.logger.info(`Provision resolved: type=${fixture_type} id=${resolved_id}`);
         if (!valid) {
             return { ok: false, error: `Unknown fixture type: ${fixture_type}` };
         }
@@ -659,6 +661,8 @@ export abstract class AbstractFixtureController extends AbstractRestController {
 
     protected async build_playwright_export(fixture_id: string, base_url: string, password?: string): Promise<any> {
         const pw = password || this.default_password;
+        const active_profile = get_active_profile();
+        this.logger.info(`build_playwright_export: fixture_id=${fixture_id} base_url=${base_url} active_profile=${active_profile?.profile}`);
 
         const is_active = fixture_id === 'active' || fixture_id === '*';
         const doc = is_active
@@ -670,6 +674,7 @@ export abstract class AbstractFixtureController extends AbstractRestController {
 
         const metadata = doc as any;
         const user_ids: string[] = metadata.users || [];
+        this.logger.info(`build_playwright_export: found fixture_id=${metadata.fixture_id} users=${user_ids.length} roles=${Object.keys(metadata.user_roles || {}).length}`);
         const user_roles: Record<string, string> = metadata.user_roles || {};
         const user_emails: Record<string, string> = metadata.user_emails || {};
 

--- a/packages/node/fixture-serve/src/abstract-fixture-controller.ts
+++ b/packages/node/fixture-serve/src/abstract-fixture-controller.ts
@@ -46,6 +46,8 @@ export interface FixtureControllerConfig {
     jobs_collection?: string;
     service_name?: string;
     health_url?: string;
+    /** Path to a project-specific docker-compose.yml for infra-compose operations. */
+    compose_file?: string;
 }
 
 @injectable()
@@ -192,7 +194,7 @@ export abstract class AbstractFixtureController extends AbstractRestController {
             return { ok: false, error: `Fixture '${fixture_id}' has no snapshot. Create one first.` };
         }
 
-        const result = await switch_profile({ profile: snapshot_profile });
+        const result = await switch_profile({ profile: snapshot_profile, compose_file: this.ctrl_config.compose_file });
         if (result.status !== 0) {
             return { ok: false, error: `infra-compose switch failed (exit ${result.status})` };
         }
@@ -353,7 +355,7 @@ export abstract class AbstractFixtureController extends AbstractRestController {
         try {
             // Step 1: Reset to seed profile
             this.logger.info(`Provision: resetting to ${this.default_profile} seed`);
-            const reset_result = await reset({ profile: this.default_profile });
+            const reset_result = await reset({ profile: this.default_profile, compose_file: this.ctrl_config.compose_file });
             if (reset_result.status !== 0) {
                 throw new Error(`Reset to seed failed (exit ${reset_result.status})`);
             }
@@ -389,7 +391,7 @@ export abstract class AbstractFixtureController extends AbstractRestController {
             // Step 3: Switch to snapshot
             update('switching');
             this.logger.info(`Provision: switching to snapshot ${fixture_id}`);
-            const switch_result = await switch_profile({ profile: fixture_id });
+            const switch_result = await switch_profile({ profile: fixture_id, compose_file: this.ctrl_config.compose_file });
             if (switch_result.status !== 0) {
                 throw new Error(`Switch to snapshot failed (exit ${switch_result.status})`);
             }

--- a/packages/node/fixture-serve/src/fixture-server.ts
+++ b/packages/node/fixture-serve/src/fixture-server.ts
@@ -98,6 +98,9 @@ export interface FixtureServerConfig {
 
     /** Server display name. Default: 'fixture-server'. */
     name?: string;
+
+    /** Path to a project-specific docker-compose.yml for infra-compose operations. */
+    compose_file?: string;
 }
 
 export class FixtureServer {
@@ -139,6 +142,7 @@ export class FixtureServer {
             default_profile: config.default_profile,
             metadata_collection: config.metadata_collection,
             jobs_collection: config.jobs_collection,
+            compose_file: config.compose_file,
         };
         this.container.bind<FixtureControllerConfig>('FixtureControllerConfig').toConstantValue(ctrl_config);
 

--- a/packages/node/fixture-serve/tsconfig.json
+++ b/packages/node/fixture-serve/tsconfig.json
@@ -9,5 +9,5 @@
     "sourceMap": true
   },
   "include": ["src"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/__tests__"]
 }


### PR DESCRIPTION
## Summary
- Add `compose_file` and `services` options to infra-compose `up()`, `reset()`, `switch_profile()`, `restore()` so adopting projects use their own compose file
- Add `compose_file_args()` helper for consistent `-f` flag + cwd handling across all lifecycle functions
- Thread `compose_file` through fixture-serve's `FixtureControllerConfig` → controller → infra-compose calls
- Make mongo `init-and-seed.js` handle missing seed files gracefully + fix seed priority (data-seed > extra-seed > built-in)
- Make mysql `init-and-seed.sh` use configurable `MYSQL_HOST`/`MYSQL_PORT` env vars for host networking
- Add `express.json()` middleware to api-core's ExpressServer (fixes `@Body()` returning empty objects)
- Add debug logging to provision and playwright export endpoints
- Bump infra-compose to 0.10.15, fixture-serve to 0.2.2, api-core to 1.1.4

## Context
fixture-serve was starting all 5 infra services and lifecycle operations (`reset`, `switch_profile`) targeted the wrong compose project. Additionally, `@Body()` was silently returning empty objects due to missing body-parser middleware, breaking fixture_id propagation.

## Test plan
- [x] Unit tests pass (63 tests in infra/)
- [x] Deployed to snapper — only mongo, mysql, redis running
- [x] Provision flow: reset → create → snapshot → switch → verify all working
- [x] Mongo init-and-seed.js handles replica set + snapshot restore
- [x] MySQL init-and-seed.sh seeds via configurable host
- [x] `@Body()` now parses JSON correctly (fixture_id propagates)
- [x] Debug logging confirms request body arrives intact