### PR TITLE
chore(test-util): drop empty test script

### DIFF
--- a/packages/node/test-util/package.json
+++ b/packages/node/test-util/package.json
@@ -13,7 +13,6 @@
   "scripts": {
     "dev": "tsup --watch",
     "build": "tsup",
-    "test": "vitest run",
     "clean": "rm -rf dist"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- `@saga-ed/soa-test-util` has no test files; its `test` script ran `vitest run` which exits 1 with "No test files found".
- Blocked the `Publish to AWS CodeArtifact` workflow during the sds_80 publish push (run [25021068830](https://github.com/saga-ed/soa/actions/runs/25021009011)).
- Removing the script lets turbo skip the task entirely; future test work in this package can re-add the script.

## Test plan

- [ ] CI: `Publish to AWS CodeArtifact` no longer fails on `@saga-ed/soa-test-util#test`
- [ ] `pnpm turbo run test` from the repo root succeeds (test-util skipped, others run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)