### PR TITLE
feat(db): TLS + SCRAM + replica set support in MongoProvider + AWS loader

### DIFF
--- a/packages/node/db/CLAUDE.md
+++ b/packages/node/db/CLAUDE.md
@@ -5,7 +5,8 @@ MongoDB connection management and database utilities.
 ## Responsibilities
 
 - MongoDB client lifecycle management (connect/disconnect)
-- Connection string building with authentication
+- Connection string building (single-host or replica-set, with optional TLS + SCRAM)
+- AWS-aware config loader for staging / prod / dev-mirror (reads SSM + Secrets Manager)
 - Inversify DI integration for database clients
 - Mock MongoDB provider for testing (mongodb-memory-server)
 - Zod-validated database configuration
@@ -20,7 +21,8 @@ See [/packages/node/CLAUDE.md](../CLAUDE.md) for Node.js package patterns.
 - **Database**: MongoDB (native driver)
 - **DI**: Inversify
 - **Validation**: Zod
-- **Testing**: mongodb-memory-server
+- **AWS**: `@aws-sdk/client-ssm`, `@aws-sdk/client-secrets-manager`
+- **Testing**: mongodb-memory-server, aws-sdk-client-mock
 - **Build**: tsup → ESM
 
 ## Structure
@@ -30,9 +32,10 @@ src/
 ├── index.ts                      # Main exports
 ├── mongo-provider.ts             # MongoDB connection manager
 ├── mongo-provider-config.ts      # Zod config schema
-├── i-mongo-conn-mgr.ts          # Connection manager interface
+├── aws-mongo-loader.ts           # SSM + Secrets Manager → MongoProviderConfig
+├── i-mongo-conn-mgr.ts           # Connection manager interface
 ├── mocks/
-│   └── mock-mongo-provider.ts   # In-memory MongoDB for tests
+│   └── mock-mongo-provider.ts    # In-memory MongoDB for tests
 ├── redis.ts                      # Placeholder for Redis
 └── sql.ts                        # Placeholder for MySQL
 ```
@@ -40,70 +43,113 @@ src/
 ## Key Exports
 
 ```typescript
-// MongoDB provider
-import { MongoProvider, MongoProviderSchema } from '@saga-ed/soa-db';
-import type { MongoProviderConfig, IMongoConnMgr } from '@saga-ed/soa-db';
-
-// DI symbols
+import { MongoProvider, MongoProviderSchema, loadMongoConfigFromAws } from '@saga-ed/soa-db';
+import type { MongoProviderConfig, IMongoConnMgr, LoadMongoConfigParams } from '@saga-ed/soa-db';
 import { MONGO_CLIENT, MONGO_CLIENT_FACTORY } from '@saga-ed/soa-db';
-
-// Testing mocks
 import { MockMongoProvider } from '@saga-ed/soa-db/mocks/mock-mongo-provider';
 ```
 
-## Usage Pattern
+## Usage
+
+### Dev — local docker mongo (no TLS, no auth)
+
+For services running against a per-service mongo on `db-host` (port-isolated Docker container; see `cloudformation_templates/dbs/db_host/` in iac), construct config directly:
 
 ```typescript
-// In inversify.config.ts
-import { MongoProvider, MONGO_CLIENT } from '@saga-ed/soa-db';
-
-const mongoConfig = {
-  host: 'localhost',
-  port: 27017,
-  database: 'mydb',
+const mongoConfig: MongoProviderConfig = {
+  configType: 'MONGO',
   instanceName: 'main',
-  options: {}
+  hosts: ['ip-10-0-1-1.us-west-2.compute.internal:27018'],
+  database: 'coach_db',
 };
 
 const provider = new MongoProvider(mongoConfig);
 await provider.connect();
-
 container.bind(MONGO_CLIENT).toConstantValue(provider.getClient());
-
-// In services
-const client = container.get<MongoClient>(MONGO_CLIENT);
-const db = client.db('mydb');
-const collection = db.collection('users');
 ```
 
-## Key Features
+Username/password aren't required when the local container runs without `--auth`. The dev `dev-auth-mongo` testbed (see `cloudformation_templates/dbs/db_host/dev-auth-mongo/`) DOES require auth — use the loader-style shape below with static credentials read from Secrets Manager.
 
-**Connection Management:**
-- Automatic connection string building with authentication
-- Connection state tracking (isConnected)
-- Graceful connect/disconnect
-- MongoClient instance caching
+### Staging / prod — shared replica set (TLS + SCRAM)
 
-**DI Integration:**
-- Inversify-compatible provider pattern
-- Symbol-based bindings for type safety
-- Factory pattern for multi-instance support
+Use `loadMongoConfigFromAws()` to assemble config from the iac-published primitives. The loader connects as the per-service SCRAM user `{project}_app` against `{project}_db`.
 
-**Testing Support:**
-- MockMongoProvider uses mongodb-memory-server
-- Isolated in-memory MongoDB for parallel tests
-- No external MongoDB dependency in test environment
+```typescript
+const config = await loadMongoConfigFromAws({
+  scope: 'shared',
+  env: 'staging',
+  project: 'ledger-api',
+  instanceName: 'main',
+});
+
+const provider = new MongoProvider(config);
+await provider.connect();
+container.bind(MONGO_CLIENT).toConstantValue(provider.getClient());
+```
+
+This:
+- Reads `/shared/infra/staging/mongodb-{hosts,replica-set-name,ca-secret-arn}` from SSM
+- Reads the CA cert from Secrets Manager via the published ARN
+- Reads `staging/mongodb-shared/ledger-api-password` from Secrets Manager
+- Returns a `MongoProviderConfig` with `tls: true`, `replicaSet: 'saga-rs'`, `authSource: 'ledger_api_db'`, multi-host
+- The `MongoProvider` writes the CA cert content to a tmp file and references it via `tlsCAFile` in the URI
+
+### Dev mirror — prod data, dev account
+
+The prod-mirror in dev (`saga-mongodb-mirror-current`) restores from a recent prod snapshot. Per-service users on the mirror inherit prod's hashed passwords (which we don't have plaintext for), so the loader connects as the rotated master admin instead.
+
+```typescript
+const config = await loadMongoConfigFromAws({
+  scope: 'mirror-current',
+  project: 'ledger-api',          // used for default DB; admin can read any DB
+  instanceName: 'mirror',
+});
+```
+
+This connects as `saga_admin` against `admin` (authSource), with `database: 'ledger_api_db'` set as the default DB. Useful for one-off prod-shape investigations against the most recent mirror.
+
+## Saga conventions (referenced by the loader)
+
+| Concept | Convention |
+|---|---|
+| Project name → Mongo DB | `{project_with_underscores}_db` (e.g., `ledger-api` → `ledger_api_db`) |
+| Project name → SCRAM user | `{project_with_underscores}_app` (e.g., `ledger_api_app`) |
+| Per-project secret name (shared) | `{env}/mongodb-shared/{project}-password` (kept with hyphens) |
+| Secret value shape | `{"username": "...", "password": "..."}` |
+| Replica-set name | `saga-rs` (all envs) |
+| TLS posture | `requireTLS` + `allowConnectionsWithoutCertificates` (SCRAM, no client cert) |
+| Region | `us-west-2` (only) |
+
+## SSM primitives consumed
+
+| Scope | Path |
+|---|---|
+| `shared` | `/shared/infra/{env}/mongodb-hosts` |
+| `shared` | `/shared/infra/{env}/mongodb-replica-set-name` |
+| `shared` | `/shared/infra/{env}/mongodb-ca-secret-arn` |
+| `mirror-current` | `/mirror/current/mongodb-shared/endpoint` |
+| `mirror-current` | `/mirror/current/mongodb-shared/port` |
+| `mirror-current` | `/mirror/current/mongodb-shared/replica-set-name` |
+| `mirror-current` | `/mirror/current/mongodb-shared/ca-secret-arn` |
+| `mirror-current` | `/mirror/current/mongodb-shared/master-secret-arn` |
+
+## Testing
+
+- `pnpm test` runs unit tests against the connection-string builder and a mocked AWS loader (using `aws-sdk-client-mock`), plus the in-memory `MockMongoProvider` integration test.
+- For local end-to-end against the auth-enabled `dev-auth-mongo` testbed on db-host, fetch the CA from Secrets Manager (`/dev/db-host/dev-auth-mongo/ca`) and write a small `pnpm tsx` script that constructs `MongoProvider` with explicit config.
 
 ## Convention Deviations
 
-None - follows all SOA patterns.
+None — follows all SOA patterns.
 
 ## See Also
 
-- `/packages/node/api-core/` - API server utilities
-- `/apps/node/CLAUDE.md` - Backend app patterns
-- `/apps/node/claude/testing.md` - Database testing patterns
+- `/packages/node/api-core/` — API server utilities
+- `/apps/node/CLAUDE.md` — Backend app patterns
+- `/apps/node/claude/testing.md` — Database testing patterns
+- `cloudformation_templates/dbs/mongodb_shared/` (iac) — Replica-set + TLS + SCRAM primitives this loader consumes
+- `cloudformation_templates/dbs/db_host/dev-auth-mongo/` (iac) — Local TLS+SCRAM testbed for client work
 
 ---
 
-*Last updated: 2026-02*
+*Last updated: 2026-04-30*

--- a/packages/node/db/CLAUDE.md
+++ b/packages/node/db/CLAUDE.md
@@ -150,28 +150,30 @@ The end-to-end paths the unit tests can't reach — TLS handshake, SCRAM auth, C
 
 #### Setup
 
-The targets are private-VPC EC2; reach them with three SSM port-forwards, one per shell or backgrounded:
+The targets are private-VPC EC2 with no stable instance IDs (db-host can be replaced; staging mongo runs under an ASG). Always resolve the current instance at runtime:
 
 ```bash
-# dev-shared-mongo
-aws --profile saga-admin-dev ssm start-session \
-  --target i-0090c49ed82e9b90c \
-  --document-name AWS-StartPortForwardingSession \
-  --parameters '{"portNumber":["27017"],"localPortNumber":["27117"]}' &
+# Resolve current targets
+DB_HOST=$(aws --profile saga-admin-dev ssm get-parameter \
+  --name /dev/db-host/instance-id --query Parameter.Value --output text)
+STG_MONGO=$(aws --profile saga-admin-dev ec2 describe-instances \
+  --filters Name=tag:aws:autoscaling:groupName,Values=saga-mongodb-staging \
+            Name=instance-state-name,Values=running \
+  --query 'Reservations[0].Instances[0].InstanceId' --output text)
 
-# dev-auth-mongo (testbed — see iac cloudformation_templates/dbs/db_host/dev-auth-mongo/)
-aws --profile saga-admin-dev ssm start-session \
-  --target i-0090c49ed82e9b90c \
+# Open three SSM port-forwards (one per shell, or backgrounded)
+aws --profile saga-admin-dev ssm start-session --target "$DB_HOST" \
   --document-name AWS-StartPortForwardingSession \
-  --parameters '{"portNumber":["27020"],"localPortNumber":["27120"]}' &
-
-# staging mongo (find the current ASG instance via aws ec2 describe-instances
-# --filters Name=tag:aws:autoscaling:groupName,Values=saga-mongodb-staging)
-aws --profile saga-admin-dev ssm start-session \
-  --target <staging-mongo-instance-id> \
+  --parameters '{"portNumber":["27017"],"localPortNumber":["27117"]}' &  # dev-shared-mongo
+aws --profile saga-admin-dev ssm start-session --target "$DB_HOST" \
   --document-name AWS-StartPortForwardingSession \
-  --parameters '{"portNumber":["27017"],"localPortNumber":["27317"]}' &
+  --parameters '{"portNumber":["27020"],"localPortNumber":["27120"]}' &  # dev-auth-mongo (testbed)
+aws --profile saga-admin-dev ssm start-session --target "$STG_MONGO" \
+  --document-name AWS-StartPortForwardingSession \
+  --parameters '{"portNumber":["27017"],"localPortNumber":["27317"]}' &  # staging shared mongo
 ```
+
+The `dev-auth-mongo` testbed lives on db-host alongside `dev-shared-mongo`; both share the same `/dev/db-host/instance-id` lookup. The dev-auth-mongo setup itself is in iac at `cloudformation_templates/dbs/db_host/dev-auth-mongo/`.
 
 Then run the smoke:
 

--- a/packages/node/db/CLAUDE.md
+++ b/packages/node/db/CLAUDE.md
@@ -136,7 +136,58 @@ This connects as `saga_admin` against `admin` (authSource), with `database: 'led
 ## Testing
 
 - `pnpm test` runs unit tests against the connection-string builder and a mocked AWS loader (using `aws-sdk-client-mock`), plus the in-memory `MockMongoProvider` integration test.
-- For local end-to-end against the auth-enabled `dev-auth-mongo` testbed on db-host, fetch the CA from Secrets Manager (`/dev/db-host/dev-auth-mongo/ca`) and write a small `pnpm tsx` script that constructs `MongoProvider` with explicit config.
+- `scripts/smoke-validate.mjs` is the canonical end-to-end smoke runner — exercises the real `MongoProvider` against three real systems via SSM port-forwards. See below.
+
+### Validation via SSM tunnels
+
+The end-to-end paths the unit tests can't reach — TLS handshake, SCRAM auth, CA-from-Secrets resolution — are exercised by `scripts/smoke-validate.mjs` against three representative targets:
+
+| Target | Tests | Auth |
+|---|---|---|
+| `dev-shared-mongo` on db-host:27017 | no-TLS / no-auth path (legacy dev pattern) | none |
+| `dev-auth-mongo` on db-host:27020 | TLS + SCRAM + per-service-user path | `ledger_api_app` (creds in `/dev/db-host/dev-auth-mongo/ledger-api-password`) |
+| Staging shared mongo | TLS + SCRAM against the real shared cluster | master admin (`/shared/infra/staging/mongodb-master-secret-arn`) |
+
+#### Setup
+
+The targets are private-VPC EC2; reach them with three SSM port-forwards, one per shell or backgrounded:
+
+```bash
+# dev-shared-mongo
+aws --profile saga-admin-dev ssm start-session \
+  --target i-0090c49ed82e9b90c \
+  --document-name AWS-StartPortForwardingSession \
+  --parameters '{"portNumber":["27017"],"localPortNumber":["27117"]}' &
+
+# dev-auth-mongo (testbed — see iac cloudformation_templates/dbs/db_host/dev-auth-mongo/)
+aws --profile saga-admin-dev ssm start-session \
+  --target i-0090c49ed82e9b90c \
+  --document-name AWS-StartPortForwardingSession \
+  --parameters '{"portNumber":["27020"],"localPortNumber":["27120"]}' &
+
+# staging mongo (find the current ASG instance via aws ec2 describe-instances
+# --filters Name=tag:aws:autoscaling:groupName,Values=saga-mongodb-staging)
+aws --profile saga-admin-dev ssm start-session \
+  --target <staging-mongo-instance-id> \
+  --document-name AWS-StartPortForwardingSession \
+  --parameters '{"portNumber":["27017"],"localPortNumber":["27317"]}' &
+```
+
+Then run the smoke:
+
+```bash
+AWS_PROFILE=saga-admin-dev node packages/node/db/scripts/smoke-validate.mjs
+```
+
+The script inserts → finds → deletes one doc per target, leaves no residue.
+
+#### Why `directConnection: true`
+
+The smoke passes `options: { directConnection: true }` and drops `replicaSet` for tunnel purposes. RS members advertise their internal VPC addresses (`10.3.137.46:27017`, `127.0.0.1:27017`, etc.) to the driver during topology discovery — those aren't reachable through an SSM tunnel from a workstation. `directConnection` skips topology discovery and pins the client to the seed (the tunneled `localhost:port`). Production callers in-VPC keep `replicaSet` and full RS topology — this is purely a tunneling accommodation.
+
+#### Cert SAN
+
+Both `dev-auth-mongo` and the staging shared cert include `localhost` in `subjectAltName`, so TLS hostname validation succeeds when connecting through `localhost:<port>` tunnels. Mirror and prod inherit the same SAN convention.
 
 ## Convention Deviations
 
@@ -152,4 +203,4 @@ None — follows all SOA patterns.
 
 ---
 
-*Last updated: 2026-04-30*
+*Last updated: 2026-05-01*

--- a/packages/node/db/package.json
+++ b/packages/node/db/package.json
@@ -10,11 +10,15 @@
   "devDependencies": {
     "@saga-ed/soa-typescript-config": "workspace:*",
     "@types/node": "^24.0.3",
+    "aws-sdk-client-mock": "^4.1.0",
     "tsup": "^8.5.0",
     "typescript": "^5.8.3",
+    "vitest": "^1.5.0",
     "@saga-ed/soa-config": "workspace:*"
   },
   "dependencies": {
+    "@aws-sdk/client-secrets-manager": "^3.968.0",
+    "@aws-sdk/client-ssm": "^3.968.0",
     "inversify": "^6.2.2",
     "mongodb": "^6.12.0",
     "mongodb-memory-server": "^10.1.4",

--- a/packages/node/db/scripts/smoke-validate.mjs
+++ b/packages/node/db/scripts/smoke-validate.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+// Validate @saga-ed/soa-db MongoProvider against three real systems via
+// SSM port-forwards (set up by the operator before running this script):
+//
+//   localhost:27117 → db-host:27017  (dev-shared-mongo, no TLS, no auth, replSet=wootmath)
+//   localhost:27120 → db-host:27020  (dev-auth-mongo,  TLS + SCRAM,    replSet=devauth)
+//   localhost:27317 → staging-mongo:27017 (TLS + SCRAM, replSet=saga-rs)
+//
+// Both staging and dev-auth-mongo cert SANs include `localhost` so TLS
+// hostname validation succeeds when connecting through localhost
+// tunnels.
+
+import { MongoProvider } from '../dist/index.js';
+import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
+import { SecretsManagerClient, GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
+
+const ssm = new SSMClient({ region: 'us-west-2' });
+const sm = new SecretsManagerClient({ region: 'us-west-2' });
+
+async function readSecret(arnOrName) {
+  const out = await sm.send(new GetSecretValueCommand({ SecretId: arnOrName }));
+  return JSON.parse(out.SecretString);
+}
+
+async function readSsm(name) {
+  const out = await ssm.send(new GetParameterCommand({ Name: name }));
+  return out.Parameter.Value;
+}
+
+async function smoke(label, config) {
+  const banner = `\n========== ${label} ==========`;
+  console.log(banner);
+  console.log('hosts:', config.hosts, 'tls:', !!config.tls, 'rs:', config.replicaSet ?? '(none, dropped for tunnel)', 'authSource:', config.authSource ?? '(none)');
+  // directConnection bypasses RS topology discovery — required when reaching
+  // the seed via an SSM tunnel, since the RS members advertise their internal
+  // VPC addresses which aren't reachable through the tunnel. directConnection
+  // conflicts with the URI's replicaSet param, so drop replicaSet here for
+  // smoke purposes — production callers keep it.
+  const { replicaSet: _drop, ...rest } = config;
+  const provider = new MongoProvider({
+    ...rest,
+    options: { ...(rest.options ?? {}), directConnection: true },
+  });
+  await provider.connect();
+  const client = provider.getClient();
+  const db = client.db(config.database);
+  const coll = db.collection('soa_smoke');
+  const doc = { run: label, ts: new Date(), nonce: Math.random().toString(36).slice(2) };
+  const ins = await coll.insertOne(doc);
+  const found = await coll.findOne({ _id: ins.insertedId });
+  if (!found || found.nonce !== doc.nonce) throw new Error(`round-trip mismatch in ${label}`);
+  await coll.deleteOne({ _id: ins.insertedId });
+  console.log('OK — insert+find+delete round-trip succeeded');
+  await provider.disconnect();
+}
+
+async function main() {
+  // Test 1: dev-shared-mongo (no TLS, no auth)
+  await smoke('dev-shared-mongo (no TLS, no auth)', {
+    configType: 'MONGO',
+    instanceName: 'dev-shared',
+    hosts: ['localhost:27117'],
+    database: 'soa_db_smoke',
+    replicaSet: 'wootmath',
+  });
+
+  // Test 2: dev-auth-mongo (TLS + SCRAM)
+  const devAuthCaArn = await readSsm('/dev/db-host/dev-auth-mongo/ca-secret-arn');
+  const devAuthCa = (await readSecret(devAuthCaArn)).ca_cert;
+  const devAuthLedger = await readSecret('/dev/db-host/dev-auth-mongo/ledger-api-password');
+  await smoke('dev-auth-mongo (TLS + SCRAM, ledger_api_app)', {
+    configType: 'MONGO',
+    instanceName: 'dev-auth',
+    hosts: ['localhost:27120'],
+    database: 'ledger_api_db',
+    username: devAuthLedger.username,
+    password: devAuthLedger.password,
+    replicaSet: 'devauth',
+    authSource: 'ledger_api_db',
+    tls: true,
+    tlsCAContent: devAuthCa,
+  });
+
+  // Test 3: staging mongo (TLS + SCRAM, master admin since per-service users not yet provisioned)
+  const stagingCaArn = await readSsm('/shared/infra/staging/mongodb-ca-secret-arn');
+  const stagingMasterArn = await readSsm('/shared/infra/staging/mongodb-master-secret-arn');
+  const stagingRsName = await readSsm('/shared/infra/staging/mongodb-replica-set-name');
+  const stagingCa = (await readSecret(stagingCaArn)).ca_cert;
+  const stagingMaster = await readSecret(stagingMasterArn);
+  await smoke('staging mongo (TLS + SCRAM, master admin)', {
+    configType: 'MONGO',
+    instanceName: 'staging',
+    hosts: ['localhost:27317'],
+    database: 'soa_db_smoke',
+    username: stagingMaster.username,
+    password: stagingMaster.password,
+    replicaSet: stagingRsName,
+    authSource: 'admin',
+    tls: true,
+    tlsCAContent: stagingCa,
+  });
+
+  console.log('\nAll three round-trips OK.');
+}
+
+main().catch((e) => {
+  console.error('FAIL:', e.message);
+  if (e.cause) console.error('cause:', e.cause);
+  process.exit(1);
+});

--- a/packages/node/db/src/__tests__/aws-mongo-loader.unit.test.ts
+++ b/packages/node/db/src/__tests__/aws-mongo-loader.unit.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mockClient } from 'aws-sdk-client-mock';
+import {
+  GetParameterCommand,
+  SSMClient,
+} from '@aws-sdk/client-ssm';
+import {
+  GetSecretValueCommand,
+  SecretsManagerClient,
+} from '@aws-sdk/client-secrets-manager';
+import { loadMongoConfigFromAws } from '../aws-mongo-loader.js';
+
+const ssmMock = mockClient(SSMClient);
+const smMock = mockClient(SecretsManagerClient);
+
+beforeEach(() => {
+  ssmMock.reset();
+  smMock.reset();
+});
+
+describe('loadMongoConfigFromAws — scope=shared', () => {
+  it('assembles a per-service config from staging SSM + Secrets', async () => {
+    ssmMock
+      .on(GetParameterCommand, { Name: '/shared/infra/staging/mongodb-hosts' })
+      .resolves({ Parameter: { Value: 'h1.compute.internal:27017,h2.compute.internal:27017' } })
+      .on(GetParameterCommand, { Name: '/shared/infra/staging/mongodb-replica-set-name' })
+      .resolves({ Parameter: { Value: 'saga-rs' } })
+      .on(GetParameterCommand, { Name: '/shared/infra/staging/mongodb-ca-secret-arn' })
+      .resolves({ Parameter: { Value: 'arn:aws:secretsmanager:us-west-2:111:secret:staging/mongodb-shared/ca-X' } });
+
+    smMock
+      .on(GetSecretValueCommand, {
+        SecretId: 'arn:aws:secretsmanager:us-west-2:111:secret:staging/mongodb-shared/ca-X',
+      })
+      .resolves({ SecretString: JSON.stringify({ ca_cert: '-----BEGIN CERT-----\nfake\n-----END CERT-----\n' }) })
+      .on(GetSecretValueCommand, { SecretId: 'staging/mongodb-shared/ledger-api-password' })
+      .resolves({ SecretString: JSON.stringify({ username: 'ledger_api_app', password: 'pw' }) });
+
+    const config = await loadMongoConfigFromAws({
+      scope: 'shared',
+      env: 'staging',
+      project: 'ledger-api',
+      instanceName: 'staging-ledger',
+    });
+
+    expect(config).toMatchObject({
+      configType: 'MONGO',
+      instanceName: 'staging-ledger',
+      hosts: ['h1.compute.internal:27017', 'h2.compute.internal:27017'],
+      database: 'ledger_api_db',
+      username: 'ledger_api_app',
+      password: 'pw',
+      replicaSet: 'saga-rs',
+      authSource: 'ledger_api_db',
+      tls: true,
+    });
+    expect(config.tlsCAContent).toContain('BEGIN CERT');
+  });
+
+  it('throws if scope=shared but env is missing', async () => {
+    await expect(
+      loadMongoConfigFromAws({
+        scope: 'shared',
+        project: 'ledger-api',
+        instanceName: 'x',
+      } as any),
+    ).rejects.toThrow(/env/);
+  });
+});
+
+describe('loadMongoConfigFromAws — scope=mirror-current', () => {
+  it('assembles an admin config from mirror SSM + Secrets', async () => {
+    ssmMock
+      .on(GetParameterCommand, { Name: '/mirror/current/mongodb-shared/endpoint' })
+      .resolves({ Parameter: { Value: 'ip-10-3-1-1.us-west-2.compute.internal' } })
+      .on(GetParameterCommand, { Name: '/mirror/current/mongodb-shared/port' })
+      .resolves({ Parameter: { Value: '27017' } })
+      .on(GetParameterCommand, { Name: '/mirror/current/mongodb-shared/replica-set-name' })
+      .resolves({ Parameter: { Value: 'saga-rs' } })
+      .on(GetParameterCommand, { Name: '/mirror/current/mongodb-shared/ca-secret-arn' })
+      .resolves({ Parameter: { Value: 'arn:aws:secretsmanager:us-west-2:222:secret:staging/mongodb-shared/ca-Y' } })
+      .on(GetParameterCommand, { Name: '/mirror/current/mongodb-shared/master-secret-arn' })
+      .resolves({ Parameter: { Value: 'arn:aws:secretsmanager:us-west-2:222:secret:/mirror/current/mongodb-shared/master-Z' } });
+
+    smMock
+      .on(GetSecretValueCommand, {
+        SecretId: 'arn:aws:secretsmanager:us-west-2:222:secret:staging/mongodb-shared/ca-Y',
+      })
+      .resolves({ SecretString: JSON.stringify({ ca_cert: 'CA-PEM' }) })
+      .on(GetSecretValueCommand, {
+        SecretId: 'arn:aws:secretsmanager:us-west-2:222:secret:/mirror/current/mongodb-shared/master-Z',
+      })
+      .resolves({ SecretString: JSON.stringify({ username: 'saga_admin', password: 'master-pw' }) });
+
+    const config = await loadMongoConfigFromAws({
+      scope: 'mirror-current',
+      project: 'ledger-api',
+      instanceName: 'mirror-ledger',
+    });
+
+    expect(config).toMatchObject({
+      configType: 'MONGO',
+      instanceName: 'mirror-ledger',
+      hosts: ['ip-10-3-1-1.us-west-2.compute.internal:27017'],
+      database: 'ledger_api_db',
+      username: 'saga_admin',
+      password: 'master-pw',
+      replicaSet: 'saga-rs',
+      authSource: 'admin',
+      tls: true,
+      tlsCAContent: 'CA-PEM',
+    });
+  });
+});

--- a/packages/node/db/src/__tests__/connection-string.unit.test.ts
+++ b/packages/node/db/src/__tests__/connection-string.unit.test.ts
@@ -1,0 +1,121 @@
+import 'reflect-metadata';
+import { describe, it, expect } from 'vitest';
+import { MongoProvider } from '../mongo-provider.js';
+import type { MongoProviderConfig } from '../mongo-provider-config.js';
+
+const baseConfig = {
+  configType: 'MONGO' as const,
+  instanceName: 'test',
+  hosts: ['db-host.example:27017'],
+  database: 'app_db',
+};
+
+function uri(config: MongoProviderConfig): string {
+  // The builder is instance-private but the inner method is intentionally
+  // _public-prefixed for test access. Use the inner method directly so we
+  // exercise URI assembly without instantiating MongoClient (which would try
+  // to resolve DNS).
+  const provider = new MongoProvider(config);
+  return provider._buildConnectionString();
+}
+
+describe('MongoProvider._buildConnectionString', () => {
+  it('builds a single-host no-auth no-tls URI', () => {
+    expect(uri(baseConfig)).toBe('mongodb://db-host.example:27017/app_db');
+  });
+
+  it('encodes username and password', () => {
+    expect(uri({
+      ...baseConfig,
+      username: 'user@with/special',
+      password: 'p@ss/word',
+    })).toBe(
+      'mongodb://user%40with%2Fspecial:p%40ss%2Fword@db-host.example:27017/app_db',
+    );
+  });
+
+  it('joins multiple hosts with commas (replica-set seed list)', () => {
+    expect(uri({
+      ...baseConfig,
+      hosts: ['a.compute.internal:27017', 'b.compute.internal:27017', 'c.compute.internal:27017'],
+      replicaSet: 'saga-rs',
+    })).toBe(
+      'mongodb://a.compute.internal:27017,b.compute.internal:27017,c.compute.internal:27017/app_db?replicaSet=saga-rs',
+    );
+  });
+
+  it('appends authSource when set', () => {
+    expect(uri({
+      ...baseConfig,
+      username: 'ledger_api_app',
+      password: 'pw',
+      authSource: 'ledger_api_db',
+    })).toBe(
+      'mongodb://ledger_api_app:pw@db-host.example:27017/app_db?authSource=ledger_api_db',
+    );
+  });
+
+  it('appends tls=true and retryWrites=true when tls is enabled', () => {
+    const u = uri({ ...baseConfig, tls: true });
+    expect(u).toContain('tls=true');
+    expect(u).toContain('retryWrites=true');
+  });
+
+  it('adds tlsCAFile to the URI when caller supplies a path', () => {
+    const u = uri({
+      ...baseConfig,
+      tls: true,
+      tlsCAFile: '/etc/ssl/saga-ca.pem',
+    });
+    expect(u).toContain('tlsCAFile=%2Fetc%2Fssl%2Fsaga-ca.pem');
+  });
+
+  it('does NOT add tls params when tls is false', () => {
+    const u = uri({ ...baseConfig, tls: false });
+    expect(u).not.toContain('tls=');
+  });
+
+  it('combines RS + TLS + SCRAM into one URI (canonical staging shape)', () => {
+    const u = uri({
+      configType: 'MONGO',
+      instanceName: 'staging',
+      hosts: ['ip-10-1-1-10.us-west-2.compute.internal:27017'],
+      database: 'ledger_api_db',
+      username: 'ledger_api_app',
+      password: 'sekret',
+      replicaSet: 'saga-rs',
+      authSource: 'ledger_api_db',
+      tls: true,
+      tlsCAFile: '/tmp/ca.pem',
+    });
+    expect(u).toBe(
+      'mongodb://ledger_api_app:sekret@ip-10-1-1-10.us-west-2.compute.internal:27017/ledger_api_db' +
+        '?replicaSet=saga-rs&authSource=ledger_api_db&tls=true&retryWrites=true&tlsCAFile=%2Ftmp%2Fca.pem',
+    );
+  });
+
+  it('rejects setting both tlsCAFile and tlsCAContent', () => {
+    expect(() => new MongoProvider({
+      ...baseConfig,
+      tls: true,
+      tlsCAFile: '/p',
+      tlsCAContent: 'PEM',
+    })).toThrow(/pick one/);
+  });
+
+  it('writes tlsCAContent to a tmp file and references it via tlsCAFile', () => {
+    const provider = new MongoProvider({
+      ...baseConfig,
+      instanceName: 'cert-from-content-test',
+      tls: true,
+      tlsCAContent: '-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----\n',
+    });
+    const u = provider._buildConnectionString();
+    // The tlsCAFile parameter is URL-encoded, so we URL-decode the URI's
+    // query before checking the path shape.
+    const queryString = u.split('?')[1] ?? '';
+    const params = new URLSearchParams(queryString);
+    const caFile = params.get('tlsCAFile');
+    expect(caFile).toMatch(/saga-mongodb-ca-cert-from-content-test\.pem$/);
+  });
+});

--- a/packages/node/db/src/__tests__/mongo-provider.int.test.ts
+++ b/packages/node/db/src/__tests__/mongo-provider.int.test.ts
@@ -20,8 +20,7 @@ describe('MockMongoProvider (Inversify Factory with MockConfigManager)', () => {
     mockConfig = {
       configType: 'MONGO',
       instanceName: MOCK_INSTANCE_NAME,
-      host: 'localhost',
-      port: 27017,
+      hosts: ['localhost:27017'],
       database: 'testdb',
       username: 'user',
       password: 'pass',

--- a/packages/node/db/src/aws-mongo-loader.ts
+++ b/packages/node/db/src/aws-mongo-loader.ts
@@ -1,0 +1,152 @@
+import {
+  GetParameterCommand,
+  SSMClient,
+} from '@aws-sdk/client-ssm';
+import {
+  GetSecretValueCommand,
+  SecretsManagerClient,
+} from '@aws-sdk/client-secrets-manager';
+import type { MongoProviderConfig } from './mongo-provider-config.js';
+
+/**
+ * Build a fully-resolved {@link MongoProviderConfig} by reading the SSM +
+ * Secrets Manager primitives published by Saga's iac
+ * (`cloudformation_templates/dbs/mongodb_shared/`).
+ *
+ * Two scopes:
+ *
+ * - `'shared'` (default): staging or prod. Reads from
+ *   `/shared/infra/{env}/mongodb-*` and Secrets Manager
+ *   `{env}/mongodb-shared/{project}-password`, returns a config that
+ *   authenticates as the per-service SCRAM user `{project}_app` against
+ *   database `{project}_db`.
+ *
+ * - `'mirror-current'`: the prod-mirror in the dev account
+ *   (`saga-mongodb-mirror-current`). Reads from
+ *   `/mirror/current/mongodb-shared/*`, returns a config that
+ *   authenticates as the master admin (per-service users on the mirror
+ *   inherit prod's hashed passwords, which we don't have plaintext for).
+ *   Caller-supplied `project` is used only to default the target database
+ *   name; admin can read any DB.
+ *
+ * Dev (`db-host` per-service docker mongo) is intentionally NOT supported
+ * by this loader — the per-service port mapping is not in SSM today. Dev
+ * callers should construct {@link MongoProviderConfig} directly from
+ * env vars or static wiring.
+ */
+export interface LoadMongoConfigParams {
+  /** Mirror-current is the dev-account mirror; shared is staging/prod. */
+  scope?: 'shared' | 'mirror-current';
+  /** Required when scope is 'shared'. Ignored for 'mirror-current'. */
+  env?: 'staging' | 'prod';
+  /** Project name (e.g. 'ledger-api'). Hyphens become underscores in db/user names. */
+  project: string;
+  /** Name to give the MongoProvider instance. */
+  instanceName: string;
+  /** Override AWS region. Defaults to us-west-2 (Saga's only region). */
+  region?: string;
+}
+
+const DEFAULT_REGION = 'us-west-2';
+
+export async function loadMongoConfigFromAws(
+  params: LoadMongoConfigParams,
+): Promise<MongoProviderConfig> {
+  const { project, instanceName } = params;
+  const scope = params.scope ?? 'shared';
+  const region = params.region ?? DEFAULT_REGION;
+
+  const ssm = new SSMClient({ region });
+  const sm = new SecretsManagerClient({ region });
+
+  const dbName = `${project.replace(/-/g, '_')}_db`;
+
+  if (scope === 'shared') {
+    const env = params.env;
+    if (env !== 'staging' && env !== 'prod') {
+      throw new Error(`scope='shared' requires env='staging'|'prod', got: ${String(env)}`);
+    }
+
+    const [hostsCsv, replicaSetName, caSecretArn] = await Promise.all([
+      readSsm(ssm, `/shared/infra/${env}/mongodb-hosts`),
+      readSsm(ssm, `/shared/infra/${env}/mongodb-replica-set-name`),
+      readSsm(ssm, `/shared/infra/${env}/mongodb-ca-secret-arn`),
+    ]);
+
+    const [caBundle, projectCreds] = await Promise.all([
+      readSecretJson<{ ca_cert: string }>(sm, caSecretArn),
+      readSecretJson<{ username: string; password: string }>(
+        sm,
+        `${env}/mongodb-shared/${project}-password`,
+      ),
+    ]);
+
+    return {
+      configType: 'MONGO',
+      instanceName,
+      hosts: splitHosts(hostsCsv),
+      database: dbName,
+      username: projectCreds.username,
+      password: projectCreds.password,
+      replicaSet: replicaSetName,
+      authSource: dbName,
+      tls: true,
+      tlsCAContent: caBundle.ca_cert,
+    };
+  }
+
+  // scope === 'mirror-current'
+  const [endpoint, port, replicaSetName, caSecretArn, masterSecretArn] =
+    await Promise.all([
+      readSsm(ssm, '/mirror/current/mongodb-shared/endpoint'),
+      readSsm(ssm, '/mirror/current/mongodb-shared/port'),
+      readSsm(ssm, '/mirror/current/mongodb-shared/replica-set-name'),
+      readSsm(ssm, '/mirror/current/mongodb-shared/ca-secret-arn'),
+      readSsm(ssm, '/mirror/current/mongodb-shared/master-secret-arn'),
+    ]);
+
+  const [caBundle, masterCreds] = await Promise.all([
+    readSecretJson<{ ca_cert: string }>(sm, caSecretArn),
+    readSecretJson<{ username: string; password: string }>(sm, masterSecretArn),
+  ]);
+
+  return {
+    configType: 'MONGO',
+    instanceName,
+    hosts: [`${endpoint}:${port}`],
+    database: dbName,
+    username: masterCreds.username,
+    password: masterCreds.password,
+    replicaSet: replicaSetName,
+    // Master user lives in admin DB (created via localhost exception during
+    // RS bootstrap), not in the per-project DB.
+    authSource: 'admin',
+    tls: true,
+    tlsCAContent: caBundle.ca_cert,
+  };
+}
+
+async function readSsm(client: SSMClient, name: string): Promise<string> {
+  const out = await client.send(new GetParameterCommand({ Name: name }));
+  const value = out.Parameter?.Value;
+  if (!value) throw new Error(`SSM parameter ${name} has no value`);
+  return value;
+}
+
+async function readSecretJson<T>(
+  client: SecretsManagerClient,
+  secretId: string,
+): Promise<T> {
+  const out = await client.send(new GetSecretValueCommand({ SecretId: secretId }));
+  if (!out.SecretString) {
+    throw new Error(`Secret ${secretId} has no SecretString`);
+  }
+  return JSON.parse(out.SecretString) as T;
+}
+
+function splitHosts(csv: string): string[] {
+  return csv
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}

--- a/packages/node/db/src/index.ts
+++ b/packages/node/db/src/index.ts
@@ -6,5 +6,7 @@ export type { MongoProviderConfig } from './mongo-provider-config.js';
 export type { IMongoConnMgr } from './i-mongo-conn-mgr.js';
 export const MONGO_CLIENT = Symbol.for('MongoClient');
 export { MockMongoProvider } from './mocks/mock-mongo-provider.js';
+export { loadMongoConfigFromAws } from './aws-mongo-loader.js';
+export type { LoadMongoConfigParams } from './aws-mongo-loader.js';
 export type MongoClientFactory = () => Promise<MongoClient>;
 export const MONGO_CLIENT_FACTORY = Symbol.for('MongoClientFactory');

--- a/packages/node/db/src/mongo-provider-config.ts
+++ b/packages/node/db/src/mongo-provider-config.ts
@@ -1,13 +1,61 @@
-import { z, ZodObject } from 'zod';
+import { z } from 'zod';
 
+/**
+ * Config schema for MongoProvider.
+ *
+ * Supports two connection topologies:
+ *
+ * 1. Single-host, no auth, no TLS — local docker-compose mongo (e.g., dev
+ *    on db-host:27018). Pass a one-element `hosts` array, leave `replicaSet`,
+ *    `tls`, and `authSource` unset.
+ *
+ * 2. Multi-host replica set with TLS + SCRAM — staging / prod / dev mirror.
+ *    `hosts` lists every replica-set member as `host:port`, `replicaSet`
+ *    identifies the RS, `tls: true` requires TLS, `authSource` is the database
+ *    where the SCRAM user was created (per Saga convention: `{project}_db`),
+ *    and the CA cert is supplied via either `tlsCAFile` (path on disk) or
+ *    `tlsCAContent` (PEM string — typically read from Secrets Manager and
+ *    written to a tmp file by the provider at construction).
+ *
+ * For staging/prod/mirror, prefer `loadMongoConfigFromAws()` from
+ * `./aws-mongo-loader.js` which assembles this config from the SSM/Secrets
+ * primitives published by `cloudformation_templates/dbs/mongodb_shared/`.
+ */
 export const MongoProviderSchema = z.object({
   configType: z.literal('MONGO'),
   instanceName: z.string().min(1),
-  host: z.string().min(1),
-  port: z.number().int().positive(),
+
+  // Replica-set members (or a single host for non-RS deployments).
+  // Each entry is `host:port`. Order doesn't matter — the driver discovers
+  // the primary via the seed list.
+  hosts: z.array(z.string().min(1)).min(1),
+
   database: z.string().min(1),
   username: z.string().optional(),
   password: z.string().optional(),
+
+  // Replica-set name. When set, the driver treats `hosts` as a seed list
+  // and discovers all members. Required for multi-host deployments.
+  replicaSet: z.string().optional(),
+
+  // Database the SCRAM user authenticates against. Defaults to `database`
+  // when unset. For Saga's per-service users, this is the project's own DB
+  // (e.g., `ledger_api_db`), since createUser ran in that DB.
+  authSource: z.string().optional(),
+
+  // TLS toggle. When true:
+  //   - The connection string adds `tls=true`.
+  //   - If `tlsCAContent` is provided, the provider writes it to a tmp file
+  //     once and adds `tlsCAFile=<path>` to the URI.
+  //   - If `tlsCAFile` is provided, that path is used directly.
+  //   - If neither is provided, the driver uses the system CA bundle.
+  tls: z.boolean().optional(),
+  tlsCAFile: z.string().optional(),
+  tlsCAContent: z.string().optional(),
+
+  // Pass-through options handed to `new MongoClient(uri, options)`. Avoid
+  // putting auth/TLS/RS settings here — prefer the typed fields above so
+  // the connection-string builder and tests stay coherent.
   options: z.record(z.string(), z.any()).optional(),
 });
 

--- a/packages/node/db/src/mongo-provider.ts
+++ b/packages/node/db/src/mongo-provider.ts
@@ -1,3 +1,6 @@
+import { writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { injectable } from 'inversify';
 import { MongoClient } from 'mongodb';
 import type { MongoProviderConfig } from './mongo-provider-config.js';
@@ -8,10 +11,15 @@ export class MongoProvider implements IMongoConnMgr {
   public readonly instanceName: string;
   private client: MongoClient | null = null;
   private config: MongoProviderConfig;
+  // Resolved CA path — either the caller-provided tlsCAFile, or a tmp path
+  // we wrote tlsCAContent to. Computed once at construction so writes don't
+  // happen on every connect() retry.
+  private readonly resolvedCAFile: string | undefined;
 
   constructor(config: MongoProviderConfig) {
     this.config = config;
     this.instanceName = config.instanceName;
+    this.resolvedCAFile = MongoProvider.resolveCAFile(config);
   }
 
   async connect(): Promise<void> {
@@ -39,13 +47,64 @@ export class MongoProvider implements IMongoConnMgr {
     return this.client;
   }
 
-  private _buildConnectionString(): string {
-    const { host, port, database, username, password } = this.config;
-    let auth = '';
-    if (username && password) {
-      auth = `${encodeURIComponent(username)}:${encodeURIComponent(password)}@`;
+  /**
+   * Build a `mongodb://` connection string from the config.
+   *
+   * Shape:
+   *   mongodb://[user:pass@]host1:port1,host2:port2,.../database?<query>
+   *
+   * Query parameters are added only when the corresponding config field is set.
+   */
+  _buildConnectionString(): string {
+    const { hosts, database, username, password, replicaSet, authSource, tls } =
+      this.config;
+
+    const auth = username && password
+      ? `${encodeURIComponent(username)}:${encodeURIComponent(password)}@`
+      : '';
+
+    const hostList = hosts.join(',');
+
+    const params = new URLSearchParams();
+    if (replicaSet) params.set('replicaSet', replicaSet);
+    if (authSource) params.set('authSource', authSource);
+    if (tls) {
+      params.set('tls', 'true');
+      params.set('retryWrites', 'true');
+      if (this.resolvedCAFile) params.set('tlsCAFile', this.resolvedCAFile);
     }
-    return `mongodb://${auth}${host}:${port}/${database}`;
+
+    const query = params.toString();
+    const querySuffix = query ? `?${query}` : '';
+
+    return `mongodb://${auth}${hostList}/${database}${querySuffix}`;
+  }
+
+  /**
+   * Resolve the CA file path. If the caller passed `tlsCAFile`, use it. If
+   * they passed `tlsCAContent` (PEM string from Secrets Manager), write it
+   * to a deterministic tmp path keyed on instanceName and return that path.
+   * If neither is set, return undefined (driver uses the system CA bundle).
+   *
+   * Throws if both `tlsCAFile` and `tlsCAContent` are set — the caller has
+   * to pick one to avoid ambiguity.
+   */
+  private static resolveCAFile(config: MongoProviderConfig): string | undefined {
+    const { tls, tlsCAFile, tlsCAContent, instanceName } = config;
+    if (!tls) return undefined;
+    if (tlsCAFile && tlsCAContent) {
+      throw new Error(
+        `MongoProviderConfig for ${instanceName} sets both tlsCAFile and tlsCAContent — pick one`,
+      );
+    }
+    if (tlsCAFile) return tlsCAFile;
+    if (tlsCAContent) {
+      const safeName = instanceName.replace(/[^a-zA-Z0-9_-]/g, '_');
+      const path = join(tmpdir(), `saga-mongodb-ca-${safeName}.pem`);
+      writeFileSync(path, tlsCAContent, { mode: 0o400 });
+      return path;
+    }
+    return undefined;
   }
 }
 

--- a/packages/node/fixture-serve/src/server/fixture-server.ts
+++ b/packages/node/fixture-serve/src/server/fixture-server.ts
@@ -154,8 +154,7 @@ export class FixtureServer {
             const provider = new MongoProvider({
                 configType: 'MONGO',
                 instanceName: 'fixture-db',
-                host: parsed_uri.hostname,
-                port: parseInt(parsed_uri.port || '27017', 10),
+                hosts: [`${parsed_uri.hostname}:${parsed_uri.port || '27017'}`],
                 database: config.db_name,
                 options: { directConnection: true, serverSelectionTimeoutMS: 30000 },
             });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -476,6 +476,9 @@ importers:
 
   infra:
     dependencies:
+      express:
+        specifier: ^4.22.1
+        version: 4.22.1
       mongodb:
         specifier: ^6.0.0
         version: 6.21.0(socks@2.8.7)
@@ -489,9 +492,6 @@ importers:
       eslint:
         specifier: ^10.1.0
         version: 10.2.0(jiti@2.6.1)
-      express:
-        specifier: ^4.22.1
-        version: 4.22.1
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -729,13 +729,13 @@ importers:
         version: 14.5.0
       '@types/node':
         specifier: latest
-        version: 25.5.2
+        version: 25.6.0
       '@types/supertest':
         specifier: ^6.0.3
         version: 6.0.3
       '@vitest/coverage-v8':
         specifier: ^1.5.0
-        version: 1.6.1(vitest@1.6.1(@types/node@25.5.2))
+        version: 1.6.1(vitest@1.6.1(@types/node@25.6.0))
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -747,7 +747,7 @@ importers:
         version: 7.16.0
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@25.5.2)
+        version: 1.6.1(@types/node@25.6.0)
 
   packages/node/api-util:
     dependencies:
@@ -763,7 +763,7 @@ importers:
         version: link:../../core/typescript-config
       '@types/node':
         specifier: latest
-        version: 25.5.2
+        version: 25.6.0
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -800,7 +800,7 @@ importers:
         version: link:../../core/typescript-config
       '@types/node':
         specifier: latest
-        version: 25.5.2
+        version: 25.6.0
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -810,6 +810,12 @@ importers:
 
   packages/node/db:
     dependencies:
+      '@aws-sdk/client-secrets-manager':
+        specifier: ^3.968.0
+        version: 3.968.0
+      '@aws-sdk/client-ssm':
+        specifier: ^3.968.0
+        version: 3.1040.0
       inversify:
         specifier: ^6.2.2
         version: 6.2.2(reflect-metadata@0.2.2)
@@ -835,12 +841,18 @@ importers:
       '@types/node':
         specifier: ^24.0.3
         version: 24.0.12
+      aws-sdk-client-mock:
+        specifier: ^4.1.0
+        version: 4.1.0
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
+      vitest:
+        specifier: ^1.5.0
+        version: 1.6.1(@types/node@24.0.12)
 
   packages/node/fixture-serve:
     dependencies:
@@ -883,7 +895,7 @@ importers:
         version: 5.0.6
       '@types/node':
         specifier: latest
-        version: 25.5.2
+        version: 25.6.0
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -892,7 +904,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@25.5.2)
+        version: 1.6.1(@types/node@25.6.0)
 
   packages/node/logger:
     dependencies:
@@ -920,7 +932,7 @@ importers:
         version: link:../../core/typescript-config
       '@types/node':
         specifier: latest
-        version: 25.5.2
+        version: 25.6.0
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -1068,7 +1080,7 @@ importers:
         version: link:../../core/typescript-config
       '@types/node':
         specifier: latest
-        version: 25.5.2
+        version: 25.6.0
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -1077,7 +1089,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@25.5.2)
+        version: 1.6.1(@types/node@25.6.0)
 
   packages/node/rabbitmq:
     dependencies:
@@ -1320,6 +1332,10 @@ packages:
     resolution: {integrity: sha512-TfMOTqwhlgFFhhNgWspOlaMpJEggw3C26MkY5ja6574zo4ybirW/UhkC793UtANxke874g1M0qZofPKtKh6aOg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-ssm@3.1040.0':
+    resolution: {integrity: sha512-Su6vrzo32lx7jL6Dk/fatQpjrGjBCQIDr7pRdlpHOGOSTfg2L+UFg/XRrZRL5blz7dCNdfhZf2uuuMK1n0hrkg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-sso@3.968.0':
     resolution: {integrity: sha512-y+k23MvMzpn1WpeQ9sdEXg1Bbw7dfi0ZH2uwyBv78F/kz0mZOI+RJ1KJg8DgSD8XvdxB8gX5GQ8rzo0LnDothA==}
     engines: {node: '>=20.0.0'}
@@ -1336,6 +1352,10 @@ packages:
     resolution: {integrity: sha512-lMPlYlYfQdNZhlkJgnkmESwrY+hNh3PljmZ+37oAqLNdJ6rnILAwFSyc6B3bJeDOtMORNnMQIej0aTRuOlDyhQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/core@3.974.7':
+    resolution: {integrity: sha512-YhRC90ofz5oolTJZlA8voU/oUrCB2azi8Usx51k8hhB5LpWbYQMMXKUqSqkoL0Cru+RQJgWTHpAfEDDIwfUhJw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/crc64-nvme@3.972.7':
     resolution: {integrity: sha512-QUagVVBbC8gODCF6e1aV0mE2TXWB9Opz4k8EJFdNrujUVQm5R4AjJa1mpOqzwOuROBzqJU9zawzig7M96L8Ejg==}
     engines: {node: '>=20.0.0'}
@@ -1348,12 +1368,20 @@ packages:
     resolution: {integrity: sha512-X/yGB73LmDW/6MdDJGCDzZBUXnM3ys4vs9l+5ZTJmiEswDdP1OjeoAFlFjVGS9o4KB2wZWQ9KOfdVNSSK6Ep3w==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-env@3.972.33':
+    resolution: {integrity: sha512-bJV7eViSJV6GSuuN+VIdNVPdwPsNSf75BiC2v5alPrjR/OCcqgKwSZInKbDFz9mNeizldsyf67jt6YSIiv53Cw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-http@3.968.0':
     resolution: {integrity: sha512-79teHBx/EtsNRR3Bq8fQdmMHtUcYwvohm9EwXXFt2Jd3BEOBH872IjIlfKdAvdkM+jW1QeeWOZBAxXGPir7GcQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-http@3.972.33':
     resolution: {integrity: sha512-c0ZF+lwoWVvX5iCaGKL5T/4DnIw88CGqxA0BcBs3U86mIp5EZYPVg+KSPkMXOyokmADvNewiMUfSG2uFwjRp0g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.35':
+    resolution: {integrity: sha512-x/BQGEIdq0oI+4WxLjKmnQvT7CnF9r8ezdGt7wXwxb7ckHXQz0Zmgxt8v3Ne0JaT3R5YefmuybHX6E8EnsDXyA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.968.0':
@@ -1364,12 +1392,20 @@ packages:
     resolution: {integrity: sha512-jsU4u/cRkKFLKQS0k918FQ27fzXLG5ENiLWQMYE6581zLeI2hWh04ptlrvZMB3wJT/5d+vSzJk74X1CMFr4y8Q==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-ini@3.972.37':
+    resolution: {integrity: sha512-eUTpmWfd/BKsq9medhCRcu+GRAhFP2Zrn7/2jKDHHOOjCkhrMoTp/t4cEthqFoG7gE0VGp5wUxrXTdvBCmSmJg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-login@3.968.0':
     resolution: {integrity: sha512-YxBaR0IMuHPOVTG+73Ve0QfllweN+EdwBRnHFhUGnahMGAcTmcaRdotqwqWfiws+9ud44IFKjxXR3t8jaGpFnQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-login@3.972.35':
     resolution: {integrity: sha512-5oa3j0cA50jPqgNhZ9XdJVopuzUf1klRb28/2MfLYWWiPi9DRVvbrBWT+DidbHTT36520VuXZJahQwR+YgSjrg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.37':
+    resolution: {integrity: sha512-Ty68y8ISSC+g5Q3D0K8uAaoINwvfaOslnNpsF/LgVUxyosYXHawcK2yV4HLXDVugiTTYLQfJfcw0ce5meAGkKw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.968.0':
@@ -1380,12 +1416,20 @@ packages:
     resolution: {integrity: sha512-4nT2T8Z7vH8KE9EdjEsuIlHpZSlcaK2PrKbQBjuUGU46BCCzF3WvP0u0Uiosni3Ykmmn4rWLVawoOCLotUtCbg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-node@3.972.38':
+    resolution: {integrity: sha512-BQ9XYnBDVxR2HuV5huXYQYF/PZMTsY+EnwfGnCU2cA8Zw63XpkOtPY8WqiMIZMQCrKPQQEiFURS/o9CIolRLqg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-process@3.968.0':
     resolution: {integrity: sha512-my9M/ijRyEACoyeEWiC2sTVM3+eck5IWPGTPQrlYMKivy4LLlZchohtIopuqTom+JZzLZD508j1s9aDvl7BA0w==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-process@3.972.31':
     resolution: {integrity: sha512-eKeT4MXumpBJsrDLCYcSzIkFPVTFn/es7It2oogp2OhU/ic7P/+xzFpQx9ZhwtXS57Mc5S42BPWi7lHmvs/nYg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.33':
+    resolution: {integrity: sha512-yfjGksI9WQbdMObb0VeLXqzTLI+a0qXLJT9gCDiv0+X/xjPpI3mTz6a5FibrhpuEKIe0gSgvs3MaoFZy5cx4WA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.968.0':
@@ -1396,12 +1440,20 @@ packages:
     resolution: {integrity: sha512-bCuBdfnj0KGDMdLp6utMTLiJcFN2ek9EgZinxQZZSc3FxjJ/HSqeqab2cjbnoNfy8RM6suDCsRkmVY1izp9I+A==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.972.37':
+    resolution: {integrity: sha512-fpwE+20ntpp3i9Xb9vUuQfXLDKYHH+5I2V+ZG96SX1nBzrruhy10RXDgmN7t1etOz3c55stlA3TeQASUA451NQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.968.0':
     resolution: {integrity: sha512-9HNAP6mx2jsBW4moWnRg5ycyZ0C1EbtMIegIHa93ga13B/8VZF9Y0iDnwW73yQYzCEt9UrDiFeRck/ChZup3rA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-web-identity@3.972.35':
     resolution: {integrity: sha512-swW6Bwvl8lanyEMtZOWE/oR6yqcRQH4HTQZUVsnDVgoXvRjRywpYpLv2BWwjUFyjPrqsdX6FeTkf4tMSe/qFTQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.37':
+    resolution: {integrity: sha512-aryawqyebf+3WhAFNHfF62rekFpYtVcVN7dQ89qnAWsa4n5hJst8qBG6gXC24WHtW7Nnhkf9ScYnjwo0Brn3bw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-bucket-endpoint@3.972.10':
@@ -1448,6 +1500,10 @@ packages:
     resolution: {integrity: sha512-/UL96JKjsjdodcRRMKl99tLQvK6Oi9ptLC9iU1yiTF/ruaDX0mtBBtnLNZDxIZRJOCVOtB49ed1YaTadqygk8Q==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-sdk-s3@3.972.36':
+    resolution: {integrity: sha512-YhPix+0x/MdQrb1Ug1GDKeS5fqylIy+naz800asX8II4jqfTk2KY2KhmmYCwZcky8YWtRQQwWCGdoqeAnip8Uw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-ssec@3.972.10':
     resolution: {integrity: sha512-Gli9A0u8EVVb+5bFDGS/QbSVg28w/wpEidg1ggVcSj65BDTdGR6punsOcVjqdiu1i42WHWo51MCvARPIIz9juw==}
     engines: {node: '>=20.0.0'}
@@ -1460,12 +1516,20 @@ packages:
     resolution: {integrity: sha512-hOFWNOjVmOocpRlrU04nYxjMOeoe0Obu5AXEuhB8zblMCPl3cG1hdluQCZERRKFyhMQjwZnDbhSHjoMUjetFGw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-user-agent@3.972.37':
+    resolution: {integrity: sha512-N1oNpdiLoVAWYD3WFBnUi3LlfoDA06ZHo4ozyjbsJNLvILzvt//0CnR8N+CZ0NWeYgVB/5V59ivixHCWCx2ALw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/nested-clients@3.968.0':
     resolution: {integrity: sha512-LLppm+8MzD3afD2IA/tYDp5AoVPOybK7MHQz5DVB4HsZ+fHvwYlvau2ZUK8nKwJSk5c1kWcxCZkyuJQjFu37ng==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/nested-clients@3.997.3':
     resolution: {integrity: sha512-SivE6GP228IVgfsrr2c/vqTg95X0Qj39Yw4uIrcddpkUzIltNMoNOR62leHOLhODfjv9K8X2mPTwS69A5kT0nQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.5':
+    resolution: {integrity: sha512-jGFr6DxtcMTmzOkG/a0jCZYv4BBDmeNYVeO+/memSoDkYCJu4Y58xviYmzwJfYyIVSts+X/BVjJm1uGBnwHEMg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/region-config-resolver@3.968.0':
@@ -1480,8 +1544,16 @@ packages:
     resolution: {integrity: sha512-/rXhMXteD+BqhFd0nYprAgcZ/KtU+963uftPqd3tiFcFfooHZINXUGtOmo2SQjRVauCTNqIEzkwuSETdZFqTTA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/signature-v4-multi-region@3.996.24':
+    resolution: {integrity: sha512-amP7tLikppN940wbBFISYqiuzVmpzMS9U3mcgtmVLjX4fdWI/SNCvrXv6ZxfVzTT4cT0rPKOLhFah2xLwzREWw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/token-providers@3.1036.0':
     resolution: {integrity: sha512-aNSJ6jjDYayxN9ZA1JpycVScX93Lx03kKZ1EXt3DGOTahcWVLJj3oLAlop0xKP+vP2Ga2t49p1tEaMkTbCCaZA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1039.0':
+    resolution: {integrity: sha512-NMSFL2HwkAOoCeLCQiqoOq5pT3vVbSjww2QZTuYgYknVwhhv125PSDzZIcL5EYnlxuPWjEOdauZK+FspkZDVdw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.968.0':
@@ -1536,12 +1608,25 @@ packages:
       aws-crt:
         optional: true
 
+  '@aws-sdk/util-user-agent-node@3.973.23':
+    resolution: {integrity: sha512-gGwq8L2Euw0aNG6Ey4EktiAo3fSCVoDy1CaBIthd+oeaKHPXUrNaApMewQ6La5Hv0lcznOtECZaNvYyc5LXXfA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+
   '@aws-sdk/xml-builder@3.968.0':
     resolution: {integrity: sha512-bZQKn41ebPh/uW9uWUE5oLuaBr44Gt78dkw2amu5zcwo1J/d8s6FdzZcRDmz0rHE2NHJWYkdQYeVQo7jhMziqA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/xml-builder@3.972.19':
     resolution: {integrity: sha512-Cw8IOMdBUEIl8ZlhRC3Dc/E64D5B5/8JhV6vhPLiPfJwcRC84S6F8aBOIi/N4vR9ZyA4I5Cc0Ateb/9EHaJXeQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.22':
+    resolution: {integrity: sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.3':
@@ -3037,6 +3122,18 @@ packages:
     resolution: {integrity: sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==}
     engines: {node: '>=14.16'}
 
+  '@sinonjs/commons@3.0.1':
+    resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
+
+  '@sinonjs/fake-timers@11.2.2':
+    resolution: {integrity: sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==}
+
+  '@sinonjs/fake-timers@15.3.2':
+    resolution: {integrity: sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==}
+
+  '@sinonjs/samsam@8.0.3':
+    resolution: {integrity: sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==}
+
   '@smithy/abort-controller@4.2.8':
     resolution: {integrity: sha512-peuVfkYHAmS5ybKxWcfraK7WBBP0J+rkfUcbHJJKQ4ir3UAUNQI+Y4Vt/PqSzGqgloJ5O1dk7+WzNL8wcCSXbw==}
     engines: {node: '>=18.0.0'}
@@ -3165,6 +3262,10 @@ packages:
     resolution: {integrity: sha512-wnYOpB5vATFKWrY2Z9Alb0KhjZI6AbzU6Fbz3Hq2GnURdRYWB4q+qWivQtSTwXcmWUA3MZ6krfwL6Cq5MAbxsA==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/middleware-retry@4.5.7':
+    resolution: {integrity: sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/middleware-serde@4.2.20':
     resolution: {integrity: sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==}
     engines: {node: '>=18.0.0'}
@@ -3237,6 +3338,10 @@ packages:
     resolution: {integrity: sha512-9jKsBYQRPR0xBLgc2415RsA5PIcP2sis4oBdN9s0D13cg1B1284mNTjx9Yc+BEERXzuPm5ObktI96OxsKh8E9A==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/service-error-classification@4.3.1':
+    resolution: {integrity: sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/shared-ini-file-loader@4.4.3':
     resolution: {integrity: sha512-DfQjxXQnzC5UbCUPeC3Ie8u+rIWZTvuDPAGU/BxzrOGhRvgUanaP68kDZA+jaT3ZI+djOf+4dERGlm9mWfFDrg==}
     engines: {node: '>=18.0.0'}
@@ -3247,10 +3352,6 @@ packages:
 
   '@smithy/signature-v4@5.3.14':
     resolution: {integrity: sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/signature-v4@5.3.8':
-    resolution: {integrity: sha512-6A4vdGj7qKNRF16UIcO8HhHjKW27thsxYci+5r/uVRkdcBEkOEiY8OMPuydLX4QHSrJqGHPJzPRwwVTqbLZJhg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/smithy-client@4.10.7':
@@ -3369,6 +3470,10 @@ packages:
     resolution: {integrity: sha512-FY1UQQ1VFmMwiYp1GVS4MeaGD5O0blLNYK0xCRHU+mJgeoH/hSY8Ld8sJWKQ6uznkh14HveRGQJncgPyNl9J+A==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/util-retry@4.3.6':
+    resolution: {integrity: sha512-p6/FO1n2KxMeQyna067i0uJ6TSbb165ZhnRtCpWh4Foxqbfc6oW+XITaL8QkFJj3KFnDe2URt4gOhgU06EP9ew==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/util-stream@4.5.10':
     resolution: {integrity: sha512-jbqemy51UFSZSp2y0ZmRfckmrzuKww95zT9BYMmuJ8v3altGcqjwoV1tzpOwuHaKrwQrCjIzOib499ymr2f98g==}
     engines: {node: '>=18.0.0'}
@@ -3399,6 +3504,10 @@ packages:
 
   '@smithy/util-waiter@4.2.16':
     resolution: {integrity: sha512-GtclrKoZ3Lt7jPQ7aTIYKfjY92OgceScftVnkTsG8e1KV8rkvZgN+ny6YSRhd9hxB8rZtwVbmln7NTvE5O3GmQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-waiter@4.3.0':
+    resolution: {integrity: sha512-JyjYmLAfS+pdxF92o4yLgEoy0zhayKTw73FU1aofLWwLcJw7iSqIY2exGmMTrl/lmZugP5p/zxdFSippJDfKWA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/uuid@1.1.0':
@@ -3627,9 +3736,6 @@ packages:
   '@types/node@24.0.12':
     resolution: {integrity: sha512-LtOrbvDf5ndC9Xi+4QZjVL0woFymF/xSTKZKPgrrl7H7XoeDvnD+E2IclKVDyaK9UM756W/3BXqSU+JEHopA9g==}
 
-  '@types/node@25.5.2':
-    resolution: {integrity: sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==}
-
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
@@ -3664,6 +3770,12 @@ packages:
 
   '@types/serve-static@2.2.0':
     resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
+
+  '@types/sinon@17.0.4':
+    resolution: {integrity: sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==}
+
+  '@types/sinonjs__fake-timers@15.0.1':
+    resolution: {integrity: sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==}
 
   '@types/superagent@8.1.9':
     resolution: {integrity: sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==}
@@ -4108,6 +4220,9 @@ packages:
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  aws-sdk-client-mock@4.1.0:
+    resolution: {integrity: sha512-h/tOYTkXEsAcV3//6C1/7U4ifSpKyJvb6auveAepqqNJl6TdZaPFEtKjBQNf8UxQdDP850knB2i/whq4zlsxJw==}
 
   aws-ssl-profiles@1.1.2:
     resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
@@ -4684,6 +4799,10 @@ packages:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
     engines: {node: '>=0.3.1'}
 
+  diff@5.2.2:
+    resolution: {integrity: sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==}
+    engines: {node: '>=0.3.1'}
+
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
@@ -5089,6 +5208,10 @@ packages:
 
   fast-xml-parser@5.7.1:
     resolution: {integrity: sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==}
+    hasBin: true
+
+  fast-xml-parser@5.7.2:
+    resolution: {integrity: sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==}
     hasBin: true
 
   fastest-levenshtein@1.0.16:
@@ -5908,6 +6031,9 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  just-extend@6.2.0:
+    resolution: {integrity: sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==}
+
   keygrip@1.1.0:
     resolution: {integrity: sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==}
     engines: {node: '>= 0.6'}
@@ -6343,6 +6469,9 @@ packages:
       sass:
         optional: true
 
+  nise@6.1.5:
+    resolution: {integrity: sha512-SnRDPDBjxZZoU2n0+gzzLtSvo1OZo7j6jnbXsoh3AFxEGhaFU7ZF0TmefuKERq79wxR2U+MPn7ArW+Tl+clC3A==}
+
   no-case@2.3.2:
     resolution: {integrity: sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==}
 
@@ -6616,6 +6745,9 @@ packages:
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -7093,6 +7225,9 @@ packages:
   signedsource@1.0.0:
     resolution: {integrity: sha512-6+eerH9fEnNmi/hyM1DXcRK3pWdoMQtlkQ+ns0ntzunjKqp5i3sKCc80ym8Fib3iaYhdJUOPdhlJWj1tvge2Ww==}
 
+  sinon@18.0.1:
+    resolution: {integrity: sha512-a2N2TDY1uGviajJ6r4D1CyRAkzE9NNVlYOV1wX5xQDuAk0ONgzgRl0EjCQuRCPxOwp13ghsMwt9Gdldujs39qw==}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -7266,9 +7401,6 @@ packages:
 
   strip-literal@2.1.1:
     resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
-
-  strnum@2.1.2:
-    resolution: {integrity: sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==}
 
   strnum@2.2.3:
     resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
@@ -7576,6 +7708,10 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-detect@4.0.8:
+    resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
+    engines: {node: '>=4'}
+
   type-detect@4.1.0:
     resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
     engines: {node: '>=4'}
@@ -7669,9 +7805,6 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-
-  undici-types@7.18.2:
-    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
@@ -8170,7 +8303,7 @@ snapshots:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.968.0
+      '@aws-sdk/types': 3.973.8
       '@aws-sdk/util-locate-window': 3.965.2
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -8178,7 +8311,7 @@ snapshots:
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.968.0
+      '@aws-sdk/types': 3.973.8
       tslib: 2.8.1
 
   '@aws-crypto/supports-web-crypto@5.2.0':
@@ -8187,7 +8320,7 @@ snapshots:
 
   '@aws-crypto/util@5.2.0':
     dependencies:
-      '@aws-sdk/types': 3.968.0
+      '@aws-sdk/types': 3.973.8
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
@@ -8312,31 +8445,76 @@ snapshots:
       '@aws-sdk/util-endpoints': 3.968.0
       '@aws-sdk/util-user-agent-browser': 3.968.0
       '@aws-sdk/util-user-agent-node': 3.968.0
-      '@smithy/config-resolver': 4.4.6
-      '@smithy/core': 3.20.5
-      '@smithy/fetch-http-handler': 5.3.9
-      '@smithy/hash-node': 4.2.8
-      '@smithy/invalid-dependency': 4.2.8
-      '@smithy/middleware-content-length': 4.2.8
-      '@smithy/middleware-endpoint': 4.4.6
-      '@smithy/middleware-retry': 4.4.22
-      '@smithy/middleware-serde': 4.2.9
-      '@smithy/middleware-stack': 4.2.8
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/node-http-handler': 4.4.8
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/smithy-client': 4.10.7
-      '@smithy/types': 4.12.0
-      '@smithy/url-parser': 4.2.8
-      '@smithy/util-base64': 4.3.0
-      '@smithy/util-body-length-browser': 4.2.0
-      '@smithy/util-body-length-node': 4.2.1
-      '@smithy/util-defaults-mode-browser': 4.3.21
-      '@smithy/util-defaults-mode-node': 4.2.24
-      '@smithy/util-endpoints': 3.2.8
-      '@smithy/util-middleware': 4.2.8
-      '@smithy/util-retry': 4.2.8
-      '@smithy/util-utf8': 4.2.0
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.5
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.4
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/client-ssm@3.1040.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/credential-provider-node': 3.972.38
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.37
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.23
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.7
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.6
+      '@smithy/util-utf8': 4.2.2
+      '@smithy/util-waiter': 4.3.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -8355,31 +8533,31 @@ snapshots:
       '@aws-sdk/util-endpoints': 3.968.0
       '@aws-sdk/util-user-agent-browser': 3.968.0
       '@aws-sdk/util-user-agent-node': 3.968.0
-      '@smithy/config-resolver': 4.4.6
-      '@smithy/core': 3.20.5
-      '@smithy/fetch-http-handler': 5.3.9
-      '@smithy/hash-node': 4.2.8
-      '@smithy/invalid-dependency': 4.2.8
-      '@smithy/middleware-content-length': 4.2.8
-      '@smithy/middleware-endpoint': 4.4.6
-      '@smithy/middleware-retry': 4.4.22
-      '@smithy/middleware-serde': 4.2.9
-      '@smithy/middleware-stack': 4.2.8
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/node-http-handler': 4.4.8
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/smithy-client': 4.10.7
-      '@smithy/types': 4.12.0
-      '@smithy/url-parser': 4.2.8
-      '@smithy/util-base64': 4.3.0
-      '@smithy/util-body-length-browser': 4.2.0
-      '@smithy/util-body-length-node': 4.2.1
-      '@smithy/util-defaults-mode-browser': 4.3.21
-      '@smithy/util-defaults-mode-node': 4.2.24
-      '@smithy/util-endpoints': 3.2.8
-      '@smithy/util-middleware': 4.2.8
-      '@smithy/util-retry': 4.2.8
-      '@smithy/util-utf8': 4.2.0
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.5
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.4
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -8432,16 +8610,16 @@ snapshots:
     dependencies:
       '@aws-sdk/types': 3.968.0
       '@aws-sdk/xml-builder': 3.968.0
-      '@smithy/core': 3.20.5
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/property-provider': 4.2.8
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/signature-v4': 5.3.8
-      '@smithy/smithy-client': 4.10.7
-      '@smithy/types': 4.12.0
-      '@smithy/util-base64': 4.3.0
-      '@smithy/util-middleware': 4.2.8
-      '@smithy/util-utf8': 4.2.0
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
   '@aws-sdk/core@3.974.5':
@@ -8461,6 +8639,23 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.974.7':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/xml-builder': 3.972.22
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.6
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
   '@aws-sdk/crc64-nvme@3.972.7':
     dependencies:
       '@smithy/types': 4.14.1
@@ -8470,8 +8665,8 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.968.0
       '@aws-sdk/types': 3.968.0
-      '@smithy/property-provider': 4.2.8
-      '@smithy/types': 4.12.0
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-env@3.972.31':
@@ -8482,22 +8677,43 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-env@3.972.33':
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-http@3.968.0':
     dependencies:
       '@aws-sdk/core': 3.968.0
       '@aws-sdk/types': 3.968.0
-      '@smithy/fetch-http-handler': 5.3.9
-      '@smithy/node-http-handler': 4.4.8
-      '@smithy/property-provider': 4.2.8
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/smithy-client': 4.10.7
-      '@smithy/types': 4.12.0
-      '@smithy/util-stream': 4.5.10
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-stream': 4.5.25
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-http@3.972.33':
     dependencies:
       '@aws-sdk/core': 3.974.5
+      '@aws-sdk/types': 3.973.8
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-stream': 4.5.25
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.35':
+    dependencies:
+      '@aws-sdk/core': 3.974.7
       '@aws-sdk/types': 3.973.8
       '@smithy/fetch-http-handler': 5.3.17
       '@smithy/node-http-handler': 4.6.1
@@ -8519,10 +8735,10 @@ snapshots:
       '@aws-sdk/credential-provider-web-identity': 3.968.0
       '@aws-sdk/nested-clients': 3.968.0
       '@aws-sdk/types': 3.968.0
-      '@smithy/credential-provider-imds': 4.2.8
-      '@smithy/property-provider': 4.2.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -8546,15 +8762,34 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-ini@3.972.37':
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/credential-provider-env': 3.972.33
+      '@aws-sdk/credential-provider-http': 3.972.35
+      '@aws-sdk/credential-provider-login': 3.972.37
+      '@aws-sdk/credential-provider-process': 3.972.33
+      '@aws-sdk/credential-provider-sso': 3.972.37
+      '@aws-sdk/credential-provider-web-identity': 3.972.37
+      '@aws-sdk/nested-clients': 3.997.5
+      '@aws-sdk/types': 3.973.8
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/credential-provider-login@3.968.0':
     dependencies:
       '@aws-sdk/core': 3.968.0
       '@aws-sdk/nested-clients': 3.968.0
       '@aws-sdk/types': 3.968.0
-      '@smithy/property-provider': 4.2.8
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -8563,6 +8798,19 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.974.5
       '@aws-sdk/nested-clients': 3.997.3
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.37':
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/nested-clients': 3.997.5
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/protocol-http': 5.3.14
@@ -8581,10 +8829,10 @@ snapshots:
       '@aws-sdk/credential-provider-sso': 3.968.0
       '@aws-sdk/credential-provider-web-identity': 3.968.0
       '@aws-sdk/types': 3.968.0
-      '@smithy/credential-provider-imds': 4.2.8
-      '@smithy/property-provider': 4.2.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -8606,18 +8854,44 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-node@3.972.38':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.33
+      '@aws-sdk/credential-provider-http': 3.972.35
+      '@aws-sdk/credential-provider-ini': 3.972.37
+      '@aws-sdk/credential-provider-process': 3.972.33
+      '@aws-sdk/credential-provider-sso': 3.972.37
+      '@aws-sdk/credential-provider-web-identity': 3.972.37
+      '@aws-sdk/types': 3.973.8
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/credential-provider-process@3.968.0':
     dependencies:
       '@aws-sdk/core': 3.968.0
       '@aws-sdk/types': 3.968.0
-      '@smithy/property-provider': 4.2.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-process@3.972.31':
     dependencies:
       '@aws-sdk/core': 3.974.5
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.33':
+    dependencies:
+      '@aws-sdk/core': 3.974.7
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
@@ -8630,9 +8904,9 @@ snapshots:
       '@aws-sdk/core': 3.968.0
       '@aws-sdk/token-providers': 3.968.0
       '@aws-sdk/types': 3.968.0
-      '@smithy/property-provider': 4.2.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -8650,14 +8924,27 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-sso@3.972.37':
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/nested-clients': 3.997.5
+      '@aws-sdk/token-providers': 3.1039.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/credential-provider-web-identity@3.968.0':
     dependencies:
       '@aws-sdk/core': 3.968.0
       '@aws-sdk/nested-clients': 3.968.0
       '@aws-sdk/types': 3.968.0
-      '@smithy/property-provider': 4.2.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -8666,6 +8953,18 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.974.5
       '@aws-sdk/nested-clients': 3.997.3
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.37':
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/nested-clients': 3.997.5
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
@@ -8711,8 +9010,8 @@ snapshots:
   '@aws-sdk/middleware-host-header@3.968.0':
     dependencies:
       '@aws-sdk/types': 3.968.0
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/types': 4.12.0
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-host-header@3.972.10':
@@ -8731,7 +9030,7 @@ snapshots:
   '@aws-sdk/middleware-logger@3.968.0':
     dependencies:
       '@aws-sdk/types': 3.968.0
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-logger@3.972.10':
@@ -8744,8 +9043,8 @@ snapshots:
     dependencies:
       '@aws-sdk/types': 3.968.0
       '@aws/lambda-invoke-store': 0.2.3
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/types': 4.12.0
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-recursion-detection@3.972.11':
@@ -8773,6 +9072,23 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-sdk-s3@3.972.36':
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-arn-parser': 3.972.3
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-stream': 4.5.25
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
   '@aws-sdk/middleware-ssec@3.972.10':
     dependencies:
       '@aws-sdk/types': 3.973.8
@@ -8784,9 +9100,9 @@ snapshots:
       '@aws-sdk/core': 3.968.0
       '@aws-sdk/types': 3.968.0
       '@aws-sdk/util-endpoints': 3.968.0
-      '@smithy/core': 3.20.5
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/types': 4.12.0
+      '@smithy/core': 3.23.17
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-user-agent@3.972.35':
@@ -8798,6 +9114,17 @@ snapshots:
       '@smithy/protocol-http': 5.3.14
       '@smithy/types': 4.14.1
       '@smithy/util-retry': 4.3.4
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-user-agent@3.972.37':
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@smithy/core': 3.23.17
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-retry': 4.3.6
       tslib: 2.8.1
 
   '@aws-sdk/nested-clients@3.968.0':
@@ -8814,31 +9141,31 @@ snapshots:
       '@aws-sdk/util-endpoints': 3.968.0
       '@aws-sdk/util-user-agent-browser': 3.968.0
       '@aws-sdk/util-user-agent-node': 3.968.0
-      '@smithy/config-resolver': 4.4.6
-      '@smithy/core': 3.20.5
-      '@smithy/fetch-http-handler': 5.3.9
-      '@smithy/hash-node': 4.2.8
-      '@smithy/invalid-dependency': 4.2.8
-      '@smithy/middleware-content-length': 4.2.8
-      '@smithy/middleware-endpoint': 4.4.6
-      '@smithy/middleware-retry': 4.4.22
-      '@smithy/middleware-serde': 4.2.9
-      '@smithy/middleware-stack': 4.2.8
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/node-http-handler': 4.4.8
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/smithy-client': 4.10.7
-      '@smithy/types': 4.12.0
-      '@smithy/url-parser': 4.2.8
-      '@smithy/util-base64': 4.3.0
-      '@smithy/util-body-length-browser': 4.2.0
-      '@smithy/util-body-length-node': 4.2.1
-      '@smithy/util-defaults-mode-browser': 4.3.21
-      '@smithy/util-defaults-mode-node': 4.2.24
-      '@smithy/util-endpoints': 3.2.8
-      '@smithy/util-middleware': 4.2.8
-      '@smithy/util-retry': 4.2.8
-      '@smithy/util-utf8': 4.2.0
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.5
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.4
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -8887,12 +9214,56 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/nested-clients@3.997.5':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.37
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/signature-v4-multi-region': 3.996.24
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.23
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.7
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.6
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/region-config-resolver@3.968.0':
     dependencies:
       '@aws-sdk/types': 3.968.0
-      '@smithy/config-resolver': 4.4.6
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/types': 4.12.0
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/region-config-resolver@3.972.13':
@@ -8912,10 +9283,31 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/signature-v4-multi-region@3.996.24':
+    dependencies:
+      '@aws-sdk/middleware-sdk-s3': 3.972.36
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/token-providers@3.1036.0':
     dependencies:
       '@aws-sdk/core': 3.974.5
       '@aws-sdk/nested-clients': 3.997.3
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/token-providers@3.1039.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/nested-clients': 3.997.5
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
@@ -8929,16 +9321,16 @@ snapshots:
       '@aws-sdk/core': 3.968.0
       '@aws-sdk/nested-clients': 3.968.0
       '@aws-sdk/types': 3.968.0
-      '@smithy/property-provider': 4.2.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
   '@aws-sdk/types@3.968.0':
     dependencies:
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/types@3.973.8':
@@ -8953,9 +9345,9 @@ snapshots:
   '@aws-sdk/util-endpoints@3.968.0':
     dependencies:
       '@aws-sdk/types': 3.968.0
-      '@smithy/types': 4.12.0
-      '@smithy/url-parser': 4.2.8
-      '@smithy/util-endpoints': 3.2.8
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-endpoints': 3.4.2
       tslib: 2.8.1
 
   '@aws-sdk/util-endpoints@3.996.8':
@@ -8973,7 +9365,7 @@ snapshots:
   '@aws-sdk/util-user-agent-browser@3.968.0':
     dependencies:
       '@aws-sdk/types': 3.968.0
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.14.1
       bowser: 2.13.1
       tslib: 2.8.1
 
@@ -8988,8 +9380,8 @@ snapshots:
     dependencies:
       '@aws-sdk/middleware-user-agent': 3.968.0
       '@aws-sdk/types': 3.968.0
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/types': 4.12.0
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/util-user-agent-node@3.973.21':
@@ -9001,9 +9393,18 @@ snapshots:
       '@smithy/util-config-provider': 4.2.2
       tslib: 2.8.1
 
+  '@aws-sdk/util-user-agent-node@3.973.23':
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.972.37
+      '@aws-sdk/types': 3.973.8
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      tslib: 2.8.1
+
   '@aws-sdk/xml-builder@3.968.0':
     dependencies:
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.14.1
       fast-xml-parser: 5.2.5
       tslib: 2.8.1
 
@@ -9011,6 +9412,13 @@ snapshots:
     dependencies:
       '@smithy/types': 4.14.1
       fast-xml-parser: 5.7.1
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.22':
+    dependencies:
+      '@nodable/entities': 2.1.0
+      '@smithy/types': 4.14.1
+      fast-xml-parser: 5.7.2
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.3': {}
@@ -10714,9 +11122,26 @@ snapshots:
 
   '@sindresorhus/is@5.6.0': {}
 
+  '@sinonjs/commons@3.0.1':
+    dependencies:
+      type-detect: 4.0.8
+
+  '@sinonjs/fake-timers@11.2.2':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+
+  '@sinonjs/fake-timers@15.3.2':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+
+  '@sinonjs/samsam@8.0.3':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+      type-detect: 4.1.0
+
   '@smithy/abort-controller@4.2.8':
     dependencies:
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/chunked-blob-reader-native@4.2.3':
@@ -10739,23 +11164,23 @@ snapshots:
 
   '@smithy/config-resolver@4.4.6':
     dependencies:
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/types': 4.12.0
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
       '@smithy/util-config-provider': 4.2.0
-      '@smithy/util-endpoints': 3.2.8
-      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
       tslib: 2.8.1
 
   '@smithy/core@3.20.5':
     dependencies:
-      '@smithy/middleware-serde': 4.2.9
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/types': 4.12.0
-      '@smithy/util-base64': 4.3.0
-      '@smithy/util-body-length-browser': 4.2.0
-      '@smithy/util-middleware': 4.2.8
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-middleware': 4.2.14
       '@smithy/util-stream': 4.5.10
-      '@smithy/util-utf8': 4.2.0
+      '@smithy/util-utf8': 4.2.2
       '@smithy/uuid': 1.1.0
       tslib: 2.8.1
 
@@ -10782,10 +11207,10 @@ snapshots:
 
   '@smithy/credential-provider-imds@4.2.8':
     dependencies:
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/property-provider': 4.2.8
-      '@smithy/types': 4.12.0
-      '@smithy/url-parser': 4.2.8
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
       tslib: 2.8.1
 
   '@smithy/eventstream-codec@4.2.14':
@@ -10828,10 +11253,10 @@ snapshots:
 
   '@smithy/fetch-http-handler@5.3.9':
     dependencies:
-      '@smithy/protocol-http': 5.3.8
+      '@smithy/protocol-http': 5.3.14
       '@smithy/querystring-builder': 4.2.8
-      '@smithy/types': 4.12.0
-      '@smithy/util-base64': 4.3.0
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
       tslib: 2.8.1
 
   '@smithy/hash-blob-browser@4.2.15':
@@ -10850,9 +11275,9 @@ snapshots:
 
   '@smithy/hash-node@4.2.8':
     dependencies:
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.14.1
       '@smithy/util-buffer-from': 4.2.0
-      '@smithy/util-utf8': 4.2.0
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
   '@smithy/hash-stream-node@4.2.14':
@@ -10868,7 +11293,7 @@ snapshots:
 
   '@smithy/invalid-dependency@4.2.8':
     dependencies:
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/is-array-buffer@2.2.0':
@@ -10897,8 +11322,8 @@ snapshots:
 
   '@smithy/middleware-content-length@4.2.8':
     dependencies:
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/types': 4.12.0
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/middleware-endpoint@4.4.32':
@@ -10914,24 +11339,24 @@ snapshots:
 
   '@smithy/middleware-endpoint@4.4.6':
     dependencies:
-      '@smithy/core': 3.20.5
-      '@smithy/middleware-serde': 4.2.9
-      '@smithy/node-config-provider': 4.3.8
+      '@smithy/core': 3.23.17
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/node-config-provider': 4.3.14
       '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
-      '@smithy/url-parser': 4.2.8
-      '@smithy/util-middleware': 4.2.8
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-middleware': 4.2.14
       tslib: 2.8.1
 
   '@smithy/middleware-retry@4.4.22':
     dependencies:
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/protocol-http': 5.3.8
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
       '@smithy/service-error-classification': 4.2.8
-      '@smithy/smithy-client': 4.10.7
-      '@smithy/types': 4.12.0
-      '@smithy/util-middleware': 4.2.8
-      '@smithy/util-retry': 4.2.8
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.4
       '@smithy/uuid': 1.1.0
       tslib: 2.8.1
 
@@ -10948,6 +11373,19 @@ snapshots:
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
+  '@smithy/middleware-retry@4.5.7':
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/service-error-classification': 4.3.1
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.6
+      '@smithy/uuid': 1.1.2
+      tslib: 2.8.1
+
   '@smithy/middleware-serde@4.2.20':
     dependencies:
       '@smithy/core': 3.23.17
@@ -10957,8 +11395,8 @@ snapshots:
 
   '@smithy/middleware-serde@4.2.9':
     dependencies:
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/types': 4.12.0
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/middleware-stack@4.2.14':
@@ -10968,7 +11406,7 @@ snapshots:
 
   '@smithy/middleware-stack@4.2.8':
     dependencies:
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/node-config-provider@4.3.14':
@@ -10982,15 +11420,15 @@ snapshots:
     dependencies:
       '@smithy/property-provider': 4.2.8
       '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/node-http-handler@4.4.8':
     dependencies:
       '@smithy/abort-controller': 4.2.8
-      '@smithy/protocol-http': 5.3.8
+      '@smithy/protocol-http': 5.3.14
       '@smithy/querystring-builder': 4.2.8
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/node-http-handler@4.6.1':
@@ -11007,7 +11445,7 @@ snapshots:
 
   '@smithy/property-provider@4.2.8':
     dependencies:
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/protocol-http@5.3.14':
@@ -11017,7 +11455,7 @@ snapshots:
 
   '@smithy/protocol-http@5.3.8':
     dependencies:
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/querystring-builder@4.2.14':
@@ -11028,7 +11466,7 @@ snapshots:
 
   '@smithy/querystring-builder@4.2.8':
     dependencies:
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.14.1
       '@smithy/util-uri-escape': 4.2.0
       tslib: 2.8.1
 
@@ -11039,20 +11477,24 @@ snapshots:
 
   '@smithy/querystring-parser@4.2.8':
     dependencies:
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/service-error-classification@4.2.8':
     dependencies:
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.14.1
 
   '@smithy/service-error-classification@4.3.0':
     dependencies:
       '@smithy/types': 4.14.1
 
+  '@smithy/service-error-classification@4.3.1':
+    dependencies:
+      '@smithy/types': 4.14.1
+
   '@smithy/shared-ini-file-loader@4.4.3':
     dependencies:
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/shared-ini-file-loader@4.4.9':
@@ -11071,24 +11513,13 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@smithy/signature-v4@5.3.8':
-    dependencies:
-      '@smithy/is-array-buffer': 4.2.0
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/types': 4.12.0
-      '@smithy/util-hex-encoding': 4.2.0
-      '@smithy/util-middleware': 4.2.8
-      '@smithy/util-uri-escape': 4.2.0
-      '@smithy/util-utf8': 4.2.0
-      tslib: 2.8.1
-
   '@smithy/smithy-client@4.10.7':
     dependencies:
-      '@smithy/core': 3.20.5
-      '@smithy/middleware-endpoint': 4.4.6
-      '@smithy/middleware-stack': 4.2.8
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/types': 4.12.0
+      '@smithy/core': 3.23.17
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
       '@smithy/util-stream': 4.5.10
       tslib: 2.8.1
 
@@ -11119,13 +11550,13 @@ snapshots:
   '@smithy/url-parser@4.2.8':
     dependencies:
       '@smithy/querystring-parser': 4.2.8
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/util-base64@4.3.0':
     dependencies:
       '@smithy/util-buffer-from': 4.2.0
-      '@smithy/util-utf8': 4.2.0
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
   '@smithy/util-base64@4.3.2':
@@ -11176,8 +11607,8 @@ snapshots:
   '@smithy/util-defaults-mode-browser@4.3.21':
     dependencies:
       '@smithy/property-provider': 4.2.8
-      '@smithy/smithy-client': 4.10.7
-      '@smithy/types': 4.12.0
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/util-defaults-mode-browser@4.3.49':
@@ -11189,12 +11620,12 @@ snapshots:
 
   '@smithy/util-defaults-mode-node@4.2.24':
     dependencies:
-      '@smithy/config-resolver': 4.4.6
+      '@smithy/config-resolver': 4.4.17
       '@smithy/credential-provider-imds': 4.2.8
-      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-config-provider': 4.3.14
       '@smithy/property-provider': 4.2.8
-      '@smithy/smithy-client': 4.10.7
-      '@smithy/types': 4.12.0
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/util-defaults-mode-node@4.2.54':
@@ -11209,8 +11640,8 @@ snapshots:
 
   '@smithy/util-endpoints@3.2.8':
     dependencies:
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/types': 4.12.0
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/util-endpoints@3.4.2':
@@ -11234,13 +11665,13 @@ snapshots:
 
   '@smithy/util-middleware@4.2.8':
     dependencies:
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/util-retry@4.2.8':
     dependencies:
       '@smithy/service-error-classification': 4.2.8
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/util-retry@4.3.4':
@@ -11249,15 +11680,21 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@smithy/util-retry@4.3.6':
+    dependencies:
+      '@smithy/service-error-classification': 4.3.1
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@smithy/util-stream@4.5.10':
     dependencies:
-      '@smithy/fetch-http-handler': 5.3.9
-      '@smithy/node-http-handler': 4.4.8
-      '@smithy/types': 4.12.0
-      '@smithy/util-base64': 4.3.0
-      '@smithy/util-buffer-from': 4.2.0
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-buffer-from': 4.2.2
       '@smithy/util-hex-encoding': 4.2.0
-      '@smithy/util-utf8': 4.2.0
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
   '@smithy/util-stream@4.5.25':
@@ -11295,6 +11732,11 @@ snapshots:
       tslib: 2.8.1
 
   '@smithy/util-waiter@4.2.16':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-waiter@4.3.0':
     dependencies:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
@@ -11566,10 +12008,6 @@ snapshots:
     dependencies:
       undici-types: 7.8.0
 
-  '@types/node@25.5.2':
-    dependencies:
-      undici-types: 7.18.2
-
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
@@ -11609,6 +12047,12 @@ snapshots:
     dependencies:
       '@types/http-errors': 2.0.5
       '@types/node': 24.0.12
+
+  '@types/sinon@17.0.4':
+    dependencies:
+      '@types/sinonjs__fake-timers': 15.0.1
+
+  '@types/sinonjs__fake-timers@15.0.1': {}
 
   '@types/superagent@8.1.9':
     dependencies:
@@ -11899,7 +12343,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@1.6.1(vitest@1.6.1(@types/node@25.5.2))':
+  '@vitest/coverage-v8@1.6.1(vitest@1.6.1(@types/node@25.6.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -11914,7 +12358,7 @@ snapshots:
       std-env: 3.10.0
       strip-literal: 2.1.1
       test-exclude: 6.0.0
-      vitest: 1.6.1(@types/node@25.5.2)
+      vitest: 1.6.1(@types/node@25.6.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -12207,6 +12651,12 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  aws-sdk-client-mock@4.1.0:
+    dependencies:
+      '@types/sinon': 17.0.4
+      sinon: 18.0.1
+      tslib: 2.8.1
 
   aws-ssl-profiles@1.1.2: {}
 
@@ -12822,6 +13272,8 @@ snapshots:
 
   diff@4.0.2: {}
 
+  diff@5.2.2: {}
+
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
@@ -13069,8 +13521,8 @@ snapshots:
       '@typescript-eslint/parser': 8.50.0(eslint@8.57.1)(typescript@5.8.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -13113,21 +13565,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 8.57.1
-      get-tsconfig: 4.13.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.15
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -13143,14 +13580,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.50.0(eslint@8.57.1)(typescript@5.8.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -13165,7 +13602,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -13176,7 +13613,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -13596,9 +14033,16 @@ snapshots:
 
   fast-xml-parser@5.2.5:
     dependencies:
-      strnum: 2.1.2
+      strnum: 2.2.3
 
   fast-xml-parser@5.7.1:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.1.5
+      path-expression-matcher: 1.5.0
+      strnum: 2.2.3
+
+  fast-xml-parser@5.7.2:
     dependencies:
       '@nodable/entities': 2.1.0
       fast-xml-builder: 1.1.5
@@ -14536,6 +14980,8 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  just-extend@6.2.0: {}
+
   keygrip@1.1.0:
     dependencies:
       tsscmp: 1.0.6
@@ -14959,6 +15405,13 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  nise@6.1.5:
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+      '@sinonjs/fake-timers': 15.3.2
+      just-extend: 6.2.0
+      path-to-regexp: 8.4.2
+
   no-case@2.3.2:
     dependencies:
       lower-case: 1.1.4
@@ -15294,6 +15747,8 @@ snapshots:
 
   path-to-regexp@6.3.0:
     optional: true
+
+  path-to-regexp@8.4.2: {}
 
   path-type@4.0.0: {}
 
@@ -15876,6 +16331,15 @@ snapshots:
 
   signedsource@1.0.0: {}
 
+  sinon@18.0.1:
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+      '@sinonjs/fake-timers': 11.2.2
+      '@sinonjs/samsam': 8.0.3
+      diff: 5.2.2
+      nise: 6.1.5
+      supports-color: 7.2.0
+
   slash@3.0.0: {}
 
   slice-ansi@3.0.0:
@@ -16080,8 +16544,6 @@ snapshots:
   strip-literal@2.1.1:
     dependencies:
       js-tokens: 9.0.1
-
-  strnum@2.1.2: {}
 
   strnum@2.2.3: {}
 
@@ -16433,6 +16895,8 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-detect@4.0.8: {}
+
   type-detect@4.1.0: {}
 
   type-fest@0.20.2: {}
@@ -16537,8 +17001,6 @@ snapshots:
   unc-path-regex@0.1.2: {}
 
   undici-types@6.21.0: {}
-
-  undici-types@7.18.2: {}
 
   undici-types@7.19.2: {}
 
@@ -16657,24 +17119,6 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@1.6.1(@types/node@25.5.2):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.3(supports-color@8.1.1)
-      pathe: 1.1.2
-      picocolors: 1.1.1
-      vite: 5.4.21(@types/node@25.5.2)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
   vite-node@1.6.1(@types/node@25.6.0):
     dependencies:
       cac: 6.7.14
@@ -16729,15 +17173,6 @@ snapshots:
       '@types/node': 24.0.12
       fsevents: 2.3.3
 
-  vite@5.4.21(@types/node@25.5.2):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.5.6
-      rollup: 4.53.5
-    optionalDependencies:
-      '@types/node': 25.5.2
-      fsevents: 2.3.3
-
   vite@5.4.21(@types/node@25.6.0):
     dependencies:
       esbuild: 0.21.5
@@ -16771,40 +17206,6 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.0.12
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  vitest@1.6.1(@types/node@25.5.2):
-    dependencies:
-      '@vitest/expect': 1.6.1
-      '@vitest/runner': 1.6.1
-      '@vitest/snapshot': 1.6.1
-      '@vitest/spy': 1.6.1
-      '@vitest/utils': 1.6.1
-      acorn-walk: 8.3.4
-      chai: 4.5.0
-      debug: 4.4.3(supports-color@8.1.1)
-      execa: 8.0.1
-      local-pkg: 0.5.1
-      magic-string: 0.30.21
-      pathe: 1.1.2
-      picocolors: 1.1.1
-      std-env: 3.10.0
-      strip-literal: 2.1.1
-      tinybench: 2.9.0
-      tinypool: 0.8.4
-      vite: 5.4.21(@types/node@25.5.2)
-      vite-node: 1.6.1(@types/node@25.5.2)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 25.5.2
     transitivePeerDependencies:
       - less
       - lightningcss


### PR DESCRIPTION
## Summary

Extends `@saga-ed/soa-db` to talk to the new shared mongo replica set introduced by iac PRs #270 / #292 / #295. Two-layer split:

1. **Pure config layer** (`MongoProviderSchema`, `MongoProvider._buildConnectionString`) now understands `hosts: string[]`, `replicaSet`, `authSource`, `tls`, and CA material (`tlsCAFile` path or `tlsCAContent` PEM that gets written to a tmp file at construction).
2. **AWS-aware loader** (`loadMongoConfigFromAws`) reads SSM + Secrets Manager primitives published by `cloudformation_templates/dbs/mongodb_shared/` and assembles a fully-resolved `MongoProviderConfig`.

### Loader scopes

- `scope: 'shared'` (staging/prod) — connects as per-service SCRAM user `{project}_app` against `{project}_db`, `authSource` matches.
- `scope: 'mirror-current'` — connects as the rotated master admin against the dev-account prod-mirror (`saga-mongodb-mirror-current`). Per-service users on the mirror inherit prod's hashed passwords (no plaintext), so admin is the only workable creds path.

### Schema migration

Clean break: top-level `host` + `port` removed in favor of `hosts: string[]`. No production wiring exists yet; the only consumer is `MockMongoProvider` (in-memory, schema fields all optional/defaulted).

### Out of scope

- Dev (db-host) loader — per-service mongo port mapping isn't in SSM today; dev callers continue to construct `MongoProviderConfig` directly.
- Postgres — auth model unchanged.
- `claude-plugins` `primitives-index.md` update for `mongodb_shared/` — separate follow-up PR.

## Test plan

- [x] Unit tests: connection-string builder (10 cases — single/multi-host, RS, TLS variants, both-CA-error)
- [x] Unit tests: AWS loader with mocked SSM/Secrets clients (3 cases)
- [x] Existing `MockMongoProvider` integration test still passes
- [x] `pnpm build` clean
- [ ] **Local end-to-end** against the `dev-auth-mongo` testbed on db-host (iac PR #297) — pending operator bring-up of the testbed
- [ ] **Loader smoke** against staging mongo over VPN
- [ ] **Loader smoke** against `mirror-current`