### PR TITLE
chore: bump soa-event-* packages to 0.1.0-dev.2

### DIFF
--- a/packages/node/event-consumer/package.json
+++ b/packages/node/event-consumer/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/soa-event-consumer",
-    "version": "0.1.0-dev.1",
+    "version": "0.1.0-dev.2",
     "private": false,
     "type": "module",
     "main": "dist/index.js",

--- a/packages/node/event-envelope/package.json
+++ b/packages/node/event-envelope/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/soa-event-envelope",
-    "version": "0.1.0-dev.1",
+    "version": "0.1.0-dev.2",
     "private": false,
     "type": "module",
     "main": "dist/index.js",

--- a/packages/node/event-outbox/package.json
+++ b/packages/node/event-outbox/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/soa-event-outbox",
-    "version": "0.1.0-dev.1",
+    "version": "0.1.0-dev.2",
     "private": false,
     "type": "module",
     "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bumps `@saga-ed/soa-event-envelope`, `@saga-ed/soa-event-outbox`, and `@saga-ed/soa-event-consumer` from `0.1.0-dev.1` → `0.1.0-dev.2`.
- Captures the public `dispatchEnvelope()` surface restored in #80 so downstream consumers can pin against a published version.
- All three already published to CodeArtifact under the `dev` dist-tag (manual `pnpm publish --tag dev`, since these packages are not yet wired into `.github/workflows/publish-codeartifact.yml`).

## Verification
- `pnpm turbo run build check-types test --filter "@saga-ed/soa-event-*"` ✅
- `aws codeartifact list-package-versions ...` confirms `0.1.0-dev.2` is live for all three packages.

## Test plan
- [x] Build, type-check, and unit tests pass locally for all three packages
- [x] All three versions published and visible in CodeArtifact `saga_js`
- [ ] Downstream branches (rostering / program-hub event-driven) can `pnpm add @saga-ed/soa-event-consumer@0.1.0-dev.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)