### PR TITLE
feat(soa-contract-check): lift contract-check tooling from PoC

### DIFF
--- a/packages/node/contract-check/README.md
+++ b/packages/node/contract-check/README.md
@@ -1,0 +1,152 @@
+# @saga-ed/soa-contract-check
+
+CI gate for event-schema changes across services. Catches three classes of mistake:
+
+1. Modifying a frozen-forever schema in place (D5/D6 violation).
+2. Adding a new schema version without recording it in pins.
+3. Dropping a published version while a consumer still pins it.
+
+The same shape works in single-repo and multi-repo settings. The publisher repo's `pins/` directory is the source of truth; in a multi-repo fleet, downstream consumers in other repos open PRs against the publisher repo's pins.
+
+See the canonical decision docs in the `soa_75` branch:
+- `claude/projects/soa_75/decisions/d-contract-testing.md`
+- `claude/projects/soa_75/decisions/d-event-versioning.md`
+
+## Install
+
+```bash
+pnpm add -D @saga-ed/soa-contract-check
+```
+
+## Configure
+
+Place `contract-check.config.ts` (or `.js`/`.mts`/`.mjs`) at your repo root:
+
+```ts
+// contract-check.config.ts
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { ContractCheckConfig } from '@saga-ed/soa-contract-check';
+import { iamEvents } from '@saga-ed/iam-events';
+// import { programsEvents } from '@saga-ed/programs-events'; // when added
+
+const repoRoot = fileURLToPath(new URL('.', import.meta.url));
+
+const config: ContractCheckConfig = {
+    registry: {
+        ...iamEvents,
+        // ...programsEvents,
+    },
+    publishedDir: resolve(repoRoot, 'tools/contract-check/published'),
+    pinsGlob: resolve(repoRoot, 'apps/*/pins/*.yaml'),
+};
+
+export default config;
+```
+
+If your repo has no `apps/<svc>/pins/` layout (e.g., a library repo), set `pinsGlob: null` to skip the pins layers.
+
+## Use
+
+Add scripts to `package.json`:
+
+```jsonc
+{
+    "scripts": {
+        "contract:check": "soa-contract-check check",
+        "contract:export": "soa-contract-check export",
+        "contract:export:write": "soa-contract-check export --write"
+    }
+}
+```
+
+Then:
+
+```bash
+pnpm contract:check          # CI gate; non-zero on any violation
+pnpm contract:export         # diff-only — show what would change
+pnpm contract:export:write   # regenerate published/<eventType>-vN.json snapshots
+```
+
+Wire `pnpm contract:check` into your CI workflow as the merge gate.
+
+## The three layers
+
+### 1. Snapshot byte-diff (publisher side)
+
+For each event in `config.registry`, the tool renders the Zod payload schema to JSON Schema and compares it byte-for-byte against the committed snapshot in `<publishedDir>/<eventType>-vN.json`.
+
+- **Adding a new version**: render fails to find a snapshot → run `soa-contract-check export --write` to write it, then commit.
+- **Editing a published version**: any byte-level difference fails the check. Per the frozen-forever rule, modifying a published schema is a wire-break disguised as a typo fix. Bump to a new version instead.
+
+The snapshots are the source of truth for "what was promised over the wire."
+
+### 2. Pins coverage
+
+Each event type has a single pins file owned by the publishing service:
+
+```
+apps/<publisher-svc>/pins/<eventType>.yaml
+```
+
+Example (`apps/iam-api/pins/iam.user.created.yaml`):
+
+```yaml
+eventType: iam.user.created
+publisher:
+    service: iam-api
+    package: '@saga-ed/iam-events'
+versions_published: [1, 2]
+consumers:
+    - service: programs-api
+      versions: [1, 2]
+      # repo: saga-ed/program-hub  # for cross-repo consumers
+```
+
+The coverage check requires `versions_published` to **equal** the set of versions in the registry:
+
+- Adding `v3` to the registry without updating `versions_published: [1, 2, 3]` → fails.
+- Listing a version in `versions_published` that the registry doesn't have → fails.
+- Adding a new event type without creating a pins file → fails.
+- Creating a pins file for an event type the registry doesn't know about → fails.
+
+### 3. Pins consumer validity (drop-protection)
+
+Each consumer's `versions[]` must be a subset of `versions_published`. This is the layer that protects against premature version drops.
+
+If `iam-api` opens a PR shrinking `versions_published: [1, 2]` to `[2]`, the check fails until each consuming service opens a PR (against the publisher repo's pins file) dropping its v1 pin.
+
+## Cross-repo coordination
+
+In a multi-repo fleet, pins live with the publisher. Downstream consumers in other repos open PRs against the publisher's `apps/<svc>/pins/` directory:
+
+- Consumer adopts v2: PR against publisher repo bumping their entry to `versions: [1, 2]`.
+- Publisher drops v1: PR shrinking `versions_published: [1, 2]` → `[2]`. CI fails because consumers still pin v1. Coordinate: each consuming team opens a PR (against the publisher repo) dropping their v1 pin. Once all are merged, the publisher PR re-runs and passes.
+
+The `repo:` field on each consumer entry tells the publisher's CI which downstream team to ping when a coverage failure happens.
+
+No central registry, no fleet-wide configuration service. The pins file in the publisher's repo is the single source of truth for "who consumes what version of this event."
+
+## Common failure modes
+
+| Failure | What happened | Fix |
+|---|---|---|
+| `[snapshot] Snapshot iam.user.created-v1.json differs` | Edited a frozen schema | Revert and bump to a new version |
+| `[snapshot] Missing snapshot iam.user.created-v3.json` | Added v3 to registry, no snapshot | `soa-contract-check export --write` and commit |
+| `[pins-coverage] versions_published doesn't match the registry` | Schema set and pins drifted | Update `versions_published` to match the registry |
+| `[pins-coverage] Registry has X but no pins file exists` | Forgot to create pins file | Create `apps/<publisher>/pins/<eventType>.yaml` |
+| `[pins-validity] programs-api pins iam.user.created v[1] but versions_published is [2]` | Publisher tried to drop a version a consumer still uses | Coordinate: consumer drops pin first |
+
+## Programmatic API
+
+```ts
+import { runCheck, runExport, loadConfig } from '@saga-ed/soa-contract-check';
+
+const { config } = await loadConfig();
+const result = await runCheck(config);
+if (result.failures.length > 0) { /* … */ }
+```
+
+## Provenance
+
+Lifted from `soa_event_driven_example/tools/contract-check/` (the POC), parameterized by config so it works against any repo layout. The PoC's hardcoded event imports are replaced with the user-supplied `config.registry`.

--- a/packages/node/contract-check/README.md
+++ b/packages/node/contract-check/README.md
@@ -26,25 +26,25 @@ Place `contract-check.config.ts` (or `.js`/`.mts`/`.mjs`) at your repo root:
 // contract-check.config.ts
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import type { ContractCheckConfig } from '@saga-ed/soa-contract-check';
+import { defineConfig } from '@saga-ed/soa-contract-check';
 import { iamEvents } from '@saga-ed/iam-events';
 // import { programsEvents } from '@saga-ed/programs-events'; // when added
 
 const repoRoot = fileURLToPath(new URL('.', import.meta.url));
 
-const config: ContractCheckConfig = {
+export default defineConfig({
     registry: {
         ...iamEvents,
         // ...programsEvents,
     },
     publishedDir: resolve(repoRoot, 'tools/contract-check/published'),
     pinsGlob: resolve(repoRoot, 'apps/*/pins/*.yaml'),
-};
-
-export default config;
+});
 ```
 
-If your repo has no `apps/<svc>/pins/` layout (e.g., a library repo), set `pinsGlob: null` to skip the pins layers.
+`defineConfig` is an identity helper — it exists purely so you get TypeScript checks on the config object without remembering a `: ContractCheckConfig` annotation. If your repo has no `apps/<svc>/pins/` layout (e.g., a library repo), set `pinsGlob: null` to skip the pins layers.
+
+**Registry-key convention.** Each entry's key MUST be `${eventType}.v${eventVersion}` (per-family event packages typically build this for you). The tool asserts the key↔descriptor match at the start of every run and throws loudly on drift — the snapshot path is derived from the key while the pins-coverage layer is derived from the descriptor's fields, so a typo'd key would diverge silently otherwise.
 
 ## Use
 
@@ -65,8 +65,16 @@ Then:
 ```bash
 pnpm contract:check          # CI gate; non-zero on any violation
 pnpm contract:export         # diff-only — show what would change
-pnpm contract:export:write   # regenerate published/<eventType>-vN.json snapshots
+pnpm contract:export:write   # write NEW snapshots; refuses to overwrite existing versions
 ```
+
+**Modifying a published version (D5/D6 violation).** `export --write` deliberately refuses to overwrite an existing snapshot whose bytes have changed and exits non-zero. To override — e.g. you genuinely intend to bump and need to regenerate — re-run with `--bump`:
+
+```bash
+soa-contract-check export --write --bump
+```
+
+Without `--bump`, a developer who edits a frozen schema and runs `export --write` would silently launder the change through committed bytes; the next `check` would pass against the new schema, defeating the gate. `--bump` is the explicit gesture that says "I know I'm modifying an existing version."
 
 Wire `pnpm contract:check` into your CI workflow as the merge gate.
 

--- a/packages/node/contract-check/package.json
+++ b/packages/node/contract-check/package.json
@@ -23,16 +23,15 @@
         "clean": "rm -rf dist"
     },
     "dependencies": {
+        "@saga-ed/soa-event-envelope": "workspace:*",
         "fast-glob": "^3.3.3",
         "js-yaml": "^4.1.0",
         "zod-to-json-schema": "^3.23.5"
     },
     "peerDependencies": {
-        "@saga-ed/soa-event-envelope": "workspace:*",
         "zod": "^3.23.0"
     },
     "devDependencies": {
-        "@saga-ed/soa-event-envelope": "workspace:*",
         "@saga-ed/soa-typescript-config": "workspace:*",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^24.0.3",

--- a/packages/node/contract-check/package.json
+++ b/packages/node/contract-check/package.json
@@ -1,0 +1,53 @@
+{
+    "name": "@saga-ed/soa-contract-check",
+    "version": "0.1.0-dev.1",
+    "private": false,
+    "type": "module",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "bin": {
+        "soa-contract-check": "dist/cli.js"
+    },
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
+        }
+    },
+    "files": ["dist"],
+    "scripts": {
+        "build": "tsup",
+        "check-types": "tsc --noEmit",
+        "test": "vitest run --passWithNoTests",
+        "lint": "eslint src/",
+        "clean": "rm -rf dist"
+    },
+    "dependencies": {
+        "fast-glob": "^3.3.3",
+        "js-yaml": "^4.1.0",
+        "zod-to-json-schema": "^3.23.5"
+    },
+    "peerDependencies": {
+        "@saga-ed/soa-event-envelope": "workspace:*",
+        "zod": "^3.23.0"
+    },
+    "devDependencies": {
+        "@saga-ed/soa-event-envelope": "workspace:*",
+        "@saga-ed/soa-typescript-config": "workspace:*",
+        "@types/js-yaml": "^4.0.9",
+        "@types/node": "^24.0.3",
+        "tsup": "^8.5.0",
+        "typescript": "5.8.2",
+        "vitest": "^1.6.1",
+        "zod": "3.25.67"
+    },
+    "publishConfig": {
+        "registry": "https://saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/",
+        "access": "public"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/saga-ed/soa.git",
+        "directory": "packages/node/contract-check"
+    }
+}

--- a/packages/node/contract-check/src/__tests__/check.unit.test.ts
+++ b/packages/node/contract-check/src/__tests__/check.unit.test.ts
@@ -1,0 +1,253 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import { z } from 'zod';
+import type { PayloadDescriptor } from '@saga-ed/soa-event-envelope';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { runCheck } from '../check.js';
+import type { ContractCheckConfig } from '../lib/config.js';
+import { renderSnapshot } from '../lib/snapshot.js';
+
+let tmp: string;
+
+beforeEach(() => {
+    tmp = mkdtempSync(resolve(tmpdir(), 'soa-cc-check-'));
+});
+
+afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+});
+
+const userCreatedV1Schema = z.object({ id: z.string() });
+const userCreatedV1: PayloadDescriptor<z.infer<typeof userCreatedV1Schema>> = {
+    eventType: 'iam.user.created',
+    eventVersion: 1,
+    payloadSchema: userCreatedV1Schema,
+};
+
+const userCreatedV2Schema = z.object({ id: z.string(), status: z.string() });
+const userCreatedV2: PayloadDescriptor<z.infer<typeof userCreatedV2Schema>> = {
+    eventType: 'iam.user.created',
+    eventVersion: 2,
+    payloadSchema: userCreatedV2Schema,
+};
+
+function writeSnapshot(
+    publishedDir: string,
+    eventKey: string,
+    descriptor: PayloadDescriptor<unknown>,
+): void {
+    mkdirSync(publishedDir, { recursive: true });
+    const filename = eventKey.replace(/\.v(\d+)$/, '-v$1') + '.json';
+    writeFileSync(resolve(publishedDir, filename), renderSnapshot(eventKey, descriptor));
+}
+
+function writePins(file: string, body: string): void {
+    mkdirSync(resolve(file, '..'), { recursive: true });
+    writeFileSync(file, body);
+}
+
+function makeConfig(opts: {
+    registry: ContractCheckConfig['registry'];
+    pinsGlob?: string | null;
+}): ContractCheckConfig {
+    return {
+        registry: opts.registry,
+        publishedDir: resolve(tmp, 'published'),
+        pinsGlob: opts.pinsGlob === undefined ? null : opts.pinsGlob,
+    };
+}
+
+describe('runCheck — snapshot layer', () => {
+    it('returns no failures when every registry entry has a matching snapshot', async () => {
+        writeSnapshot(resolve(tmp, 'published'), 'iam.user.created.v1', userCreatedV1);
+        const config = makeConfig({
+            registry: { 'iam.user.created.v1': userCreatedV1 },
+        });
+        const result = await runCheck(config);
+        expect(result.failures).toEqual([]);
+        expect(result.eventCount).toBe(1);
+    });
+
+    it('reports a `snapshot` failure when a registered event has no committed snapshot', async () => {
+        const config = makeConfig({
+            registry: { 'iam.user.created.v1': userCreatedV1 },
+        });
+        const result = await runCheck(config);
+        expect(result.failures).toHaveLength(1);
+        expect(result.failures[0].layer).toBe('snapshot');
+        expect(result.failures[0].message).toMatch(/Missing snapshot.*export --write/);
+    });
+
+    it('reports a `snapshot` failure when committed bytes differ from the registry schema (frozen-forever)', async () => {
+        // Pre-write an outdated snapshot (v2 schema bytes for the v1 key — drift).
+        writeSnapshot(resolve(tmp, 'published'), 'iam.user.created.v1', userCreatedV2);
+        const config = makeConfig({
+            registry: { 'iam.user.created.v1': userCreatedV1 },
+        });
+        const result = await runCheck(config);
+        expect(result.failures).toHaveLength(1);
+        expect(result.failures[0].layer).toBe('snapshot');
+        expect(result.failures[0].message).toMatch(/frozen-forever|forbidden/);
+    });
+});
+
+describe('runCheck — pins-coverage layer', () => {
+    it('skips pins layers when pinsGlob is null', async () => {
+        writeSnapshot(resolve(tmp, 'published'), 'iam.user.created.v1', userCreatedV1);
+        const config = makeConfig({
+            registry: { 'iam.user.created.v1': userCreatedV1 },
+            pinsGlob: null,
+        });
+        const result = await runCheck(config);
+        expect(result.failures).toEqual([]);
+        expect(result.pinsCount).toBe(0);
+    });
+
+    it('reports `pins-coverage` when a registered event has no pins file', async () => {
+        writeSnapshot(resolve(tmp, 'published'), 'iam.user.created.v1', userCreatedV1);
+        const config = makeConfig({
+            registry: { 'iam.user.created.v1': userCreatedV1 },
+            pinsGlob: `${tmp}/apps/*/pins/*.yaml`,
+        });
+        const result = await runCheck(config);
+        const pinsFailures = result.failures.filter((f) => f.layer === 'pins-coverage');
+        expect(pinsFailures).toHaveLength(1);
+        expect(pinsFailures[0].message).toMatch(/no pins file exists/);
+    });
+
+    it('reports `pins-coverage` when versions_published is missing a registry version', async () => {
+        writeSnapshot(resolve(tmp, 'published'), 'iam.user.created.v1', userCreatedV1);
+        writeSnapshot(resolve(tmp, 'published'), 'iam.user.created.v2', userCreatedV2);
+        writePins(
+            `${tmp}/apps/iam-api/pins/iam.user.created.yaml`,
+            `eventType: iam.user.created
+publisher: { service: iam-api, package: '@saga-ed/iam-events' }
+versions_published: [1]
+consumers: []
+`,
+        );
+        const config = makeConfig({
+            registry: {
+                'iam.user.created.v1': userCreatedV1,
+                'iam.user.created.v2': userCreatedV2,
+            },
+            pinsGlob: `${tmp}/apps/*/pins/*.yaml`,
+        });
+        const result = await runCheck(config);
+        const pinsFailures = result.failures.filter((f) => f.layer === 'pins-coverage');
+        expect(pinsFailures).toHaveLength(1);
+        expect(pinsFailures[0].message).toMatch(/missing from versions_published/);
+    });
+
+    it('reports `pins-coverage` when versions_published has an extra version not in the registry', async () => {
+        writeSnapshot(resolve(tmp, 'published'), 'iam.user.created.v1', userCreatedV1);
+        writePins(
+            `${tmp}/apps/iam-api/pins/iam.user.created.yaml`,
+            `eventType: iam.user.created
+publisher: { service: iam-api, package: '@saga-ed/iam-events' }
+versions_published: [1, 2]
+consumers: []
+`,
+        );
+        const config = makeConfig({
+            registry: { 'iam.user.created.v1': userCreatedV1 },
+            pinsGlob: `${tmp}/apps/*/pins/*.yaml`,
+        });
+        const result = await runCheck(config);
+        const pinsFailures = result.failures.filter((f) => f.layer === 'pins-coverage');
+        expect(pinsFailures).toHaveLength(1);
+        expect(pinsFailures[0].message).toMatch(/no schema in the registry/);
+    });
+
+    it('reports `pins-coverage` when a pins file declares an event the registry does not know', async () => {
+        writeSnapshot(resolve(tmp, 'published'), 'iam.user.created.v1', userCreatedV1);
+        writePins(
+            `${tmp}/apps/iam-api/pins/iam.user.created.yaml`,
+            `eventType: iam.user.created
+publisher: { service: iam-api, package: '@saga-ed/iam-events' }
+versions_published: [1]
+consumers: []
+`,
+        );
+        // Stray pins for an event not in the registry.
+        writePins(
+            `${tmp}/apps/iam-api/pins/iam.user.deleted.yaml`,
+            `eventType: iam.user.deleted
+publisher: { service: iam-api, package: '@saga-ed/iam-events' }
+versions_published: [1]
+consumers: []
+`,
+        );
+        const config = makeConfig({
+            registry: { 'iam.user.created.v1': userCreatedV1 },
+            pinsGlob: `${tmp}/apps/*/pins/*.yaml`,
+        });
+        const result = await runCheck(config);
+        const pinsFailures = result.failures.filter((f) => f.layer === 'pins-coverage');
+        expect(pinsFailures).toHaveLength(1);
+        expect(pinsFailures[0].message).toMatch(/no schema for it exists/);
+    });
+});
+
+describe('runCheck — pins-validity layer (drop-protection)', () => {
+    it('reports `pins-validity` when a consumer pins a version no longer in versions_published', async () => {
+        writeSnapshot(resolve(tmp, 'published'), 'iam.user.created.v2', userCreatedV2);
+        writePins(
+            `${tmp}/apps/iam-api/pins/iam.user.created.yaml`,
+            `eventType: iam.user.created
+publisher: { service: iam-api, package: '@saga-ed/iam-events' }
+versions_published: [2]
+consumers:
+    - service: programs-api
+      versions: [1, 2]
+`,
+        );
+        const config = makeConfig({
+            registry: { 'iam.user.created.v2': userCreatedV2 },
+            pinsGlob: `${tmp}/apps/*/pins/*.yaml`,
+        });
+        const result = await runCheck(config);
+        const validityFailures = result.failures.filter((f) => f.layer === 'pins-validity');
+        expect(validityFailures).toHaveLength(1);
+        expect(validityFailures[0].message).toMatch(/programs-api pins.*\[1\]/);
+    });
+
+    it('passes when every consumer pin is a subset of versions_published', async () => {
+        writeSnapshot(resolve(tmp, 'published'), 'iam.user.created.v1', userCreatedV1);
+        writeSnapshot(resolve(tmp, 'published'), 'iam.user.created.v2', userCreatedV2);
+        writePins(
+            `${tmp}/apps/iam-api/pins/iam.user.created.yaml`,
+            `eventType: iam.user.created
+publisher: { service: iam-api, package: '@saga-ed/iam-events' }
+versions_published: [1, 2]
+consumers:
+    - service: programs-api
+      versions: [1, 2]
+    - service: scheduling-api
+      versions: [2]
+`,
+        );
+        const config = makeConfig({
+            registry: {
+                'iam.user.created.v1': userCreatedV1,
+                'iam.user.created.v2': userCreatedV2,
+            },
+            pinsGlob: `${tmp}/apps/*/pins/*.yaml`,
+        });
+        const result = await runCheck(config);
+        expect(result.failures).toEqual([]);
+    });
+});
+
+describe('runCheck — registry consistency', () => {
+    it('throws when an entry key disagrees with its descriptor (key/descriptor drift)', async () => {
+        // The key says v2 but the descriptor is v1 — the snapshot path would
+        // be derived from the key while pins-coverage uses the descriptor's
+        // fields, producing inconsistent output across layers. Catch loudly.
+        const config = makeConfig({
+            registry: { 'iam.user.created.v2': userCreatedV1 },
+        });
+        await expect(runCheck(config)).rejects.toThrow(/registry key/);
+    });
+});

--- a/packages/node/contract-check/src/__tests__/export.unit.test.ts
+++ b/packages/node/contract-check/src/__tests__/export.unit.test.ts
@@ -1,0 +1,161 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import { z } from 'zod';
+import type { PayloadDescriptor } from '@saga-ed/soa-event-envelope';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { ContractCheckConfig } from '../lib/config.js';
+import { renderSnapshot } from '../lib/snapshot.js';
+import { runExport } from '../export.js';
+
+let tmp: string;
+
+beforeEach(() => {
+    tmp = mkdtempSync(resolve(tmpdir(), 'soa-cc-export-'));
+    // Tests pre-write into <tmp>/published/ before runExport runs (so we can
+    // assert the "REFUSED" path), so the directory must already exist.
+    mkdirSync(resolve(tmp, 'published'), { recursive: true });
+});
+
+afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+});
+
+const v1Schema = z.object({ id: z.string() });
+const v1: PayloadDescriptor<z.infer<typeof v1Schema>> = {
+    eventType: 'iam.user.created',
+    eventVersion: 1,
+    payloadSchema: v1Schema,
+};
+
+const v2Schema = z.object({ id: z.string(), status: z.string() });
+const v2: PayloadDescriptor<z.infer<typeof v2Schema>> = {
+    eventType: 'iam.user.created',
+    eventVersion: 2,
+    payloadSchema: v2Schema,
+};
+
+function makeConfig(registry: ContractCheckConfig['registry']): ContractCheckConfig {
+    return {
+        registry,
+        publishedDir: resolve(tmp, 'published'),
+        pinsGlob: null,
+    };
+}
+
+describe('runExport — dry run (no write)', () => {
+    it('reports every entry as new when publishedDir is empty', () => {
+        const summary = runExport(makeConfig({ 'iam.user.created.v1': v1 }));
+        expect(summary.written).toBe(false);
+        expect(summary.newCount).toBe(1);
+        expect(summary.modifiedCount).toBe(0);
+        expect(summary.refusedCount).toBe(0);
+        expect(summary.results[0].isNew).toBe(true);
+        expect(summary.results[0].changed).toBe(true);
+        // No file written.
+        expect(existsSync(resolve(tmp, 'published/iam.user.created-v1.json'))).toBe(false);
+    });
+
+    it('reports zero modifications when committed snapshots match the registry', () => {
+        const dir = resolve(tmp, 'published');
+        writeFileSync(
+            resolve(tmp, 'published/iam.user.created-v1.json'),
+            renderSnapshot('iam.user.created.v1', v1),
+        );
+        const summary = runExport({ ...makeConfig({ 'iam.user.created.v1': v1 }), publishedDir: dir });
+        expect(summary.newCount).toBe(0);
+        expect(summary.modifiedCount).toBe(0);
+        expect(summary.results[0].isNew).toBe(false);
+        expect(summary.results[0].changed).toBe(false);
+    });
+
+    it('detects a modified existing snapshot without overwriting it', () => {
+        // Pre-write a stale (v2) snapshot at the v1 path.
+        writeFileSync(
+            resolve(tmp, 'published/iam.user.created-v1.json'),
+            renderSnapshot('iam.user.created.v2', v2),
+        );
+        const before = readFileSync(resolve(tmp, 'published/iam.user.created-v1.json'), 'utf8');
+        const summary = runExport(makeConfig({ 'iam.user.created.v1': v1 }));
+        expect(summary.modifiedCount).toBe(1);
+        expect(summary.results[0].isNew).toBe(false);
+        expect(summary.results[0].changed).toBe(true);
+        // File was not modified — dry run.
+        expect(readFileSync(resolve(tmp, 'published/iam.user.created-v1.json'), 'utf8')).toBe(
+            before,
+        );
+    });
+});
+
+describe('runExport — write mode', () => {
+    it('writes new snapshots verbatim from renderSnapshot', () => {
+        const summary = runExport(makeConfig({ 'iam.user.created.v1': v1 }), { write: true });
+        expect(summary.newCount).toBe(1);
+        expect(summary.refusedCount).toBe(0);
+        const written = readFileSync(
+            resolve(tmp, 'published/iam.user.created-v1.json'),
+            'utf8',
+        );
+        expect(written).toBe(renderSnapshot('iam.user.created.v1', v1));
+    });
+
+    it('creates publishedDir when missing', () => {
+        // Use a deep path that doesn't exist yet; mkdirSync({ recursive: true })
+        // should create the chain.
+        const config: ContractCheckConfig = {
+            registry: { 'iam.user.created.v1': v1 },
+            publishedDir: resolve(tmp, 'never/created/published'),
+            pinsGlob: null,
+        };
+        runExport(config, { write: true });
+        expect(existsSync(resolve(tmp, 'never/created/published'))).toBe(true);
+    });
+
+    it('REFUSES to overwrite an existing modified snapshot without --bump (allowModify)', () => {
+        // Pre-write a stale snapshot.
+        const path = resolve(tmp, 'published/iam.user.created-v1.json');
+        writeFileSync(path, renderSnapshot('iam.user.created.v2', v2));
+        const before = readFileSync(path, 'utf8');
+
+        const summary = runExport(makeConfig({ 'iam.user.created.v1': v1 }), { write: true });
+        expect(summary.refusedCount).toBe(1);
+        expect(summary.results[0].refusedWrite).toBe(true);
+        // File MUST be unchanged — this is the load-bearing test for the
+        // D5/D6 frozen-forever guarantee. If this regresses, `export --write`
+        // can silently launder a schema modification through committed bytes.
+        expect(readFileSync(path, 'utf8')).toBe(before);
+    });
+
+    it('overwrites a modified snapshot when allowModify (--bump) is set', () => {
+        const path = resolve(tmp, 'published/iam.user.created-v1.json');
+        writeFileSync(path, renderSnapshot('iam.user.created.v2', v2));
+
+        const summary = runExport(makeConfig({ 'iam.user.created.v1': v1 }), {
+            write: true,
+            allowModify: true,
+        });
+        expect(summary.refusedCount).toBe(0);
+        expect(summary.modifiedCount).toBe(1);
+        expect(readFileSync(path, 'utf8')).toBe(renderSnapshot('iam.user.created.v1', v1));
+    });
+
+    it('always writes new snapshots even without --bump', () => {
+        // A new event being added is not a D5/D6 violation; --bump is only
+        // needed for modifying an EXISTING snapshot.
+        const summary = runExport(
+            makeConfig({ 'iam.user.created.v1': v1, 'iam.user.created.v2': v2 }),
+            { write: true },
+        );
+        expect(summary.newCount).toBe(2);
+        expect(summary.refusedCount).toBe(0);
+        expect(existsSync(resolve(tmp, 'published/iam.user.created-v1.json'))).toBe(true);
+        expect(existsSync(resolve(tmp, 'published/iam.user.created-v2.json'))).toBe(true);
+    });
+});
+
+describe('runExport — registry consistency', () => {
+    it('throws when an entry key disagrees with its descriptor (key/descriptor drift)', () => {
+        // Wrong key — caught by assertRegistryConsistent before any I/O.
+        expect(() => runExport(makeConfig({ 'iam.user.created.v99': v1 }))).toThrow(/registry key/);
+    });
+});

--- a/packages/node/contract-check/src/__tests__/pins.unit.test.ts
+++ b/packages/node/contract-check/src/__tests__/pins.unit.test.ts
@@ -1,0 +1,148 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { loadPinsFiles } from '../lib/pins.js';
+
+let tmp: string;
+
+beforeEach(() => {
+    tmp = mkdtempSync(resolve(tmpdir(), 'soa-contract-check-pins-'));
+});
+
+afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+});
+
+function writePins(svc: string, eventType: string, body: string): string {
+    const dir = resolve(tmp, 'apps', svc, 'pins');
+    mkdirSync(dir, { recursive: true });
+    const file = resolve(dir, `${eventType}.yaml`);
+    writeFileSync(file, body);
+    return file;
+}
+
+describe('loadPinsFiles', () => {
+    it('loads a well-formed pins file', async () => {
+        writePins(
+            'iam-api',
+            'iam.user.created',
+            `eventType: iam.user.created
+publisher:
+    service: iam-api
+    package: '@saga-ed/iam-events'
+versions_published: [1, 2]
+consumers:
+    - service: programs-api
+      versions: [1, 2]
+`,
+        );
+
+        const { pins, failures } = await loadPinsFiles(`${tmp}/apps/*/pins/*.yaml`);
+        expect(failures).toEqual([]);
+        expect(pins).toHaveLength(1);
+        expect(pins[0].eventType).toBe('iam.user.created');
+        expect(pins[0].publisher.service).toBe('iam-api');
+        expect(pins[0].versions_published).toEqual([1, 2]);
+        expect(pins[0].consumers).toEqual([
+            { service: 'programs-api', versions: [1, 2] },
+        ]);
+    });
+
+    it('records optional cross-repo `repo` field on consumers', async () => {
+        writePins(
+            'iam-api',
+            'iam.user.created',
+            `eventType: iam.user.created
+publisher:
+    service: iam-api
+    package: '@saga-ed/iam-events'
+versions_published: [1]
+consumers:
+    - service: programs-api
+      versions: [1]
+      repo: saga-ed/program-hub
+`,
+        );
+
+        const { pins } = await loadPinsFiles(`${tmp}/apps/*/pins/*.yaml`);
+        expect(pins[0].consumers[0].repo).toBe('saga-ed/program-hub');
+    });
+
+    it('reports invalid YAML as a failure (not a thrown exception)', async () => {
+        writePins('iam-api', 'iam.user.created', '::: not yaml :::\n  - oops');
+        const { pins, failures } = await loadPinsFiles(`${tmp}/apps/*/pins/*.yaml`);
+        expect(pins).toEqual([]);
+        expect(failures).toHaveLength(1);
+        expect(failures[0].message).toMatch(/Invalid YAML/);
+    });
+
+    it('rejects a missing publisher block', async () => {
+        writePins(
+            'iam-api',
+            'iam.user.created',
+            `eventType: iam.user.created
+versions_published: [1]
+consumers: []
+`,
+        );
+        const { failures } = await loadPinsFiles(`${tmp}/apps/*/pins/*.yaml`);
+        expect(failures[0].message).toMatch(/publisher/);
+    });
+
+    it('rejects a versions_published with non-positive integers', async () => {
+        writePins(
+            'iam-api',
+            'iam.user.created',
+            `eventType: iam.user.created
+publisher:
+    service: iam-api
+    package: '@saga-ed/iam-events'
+versions_published: [0, 1]
+consumers: []
+`,
+        );
+        const { failures } = await loadPinsFiles(`${tmp}/apps/*/pins/*.yaml`);
+        expect(failures[0].message).toMatch(/versions_published/);
+    });
+
+    it('rejects a filename that does not match the eventType (copy-paste foot-gun)', async () => {
+        writePins(
+            'iam-api',
+            'iam.user.created',
+            `eventType: iam.group.created
+publisher:
+    service: iam-api
+    package: '@saga-ed/iam-events'
+versions_published: [1]
+consumers: []
+`,
+        );
+        const { failures } = await loadPinsFiles(`${tmp}/apps/*/pins/*.yaml`);
+        expect(failures[0].message).toMatch(/Filename should be/);
+    });
+
+    it('returns multiple pins from multiple services', async () => {
+        writePins(
+            'iam-api',
+            'iam.user.created',
+            `eventType: iam.user.created
+publisher: { service: iam-api, package: '@saga-ed/iam-events' }
+versions_published: [1]
+consumers: []
+`,
+        );
+        writePins(
+            'programs-api',
+            'programs.program.created',
+            `eventType: programs.program.created
+publisher: { service: programs-api, package: '@saga-ed/programs-events' }
+versions_published: [1]
+consumers: []
+`,
+        );
+        const { pins } = await loadPinsFiles(`${tmp}/apps/*/pins/*.yaml`);
+        const names = pins.map((p) => p.eventType).sort();
+        expect(names).toEqual(['iam.user.created', 'programs.program.created']);
+    });
+});

--- a/packages/node/contract-check/src/__tests__/snapshot.unit.test.ts
+++ b/packages/node/contract-check/src/__tests__/snapshot.unit.test.ts
@@ -1,0 +1,118 @@
+import { z } from 'zod';
+import type { PayloadDescriptor } from '@saga-ed/soa-event-envelope';
+import { describe, expect, it } from 'vitest';
+import { renderSnapshot, snapshotFilename } from '../lib/snapshot.js';
+
+// Byte stability is the load-bearing invariant of contract-check: if
+// renderSnapshot's output drifts (indent, key order, trailing newline,
+// $id format, default $schema), every committed snapshot is silently
+// invalidated. These tests pin the canonical bytes.
+
+describe('snapshotFilename', () => {
+    it('translates eventKey suffix .vN into filename suffix -vN.json', () => {
+        expect(snapshotFilename('iam.user.created.v1')).toBe('iam.user.created-v1.json');
+    });
+
+    it('handles multi-digit versions', () => {
+        expect(snapshotFilename('foo.bar.v10')).toBe('foo.bar-v10.json');
+        expect(snapshotFilename('foo.bar.v123')).toBe('foo.bar-v123.json');
+    });
+
+    it('leaves a key without a version suffix unchanged (degenerate input)', () => {
+        // Documents the behavior — the regex only fires on `.v\d+$`. Adopters
+        // shouldn't construct keys without a version anyway, but we shouldn't
+        // crash on them.
+        expect(snapshotFilename('iam.user.created')).toBe('iam.user.created.json');
+    });
+});
+
+describe('renderSnapshot', () => {
+    const payloadSchema = z.object({ id: z.string(), count: z.number() });
+    const descriptor: PayloadDescriptor<z.infer<typeof payloadSchema>> = {
+        eventType: 'test.thing.created',
+        eventVersion: 1,
+        payloadSchema,
+    };
+
+    it('produces canonical bytes (golden) for a simple schema', () => {
+        const out = renderSnapshot('test.thing.created.v1', descriptor);
+        // 4-space indent, trailing newline, key order, default $id prefix.
+        // Any change here means every committed snapshot must be regenerated.
+        expect(out).toBe(
+            `{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://saga-ed.example.local/events/test.thing.created-v1.json",
+    "eventType": "test.thing.created",
+    "eventVersion": 1,
+    "payload": {
+        "type": "object",
+        "properties": {
+            "id": {
+                "type": "string"
+            },
+            "count": {
+                "type": "number"
+            }
+        },
+        "required": [
+            "id",
+            "count"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+}
+`,
+        );
+    });
+
+    it('is deterministic across repeated calls', () => {
+        const a = renderSnapshot('test.thing.created.v1', descriptor);
+        const b = renderSnapshot('test.thing.created.v1', descriptor);
+        expect(a).toBe(b);
+    });
+
+    it('always ends with a single trailing newline', () => {
+        const out = renderSnapshot('test.thing.created.v1', descriptor);
+        expect(out.endsWith('\n')).toBe(true);
+        expect(out.endsWith('\n\n')).toBe(false);
+    });
+
+    it('uses 4-space indentation', () => {
+        const out = renderSnapshot('test.thing.created.v1', descriptor);
+        // First indented line under the top-level object is "    \"$schema\":…".
+        expect(out).toMatch(/\n {4}"\$schema":/);
+    });
+
+    it('respects an explicit snapshotIdPrefix', () => {
+        const out = renderSnapshot('test.thing.created.v1', descriptor, 'https://example.com/');
+        expect(out).toContain('"$id": "https://example.com/test.thing.created-v1.json"');
+        // And does not leak into the payload schema.
+        const parsed = JSON.parse(out) as { payload: { $schema: string } };
+        expect(parsed.payload.$schema).toBe('http://json-schema.org/draft-07/schema#');
+    });
+
+    it('uses the default snapshotIdPrefix when omitted', () => {
+        // Pinned because the default URL is part of every committed snapshot;
+        // changing it silently invalidates them.
+        const out = renderSnapshot('foo.bar.v1', {
+            eventType: 'foo.bar',
+            eventVersion: 1,
+            payloadSchema: z.object({}),
+        });
+        expect(out).toContain('"$id": "https://saga-ed.example.local/events/foo.bar-v1.json"');
+    });
+
+    it('preserves $refStrategy=none — no inline $refs in the rendered payload', () => {
+        // Two structurally identical sub-objects. With $refStrategy other than
+        // 'none', zod-to-json-schema would dedupe one to a $ref pointing at
+        // the other, producing different bytes depending on encounter order.
+        const inner = z.object({ id: z.string() });
+        const out = renderSnapshot('foo.bar.v1', {
+            eventType: 'foo.bar',
+            eventVersion: 1,
+            payloadSchema: z.object({ a: inner, b: inner }),
+        });
+        expect(out).not.toContain('"$ref"');
+    });
+});

--- a/packages/node/contract-check/src/check.ts
+++ b/packages/node/contract-check/src/check.ts
@@ -18,7 +18,7 @@
 
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import type { ContractCheckConfig } from './lib/config.js';
+import { assertRegistryConsistent, type ContractCheckConfig } from './lib/config.js';
 import { loadPinsFiles, type PinsFile } from './lib/pins.js';
 import { renderSnapshot, snapshotFilename } from './lib/snapshot.js';
 
@@ -175,6 +175,7 @@ async function checkPinsLayer(
 }
 
 export async function runCheck(config: ContractCheckConfig): Promise<CheckResult> {
+    assertRegistryConsistent(config);
     const snapshotFailures = checkSnapshots(config);
     const { failures: pinsFailures, pinsCount } = await checkPinsLayer(config);
     return {

--- a/packages/node/contract-check/src/check.ts
+++ b/packages/node/contract-check/src/check.ts
@@ -1,0 +1,185 @@
+// Validates publisher snapshots + publisher-owned pins files. Three layers:
+//
+//   1. SNAPSHOT BYTE-DIFF — exporting the registry must produce exactly the
+//      snapshots currently in `publishedDir`. Any diff means a frozen schema
+//      was modified or a new version was added without committing it.
+//
+//   2. PINS COVERAGE — for every event type with a registry entry, a pins
+//      file must exist matching `pinsGlob`, and its `versions_published`
+//      must equal the set of versions in the registry. Catches "publisher
+//      added/dropped a schema but didn't update pins."
+//
+//   3. PINS CONSUMER VALIDITY (drop-protection) — every consumer pin's
+//      `versions[]` must be a subset of `versions_published`. When a
+//      publisher's PR shrinks `versions_published`, this fails until
+//      consumers drop their pins.
+//
+// Returns a list of failures; CLI maps non-empty list to exit 1.
+
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { ContractCheckConfig } from './lib/config.js';
+import { loadPinsFiles, type PinsFile } from './lib/pins.js';
+import { renderSnapshot, snapshotFilename } from './lib/snapshot.js';
+
+export interface CheckFailure {
+    layer: 'snapshot' | 'pins-coverage' | 'pins-validity';
+    file: string;
+    message: string;
+}
+
+export interface CheckResult {
+    failures: CheckFailure[];
+    eventCount: number;
+    pinsCount: number;
+}
+
+function checkSnapshots(config: ContractCheckConfig): CheckFailure[] {
+    const failures: CheckFailure[] = [];
+    for (const [eventKey, descriptor] of Object.entries(config.registry)) {
+        const filename = snapshotFilename(eventKey);
+        const target = resolve(config.publishedDir, filename);
+        const expected = renderSnapshot(eventKey, descriptor, config.snapshotIdPrefix);
+
+        if (!existsSync(target)) {
+            failures.push({
+                layer: 'snapshot',
+                file: filename,
+                message:
+                    `Missing snapshot ${filename} for ${eventKey}. ` +
+                    'Run `soa-contract-check export --write` and commit the new file.',
+            });
+            continue;
+        }
+
+        const committed = readFileSync(target, 'utf8');
+        if (committed !== expected) {
+            failures.push({
+                layer: 'snapshot',
+                file: filename,
+                message:
+                    `Snapshot ${filename} differs from current schema for ${eventKey}. ` +
+                    'Per Model A (frozen-forever), modifying an existing version is forbidden. ' +
+                    'Either revert the change or bump to a new version.',
+            });
+        }
+    }
+    return failures;
+}
+
+async function checkPinsLayer(
+    config: ContractCheckConfig,
+): Promise<{ failures: CheckFailure[]; pinsCount: number }> {
+    if (config.pinsGlob === null) {
+        return { failures: [], pinsCount: 0 };
+    }
+
+    const failures: CheckFailure[] = [];
+    const { pins, failures: loadFailures } = await loadPinsFiles(config.pinsGlob);
+
+    for (const f of loadFailures) {
+        failures.push({ layer: 'pins-validity', file: f.file, message: f.message });
+    }
+
+    // Map eventType → registered versions.
+    const registryVersions = new Map<string, Set<number>>();
+    for (const descriptor of Object.values(config.registry)) {
+        const versions = registryVersions.get(descriptor.eventType) ?? new Set();
+        versions.add(descriptor.eventVersion);
+        registryVersions.set(descriptor.eventType, versions);
+    }
+
+    // Index pins by eventType + flag duplicates.
+    const pinsByEventType = new Map<string, PinsFile>();
+    for (const p of pins) {
+        const existing = pinsByEventType.get(p.eventType);
+        if (existing) {
+            failures.push({
+                layer: 'pins-coverage',
+                file: p.sourcePath,
+                message: `Duplicate pins file for ${p.eventType} (also at ${existing.sourcePath}).`,
+            });
+            continue;
+        }
+        pinsByEventType.set(p.eventType, p);
+    }
+
+    // Layer 2a: every registered eventType must have a pins file with
+    // versions_published equal to the registry's version set.
+    for (const [eventType, regSet] of registryVersions) {
+        const pinsFile = pinsByEventType.get(eventType);
+        if (!pinsFile) {
+            failures.push({
+                layer: 'pins-coverage',
+                file: `apps/<publisher>/pins/${eventType}.yaml`,
+                message:
+                    `Registry has ${eventType} but no pins file exists. ` +
+                    'Create the pins file with versions_published equal to the registry versions.',
+            });
+            continue;
+        }
+        const pubSet = new Set(pinsFile.versions_published);
+        const missing = [...regSet].filter((v) => !pubSet.has(v)).sort((a, b) => a - b);
+        const extra = [...pubSet].filter((v) => !regSet.has(v)).sort((a, b) => a - b);
+        if (missing.length > 0 || extra.length > 0) {
+            const parts: string[] = [];
+            if (missing.length > 0) {
+                parts.push(`registry has [${missing.join(', ')}] missing from versions_published`);
+            }
+            if (extra.length > 0) {
+                parts.push(
+                    `versions_published has [${extra.join(', ')}] with no schema in the registry`,
+                );
+            }
+            failures.push({
+                layer: 'pins-coverage',
+                file: pinsFile.sourcePath,
+                message: `versions_published doesn't match the registry for ${eventType}: ${parts.join('; ')}.`,
+            });
+        }
+    }
+
+    // Layer 2b: pins file for an event the registry doesn't know about.
+    for (const [eventType, pinsFile] of pinsByEventType) {
+        if (!registryVersions.has(eventType)) {
+            failures.push({
+                layer: 'pins-coverage',
+                file: pinsFile.sourcePath,
+                message:
+                    `Pins file declares ${eventType} but no schema for it exists in the registry. ` +
+                    'Either remove this pins file or add the schema.',
+            });
+        }
+    }
+
+    // Layer 3: every consumer pin must be a subset of versions_published.
+    // This is the drop-protection check.
+    for (const pinsFile of pins) {
+        const pubSet = new Set(pinsFile.versions_published);
+        for (const consumer of pinsFile.consumers) {
+            const stalePins = consumer.versions.filter((v) => !pubSet.has(v));
+            if (stalePins.length > 0) {
+                failures.push({
+                    layer: 'pins-validity',
+                    file: pinsFile.sourcePath,
+                    message:
+                        `${consumer.service} pins ${pinsFile.eventType} version(s) [${stalePins.join(', ')}] ` +
+                        `but versions_published is [${pinsFile.versions_published.join(', ')}]. ` +
+                        `Either restore those versions to versions_published, or have ${consumer.service} drop the pin first.`,
+                });
+            }
+        }
+    }
+
+    return { failures, pinsCount: pins.length };
+}
+
+export async function runCheck(config: ContractCheckConfig): Promise<CheckResult> {
+    const snapshotFailures = checkSnapshots(config);
+    const { failures: pinsFailures, pinsCount } = await checkPinsLayer(config);
+    return {
+        failures: [...snapshotFailures, ...pinsFailures],
+        eventCount: Object.keys(config.registry).length,
+        pinsCount,
+    };
+}

--- a/packages/node/contract-check/src/cli.ts
+++ b/packages/node/contract-check/src/cli.ts
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+import { loadConfig } from './lib/config.js';
+import { runCheck } from './check.js';
+import { runExport } from './export.js';
+
+function usage(): void {
+    process.stderr.write(
+        [
+            'Usage: soa-contract-check <command>',
+            '',
+            'Commands:',
+            '  check          Validate snapshots + pins against the registry. Exits 1 on failure.',
+            '  export         Render snapshots from the registry. Diff-only by default.',
+            '  export --write Write snapshots to disk.',
+            '',
+            'The tool walks up from the current directory looking for a',
+            'contract-check.config.{ts,js,mts,mjs} that default-exports a',
+            'ContractCheckConfig.',
+            '',
+        ].join('\n'),
+    );
+}
+
+async function main(): Promise<void> {
+    const args = process.argv.slice(2);
+    const cmd = args[0];
+
+    if (!cmd || cmd === '-h' || cmd === '--help') {
+        usage();
+        process.exit(cmd ? 0 : 1);
+    }
+
+    const { config, configPath } = await loadConfig();
+
+    if (cmd === 'check') {
+        const result = await runCheck(config);
+        if (result.failures.length === 0) {
+            process.stdout.write(
+                `[contract-check] OK — ${result.eventCount} event(s) snapshot-clean, ${result.pinsCount} pins file(s) valid (config: ${configPath})\n`,
+            );
+            process.exit(0);
+        }
+        process.stderr.write(`[contract-check] ${result.failures.length} violation(s):\n\n`);
+        for (const f of result.failures) {
+            process.stderr.write(`  [${f.layer}] ${f.file}\n    ${f.message}\n\n`);
+        }
+        process.exit(1);
+    }
+
+    if (cmd === 'export') {
+        const flags = new Set(args.slice(1));
+        const write = flags.has('--write') || flags.has('-w');
+        const bump = flags.has('--bump');
+        const summary = runExport(config, { write });
+
+        if (write) {
+            process.stdout.write(
+                `[export] wrote ${summary.results.length} schema(s) (${summary.newCount} new, ${summary.modifiedCount} modified existing) to ${config.publishedDir}\n`,
+            );
+            if (summary.modifiedCount > 0 && !bump) {
+                process.stdout.write(
+                    '[export] NOTE: existing snapshot files were modified. ' +
+                        'Per Model A (frozen-forever), modifying an existing version is forbidden. ' +
+                        'You probably want to introduce a new version (vN+1) instead. ' +
+                        'See soa_75/decisions/d-event-versioning.md.\n',
+                );
+            }
+            process.exit(0);
+        }
+
+        if (summary.newCount === 0 && summary.modifiedCount === 0) {
+            process.stdout.write(
+                `[export] all ${summary.results.length} schemas match committed snapshots\n`,
+            );
+            process.exit(0);
+        }
+        if (summary.newCount > 0) {
+            process.stdout.write(`[export] ${summary.newCount} NEW schema(s) (would write):\n`);
+            for (const r of summary.results.filter((r) => r.isNew)) {
+                process.stdout.write(`  + ${r.filename}\n`);
+            }
+        }
+        if (summary.modifiedCount > 0) {
+            process.stdout.write(
+                `[export] ${summary.modifiedCount} MODIFIED schema(s) — frozen-forever rule violated:\n`,
+            );
+            for (const r of summary.results.filter((r) => r.changed && !r.isNew)) {
+                process.stdout.write(`  ! ${r.filename}\n`);
+            }
+        }
+        process.stdout.write('[export] re-run with --write to apply.\n');
+        // Diff-only mode is informational, not a CI gate (use `check` for that).
+        process.exit(0);
+    }
+
+    process.stderr.write(`Unknown command: ${cmd}\n\n`);
+    usage();
+    process.exit(1);
+}
+
+void main();

--- a/packages/node/contract-check/src/cli.ts
+++ b/packages/node/contract-check/src/cli.ts
@@ -9,9 +9,10 @@ function usage(): void {
             'Usage: soa-contract-check <command>',
             '',
             'Commands:',
-            '  check          Validate snapshots + pins against the registry. Exits 1 on failure.',
-            '  export         Render snapshots from the registry. Diff-only by default.',
-            '  export --write Write snapshots to disk.',
+            '  check                 Validate snapshots + pins against the registry. Exits 1 on failure.',
+            '  export                Render snapshots from the registry. Diff-only by default.',
+            '  export --write        Write NEW snapshots; refuses to overwrite existing versions.',
+            '  export --write --bump Allow overwriting an existing snapshot (D5/D6 opt-in).',
             '',
             'The tool walks up from the current directory looking for a',
             'contract-check.config.{ts,js,mts,mjs} that default-exports a',
@@ -51,19 +52,30 @@ async function main(): Promise<void> {
         const flags = new Set(args.slice(1));
         const write = flags.has('--write') || flags.has('-w');
         const bump = flags.has('--bump');
-        const summary = runExport(config, { write });
+        // `--bump` is the explicit gesture an adopter must make to acknowledge
+        // they are intentionally modifying an existing snapshot (D5/D6 violation
+        // territory). Without it, runExport refuses such writes and we exit 1
+        // so the developer's CI/local pipeline catches the mistake.
+        const summary = runExport(config, { write, allowModify: bump });
 
         if (write) {
+            const wrote = summary.results.length - summary.refusedCount;
             process.stdout.write(
-                `[export] wrote ${summary.results.length} schema(s) (${summary.newCount} new, ${summary.modifiedCount} modified existing) to ${config.publishedDir}\n`,
+                `[export] wrote ${wrote} schema(s) (${summary.newCount} new, ${summary.modifiedCount - summary.refusedCount} modified existing) to ${config.publishedDir}\n`,
             );
-            if (summary.modifiedCount > 0 && !bump) {
-                process.stdout.write(
-                    '[export] NOTE: existing snapshot files were modified. ' +
-                        'Per Model A (frozen-forever), modifying an existing version is forbidden. ' +
-                        'You probably want to introduce a new version (vN+1) instead. ' +
+            if (summary.refusedCount > 0) {
+                process.stderr.write(
+                    `[export] REFUSED to write ${summary.refusedCount} snapshot(s) that would modify existing version(s):\n`,
+                );
+                for (const r of summary.results.filter((r) => r.refusedWrite)) {
+                    process.stderr.write(`  ! ${r.filename}\n`);
+                }
+                process.stderr.write(
+                    '[export] Per Model A (frozen-forever), modifying an existing version is forbidden. ' +
+                        'Either revert the schema change and bump to a new version, OR re-run with --bump to confirm intent. ' +
                         'See soa_75/decisions/d-event-versioning.md.\n',
                 );
+                process.exit(1);
             }
             process.exit(0);
         }

--- a/packages/node/contract-check/src/export.ts
+++ b/packages/node/contract-check/src/export.ts
@@ -1,0 +1,70 @@
+// Renders every event's payload schema to JSON Schema and writes one file per
+// (eventType, eventVersion) under `publishedDir`. Files are committed to git;
+// the next `runCheck()` fails if a write here would diff against the
+// committed snapshot, OR if the developer hasn't passed `--bump` to indicate
+// the change is intentional.
+
+import { mkdirSync, writeFileSync, readdirSync, readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { ContractCheckConfig } from './lib/config.js';
+import { renderSnapshot, snapshotFilename } from './lib/snapshot.js';
+
+export interface ExportResult {
+    eventKey: string;
+    filename: string;
+    json: string;
+    changed: boolean;
+    isNew: boolean;
+}
+
+export interface ExportSummary {
+    results: ExportResult[];
+    written: boolean;
+    newCount: number;
+    modifiedCount: number;
+}
+
+export interface ExportOpts {
+    /** Write snapshots to disk. Default: false (dry-run / diff-only). */
+    write?: boolean;
+}
+
+export function runExport(
+    config: ContractCheckConfig,
+    opts: ExportOpts = {},
+): ExportSummary {
+    mkdirSync(config.publishedDir, { recursive: true });
+
+    const existing = new Map<string, string>();
+    if (existsSync(config.publishedDir)) {
+        for (const f of readdirSync(config.publishedDir)) {
+            if (f.endsWith('.json')) {
+                existing.set(f, readFileSync(resolve(config.publishedDir, f), 'utf8'));
+            }
+        }
+    }
+
+    const results: ExportResult[] = [];
+    let newCount = 0;
+    let modifiedCount = 0;
+    for (const [eventKey, descriptor] of Object.entries(config.registry)) {
+        const filename = snapshotFilename(eventKey);
+        const json = renderSnapshot(eventKey, descriptor, config.snapshotIdPrefix);
+        const previous = existing.get(filename);
+        const changed = previous !== json;
+        const isNew = previous === undefined;
+        results.push({ eventKey, filename, json, changed, isNew });
+        if (isNew) newCount++;
+        else if (changed) modifiedCount++;
+        if (opts.write) {
+            writeFileSync(resolve(config.publishedDir, filename), json);
+        }
+    }
+
+    return {
+        results,
+        written: opts.write ?? false,
+        newCount,
+        modifiedCount,
+    };
+}

--- a/packages/node/contract-check/src/export.ts
+++ b/packages/node/contract-check/src/export.ts
@@ -1,12 +1,11 @@
 // Renders every event's payload schema to JSON Schema and writes one file per
 // (eventType, eventVersion) under `publishedDir`. Files are committed to git;
-// the next `runCheck()` fails if a write here would diff against the
-// committed snapshot, OR if the developer hasn't passed `--bump` to indicate
-// the change is intentional.
+// `runCheck()` then fails if any committed snapshot has drifted from the
+// schema, OR if a new version was added without committing its snapshot.
 
 import { mkdirSync, writeFileSync, readdirSync, readFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
-import type { ContractCheckConfig } from './lib/config.js';
+import { assertRegistryConsistent, type ContractCheckConfig } from './lib/config.js';
 import { renderSnapshot, snapshotFilename } from './lib/snapshot.js';
 
 export interface ExportResult {
@@ -15,6 +14,14 @@ export interface ExportResult {
     json: string;
     changed: boolean;
     isNew: boolean;
+    /**
+     * True when `opts.write` was set but the write was refused because the
+     * snapshot would have overwritten an existing file with different bytes
+     * and `opts.allowModify` was not set. The caller should treat this as a
+     * D5/D6 violation: the developer should bump to a new version, not edit
+     * the committed schema.
+     */
+    refusedWrite: boolean;
 }
 
 export interface ExportSummary {
@@ -22,17 +29,27 @@ export interface ExportSummary {
     written: boolean;
     newCount: number;
     modifiedCount: number;
+    /** Count of `results` with `refusedWrite: true`. */
+    refusedCount: number;
 }
 
 export interface ExportOpts {
     /** Write snapshots to disk. Default: false (dry-run / diff-only). */
     write?: boolean;
+    /**
+     * Allow `write` to overwrite existing snapshots whose bytes have changed.
+     * Wired to `--bump` on the CLI. Default: false — modifying an existing
+     * version is a D5/D6 violation, so a developer must opt in explicitly.
+     * New snapshots (no prior file on disk) are always written by `write`.
+     */
+    allowModify?: boolean;
 }
 
 export function runExport(
     config: ContractCheckConfig,
     opts: ExportOpts = {},
 ): ExportSummary {
+    assertRegistryConsistent(config);
     mkdirSync(config.publishedDir, { recursive: true });
 
     const existing = new Map<string, string>();
@@ -47,16 +64,23 @@ export function runExport(
     const results: ExportResult[] = [];
     let newCount = 0;
     let modifiedCount = 0;
+    let refusedCount = 0;
     for (const [eventKey, descriptor] of Object.entries(config.registry)) {
         const filename = snapshotFilename(eventKey);
         const json = renderSnapshot(eventKey, descriptor, config.snapshotIdPrefix);
         const previous = existing.get(filename);
         const changed = previous !== json;
         const isNew = previous === undefined;
-        results.push({ eventKey, filename, json, changed, isNew });
+        const wouldModifyExisting = changed && !isNew;
+        const refusedWrite =
+            (opts.write ?? false) && wouldModifyExisting && !(opts.allowModify ?? false);
+
+        results.push({ eventKey, filename, json, changed, isNew, refusedWrite });
         if (isNew) newCount++;
         else if (changed) modifiedCount++;
-        if (opts.write) {
+        if (refusedWrite) refusedCount++;
+
+        if (opts.write && !refusedWrite) {
             writeFileSync(resolve(config.publishedDir, filename), json);
         }
     }
@@ -66,5 +90,6 @@ export function runExport(
         written: opts.write ?? false,
         newCount,
         modifiedCount,
+        refusedCount,
     };
 }

--- a/packages/node/contract-check/src/index.ts
+++ b/packages/node/contract-check/src/index.ts
@@ -1,0 +1,22 @@
+export {
+    type ContractCheckConfig,
+    loadConfig,
+} from './lib/config.js';
+export {
+    type PinsFile,
+    type PinsConsumer,
+    type PinsValidationFailure,
+    loadPinsFiles,
+} from './lib/pins.js';
+export { renderSnapshot, snapshotFilename } from './lib/snapshot.js';
+export {
+    type CheckFailure,
+    type CheckResult,
+    runCheck,
+} from './check.js';
+export {
+    type ExportOpts,
+    type ExportResult,
+    type ExportSummary,
+    runExport,
+} from './export.js';

--- a/packages/node/contract-check/src/index.ts
+++ b/packages/node/contract-check/src/index.ts
@@ -1,5 +1,7 @@
 export {
     type ContractCheckConfig,
+    assertRegistryConsistent,
+    defineConfig,
     loadConfig,
 } from './lib/config.js';
 export {

--- a/packages/node/contract-check/src/lib/config.ts
+++ b/packages/node/contract-check/src/lib/config.ts
@@ -1,0 +1,82 @@
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type { PayloadDescriptor } from '@saga-ed/soa-event-envelope';
+
+/**
+ * Configuration the adopter repo provides to soa-contract-check. The tool is
+ * layout-agnostic: each repo's config tells it where its events live, where
+ * to write snapshots, and where to find pins files.
+ */
+export interface ContractCheckConfig {
+    /**
+     * Map from `<eventType>.v<version>` keys to PayloadDescriptors. Adopters
+     * typically build this by spreading their per-family event registries
+     * (e.g., `{ ...iamEvents, ...programsEvents }`).
+     */
+    registry: Record<string, PayloadDescriptor<unknown>>;
+    /**
+     * Absolute path to the directory holding committed JSON-Schema snapshots.
+     * Recommended: `<repoRoot>/tools/contract-check/published`.
+     */
+    publishedDir: string;
+    /**
+     * Absolute glob matching pins YAML files. Recommended:
+     * `<repoRoot>/apps/*&zwj;/pins/*.yaml`.
+     *
+     * Set to `null` if the repo has no apps/ layout (e.g., this very soa
+     * package itself, which holds the tool but publishes no events). In that
+     * case the pins layers are skipped entirely.
+     */
+    pinsGlob: string | null;
+    /**
+     * Optional `$id` prefix used in snapshot files (`https://…/<filename>`).
+     * Defaults to `https://saga-ed.example.local/events/`. Affects bytes —
+     * any change to this requires regenerating snapshots.
+     */
+    snapshotIdPrefix?: string;
+}
+
+const CONFIG_FILENAMES = [
+    'contract-check.config.ts',
+    'contract-check.config.mts',
+    'contract-check.config.js',
+    'contract-check.config.mjs',
+];
+
+/**
+ * Find the contract-check config file by walking up from `cwd`. The repo root
+ * is wherever the config sits — convention is that adopters put it next to
+ * their `pnpm-workspace.yaml` or `package.json`.
+ */
+export async function loadConfig(cwd: string = process.cwd()): Promise<{
+    config: ContractCheckConfig;
+    configPath: string;
+}> {
+    let dir = resolve(cwd);
+    for (;;) {
+        for (const name of CONFIG_FILENAMES) {
+            const candidate = resolve(dir, name);
+            if (existsSync(candidate)) {
+                const mod = (await import(pathToFileURL(candidate).href)) as {
+                    default?: ContractCheckConfig;
+                    config?: ContractCheckConfig;
+                };
+                const config = mod.default ?? mod.config;
+                if (!config) {
+                    throw new Error(
+                        `${candidate} must default-export (or named-export \`config\`) a ContractCheckConfig object`,
+                    );
+                }
+                return { config, configPath: candidate };
+            }
+        }
+        const parent = resolve(dir, '..');
+        if (parent === dir) {
+            throw new Error(
+                `Could not find a contract-check config file. Searched up from ${cwd} for: ${CONFIG_FILENAMES.join(', ')}`,
+            );
+        }
+        dir = parent;
+    }
+}

--- a/packages/node/contract-check/src/lib/config.ts
+++ b/packages/node/contract-check/src/lib/config.ts
@@ -37,6 +37,40 @@ export interface ContractCheckConfig {
     snapshotIdPrefix?: string;
 }
 
+/**
+ * Identity helper that exists purely so adopters get TypeScript type-checking
+ * on their `contract-check.config.ts` without having to remember the
+ * `: ContractCheckConfig` annotation. Mirrors the `defineConfig` convention
+ * used by vite, vitest, tsup, etc.
+ *
+ * @example
+ *   import { defineConfig } from '@saga-ed/soa-contract-check';
+ *   export default defineConfig({ registry, publishedDir, pinsGlob });
+ */
+export function defineConfig(config: ContractCheckConfig): ContractCheckConfig {
+    return config;
+}
+
+/**
+ * Verify that every `registry` key matches its descriptor's
+ * `eventType` and `eventVersion`. The registry is keyed by string for
+ * spreadability (`{ ...iamEvents, ...programsEvents }`) but the snapshot
+ * filename is derived from the key while the pins-coverage layer is derived
+ * from the descriptor's fields — so a drifting key would produce
+ * inconsistent failures across the layers. Catch it loudly at entry.
+ */
+export function assertRegistryConsistent(config: ContractCheckConfig): void {
+    for (const [eventKey, descriptor] of Object.entries(config.registry)) {
+        const expected = `${descriptor.eventType}.v${descriptor.eventVersion}`;
+        if (eventKey !== expected) {
+            throw new Error(
+                `contract-check: registry key '${eventKey}' does not match its descriptor (expected '${expected}'). ` +
+                    'Each entry must be keyed by `${eventType}.v${eventVersion}` so the snapshot path and pins path agree.',
+            );
+        }
+    }
+}
+
 const CONFIG_FILENAMES = [
     'contract-check.config.ts',
     'contract-check.config.mts',

--- a/packages/node/contract-check/src/lib/pins.ts
+++ b/packages/node/contract-check/src/lib/pins.ts
@@ -16,6 +16,7 @@
 // pins file is keyed by the `eventType` field, not by directory.
 
 import { readFileSync } from 'node:fs';
+import { basename } from 'node:path';
 import fastGlob from 'fast-glob';
 import { load as parseYaml } from 'js-yaml';
 
@@ -124,9 +125,10 @@ function validateShape(parsed: unknown, file: string): ShapeResult {
 
     // Sanity check: pins file's eventType should match its filename (less the
     // `.yaml` extension). Catches the common foot-gun of copy-pasting a pins
-    // file and forgetting to rename one of the two.
+    // file and forgetting to rename one of the two. Use basename rather than
+    // a forward-slash endsWith so adopters on Windows CI aren't surprised.
     const expectedFilename = `${eventType}.yaml`;
-    if (!file.endsWith(`/${expectedFilename}`)) {
+    if (basename(file) !== expectedFilename) {
         return {
             error: `Filename should be ${expectedFilename} to match eventType`,
         };

--- a/packages/node/contract-check/src/lib/pins.ts
+++ b/packages/node/contract-check/src/lib/pins.ts
@@ -1,0 +1,158 @@
+// Loads + validates pins YAML files. Each pins file describes ONE event type
+// owned by a single publisher service. Schema:
+//
+//   eventType: iam.user.created
+//   publisher:
+//       service: iam-api
+//       package: '@saga-ed/iam-events'
+//   versions_published: [1, 2]
+//   consumers:
+//       - service: programs-api
+//         versions: [1, 2]
+//         repo: <optional, for cross-repo>
+//
+// Files live at `apps/<svc>/pins/<eventType>.yaml` by convention. Loading is
+// a flat read of the configured glob — no per-app aggregation, since each
+// pins file is keyed by the `eventType` field, not by directory.
+
+import { readFileSync } from 'node:fs';
+import fastGlob from 'fast-glob';
+import { load as parseYaml } from 'js-yaml';
+
+export interface PinsConsumer {
+    service: string;
+    versions: number[];
+    /** Optional — for cross-repo consumers. Single-repo cases omit it. */
+    repo?: string;
+}
+
+export interface PinsFile {
+    eventType: string;
+    publisher: { service: string; package: string };
+    versions_published: number[];
+    consumers: PinsConsumer[];
+    /** Filesystem path of the loaded file (for error messages). */
+    sourcePath: string;
+}
+
+export interface PinsValidationFailure {
+    file: string;
+    message: string;
+}
+
+/**
+ * Glob + parse + structurally validate every pins file matching `pinsGlob`.
+ * Returns parsed pins; any structural problem becomes a `failures[]` entry
+ * (the caller decides how to surface it). The split lets the check tool
+ * report multiple bad files in a single run.
+ */
+export async function loadPinsFiles(pinsGlob: string): Promise<{
+    pins: PinsFile[];
+    failures: PinsValidationFailure[];
+}> {
+    const paths = await fastGlob(pinsGlob, { absolute: true });
+    const pins: PinsFile[] = [];
+    const failures: PinsValidationFailure[] = [];
+
+    for (const file of paths) {
+        const raw = readFileSync(file, 'utf8');
+        let parsed: unknown;
+        try {
+            parsed = parseYaml(raw);
+        } catch (err) {
+            failures.push({
+                file,
+                message: `Invalid YAML: ${err instanceof Error ? err.message : String(err)}`,
+            });
+            continue;
+        }
+
+        const validated = validateShape(parsed, file);
+        if ('error' in validated) {
+            failures.push({ file, message: validated.error });
+            continue;
+        }
+        pins.push({ ...validated.value, sourcePath: file });
+    }
+
+    return { pins, failures };
+}
+
+type ShapeResult =
+    | { value: Omit<PinsFile, 'sourcePath'> }
+    | { error: string };
+
+function validateShape(parsed: unknown, file: string): ShapeResult {
+    if (!isRecord(parsed)) {
+        return { error: 'Top-level must be a YAML object' };
+    }
+
+    const { eventType, publisher, versions_published, consumers } = parsed;
+
+    if (typeof eventType !== 'string' || eventType.length === 0) {
+        return { error: 'Missing or empty `eventType` (string)' };
+    }
+    if (
+        !isRecord(publisher) ||
+        typeof publisher.service !== 'string' ||
+        typeof publisher.package !== 'string'
+    ) {
+        return { error: 'Missing `publisher: { service, package }`' };
+    }
+    if (!isVersionArray(versions_published)) {
+        return { error: '`versions_published` must be a non-empty array of positive integers' };
+    }
+    if (!Array.isArray(consumers)) {
+        return { error: '`consumers` must be an array (use [] for none)' };
+    }
+
+    const validatedConsumers: PinsConsumer[] = [];
+    for (let i = 0; i < consumers.length; i++) {
+        const c = consumers[i];
+        if (!isRecord(c) || typeof c.service !== 'string' || !isVersionArray(c.versions)) {
+            return {
+                error: `consumers[${i}] must be { service: string, versions: number[] }`,
+            };
+        }
+        const consumer: PinsConsumer = {
+            service: c.service,
+            versions: c.versions,
+        };
+        if (typeof c.repo === 'string') consumer.repo = c.repo;
+        validatedConsumers.push(consumer);
+    }
+
+    // Sanity check: pins file's eventType should match its filename (less the
+    // `.yaml` extension). Catches the common foot-gun of copy-pasting a pins
+    // file and forgetting to rename one of the two.
+    const expectedFilename = `${eventType}.yaml`;
+    if (!file.endsWith(`/${expectedFilename}`)) {
+        return {
+            error: `Filename should be ${expectedFilename} to match eventType`,
+        };
+    }
+
+    return {
+        value: {
+            eventType,
+            publisher: {
+                service: publisher.service as string,
+                package: publisher.package as string,
+            },
+            versions_published: versions_published as number[],
+            consumers: validatedConsumers,
+        },
+    };
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+    return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+function isVersionArray(v: unknown): v is number[] {
+    return (
+        Array.isArray(v) &&
+        v.length > 0 &&
+        v.every((n) => typeof n === 'number' && Number.isInteger(n) && n > 0)
+    );
+}

--- a/packages/node/contract-check/src/lib/snapshot.ts
+++ b/packages/node/contract-check/src/lib/snapshot.ts
@@ -1,0 +1,44 @@
+import type { ZodTypeAny } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+import type { PayloadDescriptor } from '@saga-ed/soa-event-envelope';
+
+const DEFAULT_ID_PREFIX = 'https://saga-ed.example.local/events/';
+
+/**
+ * Filename convention for committed snapshots: `iam.user.created-v1.json`
+ * (NOT `.v1` in filename). The `eventKey` form `iam.user.created.v1` is
+ * convenient for Map keys but ugly on disk; the canonical filename uses
+ * `-v` to separate.
+ */
+export function snapshotFilename(eventKey: string): string {
+    return `${eventKey.replace(/\.v(\d+)$/, '-v$1')}.json`;
+}
+
+/**
+ * Render a PayloadDescriptor to the canonical JSON-Schema snapshot string
+ * (4-space indent, trailing newline). Stable byte output for diff-gating.
+ */
+export function renderSnapshot(
+    eventKey: string,
+    descriptor: PayloadDescriptor<unknown>,
+    idPrefix: string = DEFAULT_ID_PREFIX,
+): string {
+    const filename = snapshotFilename(eventKey);
+    // Cast to ZodTypeAny: the PayloadDescriptor's `payloadSchema: z.ZodType<T>`
+    // with `T = unknown` triggers a "type instantiation is excessively deep"
+    // error inside zod-to-json-schema's internal generic recursion. We only
+    // need the structural conversion here, not type-level T preservation.
+    const schema = zodToJsonSchema(descriptor.payloadSchema as ZodTypeAny, {
+        target: 'jsonSchema7',
+        // Stable, deterministic output: no auto $ref deduplication.
+        $refStrategy: 'none',
+    });
+    const annotated = {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        $id: `${idPrefix}${filename}`,
+        eventType: descriptor.eventType,
+        eventVersion: descriptor.eventVersion,
+        payload: schema,
+    };
+    return `${JSON.stringify(annotated, null, 4)}\n`;
+}

--- a/packages/node/contract-check/tsconfig.json
+++ b/packages/node/contract-check/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "@saga-ed/soa-typescript-config/base.json",
+    "compilerOptions": {
+        "outDir": "./dist",
+        "rootDir": "./src",
+        "noEmit": true
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/node/contract-check/tsup.config.ts
+++ b/packages/node/contract-check/tsup.config.ts
@@ -6,8 +6,11 @@ export default defineConfig({
     dts: true,
     clean: true,
     sourcemap: true,
-    // zod and @saga-ed/soa-event-envelope are peer deps. Bundling them would
-    // create a second copy at runtime; zod-to-json-schema's `instanceof` checks
-    // would then silently fail and emit an empty payload schema.
+    // zod stays external because it's a peer dep — adopters and the tool
+    // must share one zod instance. Bundling a second copy would silently
+    // break zod-to-json-schema's `instanceof ZodObject` checks and emit an
+    // empty payload schema. envelope is external for hygiene — we only
+    // import its types (PayloadDescriptor), so this just keeps the bundle
+    // smaller.
     external: ['zod', '@saga-ed/soa-event-envelope'],
 });

--- a/packages/node/contract-check/tsup.config.ts
+++ b/packages/node/contract-check/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+    entry: ['src/index.ts', 'src/cli.ts'],
+    format: ['esm'],
+    dts: true,
+    clean: true,
+    sourcemap: true,
+    // zod and @saga-ed/soa-event-envelope are peer deps. Bundling them would
+    // create a second copy at runtime; zod-to-json-schema's `instanceof` checks
+    // would then silently fail and emit an empty payload schema.
+    external: ['zod', '@saga-ed/soa-event-envelope'],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -808,6 +808,43 @@ importers:
         specifier: ^5.8.3
         version: 5.9.3
 
+  packages/node/contract-check:
+    dependencies:
+      fast-glob:
+        specifier: ^3.3.3
+        version: 3.3.3
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.1.1
+      zod-to-json-schema:
+        specifier: ^3.23.5
+        version: 3.25.2(zod@3.25.67)
+    devDependencies:
+      '@saga-ed/soa-event-envelope':
+        specifier: workspace:*
+        version: link:../event-envelope
+      '@saga-ed/soa-typescript-config':
+        specifier: workspace:*
+        version: link:../../core/typescript-config
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
+      '@types/node':
+        specifier: ^24.0.3
+        version: 24.0.12
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.2)(yaml@2.8.2)
+      typescript:
+        specifier: 5.8.2
+        version: 5.8.2
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@24.0.12)
+      zod:
+        specifier: 3.25.67
+        version: 3.25.67
+
   packages/node/db:
     dependencies:
       '@aws-sdk/client-secrets-manager':
@@ -8881,6 +8918,11 @@ packages:
   zip-stream@6.0.1:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod@3.25.67:
     resolution: {integrity: sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==}
@@ -18835,6 +18877,10 @@ snapshots:
       archiver-utils: 5.0.2
       compress-commons: 6.0.2
       readable-stream: 4.7.0
+
+  zod-to-json-schema@3.25.2(zod@3.25.67):
+    dependencies:
+      zod: 3.25.67
 
   zod@3.25.67: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -810,6 +810,9 @@ importers:
 
   packages/node/contract-check:
     dependencies:
+      '@saga-ed/soa-event-envelope':
+        specifier: workspace:*
+        version: link:../event-envelope
       fast-glob:
         specifier: ^3.3.3
         version: 3.3.3
@@ -820,9 +823,6 @@ importers:
         specifier: ^3.23.5
         version: 3.25.2(zod@3.25.67)
     devDependencies:
-      '@saga-ed/soa-event-envelope':
-        specifier: workspace:*
-        version: link:../event-envelope
       '@saga-ed/soa-typescript-config':
         specifier: workspace:*
         version: link:../../core/typescript-config
@@ -4257,6 +4257,12 @@ packages:
   '@types/shimmer@1.2.0':
     resolution: {integrity: sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==}
 
+  '@types/sinon@17.0.4':
+    resolution: {integrity: sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==}
+
+  '@types/sinonjs__fake-timers@15.0.1':
+    resolution: {integrity: sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==}
+
   '@types/ssh2-streams@0.1.13':
     resolution: {integrity: sha512-faHyY3brO9oLEA0QlcO8N2wT7R0+1sHWZvQ+y3rMLwdY1ZyS1z0W3t65j9PqT4HmQ6ALzNe7RZlNuCNE0wBSWA==}
 
@@ -4265,11 +4271,6 @@ packages:
 
   '@types/ssh2@1.15.5':
     resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
-  '@types/sinon@17.0.4':
-    resolution: {integrity: sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==}
-
-  '@types/sinonjs__fake-timers@15.0.1':
-    resolution: {integrity: sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==}
 
   '@types/superagent@8.1.9':
     resolution: {integrity: sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==}
@@ -13109,6 +13110,12 @@ snapshots:
 
   '@types/shimmer@1.2.0': {}
 
+  '@types/sinon@17.0.4':
+    dependencies:
+      '@types/sinonjs__fake-timers': 15.0.1
+
+  '@types/sinonjs__fake-timers@15.0.1': {}
+
   '@types/ssh2-streams@0.1.13':
     dependencies:
       '@types/node': 24.0.12
@@ -13121,11 +13128,6 @@ snapshots:
   '@types/ssh2@1.15.5':
     dependencies:
       '@types/node': 18.19.130
-  '@types/sinon@17.0.4':
-    dependencies:
-      '@types/sinonjs__fake-timers': 15.0.1
-
-  '@types/sinonjs__fake-timers@15.0.1': {}
 
   '@types/superagent@8.1.9':
     dependencies:
@@ -14727,8 +14729,8 @@ snapshots:
       '@typescript-eslint/parser': 8.50.0(eslint@8.57.1)(typescript@5.8.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -14771,6 +14773,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 8.57.1
+      get-tsconfig: 4.13.0
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.15
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -14786,14 +14803,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.50.0(eslint@8.57.1)(typescript@5.8.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -14808,7 +14825,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -14819,7 +14836,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## Summary

Lifts the contract-check tooling from \`soa_event_driven_example\` (the PoC) into a new publishable package \`@saga-ed/soa-contract-check\`. \`d-contract-testing.md\` documents three layers (publisher snapshot byte-diff + consumer pins coverage + Zod runtime validation); only Layer 3 was implemented (in \`@saga-ed/soa-event-consumer\`) — adopters following the docs got runtime validation only, with no CI gate on frozen-schema modifications or stranded consumer pins.

The lift is config-driven so it works against any repo layout. Adopters add a \`contract-check.config.ts\` at the repo root that exports \`{ registry, publishedDir, pinsGlob }\`; the bin walks up to find it.

\`zod\` and \`@saga-ed/soa-event-envelope\` are peer deps + tsup externals — bundling \`zod-to-json-schema\` with its own zod copy would silently produce empty payload schemas because the \`instanceof\` checks fall through. This was caught and fixed during smoke testing.

## Stacked on #83

This PR is stacked on #83 (preview-isolation helpers). It uses no APIs from the helpers, but the branch was authored on top. **After #83 merges**, switch this PR's base from \`feat/preview-isolation-helpers\` → \`main\` (GitHub's auto-base-update should handle it; otherwise rebase locally).

## Hardening (from PR review)

- **\`runExport --write\` REFUSES to overwrite an existing snapshot whose bytes have changed**, unless \`opts.allowModify\` (CLI: \`--bump\`) is set. CLI exits 1 on REFUSED. Without this gate, \`export --write\` after editing a frozen schema would silently launder the change through committed bytes and the next \`check\` would pass — defeating the gate. End-to-end smoke verified the three \`--write\` paths.
- **\`assertRegistryConsistent\` runs at the entry of \`runCheck\` / \`runExport\`** — the registry is keyed by \`<eventType>.v<version>\` strings; the snapshot path is derived from the key while pins-coverage uses the descriptor's eventType/eventVersion fields. A drifting key would split the layers' paths silently. Now throws loudly.
- **\`defineConfig\`** identity helper — adopters get TypeScript checks on their config without remembering a type annotation. Mirrors vite/vitest/tsup convention.
- Pins filename validator switched from forward-slash \`endsWith\` to \`path.basename\` — Windows CI safe.

## Files

- \`packages/node/contract-check/src/index.ts\` — programmatic API (\`runCheck\`, \`runExport\`, \`loadConfig\`, \`defineConfig\`, \`assertRegistryConsistent\`)
- \`packages/node/contract-check/src/cli.ts\` — \`soa-contract-check check|export [--write|--bump]\` bin
- \`packages/node/contract-check/src/check.ts\`, \`export.ts\` — three-layer logic + write/refuse logic
- \`packages/node/contract-check/src/lib/{config,pins,snapshot}.ts\` — config loader, pins YAML parser, byte-stable JSON-Schema renderer
- \`packages/node/contract-check/README.md\` — adopter onboarding

## Test plan

- [x] \`pnpm --filter @saga-ed/soa-contract-check test\` — 37/37 pass across 4 files:
  - \`pins.unit.test.ts\` (7) — YAML loader + shape validation + cross-repo \`repo:\` field
  - \`snapshot.unit.test.ts\` (10) — byte stability, golden output, \$id propagation, \$refStrategy=none
  - \`check.unit.test.ts\` (11) — all three layers + registry consistency throws
  - \`export.unit.test.ts\` (9) — dry-run/write paths, REFUSED branch is the load-bearing test
- [x] \`check-types\` + \`lint\` + \`build\` clean
- [x] End-to-end smoke verified all three \`export --write\` paths: new (exit 0) → modified-without-bump (REFUSED, exit 1) → modified-with-bump (exit 0)
- [ ] Wire into a real adopter repo (rostering / program-hub) and run \`pnpm contract:check\` in CI before publishing 0.1.0-dev.1 to CodeArtifact

## Deferred (review feedback, not addressed here)

- \`loadConfig\` walking past \`.git\` boundary as a stop condition
- \`pinsGlob: string | null\` redesign (keep \`null\` as explicit "skip pins layers" sentinel)
- \`ExportResult\` discriminated union refactor
- Tightening \`versions_published: number[]\` to \`[number, ...number[]]\` non-empty tuple

---

## Update: rebased + envelope dep type changed

After the initial push, CI surfaced a \`check-types\` failure: tsc couldn't find \`@saga-ed/soa-event-envelope\`. Root cause was the same workspace-wide CI bug fixed in #83 (turbo's \`check-types\` not depending on \`^build\`).

Rebased onto the updated #83. Also moved envelope from \`peerDependencies\` to plain \`dependencies\` — envelope is imported type-only here, so the peer-dep treatment was overkill. zod stays as a peer dep because zod-to-json-schema's \`instanceof ZodObject\` checks need a single shared zod instance between adopters and the tool. Tsup config keeps envelope external (we only import its types; not bundling saves a few KB).

Verified locally with \`rm -rf packages/**/dist && pnpm turbo run check-types --filter=@saga-ed/soa-contract-check... --force\` — passes from a fully clean state.