### PR TITLE
feat(soa-event-consumer): expose public dispatchEnvelope() for direct-dispatch test pathway

### DIFF
--- a/packages/node/event-consumer/src/__tests__/dispatch-envelope.unit.test.ts
+++ b/packages/node/event-consumer/src/__tests__/dispatch-envelope.unit.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import type { Pool, PoolClient, QueryResult } from 'pg';
+import type { ILogger } from '@saga-ed/soa-logger';
+import type { ConnectionManager } from '@saga-ed/soa-rabbitmq';
+import type { EventEnvelope } from '@saga-ed/soa-event-envelope';
+import { EventConsumer, type EventHandler } from '../consumer.js';
+
+/**
+ * Verifies the public dispatchEnvelope() entry point runs an envelope through
+ * the same idempotency + tx pipeline as the broker path. Three behaviors are
+ * load-bearing for downstream test helpers (e.g. MockPublisher in
+ * ads-adm-api): handler runs inside a tx, duplicate envelopes skip the
+ * handler, and handler errors trigger ROLLBACK.
+ */
+
+interface RecordedQuery {
+    sql: string;
+    params: ReadonlyArray<unknown>;
+}
+
+function makeFakeClient(insertRowCount: number): PoolClient & { queries: RecordedQuery[]; released: boolean } {
+    const queries: RecordedQuery[] = [];
+    let released = false;
+
+    const client = {
+        queries,
+        get released() {
+            return released;
+        },
+        async query(sql: string, params: unknown[] = []): Promise<QueryResult> {
+            queries.push({ sql, params });
+            if (sql.includes('INSERT INTO consumed_events')) {
+                return {
+                    rowCount: insertRowCount,
+                    rows: insertRowCount > 0 ? [{ event_id: params[1] }] : [],
+                    command: 'INSERT',
+                    oid: 0,
+                    fields: [],
+                } as unknown as QueryResult;
+            }
+            return {
+                rowCount: 0,
+                rows: [],
+                command: 'OTHER',
+                oid: 0,
+                fields: [],
+            } as unknown as QueryResult;
+        },
+        release() {
+            released = true;
+        },
+    };
+
+    return client as unknown as PoolClient & { queries: RecordedQuery[]; released: boolean };
+}
+
+function makeFakePool(client: PoolClient): Pool {
+    return {
+        async connect() {
+            return client;
+        },
+    } as unknown as Pool;
+}
+
+const silentLogger: ILogger = {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+};
+
+const stubConnectionManager: ConnectionManager =
+    {} as unknown as ConnectionManager;
+
+function makeEnvelope(overrides: Partial<EventEnvelope> = {}): EventEnvelope {
+    return {
+        eventId: '00000000-0000-4000-8000-000000000001',
+        eventType: 'test.thing.upserted',
+        eventVersion: 1,
+        aggregateType: 'thing',
+        aggregateId: 'thing-1',
+        occurredAt: '2026-05-05T00:00:00.000Z',
+        payload: { value: 42 },
+        ...overrides,
+    };
+}
+
+function makeHandler(): EventHandler<{ value: number }> & {
+    invocations: Array<{ envelope: EventEnvelope; payload: { value: number } }>;
+} {
+    const invocations: Array<{
+        envelope: EventEnvelope;
+        payload: { value: number };
+    }> = [];
+
+    return {
+        invocations,
+        eventType: 'test.thing.upserted',
+        eventVersion: 1,
+        payloadSchema: z.object({ value: z.number() }),
+        async handle(envelope, payload) {
+            invocations.push({ envelope, payload });
+        },
+    };
+}
+
+describe('EventConsumer.dispatchEnvelope', () => {
+    it('runs handler inside the same tx as the consumed_events insert', async () => {
+        const client = makeFakeClient(1);
+        const handler = makeHandler();
+
+        const consumer = new EventConsumer({
+            consumerName: 'test-consumer',
+            pool: makeFakePool(client),
+            connectionManager: stubConnectionManager,
+            queue: 'test.queue',
+            bindings: [],
+            handlers: [handler],
+            logger: silentLogger,
+        });
+
+        await consumer.dispatchEnvelope(makeEnvelope());
+
+        const sqls = client.queries.map((q) => q.sql.trim().split(/\s+/)[0]);
+        // BEGIN, INSERT, COMMIT — handler runs between INSERT and COMMIT.
+        expect(sqls[0]).toBe('BEGIN');
+        expect(client.queries[1]?.sql).toContain('INSERT INTO consumed_events');
+        expect(sqls[sqls.length - 1]).toBe('COMMIT');
+        expect(handler.invocations).toHaveLength(1);
+        expect(handler.invocations[0]?.payload).toEqual({ value: 42 });
+        expect(client.released).toBe(true);
+    });
+
+    it('skips the handler and calls onDuplicate when consumed_events insert returns 0 rows', async () => {
+        const client = makeFakeClient(0); // ON CONFLICT DO NOTHING — duplicate
+        const handler = makeHandler();
+        const onDuplicate = vi.fn();
+
+        const consumer = new EventConsumer({
+            consumerName: 'test-consumer',
+            pool: makeFakePool(client),
+            connectionManager: stubConnectionManager,
+            queue: 'test.queue',
+            bindings: [],
+            handlers: [handler],
+            logger: silentLogger,
+            metrics: {
+                onProcessed: () => {},
+                onFailed: () => {},
+                onDuplicate,
+            },
+        });
+
+        await consumer.dispatchEnvelope(makeEnvelope());
+
+        expect(handler.invocations).toHaveLength(0);
+        expect(onDuplicate).toHaveBeenCalledWith('test.thing.upserted', 1);
+        // Even on duplicate path the tx must commit, not roll back.
+        const sqls = client.queries.map((q) => q.sql.trim().split(/\s+/)[0]);
+        expect(sqls).toContain('COMMIT');
+        expect(sqls).not.toContain('ROLLBACK');
+        expect(client.released).toBe(true);
+    });
+
+    it('issues ROLLBACK and rethrows when the handler throws', async () => {
+        const client = makeFakeClient(1);
+        const handlerError = new Error('handler boom');
+
+        const throwingHandler: EventHandler<{ value: number }> = {
+            eventType: 'test.thing.upserted',
+            eventVersion: 1,
+            payloadSchema: z.object({ value: z.number() }),
+            async handle() {
+                throw handlerError;
+            },
+        };
+
+        const consumer = new EventConsumer({
+            consumerName: 'test-consumer',
+            pool: makeFakePool(client),
+            connectionManager: stubConnectionManager,
+            queue: 'test.queue',
+            bindings: [],
+            handlers: [throwingHandler],
+            logger: silentLogger,
+        });
+
+        await expect(consumer.dispatchEnvelope(makeEnvelope())).rejects.toBe(
+            handlerError,
+        );
+
+        const sqls = client.queries.map((q) => q.sql.trim().split(/\s+/)[0]);
+        expect(sqls).toContain('ROLLBACK');
+        expect(sqls).not.toContain('COMMIT');
+        expect(client.released).toBe(true);
+    });
+});

--- a/packages/node/event-consumer/src/consumer.ts
+++ b/packages/node/event-consumer/src/consumer.ts
@@ -243,6 +243,23 @@ export class EventConsumer {
         this.opts.logger.info(`[EventConsumer:${this.opts.consumerName}] stopped`);
     }
 
+    /**
+     * Direct-dispatch entry point — bypasses the broker. Used by test
+     * helpers (e.g. MockPublisher patterns in downstream consumers) and
+     * ad-hoc seed scripts. Goes through the same consumed_events idempotency
+     * check + tx-wrapped handler invocation as the broker path, so test
+     * coverage on idempotency / tx atomicity is real and not a separate
+     * code path.
+     *
+     * Does NOT extract OTel context from envelope.meta — the broker path
+     * does that in handleMessage(). Tests exercising tracing should go
+     * through the broker path; tests exercising handler logic should use
+     * this.
+     */
+    async dispatchEnvelope(envelope: EventEnvelope): Promise<void> {
+        await this.processEnvelope(envelope);
+    }
+
     private async dispatch(msg: ConsumeMessage): Promise<void> {
         try {
             await this.handleMessage(msg.content);


### PR DESCRIPTION
## Summary

- Restores a public entry point for direct envelope dispatch on `EventConsumer`, removed (likely accidentally) by the `/simplify` pass.
- The `/simplify` pass renamed the public `dispatch(envelope)` method to a private `dispatch(msg: ConsumeMessage)` to encapsulate the broker-side ack/nack flow. Side effect: there is no longer a public way to feed a parsed `EventEnvelope` through `processEnvelope()` from outside the broker path.
- Downstream consumers (e.g. ads-adm-api's `MockPublisher`) use this entry point for fast, broker-free unit tests that exercise the same idempotency + tx pipeline as the broker path. Without it, every consumer-pathway test has to spin up testcontainers RabbitMQ.

## What this PR adds

`EventConsumer.dispatchEnvelope(envelope)` — a thin public wrapper around the existing private `processEnvelope()`. Pure addition, no behavior change to the broker path. The new method intentionally does NOT extract OTel context from `envelope.meta` (the broker path does that in `handleMessage()`); tests exercising tracing should still go through the broker path.

## Why `dispatchEnvelope` and not restoring `dispatch(envelope)`

The post-`/simplify` private method is `dispatch(msg: ConsumeMessage)`. Reusing the name `dispatch` for both the public envelope-typed method and the private message-typed method is overload-confusing. `dispatchEnvelope` is descriptive, additive, and avoids touching anything that already works.

## Test plan

- [x] 3 new unit tests in `dispatch-envelope.unit.test.ts`:
  - Handler runs inside the same tx as the `consumed_events` insert (BEGIN → INSERT → handler → COMMIT)
  - Duplicate envelope (insert returns 0 rows) skips the handler and calls `metrics.onDuplicate`; tx still commits
  - Handler errors trigger ROLLBACK and rethrow; client is released
- [x] `pnpm --filter @saga-ed/soa-event-consumer test` — 9 passed (3 new + 6 pre-existing handler-map tests)
- [x] `pnpm --filter @saga-ed/soa-event-consumer check-types` — clean
- [x] `pnpm --filter @saga-ed/soa-event-consumer build` — clean
- [x] `pnpm --filter @saga-ed/soa-event-consumer lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)