### PR TITLE
chore: drop private flag on mesh-fixture-cli + fixture-deidentify

### DIFF
--- a/packages/core/fixture-deidentify/package.json
+++ b/packages/core/fixture-deidentify/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@saga-ed/fixture-deidentify",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -25,5 +24,9 @@
     "tsup": "^8.5.0",
     "typescript": "5.8.2",
     "vitest": "^1.6.1"
+  },
+  "publishConfig": {
+    "registry": "https://saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/",
+    "access": "public"
   }
 }

--- a/packages/node/mesh-fixture-cli/package.json
+++ b/packages/node/mesh-fixture-cli/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@saga-ed/mesh-fixture-cli",
   "version": "0.0.1",
-  "private": true,
   "type": "module",
   "description": "CLI for authoring, storing, and restoring cross-repo fixtures on the saga-mesh (rostering + program-hub + SDS). Part of saga-ed/student-data-system#80 Phase 3.",
   "bin": {


### PR DESCRIPTION
## Summary

- Both packages were scaffolded with `"private": true` as a draft-state guard.
- Now consumed by downstream sds_80 PRs in rostering/program-hub/student-data-system, which need these on CodeArtifact.
- Drops `"private": true` from both, and adds the standard `publishConfig` (registry + access) to fixture-deidentify to match the convention used by every other published `@saga-ed/*` package.

## Why now

`pnpm publish --no-git-checks --access public` from each package directory currently fails with:
```
npm error code EPRIVATE
npm error This package has been marked as private
```

This PR + #70 (which adds these packages to the workflow's `PUBLISHABLE_PACKAGES`) clears both publish paths.

## Test plan

- [ ] After merge: `pnpm --filter @saga-ed/fixture-deidentify build && (cd packages/core/fixture-deidentify && pnpm publish --no-git-checks --access public)` succeeds.
- [ ] Same for `@saga-ed/mesh-fixture-cli`.
- [ ] Once published, `pnpm view @saga-ed/fixture-deidentify versions --json` lists `0.1.0`; same for mesh-fixture-cli at `0.0.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)