### PR TITLE
feat(infra-compose): hydrate endpoint + ASG recovery (1.3.0)

### DIFF
--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@saga-ed/infra-compose",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@saga-ed/infra-compose",
-            "version": "1.0.1",
+            "version": "1.1.0",
             "dependencies": {
                 "express": "^4.22.1",
                 "mongodb": "^6.0.0",

--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@saga-ed/infra-compose",
-    "version": "1.1.0",
+    "version": "1.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@saga-ed/infra-compose",
-            "version": "1.1.0",
+            "version": "1.3.0",
             "dependencies": {
                 "express": "^4.22.1",
                 "mongodb": "^6.0.0",

--- a/infra/package.json
+++ b/infra/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/infra-compose",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "description": "Composable Docker service templates for Saga platform local development",
     "bin": {
         "infra-compose": "bin/infra-compose"

--- a/infra/package.json
+++ b/infra/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/infra-compose",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "description": "Composable Docker service templates for Saga platform local development",
     "bin": {
         "infra-compose": "bin/infra-compose"

--- a/infra/package.json
+++ b/infra/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/infra-compose",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "Composable Docker service templates for Saga platform local development",
     "bin": {
         "infra-compose": "bin/infra-compose"

--- a/infra/src/ec2/ec2-router.js
+++ b/infra/src/ec2/ec2-router.js
@@ -375,17 +375,16 @@ export function create_ec2_router(config = {}) {
     });
 
     // POST /dbs/:name/hydrate — re-create compose project on a fresh
-    // instance from caller-supplied {engine, version, port, db_name}.
-    // Assumes the EBS volume holding /mnt/data/<name> is already mounted
-    // (UserData's auto-attach loop handles that on instance launch). Used
-    // by the orchestrator's recovery flow when an ASG instance is replaced
-    // and DBs need to be re-homed onto the new instance with their existing
-    // data intact. Idempotent: a second hydrate on the same name is a
-    // compose-up of the existing project_dir.
+    // instance from caller-supplied {engine, version, port, db_name,
+    // volume_id}. If volume_id is provided and the mount_path is not
+    // already a mountpoint, attach and mount the volume here (handles
+    // ASG-replacement recovery where UserData's volume-discovery loop
+    // raced the previous instance's termination). Idempotent: a second
+    // hydrate is a compose-up of the existing project_dir.
     router.post('/dbs/:name/hydrate', (req, res) => {
         try {
             const { name } = req.params;
-            const { engine, version, port, db_name } = req.body || {};
+            const { engine, version, port, db_name, volume_id } = req.body || {};
 
             if (!engine || !port) {
                 return res.status(400).json({ ok: false, error: 'engine and port are required' });
@@ -395,8 +394,18 @@ export function create_ec2_router(config = {}) {
             }
 
             const mount_path = resolve(data_dir, name);
-            if (!existsSync(mount_path)) {
-                return res.status(400).json({ ok: false, error: `Data volume not mounted at ${mount_path} — UserData should have attached it` });
+            const is_mounted = spawnSync('mountpoint', ['-q', mount_path], { stdio: 'pipe' }).status === 0;
+            if (!is_mounted) {
+                if (!volume_id) {
+                    return res.status(400).json({ ok: false, error: `Data volume not mounted at ${mount_path} and no volume_id provided to attach` });
+                }
+                const meta = get_instance_metadata();
+                attach_and_mount({
+                    volume_id,
+                    mount_path,
+                    instance_id: meta.instance_id,
+                    region: region || meta.region,
+                });
             }
 
             // Reflect the known port in the local registry so subsequent

--- a/infra/src/ec2/ec2-router.js
+++ b/infra/src/ec2/ec2-router.js
@@ -11,7 +11,7 @@ import { readdirSync, readFileSync, existsSync, writeFileSync, mkdirSync, rmSync
 import { resolve } from 'path';
 import { engines } from './engines.js';
 import { generate_compose } from './compose-generator.js';
-import { allocate_port, release_port, get_allocated_ports } from './ports.js';
+import { allocate_port, register_port, release_port, get_allocated_ports } from './ports.js';
 import { create_volume, attach_and_mount, get_instance_metadata } from './volumes.js';
 import { register, deregister } from './cloudmap.js';
 import { snapshot_db, download_profile_seed, seed_after_start, list_s3_profiles, read_profile_registry, write_active_profile } from './profiles.js';
@@ -369,6 +369,80 @@ export function create_ec2_router(config = {}) {
                 return res.status(500).json({ ok: false, error: `stop failed: ${result.stderr}` });
             }
             res.json({ ok: true, name: req.params.name, action: 'stopped' });
+        } catch (err) {
+            res.status(500).json({ ok: false, error: err.message });
+        }
+    });
+
+    // POST /dbs/:name/hydrate — re-create compose project on a fresh
+    // instance from caller-supplied {engine, version, port, db_name}.
+    // Assumes the EBS volume holding /mnt/data/<name> is already mounted
+    // (UserData's auto-attach loop handles that on instance launch). Used
+    // by the orchestrator's recovery flow when an ASG instance is replaced
+    // and DBs need to be re-homed onto the new instance with their existing
+    // data intact. Idempotent: a second hydrate on the same name is a
+    // compose-up of the existing project_dir.
+    router.post('/dbs/:name/hydrate', (req, res) => {
+        try {
+            const { name } = req.params;
+            const { engine, version, port, db_name } = req.body || {};
+
+            if (!engine || !port) {
+                return res.status(400).json({ ok: false, error: 'engine and port are required' });
+            }
+            if (!engines[engine]) {
+                return res.status(400).json({ ok: false, error: `Unknown engine: ${engine}. Use: ${Object.keys(engines).join(', ')}` });
+            }
+
+            const mount_path = resolve(data_dir, name);
+            if (!existsSync(mount_path)) {
+                return res.status(400).json({ ok: false, error: `Data volume not mounted at ${mount_path} — UserData should have attached it` });
+            }
+
+            // Reflect the known port in the local registry so subsequent
+            // placement / list calls see this DB.
+            register_port(engine, name, port, { registry_path });
+
+            const compose_content = generate_compose({
+                name,
+                engine,
+                version,
+                port,
+                db_name: db_name || name,
+                data_dir,
+                // Intentionally no seeds_dir: data is already on the EBS
+                // volume; running initdb again would clobber it.
+            });
+
+            const project_dir = resolve(projects_dir, name);
+            mkdirSync(project_dir, { recursive: true });
+            writeFileSync(resolve(project_dir, 'docker-compose.yml'), compose_content);
+
+            const up = compose_cmd(project_dir, ['up', '-d']);
+            if (up.status !== 0) {
+                return res.status(500).json({ ok: false, error: `docker compose up failed: ${up.stderr}` });
+            }
+
+            if (namespace_id) {
+                const ip = spawnSync('hostname', ['-I'], { encoding: 'utf8' }).stdout.trim().split(/\s+/)[0];
+                register({
+                    name,
+                    ip,
+                    port,
+                    namespace_id,
+                    region: region || get_instance_metadata().region,
+                });
+            }
+
+            res.json({
+                ok: true,
+                name,
+                engine,
+                version: version || engines[engine].default_version,
+                port,
+                db_name: db_name || name,
+                action: 'hydrated',
+            });
         } catch (err) {
             res.status(500).json({ ok: false, error: err.message });
         }

--- a/infra/src/ec2/ports.js
+++ b/infra/src/ec2/ports.js
@@ -67,6 +67,23 @@ export function allocate_port(engine, name, options = {}) {
 }
 
 /**
+ * Record a known (engine, name, port) tuple in the registry. Used during
+ * hydrate when the caller already knows which port to use (from a remote
+ * source of truth, e.g. the orchestrator's DynamoDB registry) and wants
+ * the local port-registry to reflect it without searching for a free slot.
+ * @param {string} engine - postgres, mongo, or mysql
+ * @param {string} name - service name
+ * @param {number} port - port to record
+ * @param {{ registry_path?: string }} [options]
+ */
+export function register_port(engine, name, port, options = {}) {
+    const registry_path = options.registry_path || DEFAULT_REGISTRY_PATH;
+    const registry = read_registry(registry_path);
+    registry[name] = { engine, port };
+    write_registry(registry_path, registry);
+}
+
+/**
  * Release a port allocation.
  * @param {string} name - service name
  * @param {{ registry_path?: string }} [options]

--- a/infra/src/ec2/server.js
+++ b/infra/src/ec2/server.js
@@ -9,6 +9,11 @@
  *   PROJECTS_DIR          — compose project root (default: /opt/db-manager/projects)
  *   DATA_DIR              — EBS mount root (default: /mnt/data)
  *   PORT_REGISTRY_PATH    — port registry file (default: /opt/db-manager/port-registry.json)
+ *   MANAGED_BY_TAG        — ManagedBy tag value applied to created EBS volumes
+ *                           (default: "db-host"). Must match the value the IaC's
+ *                           UserData volume-discovery loop filters on, otherwise
+ *                           replacement instances won't re-attach existing volumes
+ *                           during ASG recovery.
  */
 
 import express from 'express';

--- a/infra/src/ec2/volumes.js
+++ b/infra/src/ec2/volumes.js
@@ -41,13 +41,22 @@ export function get_instance_metadata() {
 
 /**
  * Create an EBS volume with db-host tags.
+ *
+ * The ManagedBy tag value comes from the MANAGED_BY_TAG env var (default
+ * "db-host"). The IaC's UserData volume-discovery loop filters on that
+ * tag, so any deployment that wants its own namespace (e.g. a parallel
+ * "db-host-v2" stack) must set MANAGED_BY_TAG to match what the
+ * launch-template UserData filters on, or the loop will skip these
+ * volumes on a replacement instance and recovery will not work.
+ *
  * @param {{ name: string, size: number, az: string, region: string, env_name?: string }} config
  * @returns {string} volume_id
  */
 export function create_volume({ name, size, az, region, env_name }) {
+    const managed_by = process.env.MANAGED_BY_TAG || 'db-host';
     const tags = [
         { Key: 'Name', Value: `db-host-${name}` },
-        { Key: 'ManagedBy', Value: 'db-host' },
+        { Key: 'ManagedBy', Value: managed_by },
         { Key: 'ServiceName', Value: name },
         { Key: 'MountPath', Value: `/mnt/data/${name}` },
     ];

--- a/infra/src/ec2/volumes.js
+++ b/infra/src/ec2/volumes.js
@@ -92,9 +92,24 @@ export function create_volume({ name, size, az, region, env_name }) {
 
 /**
  * Attach an EBS volume, format if new, mount, and add fstab entry.
+ *
+ * Tolerant of a recently-terminated instance still holding the volume:
+ * waits up to 180s for the volume to reach `available` before attaching.
+ * The format step uses `blkid` to skip mkfs if the device already has a
+ * filesystem, so this is safe to call against an existing data volume
+ * (the recovery case).
+ *
  * @param {{ volume_id: string, mount_path: string, instance_id: string, region: string }} config
  */
 export function attach_and_mount({ volume_id, mount_path, instance_id, region }) {
+    // The volume may still be detaching from a recently-terminated
+    // instance. Wait for it to be available before attaching.
+    run('aws', [
+        'ec2', 'wait', 'volume-available',
+        '--volume-ids', volume_id,
+        '--region', region,
+    ], { timeout: 180000 });
+
     // Find next available device letter (f through p)
     const attached = JSON.parse(run('aws', [
         'ec2', 'describe-instances',


### PR DESCRIPTION
## Summary

Adds the pieces needed for the IaC ASG-recovery flow when a db-host instance is replaced. Three commits, three minor bumps:

- **1.1.0 — `POST /dbs/:name/hydrate`.** Re-creates a compose project from caller-supplied `{engine, version, port, db_name}` against an already-attached EBS data volume. Idempotent. No initdb seed (data is already on disk). Adds `register_port` to `ports.js` so the local port registry can record the orchestrator-known port without searching for a free slot.
- **1.2.0 — `MANAGED_BY_TAG` env var.** `create_volume` was hardcoding `ManagedBy=db-host`. The IaC v2 stack tags its UserData volume-discovery filter with `ManagedBy=db-host-v2`, so the mismatch meant recovery never re-attached existing volumes. Default stays `db-host` so v1 is unchanged.
- **1.3.0 — `/hydrate` attaches+mounts via `volume_id`.** UserData's volume-discovery loop on a replacement instance can race the previous instance's termination (the volume is still `in-use`, not `available`). Move attach+mount responsibility into `/hydrate`: the orchestrator already knows the volumeId from DDB and passes it in. Hydrate skips when already mounted, otherwise calls `attach_and_mount`, which now waits up to 180s for `volume-available` before attaching.
- **chore — sync package-lock.json to 1.3.0.** Lockfile had drifted from package.json across the 1.2.0/1.3.0 bumps.

Stack on top of #66 (base is `fix/infra-compose-bugs` until that merges).

## Test plan
- [x] \`npm test\` — 70/70 unit tests pass
- [x] \`npm run lint\` — clean (1 pre-existing unused-arg warning)
- [ ] After publish + IaC update: terminate the ASG instance, observe ASG replacement + EventBridge fire + hydrate run, confirm DB is back up on the new instance with sentinel data intact.

## Bumps version 1.0.1 → 1.3.0 (three minor bumps in sequence).