### PR TITLE
fix(infra-compose): thread compose_file through router handlers

### DIFF
--- a/infra/handlers.js
+++ b/infra/handlers.js
@@ -34,7 +34,7 @@ export async function handle_switch(input) {
     const err = require_profile(input);
     if (err) return err;
 
-    const result = await switch_profile({ profile: input.profile, seed_dir: input.seed_dir, data_dir: input.data_dir });
+    const result = await switch_profile({ profile: input.profile, seed_dir: input.seed_dir, data_dir: input.data_dir, compose_file: input.compose_file });
     return result.status === 0
         ? { ok: true, profile: input.profile }
         : { ok: false, error: `switch failed (exit ${result.status})` };
@@ -48,7 +48,7 @@ export async function handle_reset(input) {
     const err = require_profile(input);
     if (err) return err;
 
-    const result = await reset({ profile: input.profile, seed_dir: input.seed_dir, data_dir: input.data_dir });
+    const result = await reset({ profile: input.profile, seed_dir: input.seed_dir, data_dir: input.data_dir, compose_file: input.compose_file });
     return result.status === 0
         ? { ok: true, profile: input.profile }
         : { ok: false, error: `reset failed (exit ${result.status})` };
@@ -62,7 +62,7 @@ export async function handle_restore(input) {
     const err = require_profile(input);
     if (err) return err;
 
-    const result = await restore({ profile: input.profile, seed_dir: input.seed_dir, data_dir: input.data_dir });
+    const result = await restore({ profile: input.profile, seed_dir: input.seed_dir, data_dir: input.data_dir, compose_file: input.compose_file });
     return result.status === 0
         ? { ok: true, profile: input.profile }
         : { ok: false, error: `restore failed (exit ${result.status})` };

--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@saga-ed/infra-compose",
-    "version": "0.10.15",
+    "version": "0.10.16",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@saga-ed/infra-compose",
-            "version": "0.10.15",
+            "version": "0.10.16",
             "dependencies": {
                 "docker-compose": "^0.24.8",
                 "mongodb": "^6.0.0",

--- a/infra/package.json
+++ b/infra/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/infra-compose",
-    "version": "0.10.15",
+    "version": "0.10.16",
     "description": "Composable Docker service templates for Saga platform local development",
     "bin": {
         "infra-compose": "bin/infra-compose"

--- a/infra/router.d.ts
+++ b/infra/router.d.ts
@@ -2,6 +2,8 @@ import { Router } from 'express';
 import { ProfileResponse } from './handlers.js';
 
 export interface InfraRouterOptions {
+    /** Path to a project-specific compose file. If omitted, uses the infra-compose master compose.yml. */
+    compose_file?: string;
     /** Called after a successful switch_profile operation. */
     on_after_switch?: (result: ProfileResponse) => Promise<void> | void;
     /** Called after a successful reset operation. */

--- a/infra/router.js
+++ b/infra/router.js
@@ -21,7 +21,7 @@ export function create_router(options = {}) {
     const wrap = (fn, hook_name) => async (req, res) => {
         try {
             const { output_dir: _output_dir, data_dir: _data_dir, seed_dir: _seed_dir, ...safe } = { ...req.query, ...req.body };
-            const input = safe;
+            const input = { ...safe, compose_file: options.compose_file };
             const result = await fn(input);
             if (result.ok && hook_name && options[hook_name]) {
                 await options[hook_name](result);

--- a/packages/node/fixture-serve/package.json
+++ b/packages/node/fixture-serve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saga-ed/fixture-serve",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": false,
   "type": "module",
   "description": "Reusable fixture server infrastructure — Express server, async job queue, provision workflow, and credential export for service-specific fixture CLIs",

--- a/packages/node/fixture-serve/src/fixture-server.ts
+++ b/packages/node/fixture-serve/src/fixture-server.ts
@@ -190,6 +190,7 @@ export class FixtureServer {
         const logger = this.container.get<ILogger>('ILogger');
         const restart_fn = create_service_restarter(config.service_name, config.health_url);
         const infra_router = create_infra_router({
+            compose_file: config.compose_file,
             on_after_switch: config.infra_hooks?.on_after_switch ?? (async () => { await restart_fn(logger); }),
             on_after_reset: config.infra_hooks?.on_after_reset ?? (async () => { await restart_fn(logger); }),
             on_after_snapshot: config.infra_hooks?.on_after_snapshot,


### PR DESCRIPTION
The /infra/switch, /infra/reset, and /infra/restore HTTP endpoints were calling lifecycle functions without compose_file, causing them to use the master compose.yml instead of the project-specific one.

Now create_router accepts compose_file in options and injects it into all handler calls. fixture-serve passes it from server config.

Session: claude -r session