### PR TITLE
fix(infra-compose): express dep + hyphenated service-name regex

### DIFF
--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -1,14 +1,14 @@
 {
     "name": "@saga-ed/infra-compose",
-    "version": "0.10.16",
+    "version": "1.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@saga-ed/infra-compose",
-            "version": "0.10.16",
+            "version": "1.0.1",
             "dependencies": {
-                "docker-compose": "^0.24.8",
+                "express": "^4.22.1",
                 "mongodb": "^6.0.0",
                 "mysql2": "^3.0.0"
             },
@@ -18,21 +18,13 @@
             "devDependencies": {
                 "@eslint/js": "^10.0.1",
                 "eslint": "^10.1.0",
-                "express": "^4.22.1",
                 "typescript": "^5.9.3",
                 "vitest": "^1.6.1"
-            },
-            "peerDependencies": {
-                "express": "^4.18.0 || ^5.0.0"
-            },
-            "peerDependenciesMeta": {
-                "express": {
-                    "optional": true
-                }
             }
         },
         "../../nimbee/node_modules/.pnpm/docker-compose@0.24.8/node_modules/docker-compose": {
             "version": "0.24.8",
+            "extraneous": true,
             "license": "MIT",
             "dependencies": {
                 "yaml": "^2.2.2"
@@ -1164,7 +1156,6 @@
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
             "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "mime-types": "~2.1.34",
@@ -1245,7 +1236,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
             "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/assertion-error": {
@@ -1280,7 +1270,6 @@
             "version": "1.20.4",
             "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
             "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "bytes": "~3.1.2",
@@ -1305,7 +1294,6 @@
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
             "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3"
@@ -1339,7 +1327,6 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
             "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
@@ -1359,7 +1346,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
             "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
@@ -1373,7 +1359,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
             "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.2",
@@ -1429,7 +1414,6 @@
             "version": "0.5.4",
             "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
             "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "safe-buffer": "5.2.1"
@@ -1442,7 +1426,6 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
             "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
@@ -1452,7 +1435,6 @@
             "version": "0.7.2",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
             "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
@@ -1462,7 +1444,6 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
             "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/cross-spawn": {
@@ -1484,7 +1465,6 @@
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
             "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ms": "2.0.0"
@@ -1522,7 +1502,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
             "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
@@ -1532,7 +1511,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
             "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8",
@@ -1549,15 +1527,10 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
-        "node_modules/docker-compose": {
-            "resolved": "../../nimbee/node_modules/.pnpm/docker-compose@0.24.8/node_modules/docker-compose",
-            "link": true
-        },
         "node_modules/dunder-proto": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
             "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.1",
@@ -1572,14 +1545,12 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
             "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/encodeurl": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
             "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
@@ -1589,7 +1560,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
             "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -1599,7 +1569,6 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -1609,7 +1578,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
             "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0"
@@ -1661,7 +1629,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
             "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/escape-string-regexp": {
@@ -1869,7 +1836,6 @@
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
             "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
@@ -1903,7 +1869,6 @@
             "version": "4.22.1",
             "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
             "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "accepts": "~1.3.8",
@@ -1984,7 +1949,6 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
             "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "debug": "2.6.9",
@@ -2041,7 +2005,6 @@
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
             "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
@@ -2051,7 +2014,6 @@
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
             "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
@@ -2076,7 +2038,6 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
             "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -2104,7 +2065,6 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
             "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.2",
@@ -2129,7 +2089,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
             "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "dunder-proto": "^1.0.1",
@@ -2169,7 +2128,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
             "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -2182,7 +2140,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
             "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -2195,7 +2152,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
             "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -2208,7 +2164,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
             "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "depd": "~2.0.0",
@@ -2274,14 +2229,12 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/ipaddr.js": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
             "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.10"
@@ -2463,7 +2416,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
             "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -2473,7 +2425,6 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
             "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
@@ -2488,7 +2439,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
             "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
-            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -2505,7 +2455,6 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
             "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
@@ -2515,7 +2464,6 @@
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
             "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-            "dev": true,
             "license": "MIT",
             "bin": {
                 "mime": "cli.js"
@@ -2528,7 +2476,6 @@
             "version": "1.52.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
             "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
@@ -2538,7 +2485,6 @@
             "version": "2.1.35",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
             "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "mime-db": "1.52.0"
@@ -2654,7 +2600,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/mysql2": {
@@ -2719,7 +2664,6 @@
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
             "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
@@ -2758,7 +2702,6 @@
             "version": "1.13.4",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
             "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -2771,7 +2714,6 @@
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
             "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ee-first": "1.1.1"
@@ -2879,7 +2821,6 @@
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
             "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
@@ -2909,7 +2850,6 @@
             "version": "0.1.13",
             "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
             "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/pathe": {
@@ -3013,7 +2953,6 @@
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
             "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "forwarded": "0.2.0",
@@ -3035,7 +2974,6 @@
             "version": "6.14.2",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
             "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
-            "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "side-channel": "^1.1.0"
@@ -3051,7 +2989,6 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
             "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
@@ -3061,7 +2998,6 @@
             "version": "2.5.3",
             "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
             "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "bytes": "~3.1.2",
@@ -3077,7 +3013,6 @@
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
             "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3"
@@ -3142,7 +3077,6 @@
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
             "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -3168,7 +3102,6 @@
             "version": "0.19.2",
             "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
             "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "debug": "2.6.9",
@@ -3193,14 +3126,12 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/serve-static": {
             "version": "1.16.3",
             "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
             "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "encodeurl": "~2.0.0",
@@ -3216,7 +3147,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
             "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/shebang-command": {
@@ -3246,7 +3176,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
             "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
@@ -3266,7 +3195,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
             "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
@@ -3283,7 +3211,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
             "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bound": "^1.0.2",
@@ -3302,7 +3229,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
             "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bound": "^1.0.2",
@@ -3381,7 +3307,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
             "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
@@ -3451,7 +3376,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
             "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.6"
@@ -3495,7 +3419,6 @@
             "version": "1.6.18",
             "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
             "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "media-typer": "0.3.0",
@@ -3535,7 +3458,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
             "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
@@ -3555,7 +3477,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
             "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4.0"
@@ -3565,7 +3486,6 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
             "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"

--- a/infra/package.json
+++ b/infra/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/infra-compose",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Composable Docker service templates for Saga platform local development",
     "bin": {
         "infra-compose": "bin/infra-compose"
@@ -30,23 +30,15 @@
         ".env.defaults"
     ],
     "dependencies": {
+        "express": "^4.22.1",
         "mongodb": "^6.0.0",
         "mysql2": "^3.0.0"
     },
     "devDependencies": {
         "@eslint/js": "^10.0.1",
         "eslint": "^10.1.0",
-        "express": "^4.22.1",
         "typescript": "^5.9.3",
         "vitest": "^1.6.1"
-    },
-    "peerDependencies": {
-        "express": "^4.18.0 || ^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "express": {
-            "optional": true
-        }
     },
     "publishConfig": {
         "registry": "https://saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/",

--- a/infra/src/ec2/ec2-router.js
+++ b/infra/src/ec2/ec2-router.js
@@ -45,9 +45,9 @@ function get_compose_config(projects_dir, name, engine) {
     if (!existsSync(compose_path)) return defaults;
     const content = readFileSync(compose_path, 'utf8');
 
-    const db_patterns = { postgres: /POSTGRES_DB:\s*"?(\w+)"?/, mysql: /MYSQL_DATABASE:\s*"?(\w+)"?/, mongo: /MONGO_INITDB_DATABASE:\s*"?(\w+)"?/ };
-    const user_patterns = { postgres: /POSTGRES_USER:\s*"?(\w+)"?/, mysql: /MYSQL_USER:\s*"?(\w+)"?/, mongo: /MONGO_INITDB_ROOT_USERNAME:\s*"?(\w+)"?/ };
-    const pw_patterns = { postgres: /POSTGRES_PASSWORD:\s*"?(\w+)"?/, mysql: /MYSQL_ROOT_PASSWORD:\s*"?(\w+)"?/, mongo: /MONGO_INITDB_ROOT_PASSWORD:\s*"?(\w+)"?/ };
+    const db_patterns = { postgres: /POSTGRES_DB:\s*"?([\w-]+)"?/, mysql: /MYSQL_DATABASE:\s*"?([\w-]+)"?/, mongo: /MONGO_INITDB_DATABASE:\s*"?([\w-]+)"?/ };
+    const user_patterns = { postgres: /POSTGRES_USER:\s*"?([\w-]+)"?/, mysql: /MYSQL_USER:\s*"?([\w-]+)"?/, mongo: /MONGO_INITDB_ROOT_USERNAME:\s*"?([\w-]+)"?/ };
+    const pw_patterns = { postgres: /POSTGRES_PASSWORD:\s*"?([\w-]+)"?/, mysql: /MYSQL_ROOT_PASSWORD:\s*"?([\w-]+)"?/, mongo: /MONGO_INITDB_ROOT_PASSWORD:\s*"?([\w-]+)"?/ };
 
     const db_match = content.match(db_patterns[engine]);
     const user_match = content.match(user_patterns[engine]);


### PR DESCRIPTION
## Summary

Two bugs surfaced when running `@saga-ed/infra-compose` on the dev db-host EC2:

1. **`express` was unreachable on global install.** `src/ec2/server.js` (and `src/router.js`) import `express` at runtime, but `express` was in `devDependencies` plus an optional `peerDependency`. `npm install -g @saga-ed/infra-compose` therefore left `/usr/lib/node_modules/@saga-ed/infra-compose/node_modules` without `express`, and `db-host-api.service` exited with `ERR_MODULE_NOT_FOUND`. Our IaC UserData currently works around this by running `(cd /usr/lib/node_modules/@saga-ed/infra-compose && npm install express@^4)` after the global install — fragile and slow. **Fix:** move `express` to a hard `dependencies` entry and drop the optional-peer-dep config.

2. **Service names with hyphens were silently truncated.** `get_compose_config` in `src/ec2/ec2-router.js:48-50` parsed `POSTGRES_DB` / `POSTGRES_USER` / `POSTGRES_PASSWORD` (and the mysql/mongo equivalents) with `\w+`, which doesn't match `-`. A service named `v2-probe-pg` got captured as `v2`, so the snapshot/switch/restore paths called `pg_dump` against a non-existent DB \"v2\". **Fix:** swap `\w+` for `[\w-]+` in all 9 patterns. Service names are already validated at `ec2-router.js:123` against `/^[a-zA-Z0-9_-]+$/`, so the new regex stays within the allowed character set.

Bumps version 0.10.16 → 1.0.1 (patch + 1.0 graduation; the previous 0.10.x series was published before this package landed in the soa monorepo).

## Test plan
- [x] \`npm test\` — 70/70 unit tests pass
- [x] \`npm run lint\` — clean (1 pre-existing unused-arg warning in \`profiles.js\` unrelated to this PR)
- [x] \`npm pack --dry-run\` — confirms \`src/ec2/*.js\` are all packaged
- [ ] After publish: bump \`InfraComposeVersion=\"1.0.1\"\` in IaC \`asg/samconfig.yaml\`, remove the post-install express workaround in UserData, redeploy ASG, verify \`db-host-api.service\` starts and a hyphenated DB survives a snapshot+switch round-trip.