### PR TITLE
feat(soa-event-*): preview-isolation helpers + coherence assert

### DIFF
--- a/packages/node/event-consumer/src/index.ts
+++ b/packages/node/event-consumer/src/index.ts
@@ -1,4 +1,5 @@
 export { CONSUMED_EVENTS_SQL, PRISMA_MODEL_FRAGMENT } from './schema.js';
+export { applyPreviewTag } from '@saga-ed/soa-event-envelope';
 export {
     EventConsumer,
     ConsumerVersionMismatchError,

--- a/packages/node/event-envelope/src/__tests__/preview-tag.unit.test.ts
+++ b/packages/node/event-envelope/src/__tests__/preview-tag.unit.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { applyPreviewTag } from '../preview-tag.js';
+
+describe('applyPreviewTag', () => {
+    const original = process.env.EVENT_PREVIEW_TAG;
+
+    beforeEach(() => {
+        delete process.env.EVENT_PREVIEW_TAG;
+    });
+
+    afterEach(() => {
+        if (original === undefined) {
+            delete process.env.EVENT_PREVIEW_TAG;
+        } else {
+            process.env.EVENT_PREVIEW_TAG = original;
+        }
+    });
+
+    it('returns the name unchanged when no tag is set', () => {
+        expect(applyPreviewTag('iam.events')).toBe('iam.events');
+    });
+
+    it('returns the name unchanged when the env var is empty', () => {
+        process.env.EVENT_PREVIEW_TAG = '';
+        expect(applyPreviewTag('iam.events')).toBe('iam.events');
+    });
+
+    it('returns the name unchanged when the env var is whitespace', () => {
+        process.env.EVENT_PREVIEW_TAG = '   ';
+        expect(applyPreviewTag('iam.events')).toBe('iam.events');
+    });
+
+    it('suffixes the env var when set', () => {
+        process.env.EVENT_PREVIEW_TAG = 'pr-142';
+        expect(applyPreviewTag('iam.events')).toBe('iam.events.pr-142');
+    });
+
+    it('explicit tag overrides the env var', () => {
+        process.env.EVENT_PREVIEW_TAG = 'pr-142';
+        expect(applyPreviewTag('iam.events', 'pr-999')).toBe('iam.events.pr-999');
+    });
+
+    it('explicit empty string overrides the env var', () => {
+        process.env.EVENT_PREVIEW_TAG = 'pr-142';
+        expect(applyPreviewTag('iam.events', '')).toBe('iam.events');
+    });
+
+    it('trims whitespace from the tag', () => {
+        process.env.EVENT_PREVIEW_TAG = '  pr-142  ';
+        expect(applyPreviewTag('iam.events')).toBe('iam.events.pr-142');
+    });
+
+    it('handles queue and consumer-tag style names', () => {
+        process.env.EVENT_PREVIEW_TAG = 'pr-7';
+        expect(applyPreviewTag('iam.user-projection')).toBe('iam.user-projection.pr-7');
+        expect(applyPreviewTag('programs-iam-projection')).toBe('programs-iam-projection.pr-7');
+    });
+});

--- a/packages/node/event-envelope/src/index.ts
+++ b/packages/node/event-envelope/src/index.ts
@@ -2,6 +2,8 @@ import { randomUUID } from 'node:crypto';
 import { context, propagation } from '@opentelemetry/api';
 import { z } from 'zod';
 
+export { applyPreviewTag } from './preview-tag.js';
+
 // W3C TraceContext requires that `tracestate` only ride along with a
 // `traceparent`. The refine catches an orphan `tracestate` at parse time
 // rather than letting OTel's propagator silently discard it (which would

--- a/packages/node/event-envelope/src/preview-tag.ts
+++ b/packages/node/event-envelope/src/preview-tag.ts
@@ -1,0 +1,19 @@
+/**
+ * Suffix an event-routing name (exchange, queue, consumer tag) with the
+ * preview-environment tag, so multiple PR-preview deploys can share a
+ * single RabbitMQ broker without cross-contamination.
+ *
+ * The tag is read from `EVENT_PREVIEW_TAG` by default; production deploys
+ * leave it unset and the helper is a no-op. Both publisher and consumer
+ * sides MUST apply the same tag — see d-preview-deploy-isolation.md.
+ *
+ * @example
+ *   applyPreviewTag('iam.events')                          // → 'iam.events'
+ *   applyPreviewTag('iam.events', 'pr-142')                // → 'iam.events.pr-142'
+ *   process.env.EVENT_PREVIEW_TAG = 'pr-142';
+ *   applyPreviewTag('iam.events')                          // → 'iam.events.pr-142'
+ */
+export function applyPreviewTag(name: string, tag?: string): string {
+    const resolved = (tag ?? process.env.EVENT_PREVIEW_TAG ?? '').trim();
+    return resolved ? `${name}.${resolved}` : name;
+}

--- a/packages/node/event-outbox/src/__tests__/create-pool.unit.test.ts
+++ b/packages/node/event-outbox/src/__tests__/create-pool.unit.test.ts
@@ -69,4 +69,46 @@ describe('createOutboxPool', () => {
         );
         expect(getOpts(pool).options).toBe('-c statement_timeout=5000');
     });
+
+    it('poolOverrides.max wins over the top-level max option', () => {
+        const pool = createOutboxPool(
+            'postgresql://u:p@h:5432/db',
+            { max: 2, poolOverrides: { max: 8 } },
+        );
+        expect(getOpts(pool).max).toBe(8);
+    });
+
+    it('treats present-but-empty ?schema= the same as absent', () => {
+        const pool = createOutboxPool('postgresql://u:p@h:5432/db?schema=');
+        expect(getOpts(pool).options).toBeUndefined();
+    });
+
+    it('throws on a non-URL connection string with a useful message', () => {
+        // libpq KV form ("host=… dbname=…") and other non-URL strings are not
+        // supported. We surface a helpful error rather than letting URL throw
+        // a raw TypeError that points at the wrong line.
+        expect(() => createOutboxPool('host=/var/run dbname=app')).toThrow(
+            /URL-form connection string/,
+        );
+        expect(() => createOutboxPool('not a url')).toThrow(/URL-form/);
+    });
+
+    it('rejects a schema name with spaces or special chars (libpq injection guard)', () => {
+        // A schema value of ` pr_142 -c statement_timeout=0` would inject a
+        // second startup parameter via the `-c search_path=…` form. The
+        // identifier-regex check forbids it.
+        expect(() =>
+            createOutboxPool('postgresql://u:p@h/db?schema=pr_142%20-c%20statement_timeout%3D0'),
+        ).toThrow(/unquoted-identifier|safely interpolated/i);
+
+        expect(() => createOutboxPool('postgresql://u:p@h/db?schema=foo%3Bbar')).toThrow(
+            /safely interpolated/i,
+        );
+    });
+
+    it('accepts hyphen-free schema names that match Postgres unquoted identifiers', () => {
+        // pr_142 (underscore) and Pr142 (mixed case) both pass.
+        expect(() => createOutboxPool('postgresql://u:p@h/db?schema=pr_142')).not.toThrow();
+        expect(() => createOutboxPool('postgresql://u:p@h/db?schema=Pr142')).not.toThrow();
+    });
 });

--- a/packages/node/event-outbox/src/__tests__/create-pool.unit.test.ts
+++ b/packages/node/event-outbox/src/__tests__/create-pool.unit.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createOutboxPool } from '../create-pool.js';
 
 // We verify the pool's `options` resolve correctly without opening a real
@@ -16,7 +16,26 @@ function getOpts(pool: unknown): { connectionString: string; max: number; option
     return opts;
 }
 
-describe('createOutboxPool', () => {
+// The coherence assert ties `?schema=` in DATABASE_URL to EVENT_PREVIEW_TAG.
+// Tests that exercise schema-aware paths must set the tag; tests that
+// exercise the production path must clear it. A beforeEach/afterEach pair
+// snapshots the env so test order doesn't matter.
+const ORIGINAL_TAG = process.env.EVENT_PREVIEW_TAG;
+
+function restoreTag(): void {
+    if (ORIGINAL_TAG === undefined) {
+        delete process.env.EVENT_PREVIEW_TAG;
+    } else {
+        process.env.EVENT_PREVIEW_TAG = ORIGINAL_TAG;
+    }
+}
+
+describe('createOutboxPool — production-shape URLs (no schema, no tag)', () => {
+    beforeEach(() => {
+        delete process.env.EVENT_PREVIEW_TAG;
+    });
+    afterEach(restoreTag);
+
     it('passes connectionString through', () => {
         const url = 'postgresql://u:p@h:5432/db';
         const pool = createOutboxPool(url);
@@ -38,10 +57,28 @@ describe('createOutboxPool', () => {
         expect(getOpts(pool).options).toBeUndefined();
     });
 
+    it('treats present-but-empty ?schema= the same as absent', () => {
+        const pool = createOutboxPool('postgresql://u:p@h:5432/db?schema=');
+        expect(getOpts(pool).options).toBeUndefined();
+    });
+
+    it('poolOverrides.max wins over the top-level max option', () => {
+        const pool = createOutboxPool('postgresql://u:p@h:5432/db', {
+            max: 2,
+            poolOverrides: { max: 8 },
+        });
+        expect(getOpts(pool).max).toBe(8);
+    });
+});
+
+describe('createOutboxPool — preview-shape URLs (schema + matching tag)', () => {
+    beforeEach(() => {
+        process.env.EVENT_PREVIEW_TAG = 'pr-42';
+    });
+    afterEach(restoreTag);
+
     it('translates ?schema=… into libpq search_path', () => {
-        const pool = createOutboxPool(
-            'postgresql://u:p@h:5432/db?schema=pr_142',
-        );
+        const pool = createOutboxPool('postgresql://u:p@h:5432/db?schema=pr_142');
         expect(getOpts(pool).options).toBe('-c search_path=pr_142');
     });
 
@@ -52,36 +89,51 @@ describe('createOutboxPool', () => {
         expect(getOpts(pool).options).toBe('-c search_path=pr_142');
     });
 
+    it('accepts the exact adopter URL form (?schema= AND ?options= belt-and-suspenders)', () => {
+        // Adopters' GitHub workflows emit URLs with both params filled in:
+        //   ?schema=pr_42&options=-c%20search_path%3Dpr_42
+        // The helper parses ?schema=, sets top-level `options` to the same
+        // value (overriding the URL's `?options=` carried via connectionString).
+        // No throw; the URL is preserved verbatim so callers can later opt out
+        // of the top-level options via poolOverrides if needed.
+        const url =
+            'postgresql://u:p@h:5432/db?schema=pr_42&options=-c%20search_path%3Dpr_42';
+        const pool = createOutboxPool(url);
+        const opts = getOpts(pool);
+        expect(opts.options).toBe('-c search_path=pr_42');
+        expect(opts.connectionString).toBe(url);
+    });
+
     it('poolOverrides win over defaults but do not strip the search_path option', () => {
-        const pool = createOutboxPool(
-            'postgresql://u:p@h:5432/db?schema=pr_7',
-            { poolOverrides: { idleTimeoutMillis: 30_000 } },
-        );
+        const pool = createOutboxPool('postgresql://u:p@h:5432/db?schema=pr_7', {
+            poolOverrides: { idleTimeoutMillis: 30_000 },
+        });
         const opts = getOpts(pool);
         expect(opts.options).toBe('-c search_path=pr_7');
         expect((opts as { idleTimeoutMillis?: number }).idleTimeoutMillis).toBe(30_000);
     });
 
     it('explicit options in poolOverrides win — escape hatch for advanced cases', () => {
-        const pool = createOutboxPool(
-            'postgresql://u:p@h:5432/db?schema=pr_7',
-            { poolOverrides: { options: '-c statement_timeout=5000' } },
-        );
+        const pool = createOutboxPool('postgresql://u:p@h:5432/db?schema=pr_7', {
+            poolOverrides: { options: '-c statement_timeout=5000' },
+        });
         expect(getOpts(pool).options).toBe('-c statement_timeout=5000');
     });
 
-    it('poolOverrides.max wins over the top-level max option', () => {
-        const pool = createOutboxPool(
-            'postgresql://u:p@h:5432/db',
-            { max: 2, poolOverrides: { max: 8 } },
-        );
-        expect(getOpts(pool).max).toBe(8);
+    it('accepts hyphen-free schema names that match Postgres unquoted identifiers', () => {
+        // pr_142 (underscore) and Pr142 (mixed case) both pass.
+        expect(() => createOutboxPool('postgresql://u:p@h/db?schema=pr_142')).not.toThrow();
+        expect(() => createOutboxPool('postgresql://u:p@h/db?schema=Pr142')).not.toThrow();
     });
+});
 
-    it('treats present-but-empty ?schema= the same as absent', () => {
-        const pool = createOutboxPool('postgresql://u:p@h:5432/db?schema=');
-        expect(getOpts(pool).options).toBeUndefined();
+describe('createOutboxPool — input validation', () => {
+    beforeEach(() => {
+        // Tests in this group fail before reaching the coherence assert;
+        // env-var state is irrelevant. Clear it for predictability.
+        delete process.env.EVENT_PREVIEW_TAG;
     });
+    afterEach(restoreTag);
 
     it('throws on a non-URL connection string with a useful message', () => {
         // libpq KV form ("host=… dbname=…") and other non-URL strings are not
@@ -96,19 +148,69 @@ describe('createOutboxPool', () => {
     it('rejects a schema name with spaces or special chars (libpq injection guard)', () => {
         // A schema value of ` pr_142 -c statement_timeout=0` would inject a
         // second startup parameter via the `-c search_path=…` form. The
-        // identifier-regex check forbids it.
+        // identifier-regex check forbids it. Set the tag so we hit the regex
+        // check (not the coherence assert).
+        process.env.EVENT_PREVIEW_TAG = 'pr-42';
         expect(() =>
-            createOutboxPool('postgresql://u:p@h/db?schema=pr_142%20-c%20statement_timeout%3D0'),
+            createOutboxPool(
+                'postgresql://u:p@h/db?schema=pr_142%20-c%20statement_timeout%3D0',
+            ),
         ).toThrow(/unquoted-identifier|safely interpolated/i);
 
         expect(() => createOutboxPool('postgresql://u:p@h/db?schema=foo%3Bbar')).toThrow(
             /safely interpolated/i,
         );
     });
+});
 
-    it('accepts hyphen-free schema names that match Postgres unquoted identifiers', () => {
-        // pr_142 (underscore) and Pr142 (mixed case) both pass.
-        expect(() => createOutboxPool('postgresql://u:p@h/db?schema=pr_142')).not.toThrow();
-        expect(() => createOutboxPool('postgresql://u:p@h/db?schema=Pr142')).not.toThrow();
+describe('createOutboxPool — preview-isolation coherence assert', () => {
+    afterEach(restoreTag);
+
+    // Truth table — every cell is exercised. The assert exists because a
+    // half-applied two-axis isolation model (DB schema-per-PR + RabbitMQ
+    // tag-per-PR) silently leaks events across PRs, and the failure mode is
+    // invisible until prod traffic hits it.
+
+    it('passes when neither tag nor schema are set (production case)', () => {
+        delete process.env.EVENT_PREVIEW_TAG;
+        expect(() => createOutboxPool('postgresql://u:p@h/db')).not.toThrow();
+    });
+
+    it('passes when both tag AND schema are set (preview case)', () => {
+        process.env.EVENT_PREVIEW_TAG = 'pr-42';
+        expect(() => createOutboxPool('postgresql://u:p@h/db?schema=pr_42')).not.toThrow();
+    });
+
+    it('throws when ?schema= is set but EVENT_PREVIEW_TAG is unset', () => {
+        delete process.env.EVENT_PREVIEW_TAG;
+        expect(() => createOutboxPool('postgresql://u:p@h/db?schema=pr_42')).toThrow(
+            /\?schema=pr_42 but EVENT_PREVIEW_TAG is unset/,
+        );
+    });
+
+    it('throws when ?schema= is set but EVENT_PREVIEW_TAG is whitespace-only', () => {
+        // Trim semantics match applyPreviewTag: a whitespace-only tag is
+        // treated as unset (otherwise it would silently route to a bogus
+        // `<exchange>.   ` queue).
+        process.env.EVENT_PREVIEW_TAG = '   ';
+        expect(() => createOutboxPool('postgresql://u:p@h/db?schema=pr_42')).toThrow(
+            /EVENT_PREVIEW_TAG is unset/,
+        );
+    });
+
+    it('throws when EVENT_PREVIEW_TAG is set but ?schema= is absent', () => {
+        process.env.EVENT_PREVIEW_TAG = 'pr-42';
+        expect(() => createOutboxPool('postgresql://u:p@h/db')).toThrow(
+            /EVENT_PREVIEW_TAG=pr-42.*no \?schema=/s,
+        );
+    });
+
+    it('throws when EVENT_PREVIEW_TAG is set but ?schema= is present-but-empty', () => {
+        // Treated as absent — same as the no-schema case. Symmetric with the
+        // "treats present-but-empty ?schema= the same as absent" production case.
+        process.env.EVENT_PREVIEW_TAG = 'pr-42';
+        expect(() => createOutboxPool('postgresql://u:p@h/db?schema=')).toThrow(
+            /no \?schema=/,
+        );
     });
 });

--- a/packages/node/event-outbox/src/__tests__/create-pool.unit.test.ts
+++ b/packages/node/event-outbox/src/__tests__/create-pool.unit.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { createOutboxPool } from '../create-pool.js';
+
+// We verify the pool's `options` resolve correctly without opening a real
+// connection. `pg.Pool` exposes a public `options` property that reflects
+// the merged config — that's what the relay (and libpq) will use when a
+// client is checked out.
+
+interface PoolWithOptions {
+    options?: { connectionString: string; max: number; options?: string };
+}
+
+function getOpts(pool: unknown): { connectionString: string; max: number; options?: string } {
+    const opts = (pool as PoolWithOptions).options;
+    if (!opts) throw new Error('pool.options not exposed');
+    return opts;
+}
+
+describe('createOutboxPool', () => {
+    it('passes connectionString through', () => {
+        const url = 'postgresql://u:p@h:5432/db';
+        const pool = createOutboxPool(url);
+        expect(getOpts(pool).connectionString).toBe(url);
+    });
+
+    it('defaults max to 2', () => {
+        const pool = createOutboxPool('postgresql://u:p@h:5432/db');
+        expect(getOpts(pool).max).toBe(2);
+    });
+
+    it('respects an explicit max', () => {
+        const pool = createOutboxPool('postgresql://u:p@h:5432/db', { max: 5 });
+        expect(getOpts(pool).max).toBe(5);
+    });
+
+    it('does not set libpq options when no schema param is present', () => {
+        const pool = createOutboxPool('postgresql://u:p@h:5432/db');
+        expect(getOpts(pool).options).toBeUndefined();
+    });
+
+    it('translates ?schema=… into libpq search_path', () => {
+        const pool = createOutboxPool(
+            'postgresql://u:p@h:5432/db?schema=pr_142',
+        );
+        expect(getOpts(pool).options).toBe('-c search_path=pr_142');
+    });
+
+    it('handles other URL params alongside schema', () => {
+        const pool = createOutboxPool(
+            'postgresql://u:p@h:5432/db?sslmode=require&schema=pr_142',
+        );
+        expect(getOpts(pool).options).toBe('-c search_path=pr_142');
+    });
+
+    it('poolOverrides win over defaults but do not strip the search_path option', () => {
+        const pool = createOutboxPool(
+            'postgresql://u:p@h:5432/db?schema=pr_7',
+            { poolOverrides: { idleTimeoutMillis: 30_000 } },
+        );
+        const opts = getOpts(pool);
+        expect(opts.options).toBe('-c search_path=pr_7');
+        expect((opts as { idleTimeoutMillis?: number }).idleTimeoutMillis).toBe(30_000);
+    });
+
+    it('explicit options in poolOverrides win — escape hatch for advanced cases', () => {
+        const pool = createOutboxPool(
+            'postgresql://u:p@h:5432/db?schema=pr_7',
+            { poolOverrides: { options: '-c statement_timeout=5000' } },
+        );
+        expect(getOpts(pool).options).toBe('-c statement_timeout=5000');
+    });
+});

--- a/packages/node/event-outbox/src/create-pool.ts
+++ b/packages/node/event-outbox/src/create-pool.ts
@@ -35,13 +35,32 @@ const SCHEMA_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
  * resolve to the same schema — the load-bearing piece of preview-environment
  * isolation (see d-preview-deploy-isolation.md).
  *
- * In production the Prisma URL has no `?schema=…`, the `options` are unset,
- * and the helper behaves like a plain `new Pool({ connectionString })`.
+ * The helper is intentionally production-safe: when neither `?schema=` nor
+ * `EVENT_PREVIEW_TAG` are set, it's equivalent to
+ * `new Pool({ connectionString, max: 2 })`. The startup coherence assert
+ * (below) ensures preview state can't leak in by accident — that's what
+ * makes a single helper safe across both environments.
  *
- * Throws if `databaseUrl` is not a parseable URL or if the `schema` value
- * contains characters outside the Postgres unquoted-identifier set
- * (`[A-Za-z_][A-Za-z0-9_]*`). The connection-string form (`host=… dbname=…`)
- * is not supported — pass a URL.
+ * Supported `databaseUrl` shape:
+ *   - URL form only (`postgresql://…`). The libpq KV form
+ *     (`host=… dbname=…`) is not supported — pass a URL.
+ *   - Optional `?schema=<name>` query parameter, where `<name>` matches
+ *     `[A-Za-z_][A-Za-z0-9_]*` (Postgres unquoted-identifier rules).
+ *     Hyphenated preview identifiers like `pr-42` belong to AWS resource
+ *     names; convert to `pr_42` before constructing the URL.
+ *   - Other URL params (`?options=`, `?sslmode=`, etc.) ride along via
+ *     `connectionString` and are NOT interpreted by this helper. Use
+ *     `opts.poolOverrides` to set additional pg.Pool config explicitly.
+ *
+ * Throws on:
+ *   - non-URL `databaseUrl`
+ *   - `?schema=` value outside the unquoted-identifier regex
+ *   - `?schema=` set but `EVENT_PREVIEW_TAG` unset (would produce
+ *     half-isolated state: per-PR DB, canonical RabbitMQ exchange — leaks
+ *     events across PRs)
+ *   - `EVENT_PREVIEW_TAG` set but `?schema=` absent (the inverse half-
+ *     isolated state: per-PR RabbitMQ tag, default DB schema — leaks outbox
+ *     rows across PRs)
  *
  * @example
  *   const pool = createOutboxPool(process.env.DATABASE_URL!);
@@ -67,6 +86,30 @@ export function createOutboxPool(
     if (schema !== null && !SCHEMA_IDENTIFIER.test(schema)) {
         throw new Error(
             `createOutboxPool: \`?schema=\` must match ${SCHEMA_IDENTIFIER} to be safely interpolated into libpq options. Received: ${truncate(schema)}`,
+        );
+    }
+
+    // Coherence assert: the two-axis preview-isolation model
+    // (DB schema-per-PR + RabbitMQ tag-per-PR) must be applied as a pair.
+    // A half-applied state silently leaks events across PRs in production —
+    // either through the broker (schema set, no tag) or through the DB
+    // (tag set, no schema). Fail startup loudly so the misconfiguration
+    // can't make it past first boot.
+    const previewTag = (process.env.EVENT_PREVIEW_TAG ?? '').trim();
+    const hasSchema = schema !== null;
+    const hasTag = previewTag !== '';
+    if (hasSchema && !hasTag) {
+        throw new Error(
+            `createOutboxPool: DATABASE_URL contains ?schema=${schema} but EVENT_PREVIEW_TAG is unset. ` +
+                'Schema-per-PR isolation is a preview-only feature; running it without EVENT_PREVIEW_TAG would publish to the canonical RabbitMQ exchange while reading from a per-PR DB schema, leaking events across PRs. ' +
+                'Either set EVENT_PREVIEW_TAG=<your-preview-id> alongside the schema, or remove ?schema= from DATABASE_URL.',
+        );
+    }
+    if (!hasSchema && hasTag) {
+        throw new Error(
+            `createOutboxPool: EVENT_PREVIEW_TAG=${previewTag} is set but DATABASE_URL has no ?schema=. ` +
+                'RabbitMQ traffic is being routed to a tagged exchange but DB writes will hit the default schema, leaking outbox rows across PRs. ' +
+                'Either add ?schema=<your-pr-schema> to DATABASE_URL, or unset EVENT_PREVIEW_TAG.',
         );
     }
 

--- a/packages/node/event-outbox/src/create-pool.ts
+++ b/packages/node/event-outbox/src/create-pool.ts
@@ -1,0 +1,50 @@
+import { Pool, type PoolConfig } from 'pg';
+
+export interface CreateOutboxPoolOpts {
+    /**
+     * Max connections in the dedicated relay pool. Defaults to 2 — the relay
+     * needs only one for the polling tick + one spare for liveness checks. Keep
+     * it small so it cannot starve request-path Prisma traffic, especially in
+     * preview environments where many PRs share a single Postgres instance.
+     */
+    max?: number;
+    /**
+     * Override pg pool options (e.g., `idleTimeoutMillis`). Merged on top of
+     * the defaults derived from `databaseUrl`.
+     */
+    poolOverrides?: Partial<PoolConfig>;
+}
+
+/**
+ * Build the dedicated `pg.Pool` used by `OutboxRelay`.
+ *
+ * The Postgres URL produced by Prisma carries the schema as a query parameter
+ * (`?schema=pr_142`). node-postgres ignores that parameter, so unqualified
+ * table references like `FROM outbox_event` fall through to the default
+ * `search_path` and miss per-PR schema tables. This helper translates the
+ * Prisma form into libpq's `options=-c search_path=<schema>` so both sides
+ * resolve to the same schema — the load-bearing piece of preview-environment
+ * isolation (see d-preview-deploy-isolation.md).
+ *
+ * In production the Prisma URL has no `?schema=…`, the `options` are unset,
+ * and the helper behaves like a plain `new Pool({ connectionString })`.
+ *
+ * @example
+ *   const pool = createOutboxPool(process.env.DATABASE_URL!);
+ *   const relay = new OutboxRelay({ pool, ...rest });
+ */
+export function createOutboxPool(
+    databaseUrl: string,
+    opts: CreateOutboxPoolOpts = {},
+): Pool {
+    const url = new URL(databaseUrl);
+    const schema = url.searchParams.get('schema');
+    const max = opts.max ?? 2;
+
+    return new Pool({
+        connectionString: databaseUrl,
+        max,
+        ...(schema ? { options: `-c search_path=${schema}` } : {}),
+        ...opts.poolOverrides,
+    });
+}

--- a/packages/node/event-outbox/src/create-pool.ts
+++ b/packages/node/event-outbox/src/create-pool.ts
@@ -10,10 +10,19 @@ export interface CreateOutboxPoolOpts {
     max?: number;
     /**
      * Override pg pool options (e.g., `idleTimeoutMillis`). Merged on top of
-     * the defaults derived from `databaseUrl`.
+     * the defaults derived from `databaseUrl`. `poolOverrides` wins over both
+     * the default `max` and the schema-derived `options` — escape hatch for
+     * advanced cases.
      */
     poolOverrides?: Partial<PoolConfig>;
 }
+
+// Postgres unquoted-identifier grammar (lowercased on entry by the server, but
+// we accept the literal forms to allow both `pr_142` and `Pr_142` styles).
+// Anything outside this set could inject a libpq startup parameter via the
+// `-c search_path=<schema>` form (e.g. ` -c statement_timeout=0`), so we
+// reject it loudly rather than silently exec'ing the unintended option.
+const SCHEMA_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 /**
  * Build the dedicated `pg.Pool` used by `OutboxRelay`.
@@ -29,6 +38,11 @@ export interface CreateOutboxPoolOpts {
  * In production the Prisma URL has no `?schema=…`, the `options` are unset,
  * and the helper behaves like a plain `new Pool({ connectionString })`.
  *
+ * Throws if `databaseUrl` is not a parseable URL or if the `schema` value
+ * contains characters outside the Postgres unquoted-identifier set
+ * (`[A-Za-z_][A-Za-z0-9_]*`). The connection-string form (`host=… dbname=…`)
+ * is not supported — pass a URL.
+ *
  * @example
  *   const pool = createOutboxPool(process.env.DATABASE_URL!);
  *   const relay = new OutboxRelay({ pool, ...rest });
@@ -37,14 +51,33 @@ export function createOutboxPool(
     databaseUrl: string,
     opts: CreateOutboxPoolOpts = {},
 ): Pool {
-    const url = new URL(databaseUrl);
-    const schema = url.searchParams.get('schema');
-    const max = opts.max ?? 2;
+    let url: URL;
+    try {
+        url = new URL(databaseUrl);
+    } catch {
+        throw new Error(
+            `createOutboxPool: \`databaseUrl\` must be a URL-form connection string (e.g. postgresql://…). Received: ${truncate(databaseUrl)}`,
+        );
+    }
+
+    const schemaParam = url.searchParams.get('schema');
+    // Treat empty `?schema=` (present-but-empty) the same as absent. libpq with
+    // `-c search_path=` (empty) would error; absent is what callers mean.
+    const schema = schemaParam === null || schemaParam === '' ? null : schemaParam;
+    if (schema !== null && !SCHEMA_IDENTIFIER.test(schema)) {
+        throw new Error(
+            `createOutboxPool: \`?schema=\` must match ${SCHEMA_IDENTIFIER} to be safely interpolated into libpq options. Received: ${truncate(schema)}`,
+        );
+    }
 
     return new Pool({
         connectionString: databaseUrl,
-        max,
+        max: opts.max ?? 2,
         ...(schema ? { options: `-c search_path=${schema}` } : {}),
         ...opts.poolOverrides,
     });
+}
+
+function truncate(s: string): string {
+    return s.length > 80 ? `${s.slice(0, 77)}...` : s;
 }

--- a/packages/node/event-outbox/src/index.ts
+++ b/packages/node/event-outbox/src/index.ts
@@ -5,3 +5,5 @@ export {
     type OutboxRelayOpts,
     type OutboxMetrics,
 } from './relay.js';
+export { createOutboxPool, type CreateOutboxPoolOpts } from './create-pool.js';
+export { applyPreviewTag } from '@saga-ed/soa-event-envelope';

--- a/turbo.json
+++ b/turbo.json
@@ -31,7 +31,7 @@
     },
     "check-types": {
       "dependsOn": [
-        "^check-types"
+        "^build"
       ]
     },
     "test": {

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://turborepo.com/schema.json",
   "ui": "tui",
+  "globalEnv": [
+    "EVENT_PREVIEW_TAG"
+  ],
   "tasks": {
     "build": {
       "dependsOn": [


### PR DESCRIPTION
## Summary

Lifts two helpers that rostering #138 (iam-api) and program-hub #60 (programs-api, scheduling-api) each independently invented to make event-driven preview deploys work on shared infrastructure:

- **`createOutboxPool(databaseUrl, opts?)`** in `@saga-ed/soa-event-outbox` — translates Prisma's `?schema=` URL parameter into libpq's `options=-c search_path=<schema>` so the relay's pg pool resolves per-PR schemas the same way Prisma does. Defaults `max=2` to keep the relay pool from contending with request-path Prisma traffic.
- **`applyPreviewTag(name, tag?)`** in `@saga-ed/soa-event-envelope` (re-exported from event-outbox + event-consumer) — reads the tag from `EVENT_PREVIEW_TAG` and suffixes RabbitMQ exchange/queue/consumer names. No-op in production.

Adopters can now drop their hand-rolled inversify shims:

```ts
const pool = createOutboxPool(databaseUrl);
new OutboxRelay({ exchange: applyPreviewTag(IAM_EXCHANGE), pool, ... });
```

## Defense-in-depth: bidirectional coherence assert

`createOutboxPool` enforces the two-axis isolation pairing as a startup invariant:

| `EVENT_PREVIEW_TAG` | URL has `?schema=` | Behavior |
|---|---|---|
| unset | no | ✅ production case — equivalent to plain `Pool({ connectionString, max: 2 })` |
| set | yes | ✅ preview case |
| unset | yes | ❌ **THROW** — schema-per-PR DB but canonical RabbitMQ exchange leaks events across PRs through the broker |
| set | no | ❌ **THROW** — tagged exchange but default DB schema leaks outbox rows across PRs through the database |

Either both or neither. The assert exists because a half-applied state silently corrupts prod traffic; closing it at boot keeps misconfiguration from making it past first deploy.

## Hardening (from PR review)

- URL parse wrapped in try/catch — non-URL strings (libpq KV form `host=… dbname=…`, malformed URLs) get a directional error message instead of a raw `TypeError`
- `?schema=` value validated against `[A-Za-z_][A-Za-z0-9_]*` (Postgres unquoted-identifier rules) — prevents libpq startup-parameter injection through the `-c search_path=<schema>` interpolation point. Adopter pipelines convert hyphenated AWS resource names (`pr-42`) to underscored schema names (`pr_42`) via bash before constructing the URL, so this is compatible with all observed adopter URL forms

## Provenance

- Pattern source: rostering #138 `apps/node/iam-api/src/inversify.config.ts`, program-hub #60 `apps/node/{programs,scheduling}-api/src/inversify.config.ts`
- Design rationale: `claude/projects/soa_75/decisions/d-preview-deploy-isolation.md` (forthcoming on soa_75 follow-up branch)

## Test plan

- [x] `pnpm --filter @saga-ed/soa-event-envelope test` — 19/19 pass
- [x] `pnpm --filter @saga-ed/soa-event-outbox test` — 20/20 pass (7 new: adopter URL form pin + 6 coherence-assert truth-table cells)
- [x] `pnpm --filter @saga-ed/soa-event-consumer test` — 9/9 pass
- [x] All 3 packages: \`check-types\` clean, \`lint\` clean
- [ ] Smoke-tested in adopter inversify configs (rostering / program-hub) — recommend doing this before merge

---

## Update: turbo.json fix appended

After pushing the initial branch, CI surfaced a pre-existing issue: \`check-types\` was failing for any package whose dependencies' \`types\` field points at a built \`dist/index.d.ts\` (the convention here). The CI workflow runs \`check-types\` **before** \`build\`, and \`turbo.json\`'s \`check-types\` task only declared \`dependsOn: ['^check-types']\` — so workspace deps' \`dist/\` didn't exist when tsc resolved the imports.

This was previously masked by turbo's local cache happening to carry prior \`dist/\` artifacts forward, but on PR runs from clean checkouts it surfaced as \`TS2307 Cannot find module\` failures (e.g., \`event-integration-tests\` couldn't find \`@saga-ed/soa-event-test-harness\`).

Fixed by changing \`check-types.dependsOn\` to \`['^build']\` — the standard turbo pattern. This is technically a fleet-wide CI fix that goes well beyond the helpers, but it's load-bearing for getting this PR (and the stacked #84) green. Verified locally with \`rm -rf packages/**/dist && pnpm turbo run check-types --filter=PKG... --force\` for both \`event-outbox\` and \`event-integration-tests\` — both now pass.