### PR TITLE
fix(fixture-serve): heartbeat re-registration so hosts don't TTL out of fixture-admin

### DIFF
--- a/packages/node/fixture-serve/package.json
+++ b/packages/node/fixture-serve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saga-ed/fixture-serve",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "private": false,
   "type": "module",
   "description": "Reusable fixture server infrastructure — Express server, async job queue, provision workflow, and credential export for service-specific fixture CLIs",

--- a/packages/node/fixture-serve/src/__tests__/admin-registration.unit.test.ts
+++ b/packages/node/fixture-serve/src/__tests__/admin-registration.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { MockLogger } from '@saga-ed/soa-logger';
-import { register_with_admin } from '../server/admin-registration.js';
+import { register_with_admin, start_heartbeat } from '../server/admin-registration.js';
 
 vi.mock('@saga-ed/infra-compose', () => ({
     get_active_profile: vi.fn(() => ({ profile: 'basic' })),
@@ -124,5 +124,85 @@ describe('register_with_admin', () => {
         const admin_call = fetch_spy.mock.calls.find(c => c[0] === 'http://admin.test/register');
         const body = JSON.parse(admin_call![1].body);
         expect(body.active_profile).toBeNull();
+    });
+});
+
+describe('start_heartbeat', () => {
+    const config = {
+        admin_url: 'http://admin.test/register',
+        port: 7777,
+        site_url: 'https://snapper.test',
+        version: '0.2.6',
+    };
+
+    let fetch_spy: ReturnType<typeof vi.fn>;
+    let logger: MockLogger;
+
+    // IMDS failures → 127.0.0.1 fallback without waiting on the real 2s timeouts.
+    const ok_response_with_imds_failure = () => {
+        fetch_spy.mockImplementation(async (url: any) => {
+            if (typeof url === 'string' && url.includes('169.254.169.254')) {
+                throw new Error('no IMDS in unit test');
+            }
+            return { ok: true, status: 200, statusText: 'OK' } as any;
+        });
+    };
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        fetch_spy = vi.fn();
+        vi.stubGlobal('fetch', fetch_spy);
+        logger = new MockLogger();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.unstubAllGlobals();
+        vi.clearAllMocks();
+    });
+
+    const register_calls = () =>
+        fetch_spy.mock.calls.filter((c: any[]) => c[0] === config.admin_url).length;
+
+    it('registers at startup and re-registers on the interval, stopping on handle.stop()', async () => {
+        ok_response_with_imds_failure();
+        const handle = start_heartbeat(config, logger, 1000);
+
+        await vi.advanceTimersByTimeAsync(0);
+        const after_startup = register_calls();
+        expect(after_startup).toBeGreaterThanOrEqual(1);
+
+        await vi.advanceTimersByTimeAsync(3500);
+        const after_intervals = register_calls();
+        expect(after_intervals).toBeGreaterThan(after_startup);
+
+        handle.stop();
+        await vi.advanceTimersByTimeAsync(5000);
+        expect(register_calls()).toBe(after_intervals);
+    });
+
+    it('stop() is idempotent', () => {
+        ok_response_with_imds_failure();
+        const handle = start_heartbeat(config, logger, 1000);
+        handle.stop();
+        expect(() => handle.stop()).not.toThrow();
+    });
+
+    it('keeps heartbeating after a failed registration', async () => {
+        fetch_spy.mockImplementation(async (url: any) => {
+            if (typeof url === 'string' && url.includes('169.254.169.254')) {
+                throw new Error('no IMDS');
+            }
+            return { ok: false, status: 503, statusText: 'Service Unavailable' } as any;
+        });
+
+        const handle = start_heartbeat(config, logger, 1000);
+        await vi.runOnlyPendingTimersAsync();
+        await vi.advanceTimersByTimeAsync(2000);
+
+        expect(register_calls()).toBeGreaterThanOrEqual(3);
+        expect(logger.logs.some(l => l.level === 'warn')).toBe(true);
+
+        handle.stop();
     });
 });

--- a/packages/node/fixture-serve/src/server/admin-registration.ts
+++ b/packages/node/fixture-serve/src/server/admin-registration.ts
@@ -66,6 +66,33 @@ export async function register_with_admin(config: AdminRegistrationConfig, logge
             logger.warn(`register_with_admin: ${resp.status} ${resp.statusText}`);
         }
     } catch (err: any) {
-        logger.warn(`register_with_admin: ${err.message} (will retry on next restart)`);
+        logger.warn(`register_with_admin: ${err.message} (will retry on next heartbeat)`);
     }
+}
+
+/** Well under the admin-side 72h DynamoDB TTL that would otherwise drop the host from the UI. */
+export const DEFAULT_HEARTBEAT_INTERVAL_MS = 30 * 60 * 1000;
+
+export interface HeartbeatHandle {
+    stop(): void;
+}
+
+/**
+ * Register with fixture-admin now, then re-register on an interval so the
+ * admin-side row does not TTL-expire. Individual registrations are
+ * fire-and-forget: a failure logs a warning and the loop continues.
+ */
+export function start_heartbeat(
+    config: AdminRegistrationConfig,
+    logger: ILogger,
+    interval_ms: number = DEFAULT_HEARTBEAT_INTERVAL_MS,
+): HeartbeatHandle {
+    void register_with_admin(config, logger);
+
+    const timer = setInterval(() => {
+        void register_with_admin(config, logger);
+    }, interval_ms);
+    timer.unref();
+
+    return { stop: () => clearInterval(timer) };
 }

--- a/packages/node/fixture-serve/src/server/fixture-server.ts
+++ b/packages/node/fixture-serve/src/server/fixture-server.ts
@@ -40,7 +40,7 @@ import type { MongoClient } from 'mongodb';
 import { get_active_profile } from '@saga-ed/infra-compose';
 import { create_router as create_infra_router } from '@saga-ed/infra-compose/router';
 import { create_service_restarter } from '../utils/service-restart.js';
-import { register_with_admin } from './admin-registration.js';
+import { start_heartbeat, type HeartbeatHandle } from './admin-registration.js';
 import type { FixtureControllerConfig } from '../controller/abstract-fixture-controller.js';
 
 export interface FixtureServerConfig {
@@ -107,6 +107,7 @@ export class FixtureServer {
     /** DI container — exposed for infra_hooks that need MongoDB reconnection or other bindings. */
     container!: Container;
     private express_server!: ExpressServer;
+    private admin_heartbeat?: HeartbeatHandle;
 
     constructor(private config: FixtureServerConfig) {}
 
@@ -231,10 +232,10 @@ export class FixtureServer {
         // 7. Start listening
         this.express_server.start();
 
-        // 8. Optional admin registration
+        // 8. Optional admin registration (with periodic heartbeat to keep TTL fresh)
         const admin_url = config.admin_register_url || process.env.FIXTURE_ADMIN_URL;
         if (admin_url) {
-            register_with_admin({
+            this.admin_heartbeat = start_heartbeat({
                 admin_url,
                 port: config.port,
                 site_url: config.site_url || '',
@@ -244,6 +245,7 @@ export class FixtureServer {
 
         // 9. Graceful shutdown
         const shutdown = async () => {
+            this.admin_heartbeat?.stop();
             try {
                 const mgr = await this.container.getAsync<IMongoConnMgr>('IMongoConnMgr');
                 await mgr.disconnect();
@@ -256,6 +258,7 @@ export class FixtureServer {
     }
 
     stop(): void {
+        this.admin_heartbeat?.stop();
         this.express_server?.stop();
     }
 


### PR DESCRIPTION
## Summary

- The fixture-admin backend stores each registered host with a 72 h DynamoDB TTL (`host_store.py:11` in the admin-side repo). fixture-serve only registers once, from `FixtureServer.start()` on startup. Any VM that stays up past 72 h silently disappears from the fixture-admin UI even though it's perfectly healthy.
- This PR adds `start_heartbeat()` — the initial registration plus a 30-minute `setInterval` that re-POSTs the same payload. The admin handler's `put_item` is already idempotent (it just refreshes `expires_at`), so no admin-side change is needed.
- `FixtureServer` now holds the heartbeat handle and cancels it in both the `SIGINT/SIGTERM` shutdown path and `stop()`. The interval is `unref`'d so it won't block node exit.

## Why 30 min

72 h TTL ÷ 30 min = 144× safety margin. The only cost is ~1 request per fixture-serve every half hour.

## Observed failure (real world)

`snapper` registered at `2026-04-15 21:04 UTC` (last systemd restart), TTL'd out on `2026-04-18 21:04`, and has been missing from the fixture-admin UI for ~6 days despite the service being `active (running)` the whole time. Verified via SSM:

```
● fixture-serve.service — active (running) since Wed 2026-04-15 21:04:15 UTC; 1 week 1 day ago
Apr 15 21:04:30 snapper fixture-serve[805327]: INFO ... Registered with fixture-admin: snapper (172.20.136.85:7777)
```

`fixture-hosts-dev` DynamoDB `ItemCount`: 0.

## Test plan

- [x] `pnpm vitest run` in `packages/node/fixture-serve` — 27 passing (5 files, including the new 3 heartbeat tests)
- [x] `pnpm run build` clean
- [ ] After merge + publish, restart one dev VM (e.g. snapper) and confirm the host appears in the fixture-admin UI and persists past the 72 h mark