### PR TITLE
docs(codeartifact): document manual dev-version publishing profile and lifecycle

### DIFF
--- a/docs/CODEARTIFACT_SETUP.md
+++ b/docs/CODEARTIFACT_SETUP.md
@@ -84,6 +84,85 @@ GitHub Actions authenticates via the `SOADeployRole` IAM role (`/github-actions-
 - `codeartifact:PublishPackageVersion` - Publish packages
 - `codeartifact:PutPackageMetadata` - Update package metadata
 
+## Manual Publishing (Dev Versions)
+
+Most package publishes go through `publish-codeartifact.yml` on merge to main. Use the manual flow below when you need to push a pre-release version from an in-flight branch — typically because a consumer in another repo (program-hub, rostering, etc.) needs to pin the change for its own preview deploy or PR review **before** the soa change has merged.
+
+### Profile selection: prod, in-account
+
+**Use `saga-deploy-prod`** (AppDeploy in the prod account, `531314149529`).
+
+The CodeArtifact `saga` domain lives in the prod account. Publishing requires an **in-account principal** because the cross-account allow-list on the domain is intentionally read-only:
+
+```yaml
+# iac repo: cloudformation_templates/codeartifact/domain/template.yaml
+# AllowDevAccountAccess statement
+Action:
+  - codeartifact:GetAuthorizationToken
+  - codeartifact:ReadFromRepository
+  # ... 12 read-only actions, no PublishPackageVersion / PutPackageMetadata
+```
+
+The dev account's AppDeploy role does carry `SagaCap-CodeArtifactPublish` (the IAM grant exists), but the prod-side resource policy blocks the cross-account write — so a `pnpm publish` under `saga-deploy-dev` returns 403 with the (misleading) error `no resource-based policy allows the codeartifact:PublishPackageVersion action`. Same-account publish from `saga-deploy-prod` doesn't traverse that boundary.
+
+### Why one CodeArtifact, not two
+
+Considered and rejected: a dedicated dev CodeArtifact domain that would isolate dev artifacts from prod ones.
+
+The trade-off is auth-token DX. Unlike ECR — where `aws ecr get-login-password` is one command and the credential is fungible across registries — CodeArtifact's auth token is **per-registry**, set into `.npmrc` keyed by the full registry hostname. A second domain would mean every developer and every CI workflow has to know which domain to log into, pin the right registry per dependency, and not mix them in a single `pnpm install`. That's a meaningful complexity tax for marginal isolation gain. The naming convention (`*-dev.N` versions) carries the dev-vs-prod signal instead.
+
+### Dev-version naming + lifecycle
+
+| Stage | Version pattern | Example | Lifetime |
+|---|---|---|---|
+| In-flight feature branch | `MAJOR.MINOR.PATCH-dev.N` | `0.1.0-dev.2` | Bump `dev.N` per iteration. Pinned by consumer feature branches that depend on the change. |
+| Production approval | `MAJOR.MINOR.PATCH` | `0.1.0` | Cut once the feature is approved to merge — typically by `publish-codeartifact.yml` on the merge commit. This is the version production-deploying branches pin. |
+
+Dev versions are temporary by design. Once a non-dev release exists for the same minor (or the feature is abandoned), the `*-dev.*` versions become safe to delete.
+
+### Publish recipe
+
+```bash
+# 1. Bump the package's version in package.json (e.g. 0.1.0-dev.1 → 0.1.0-dev.2)
+
+# 2. Auth + publish from the prod account
+export CODEARTIFACT_AUTH_TOKEN=$(aws --profile saga-deploy-prod codeartifact get-authorization-token \
+  --domain saga --domain-owner 531314149529 --query authorizationToken --output text)
+npm config set //saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/:_authToken=$CODEARTIFACT_AUTH_TOKEN
+
+# 3. Build + publish (workspace-package example)
+pnpm --filter @saga-ed/<package> build
+pnpm --filter @saga-ed/<package> publish --no-git-checks --access restricted
+
+# 4. In the consumer repo: bump the dep in package.json and `pnpm install` to lock the new version.
+#    (`pnpm update <pkg> --recursive` alone won't move the lockfile if the specifier is pinned.)
+```
+
+### Cleanup of dev versions
+
+There's no automated reaper today; treat cleanup as a quarterly hygiene pass or on-demand when a package's version list gets noisy. Safe-to-delete criteria:
+
+- A non-dev version exists for the same `MAJOR.MINOR` (the feature shipped — earlier `*-dev.N` versions are no longer pinned by anything live).
+- The corresponding feature branch is closed without merging.
+
+```bash
+# List dev versions for a package
+aws codeartifact list-package-versions \
+  --profile saga-deploy-prod \
+  --domain saga --domain-owner 531314149529 \
+  --repository saga_js \
+  --format npm --namespace saga-ed --package <pkg> \
+  --query "versions[?contains(version, '-dev.')].version" --output table
+
+# Delete the ones that are safe to remove
+aws codeartifact delete-package-versions \
+  --profile saga-deploy-prod \
+  --domain saga --domain-owner 531314149529 \
+  --repository saga_js \
+  --format npm --namespace saga-ed --package <pkg> \
+  --versions 0.1.0-dev.1 0.1.0-dev.2  # etc.
+```
+
 ## Consuming Packages in Other Projects
 
 ### 1. Configure .npmrc


### PR DESCRIPTION
## Summary

Adds \`docs/CODEARTIFACT_SETUP.md\` capturing the publish-profile situation discovered while shipping \`@saga-ed/iam-events@0.1.0-dev.2\` from rostering's \`feat/iam-events-read-path\` branch.

Documents:

- Which AWS profile is needed for \`pnpm publish\` to CodeArtifact (manual dev-version flow)
- Why we use \`*-dev.N\` version naming as the dev-vs-prod signal rather than running a separate dev CodeArtifact domain (per-registry auth-token model would double .npmrc/CI complexity for marginal isolation gain)
- Cleanup CLI snippets for the quarterly hygiene pass on temporary \`*-dev.N\` versions

## Test plan

- [x] Markdown only, no code changes
- [ ] Eyeball: a developer publishing their first dev version should be able to follow the doc end-to-end without asking