### PR TITLE
chore(ci): add mesh-fixture-cli + fixture-deidentify to publish workflow

### DIFF
--- a/.github/workflows/publish-codeartifact.yml
+++ b/.github/workflows/publish-codeartifact.yml
@@ -265,6 +265,8 @@ jobs:
             "packages/node/rabbitmq"
             "packages/node/redis-core"
             "packages/node/test-util"
+            "packages/core/fixture-deidentify"
+            "packages/node/mesh-fixture-cli"
           )
 
           # Build npm version command with preid for prerelease versions


### PR DESCRIPTION
## Summary

- Both packages landed in #67 (sds_80) but were missing from `PUBLISHABLE_PACKAGES` in `publish-codeartifact.yml`, so the manual `Publish to AWS CodeArtifact` workflow silently skipped them.
- First publish of `@saga-ed/fixture-deidentify@0.1.0` and `@saga-ed/mesh-fixture-cli@0.0.1` was done manually via `pnpm publish` from the package directories.
- This change ensures future bumps for these two packages go through CI like every other `@saga-ed/*` package.

## Test plan

- [ ] After merge: `gh workflow run publish-codeartifact.yml --ref main -f version=patch -f publish_target=codeartifact -f dry_run=true` lists both packages in the dry-run output
- [ ] Future patch bump publishes `mesh-fixture-cli@0.0.2` + `fixture-deidentify@0.1.1` to CodeArtifact (note: 0.0.2 will require downstream spec loosening — see sds_80 docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)