### PR TITLE
chore: cross-repo dev docs (qa-cross-validation skill + dev guide)

### DIFF
--- a/.claude/skills/qa-cross-validation/SKILL.md
+++ b/.claude/skills/qa-cross-validation/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: qa-cross-validation
+description: Set up a QA team with two independent testers that cross-validate each other's work. Uses Claude Code experimental agent teams to run parallel test passes, swap sections, and produce an agreement matrix highlighting confirmed passes, confirmed failures, and disagreements requiring investigation.
+---
+
+# QA Cross-Validation Skill
+
+## Purpose
+
+This skill sets up a 3-agent QA team that independently verifies a feature or deployment using cross-validation. Two testers each run half the test plan, then swap sections, producing 4 reports that the QA lead analyzes for agreement and disagreement.
+
+## When to Use
+
+Invoke this skill when you need to:
+- Verify a deployment or fixture against requirements
+- Validate database state matches expected configuration
+- Run acceptance tests that require querying live systems (VMs, APIs, databases)
+- Get high-confidence results by having two independent observers
+
+## Prerequisites
+
+Experimental teams must be enabled:
+
+```bash
+export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
+```
+
+## How It Works
+
+### Phase 1: Test Plan Split
+
+The QA lead (you) divides the requirements into two roughly equal sections:
+
+| Section A (Configuration/Static) | Section B (Relationships/Dynamic) |
+|----------------------------------|-----------------------------------|
+| Entity existence and properties | Entity-to-entity assignments |
+| Config values (names, settings) | Cross-entity relationships |
+| Individual resource verification | Schedule/session data |
+| Static data correctness | Behavioral/computed data |
+
+**Rules for splitting:**
+1. Roughly equal test counts per section
+2. Minimize cross-dependencies between sections
+3. Each section independently runnable
+4. Group related tests together (don't split categories)
+5. Each test is a single, self-contained verification
+
+### Phase 2: First Pass (parallel)
+
+Spawn two testers simultaneously:
+
+```
+TeamCreate:
+  team_name: "<project>-qa"
+  description: "QA cross-validation for <feature>"
+  agent_type: "qa-lead"
+
+Task (qa-tester-alpha):
+  subagent_type: general-purpose
+  team_name: "<project>-qa"
+  mode: bypassPermissions
+  run_in_background: true
+  prompt: |
+    You are QA Tester Alpha on the <project>-qa team.
+
+    ## Your Test Section (Section A)
+    <test items with IDs, descriptions, expected values>
+
+    ## How to Test
+    <environment access: SSH commands, DB queries, API calls>
+
+    ## Output
+    Write report to: <path>/qa-report-alpha-section-a.md
+    Send summary to qa-lead when done.
+
+Task (qa-tester-beta):
+  subagent_type: general-purpose
+  team_name: "<project>-qa"
+  mode: bypassPermissions
+  run_in_background: true
+  prompt: |
+    You are QA Tester Beta on the <project>-qa team.
+
+    ## Your Test Section (Section B)
+    <test items with IDs, descriptions, expected values>
+
+    ## How to Test
+    <environment access: SSH commands, DB queries, API calls>
+
+    ## Output
+    Write report to: <path>/qa-report-beta-section-b.md
+    Send summary to qa-lead when done.
+```
+
+### Phase 3: Section Swap (parallel)
+
+After first pass completes, send swap instructions:
+
+```
+SendMessage -> qa-tester-alpha:
+  "First pass complete. Now run Section B.
+   [Include any corrections discovered during first pass]
+   Write report to: <path>/qa-report-alpha-section-b.md"
+
+SendMessage -> qa-tester-beta:
+  "First pass complete. Now run Section A.
+   [Include any corrections discovered during first pass]
+   Write report to: <path>/qa-report-beta-section-a.md"
+```
+
+**Key insight:** Between phases 2 and 3, the QA lead can investigate any FAILs or WARNs from the first pass. If a tester checked the wrong data source, the swap instructions should include corrections so the second tester gets it right.
+
+### Phase 4: Cross-Validation Analysis
+
+QA lead reads all 4 reports and produces the agreement matrix:
+
+```
+Alpha-A vs Beta-A  →  Two independent observations of Section A
+Alpha-B vs Beta-B  →  Two independent observations of Section B
+```
+
+| Outcome | Meaning | Action |
+|---------|---------|--------|
+| Both PASS | **CONFIRMED PASS** | No action |
+| Both FAIL | **CONFIRMED FAIL** | Fix required |
+| Both WARN | **CONFIRMED WARN** | Investigate or accept |
+| PASS vs FAIL | **DISAGREE** | QA lead investigates root cause |
+| PASS vs WARN | **RESOLVED** | QA lead determines which is correct |
+
+### Phase 5: Cleanup
+
+```
+SendMessage (shutdown_request) -> qa-tester-alpha
+SendMessage (shutdown_request) -> qa-tester-beta
+TeamDelete
+```
+
+## Test Report Format
+
+Each tester produces one report per section:
+
+```markdown
+# QA Report - [Tester] - Section [A/B]
+
+**Date:** YYYY-MM-DD
+**Feature:** <what's being tested>
+
+## [Category Name]
+
+### [Test ID] - [Test Name]
+- **Description:** What is being verified
+- **Expected:** Expected value or condition
+- **Actual:** Observed value or condition
+- **Source:** Where the data was queried from
+- **Status:** PASS | FAIL | WARN
+- **Notes:** (if FAIL or WARN) Explanation
+
+## Summary
+| Section | Tests | Pass | Fail | Warn |
+|---------|-------|------|------|------|
+| ...     | N     | N    | N    | N    |
+```
+
+## Final Report Format
+
+See `templates/cross-validation-summary.md` for the full template.
+
+Key sections:
+- **Agreement Matrix** - Per-test comparison of Alpha vs Beta results
+- **Resolution Notes** - Explanation of disagreements
+- **Remaining Work** - Actionable checklist of fixes and investigations
+
+## Why Cross-Validation?
+
+- Two independent observers catch tester-specific blind spots (wrong query, wrong table, misread field)
+- Agreement = high confidence in the result
+- Disagreement surfaces ambiguity, flaky conditions, or incorrect test methodology
+- Prevents single-point-of-failure in automated testing
+- Mimics real QA practice of independent verification
+
+## Adapting for Your Project
+
+| Placeholder | Description | Example |
+|-------------|-------------|---------|
+| `<project>` | Short project name | `jw-fixture`, `coach-api` |
+| `<feature>` | What's being tested | `User auth flow`, `Fixture v3` |
+| `<path>` | Report output directory | `claude/projects/gh_123/` |
+| Test access | How testers query the system | SSH+mongosh, curl, psql |
+
+## Example Configurations
+
+### MongoDB on VM (via SSM)
+
+```
+## How to Test
+
+SSH into VM and query Docker MongoDB:
+  ssh -i ~/.ssh/dev-key.pem \
+    -o "ProxyCommand aws ssm start-session --target <id> ..." \
+    ubuntu@<id> \
+    'docker exec <container> mongosh --quiet <db> --eval "QUERY"'
+```
+
+### PostgreSQL (local Docker)
+
+```
+## How to Test
+
+Query via Docker:
+  docker exec <container> psql -U postgres <db> -c "QUERY"
+```
+
+### REST API
+
+```
+## How to Test
+
+Query via curl:
+  curl -s -H "Authorization: Bearer $TOKEN" https://<host>/api/endpoint | jq .
+```

--- a/.claude/skills/qa-cross-validation/templates/cross-validation-summary.md
+++ b/.claude/skills/qa-cross-validation/templates/cross-validation-summary.md
@@ -1,0 +1,79 @@
+# QA Cross-Validation Summary
+
+**Feature:** <feature name>
+**Date:** YYYY-MM-DD
+**QA Lead:** <name>
+
+---
+
+## Test Plan Coverage
+
+- **Section A**: N tests (categories: ...)
+- **Section B**: N tests (categories: ...)
+- **Total**: N tests
+
+## Reports
+
+| Report | Tester | Section | Pass | Fail | Warn |
+|--------|--------|---------|------|------|------|
+| First pass | Alpha | A | | | |
+| First pass | Beta | B | | | |
+| Swap | Alpha | B | | | |
+| Swap | Beta | A | | | |
+
+---
+
+## Section A Agreement Matrix
+
+| Test ID | Description | Alpha | Beta | Consensus | Action |
+|---------|-------------|-------|------|-----------|--------|
+| A1.1 | ... | PASS | PASS | CONFIRMED PASS | None |
+| A1.2 | ... | WARN | PASS | RESOLVED PASS | [explanation] |
+
+## Section B Agreement Matrix
+
+| Test ID | Description | Alpha (swap) | Beta | Consensus | Action |
+|---------|-------------|--------------|------|-----------|--------|
+| B1.1 | ... | PASS | PASS | CONFIRMED PASS | None |
+| B2.1 | ... | PASS | FAIL | RESOLVED PASS | [explanation] |
+
+---
+
+## Final Summary
+
+| Category | Count |
+|----------|-------|
+| **CONFIRMED PASS** | N |
+| **RESOLVED PASS** (disagreement resolved) | N |
+| **CONFIRMED WARN** | N |
+| **CONFIRMED FAIL** | N |
+| **Unresolved Disagreements** | N |
+
+---
+
+## Remaining Work
+
+### Confirmed Failures (fix required)
+
+1. [ ] **Fix**: [test ID] - [description of confirmed failure]
+
+### Disagreements (investigate)
+
+1. [ ] **Investigate**: [test ID] - [description of disagreement, which tester was right]
+
+### Warnings (decide)
+
+1. [ ] **Decide**: [test ID] - [description of warning, whether it needs action]
+
+### Retest After Fixes
+
+1. [ ] **Retest**: [test IDs that need re-verification after fixes are applied]
+
+---
+
+## Cross-Validation Insights
+
+[Document any valuable findings from the cross-validation process itself:
+- Did one tester query a different data source that resolved the other's WARN?
+- Did the swap catch a false positive from the first pass?
+- Any methodology improvements for next time?]

--- a/docs/cross-repo-development-guide.md
+++ b/docs/cross-repo-development-guide.md
@@ -1,0 +1,380 @@
+# Cross-Repo Development with pnpm Workspaces
+
+Best practices for developing across soa and its consuming monorepos (thrive, coach).
+
+## The Core Problem
+
+Our architecture has a shared foundation repo (`soa`) that publishes `@saga-ed/soa-*` packages to AWS CodeArtifact. Consuming repos (`thrive`, `coach`) pull these packages from the registry. When you need to change a soa package and test it in a consumer *simultaneously*, the publish-install cycle is too slow.
+
+pnpm's `overrides` feature solves this by redirecting package resolution from the registry to a local filesystem path using the `link:` protocol.
+
+## The Critical Rule
+
+**Overrides MUST be declared in the root `package.json` of the consuming monorepo.**
+
+```
+thrive/
+  package.json          <-- overrides go HERE
+  apps/
+    node/
+      sessions-api/
+        package.json    <-- NOT here
+```
+
+pnpm only reads `pnpm.overrides` from the **workspace root** `package.json`. Putting overrides in a nested `package.json` (e.g., `apps/node/sessions-api/package.json`) has no effect. pnpm silently ignores them. This is the single most common mistake when setting up cross-repo linking.
+
+### Why Root-Level Only?
+
+pnpm workspaces have a single resolution context anchored at the workspace root. The `pnpm.overrides` field acts as a global resolution directive — it tells pnpm "whenever *any* package in this workspace asks for `@saga-ed/soa-logger`, resolve it to this path instead." Nested `package.json` files define what a package *needs*, but only the root controls *how* those needs are resolved.
+
+## How It Works
+
+### Directory Layout
+
+```
+~/dev/
+  soa/                              # Source of @saga-ed/soa-* packages
+    packages/
+      node/
+        api-core/                   # @saga-ed/soa-api-core
+        db/                         # @saga-ed/soa-db
+        logger/                     # @saga-ed/soa-logger
+        rabbitmq/                   # @saga-ed/soa-rabbitmq
+      core/
+        config/                     # @saga-ed/soa-config
+    scripts/
+      cross-repo-link.sh           # The linking tool
+
+  thrive/                           # Consumer repo
+    package.json                    # Root — overrides go here
+    soa-link.json                   # Declares which soa packages to link
+    apps/node/sessions-api/         # Uses @saga-ed/soa-db, soa-logger, etc.
+
+  coach/                            # Consumer repo
+    package.json                    # Root — overrides go here
+    soa-link.json                   # Declares which soa packages to link
+    apps/node/coach-api/            # Uses @saga-ed/soa-api-core, soa-db, etc.
+```
+
+### The Override Mechanism
+
+When linking is **off** (default, committed state):
+
+```jsonc
+// thrive/package.json
+{
+  "pnpm": {
+    "overrides": {
+      "zod": "^3.24.0"            // Only non-soa overrides
+    }
+  }
+}
+```
+
+All `@saga-ed/soa-*` packages resolve from AWS CodeArtifact per `.npmrc`:
+```
+@saga-ed:registry=https://saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/
+```
+
+When linking is **on** (local development only):
+
+```jsonc
+// thrive/package.json (modified by cross-repo-link.sh)
+{
+  "pnpm": {
+    "overrides": {
+      "zod": "^3.24.0",
+      "@saga-ed/soa-api-core": "link:../soa/packages/node/api-core",
+      "@saga-ed/soa-config": "link:../soa/packages/core/config",
+      "@saga-ed/soa-db": "link:../soa/packages/node/db",
+      "@saga-ed/soa-logger": "link:../soa/packages/node/logger",
+      "@saga-ed/soa-rabbitmq": "link:../soa/packages/node/rabbitmq"
+    }
+  }
+}
+```
+
+The `link:` protocol creates symlinks in `node_modules` pointing to the soa source directories. Changes to soa package source files are immediately available in the consumer — but the soa package must be **built** (`pnpm build` in soa) for its `dist/` output to reflect source changes.
+
+## Tooling
+
+### `cross-repo-link.sh`
+
+The `soa/scripts/cross-repo-link.sh` script automates the override toggle. It lives in soa and is called from consuming repos.
+
+#### Setup
+
+Each consuming repo needs two things:
+
+**1. `soa-link.json`** — declares which packages to link:
+
+```jsonc
+// thrive/soa-link.json
+{
+  "soaPath": "../soa",
+  "packages": {
+    "@saga-ed/soa-api-core": "packages/node/api-core",
+    "@saga-ed/soa-config": "packages/core/config",
+    "@saga-ed/soa-db": "packages/node/db",
+    "@saga-ed/soa-logger": "packages/node/logger",
+    "@saga-ed/soa-rabbitmq": "packages/node/rabbitmq"
+  }
+}
+```
+
+Only list the packages your repo actually uses. Run `init` to generate a default with all 11 available packages, then trim it:
+
+```bash
+../soa/scripts/cross-repo-link.sh init
+```
+
+**2. npm scripts** — convenience wrappers in root `package.json`:
+
+```json
+{
+  "scripts": {
+    "soa:link:on": "../soa/scripts/cross-repo-link.sh on",
+    "soa:link:off": "../soa/scripts/cross-repo-link.sh off",
+    "soa:link:status": "../soa/scripts/cross-repo-link.sh status"
+  }
+}
+```
+
+#### Commands
+
+| Command | Effect |
+|---------|--------|
+| `pnpm soa:link:on` | Injects `link:` overrides into root `package.json`, runs `pnpm install` |
+| `pnpm soa:link:off` | Removes `link:` overrides, runs `pnpm install` |
+| `pnpm soa:link:status` | Reports current state and lists linked packages |
+
+### Current Package Inventories
+
+**Thrive** links 5 packages:
+
+| Package | SOA Path |
+|---------|----------|
+| `@saga-ed/soa-api-core` | `packages/node/api-core` |
+| `@saga-ed/soa-config` | `packages/core/config` |
+| `@saga-ed/soa-db` | `packages/node/db` |
+| `@saga-ed/soa-logger` | `packages/node/logger` |
+| `@saga-ed/soa-rabbitmq` | `packages/node/rabbitmq` |
+
+**Coach** links 5 packages:
+
+| Package | SOA Path |
+|---------|----------|
+| `@saga-ed/soa-api-core` | `packages/node/api-core` |
+| `@saga-ed/soa-aws-util` | `packages/node/aws-util` |
+| `@saga-ed/soa-config` | `packages/core/config` |
+| `@saga-ed/soa-db` | `packages/node/db` |
+| `@saga-ed/soa-logger` | `packages/node/logger` |
+
+## Safety Guards
+
+Accidentally committing `link:` overrides breaks CI and other developers' environments. We have three layers of protection:
+
+### 1. Claude Code Hook (thrive)
+
+A `PreToolUse` hook in `.claude/hooks/check-soa-link.sh` blocks `git push` when `link:` overrides are detected in `package.json` — either in the working tree or the committed HEAD.
+
+### 2. CI Check (coach)
+
+`scripts/ensure-no-soa-links.js` runs in the deploy workflow and fails the build if:
+- `pnpm.overrides` contains any `link:` references
+- Root `dependencies`/`devDependencies` have `@saga-ed` packages with `link:` references
+- Any `@saga-ed/soa-*` package used in the repo is not listed in `overrides` or `overridesLocal` (coverage check)
+
+### 3. The `overridesLocal` Pattern (coach)
+
+Coach uses a custom `pnpm.overridesLocal` field as a metadata registry:
+
+```jsonc
+// coach/package.json
+{
+  "pnpm": {
+    "overrides": {},                         // Empty when not linked
+    "overridesLocal": {                      // NOT a pnpm feature — metadata only
+      "@saga-ed/soa-api-core": "link:../soa/packages/node/api-core",
+      "@saga-ed/soa-aws-util": "link:../soa/packages/node/aws-util",
+      "@saga-ed/soa-config": "link:../soa/packages/core/config",
+      "@saga-ed/soa-db": "link:../soa/packages/node/db",
+      "@saga-ed/soa-logger": "link:../soa/packages/node/logger"
+    }
+  }
+}
+```
+
+pnpm ignores `overridesLocal` entirely — it's a convention the CI script reads to validate that all consumed `@saga-ed/soa-*` packages are accounted for. This catches cases where someone adds a new soa dependency to a nested `package.json` without updating the link config.
+
+## Development Workflow
+
+### Cross-Repo Feature Development
+
+```bash
+# 1. Start in soa — make your changes
+cd ~/dev/soa
+# edit packages/node/logger/src/index.ts
+pnpm build                          # Build so dist/ is current
+
+# 2. Switch to consumer — enable linking
+cd ~/dev/thrive
+pnpm soa:link:on                    # Injects overrides, runs pnpm install
+
+# 3. Develop and test
+pnpm test                           # Tests use local soa-logger
+pnpm dev                            # Dev server uses local soa-logger
+
+# 4. Iterate: edit soa source -> rebuild soa -> changes appear in thrive
+cd ~/dev/soa
+# edit more files...
+pnpm build                          # Rebuild — thrive picks up changes immediately
+
+# 5. Before committing thrive changes
+cd ~/dev/thrive
+pnpm soa:link:off                   # Remove overrides, back to registry
+pnpm soa:link:status                # Verify: should say "REGISTRY"
+git add . && git commit             # Safe to commit
+
+# 6. Publish soa changes separately
+cd ~/dev/soa
+# Follow soa's publishing workflow to push new package versions to CodeArtifact
+```
+
+### Quick Check: Am I Linked?
+
+```bash
+pnpm soa:link:status
+# Output when linked:
+#   SOA packages: LINKED (local)
+#   Source: /home/skelly/dev/thrive/../soa/packages/*
+#   Linked packages:
+#     @saga-ed/soa-logger -> packages/node/logger
+#     ...
+
+# Output when not linked:
+#   SOA packages: REGISTRY
+```
+
+## Common Pitfalls
+
+### 1. Overrides in the Wrong `package.json`
+
+**Symptom**: You added overrides but the consumer still uses the registry version.
+
+**Cause**: Overrides were placed in a nested `package.json` instead of the workspace root.
+
+**Fix**: Move overrides to the root `package.json`. Or better, use `pnpm soa:link:on`.
+
+### 2. Stale Builds
+
+**Symptom**: Changes in soa source don't appear in the consumer.
+
+**Cause**: The `link:` protocol points to the soa package directory, but the consumer imports from `dist/`. If soa hasn't been rebuilt, `dist/` is stale.
+
+**Fix**: Run `pnpm build` in soa after making changes. For faster iteration on a specific package:
+```bash
+cd ~/dev/soa
+pnpm --filter @saga-ed/soa-logger build
+```
+
+### 3. Missing Packages in `soa-link.json`
+
+**Symptom**: Most soa packages are linked but one still comes from the registry.
+
+**Cause**: The package isn't listed in `soa-link.json`.
+
+**Example**: Thrive's `jobs-api` depends on `@saga-ed/soa-api-util` but `soa-link.json` doesn't include it — so it resolves from the registry even when linking is on.
+
+**Fix**: Add the missing package to `soa-link.json` and re-run `pnpm soa:link:on`.
+
+### 4. Committed Link Overrides
+
+**Symptom**: CI fails, other developers get resolution errors.
+
+**Cause**: `link:` overrides were committed to `package.json`.
+
+**Fix**: Run `pnpm soa:link:off`, commit the cleaned `package.json`.
+
+**Prevention**: The Claude Code hook and CI check catch this. For extra safety, add a git pre-push hook.
+
+### 5. Auth Token Expired
+
+**Symptom**: `pnpm install` fails with 401/403 for `@saga-ed` packages after turning linking off.
+
+**Cause**: AWS CodeArtifact auth token has expired.
+
+**Fix**: Re-authenticate:
+```bash
+pnpm co:login
+```
+
+### 6. `NODE_ENV=production` Skips devDependencies
+
+**Symptom**: `pnpm install` after toggling linking doesn't install everything.
+
+**Fix**: 
+```bash
+NODE_ENV=development pnpm install
+```
+
+## Adding a New Consuming Repo
+
+To set up cross-repo linking for a new repo that depends on `@saga-ed/soa-*` packages:
+
+1. **Clone side-by-side** with soa:
+   ```
+   ~/dev/
+     soa/          # Must exist at ../soa relative to your repo
+     your-repo/
+   ```
+
+2. **Initialize the config**:
+   ```bash
+   cd ~/dev/your-repo
+   ../soa/scripts/cross-repo-link.sh init
+   ```
+
+3. **Trim `soa-link.json`** to only the packages your repo uses.
+
+4. **Add npm scripts** to root `package.json`:
+   ```json
+   {
+     "scripts": {
+       "soa:link:on": "../soa/scripts/cross-repo-link.sh on",
+       "soa:link:off": "../soa/scripts/cross-repo-link.sh off",
+       "soa:link:status": "../soa/scripts/cross-repo-link.sh status"
+     }
+   }
+   ```
+
+5. **Add safety guards** — at minimum, adopt the CI check from coach:
+   - Copy `coach/scripts/ensure-no-soa-links.js` to your repo
+   - Add it to your CI workflow
+   - Add `overridesLocal` to root `package.json` for coverage validation
+
+## Available SOA Packages
+
+All packages that can be linked from soa:
+
+| Package | SOA Path | Key Dependencies |
+|---------|----------|-----------------|
+| `@saga-ed/soa-logger` | `packages/node/logger` | (none) |
+| `@saga-ed/soa-config` | `packages/core/config` | (none) |
+| `@saga-ed/soa-api-util` | `packages/node/api-util` | soa-logger |
+| `@saga-ed/soa-api-core` | `packages/node/api-core` | soa-logger |
+| `@saga-ed/soa-db` | `packages/node/db` | soa-config |
+| `@saga-ed/soa-rabbitmq` | `packages/node/rabbitmq` | soa-logger |
+| `@saga-ed/soa-aws-util` | `packages/node/aws-util` | soa-api-util, soa-logger |
+| `@saga-ed/soa-test-util` | `packages/node/test-util` | soa-api-util |
+| `@saga-ed/soa-redis-core` | `packages/node/redis-core` | soa-api-util, soa-logger |
+| `@saga-ed/soa-pubsub-core` | `packages/node/pubsub-core` | (none) |
+| `@saga-ed/soa-pubsub-server` | `packages/node/pubsub-server` | soa-pubsub-core, soa-api-core, soa-logger |
+| `@saga-ed/soa-pubsub-client` | `packages/node/pubsub-client` | soa-pubsub-core, soa-pubsub-server, soa-logger |
+
+Note the dependency chains: if you link `soa-aws-util`, you should also link `soa-api-util` and `soa-logger` for a fully local resolution chain. Otherwise, `soa-aws-util` resolves locally but its own `soa-api-util` dependency resolves from the registry, creating a mixed state.
+
+---
+
+*Tooling: [`soa/scripts/cross-repo-link.sh`](../scripts/cross-repo-link.sh)*
+*See also: [`cross-repo-linking-summary.md`](./cross-repo-linking-summary.md) for the quick reference version*


### PR DESCRIPTION
## Summary
- Adds `.claude/skills/qa-cross-validation/SKILL.md` (220 lines) — agent skill for QA cross-validation across the saga-ed multi-repo workspace
- Adds `.claude/skills/qa-cross-validation/templates/cross-validation-summary.md` (79 lines) — template for cross-validation output
- Adds `docs/cross-repo-development-guide.md` (380 lines) — developer guide for working across `soa` / `rostering` / `program-hub` / `student-data-system` / `saga-dash`

Originally committed locally as `419d84c` on 2026-04-23 during the sds_80 initiative; cherry-picked off the post-merge cleanup so it can land via the normal PR flow.

## Test plan
- [ ] Skim `cross-repo-development-guide.md` for accuracy against current paths/branches (post-sds_80 merge state)
- [ ] Confirm skill template renders / loads as expected