### PR TITLE
fix(fixture-serve): reconnect MongoDB after infra profile switches

### DIFF
--- a/packages/node/fixture-serve/package.json
+++ b/packages/node/fixture-serve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saga-ed/fixture-serve",
-  "version": "0.2.3",
+  "version": "0.2.6",
   "private": false,
   "type": "module",
   "description": "Reusable fixture server infrastructure — Express server, async job queue, provision workflow, and credential export for service-specific fixture CLIs",

--- a/packages/node/fixture-serve/src/abstract-fixture-controller.ts
+++ b/packages/node/fixture-serve/src/abstract-fixture-controller.ts
@@ -128,11 +128,15 @@ export abstract class AbstractFixtureController extends AbstractRestController {
     }
 
     protected get metadata_collection() {
-        return this.mongo_client.db(this.ctrl_config.db_name).collection(this.metadata_collection_name);
+        // Always resolve from the connection manager so infra hook reconnects
+        // (which bypass the controller) are picked up automatically.
+        const client = this.mongo_mgr.getClient();
+        return client.db(this.ctrl_config.db_name).collection(this.metadata_collection_name);
     }
 
     protected get jobs_collection() {
-        return this.mongo_client.db(this.ctrl_config.db_name).collection(this.jobs_collection_name);
+        const client = this.mongo_mgr.getClient();
+        return client.db(this.ctrl_config.db_name).collection(this.jobs_collection_name);
     }
 
     protected get default_profile() {

--- a/packages/node/fixture-serve/src/fixture-server.ts
+++ b/packages/node/fixture-serve/src/fixture-server.ts
@@ -104,7 +104,8 @@ export interface FixtureServerConfig {
 }
 
 export class FixtureServer {
-    private container!: Container;
+    /** DI container — exposed for infra_hooks that need MongoDB reconnection or other bindings. */
+    container!: Container;
     private express_server!: ExpressServer;
 
     constructor(private config: FixtureServerConfig) {}
@@ -189,10 +190,25 @@ export class FixtureServer {
         // 4. Mount infra-compose router with lifecycle hooks
         const logger = this.container.get<ILogger>('ILogger');
         const restart_fn = create_service_restarter(config.service_name, config.health_url);
+        // Reconnect MongoDB after volume swaps so queries hit the new profile's data.
+        // Without this, the controller's metadata_collection reads stale documents
+        // from the previous profile's connection.
+        const reconnect_mongo = async () => {
+            const mgr = await this.container.getAsync<IMongoConnMgr>('IMongoConnMgr');
+            await mgr.disconnect();
+            await mgr.connect();
+            logger.info('infra hook: reconnected MongoDB after profile change');
+        };
         const infra_router = create_infra_router({
             compose_file: config.compose_file,
-            on_after_switch: config.infra_hooks?.on_after_switch ?? (async () => { await restart_fn(logger); }),
-            on_after_reset: config.infra_hooks?.on_after_reset ?? (async () => { await restart_fn(logger); }),
+            on_after_switch: config.infra_hooks?.on_after_switch ?? (async () => {
+                await reconnect_mongo();
+                await restart_fn(logger);
+            }),
+            on_after_reset: config.infra_hooks?.on_after_reset ?? (async () => {
+                await reconnect_mongo();
+                await restart_fn(logger);
+            }),
             on_after_snapshot: config.infra_hooks?.on_after_snapshot,
         });
         app.use('/infra', infra_router);


### PR DESCRIPTION
## Summary
- Default infra hooks now reconnect `IMongoConnMgr` after switch/reset — fixes stale fixture_metadata served from the previous profile's MongoDB data
- Collection getters resolve from the connection manager on every access instead of using a cached `MongoClient` reference
- `FixtureServer.container` made public so consumer packages can wire custom infra_hooks with DI access

## Context
After `/infra/switch` swaps Docker volumes, the fixture-serve controller's `metadata_collection` getter was returning stale data because it used a cached `MongoClient` from before the switch. The abstract controller's `reconnect_mongo()` only runs for `/fixture/*` routes (provision, restore), not for `/infra/*` routes which go through the infra-compose router directly.

## Test plan
- [x] Published as `@saga-ed/fixture-serve@0.2.6` and deployed to snapper + gh-7763
- [x] fixture-cli e2e tests pass (33/33) including reconnect recovery test
- [x] Verified fixture-admin dashboard shows correct data after profile switch