### PR TITLE
feat(packages/node): lift event-driven infra packages from soa_event_driven_example

### DIFF
--- a/packages/node/CLAUDE.md
+++ b/packages/node/CLAUDE.md
@@ -28,8 +28,21 @@ See [/packages/CLAUDE.md](../CLAUDE.md) for packages overview.
 | `redis-core/` | Redis client wrapper with ioredis. Connection pooling and error handling. **Usage:** `import { RedisClient } from '@saga-ed/soa-redis-core'` | Tier |
 | `aws-util/` | AWS SDK utilities for S3, SQS, and SNS. Helper functions for common AWS operations. | Tier |
 | `test-util/` | Vitest testing utilities with custom matchers and test helpers. **Usage:** `import { createMockRequest } from '@saga-ed/soa-test-util'` | Tier |
+| `event-envelope/` | Zod-validated cross-service event envelope (id, type, version, occurredAt, traceparent, payload). **Usage:** `import { EventEnvelopeSchema } from '@saga-ed/soa-event-envelope'` | [event-driven.md](./claude/event-driven.md) |
+| `event-outbox/` | Transactional outbox: `writeOutbox()` writes inside the same pg tx as your domain change; `startRelay()` ships rows to RabbitMQ with at-least-once delivery. | [event-driven.md](./claude/event-driven.md) |
+| `event-consumer/` | Idempotent RabbitMQ consumer with `consumed_events` dedup table, Zod runtime validation, OTel trace propagation. | [event-driven.md](./claude/event-driven.md) |
+| `observability/` | OpenTelemetry tracing setup, Prometheus metrics for outbox/consumer, Express error middleware. **Usage:** `import { initTracing } from '@saga-ed/soa-observability'` | [event-driven.md](./claude/event-driven.md) |
+| `event-test-harness/` | Testcontainers helpers for spinning up Postgres + RabbitMQ in integration tests. **Usage:** `import { startInfra } from '@saga-ed/soa-event-test-harness'` | [event-driven.md](./claude/event-driven.md) |
+| `event-integration-tests/` | Cross-package integration tests for the event-driven stack (outbox → broker → consumer round-trips). | [event-driven.md](./claude/event-driven.md) |
 
-**Note:** Packages marked "Tier" are simple/single-purpose and adequately documented here. Complex packages have dedicated CLAUDE.md files.
+**Note:** Packages marked "Tier" are simple/single-purpose and adequately documented here. Complex packages have dedicated CLAUDE.md files. The event-driven family share [claude/event-driven.md](./claude/event-driven.md).
+
+## Two pubsub families — pick one
+
+- **`pubsub-*`** (`pubsub-core`, `pubsub-client`, `pubsub-server`) — real-time UI push (browser ↔ server). Lives on top of HTTP/SSE. Use for live dashboards, notifications, collaborative cursors.
+- **`event-*`** + `observability` — durable cross-service eventing (server ↔ server) over RabbitMQ with transactional outbox + idempotency. Use for domain events that must survive broker restarts and be replayed safely.
+
+These are NOT interchangeable. See `~/dev/soa/.claude/projects/soa_75/decisions/d-soa-pubsub-divorce.md` for the rationale.
 
 ## Node.js Constraints
 

--- a/packages/node/claude/event-driven.md
+++ b/packages/node/claude/event-driven.md
@@ -1,0 +1,118 @@
+# Event-driven packages — adopter conventions
+
+Reference for fleet services consuming `@saga-ed/soa-event-envelope`, `event-outbox`, `event-consumer`, `observability`, `event-test-harness`. Conventions originated in the `soa_event_driven_example` POC; design decisions live under `~/dev/soa/.claude/projects/soa_75/decisions/`.
+
+## What this stack is (and isn't)
+
+- **IS:** durable, server-to-server domain eventing over RabbitMQ with a transactional outbox per publisher and a `consumed_events` idempotency table per consumer.
+- **IS NOT:** real-time UI push. That's `@saga-ed/soa-pubsub-*`. Don't mix them — see `decisions/d-soa-pubsub-divorce.md`.
+
+## HTTP framework
+
+Use **plain `@trpc/server`** with a hand-composed `appRouter`. Compose data services with **Inversify**.
+
+Do **not** use `AbstractTRPCController` or `ControllerLoader` from `@saga-ed/soa-api-core` for new event-driven services — the convention here is the iam-api/programs-api shape, not the dynamic loader pattern. See `decisions/d-http-framework.md`.
+
+## Sector pattern
+
+Per service, organise domain logic by sector (bounded context):
+
+```
+apps/node/<svc>/src/sectors/<domain>/
+├── <domain>.data.ts           # Inversify-injected data service (pg + outbox writes)
+├── <domain>.router.ts         # tRPC router for this domain
+├── <domain>.input-schemas.ts  # Zod input schemas
+└── __tests__/
+    ├── <domain>.unit.test.ts  # hermetic
+    └── <domain>.int.test.ts   # testcontainers
+```
+
+The top-level `appRouter` merges sector routers.
+
+## Per-family event packages
+
+Cross-service event types live in their own `@saga-ed/<family>-events` package (e.g. `@saga-ed/iam-events`, `@saga-ed/programs-events`). Each event has a Zod schema, a TypeScript type, and a string discriminator like `iam.user.created.v1`.
+
+**Frozen-once-published versioning:** once an event version ships to a consumer, the schema is immutable. Any wire change → new `vN+1`. Snapshots under `tools/contract-check/published/` are byte-checked in CI; modifying without `--bump` fails the build. See `decisions/d-event-versioning.md` and `d-event-package-shape.md`.
+
+## Outbox + consumer wiring (publisher side)
+
+```ts
+import { writeOutbox } from '@saga-ed/soa-event-outbox';
+
+await pg.transaction(async (tx) => {
+    await tx.insert(...);                        // domain change
+    await writeOutbox(tx, {                      // same transaction
+        type: 'iam.user.created.v1',
+        payload: { ... },
+    });
+});
+```
+
+A separate process (or boot-time call in dev) runs `startRelay({ pg, rabbit, ... })` to ship outbox rows to the broker.
+
+## Idempotent consumer (consumer side)
+
+```ts
+import { createConsumer } from '@saga-ed/soa-event-consumer';
+
+const consumer = createConsumer({
+    pg, rabbit,
+    queue: 'admissions.iam-projection',
+    handlers: {
+        'iam.user.created.v1': async (envelope, tx) => {
+            await tx.insert(...);                 // projection write
+        },
+    },
+});
+await consumer.start();
+```
+
+The consumer writes to `consumed_events(envelope_id PK)` inside the same tx as the projection — duplicates are no-ops.
+
+## Hybrid contract testing
+
+Three layers, all required:
+
+1. **Publisher snapshot:** `pnpm contract:export` regenerates `tools/contract-check/published/<event>.json` for every emitted type. CI fails on byte-diffs.
+2. **Per-consumer pin:** each consumer keeps `consumed-events.json` listing the exact `(type, version)` it depends on. CI cross-checks pins against published snapshots.
+3. **Zod runtime validation:** every consumer validates inbound envelopes against its pinned schema. Validation failure → reject + DLQ, never silently drop.
+
+See `decisions/d-contract-testing.md`.
+
+## Test config
+
+Two vitest configs per service:
+
+- `vitest.config.ts` — `*.unit.test.ts` only, hermetic, fast.
+- `vitest.int.config.ts` — `*.int.test.ts`, uses `@saga-ed/soa-event-test-harness` to spin up real Postgres + RabbitMQ via testcontainers. `testTimeout: 120_000`, `fileParallelism: false`.
+
+## Observability
+
+`@saga-ed/soa-observability` wires:
+
+- OTel tracing with W3C `traceparent` propagation through envelopes
+- Prometheus metrics for outbox depth, relay lag, consumer lag, retries
+- An Express error middleware for tRPC HTTP layer
+
+Initialise once at process boot — before importing any instrumented module:
+
+```ts
+import { initTracing } from '@saga-ed/soa-observability';
+initTracing({ serviceName: 'programs-api' });
+```
+
+See `decisions/d-observability.md`.
+
+## What NOT to do
+
+- ❌ Import `@saga-ed/soa-pubsub-*` for cross-service events.
+- ❌ Modify a published event schema without bumping the version.
+- ❌ Read cross-service data via HTTP on the request path — go through projections built from events.
+- ❌ Ack a message without writing to `consumed_events` in the same tx.
+- ❌ Use `AbstractTRPCController` / `ControllerLoader` for new event-driven services.
+
+---
+
+*Source decisions:* `~/dev/soa/.claude/projects/soa_75/decisions/`
+*Reference POC:* `~/dev/soa_event_driven_example/`

--- a/packages/node/event-consumer/package.json
+++ b/packages/node/event-consumer/package.json
@@ -1,0 +1,49 @@
+{
+    "name": "@saga-ed/soa-event-consumer",
+    "version": "0.0.1",
+    "private": true,
+    "type": "module",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
+        }
+    },
+    "files": ["dist"],
+    "scripts": {
+        "build": "tsup",
+        "check-types": "tsc --noEmit",
+        "test": "vitest run --passWithNoTests",
+        "lint": "eslint src/",
+        "clean": "rm -rf dist"
+    },
+    "dependencies": {
+        "@saga-ed/soa-event-envelope": "workspace:*",
+        "@saga-ed/soa-logger": "workspace:*",
+        "@saga-ed/soa-rabbitmq": "workspace:*",
+        "@opentelemetry/api": "^1.9.0",
+        "amqplib": "^0.10.4",
+        "pg": "^8.13.0",
+        "zod": "3.25.67"
+    },
+    "devDependencies": {
+        "@saga-ed/soa-typescript-config": "workspace:*",
+        "@types/amqplib": "^0.10.4",
+        "@types/node": "^24.0.3",
+        "@types/pg": "^8.11.10",
+        "tsup": "^8.5.0",
+        "typescript": "5.8.2",
+        "vitest": "^1.6.1"
+    },
+    "publishConfig": {
+        "registry": "https://saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/",
+        "access": "public"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/saga-ed/soa.git",
+        "directory": "packages/node/event-consumer"
+    }
+}

--- a/packages/node/event-consumer/src/consumer.ts
+++ b/packages/node/event-consumer/src/consumer.ts
@@ -1,0 +1,313 @@
+import type { Channel } from 'amqplib';
+import type { Pool, PoolClient } from 'pg';
+import type { ZodType } from 'zod';
+import type { ILogger } from '@saga-ed/soa-logger';
+import type { ConnectionManager } from '@saga-ed/soa-rabbitmq';
+import {
+    SpanKind,
+    SpanStatusCode,
+    context,
+    propagation,
+    trace,
+} from '@opentelemetry/api';
+import { EventEnvelopeSchema, type EventEnvelope } from '@saga-ed/soa-event-envelope';
+
+export class ConsumerVersionMismatchError extends Error {
+    constructor(public readonly key: string) {
+        super(`No handler registered for event key "${key}"`);
+        this.name = 'ConsumerVersionMismatchError';
+    }
+}
+
+export interface EventHandler<T> {
+    /** "<eventType>.v<eventVersion>" — must match envelope's lookup key. */
+    key: string;
+    payloadSchema: ZodType<T>;
+    /**
+     * Run the projection / side effect within the supplied tx-scoped client.
+     * The consumer guarantees: (a) the consumed_events row was just inserted,
+     * (b) the handler runs in the same tx, (c) errors will roll back the
+     * idempotency row alongside the projection.
+     */
+    handle: (
+        envelope: EventEnvelope,
+        payload: T,
+        tx: PoolClient,
+    ) => Promise<void>;
+}
+
+export interface EventConsumerBinding {
+    /** Topic exchange to bind from (e.g., "identity.events"). */
+    exchange: string;
+    /** Routing-key pattern (e.g., "identity.user.*" or "#"). */
+    routingKey: string;
+}
+
+export interface DlqConfig {
+    /**
+     * Dead-letter exchange name. The main queue is declared with
+     * `x-dead-letter-exchange = exchange` so RabbitMQ routes nacked-with-
+     * noRequeue messages here automatically.
+     */
+    exchange: string;
+    /** Durable DLQ queue name; bound to `exchange` with routing key `#`. */
+    queue: string;
+}
+
+export interface ConsumerMetrics {
+    /** Called after a handler successfully completes. */
+    onProcessed: (eventType: string, eventVersion: number) => void;
+    /** Called when handler/parsing throws. `reason` is err.message. */
+    onFailed: (eventType: string, eventVersion: number, reason: string) => void;
+    /** Called for events skipped as duplicates (idempotency hit). */
+    onDuplicate: (eventType: string, eventVersion: number) => void;
+}
+
+export interface EventConsumerOpts {
+    /** Stable identifier used for the consumed_events idempotency key. */
+    consumerName: string;
+    pool: Pool;
+    connectionManager: ConnectionManager;
+    /** Durable queue name (e.g., "admissions-svc.upstream-events"). */
+    queue: string;
+    /**
+     * One or more `{ exchange, routingKey }` pairs to bind this queue to.
+     * A consumer can fan in events from multiple upstream domains via the
+     * same queue (single handlers map dispatches by `<eventType>.v<version>`).
+     */
+    bindings: EventConsumerBinding[];
+    /** Handlers keyed by "<eventType>.v<eventVersion>". */
+    handlers: Record<string, EventHandler<unknown>>;
+    /** Prefetch count (default 10). */
+    prefetch?: number;
+    /**
+     * Optional dead-letter wiring. When set, the main queue is declared
+     * with `x-dead-letter-exchange` and a sibling DLQ is asserted + bound
+     * to that DLX. On ANY handler error, the message is nacked WITHOUT
+     * requeue (`channel.nack(msg, false, false)`), causing RabbitMQ to
+     * route it to the DLX → DLQ. Phase 3.5 fail-fast model: every error
+     * → DLQ; ops drain via the RabbitMQ management UI (a dedicated
+     * /dlq/replay endpoint is a deferred follow-up).
+     *
+     * Without this option, errors nack-with-requeue (legacy behavior).
+     */
+    dlq?: DlqConfig;
+    /** Optional Prometheus hooks. No-op when undefined. */
+    metrics?: ConsumerMetrics;
+    logger: ILogger;
+}
+
+const tracer = trace.getTracer('@saga-ed/soa-event-consumer');
+
+/**
+ * RabbitMQ consumer that gives at-least-once delivery + idempotent processing.
+ *
+ * On each message:
+ *   1. Parse envelope (Zod-validate the wire shape).
+ *   2. Look up handler by "<eventType>.v<eventVersion>"; missing → throw.
+ *   3. BEGIN; INSERT consumed_events ON CONFLICT DO NOTHING.
+ *   4. If 0 rows inserted → already processed; COMMIT and ack.
+ *   5. Else: validate payload, run handler within the tx, COMMIT, ack.
+ *   6. On error: ROLLBACK, nack — to DLQ if configured, requeue otherwise.
+ */
+export class EventConsumer {
+    private channel: Channel | null = null;
+    private consumerTag: string | null = null;
+
+    constructor(private readonly opts: EventConsumerOpts) {}
+
+    async start(): Promise<void> {
+        this.channel = await this.opts.connectionManager.newChannel();
+        await this.channel.prefetch(this.opts.prefetch ?? 10);
+
+        // Wire DLQ first if configured — must be declared before the main queue
+        // so the main queue's x-dead-letter-exchange resolves.
+        if (this.opts.dlq) {
+            await this.channel.assertExchange(this.opts.dlq.exchange, 'topic', {
+                durable: true,
+            });
+            await this.channel.assertQueue(this.opts.dlq.queue, { durable: true });
+            await this.channel.bindQueue(
+                this.opts.dlq.queue,
+                this.opts.dlq.exchange,
+                '#',
+            );
+        }
+
+        await this.channel.assertQueue(this.opts.queue, {
+            durable: true,
+            ...(this.opts.dlq
+                ? { arguments: { 'x-dead-letter-exchange': this.opts.dlq.exchange } }
+                : {}),
+        });
+
+        for (const binding of this.opts.bindings) {
+            await this.channel.assertExchange(binding.exchange, 'topic', {
+                durable: true,
+            });
+            await this.channel.bindQueue(
+                this.opts.queue,
+                binding.exchange,
+                binding.routingKey,
+            );
+        }
+
+        const useDlq = Boolean(this.opts.dlq);
+        const consumeRes = await this.channel.consume(
+            this.opts.queue,
+            (msg) => {
+                if (!msg) return;
+                void this.handleMessage(msg.content)
+                    .then(() => this.channel?.ack(msg))
+                    .catch((err) => {
+                        this.opts.logger.error(
+                            `[EventConsumer:${this.opts.consumerName}] handler error → ${useDlq ? 'DLQ' : 'requeue'}`,
+                            err instanceof Error ? err : undefined,
+                        );
+                        // useDlq: nack-without-requeue → DLX routes to DLQ.
+                        // Otherwise: nack-with-requeue (legacy behavior).
+                        this.channel?.nack(msg, false, !useDlq);
+                    });
+            },
+            { noAck: false },
+        );
+
+        this.consumerTag = consumeRes.consumerTag;
+        this.opts.logger.info(
+            `[EventConsumer:${this.opts.consumerName}] started (queue=${this.opts.queue})`,
+        );
+    }
+
+    async stop(): Promise<void> {
+        if (this.channel && this.consumerTag) {
+            try {
+                await this.channel.cancel(this.consumerTag);
+            } catch {
+                // already cancelled
+            }
+            this.consumerTag = null;
+        }
+        if (this.channel) {
+            try {
+                await this.channel.close();
+            } catch {
+                // already closed
+            }
+            this.channel = null;
+        }
+        this.opts.logger.info(`[EventConsumer:${this.opts.consumerName}] stopped`);
+    }
+
+    private async handleMessage(buffer: Buffer): Promise<void> {
+        let envelope: EventEnvelope;
+        try {
+            const raw = JSON.parse(buffer.toString('utf8')) as unknown;
+            envelope = EventEnvelopeSchema.parse(raw);
+        } catch (err) {
+            // Malformed envelope: surface as error so DLQ can quarantine it.
+            // No metrics call here — eventType/version unknown.
+            throw new Error(
+                `Malformed envelope: ${err instanceof Error ? err.message : String(err)}`,
+            );
+        }
+
+        const parentCtx = envelope.meta
+            ? propagation.extract(
+                  context.active(),
+                  envelope.meta as Record<string, string>,
+              )
+            : context.active();
+
+        await context.with(parentCtx, async () => {
+            const span = tracer.startSpan(
+                `consume ${envelope.eventType}.v${envelope.eventVersion}`,
+                {
+                    kind: SpanKind.CONSUMER,
+                    attributes: {
+                        'messaging.system': 'rabbitmq',
+                        'messaging.destination': this.opts.queue,
+                        'messaging.operation': 'process',
+                        'event.id': envelope.eventId,
+                        'event.type': envelope.eventType,
+                        'event.version': envelope.eventVersion,
+                        'event.aggregate_type': envelope.aggregateType,
+                        'event.aggregate_id': envelope.aggregateId,
+                        'consumer.name': this.opts.consumerName,
+                    },
+                },
+            );
+
+            try {
+                await context.with(
+                    trace.setSpan(context.active(), span),
+                    () => this.processEnvelope(envelope),
+                );
+                span.setStatus({ code: SpanStatusCode.OK });
+                this.opts.metrics?.onProcessed(
+                    envelope.eventType,
+                    envelope.eventVersion,
+                );
+            } catch (err) {
+                const reason = err instanceof Error ? err.message : String(err);
+                span.recordException(err instanceof Error ? err : new Error(reason));
+                span.setStatus({ code: SpanStatusCode.ERROR, message: reason });
+                this.opts.metrics?.onFailed(
+                    envelope.eventType,
+                    envelope.eventVersion,
+                    reason,
+                );
+                throw err;
+            } finally {
+                span.end();
+            }
+        });
+    }
+
+    private async processEnvelope(envelope: EventEnvelope): Promise<void> {
+        const key = `${envelope.eventType}.v${envelope.eventVersion}`;
+        const handler = this.opts.handlers[key];
+        if (!handler) {
+            throw new ConsumerVersionMismatchError(key);
+        }
+
+        const payload = handler.payloadSchema.parse(envelope.payload);
+
+        const client = await this.opts.pool.connect();
+        try {
+            await client.query('BEGIN');
+
+            const insertResult = await client.query<{ event_id: string }>(
+                `INSERT INTO consumed_events (consumer_name, event_id)
+                 VALUES ($1, $2)
+                 ON CONFLICT (consumer_name, event_id) DO NOTHING
+                 RETURNING event_id`,
+                [this.opts.consumerName, envelope.eventId],
+            );
+
+            if (insertResult.rowCount === 0) {
+                // Duplicate delivery — already processed.
+                await client.query('COMMIT');
+                this.opts.logger.info(
+                    `[EventConsumer:${this.opts.consumerName}] skip duplicate ${envelope.eventId}`,
+                );
+                this.opts.metrics?.onDuplicate(
+                    envelope.eventType,
+                    envelope.eventVersion,
+                );
+                return;
+            }
+
+            await handler.handle(envelope, payload as never, client);
+            await client.query('COMMIT');
+        } catch (err) {
+            try {
+                await client.query('ROLLBACK');
+            } catch {
+                // ignore rollback failures
+            }
+            throw err;
+        } finally {
+            client.release();
+        }
+    }
+}

--- a/packages/node/event-consumer/src/index.ts
+++ b/packages/node/event-consumer/src/index.ts
@@ -1,0 +1,10 @@
+export { CONSUMED_EVENTS_SQL, PRISMA_MODEL_FRAGMENT } from './schema.js';
+export {
+    EventConsumer,
+    ConsumerVersionMismatchError,
+    type EventConsumerOpts,
+    type EventConsumerBinding,
+    type DlqConfig,
+    type EventHandler,
+    type ConsumerMetrics,
+} from './consumer.js';

--- a/packages/node/event-consumer/src/schema.ts
+++ b/packages/node/event-consumer/src/schema.ts
@@ -1,0 +1,29 @@
+// Canonical SQL for the consumed_events table. Per-consumer idempotency:
+// `INSERT ... ON CONFLICT DO NOTHING RETURNING event_id` returns 0 rows
+// if we've already processed this (consumer_name, event_id), so the handler
+// is skipped. Combined with publisher confirms + RabbitMQ persistence, this
+// gives at-least-once delivery + exactly-once semantics on the projection.
+
+export const CONSUMED_EVENTS_SQL = `
+CREATE TABLE IF NOT EXISTS consumed_events (
+    consumer_name  TEXT NOT NULL,
+    event_id       UUID NOT NULL,
+    processed_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (consumer_name, event_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_consumed_events_processed_at
+    ON consumed_events (processed_at);
+`.trim();
+
+export const PRISMA_MODEL_FRAGMENT = `
+model ConsumedEvent {
+    consumerName String   @map("consumer_name")
+    eventId      String   @map("event_id") @db.Uuid
+    processedAt  DateTime @default(now()) @map("processed_at") @db.Timestamptz(6)
+
+    @@id([consumerName, eventId])
+    @@map("consumed_events")
+    @@index([processedAt])
+}
+`.trim();

--- a/packages/node/event-consumer/tsconfig.json
+++ b/packages/node/event-consumer/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "@saga-ed/soa-typescript-config/base.json",
+    "compilerOptions": {
+        "outDir": "./dist",
+        "rootDir": "./src",
+        "noEmit": false
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/node/event-consumer/tsup.config.ts
+++ b/packages/node/event-consumer/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+    entry: ['src/index.ts'],
+    format: ['esm'],
+    dts: true,
+    clean: true,
+    sourcemap: true,
+});

--- a/packages/node/event-envelope/package.json
+++ b/packages/node/event-envelope/package.json
@@ -1,0 +1,42 @@
+{
+    "name": "@saga-ed/soa-event-envelope",
+    "version": "0.0.1",
+    "private": true,
+    "type": "module",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
+        }
+    },
+    "files": ["dist"],
+    "scripts": {
+        "build": "tsup",
+        "check-types": "tsc --noEmit",
+        "test": "vitest run --passWithNoTests",
+        "lint": "eslint src/",
+        "clean": "rm -rf dist"
+    },
+    "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "zod": "3.25.67"
+    },
+    "devDependencies": {
+        "@saga-ed/soa-typescript-config": "workspace:*",
+        "@types/node": "^24.0.3",
+        "tsup": "^8.5.0",
+        "typescript": "5.8.2",
+        "vitest": "^1.6.1"
+    },
+    "publishConfig": {
+        "registry": "https://saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/",
+        "access": "public"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/saga-ed/soa.git",
+        "directory": "packages/node/event-envelope"
+    }
+}

--- a/packages/node/event-envelope/src/__tests__/envelope.unit.test.ts
+++ b/packages/node/event-envelope/src/__tests__/envelope.unit.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import {
+    EventEnvelopeMetaSchema,
+    EventEnvelopeSchema,
+    buildEnvelope,
+} from '../index.js';
+
+describe('EventEnvelopeSchema', () => {
+    it('validates a minimal envelope', () => {
+        const env = buildEnvelope({
+            eventType: 'identity.user.created',
+            eventVersion: 1,
+            aggregateType: 'user',
+            aggregateId: '00000000-0000-4000-8000-000000000001',
+            payload: { userId: 'u1' },
+        });
+        expect(env.eventType).toBe('identity.user.created');
+        expect(env.eventVersion).toBe(1);
+        expect(env.payload).toEqual({ userId: 'u1' });
+    });
+
+    it('rejects non-positive version', () => {
+        const result = EventEnvelopeSchema.safeParse({
+            eventId: '00000000-0000-4000-8000-000000000001',
+            eventType: 'foo',
+            eventVersion: 0,
+            aggregateType: 'thing',
+            aggregateId: 'a',
+            occurredAt: new Date().toISOString(),
+            payload: {},
+        });
+        expect(result.success).toBe(false);
+    });
+
+    it('rejects empty eventType', () => {
+        const result = EventEnvelopeSchema.safeParse({
+            eventId: '00000000-0000-4000-8000-000000000001',
+            eventType: '',
+            eventVersion: 1,
+            aggregateType: 'thing',
+            aggregateId: 'a',
+            occurredAt: new Date().toISOString(),
+            payload: {},
+        });
+        expect(result.success).toBe(false);
+    });
+
+    it('strips unknown top-level fields (forward compat)', () => {
+        const env = EventEnvelopeSchema.parse({
+            eventId: '00000000-0000-4000-8000-000000000001',
+            eventType: 'foo',
+            eventVersion: 1,
+            aggregateType: 'thing',
+            aggregateId: 'a',
+            occurredAt: new Date().toISOString(),
+            payload: {},
+            futureField: 'should be stripped',
+        });
+        expect((env as Record<string, unknown>).futureField).toBeUndefined();
+    });
+});
+
+describe('EventEnvelopeMetaSchema', () => {
+    it('accepts traceparent + tracestate together', () => {
+        const result = EventEnvelopeMetaSchema.safeParse({
+            traceparent: '00-aaaa-bbbb-01',
+            tracestate: 'rojo=00f067aa0ba902b7',
+        });
+        expect(result.success).toBe(true);
+    });
+
+    it('accepts traceparent alone', () => {
+        const result = EventEnvelopeMetaSchema.safeParse({
+            traceparent: '00-aaaa-bbbb-01',
+        });
+        expect(result.success).toBe(true);
+    });
+
+    it('rejects orphan tracestate (W3C invariant)', () => {
+        const result = EventEnvelopeMetaSchema.safeParse({
+            tracestate: 'rojo=00f067aa0ba902b7',
+        });
+        expect(result.success).toBe(false);
+    });
+
+    it('accepts empty meta', () => {
+        const result = EventEnvelopeMetaSchema.safeParse({});
+        expect(result.success).toBe(true);
+    });
+});

--- a/packages/node/event-envelope/src/index.ts
+++ b/packages/node/event-envelope/src/index.ts
@@ -1,0 +1,85 @@
+import { randomUUID } from 'node:crypto';
+import { context, propagation } from '@opentelemetry/api';
+import { z } from 'zod';
+
+// W3C TraceContext requires that `tracestate` only ride along with a
+// `traceparent`. The refine catches an orphan `tracestate` at parse time
+// rather than letting OTel's propagator silently discard it (which would
+// look like trace continuity bug instead of a malformed envelope).
+export const EventEnvelopeMetaSchema = z
+    .object({
+        traceparent: z.string().optional(),
+        tracestate: z.string().optional(),
+        correlationId: z.string().optional(),
+        causationId: z.string().optional(),
+    })
+    .strip()
+    .refine((m) => !(m.tracestate && !m.traceparent), {
+        message: 'tracestate requires traceparent (W3C TraceContext)',
+        path: ['tracestate'],
+    });
+
+export type EventEnvelopeMeta = z.infer<typeof EventEnvelopeMetaSchema>;
+
+// Per D5, the envelope shape itself is treated as v1: any change
+// requires coordinated migration across all publishers and consumers.
+export const EventEnvelopeSchema = z
+    .object({
+        eventId: z.string().uuid(),
+        eventType: z.string().min(1),
+        eventVersion: z.number().int().positive(),
+        aggregateType: z.string().min(1),
+        aggregateId: z.string().min(1),
+        occurredAt: z.string().datetime({ offset: true }),
+        payload: z.record(z.unknown()),
+        meta: EventEnvelopeMetaSchema.optional(),
+    })
+    .strip();
+
+export type EventEnvelope = z.infer<typeof EventEnvelopeSchema>;
+
+export interface PayloadDescriptor<T> {
+    eventType: string;
+    eventVersion: number;
+    payloadSchema: z.ZodType<T>;
+}
+
+/**
+ * Build an envelope and snapshot the active OTel trace context into
+ * `meta.traceparent`/`meta.tracestate` so the relay-published message
+ * carries enough W3C TraceContext for the consumer to chain its CONSUMER
+ * span under the original request span.
+ *
+ * If no SDK is registered (e.g., in tests without tracing), `propagation.inject`
+ * is a no-op — `meta` simply stays empty and tracing degrades gracefully.
+ *
+ * Callers can pass `meta` explicitly to override (e.g., to inject a
+ * cross-system traceparent received over HTTP).
+ */
+export function buildEnvelope<T extends Record<string, unknown>>(args: {
+    eventType: string;
+    eventVersion: number;
+    aggregateType: string;
+    aggregateId: string;
+    payload: T;
+    meta?: EventEnvelopeMeta;
+    occurredAt?: Date;
+    eventId?: string;
+}): EventEnvelope {
+    const carrier: Record<string, string> = {};
+    propagation.inject(context.active(), carrier);
+
+    const mergedMeta: EventEnvelopeMeta = { ...carrier, ...(args.meta ?? {}) };
+    const meta = Object.keys(mergedMeta).length > 0 ? mergedMeta : undefined;
+
+    return EventEnvelopeSchema.parse({
+        eventId: args.eventId ?? randomUUID(),
+        eventType: args.eventType,
+        eventVersion: args.eventVersion,
+        aggregateType: args.aggregateType,
+        aggregateId: args.aggregateId,
+        occurredAt: (args.occurredAt ?? new Date()).toISOString(),
+        payload: args.payload,
+        meta,
+    });
+}

--- a/packages/node/event-envelope/tsconfig.json
+++ b/packages/node/event-envelope/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "@saga-ed/soa-typescript-config/base.json",
+    "compilerOptions": {
+        "outDir": "./dist",
+        "rootDir": "./src",
+        "noEmit": false
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/node/event-envelope/tsup.config.ts
+++ b/packages/node/event-envelope/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+    entry: ['src/index.ts'],
+    format: ['esm'],
+    dts: true,
+    clean: true,
+    sourcemap: true,
+});

--- a/packages/node/event-envelope/vitest.config.ts
+++ b/packages/node/event-envelope/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        environment: 'node',
+        include: ['src/**/__tests__/**/*.test.ts', 'src/**/*.test.ts'],
+        exclude: ['**/node_modules/**', '**/*.int.test.ts'],
+    },
+});

--- a/packages/node/event-integration-tests/package.json
+++ b/packages/node/event-integration-tests/package.json
@@ -1,0 +1,26 @@
+{
+    "name": "@saga-ed/soa-event-integration-tests",
+    "version": "0.0.1",
+    "private": true,
+    "type": "module",
+    "scripts": {
+        "test": "vitest run --passWithNoTests",
+        "test:int": "vitest run --config vitest.int.config.ts",
+        "check-types": "tsc --noEmit",
+        "lint": "eslint src/",
+        "clean": "rm -rf dist"
+    },
+    "dependencies": {
+        "@saga-ed/soa-event-test-harness": "workspace:*",
+        "amqplib": "^0.10.4",
+        "pg": "^8.13.0"
+    },
+    "devDependencies": {
+        "@saga-ed/soa-typescript-config": "workspace:*",
+        "@types/amqplib": "^0.10.4",
+        "@types/node": "^24.0.3",
+        "@types/pg": "^8.11.10",
+        "typescript": "5.8.2",
+        "vitest": "^1.6.1"
+    }
+}

--- a/packages/node/event-integration-tests/src/__tests__/cross-service-user-enrollment.int.test.ts
+++ b/packages/node/event-integration-tests/src/__tests__/cross-service-user-enrollment.int.test.ts
@@ -1,0 +1,206 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { startInfra, type InfraHandle } from '@saga-ed/soa-event-test-harness';
+import {
+    ADMISSIONS_SVC,
+    IDENTITY_SVC,
+    migrate,
+    spawnService,
+    type SpawnedService,
+} from '../lib/services.js';
+import { pollUntil, waitForReady } from '../lib/wait.js';
+import { trpcMutate, trpcQuery } from '../lib/trpc-fetch.js';
+
+const here = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(here, '../../../../..');
+const CATALOG_SVC = resolve(REPO_ROOT, 'apps/catalog-svc');
+
+interface CreatedUser {
+    id: string;
+    name: string;
+    email: string;
+    createdAt: string;
+}
+interface CreatedGroup {
+    id: string;
+    name: string;
+    parentGroupId: string | null;
+    createdAt: string;
+}
+interface CreatedProgram {
+    id: string;
+    name: string;
+    schoolGroupId: string;
+    createdAt: string;
+}
+interface CreatedPeriod {
+    id: string;
+    programId: string;
+    name: string;
+    sectionGroupId: string;
+    createdAt: string;
+}
+interface AttendanceRow {
+    id: string;
+    userId: string;
+    programId: string;
+    periodId: string;
+    date: string;
+    status: string;
+    recordedAt: string;
+    recordedByUserId: string;
+}
+
+describe('cross-service user enrollment (Phase 2 full triplet)', () => {
+    let infra: InfraHandle;
+    let identity: SpawnedService;
+    let catalog: SpawnedService;
+    let admissions: SpawnedService;
+
+    beforeAll(async () => {
+        infra = await startInfra();
+
+        const identityDbUrl = await infra.createDatabase('identity_test');
+        const catalogDbUrl = await infra.createDatabase('catalog_test');
+        const admissionsDbUrl = await infra.createDatabase('admissions_test');
+
+        migrate(IDENTITY_SVC, identityDbUrl);
+        migrate(CATALOG_SVC, catalogDbUrl);
+        migrate(ADMISSIONS_SVC, admissionsDbUrl);
+
+        identity = spawnService({
+            serviceDir: IDENTITY_SVC,
+            port: 4001,
+            env: {
+                NODE_ENV: 'test',
+                LOG_LEVEL: 'warn',
+                DATABASE_URL: identityDbUrl,
+                RABBITMQ_URL: infra.rabbitmqUrl,
+                EVENTS_EXCHANGE: 'identity.events',
+            },
+        });
+        catalog = spawnService({
+            serviceDir: CATALOG_SVC,
+            port: 4002,
+            env: {
+                NODE_ENV: 'test',
+                LOG_LEVEL: 'warn',
+                DATABASE_URL: catalogDbUrl,
+                RABBITMQ_URL: infra.rabbitmqUrl,
+                EVENTS_EXCHANGE: 'catalog.events',
+            },
+        });
+        admissions = spawnService({
+            serviceDir: ADMISSIONS_SVC,
+            port: 4003,
+            env: {
+                NODE_ENV: 'test',
+                LOG_LEVEL: 'warn',
+                DATABASE_URL: admissionsDbUrl,
+                RABBITMQ_URL: infra.rabbitmqUrl,
+                IDENTITY_EVENTS_EXCHANGE: 'identity.events',
+                CATALOG_EVENTS_EXCHANGE: 'catalog.events',
+                UPSTREAM_EVENTS_QUEUE: 'admissions-svc.upstream-events.test',
+                EVENTS_EXCHANGE: 'admissions.events',
+            },
+        });
+
+        await Promise.all([
+            waitForReady(identity.baseUrl),
+            waitForReady(catalog.baseUrl),
+            waitForReady(admissions.baseUrl),
+        ]);
+    }, 120_000);
+
+    afterAll(async () => {
+        await Promise.allSettled([
+            identity?.stop(),
+            catalog?.stop(),
+            admissions?.stop(),
+        ]);
+        await infra?.stop();
+    });
+
+    it('drives the full triplet flow with eventual-consistency UX', async () => {
+        // 1. Create user
+        const user = await trpcMutate<CreatedUser>(identity.baseUrl, 'users.create', {
+            name: 'Ada Lovelace',
+            email: 'ada@example.com',
+        });
+
+        // 2. Create school group + add user
+        const schoolGroup = await trpcMutate<CreatedGroup>(
+            identity.baseUrl,
+            'groups.create',
+            { name: 'Saga School', parentGroupId: null },
+        );
+        await trpcMutate(identity.baseUrl, 'groups.addMember', {
+            groupId: schoolGroup.id,
+            userId: user.id,
+        });
+
+        // 3. Create program (references school group)
+        const program = await trpcMutate<CreatedProgram>(
+            catalog.baseUrl,
+            'programs.create',
+            { name: 'Algebra', schoolGroupId: schoolGroup.id },
+        );
+
+        // 4. Create section group + period
+        const sectionGroup = await trpcMutate<CreatedGroup>(
+            identity.baseUrl,
+            'groups.create',
+            { name: 'Section A', parentGroupId: schoolGroup.id },
+        );
+        const period = await trpcMutate<CreatedPeriod>(
+            catalog.baseUrl,
+            'periods.create',
+            {
+                programId: program.id,
+                name: 'Period 1',
+                sectionGroupId: sectionGroup.id,
+            },
+        );
+
+        // 5. Eventual-consistency UX: poll /enrollment-readiness
+        // Initially admissions-svc may not have processed the user/group/program
+        // events yet — endpoint returns 202 + Retry-After. We poll until 200.
+        const readinessRes = await pollUntil(
+            () =>
+                fetch(
+                    `${admissions.baseUrl}/enrollment-readiness?userId=${user.id}&programId=${program.id}`,
+                ),
+            (r) => r.status === 200,
+            { timeoutMs: 10_000, intervalMs: 100 },
+        );
+        const readinessBody = (await readinessRes.json()) as { ready: boolean };
+        expect(readinessBody.ready).toBe(true);
+
+        // 6. Record attendance
+        const today = new Date().toISOString().slice(0, 10);
+        const attendanceRow = await trpcMutate<AttendanceRow>(
+            admissions.baseUrl,
+            'attendance.record',
+            {
+                userId: user.id,
+                programId: program.id,
+                periodId: period.id,
+                date: today,
+                status: 'present',
+                recordedByUserId: user.id,
+            },
+        );
+        expect(attendanceRow.userId).toBe(user.id);
+        expect(attendanceRow.status).toBe('present');
+
+        // 7. Read attendance back
+        const rows = await trpcQuery<AttendanceRow[]>(
+            admissions.baseUrl,
+            'attendance.listByPeriodAndDate',
+            { periodId: period.id, date: today },
+        );
+        expect(rows).toHaveLength(1);
+        expect(rows[0]?.id).toBe(attendanceRow.id);
+    });
+});

--- a/packages/node/event-integration-tests/src/__tests__/cross-service-user-projection.int.test.ts
+++ b/packages/node/event-integration-tests/src/__tests__/cross-service-user-projection.int.test.ts
@@ -1,0 +1,128 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { startInfra, type InfraHandle } from '@saga-ed/soa-event-test-harness';
+import {
+    ADMISSIONS_SVC,
+    IDENTITY_SVC,
+    migrate,
+    spawnService,
+    type SpawnedService,
+} from '../lib/services.js';
+import { pollUntil, waitForReady } from '../lib/wait.js';
+import { trpcMutate, trpcQuery } from '../lib/trpc-fetch.js';
+
+interface CreatedUser {
+    id: string;
+    name: string;
+    email: string;
+    createdAt: string;
+}
+
+interface UserProjection {
+    userId: string;
+    name: string;
+    email: string;
+    createdAt: string;
+    updatedAt: string;
+}
+
+describe('cross-service user projection (integration)', () => {
+    let infra: InfraHandle;
+    let identity: SpawnedService;
+    let admissions: SpawnedService;
+
+    beforeAll(async () => {
+        infra = await startInfra();
+
+        const identityDbUrl = await infra.createDatabase('identity_test');
+        const admissionsDbUrl = await infra.createDatabase('admissions_test');
+
+        migrate(IDENTITY_SVC, identityDbUrl);
+        migrate(ADMISSIONS_SVC, admissionsDbUrl);
+
+        identity = spawnService({
+            serviceDir: IDENTITY_SVC,
+            port: 4001,
+            env: {
+                NODE_ENV: 'test',
+                LOG_LEVEL: 'warn',
+                DATABASE_URL: identityDbUrl,
+                RABBITMQ_URL: infra.rabbitmqUrl,
+                EVENTS_EXCHANGE: 'identity.events',
+            },
+        });
+        admissions = spawnService({
+            serviceDir: ADMISSIONS_SVC,
+            port: 4003,
+            env: {
+                NODE_ENV: 'test',
+                LOG_LEVEL: 'warn',
+                DATABASE_URL: admissionsDbUrl,
+                RABBITMQ_URL: infra.rabbitmqUrl,
+                IDENTITY_EVENTS_EXCHANGE: 'identity.events',
+                IDENTITY_EVENTS_QUEUE: 'admissions-svc.identity-events.test',
+            },
+        });
+
+        await Promise.all([waitForReady(identity.baseUrl), waitForReady(admissions.baseUrl)]);
+    }, 120_000);
+
+    afterAll(async () => {
+        await Promise.allSettled([identity?.stop(), admissions?.stop()]);
+        await infra?.stop();
+    });
+
+    it('projects identity.user.created.v1 from identity-svc to admissions-svc', async () => {
+        // 1. Create a user via identity-svc
+        const created = await trpcMutate<CreatedUser>(identity.baseUrl, 'users.create', {
+            name: 'Ada Lovelace',
+            email: 'ada@example.com',
+        });
+        expect(created.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+        expect(created.email).toBe('ada@example.com');
+
+        // 2. Poll admissions-svc projection until the consumer has applied
+        // the event. Latency budget: 5s (publish + consume + project).
+        const projection = await pollUntil<UserProjection>(
+            () =>
+                trpcQuery<UserProjection>(
+                    admissions.baseUrl,
+                    'userProjection.getById',
+                    { userId: created.id },
+                ),
+            (p) => p.userId === created.id,
+            { timeoutMs: 5_000, intervalMs: 100 },
+        );
+
+        // 3. Assert the projection matches the source
+        expect(projection.userId).toBe(created.id);
+        expect(projection.name).toBe('Ada Lovelace');
+        expect(projection.email).toBe('ada@example.com');
+        expect(projection.createdAt).toBe(created.createdAt);
+    });
+
+    it('does not duplicate the projection on duplicate event delivery', async () => {
+        // The consumed_events table guarantees idempotency — even if the
+        // broker redelivers the same eventId, the handler runs once.
+        // We simulate this by creating two distinct users; the second
+        // should produce a separate projection row, not collide.
+        const a = await trpcMutate<CreatedUser>(identity.baseUrl, 'users.create', {
+            name: 'Grace Hopper',
+            email: 'grace@example.com',
+        });
+        const b = await trpcMutate<CreatedUser>(identity.baseUrl, 'users.create', {
+            name: 'Margaret Hamilton',
+            email: 'margaret@example.com',
+        });
+
+        await pollUntil<UserProjection>(
+            () => trpcQuery<UserProjection>(admissions.baseUrl, 'userProjection.getById', { userId: a.id }),
+            (p) => p.userId === a.id,
+            { timeoutMs: 5_000 },
+        );
+        await pollUntil<UserProjection>(
+            () => trpcQuery<UserProjection>(admissions.baseUrl, 'userProjection.getById', { userId: b.id }),
+            (p) => p.userId === b.id,
+            { timeoutMs: 5_000 },
+        );
+    });
+});

--- a/packages/node/event-integration-tests/src/__tests__/idempotency-key.int.test.ts
+++ b/packages/node/event-integration-tests/src/__tests__/idempotency-key.int.test.ts
@@ -1,0 +1,143 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { startInfra, type InfraHandle } from '@saga-ed/soa-event-test-harness';
+import {
+    IDENTITY_SVC,
+    migrate,
+    spawnService,
+    type SpawnedService,
+} from '../lib/services.js';
+import { waitForReady } from '../lib/wait.js';
+
+interface CreatedUser {
+    id: string;
+    name: string;
+    email: string;
+    createdAt: string;
+}
+
+interface TrpcResult<T> {
+    result: { data: T };
+}
+
+describe('publisher-edge idempotency (Idempotency-Key)', () => {
+    let infra: InfraHandle;
+    let identity: SpawnedService;
+
+    beforeAll(async () => {
+        infra = await startInfra();
+        const dbUrl = await infra.createDatabase('identity_idempotency_test');
+        migrate(IDENTITY_SVC, dbUrl);
+
+        identity = spawnService({
+            serviceDir: IDENTITY_SVC,
+            port: 4011,
+            env: {
+                NODE_ENV: 'test',
+                LOG_LEVEL: 'warn',
+                DATABASE_URL: dbUrl,
+                RABBITMQ_URL: infra.rabbitmqUrl,
+                EVENTS_EXCHANGE: 'identity.events.idempotency-test',
+            },
+        });
+        await waitForReady(identity.baseUrl);
+    }, 120_000);
+
+    afterAll(async () => {
+        await identity?.stop();
+        await infra?.stop();
+    });
+
+    it('returns cached response for duplicate Idempotency-Key', async () => {
+        const key = 'idem-' + Date.now() + '-' + Math.random();
+        const input = { name: 'Ada Lovelace', email: `ada-${Date.now()}@example.com` };
+
+        const first = await fetch(`${identity.baseUrl}/trpc/users.create`, {
+            method: 'POST',
+            headers: {
+                'content-type': 'application/json',
+                'idempotency-key': key,
+            },
+            body: JSON.stringify(input),
+        });
+        expect(first.ok).toBe(true);
+        const firstBody = (await first.json()) as TrpcResult<CreatedUser>;
+        const firstUserId = firstBody.result.data.id;
+        expect(firstUserId).toBeTruthy();
+
+        // Second request with SAME key but DIFFERENT email — should return the
+        // cached response from the first call (same userId, same email).
+        // The body input is ignored for cached responses.
+        const second = await fetch(`${identity.baseUrl}/trpc/users.create`, {
+            method: 'POST',
+            headers: {
+                'content-type': 'application/json',
+                'idempotency-key': key,
+            },
+            body: JSON.stringify({
+                name: 'Different Person',
+                email: `diff-${Date.now()}@example.com`,
+            }),
+        });
+        expect(second.ok).toBe(true);
+        const secondBody = (await second.json()) as TrpcResult<CreatedUser>;
+
+        // Cached response — same userId as first, NOT a new user.
+        expect(secondBody.result.data.id).toBe(firstUserId);
+        expect(secondBody.result.data.email).toBe(input.email);
+        expect(secondBody.result.data.name).toBe(input.name);
+    });
+
+    it('different Idempotency-Keys create distinct users', async () => {
+        const k1 = 'idem-a-' + Date.now();
+        const k2 = 'idem-b-' + Date.now();
+
+        const r1 = await fetch(`${identity.baseUrl}/trpc/users.create`, {
+            method: 'POST',
+            headers: {
+                'content-type': 'application/json',
+                'idempotency-key': k1,
+            },
+            body: JSON.stringify({
+                name: 'A',
+                email: `a-${Date.now()}-${Math.random()}@example.com`,
+            }),
+        });
+        const r2 = await fetch(`${identity.baseUrl}/trpc/users.create`, {
+            method: 'POST',
+            headers: {
+                'content-type': 'application/json',
+                'idempotency-key': k2,
+            },
+            body: JSON.stringify({
+                name: 'B',
+                email: `b-${Date.now()}-${Math.random()}@example.com`,
+            }),
+        });
+        const b1 = (await r1.json()) as TrpcResult<CreatedUser>;
+        const b2 = (await r2.json()) as TrpcResult<CreatedUser>;
+        expect(b1.result.data.id).not.toBe(b2.result.data.id);
+    });
+
+    it('no Idempotency-Key — every request is independent', async () => {
+        const stamp = Date.now();
+        const r1 = await fetch(`${identity.baseUrl}/trpc/users.create`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({
+                name: 'C',
+                email: `c-${stamp}-${Math.random()}@example.com`,
+            }),
+        });
+        const r2 = await fetch(`${identity.baseUrl}/trpc/users.create`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({
+                name: 'D',
+                email: `d-${stamp}-${Math.random()}@example.com`,
+            }),
+        });
+        const b1 = (await r1.json()) as TrpcResult<CreatedUser>;
+        const b2 = (await r2.json()) as TrpcResult<CreatedUser>;
+        expect(b1.result.data.id).not.toBe(b2.result.data.id);
+    });
+});

--- a/packages/node/event-integration-tests/src/__tests__/outbox-meta-roundtrip.int.test.ts
+++ b/packages/node/event-integration-tests/src/__tests__/outbox-meta-roundtrip.int.test.ts
@@ -1,0 +1,194 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import amqplib, { type Channel, type ChannelModel } from 'amqplib';
+import { Pool } from 'pg';
+import { startInfra, type InfraHandle } from '@saga-ed/soa-event-test-harness';
+import {
+    IDENTITY_SVC,
+    migrate,
+    spawnService,
+    type SpawnedService,
+} from '../lib/services.js';
+import { trpcMutate } from '../lib/trpc-fetch.js';
+import { waitForReady } from '../lib/wait.js';
+
+interface CreatedUser {
+    id: string;
+    name: string;
+    email: string;
+    createdAt: string;
+}
+
+interface PublishedMessage {
+    eventId: string;
+    eventType: string;
+    eventVersion: number;
+    aggregateType: string;
+    aggregateId: string;
+    occurredAt: string;
+    payload: Record<string, unknown>;
+    meta?: Record<string, string>;
+}
+
+/**
+ * Verifies that the meta JSONB column added in 20260501033000_add_outbox_meta
+ * round-trips through outbox → relay → broker → consumer:
+ *   1. Real publish has the wire shape we expect (broker message includes
+ *      eventId / payload / etc) — catches relay regressions.
+ *   2. meta INSERT'd into the outbox row is republished verbatim into
+ *      message.meta — catches relay regression OR the meta column being
+ *      dropped from the SELECT.
+ *
+ * This is the regression guard for the trace-context propagation chain
+ * even though the test doesn't itself use OTel — if either of these two
+ * properties breaks, cross-service trace continuity silently fails.
+ */
+describe('outbox meta round-trip (integration)', () => {
+    let infra: InfraHandle;
+    let identity: SpawnedService;
+    let identityDbUrl: string;
+    let mqConn: ChannelModel;
+    let snifferChannel: Channel;
+    const sniffQueue = `test.sniffer.${Date.now()}`;
+
+    beforeAll(async () => {
+        infra = await startInfra();
+        identityDbUrl = await infra.createDatabase('identity_meta_test');
+        migrate(IDENTITY_SVC, identityDbUrl);
+
+        identity = spawnService({
+            serviceDir: IDENTITY_SVC,
+            port: 4011,
+            env: {
+                NODE_ENV: 'test',
+                LOG_LEVEL: 'warn',
+                DATABASE_URL: identityDbUrl,
+                RABBITMQ_URL: infra.rabbitmqUrl,
+                EVENTS_EXCHANGE: 'identity.events',
+            },
+        });
+        await waitForReady(identity.baseUrl);
+
+        // Sniffer queue: ephemeral exclusive queue bound to identity.events
+        // with `#` so we capture every message the relay publishes. The
+        // identity-svc startup already asserted the exchange.
+        mqConn = await amqplib.connect(infra.rabbitmqUrl);
+        snifferChannel = await mqConn.createChannel();
+        await snifferChannel.assertQueue(sniffQueue, {
+            durable: false,
+            autoDelete: true,
+            exclusive: true,
+        });
+        await snifferChannel.bindQueue(sniffQueue, 'identity.events', '#');
+    }, 120_000);
+
+    afterAll(async () => {
+        try {
+            await snifferChannel?.close();
+            await mqConn?.close();
+        } catch {
+            // already closed
+        }
+        await identity?.stop();
+        await infra?.stop();
+    });
+
+    it('publishes the canonical wire shape to the broker', async () => {
+        const created = await trpcMutate<CreatedUser>(identity.baseUrl, 'users.create', {
+            name: 'Wire Test',
+            email: `wire-${Date.now()}@example.com`,
+        });
+
+        const messages = await collectMessages(snifferChannel, sniffQueue, {
+            timeoutMs: 5_000,
+            until: (msgs) =>
+                msgs.some(
+                    (m) => m.eventType === 'identity.user.created' && m.aggregateId === created.id,
+                ),
+        });
+
+        const userCreated = messages.find(
+            (m) => m.eventType === 'identity.user.created' && m.aggregateId === created.id,
+        );
+        expect(userCreated).toBeDefined();
+        expect(userCreated!.eventId).toMatch(/^[0-9a-f-]{36}$/);
+        expect(userCreated!.eventVersion).toBeGreaterThanOrEqual(1);
+        expect(userCreated!.aggregateType).toBe('user');
+        expect(userCreated!.occurredAt).toBeDefined();
+        expect(userCreated!.payload.userId).toBe(created.id);
+        expect(userCreated!.payload.email).toBe(created.email);
+    });
+
+    it('round-trips meta JSONB from outbox row through to broker message', async () => {
+        // Insert a synthetic outbox row with meta — bypassing the publisher
+        // path so we can isolate the relay's read+publish behavior. We use
+        // a valid traceparent format (00-traceid-spanid-flags) so any
+        // future Zod re-validation in the consumer would also accept it.
+        const pool = new Pool({ connectionString: identityDbUrl });
+        const eventId = '00000000-0000-4000-8000-' + Date.now().toString(16).padStart(12, '0');
+        const traceparent = '00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01';
+        try {
+            await pool.query(
+                `INSERT INTO outbox_event (
+                    event_id, aggregate_type, aggregate_id, event_type,
+                    event_version, payload, meta, occurred_at
+                ) VALUES (
+                    $1::uuid, 'user', $2, 'identity.user.created',
+                    1, $3::jsonb, $4::jsonb, NOW()
+                )`,
+                [
+                    eventId,
+                    'meta-roundtrip-' + Date.now(),
+                    JSON.stringify({
+                        userId: 'meta-roundtrip-test',
+                        name: 'Meta Roundtrip',
+                        email: 'meta@example.com',
+                        createdAt: new Date().toISOString(),
+                    }),
+                    JSON.stringify({ traceparent }),
+                ],
+            );
+        } finally {
+            await pool.end();
+        }
+
+        const messages = await collectMessages(snifferChannel, sniffQueue, {
+            timeoutMs: 5_000,
+            until: (msgs) => msgs.some((m) => m.eventId === eventId),
+        });
+
+        const ours = messages.find((m) => m.eventId === eventId);
+        expect(ours).toBeDefined();
+        expect(ours!.meta).toBeDefined();
+        // Note: relay re-injects publish-span context AFTER the row's
+        // traceparent, so message.meta.traceparent is the publish span's
+        // — not byte-equal to the row's — but it's still a valid W3C
+        // traceparent string. Without OTel SDK in this test process,
+        // propagation.inject is a no-op so the original survives.
+        expect(typeof ours!.meta!.traceparent).toBe('string');
+        expect(ours!.meta!.traceparent).toBe(traceparent);
+    });
+});
+
+interface CollectOpts {
+    timeoutMs: number;
+    until: (msgs: PublishedMessage[]) => boolean;
+}
+
+async function collectMessages(
+    channel: Channel,
+    queue: string,
+    opts: CollectOpts,
+): Promise<PublishedMessage[]> {
+    const collected: PublishedMessage[] = [];
+    const deadline = Date.now() + opts.timeoutMs;
+    while (Date.now() < deadline) {
+        const msg = await channel.get(queue, { noAck: true });
+        if (msg) {
+            collected.push(JSON.parse(msg.content.toString('utf8')) as PublishedMessage);
+            if (opts.until(collected)) return collected;
+        } else {
+            await new Promise((r) => setTimeout(r, 50));
+        }
+    }
+    return collected;
+}

--- a/packages/node/event-integration-tests/src/lib/services.ts
+++ b/packages/node/event-integration-tests/src/lib/services.ts
@@ -1,0 +1,77 @@
+import { spawn, execFileSync, type ChildProcess } from 'node:child_process';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = fileURLToPath(import.meta.url);
+// services.ts → lib → src → integration-tests → packages → repo root (5 ups)
+const REPO_ROOT = resolve(here, '../../../../..');
+export const IDENTITY_SVC = resolve(REPO_ROOT, 'apps/identity-svc');
+export const ADMISSIONS_SVC = resolve(REPO_ROOT, 'apps/admissions-svc');
+
+/**
+ * Run `prisma migrate deploy` against a fresh test database to bring it up
+ * to the current schema. Uses the service-local prisma binary (avoids needing
+ * pnpm on PATH inside the test process). Synchronous because vitest's beforeAll
+ * handles awaits.
+ */
+export function migrate(serviceDir: string, databaseUrl: string): void {
+    const prismaBin = resolve(serviceDir, 'node_modules', '.bin', 'prisma');
+    execFileSync(prismaBin, ['migrate', 'deploy'], {
+        cwd: serviceDir,
+        env: { ...process.env, DATABASE_URL: databaseUrl },
+        stdio: 'pipe',
+    });
+}
+
+export interface SpawnedService {
+    proc: ChildProcess;
+    baseUrl: string;
+    stop: () => Promise<void>;
+}
+
+export interface SpawnOpts {
+    serviceDir: string;
+    port: number;
+    env: Record<string, string>;
+}
+
+export function spawnService(opts: SpawnOpts): SpawnedService {
+    const proc = spawn('node', ['dist/main.js'], {
+        cwd: opts.serviceDir,
+        env: {
+            // Default OTel off in tests so spawned services don't spam stderr
+            // about unreachable Jaeger. Per-test env can re-enable if needed.
+            OTEL_TRACES_DISABLED: 'true',
+            ...process.env,
+            ...opts.env,
+            PORT: String(opts.port),
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const baseUrl = `http://localhost:${opts.port}`;
+
+    // Surface logs from the subprocess so test output shows what failed.
+    proc.stdout?.on('data', (data: Buffer) => {
+        process.stdout.write(`[${opts.serviceDir.split('/').pop()}] ${data.toString()}`);
+    });
+    proc.stderr?.on('data', (data: Buffer) => {
+        process.stderr.write(`[${opts.serviceDir.split('/').pop()}:err] ${data.toString()}`);
+    });
+
+    const stop = async (): Promise<void> => {
+        if (proc.exitCode !== null) return;
+        proc.kill('SIGTERM');
+        await new Promise<void>((resolve) => {
+            const t = setTimeout(() => {
+                proc.kill('SIGKILL');
+                resolve();
+            }, 5_000);
+            proc.once('exit', () => {
+                clearTimeout(t);
+                resolve();
+            });
+        });
+    };
+
+    return { proc, baseUrl, stop };
+}

--- a/packages/node/event-integration-tests/src/lib/trpc-fetch.ts
+++ b/packages/node/event-integration-tests/src/lib/trpc-fetch.ts
@@ -1,0 +1,41 @@
+/**
+ * Minimal tRPC HTTP helpers. We avoid pulling in @trpc/client (and the AppRouter
+ * type imports across services) — the wire format is stable enough that hand-rolled
+ * fetches are simpler than configuring a full tRPC client per service.
+ */
+
+export async function trpcMutate<T>(
+    baseUrl: string,
+    procedure: string,
+    input: unknown,
+): Promise<T> {
+    const res = await fetch(`${baseUrl}/trpc/${procedure}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(input),
+    });
+    if (!res.ok) {
+        const body = await res.text();
+        throw new Error(`tRPC mutation ${procedure} failed: ${res.status} ${body}`);
+    }
+    const data = (await res.json()) as { result: { data: T } };
+    return data.result.data;
+}
+
+export async function trpcQuery<T>(
+    baseUrl: string,
+    procedure: string,
+    input?: unknown,
+): Promise<T> {
+    const url = new URL(`${baseUrl}/trpc/${procedure}`);
+    if (input !== undefined) {
+        url.searchParams.set('input', JSON.stringify(input));
+    }
+    const res = await fetch(url);
+    if (!res.ok) {
+        const body = await res.text();
+        throw new Error(`tRPC query ${procedure} failed: ${res.status} ${body}`);
+    }
+    const data = (await res.json()) as { result: { data: T } };
+    return data.result.data;
+}

--- a/packages/node/event-integration-tests/src/lib/wait.ts
+++ b/packages/node/event-integration-tests/src/lib/wait.ts
@@ -1,0 +1,35 @@
+export interface PollOpts {
+    timeoutMs?: number;
+    intervalMs?: number;
+}
+
+export async function pollUntil<T>(
+    fn: () => Promise<T>,
+    predicate: (value: T) => boolean,
+    opts: PollOpts = {},
+): Promise<T> {
+    const timeoutMs = opts.timeoutMs ?? 10_000;
+    const intervalMs = opts.intervalMs ?? 100;
+    const deadline = Date.now() + timeoutMs;
+    let lastError: unknown;
+    while (Date.now() < deadline) {
+        try {
+            const value = await fn();
+            if (predicate(value)) return value;
+        } catch (err) {
+            lastError = err;
+        }
+        await new Promise((r) => setTimeout(r, intervalMs));
+    }
+    throw new Error(
+        `pollUntil timed out after ${timeoutMs}ms${lastError ? ` (last error: ${lastError instanceof Error ? lastError.message : String(lastError)})` : ''}`,
+    );
+}
+
+export async function waitForReady(baseUrl: string, timeoutMs = 30_000): Promise<void> {
+    await pollUntil(
+        () => fetch(`${baseUrl}/health/ready`),
+        (res) => res.ok,
+        { timeoutMs, intervalMs: 200 },
+    );
+}

--- a/packages/node/event-integration-tests/tsconfig.json
+++ b/packages/node/event-integration-tests/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "@saga-ed/soa-typescript-config/base.json",
+    "compilerOptions": {
+        "noEmit": true
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/packages/node/event-integration-tests/vitest.config.ts
+++ b/packages/node/event-integration-tests/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+// Default test run picks up ONLY hermetic tests. The cross-service tests
+// in src/__tests__/*.int.test.ts are run via vitest.int.config.ts so
+// `pnpm test` stays fast and doesn't require Docker.
+export default defineConfig({
+    test: {
+        environment: 'node',
+        include: ['src/**/__tests__/**/*.test.ts'],
+        exclude: ['**/node_modules/**', '**/*.int.test.ts'],
+    },
+});

--- a/packages/node/event-integration-tests/vitest.int.config.ts
+++ b/packages/node/event-integration-tests/vitest.int.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        environment: 'node',
+        include: ['src/__tests__/**/*.int.test.ts'],
+        // Spawning services + spinning up testcontainers takes time.
+        testTimeout: 120_000,
+        hookTimeout: 120_000,
+        fileParallelism: false,
+    },
+});

--- a/packages/node/event-outbox/package.json
+++ b/packages/node/event-outbox/package.json
@@ -1,0 +1,48 @@
+{
+    "name": "@saga-ed/soa-event-outbox",
+    "version": "0.0.1",
+    "private": true,
+    "type": "module",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
+        }
+    },
+    "files": ["dist"],
+    "scripts": {
+        "build": "tsup",
+        "check-types": "tsc --noEmit",
+        "test": "vitest run --passWithNoTests",
+        "lint": "eslint src/",
+        "clean": "rm -rf dist"
+    },
+    "dependencies": {
+        "@saga-ed/soa-event-envelope": "workspace:*",
+        "@saga-ed/soa-logger": "workspace:*",
+        "@saga-ed/soa-rabbitmq": "workspace:*",
+        "@opentelemetry/api": "^1.9.0",
+        "amqplib": "^0.10.4",
+        "pg": "^8.13.0"
+    },
+    "devDependencies": {
+        "@saga-ed/soa-typescript-config": "workspace:*",
+        "@types/amqplib": "^0.10.4",
+        "@types/node": "^24.0.3",
+        "@types/pg": "^8.11.10",
+        "tsup": "^8.5.0",
+        "typescript": "5.8.2",
+        "vitest": "^1.6.1"
+    },
+    "publishConfig": {
+        "registry": "https://saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/",
+        "access": "public"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/saga-ed/soa.git",
+        "directory": "packages/node/event-outbox"
+    }
+}

--- a/packages/node/event-outbox/src/index.ts
+++ b/packages/node/event-outbox/src/index.ts
@@ -1,0 +1,7 @@
+export { OUTBOX_EVENT_SQL, PRISMA_MODEL_FRAGMENT } from './schema.js';
+export { writeOutbox, type SqlTagExecutor } from './write-outbox.js';
+export {
+    OutboxRelay,
+    type OutboxRelayOpts,
+    type OutboxMetrics,
+} from './relay.js';

--- a/packages/node/event-outbox/src/relay.ts
+++ b/packages/node/event-outbox/src/relay.ts
@@ -1,0 +1,276 @@
+import type { Channel } from 'amqplib';
+import type { Pool, PoolClient } from 'pg';
+import type { ILogger } from '@saga-ed/soa-logger';
+import type { ConnectionManager } from '@saga-ed/soa-rabbitmq';
+import {
+    SpanKind,
+    SpanStatusCode,
+    context,
+    propagation,
+    trace,
+} from '@opentelemetry/api';
+
+export interface OutboxMetrics {
+    /** Called after a row is successfully published. */
+    onPublished: (eventType: string, eventVersion: number) => void;
+    /** Called when publishing a row throws. */
+    onPublishFailed: (eventType: string, eventVersion: number, reason: string) => void;
+}
+
+export interface OutboxRelayOpts {
+    /** Dedicated pg pool for the relay (separate from the service's Prisma client). */
+    pool: Pool;
+    /** Connection manager from @saga-ed/soa-rabbitmq for resilient AMQP. */
+    connectionManager: ConnectionManager;
+    /** Topic exchange to publish into (e.g., "identity.events"). */
+    exchange: string;
+    /** Polling cadence. Defaults to 500ms (matches ledger-api). */
+    pollIntervalMs?: number;
+    /** Max rows per poll. Defaults to 100. */
+    batchSize?: number;
+    /** Optional Prometheus hooks. No-op when undefined. */
+    metrics?: OutboxMetrics;
+    logger: ILogger;
+}
+
+interface OutboxRow {
+    event_id: string;
+    aggregate_type: string;
+    aggregate_id: string;
+    event_type: string;
+    event_version: number;
+    payload: unknown;
+    meta: Record<string, unknown> | null;
+    occurred_at: Date;
+    attempts: number;
+}
+
+const tracer = trace.getTracer('@saga-ed/soa-event-outbox');
+
+/**
+ * Polling outbox relay. On each tick:
+ *   1. SELECT unpublished rows FOR UPDATE SKIP LOCKED (multi-relay safe).
+ *   2. For each row: publish to RabbitMQ, mark published_at = NOW().
+ *   3. COMMIT.
+ *
+ * On error within a row, the row stays unpublished and is retried next tick.
+ * Phase 4+ will add per-row retry budgets + DLQ wiring.
+ */
+export class OutboxRelay {
+    private channel: Channel | null = null;
+    private timer: NodeJS.Timeout | null = null;
+    private running = false;
+
+    constructor(private readonly opts: OutboxRelayOpts) {}
+
+    async start(): Promise<void> {
+        this.channel = await this.opts.connectionManager.newChannel();
+        await this.channel.assertExchange(this.opts.exchange, 'topic', { durable: true });
+        // NOTE: Phase 1 uses `persistent: true` for durability but does not
+        // wait for publisher confirms (soa-rabbitmq's `newChannel()` returns
+        // a plain Channel, not a ConfirmChannel). This means a broker crash
+        // between `channel.publish` and disk persistence could drop messages.
+        // Phase 4+ will widen soa-rabbitmq with `newConfirmChannel()` and
+        // restore strict at-least-once semantics.
+
+        this.running = true;
+        this.opts.logger.info(`[OutboxRelay] started (exchange=${this.opts.exchange})`);
+        this.scheduleNext();
+    }
+
+    async stop(): Promise<void> {
+        this.running = false;
+        if (this.timer) {
+            clearTimeout(this.timer);
+            this.timer = null;
+        }
+        if (this.channel) {
+            try {
+                await this.channel.close();
+            } catch {
+                // Already closed by connection manager
+            }
+            this.channel = null;
+        }
+        this.opts.logger.info('[OutboxRelay] stopped');
+    }
+
+    private scheduleNext(): void {
+        if (!this.running) return;
+        const interval = this.opts.pollIntervalMs ?? 500;
+        this.timer = setTimeout(() => {
+            void this.tick();
+        }, interval);
+    }
+
+    private async tick(): Promise<void> {
+        try {
+            await this.drainBatch();
+        } catch (err) {
+            this.opts.logger.error(
+                '[OutboxRelay] poll failed',
+                err instanceof Error ? err : undefined,
+            );
+        }
+        this.scheduleNext();
+    }
+
+    private async drainBatch(): Promise<void> {
+        if (!this.channel) {
+            throw new Error('OutboxRelay not started');
+        }
+        const batchSize = this.opts.batchSize ?? 100;
+        const client = await this.opts.pool.connect();
+        try {
+            await client.query('BEGIN');
+            const result = await client.query<OutboxRow>(
+                `SELECT event_id, aggregate_type, aggregate_id, event_type,
+                        event_version, payload, meta, occurred_at, attempts
+                 FROM outbox_event
+                 WHERE published_at IS NULL
+                 ORDER BY occurred_at
+                 LIMIT $1
+                 FOR UPDATE SKIP LOCKED`,
+                [batchSize],
+            );
+
+            if (result.rows.length === 0) {
+                await client.query('COMMIT');
+                return;
+            }
+
+            for (const row of result.rows) {
+                await this.publishRow(client, row);
+            }
+
+            await client.query('COMMIT');
+        } catch (err) {
+            try {
+                await client.query('ROLLBACK');
+            } catch {
+                // Ignore rollback failures
+            }
+            throw err;
+        } finally {
+            client.release();
+        }
+    }
+
+    private async publishRow(client: PoolClient, row: OutboxRow): Promise<void> {
+        if (!this.channel) {
+            throw new Error('OutboxRelay channel missing');
+        }
+
+        // Restore the trace context the publisher captured at outbox-write
+        // time so this PRODUCER span chains under the original request span,
+        // and the consumer's CONSUMER span chains under this one. End-to-end
+        // trace stays connected even though publish happens asynchronously.
+        const parentCtx = row.meta
+            ? propagation.extract(context.active(), row.meta as Record<string, string>)
+            : context.active();
+
+        await context.with(parentCtx, async () => {
+            const span = tracer.startSpan(
+                `publish ${row.event_type}.v${row.event_version}`,
+                {
+                    kind: SpanKind.PRODUCER,
+                    attributes: {
+                        'messaging.system': 'rabbitmq',
+                        'messaging.destination': this.opts.exchange,
+                        'messaging.destination_kind': 'topic',
+                        'messaging.rabbitmq.routing_key': row.event_type,
+                        'event.id': row.event_id,
+                        'event.type': row.event_type,
+                        'event.version': row.event_version,
+                        'event.aggregate_type': row.aggregate_type,
+                        'event.aggregate_id': row.aggregate_id,
+                    },
+                },
+            );
+
+            try {
+                // Re-inject trace context AFTER starting the publish span so
+                // the consumer's parent is THIS span (not the original
+                // request span). That gives the consumer a direct parent
+                // pointer to the publish hop, which is what shows up cleanly
+                // in Jaeger as `request → publish → consume`.
+                const wireMeta: Record<string, unknown> = { ...(row.meta ?? {}) };
+                propagation.inject(
+                    trace.setSpan(context.active(), span),
+                    wireMeta,
+                );
+
+                const message = {
+                    eventId: row.event_id,
+                    eventType: row.event_type,
+                    eventVersion: row.event_version,
+                    aggregateType: row.aggregate_type,
+                    aggregateId: row.aggregate_id,
+                    occurredAt: row.occurred_at.toISOString(),
+                    payload: row.payload,
+                    ...(Object.keys(wireMeta).length > 0 ? { meta: wireMeta } : {}),
+                };
+
+                const ok = this.channel!.publish(
+                    this.opts.exchange,
+                    row.event_type,
+                    Buffer.from(JSON.stringify(message)),
+                    {
+                        contentType: 'application/json',
+                        persistent: true,
+                        messageId: row.event_id,
+                    },
+                );
+
+                if (!ok) {
+                    // Channel buffer full. Wait for drain, but also listen
+                    // for 'error' / 'close' — without those, a connection
+                    // drop while we're awaiting drain leaves the row locked
+                    // under FOR UPDATE SKIP LOCKED forever and the relay
+                    // hangs.
+                    const ch = this.channel!;
+                    await new Promise<void>((resolve, reject) => {
+                        const onDrain = (): void => {
+                            ch.removeListener('error', onError);
+                            ch.removeListener('close', onClose);
+                            resolve();
+                        };
+                        const onError = (err: Error): void => {
+                            ch.removeListener('drain', onDrain);
+                            ch.removeListener('close', onClose);
+                            reject(err);
+                        };
+                        const onClose = (): void => {
+                            ch.removeListener('drain', onDrain);
+                            ch.removeListener('error', onError);
+                            reject(new Error('channel closed while awaiting drain'));
+                        };
+                        ch.once('drain', onDrain);
+                        ch.once('error', onError);
+                        ch.once('close', onClose);
+                    });
+                }
+
+                await client.query(
+                    `UPDATE outbox_event SET published_at = NOW() WHERE event_id = $1`,
+                    [row.event_id],
+                );
+
+                this.opts.metrics?.onPublished(row.event_type, row.event_version);
+                span.setStatus({ code: SpanStatusCode.OK });
+            } catch (err) {
+                const reason = err instanceof Error ? err.message : String(err);
+                this.opts.metrics?.onPublishFailed(
+                    row.event_type,
+                    row.event_version,
+                    reason,
+                );
+                span.recordException(err instanceof Error ? err : new Error(reason));
+                span.setStatus({ code: SpanStatusCode.ERROR, message: reason });
+                throw err;
+            } finally {
+                span.end();
+            }
+        });
+    }
+}

--- a/packages/node/event-outbox/src/schema.ts
+++ b/packages/node/event-outbox/src/schema.ts
@@ -1,0 +1,54 @@
+// Canonical SQL for the outbox_event table. Mirrors the shape used by
+// student-data-system's ledger-api so eventual back-port to the soa fleet
+// is a drop-in. Services run this as part of their initial migration.
+//
+// We intentionally keep this as raw SQL (not a Prisma model) so it can be
+// shared across services without coupling to a particular generated client.
+// Each service's prisma/schema.prisma can declare a matching `OutboxEvent`
+// model that points at the same table for queries — see PRISMA_MODEL_FRAGMENT
+// for the canonical declaration.
+
+export const OUTBOX_EVENT_SQL = `
+CREATE TABLE IF NOT EXISTS outbox_event (
+    event_id        UUID PRIMARY KEY,
+    aggregate_type  TEXT NOT NULL,
+    aggregate_id    TEXT NOT NULL,
+    event_type      TEXT NOT NULL,
+    event_version   INTEGER NOT NULL DEFAULT 1,
+    payload         JSONB NOT NULL,
+    meta            JSONB,
+    occurred_at     TIMESTAMPTZ NOT NULL,
+    claimed_at      TIMESTAMPTZ,
+    published_at    TIMESTAMPTZ,
+    attempts        INTEGER NOT NULL DEFAULT 0,
+    last_error      TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_outbox_event_unpublished
+    ON outbox_event (occurred_at)
+    WHERE published_at IS NULL;
+`.trim();
+
+// Drop-in for prisma/schema.prisma. Services copy this verbatim into their
+// schema if they want a typed Prisma client over the table (e.g., for ops
+// queries via Prisma Studio). Not required for outbox writes — writeOutbox()
+// uses raw SQL and works against any tx client that exposes $executeRaw.
+export const PRISMA_MODEL_FRAGMENT = `
+model OutboxEvent {
+    eventId       String    @id @map("event_id") @db.Uuid
+    aggregateType String    @map("aggregate_type")
+    aggregateId   String    @map("aggregate_id")
+    eventType     String    @map("event_type")
+    eventVersion  Int       @default(1) @map("event_version")
+    payload       Json
+    meta          Json?
+    occurredAt    DateTime  @map("occurred_at") @db.Timestamptz(6)
+    claimedAt     DateTime? @map("claimed_at") @db.Timestamptz(6)
+    publishedAt   DateTime? @map("published_at") @db.Timestamptz(6)
+    attempts      Int       @default(0)
+    lastError     String?   @map("last_error")
+
+    @@map("outbox_event")
+    @@index([occurredAt(sort: Asc)], map: "idx_outbox_event_unpublished")
+}
+`.trim();

--- a/packages/node/event-outbox/src/write-outbox.ts
+++ b/packages/node/event-outbox/src/write-outbox.ts
@@ -1,0 +1,41 @@
+import type { EventEnvelope } from '@saga-ed/soa-event-envelope';
+
+// Minimal duck-typed interface for any tx client that exposes Prisma's
+// `$executeRaw` template-tag method. The intent is that services pass their
+// own `Prisma.TransactionClient` here without needing to import a specific
+// service's generated Prisma client into this package.
+export interface SqlTagExecutor {
+    $executeRaw(query: TemplateStringsArray, ...values: unknown[]): Promise<number>;
+}
+
+/**
+ * Append an envelope to outbox_event in the same transaction as the domain
+ * write. Caller is responsible for the surrounding Prisma `$transaction`.
+ *
+ * `meta` is persisted alongside payload so traceparent + correlationId
+ * captured at write-time survives the (potentially milliseconds-later)
+ * relay publish — that's how the consumer sees the original request's
+ * trace as parent. See packages/envelope's buildEnvelope for the
+ * auto-capture path that snapshots the active OTel context.
+ */
+export async function writeOutbox(
+    tx: SqlTagExecutor,
+    envelope: EventEnvelope,
+): Promise<void> {
+    const metaJson = envelope.meta ? JSON.stringify(envelope.meta) : null;
+    await tx.$executeRaw`
+        INSERT INTO outbox_event (
+            event_id, aggregate_type, aggregate_id,
+            event_type, event_version, payload, meta, occurred_at
+        ) VALUES (
+            ${envelope.eventId}::uuid,
+            ${envelope.aggregateType},
+            ${envelope.aggregateId},
+            ${envelope.eventType},
+            ${envelope.eventVersion},
+            ${JSON.stringify(envelope.payload)}::jsonb,
+            ${metaJson}::jsonb,
+            ${envelope.occurredAt}::timestamptz
+        )
+    `;
+}

--- a/packages/node/event-outbox/tsconfig.json
+++ b/packages/node/event-outbox/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "@saga-ed/soa-typescript-config/base.json",
+    "compilerOptions": {
+        "outDir": "./dist",
+        "rootDir": "./src",
+        "noEmit": false
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/node/event-outbox/tsup.config.ts
+++ b/packages/node/event-outbox/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+    entry: ['src/index.ts'],
+    format: ['esm'],
+    dts: true,
+    clean: true,
+    sourcemap: true,
+});

--- a/packages/node/event-test-harness/package.json
+++ b/packages/node/event-test-harness/package.json
@@ -1,0 +1,45 @@
+{
+    "name": "@saga-ed/soa-event-test-harness",
+    "version": "0.0.1",
+    "private": true,
+    "type": "module",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
+        }
+    },
+    "files": ["dist"],
+    "scripts": {
+        "build": "tsup",
+        "check-types": "tsc --noEmit",
+        "test": "vitest run --passWithNoTests",
+        "lint": "eslint src/",
+        "clean": "rm -rf dist"
+    },
+    "dependencies": {
+        "@testcontainers/postgresql": "^10.13.0",
+        "@testcontainers/rabbitmq": "^10.13.0",
+        "pg": "^8.13.0",
+        "testcontainers": "^10.13.0"
+    },
+    "devDependencies": {
+        "@saga-ed/soa-typescript-config": "workspace:*",
+        "@types/node": "^24.0.3",
+        "@types/pg": "^8.11.10",
+        "tsup": "^8.5.0",
+        "typescript": "5.8.2",
+        "vitest": "^1.6.1"
+    },
+    "publishConfig": {
+        "registry": "https://saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/",
+        "access": "public"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/saga-ed/soa.git",
+        "directory": "packages/node/event-test-harness"
+    }
+}

--- a/packages/node/event-test-harness/src/index.ts
+++ b/packages/node/event-test-harness/src/index.ts
@@ -1,0 +1,100 @@
+import {
+    PostgreSqlContainer,
+    type StartedPostgreSqlContainer,
+} from '@testcontainers/postgresql';
+import {
+    RabbitMQContainer,
+    type StartedRabbitMQContainer,
+} from '@testcontainers/rabbitmq';
+import { Pool } from 'pg';
+
+export interface InfraHandle {
+    /** Postgres URL pointing at the default `test` admin database. */
+    postgresAdminUrl: string;
+    /** AMQP URL with credentials. */
+    rabbitmqUrl: string;
+    /**
+     * Create a fresh database within the running Postgres container and
+     * return a URL pointing at it. Idempotent — calling twice with the
+     * same name throws on the second create unless `dropIfExists` is set.
+     */
+    createDatabase: (name: string, opts?: { dropIfExists?: boolean }) => Promise<string>;
+    /**
+     * Run an arbitrary SQL block against a database (e.g., apply migrations
+     * extracted from @saga-ed/soa-event-outbox / @saga-ed/soa-event-consumer + the
+     * service's own table SQL).
+     */
+    runSql: (databaseUrl: string, sql: string) => Promise<void>;
+    /** Stop both containers. Test suites should call this in afterAll. */
+    stop: () => Promise<void>;
+}
+
+class TestcontainersInfraHandle implements InfraHandle {
+    constructor(
+        private readonly postgres: StartedPostgreSqlContainer,
+        private readonly rabbitmq: StartedRabbitMQContainer,
+    ) {}
+
+    get postgresAdminUrl(): string {
+        return this.postgres.getConnectionUri();
+    }
+
+    get rabbitmqUrl(): string {
+        return this.rabbitmq.getAmqpUrl();
+    }
+
+    async createDatabase(
+        name: string,
+        opts: { dropIfExists?: boolean } = {},
+    ): Promise<string> {
+        const adminPool = new Pool({ connectionString: this.postgresAdminUrl });
+        try {
+            if (opts.dropIfExists) {
+                await adminPool.query(`DROP DATABASE IF EXISTS "${name}"`);
+            }
+            await adminPool.query(`CREATE DATABASE "${name}"`);
+        } finally {
+            await adminPool.end();
+        }
+        const url = new URL(this.postgresAdminUrl);
+        url.pathname = `/${name}`;
+        return url.toString();
+    }
+
+    async runSql(databaseUrl: string, sql: string): Promise<void> {
+        const pool = new Pool({ connectionString: databaseUrl });
+        try {
+            await pool.query(sql);
+        } finally {
+            await pool.end();
+        }
+    }
+
+    async stop(): Promise<void> {
+        await Promise.all([this.postgres.stop(), this.rabbitmq.stop()]);
+    }
+}
+
+export interface StartInfraOpts {
+    postgresImage?: string;
+    rabbitmqImage?: string;
+}
+
+/**
+ * Start a Postgres container + RabbitMQ container in parallel, return a
+ * handle that exposes their URLs and helpers for creating per-test databases.
+ *
+ * Usage:
+ *   const infra = await startInfra();
+ *   const dbUrl = await infra.createDatabase('identity');
+ *   await infra.runSql(dbUrl, '...migrations...');
+ *   // ...run integration test...
+ *   await infra.stop();
+ */
+export async function startInfra(opts: StartInfraOpts = {}): Promise<InfraHandle> {
+    const [postgres, rabbitmq] = await Promise.all([
+        new PostgreSqlContainer(opts.postgresImage ?? 'postgres:17-alpine').start(),
+        new RabbitMQContainer(opts.rabbitmqImage ?? 'rabbitmq:3.13-management-alpine').start(),
+    ]);
+    return new TestcontainersInfraHandle(postgres, rabbitmq);
+}

--- a/packages/node/event-test-harness/tsconfig.json
+++ b/packages/node/event-test-harness/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "@saga-ed/soa-typescript-config/base.json",
+    "compilerOptions": {
+        "outDir": "./dist",
+        "rootDir": "./src",
+        "noEmit": false
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/node/event-test-harness/tsup.config.ts
+++ b/packages/node/event-test-harness/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+    entry: ['src/index.ts'],
+    format: ['esm'],
+    dts: true,
+    clean: true,
+    sourcemap: true,
+});

--- a/packages/node/observability/package.json
+++ b/packages/node/observability/package.json
@@ -1,0 +1,53 @@
+{
+    "name": "@saga-ed/soa-observability",
+    "version": "0.0.1",
+    "private": true,
+    "type": "module",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
+        }
+    },
+    "files": ["dist"],
+    "scripts": {
+        "build": "tsup",
+        "check-types": "tsc --noEmit",
+        "test": "vitest run --passWithNoTests",
+        "lint": "eslint src/",
+        "clean": "rm -rf dist"
+    },
+    "dependencies": {
+        "@saga-ed/soa-event-consumer": "workspace:*",
+        "@saga-ed/soa-event-outbox": "workspace:*",
+        "@saga-ed/soa-logger": "workspace:*",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.55.0",
+        "@opentelemetry/resources": "^1.28.0",
+        "@opentelemetry/sdk-node": "^0.55.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "express": "^4.18.2",
+        "pg": "^8.13.0",
+        "prom-client": "^15.1.3"
+    },
+    "devDependencies": {
+        "@saga-ed/soa-typescript-config": "workspace:*",
+        "@types/express": "^5.0.3",
+        "@types/node": "^24.0.3",
+        "@types/pg": "^8.11.10",
+        "tsup": "^8.5.0",
+        "typescript": "5.8.2",
+        "vitest": "^1.6.1"
+    },
+    "publishConfig": {
+        "registry": "https://saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/",
+        "access": "public"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/saga-ed/soa.git",
+        "directory": "packages/node/observability"
+    }
+}

--- a/packages/node/observability/src/error-middleware.ts
+++ b/packages/node/observability/src/error-middleware.ts
@@ -1,0 +1,25 @@
+import type { ErrorRequestHandler } from 'express';
+import type { ILogger } from '@saga-ed/soa-logger';
+
+/**
+ * Express error middleware that routes `next(err)` calls through the
+ * structured logger instead of falling back to `finalhandler` / console.error.
+ *
+ * Without this, errors from any route's `next(err)` (snapshot endpoints,
+ * /metrics, enrollment-readiness) get serialized to raw stderr, bypassing
+ * the Pino JSON pipeline and any centralized log aggregation.
+ *
+ * Register AFTER all routes via `app.use(structuredErrorMiddleware(logger))`.
+ */
+export function structuredErrorMiddleware(logger: ILogger): ErrorRequestHandler {
+    return (err, req, res, _next) => {
+        logger.error(
+            `unhandled error on ${req.method} ${req.originalUrl}`,
+            err instanceof Error ? err : new Error(String(err)),
+        );
+        if (res.headersSent) {
+            return;
+        }
+        res.status(500).json({ error: 'internal server error' });
+    };
+}

--- a/packages/node/observability/src/index.ts
+++ b/packages/node/observability/src/index.ts
@@ -1,0 +1,14 @@
+export {
+    initTracing,
+    shutdownTracing,
+    type InitTracingOpts,
+    type TracingHandle,
+} from './tracing.js';
+export {
+    createObservability,
+    metricsRoute,
+    type Observability,
+    type ConsumerMetrics,
+    type OutboxMetrics,
+} from './metrics.js';
+export { structuredErrorMiddleware } from './error-middleware.js';

--- a/packages/node/observability/src/metrics.ts
+++ b/packages/node/observability/src/metrics.ts
@@ -1,0 +1,222 @@
+import type { RequestHandler } from 'express';
+import type { Pool } from 'pg';
+import {
+    Counter,
+    Gauge,
+    Registry,
+    collectDefaultMetrics,
+} from 'prom-client';
+import type { ILogger } from '@saga-ed/soa-logger';
+import type { ConsumerMetrics } from '@saga-ed/soa-event-consumer';
+import type { OutboxMetrics } from '@saga-ed/soa-event-outbox';
+
+export type { ConsumerMetrics, OutboxMetrics };
+
+export interface Observability {
+    /** prom-client registry served at GET /metrics. */
+    registry: Registry;
+    /**
+     * Wire the logger used for gauge-collect failures and metrics-route
+     * errors. Without this, gauge SQL failures are silent (a stale value
+     * masks DB outages); after binding, failures surface via the logger
+     * AND `gauge_collect_failures_total`.
+     */
+    bindLogger: (logger: ILogger) => void;
+    /**
+     * Register publisher counters + the outbox lag gauge. The pool feeds
+     * the gauge's `collect()` callback. Returns the metrics callbacks
+     * to hand to OutboxRelay opts.
+     *
+     * Call once per service. Calling on a consumer-only service is a
+     * design error and intentionally not modeled — services that don't
+     * publish simply don't call this.
+     */
+    addOutbox: (pool: Pool) => OutboxMetrics;
+    /**
+     * Register consumer counters + the consumed-events gauge. Symmetrical
+     * to `addOutbox`. Returns the metrics callbacks to hand to
+     * EventConsumer opts.
+     */
+    addConsumer: (pool: Pool, consumerName: string) => ConsumerMetrics;
+}
+
+/**
+ * Build a service's Prometheus registry. Counters and gauges are added
+ * lazily via `addOutbox` / `addConsumer` once the pg pool is connected
+ * — that ordering is forced by the pool needing to exist for gauge
+ * `collect()` callbacks.
+ *
+ * Compared to a flag-driven `{ hasOutbox, hasConsumer }` API, this shape
+ * makes "this service has no outbox" explicit at the call site (you
+ * simply don't call `addOutbox`) instead of returning no-op callbacks
+ * that silently do nothing.
+ */
+export function createObservability(serviceName: string): Observability {
+    const registry = new Registry();
+    const prefix = `${serviceName.replace(/-/g, '_')}_`;
+    collectDefaultMetrics({ register: registry, prefix });
+
+    const gaugeFailures = new Counter({
+        name: 'gauge_collect_failures_total',
+        help: 'Times a metrics-gauge collect() callback threw — DB outage, role drift, or missing migration. Stale gauge values would otherwise hide these.',
+        labelNames: ['gauge'] as const,
+        registers: [registry],
+    });
+
+    let logger: ILogger | null = null;
+    const reportGaugeFailure = (gauge: string, err: unknown): void => {
+        gaugeFailures.inc({ gauge });
+        logger?.warn(
+            `[observability] ${gauge} collect() failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+    };
+
+    return {
+        registry,
+        bindLogger: (l) => {
+            logger = l;
+        },
+        addOutbox: (pool) => createOutboxMetrics(registry, pool, reportGaugeFailure),
+        addConsumer: (pool, consumerName) =>
+            createConsumerMetrics(registry, pool, consumerName, reportGaugeFailure),
+    };
+}
+
+type ReportGaugeFailure = (gauge: string, err: unknown) => void;
+
+function createOutboxMetrics(
+    registry: Registry,
+    pool: Pool,
+    reportFailure: ReportGaugeFailure,
+): OutboxMetrics {
+    const eventsPublishedTotal = new Counter({
+        name: 'events_published_total',
+        help: 'Outbox rows published to broker since process start.',
+        labelNames: ['event_type', 'event_version'] as const,
+        registers: [registry],
+    });
+
+    const eventsPublishFailedTotal = new Counter({
+        name: 'events_publish_failed_total',
+        help: 'Outbox publish attempts that threw before persisting.',
+        labelNames: ['event_type', 'event_version', 'reason'] as const,
+        registers: [registry],
+    });
+
+    new Gauge({
+        name: 'outbox_unpublished_count',
+        help: 'Outbox rows where published_at IS NULL. Lag indicator.',
+        registers: [registry],
+        async collect() {
+            try {
+                const result = await pool.query<{ c: string }>(
+                    `SELECT count(*)::text AS c FROM outbox_event WHERE published_at IS NULL`,
+                );
+                this.set(Number(result.rows[0]?.c ?? '0'));
+            } catch (err) {
+                reportFailure('outbox_unpublished_count', err);
+            }
+        },
+    });
+
+    return {
+        onPublished: (eventType, eventVersion) => {
+            eventsPublishedTotal.inc({
+                event_type: eventType,
+                event_version: String(eventVersion),
+            });
+        },
+        onPublishFailed: (eventType, eventVersion, reason) => {
+            eventsPublishFailedTotal.inc({
+                event_type: eventType,
+                event_version: String(eventVersion),
+                reason: reason.slice(0, 120),
+            });
+        },
+    };
+}
+
+function createConsumerMetrics(
+    registry: Registry,
+    pool: Pool,
+    consumerName: string,
+    reportFailure: ReportGaugeFailure,
+): ConsumerMetrics {
+    const eventsProcessedTotal = new Counter({
+        name: 'events_processed_total',
+        help: 'Events successfully consumed and projected since process start.',
+        labelNames: ['event_type', 'event_version'] as const,
+        registers: [registry],
+    });
+
+    const eventsFailedTotal = new Counter({
+        name: 'events_failed_total',
+        help: 'Events that threw during consumption (routed to DLQ via fail-fast).',
+        labelNames: ['event_type', 'event_version', 'reason'] as const,
+        registers: [registry],
+    });
+
+    const eventsDuplicateTotal = new Counter({
+        name: 'events_duplicate_total',
+        help: 'Events skipped as already-processed (idempotency hit).',
+        labelNames: ['event_type', 'event_version'] as const,
+        registers: [registry],
+    });
+
+    new Gauge({
+        name: 'consumed_events_count',
+        help: 'Total rows in consumed_events. Useful as a sanity counter.',
+        registers: [registry],
+        async collect() {
+            try {
+                const result = await pool.query<{ c: string }>(
+                    `SELECT count(*)::text AS c FROM consumed_events WHERE consumer_name = $1`,
+                    [consumerName],
+                );
+                this.set(Number(result.rows[0]?.c ?? '0'));
+            } catch (err) {
+                reportFailure('consumed_events_count', err);
+            }
+        },
+    });
+
+    return {
+        onProcessed: (eventType, eventVersion) => {
+            eventsProcessedTotal.inc({
+                event_type: eventType,
+                event_version: String(eventVersion),
+            });
+        },
+        onFailed: (eventType, eventVersion, reason) => {
+            eventsFailedTotal.inc({
+                event_type: eventType,
+                event_version: String(eventVersion),
+                reason: reason.slice(0, 120),
+            });
+        },
+        onDuplicate: (eventType, eventVersion) => {
+            eventsDuplicateTotal.inc({
+                event_type: eventType,
+                event_version: String(eventVersion),
+            });
+        },
+    };
+}
+
+/** Express handler that serves the Prometheus text exposition format. */
+export function metricsRoute(registry: Registry, logger?: ILogger): RequestHandler {
+    return async (_req, res, next) => {
+        try {
+            res.set('Content-Type', registry.contentType);
+            res.send(await registry.metrics());
+        } catch (err) {
+            // Without a logger, this would surface only via Express's default
+            // finalhandler (raw stderr), bypassing the structured Pino pipeline.
+            logger?.error(
+                'metrics endpoint failed to serialize registry',
+                err instanceof Error ? err : new Error(String(err)),
+            );
+            next(err);
+        }
+    };
+}

--- a/packages/node/observability/src/tracing.ts
+++ b/packages/node/observability/src/tracing.ts
@@ -1,0 +1,107 @@
+import { diag, DiagLogLevel, type DiagLogger } from '@opentelemetry/api';
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { Resource } from '@opentelemetry/resources';
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+import type { ILogger } from '@saga-ed/soa-logger';
+
+/**
+ * Opaque handle to an initialized OTel SDK. Services don't need to import
+ * NodeSDK directly — they hold this handle and pass it to `shutdownTracing`.
+ */
+export interface TracingHandle {
+    shutdown: () => Promise<void>;
+}
+
+export interface InitTracingOpts {
+    /**
+     * If supplied, OTel internal diagnostics (exporter failures, batch span
+     * processor warnings) flow through this logger instead of console.error.
+     * Strongly recommended in production so Jaeger-down / URL-typo errors
+     * land in the same log stream as the rest of the service.
+     */
+    logger?: ILogger;
+}
+
+/**
+ * Initialize the OTel SDK for a service. Must be called BEFORE any module
+ * that calls `trace.getTracer()` — otherwise our manual spans in
+ * @saga-ed/soa-event-outbox / @saga-ed/soa-event-consumer silently no-op.
+ *
+ * Disable at runtime with OTEL_TRACES_DISABLED=true (handy in tests where
+ * the OTLP exporter would just dump errors to stderr).
+ */
+export function initTracing(
+    serviceName: string,
+    opts: InitTracingOpts = {},
+): TracingHandle {
+    if (opts.logger) {
+        diag.setLogger(makeDiagLogger(opts.logger), DiagLogLevel.WARN);
+    }
+
+    const sdk = new NodeSDK({
+        resource: new Resource({
+            [ATTR_SERVICE_NAME]: serviceName,
+        }),
+        traceExporter: new OTLPTraceExporter({ url: resolveOtlpTracesUrl() }),
+    });
+
+    if (process.env.OTEL_TRACES_DISABLED !== 'true') {
+        sdk.start();
+    }
+
+    return sdk;
+}
+
+/**
+ * Per OTel spec, OTEL_EXPORTER_OTLP_ENDPOINT is the base URL (signal path
+ * gets appended) while OTEL_EXPORTER_OTLP_TRACES_ENDPOINT is a full URL
+ * (used as-is). Passing a base URL through to OTLPTraceExporter's `url`
+ * option silently 404s because that option is treated as full — so we
+ * normalize here instead of relying on the SDK's env auto-detection.
+ */
+function resolveOtlpTracesUrl(): string {
+    const tracesEndpoint = process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
+    if (tracesEndpoint) return tracesEndpoint;
+
+    const baseEndpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+    if (baseEndpoint) {
+        return baseEndpoint.endsWith('/v1/traces')
+            ? baseEndpoint
+            : `${baseEndpoint.replace(/\/$/, '')}/v1/traces`;
+    }
+
+    return 'http://localhost:4318/v1/traces';
+}
+
+function makeDiagLogger(logger: ILogger): DiagLogger {
+    return {
+        verbose: () => {},
+        debug: () => {},
+        info: (msg, ...args) => logger.info(`[otel] ${formatDiag(msg, args)}`),
+        warn: (msg, ...args) => logger.warn(`[otel] ${formatDiag(msg, args)}`),
+        error: (msg, ...args) => logger.error(`[otel] ${formatDiag(msg, args)}`),
+    };
+}
+
+function formatDiag(msg: string, args: unknown[]): string {
+    if (args.length === 0) return msg;
+    return `${msg} ${args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ')}`;
+}
+
+export async function shutdownTracing(
+    handle: TracingHandle,
+    logger: ILogger,
+): Promise<void> {
+    try {
+        await handle.shutdown();
+    } catch (err) {
+        // Pending spans in the BatchSpanProcessor's queue are dropped on
+        // shutdown failure — typically the most interesting window if the
+        // shutdown was triggered by a crash or OOM kill.
+        logger.error(
+            'OTel SDK shutdown failed — pending spans likely lost',
+            err instanceof Error ? err : new Error(String(err)),
+        );
+    }
+}

--- a/packages/node/observability/tsconfig.json
+++ b/packages/node/observability/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "@saga-ed/soa-typescript-config/base.json",
+    "compilerOptions": {
+        "outDir": "./dist",
+        "rootDir": "./src",
+        "noEmit": false
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/node/observability/tsup.config.ts
+++ b/packages/node/observability/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+    entry: ['src/index.ts'],
+    format: ['esm'],
+    dts: true,
+    clean: true,
+    sourcemap: true,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -395,7 +395,7 @@ importers:
         version: link:../../../packages/web/ui
       next:
         specifier: ^15.3.0
-        version: 15.5.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 15.5.9(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: ^19.1.0
         version: 19.2.3
@@ -441,7 +441,7 @@ importers:
         version: 11.8.0(@trpc/server@11.8.0(typescript@5.8.2))(typescript@5.8.2)
       next:
         specifier: ^15.3.0
-        version: 15.5.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 15.5.9(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: ^19.1.0
         version: 19.2.3
@@ -476,6 +476,9 @@ importers:
 
   infra:
     dependencies:
+      express:
+        specifier: ^4.22.1
+        version: 4.22.1
       mongodb:
         specifier: ^6.0.0
         version: 6.21.0(socks@2.8.7)
@@ -489,9 +492,6 @@ importers:
       eslint:
         specifier: ^10.1.0
         version: 10.2.0(jiti@2.6.1)
-      express:
-        specifier: ^4.22.1
-        version: 4.22.1
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -842,6 +842,185 @@ importers:
         specifier: ^5.8.3
         version: 5.9.3
 
+  packages/node/event-consumer:
+    dependencies:
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.1
+      '@saga-ed/soa-event-envelope':
+        specifier: workspace:*
+        version: link:../event-envelope
+      '@saga-ed/soa-logger':
+        specifier: workspace:*
+        version: link:../logger
+      '@saga-ed/soa-rabbitmq':
+        specifier: workspace:*
+        version: link:../rabbitmq
+      amqplib:
+        specifier: ^0.10.4
+        version: 0.10.9
+      pg:
+        specifier: ^8.13.0
+        version: 8.20.0
+      zod:
+        specifier: 3.25.67
+        version: 3.25.67
+    devDependencies:
+      '@saga-ed/soa-typescript-config':
+        specifier: workspace:*
+        version: link:../../core/typescript-config
+      '@types/amqplib':
+        specifier: ^0.10.4
+        version: 0.10.8
+      '@types/node':
+        specifier: ^24.0.3
+        version: 24.0.12
+      '@types/pg':
+        specifier: ^8.11.10
+        version: 8.20.0
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.2)(yaml@2.8.2)
+      typescript:
+        specifier: 5.8.2
+        version: 5.8.2
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@24.0.12)
+
+  packages/node/event-envelope:
+    dependencies:
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.1
+      zod:
+        specifier: 3.25.67
+        version: 3.25.67
+    devDependencies:
+      '@saga-ed/soa-typescript-config':
+        specifier: workspace:*
+        version: link:../../core/typescript-config
+      '@types/node':
+        specifier: ^24.0.3
+        version: 24.0.12
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.2)(yaml@2.8.2)
+      typescript:
+        specifier: 5.8.2
+        version: 5.8.2
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@24.0.12)
+
+  packages/node/event-integration-tests:
+    dependencies:
+      '@saga-ed/soa-event-test-harness':
+        specifier: workspace:*
+        version: link:../event-test-harness
+      amqplib:
+        specifier: ^0.10.4
+        version: 0.10.9
+      pg:
+        specifier: ^8.13.0
+        version: 8.20.0
+    devDependencies:
+      '@saga-ed/soa-typescript-config':
+        specifier: workspace:*
+        version: link:../../core/typescript-config
+      '@types/amqplib':
+        specifier: ^0.10.4
+        version: 0.10.8
+      '@types/node':
+        specifier: ^24.0.3
+        version: 24.0.12
+      '@types/pg':
+        specifier: ^8.11.10
+        version: 8.20.0
+      typescript:
+        specifier: 5.8.2
+        version: 5.8.2
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@24.0.12)
+
+  packages/node/event-outbox:
+    dependencies:
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.1
+      '@saga-ed/soa-event-envelope':
+        specifier: workspace:*
+        version: link:../event-envelope
+      '@saga-ed/soa-logger':
+        specifier: workspace:*
+        version: link:../logger
+      '@saga-ed/soa-rabbitmq':
+        specifier: workspace:*
+        version: link:../rabbitmq
+      amqplib:
+        specifier: ^0.10.4
+        version: 0.10.9
+      pg:
+        specifier: ^8.13.0
+        version: 8.20.0
+    devDependencies:
+      '@saga-ed/soa-typescript-config':
+        specifier: workspace:*
+        version: link:../../core/typescript-config
+      '@types/amqplib':
+        specifier: ^0.10.4
+        version: 0.10.8
+      '@types/node':
+        specifier: ^24.0.3
+        version: 24.0.12
+      '@types/pg':
+        specifier: ^8.11.10
+        version: 8.20.0
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.2)(yaml@2.8.2)
+      typescript:
+        specifier: 5.8.2
+        version: 5.8.2
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@24.0.12)
+
+  packages/node/event-test-harness:
+    dependencies:
+      '@testcontainers/postgresql':
+        specifier: ^10.13.0
+        version: 10.28.0
+      '@testcontainers/rabbitmq':
+        specifier: ^10.13.0
+        version: 10.28.0
+      pg:
+        specifier: ^8.13.0
+        version: 8.20.0
+      testcontainers:
+        specifier: ^10.13.0
+        version: 10.28.0
+    devDependencies:
+      '@saga-ed/soa-typescript-config':
+        specifier: workspace:*
+        version: link:../../core/typescript-config
+      '@types/node':
+        specifier: ^24.0.3
+        version: 24.0.12
+      '@types/pg':
+        specifier: ^8.11.10
+        version: 8.20.0
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.2)(yaml@2.8.2)
+      typescript:
+        specifier: 5.8.2
+        version: 5.8.2
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@24.0.12)
+
   packages/node/fixture-serve:
     dependencies:
       express:
@@ -958,6 +1137,64 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
+
+  packages/node/observability:
+    dependencies:
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.1
+      '@opentelemetry/exporter-trace-otlp-http':
+        specifier: ^0.55.0
+        version: 0.55.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources':
+        specifier: ^1.28.0
+        version: 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-node':
+        specifier: ^0.55.0
+        version: 0.55.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions':
+        specifier: ^1.28.0
+        version: 1.40.0
+      '@saga-ed/soa-event-consumer':
+        specifier: workspace:*
+        version: link:../event-consumer
+      '@saga-ed/soa-event-outbox':
+        specifier: workspace:*
+        version: link:../event-outbox
+      '@saga-ed/soa-logger':
+        specifier: workspace:*
+        version: link:../logger
+      express:
+        specifier: ^4.18.2
+        version: 4.22.1
+      pg:
+        specifier: ^8.13.0
+        version: 8.20.0
+      prom-client:
+        specifier: ^15.1.3
+        version: 15.1.3
+    devDependencies:
+      '@saga-ed/soa-typescript-config':
+        specifier: workspace:*
+        version: link:../../core/typescript-config
+      '@types/express':
+        specifier: ^5.0.3
+        version: 5.0.6
+      '@types/node':
+        specifier: ^24.0.3
+        version: 24.0.12
+      '@types/pg':
+        specifier: ^8.11.10
+        version: 8.20.0
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.2)(yaml@2.8.2)
+      typescript:
+        specifier: 5.8.2
+        version: 5.8.2
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@24.0.12)
 
   packages/node/pubsub-client:
     dependencies:
@@ -1633,6 +1870,9 @@ packages:
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
+  '@balena/dockerignore@1.0.2':
+    resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
+
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
@@ -2030,6 +2270,10 @@ packages:
     resolution: {integrity: sha512-ejvBr8MQCbVsWNZnCwDXjUKq40MDmHalq7cJ6e9s/qzTUFIIo/afzt1Vui9T97FM/V/pN4YsFVoed5NIa96RDg==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  '@fastify/busboy@2.1.1':
+    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
+    engines: {node: '>=14'}
+
   '@fastify/busboy@3.2.0':
     resolution: {integrity: sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==}
 
@@ -2300,6 +2544,20 @@ packages:
   '@graphql-yoga/typed-event-target@3.0.2':
     resolution: {integrity: sha512-ZpJxMqB+Qfe3rp6uszCQoag4nSw42icURnBRfFYSOmTgEeOe4rD0vYlbA8spvCu2TlCesNTlEN9BLWtQqLxabA==}
     engines: {node: '>=18.0.0'}
+
+  '@grpc/grpc-js@1.14.3':
+    resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
+    engines: {node: '>=12.10.0'}
+
+  '@grpc/proto-loader@0.7.15':
+    resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  '@grpc/proto-loader@0.8.0':
+    resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   '@hapi/bourne@3.0.0':
     resolution: {integrity: sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w==}
@@ -2666,6 +2924,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
+  '@js-sdsl/ordered-map@4.4.2':
+    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
+
   '@koa/multer@3.1.0':
     resolution: {integrity: sha512-ETf4OLpOew9XE9lyU+5HIqk3TCmdGAw9pUXgxzrlYip+PkxLGoU4meiVTxiW4B6lxdBNijb3DFQ7M2woLcDL1g==}
     engines: {node: '>= 14'}
@@ -2780,6 +3041,164 @@ packages:
     resolution: {integrity: sha512-cRKBZm14IuA6G8W84dfd3iXj3BTAoxQ5o3pUE8DKEQ4n/tVha20t5nkVeD+ISC68e0Fuw5koTMvRwXb1lJSnzg==}
     engines: {node: '>=18.0.0'}
 
+  '@opentelemetry/api-logs@0.55.0':
+    resolution: {integrity: sha512-3cpa+qI45VHYcA5c0bHM6VHo9gicv3p5mlLHNG3rLyjQU8b7e0st1rWtrUn3JbZ3DwwCfhKop4eQ9UuYlC6Pkg==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/context-async-hooks@1.28.0':
+    resolution: {integrity: sha512-igcl4Ve+F1N2063PJUkesk/GkYyuGIWinYkSyAFTnIj3gzrOgvOA4k747XNdL47HRRL1w/qh7UW8NDuxOLvKFA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@1.28.0':
+    resolution: {integrity: sha512-ZLwRMV+fNDpVmF2WYUdBHlq0eOWtEaUJSusrzjGnBt7iSRvfjFE3RXYUZJrqou/wIDWV0DwQ5KIfYe9WXg9Xqw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@1.30.1':
+    resolution: {integrity: sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-logs-otlp-grpc@0.55.0':
+    resolution: {integrity: sha512-ykqawCL0ILJWyCJlxCPSAlqQXZ6x2bQsxAVUu8S3z22XNqY5SMx0rl2d93XnvnrOwtcfm+sM9ZhbGh/i5AZ9xw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-http@0.55.0':
+    resolution: {integrity: sha512-fpFObWWq+DoLVrBU2dyMEaVkibByEkmKQZIUIjW/4j7lwIsTgW7aJCoD9RYFVB/tButcqov5Es2C0J2wTjM2tg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.55.0':
+    resolution: {integrity: sha512-vjE+DxUr+cUpxikdKCPiLZM5Wx7g1bywjCG76TQocvsA7Tmbb9p0t1+8gPlu9AGH7VEzPwDxxpN4p1ajpOurzQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-grpc@0.55.0':
+    resolution: {integrity: sha512-ohIkCLn2Wc3vhhFuf1bH8kOXHMEdcWiD847x7f3Qfygc+CGiatGLzQYscTcEYsWGMV22gVwB/kVcNcx5a3o8gA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-http@0.55.0':
+    resolution: {integrity: sha512-lMiNic63EVHpW+eChmLD2CieDmwQBFi72+LFbh8+5hY0ShrDGrsGP/zuT5MRh7M/vM/UZYO/2A/FYd7CMQGR7A==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.55.0':
+    resolution: {integrity: sha512-qxiJFP+bBZW3+goHCGkE1ZdW9gJU0fR7eQ6OP+Rz5oGtEBbq4nkGodhb7C9FJlEFlE2siPtCxoeupV0gtYynag==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-zipkin@1.28.0':
+    resolution: {integrity: sha512-AMwr3eGXaPEH7gk8yhcUcen31VXy1yU5VJETu0pCfGpggGCYmhm0FKgYBpL5/vlIgQJWU/sW2vIjCL7aSilpKg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/instrumentation@0.55.0':
+    resolution: {integrity: sha512-YDCMlaQRZkziLL3t6TONRgmmGxDx6MyQDXRD0dknkkgUZtOK5+8MWft1OXzmNu6XfBOdT12MKN5rz+jHUkafKQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.55.0':
+    resolution: {integrity: sha512-iHQI0Zzq3h1T6xUJTVFwmFl5Dt5y1es+fl4kM+k5T/3YvmVyeYkSiF+wHCg6oKrlUAJfk+t55kaAu3sYmt7ZYA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.55.0':
+    resolution: {integrity: sha512-gebbjl9FiSp52igWXuGjcWQKfB6IBwFGt5z1VFwTcVZVeEZevB6bJIqoFrhH4A02m7OUlpJ7l4EfRi3UtkNANQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.55.0':
+    resolution: {integrity: sha512-kVqEfxtp6mSN2Dhpy0REo1ghP4PYhC1kMHQJ2qVlO99Pc+aigELjZDfg7/YKmL71gR6wVGIeJfiql/eXL7sQPA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/propagator-b3@1.28.0':
+    resolution: {integrity: sha512-Q7HVDIMwhN5RxL4bECMT4BdbyYSAKkC6U/RGn4NpO/cbqP6ZRg+BS7fPo/pGZi2w8AHfpIGQFXQmE8d2PC5xxQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/propagator-jaeger@1.28.0':
+    resolution: {integrity: sha512-wKJ94+s8467CnIRgoSRh0yXm/te0QMOwTq9J01PfG/RzYZvlvN8aRisN2oZ9SznB45dDGnMj3BhUlchSA9cEKA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/resources@1.28.0':
+    resolution: {integrity: sha512-cIyXSVJjGeTICENN40YSvLDAq4Y2502hGK3iN7tfdynQLKWb3XWZQEkPc+eSx47kiy11YeFAlYkEfXwR1w8kfw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/resources@1.30.1':
+    resolution: {integrity: sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.55.0':
+    resolution: {integrity: sha512-TSx+Yg/d48uWW6HtjS1AD5x6WPfLhDWLl/WxC7I2fMevaiBuKCuraxTB8MDXieCNnBI24bw9ytyXrDCswFfWgA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@1.28.0':
+    resolution: {integrity: sha512-43tqMK/0BcKTyOvm15/WQ3HLr0Vu/ucAl/D84NO7iSlv6O4eOprxSHa3sUtmYkaZWHqdDJV0AHVz/R6u4JALVQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-node@0.55.0':
+    resolution: {integrity: sha512-gSXQWV23+9vhbjsvAIeM0LxY3W8DTKI3MZlzFp61noIb1jSr46ET+qoUjHlfZ1Yymebv9KXWeZsqhft81HBXuQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@1.28.0':
+    resolution: {integrity: sha512-ceUVWuCpIao7Y5xE02Xs3nQi0tOGmMea17ecBdwtCvdo9ekmO+ijc9RFDgfifMl7XCBf41zne/1POM3LqSTZDA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-node@1.28.0':
+    resolution: {integrity: sha512-N0sYfYXvHpP0FNIyc+UfhLnLSTOuZLytV0qQVrDWIlABeD/DWJIGttS7nYeR14gQLXch0M1DW8zm3VeN6Opwtg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.27.0':
+    resolution: {integrity: sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/semantic-conventions@1.28.0':
+    resolution: {integrity: sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/semantic-conventions@1.40.0':
+    resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
+    engines: {node: '>=14'}
+
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
 
@@ -2808,6 +3227,9 @@ packages:
   '@protobufjs/codegen@2.0.4':
     resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
 
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
   '@protobufjs/eventemitter@1.1.0':
     resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
 
@@ -2820,6 +3242,9 @@ packages:
   '@protobufjs/inquire@1.1.0':
     resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
 
+  '@protobufjs/inquire@1.1.1':
+    resolution: {integrity: sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==}
+
   '@protobufjs/path@1.1.2':
     resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
 
@@ -2828,6 +3253,9 @@ packages:
 
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
   '@redis/bloom@5.10.0':
     resolution: {integrity: sha512-doIF37ob+l47n0rkpRNgU8n4iacBlKM9xLiP1LtTZTvz8TloJB8qx/MgvhMhKdYG+CvCY2aPBnN2706izFn/4A==}
@@ -3494,6 +3922,12 @@ packages:
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
     engines: {node: '>=14.16'}
 
+  '@testcontainers/postgresql@10.28.0':
+    resolution: {integrity: sha512-NN25rruG5D4Q7pCNIJuHwB+G85OSeJ3xHZ2fWx0O6sPoPEfCYwvpj8mq99cyn68nxFkFYZeyrZJtSFO+FnydiA==}
+
+  '@testcontainers/rabbitmq@10.28.0':
+    resolution: {integrity: sha512-Gl8/gAYfRCsjuhTfAIT7/0e49ozMRe05RDFr2CFQWcZDgB4A7qx2QaUqEIhcQnHqRjfEQTWoV1PovnGNZU+dGQ==}
+
   '@theguild/federation-composition@0.21.1':
     resolution: {integrity: sha512-iw1La4tbRaWKBgz+J9b1ydxv+kgt+7n04ZgD8HSeDJodLsLAxbXj/gLif5f2vyMa98ommBQ73ztBe8zOzGq5YQ==}
     engines: {node: '>=18'}
@@ -3551,6 +3985,12 @@ packages:
 
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
+
+  '@types/docker-modem@3.0.6':
+    resolution: {integrity: sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==}
+
+  '@types/dockerode@3.3.47':
+    resolution: {integrity: sha512-ShM1mz7rCjdssXt7Xz0u1/R2BJC7piWa3SJpUBiVjCf2A3XNn4cP6pUVaD8bLanpPVVn4IKzJuw3dOvkJ8IbYw==}
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
@@ -3621,6 +4061,9 @@ packages:
   '@types/node-fetch@2.6.13':
     resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
 
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
+
   '@types/node@22.19.3':
     resolution: {integrity: sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==}
 
@@ -3632,6 +4075,9 @@ packages:
 
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
 
   '@types/qs@6.14.0':
     resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
@@ -3664,6 +4110,18 @@ packages:
 
   '@types/serve-static@2.2.0':
     resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
+
+  '@types/shimmer@1.2.0':
+    resolution: {integrity: sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==}
+
+  '@types/ssh2-streams@0.1.13':
+    resolution: {integrity: sha512-faHyY3brO9oLEA0QlcO8N2wT7R0+1sHWZvQ+y3rMLwdY1ZyS1z0W3t65j9PqT4HmQ6ALzNe7RZlNuCNE0wBSWA==}
+
+  '@types/ssh2@0.5.52':
+    resolution: {integrity: sha512-lbLLlXxdCZOSJMCInKH2+9V/77ET2J6NPQHpFI0kda61Dd1KglJs+fPQBchizmzYSOJBgdTajhPqBO1xxLywvg==}
+
+  '@types/ssh2@1.15.5':
+    resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
 
   '@types/superagent@8.1.9':
     resolution: {integrity: sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==}
@@ -3932,6 +4390,11 @@ packages:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
 
+  acorn-import-attributes@1.9.5:
+    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
+    peerDependencies:
+      acorn: ^8
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -4011,6 +4474,14 @@ packages:
   append-field@1.0.0:
     resolution: {integrity: sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==}
 
+  archiver-utils@5.0.2:
+    resolution: {integrity: sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==}
+    engines: {node: '>= 14'}
+
+  archiver@7.0.1:
+    resolution: {integrity: sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==}
+    engines: {node: '>= 14'}
+
   arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
@@ -4063,6 +4534,9 @@ packages:
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+
   assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
 
@@ -4084,6 +4558,9 @@ packages:
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
+
+  async-lock@1.4.1:
+    resolution: {integrity: sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==}
 
   async-mutex@0.5.0:
     resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
@@ -4144,6 +4621,39 @@ packages:
       bare-abort-controller:
         optional: true
 
+  bare-fs@4.7.1:
+    resolution: {integrity: sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-os@3.9.1:
+    resolution: {integrity: sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==}
+    engines: {bare: '>=1.14.0'}
+
+  bare-path@3.0.0:
+    resolution: {integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==}
+
+  bare-stream@2.13.1:
+    resolution: {integrity: sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.4.2:
+    resolution: {integrity: sha512-/9a2j4ac6ckpmAHvod/ob7x439OAHst/drc2Clnq+reRYd/ovddwcF4LfoxHyNk5AuGBnPg+HqFjmE/Zpq6v0A==}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -4156,9 +4666,15 @@ packages:
     engines: {node: '>=10.0.0'}
     deprecated: Security vulnerability fixed in 5.2.0, please upgrade
 
+  bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
+
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
+
+  bintrees@1.0.2:
+    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -4203,6 +4719,10 @@ packages:
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
+  buffer-crc32@1.0.0:
+    resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
+    engines: {node: '>=8.0.0'}
+
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
@@ -4214,6 +4734,10 @@ packages:
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  buildcheck@0.0.7:
+    resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
+    engines: {node: '>=10.0.0'}
 
   bunchee@6.6.2:
     resolution: {integrity: sha512-hf9B4X/2jgFl0hYhE1NT/mnhnxEBxDNfiZnhtAVMWSUPIAtPLqcoLXUZYsmRhureNGcsowQI8a22e8kQ9Un/AA==}
@@ -4234,6 +4758,10 @@ packages:
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
+
+  byline@5.0.0:
+    resolution: {integrity: sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==}
+    engines: {node: '>=0.10.0'}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -4332,6 +4860,12 @@ packages:
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
+  cjs-module-lexer@1.4.3:
+    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
 
   class-transformer@0.5.1:
     resolution: {integrity: sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==}
@@ -4436,6 +4970,10 @@ packages:
   component-emitter@1.3.1:
     resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
 
+  compress-commons@6.0.2:
+    resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
+    engines: {node: '>= 14'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -4494,6 +5032,9 @@ packages:
   core-js-pure@3.47.0:
     resolution: {integrity: sha512-BcxeDbzUrRnXGYIVAGFtcGQVNpFcUhVjr6W7F8XktvQW2iJP9e66GP6xdKotCRFlrxBvNIBrhwKteRXqMV86Nw==}
 
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
   cors@2.8.5:
     resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
     engines: {node: '>= 0.10'}
@@ -4506,6 +5047,19 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  cpu-features@0.0.10:
+    resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
+    engines: {node: '>=10.0.0'}
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
+
+  crc32-stream@6.0.0:
+    resolution: {integrity: sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==}
+    engines: {node: '>= 14'}
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
@@ -4687,6 +5241,18 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
+
+  docker-compose@0.24.8:
+    resolution: {integrity: sha512-plizRs/Vf15H+GCVxq2EUvyPK7ei9b/cVesHvjnX4xaXjM9spHe2Ytq0BitndFgvTJ3E3NljPNUEl7BAN43iZw==}
+    engines: {node: '>= 6.0.0'}
+
+  docker-modem@5.0.7:
+    resolution: {integrity: sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==}
+    engines: {node: '>= 8.0'}
+
+  dockerode@4.0.12:
+    resolution: {integrity: sha512-/bCZd6KlGcjZO8Buqmi/vXuqEGVEZ0PNjx/biBNqJD3MhK9DmdiAuKxqfNhflgDESDIiBz3qF+0e55+CpnrUcw==}
+    engines: {node: '>= 8.0'}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -5221,6 +5787,9 @@ packages:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
 
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
@@ -5272,6 +5841,10 @@ packages:
   get-package-type@0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
     engines: {node: '>=8.0.0'}
+
+  get-port@7.2.0:
+    resolution: {integrity: sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==}
+    engines: {node: '>=16'}
 
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
@@ -5551,6 +6124,9 @@ packages:
     resolution: {integrity: sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==}
     engines: {node: '>=12.2'}
 
+  import-in-the-middle@1.15.0:
+    resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
+
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -5793,6 +6369,9 @@ packages:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
     engines: {node: '>=8'}
 
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
@@ -5933,6 +6512,10 @@ packages:
     resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
     engines: {node: '>=0.10'}
 
+  lazystream@1.0.1:
+    resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
+    engines: {node: '>= 0.6.3'}
+
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
@@ -5971,6 +6554,9 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
   lodash.get@4.4.2:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
@@ -6184,12 +6770,23 @@ packages:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
   mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
 
+  mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
+
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
   mongodb-connection-string-url@2.6.0:
     resolution: {integrity: sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==}
@@ -6286,6 +6883,9 @@ packages:
   named-placeholders@1.1.6:
     resolution: {integrity: sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==}
     engines: {node: '>=8.0.0'}
+
+  nan@2.26.2:
+    resolution: {integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -6637,6 +7237,40 @@ packages:
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
+  pg-cloudflare@1.3.0:
+    resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
+
+  pg-connection-string@2.12.0:
+    resolution: {integrity: sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.13.0:
+    resolution: {integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.13.0:
+    resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.20.0:
+    resolution: {integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
   picocolors@1.0.1:
     resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
 
@@ -6706,6 +7340,22 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -6723,6 +7373,9 @@ packages:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
   process-warning@3.0.0:
     resolution: {integrity: sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==}
 
@@ -6730,14 +7383,29 @@ packages:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
 
+  prom-client@15.1.3:
+    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
+    engines: {node: ^16 || ^18 || >=20}
+
   promise@7.3.1:
     resolution: {integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
+
+  properties-reader@2.3.0:
+    resolution: {integrity: sha512-z597WicA7nDZxK12kZqHr2TcvwNU1GCfA5UwfDY/HDp3hXPoPlb5rlEx9bwGTiJnc0OqbBTkU975jDToth8Gxw==}
+    engines: {node: '>=14'}
+
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
+
+  protobufjs@7.5.6:
+    resolution: {integrity: sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==}
+    engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -6805,6 +7473,9 @@ packages:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
 
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
@@ -6812,6 +7483,9 @@ packages:
   readable-stream@4.7.0:
     resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  readdir-glob@1.1.3:
+    resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
 
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
@@ -6867,6 +7541,10 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  require-in-the-middle@7.5.2:
+    resolution: {integrity: sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==}
+    engines: {node: '>=8.6.0'}
+
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
@@ -6900,6 +7578,10 @@ packages:
   restore-cursor@3.1.0:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
     engines: {node: '>=8'}
+
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
 
   retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
@@ -6964,6 +7646,9 @@ packages:
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
+
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -7064,6 +7749,9 @@ packages:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
     engines: {node: '>= 0.4'}
 
+  shimmer@1.2.1:
+    resolution: {integrity: sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==}
+
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
     engines: {node: '>= 0.4'}
@@ -7160,6 +7848,9 @@ packages:
   spdx-license-ids@3.0.23:
     resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
 
+  split-ca@1.0.1:
+    resolution: {integrity: sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==}
+
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
@@ -7170,6 +7861,13 @@ packages:
   sql-escaper@1.3.3:
     resolution: {integrity: sha512-BsTCV265VpTp8tm1wyIm1xqQCS+Q9NHx2Sr+WcnUrgLrQ6yiDIvHYJV5gHxsj1lMBy2zm5twLaZao8Jd+S8JJw==}
     engines: {bun: '>=1.0.0', deno: '>=2.0.0', node: '>=12.0.0'}
+
+  ssh-remote-port-forward@1.0.4:
+    resolution: {integrity: sha512-x0LV1eVDwjf1gmG7TTnfqIzf+3VPRz7vrNIjX6oYLbeCrf/PeVY6hkT68Mg+q02qXxQhrLjB0jfgvhevoCRmLQ==}
+
+  ssh2@1.17.0:
+    resolution: {integrity: sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==}
+    engines: {node: '>=10.16.0'}
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
@@ -7198,6 +7896,9 @@ packages:
 
   streamx@2.23.0:
     resolution: {integrity: sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==}
+
+  streamx@2.25.0:
+    resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
 
   string-env-interpolation@1.0.1:
     resolution: {integrity: sha512-78lwMoCcn0nNu8LszbP1UA7g55OeE4v7rCeWnM5B453rnNr4aq+5it3FEYtZrSEiMvHZOZ9Jlqb0OD0M2VInqg==}
@@ -7232,6 +7933,9 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -7360,8 +8064,24 @@ packages:
     engines: {node: '>=14.17.0'}
     hasBin: true
 
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-fs@3.1.2:
+    resolution: {integrity: sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
+
+  tdigest@0.1.2:
+    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
   template-url@1.0.0:
     resolution: {integrity: sha512-QUjZNE7yTdIzB91sITTSYcSX5GRF5FulKvIYCqV5350NfSNfiuuCYQIJZ5PIN7k/uJ+kpurEEv9hFqRRc+JilA==}
@@ -7369,6 +8089,9 @@ packages:
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
+
+  testcontainers@10.28.0:
+    resolution: {integrity: sha512-1fKrRRCsgAQNkarjHCMKzBKXSJFmzNTiTbhb5E/j5hflRXChEtHvkefjaHlgkNUjfw92/Dq8LTgwQn6RDBFbMg==}
 
   text-decoder@1.2.3:
     resolution: {integrity: sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==}
@@ -7441,6 +8164,10 @@ packages:
   tmp@0.0.33:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
     engines: {node: '>=0.6.0'}
+
+  tmp@0.2.5:
+    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+    engines: {node: '>=14.14'}
 
   to-buffer@1.2.2:
     resolution: {integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==}
@@ -7572,6 +8299,9 @@ packages:
     resolution: {integrity: sha512-bf6YKUv11l5Xfcmg76PyWoy/e2vbkkxFNBGJSnfdSXQC33ZiUfutYh6IXidc5MhsnrFkWfdNNLyaRk+kHMLlwA==}
     hasBin: true
 
+  tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -7667,6 +8397,9 @@ packages:
     resolution: {integrity: sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==}
     engines: {node: '>=0.10.0'}
 
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
@@ -7678,6 +8411,10 @@ packages:
 
   undici-types@7.8.0:
     resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
+
+  undici@5.29.0:
+    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
+    engines: {node: '>=14.0'}
 
   undici@7.16.0:
     resolution: {integrity: sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==}
@@ -7738,6 +8475,11 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
@@ -8003,6 +8745,10 @@ packages:
   yoctocolors-cjs@2.1.3:
     resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
     engines: {node: '>=18'}
+
+  zip-stream@6.0.1:
+    resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
+    engines: {node: '>= 14'}
 
   zod@3.25.67:
     resolution: {integrity: sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==}
@@ -9128,6 +9874,8 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@balena/dockerignore@1.0.2': {}
+
   '@bcoe/v8-coverage@0.2.3': {}
 
   '@cspotcode/source-map-support@0.8.1':
@@ -9412,6 +10160,8 @@ snapshots:
     dependencies:
       '@eslint/core': 1.2.0
       levn: 0.4.1
+
+  '@fastify/busboy@2.1.1': {}
 
   '@fastify/busboy@3.2.0': {}
 
@@ -10034,6 +10784,25 @@ snapshots:
       '@repeaterjs/repeater': 3.0.6
       tslib: 2.8.1
 
+  '@grpc/grpc-js@1.14.3':
+    dependencies:
+      '@grpc/proto-loader': 0.8.0
+      '@js-sdsl/ordered-map': 4.4.2
+
+  '@grpc/proto-loader@0.7.15':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.5.6
+      yargs: 17.7.2
+
+  '@grpc/proto-loader@0.8.0':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.5.6
+      yargs: 17.7.2
+
   '@hapi/bourne@3.0.0':
     optional: true
 
@@ -10387,6 +11156,8 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@js-sdsl/ordered-map@4.4.2': {}
+
   '@koa/multer@3.1.0(multer@2.0.2)':
     dependencies:
       multer: 2.0.2
@@ -10527,6 +11298,208 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/api-logs@0.55.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/context-async-hooks@1.28.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/core@1.28.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.27.0
+
+  '@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/exporter-logs-otlp-grpc@0.55.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.28.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.55.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.55.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.55.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-logs-otlp-http@0.55.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.55.0
+      '@opentelemetry/core': 1.28.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.55.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.55.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.55.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.55.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.55.0
+      '@opentelemetry/core': 1.28.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.55.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.55.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.28.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.55.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.28.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-trace-otlp-grpc@0.55.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.28.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.55.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.55.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.28.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.28.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-trace-otlp-http@0.55.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.28.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.55.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.55.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.28.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.28.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.55.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.28.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.55.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.55.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.28.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.28.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-zipkin@1.28.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.28.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.28.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.28.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.27.0
+
+  '@opentelemetry/instrumentation@0.55.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.55.0
+      '@types/shimmer': 1.2.0
+      import-in-the-middle: 1.15.0
+      require-in-the-middle: 7.5.2
+      semver: 7.7.4
+      shimmer: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/otlp-exporter-base@0.55.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.28.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.55.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.55.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.28.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.55.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.55.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-transformer@0.55.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.55.0
+      '@opentelemetry/core': 1.28.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.28.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.55.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 1.28.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.28.0(@opentelemetry/api@1.9.1)
+      protobufjs: 7.5.6
+
+  '@opentelemetry/propagator-b3@1.28.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.28.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/propagator-jaeger@1.28.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.28.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/resources@1.28.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.28.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.27.0
+
+  '@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/sdk-logs@0.55.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.55.0
+      '@opentelemetry/core': 1.28.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.28.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-metrics@1.28.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.28.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.28.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-node@0.55.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.55.0
+      '@opentelemetry/core': 1.28.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-grpc': 0.55.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-http': 0.55.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-proto': 0.55.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-grpc': 0.55.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-http': 0.55.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-proto': 0.55.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-zipkin': 1.28.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.55.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.28.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.55.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 1.28.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.28.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node': 1.28.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.27.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/sdk-trace-base@1.28.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.28.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.28.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.27.0
+
+  '@opentelemetry/sdk-trace-node@1.28.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 1.28.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 1.28.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagator-b3': 1.28.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagator-jaeger': 1.28.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.28.0(@opentelemetry/api@1.9.1)
+      semver: 7.7.4
+
+  '@opentelemetry/semantic-conventions@1.27.0': {}
+
+  '@opentelemetry/semantic-conventions@1.28.0': {}
+
+  '@opentelemetry/semantic-conventions@1.40.0': {}
+
   '@paralleldrive/cuid2@2.3.1':
     dependencies:
       '@noble/hashes': 1.8.0
@@ -10552,6 +11525,8 @@ snapshots:
 
   '@protobufjs/codegen@2.0.4': {}
 
+  '@protobufjs/codegen@2.0.5': {}
+
   '@protobufjs/eventemitter@1.1.0': {}
 
   '@protobufjs/fetch@1.1.0':
@@ -10563,11 +11538,15 @@ snapshots:
 
   '@protobufjs/inquire@1.1.0': {}
 
+  '@protobufjs/inquire@1.1.1': {}
+
   '@protobufjs/path@1.1.2': {}
 
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
 
   '@redis/bloom@5.10.0(@redis/client@5.10.0)':
     dependencies:
@@ -11372,6 +12351,24 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
+  '@testcontainers/postgresql@10.28.0':
+    dependencies:
+      testcontainers: 10.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
+
+  '@testcontainers/rabbitmq@10.28.0':
+    dependencies:
+      testcontainers: 10.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
+
   '@theguild/federation-composition@0.21.1(graphql@16.12.0)':
     dependencies:
       constant-case: 3.0.4
@@ -11470,6 +12467,17 @@ snapshots:
     dependencies:
       '@types/node': 24.0.12
 
+  '@types/docker-modem@3.0.6':
+    dependencies:
+      '@types/node': 24.0.12
+      '@types/ssh2': 1.15.5
+
+  '@types/dockerode@3.3.47':
+    dependencies:
+      '@types/docker-modem': 3.0.6
+      '@types/node': 24.0.12
+      '@types/ssh2': 1.15.5
+
   '@types/esrecurse@4.3.1': {}
 
   '@types/estree@1.0.8': {}
@@ -11558,6 +12566,10 @@ snapshots:
       '@types/node': 24.0.12
       form-data: 4.0.5
 
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
+
   '@types/node@22.19.3':
     dependencies:
       undici-types: 6.21.0
@@ -11573,6 +12585,12 @@ snapshots:
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
+
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 24.0.12
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
 
   '@types/qs@6.14.0': {}
 
@@ -11609,6 +12627,21 @@ snapshots:
     dependencies:
       '@types/http-errors': 2.0.5
       '@types/node': 24.0.12
+
+  '@types/shimmer@1.2.0': {}
+
+  '@types/ssh2-streams@0.1.13':
+    dependencies:
+      '@types/node': 24.0.12
+
+  '@types/ssh2@0.5.52':
+    dependencies:
+      '@types/node': 24.0.12
+      '@types/ssh2-streams': 0.1.13
+
+  '@types/ssh2@1.15.5':
+    dependencies:
+      '@types/node': 18.19.130
 
   '@types/superagent@8.1.9':
     dependencies:
@@ -12021,6 +13054,10 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
+  acorn-import-attributes@1.9.5(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -12094,6 +13131,29 @@ snapshots:
 
   append-field@1.0.0:
     optional: true
+
+  archiver-utils@5.0.2:
+    dependencies:
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      is-stream: 2.0.1
+      lazystream: 1.0.1
+      lodash: 4.18.1
+      normalize-path: 3.0.0
+      readable-stream: 4.7.0
+
+  archiver@7.0.1:
+    dependencies:
+      archiver-utils: 5.0.2
+      async: 3.2.6
+      buffer-crc32: 1.0.0
+      readable-stream: 4.7.0
+      readdir-glob: 1.1.3
+      tar-stream: 3.1.7
+      zip-stream: 6.0.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
 
   arg@4.1.3: {}
 
@@ -12174,6 +13234,10 @@ snapshots:
 
   asap@2.0.6: {}
 
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
+
   assertion-error@1.1.0: {}
 
   assertion-error@2.0.1: {}
@@ -12187,6 +13251,8 @@ snapshots:
   astral-regex@2.0.0: {}
 
   async-function@1.0.0: {}
+
+  async-lock@1.4.1: {}
 
   async-mutex@0.5.0:
     dependencies:
@@ -12222,13 +13288,54 @@ snapshots:
 
   bare-events@2.8.2: {}
 
+  bare-fs@4.7.1:
+    dependencies:
+      bare-events: 2.8.2
+      bare-path: 3.0.0
+      bare-stream: 2.13.1(bare-events@2.8.2)
+      bare-url: 2.4.2
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+    optional: true
+
+  bare-os@3.9.1:
+    optional: true
+
+  bare-path@3.0.0:
+    dependencies:
+      bare-os: 3.9.1
+    optional: true
+
+  bare-stream@2.13.1(bare-events@2.8.2):
+    dependencies:
+      streamx: 2.25.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - react-native-b4a
+    optional: true
+
+  bare-url@2.4.2:
+    dependencies:
+      bare-path: 3.0.0
+    optional: true
+
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.9.10: {}
 
   basic-ftp@5.0.5: {}
 
+  bcrypt-pbkdf@1.0.2:
+    dependencies:
+      tweetnacl: 0.14.5
+
   binary-extensions@2.3.0: {}
+
+  bintrees@1.0.2: {}
 
   bl@4.1.0:
     dependencies:
@@ -12290,6 +13397,8 @@ snapshots:
 
   buffer-crc32@0.2.13: {}
 
+  buffer-crc32@1.0.0: {}
+
   buffer-from@1.1.2:
     optional: true
 
@@ -12304,6 +13413,9 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+
+  buildcheck@0.0.7:
+    optional: true
 
   bunchee@6.6.2(typescript@5.8.2):
     dependencies:
@@ -12339,6 +13451,8 @@ snapshots:
     dependencies:
       streamsearch: 1.1.0
     optional: true
+
+  byline@5.0.0: {}
 
   bytes@3.1.2: {}
 
@@ -12504,6 +13618,10 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
+  chownr@1.1.4: {}
+
+  cjs-module-lexer@1.4.3: {}
+
   class-transformer@0.5.1: {}
 
   class-validator@0.14.3:
@@ -12590,6 +13708,14 @@ snapshots:
 
   component-emitter@1.3.1: {}
 
+  compress-commons@6.0.2:
+    dependencies:
+      crc-32: 1.2.2
+      crc32-stream: 6.0.0
+      is-stream: 2.0.1
+      normalize-path: 3.0.0
+      readable-stream: 4.7.0
+
   concat-map@0.0.1: {}
 
   concat-stream@2.0.0:
@@ -12647,6 +13773,8 @@ snapshots:
 
   core-js-pure@3.47.0: {}
 
+  core-util-is@1.0.3: {}
+
   cors@2.8.5:
     dependencies:
       object-assign: 4.1.1
@@ -12669,6 +13797,19 @@ snapshots:
       path-type: 4.0.0
     optionalDependencies:
       typescript: 5.9.3
+
+  cpu-features@0.0.10:
+    dependencies:
+      buildcheck: 0.0.7
+      nan: 2.26.2
+    optional: true
+
+  crc-32@1.2.2: {}
+
+  crc32-stream@6.0.0:
+    dependencies:
+      crc-32: 1.2.2
+      readable-stream: 4.7.0
 
   create-require@1.1.1: {}
 
@@ -12825,6 +13966,31 @@ snapshots:
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
+
+  docker-compose@0.24.8:
+    dependencies:
+      yaml: 2.8.2
+
+  docker-modem@5.0.7:
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      readable-stream: 3.6.2
+      split-ca: 1.0.1
+      ssh2: 1.17.0
+    transitivePeerDependencies:
+      - supports-color
+
+  dockerode@4.0.12:
+    dependencies:
+      '@balena/dockerignore': 1.0.2
+      '@grpc/grpc-js': 1.14.3
+      '@grpc/proto-loader': 0.7.15
+      docker-modem: 5.0.7
+      protobufjs: 7.5.6
+      tar-fs: 2.1.4
+      uuid: 10.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   doctrine@2.1.0:
     dependencies:
@@ -13754,6 +14920,8 @@ snapshots:
 
   fresh@0.5.2: {}
 
+  fs-constants@1.0.0: {}
+
   fs-extra@10.1.0:
     dependencies:
       graceful-fs: 4.2.11
@@ -13810,6 +14978,8 @@ snapshots:
       math-intrinsics: 1.1.0
 
   get-package-type@0.1.0: {}
+
+  get-port@7.2.0: {}
 
   get-proto@1.0.1:
     dependencies:
@@ -14151,6 +15321,13 @@ snapshots:
 
   import-from@4.0.0: {}
 
+  import-in-the-middle@1.15.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      cjs-module-lexer: 1.4.3
+      module-details-from-path: 1.0.4
+
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
@@ -14424,6 +15601,8 @@ snapshots:
     dependencies:
       is-docker: 2.2.1
 
+  isarray@1.0.0: {}
+
   isarray@2.0.5: {}
 
   isbinaryfile@4.0.10: {}
@@ -14583,6 +15762,10 @@ snapshots:
     dependencies:
       language-subtag-registry: 0.3.23
 
+  lazystream@1.0.1:
+    dependencies:
+      readable-stream: 2.3.8
+
   levn@0.4.1:
     dependencies:
       prelude-ls: 1.2.1
@@ -14619,6 +15802,8 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash.camelcase@4.3.0: {}
 
   lodash.get@4.4.2: {}
 
@@ -14790,9 +15975,13 @@ snapshots:
 
   minipass@7.1.2: {}
 
+  mkdirp-classic@0.5.3: {}
+
   mkdirp@0.5.6:
     dependencies:
       minimist: 1.2.8
+
+  mkdirp@1.0.4: {}
 
   mlly@1.8.0:
     dependencies:
@@ -14800,6 +15989,8 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.1
+
+  module-details-from-path@1.0.4: {}
 
   mongodb-connection-string-url@2.6.0:
     dependencies:
@@ -14912,6 +16103,9 @@ snapshots:
     dependencies:
       lru.min: 1.1.4
 
+  nan@2.26.2:
+    optional: true
+
   nanoid@3.3.11: {}
 
   nanospinner@1.2.2:
@@ -14936,7 +16130,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  next@15.5.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@15.5.9(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 15.5.9
       '@swc/helpers': 0.5.15
@@ -14954,6 +16148,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.5.7
       '@next/swc-win32-arm64-msvc': 15.5.7
       '@next/swc-win32-x64-msvc': 15.5.7
+      '@opentelemetry/api': 1.9.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -15307,6 +16502,41 @@ snapshots:
 
   pend@1.2.0: {}
 
+  pg-cloudflare@1.3.0:
+    optional: true
+
+  pg-connection-string@2.12.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.13.0(pg@8.20.0):
+    dependencies:
+      pg: 8.20.0
+
+  pg-protocol@1.13.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.20.0:
+    dependencies:
+      pg-connection-string: 2.12.0
+      pg-pool: 3.13.0(pg@8.20.0)
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.3.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   picocolors@1.0.1: {}
 
   picocolors@1.1.1: {}
@@ -15388,6 +16618,16 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
+
   prelude-ls@1.2.1: {}
 
   prettier@3.7.4: {}
@@ -15400,9 +16640,16 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
+  process-nextick-args@2.0.1: {}
+
   process-warning@3.0.0: {}
 
   process@0.11.10: {}
+
+  prom-client@15.1.3:
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      tdigest: 0.1.2
 
   promise@7.3.1:
     dependencies:
@@ -15414,7 +16661,32 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
+
+  properties-reader@2.3.0:
+    dependencies:
+      mkdirp: 1.0.4
+
   proto-list@1.2.4: {}
+
+  protobufjs@7.5.6:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.1
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 24.0.12
+      long: 5.3.2
 
   proxy-addr@2.0.7:
     dependencies:
@@ -15485,6 +16757,16 @@ snapshots:
 
   react@19.2.3: {}
 
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
   readable-stream@3.6.2:
     dependencies:
       inherits: 2.0.4
@@ -15498,6 +16780,10 @@ snapshots:
       events: 3.3.0
       process: 0.11.10
       string_decoder: 1.3.0
+
+  readdir-glob@1.1.3:
+    dependencies:
+      minimatch: 5.1.9
 
   readdirp@3.6.0:
     dependencies:
@@ -15566,6 +16852,14 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  require-in-the-middle@7.5.2:
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      module-details-from-path: 1.0.4
+      resolve: 1.22.11
+    transitivePeerDependencies:
+      - supports-color
+
   requires-port@1.0.0: {}
 
   resolve-alpn@1.2.1: {}
@@ -15596,6 +16890,8 @@ snapshots:
     dependencies:
       onetime: 5.1.2
       signal-exit: 3.0.7
+
+  retry@0.12.0: {}
 
   retry@0.13.1: {}
 
@@ -15698,6 +16994,8 @@ snapshots:
       get-intrinsic: 1.3.0
       has-symbols: 1.1.0
       isarray: 2.0.5
+
+  safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
 
@@ -15840,6 +17138,8 @@ snapshots:
 
   shell-quote@1.8.3: {}
 
+  shimmer@1.2.1: {}
+
   side-channel-list@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -15955,6 +17255,8 @@ snapshots:
 
   spdx-license-ids@3.0.23: {}
 
+  split-ca@1.0.1: {}
+
   split2@4.2.0: {}
 
   sponge-case@1.0.1:
@@ -15962,6 +17264,19 @@ snapshots:
       tslib: 2.8.1
 
   sql-escaper@1.3.3: {}
+
+  ssh-remote-port-forward@1.0.4:
+    dependencies:
+      '@types/ssh2': 0.5.52
+      ssh2: 1.17.0
+
+  ssh2@1.17.0:
+    dependencies:
+      asn1: 0.2.6
+      bcrypt-pbkdf: 1.0.2
+    optionalDependencies:
+      cpu-features: 0.0.10
+      nan: 2.26.2
 
   stable-hash@0.0.5: {}
 
@@ -15990,6 +17305,16 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
+
+  streamx@2.25.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.3
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+    optional: true
 
   string-env-interpolation@1.0.1: {}
 
@@ -16054,6 +17379,10 @@ snapshots:
       call-bind: 1.0.8
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   string_decoder@1.3.0:
     dependencies:
@@ -16179,6 +17508,33 @@ snapshots:
       syncpack-windows-arm64: 14.0.0-alpha.16
       syncpack-windows-x64: 14.0.0-alpha.16
 
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.3
+      tar-stream: 2.2.0
+
+  tar-fs@3.1.2:
+    dependencies:
+      pump: 3.0.3
+      tar-stream: 3.1.7
+    optionalDependencies:
+      bare-fs: 4.7.1
+      bare-path: 3.0.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
   tar-stream@3.1.7:
     dependencies:
       b4a: 1.7.3
@@ -16188,6 +17544,18 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
+  tdigest@0.1.2:
+    dependencies:
+      bintrees: 1.0.2
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+    optional: true
+
   template-url@1.0.0: {}
 
   test-exclude@6.0.0:
@@ -16195,6 +17563,29 @@ snapshots:
       '@istanbuljs/schema': 0.1.3
       glob: 7.2.3
       minimatch: 3.1.2
+
+  testcontainers@10.28.0:
+    dependencies:
+      '@balena/dockerignore': 1.0.2
+      '@types/dockerode': 3.3.47
+      archiver: 7.0.1
+      async-lock: 1.4.1
+      byline: 5.0.0
+      debug: 4.4.3(supports-color@8.1.1)
+      docker-compose: 0.24.8
+      dockerode: 4.0.12
+      get-port: 7.2.0
+      proper-lockfile: 4.1.2
+      properties-reader: 2.3.0
+      ssh-remote-port-forward: 1.0.4
+      tar-fs: 3.1.2
+      tmp: 0.2.5
+      undici: 5.29.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
 
   text-decoder@1.2.3:
     dependencies:
@@ -16260,6 +17651,8 @@ snapshots:
   tmp@0.0.33:
     dependencies:
       os-tmpdir: 1.0.2
+
+  tmp@0.2.5: {}
 
   to-buffer@1.2.2:
     dependencies:
@@ -16429,6 +17822,8 @@ snapshots:
       turbo-windows-64: 2.6.3
       turbo-windows-arm64: 2.6.3
 
+  tweetnacl@0.14.5: {}
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -16536,6 +17931,8 @@ snapshots:
 
   unc-path-regex@0.1.2: {}
 
+  undici-types@5.26.5: {}
+
   undici-types@6.21.0: {}
 
   undici-types@7.18.2: {}
@@ -16543,6 +17940,10 @@ snapshots:
   undici-types@7.19.2: {}
 
   undici-types@7.8.0: {}
+
+  undici@5.29.0:
+    dependencies:
+      '@fastify/busboy': 2.1.1
 
   undici@7.16.0: {}
 
@@ -16619,6 +18020,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
+
+  uuid@10.0.0: {}
 
   uuid@11.1.0: {}
 
@@ -16993,8 +18396,7 @@ snapshots:
 
   ws@8.18.3: {}
 
-  xtend@4.0.2:
-    optional: true
+  xtend@4.0.2: {}
 
   y18n@5.0.8: {}
 
@@ -17028,6 +18430,12 @@ snapshots:
   yocto-queue@1.2.2: {}
 
   yoctocolors-cjs@2.1.3: {}
+
+  zip-stream@6.0.1:
+    dependencies:
+      archiver-utils: 5.0.2
+      compress-commons: 6.0.2
+      readable-stream: 4.7.0
 
   zod@3.25.67: {}
 


### PR DESCRIPTION
## Summary

Promotes six reusable building blocks from `~/dev/soa_event_driven_example/` into first-class soa packages so fleet services (starting with the upcoming program-hub slice) can adopt the event-driven pattern without copying code.

| Source (`@example/*`) | Destination (`@saga-ed/soa-*`) |
| --- | --- |
| `envelope` | `event-envelope` |
| `event-outbox` | `event-outbox` |
| `event-consumer` | `event-consumer` |
| `observability` | `observability` |
| `test-harness` | `event-test-harness` |
| `integration-tests` | `event-integration-tests` |

All under `packages/node/`. Renamed `@example/*` -> `@saga-ed/soa-*` (imports + tracer names), retargeted tsconfigs to `@saga-ed/soa-typescript-config/base.json`, swapped versioned soa deps to `workspace:*`. Packages remain `private: true` for now; CodeArtifact publishing will follow in a separate PR mirroring #71.

## Docs

- `packages/node/CLAUDE.md` — new package rows + a "two pubsub families" pointer (durable cross-service eventing vs realtime UI push)
- `packages/node/claude/event-driven.md` — adopter conventions (sector pattern, plain `@trpc/server` + Inversify, frozen-once-published Zod schemas, hybrid contract testing, two vitest configs, outbox/consumer wiring) cross-linked to `soa_75/decisions/`

## Out of scope

- Domain event packages (identity/catalog/admissions-events) — POC-specific
- Example apps under `apps/`
- Replacing existing `@saga-ed/soa-pubsub-*` usage in fleet apps
- Publishing to CodeArtifact

## Test plan

- [x] `pnpm install` clean
- [x] `pnpm turbo build` green for all 6 packages
- [x] `pnpm turbo check-types` green for all 6 packages
- [x] `pnpm turbo test` (unit) green — envelope's 8 tests pass; others have no unit suite
- [ ] `pnpm --filter @saga-ed/soa-event-integration-tests test:int` — needs Docker; defer to local verification
- [ ] Sanity import in a scratch consumer:
  ```ts
  import { EventEnvelopeSchema } from '@saga-ed/soa-event-envelope';
  import { writeOutbox, startRelay } from '@saga-ed/soa-event-outbox';
  import { createConsumer } from '@saga-ed/soa-event-consumer';
  ```

## Follow-ups

1. `saga-ed/program-hub-svc` — first real consumer (programs-api on the sector pattern)
2. `chore/unprivate-soa-event-packages` — flip `private: false` and publish, mirroring #71