### PR TITLE
docs(soa_75): adopter-lesson decisions from rostering #138 + program-hub #60

### DIFF
--- a/claude/projects/soa_75/decisions/d-consumer-resilience.md
+++ b/claude/projects/soa_75/decisions/d-consumer-resilience.md
@@ -1,0 +1,139 @@
+# d-consumer-resilience — Operational patterns for event consumers
+
+**Status:** RESOLVED 2026-05-05 — Idempotent UPSERT handlers, soft-delete projections (when historical resolution matters), non-fatal broker startup in non-prod, OTel `initTracing` as the first import. Lifted from rostering #138 and program-hub #60 after both adopters independently arrived at the same set.
+
+## Context
+
+`@saga-ed/soa-event-consumer` provides the primitives — Zod-validated handlers, `consumed_events` dedup table, DLQ wiring — but says nothing about the operational shape of a *real* consumer. Both adopters discovered the same set of resilience patterns the hard way:
+
+1. Events arrive out of order (a `user.updated` before a `user.created`).
+2. Source aggregates get deleted but downstream rows still need to resolve them (a calendar event referencing a deleted program).
+3. The broker is sometimes unavailable; request-path traffic must not stop just because consumers can't connect.
+4. OTel must be initialized before *any* module that calls `trace.getTracer()` at module load — otherwise spans silently no-op.
+
+This document codifies the operational pattern set so the next adopter has a checklist instead of a rediscovery.
+
+## The pattern set
+
+### 1. Idempotent UPSERT handlers (out-of-order delivery is the default)
+
+Event ordering is **not guaranteed** even within a single source aggregate, because:
+
+- The outbox relay batches writes and a second-batch row can be acknowledged before a first-batch row that's stuck on a transient broker error.
+- Multiple OutboxRelay instances (rare but possible during deploys) can race.
+- A consumer's retry queue can deliver an old envelope after a newer one was already processed.
+
+**Convention:** every projection handler must use `INSERT … ON CONFLICT DO UPDATE` (or equivalent UPSERT) so that the projection converges to the correct state regardless of arrival order.
+
+```typescript
+// In programs-api iam-projection (program-hub #60):
+async handle(_envelope, payload, tx) {
+  await tx.query(
+    `INSERT INTO user_projection (id, status, created_at, updated_at)
+     VALUES ($1::uuid, $2, $3::timestamptz, $3::timestamptz)
+     ON CONFLICT (id) DO UPDATE SET
+       status = EXCLUDED.status,
+       updated_at = EXCLUDED.updated_at`,
+    [payload.id, payload.status, payload.updatedAt],
+  );
+}
+```
+
+If a `user.updated` arrives first, the row is inserted with `status` = updated value. When `user.created` arrives later, ON CONFLICT updates only the fields it owns — the projection has converged.
+
+**Anti-pattern:** straight `INSERT` followed by separate `UPDATE`, with a "row not found" branch. This produces a brittle handler that fails on out-of-order delivery and produces partial state.
+
+### 2. Soft-delete projection rows when historical resolution matters
+
+When a domain `*.deleted` event arrives, the handler has a choice:
+
+- **DELETE the projection row** — clean, but breaks downstream foreign-key resolution.
+- **UPDATE … SET deleted_at = now()** — preserves the row for historical lookups.
+
+The right choice depends on whether downstream queries need to resolve references to deleted aggregates. In program-hub #60, scheduling-api's calendar events hold foreign keys to programs; if the program is deleted, the calendar event still needs to render "Program X (deleted)" rather than "Program null". Soft-delete preserves that.
+
+```typescript
+// scheduling-api programs-projection (program-hub #60):
+const programDeletedHandler: EventHandler<ProgramDeletedV1Payload> = {
+  eventType: ProgramDeletedV1.eventType,
+  eventVersion: ProgramDeletedV1.eventVersion,
+  payloadSchema: ProgramDeletedV1.payloadSchema,
+  async handle(_envelope, payload, tx) {
+    await tx.query(
+      `UPDATE program_projection
+       SET deleted_at = $1::timestamptz, updated_at = NOW()
+       WHERE id = $2::uuid`,
+      [payload.deletedAt, payload.id],
+    );
+  },
+};
+```
+
+**When to use hard-DELETE:** when the projection is purely a cache (e.g., a name lookup with no FK references), and downstream queries should treat absence as "doesn't exist." Be explicit in the handler comment which case applies.
+
+### 3. Non-fatal broker startup in non-production
+
+Both adopters wrap OutboxRelay and EventConsumer startup in a try/catch that logs but does not throw — except in production:
+
+```typescript
+try {
+  await connectionManager.connect();
+  outboxRelay = container.get<OutboxRelay>('OutboxRelay');
+  await outboxRelay.start();
+} catch (err) {
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error(`OutboxRelay startup failed in production: ${err.message}`);
+  }
+  logger.warn('OutboxRelay startup failed — events will accumulate, retry on broker reconnect', err);
+}
+```
+
+**Rationale:** request-path mutations still succeed (they write to the outbox table inside the request transaction). The relay catches up when the broker comes back. Crashing the service on broker unavailability would break dev/staging environments where the broker is more flaky than the service.
+
+**In production, fail loud.** A production service that "soft fails" event publication will accumulate outbox debt invisibly until alerting catches it. The startup crash is the alert.
+
+### 4. OTel initialization MUST be the first import in `main.ts`
+
+`@saga-ed/soa-event-outbox` and `@saga-ed/soa-event-consumer` (and many other packages) call `trace.getTracer()` at module-load time. If OTel has not been initialized when those imports resolve, the tracer is a no-op and no spans are emitted from those modules — for the rest of the process lifetime.
+
+**Convention:** `initTracing(serviceName)` is the *very first statement* in `main.ts`, before any application imports.
+
+```typescript
+// CORRECT:
+import { initTracing, shutdownTracing } from '@saga-ed/soa-observability';
+const tracingHandle = initTracing('iam-api');
+
+// Now everything else can import freely:
+import { container } from './inversify.config.js';
+import { ConnectionManager } from '@saga-ed/soa-rabbitmq';
+// ...
+
+// WRONG:
+import { container } from './inversify.config.js'; // imports outbox → grabs no-op tracer
+import { initTracing } from '@saga-ed/soa-observability';
+initTracing('iam-api'); // too late — tracers were already cached
+```
+
+**Symptom of getting it wrong:** spans simply don't appear in Jaeger / X-Ray for outbox publish or consume operations. The HTTP request span shows up; the event-driven hop is invisible. Easy to mis-diagnose as "broker not propagating context."
+
+This footgun should be loud-documented in `@saga-ed/soa-observability`'s README and `d-observability.md` (see follow-ups in companion docs work).
+
+## Operational gaps not yet addressed
+
+- **DLQ alerting:** events that fail repeatedly land on the DLQ but no `events_in_dlq` alert is wired. Adopters should add a Prometheus alert on DLQ depth > 0 sustained, but this is per-service today. A canonical rule template would help.
+- **Consumer lag dashboards:** `outbox_unpublished_count` and `consumed_events_count` gauges exist but no shared Grafana dashboard yet captures lag per (publisher, consumer) pair. Defer until a third adopter — pattern is clear once we have it.
+- **Schema-version mismatch handling:** consumers fail loudly on `ConsumerVersionMismatch` (good — explicit pin). But there's no documented runbook for "publisher emitted v2, my consumer pinned v1, what now." Should be covered in `d-event-versioning.md` follow-up.
+- **Bulk-mutation events:** scheduling-api's `regenerate` and `setHolidays` operations would emit thousands of per-event envelopes. Currently they don't emit at all. Open question: bulk summary events (`schedule.regenerated.v1` carrying a count + range) vs per-event envelopes vs neither.
+
+## Related artifacts
+
+**Adopter implementations (current source of truth):**
+- `apps/node/programs-api/src/event-handlers/iam-projection.ts` — UPSERT handlers
+- `apps/node/scheduling-api/src/event-handlers/programs-projection.ts` — soft-delete pattern
+- `apps/node/{iam,programs,scheduling}-api/src/main.ts` — OTel-first-import + non-fatal startup
+
+**Related decisions:**
+- `d-preview-deploy-isolation.md` — companion operational pattern (preview-tag isolation)
+- `d-publisher-migration.md` — companion publisher-side patterns
+- `d-observability.md` — should be updated to call out the import-order requirement
+- `d-event-versioning.md` — schema mismatch handling belongs there

--- a/claude/projects/soa_75/decisions/d-contract-testing.md
+++ b/claude/projects/soa_75/decisions/d-contract-testing.md
@@ -4,7 +4,7 @@ RESOLVED 2026-04-30: Three layers, zero new infra: (1) publisher snapshot-diff i
 
 **Implementation status as of 2026-05-05:**
 - **Layer 3 (runtime Zod validation):** ✅ implemented in `@saga-ed/soa-event-consumer` and used by adopters in rostering #138 and program-hub #60.
-- **Layers 1 + 2 (snapshot + pins + CI gate):** ⚠️ documented here and demonstrated in `soa_event_driven_example` (`tools/contract-check/`), but **not yet lifted into soa**. Adopters today cannot follow the full workflow — they have runtime validation only. Lifting the PoC tooling into soa is tracked as companion work.
+- **Layers 1 + 2 (snapshot + pins + CI gate):** ✅ implemented in `@saga-ed/soa-contract-check` (a config-driven lift of the PoC tool). Adopters wire it up by adding the package, creating `contract-check.config.ts` at the repo root that exports their event registry + paths, and running `soa-contract-check check` in CI. See the package README for the full setup.
 
 ## Context
 

--- a/claude/projects/soa_75/decisions/d-contract-testing.md
+++ b/claude/projects/soa_75/decisions/d-contract-testing.md
@@ -2,6 +2,10 @@
 
 RESOLVED 2026-04-30: Three layers, zero new infra: (1) publisher snapshot-diff in CI, (2) per-consumer `consumed-events.json` declarations cross-checked in CI, (3) Zod runtime validation at consume time.
 
+**Implementation status as of 2026-05-05:**
+- **Layer 3 (runtime Zod validation):** ✅ implemented in `@saga-ed/soa-event-consumer` and used by adopters in rostering #138 and program-hub #60.
+- **Layers 1 + 2 (snapshot + pins + CI gate):** ⚠️ documented here and demonstrated in `soa_event_driven_example` (`tools/contract-check/`), but **not yet lifted into soa**. Adopters today cannot follow the full workflow — they have runtime validation only. Lifting the PoC tooling into soa is tracked as companion work.
+
 ## Context
 
 Two failure modes the POC must prevent reaching production:

--- a/claude/projects/soa_75/decisions/d-event-package-shape.md
+++ b/claude/projects/soa_75/decisions/d-event-package-shape.md
@@ -2,6 +2,17 @@
 
 RESOLVED 2026-04-30: Four packages — `@example/envelope` + per-publisher `@example/{identity,catalog,admissions}-events`. Mirrors the back-port target shape; ownership visible in `package.json` deps.
 
+**Validated in adopters as of 2026-05-05:** the per-family pattern was applied directly:
+
+| PoC package (in `soa_event_driven_example`) | Adopter package | Owner repo |
+|---|---|---|
+| `@example/envelope` | `@saga-ed/soa-event-envelope` | soa (shared) |
+| `@example/identity-events` | `@saga-ed/iam-events` | rostering |
+| `@example/catalog-events` | `@saga-ed/programs-events` | program-hub |
+| `@example/admissions-events` | `@saga-ed/scheduling-events` | program-hub |
+
+The per-publisher families landed cleanly in their owning repos with no friction. Naming convention confirmed: `@saga-ed/<domain>-events` where `<domain>` is the publisher's bounded context (not its service name). One known gap: the events-package owner is also responsible for wire-format enum mapping helpers — see `d-publisher-migration.md` § 2 for that pattern.
+
 ## Context
 
 How should event Zod schemas be organized as npm packages? The choice affects publisher-consumer release coupling, contract-check tool structure, and how lift-and-shift to soa fleet repos works.

--- a/claude/projects/soa_75/decisions/d-observability.md
+++ b/claude/projects/soa_75/decisions/d-observability.md
@@ -54,6 +54,26 @@ tooling answers the operational questions: "is the outbox falling behind",
      publish rate.
    - Anonymous Admin role enabled so the dev experience is one-click.
 
+## Import-order requirement (added 2026-05-05)
+
+**`initTracing(serviceName)` MUST be the first statement in `main.ts`, before any application imports.**
+
+`@saga-ed/soa-event-outbox` and `@saga-ed/soa-event-consumer` (and other packages) call `trace.getTracer()` at module load. If those modules are imported before OTel has initialized, they cache a no-op tracer for the rest of the process lifetime — and no spans appear for outbox publish or consume operations.
+
+```typescript
+// CORRECT — initTracing first, then everything else:
+import { initTracing, shutdownTracing } from '@saga-ed/soa-observability';
+const tracingHandle = initTracing('iam-api');
+
+import { container } from './inversify.config.js';   // safe now
+import { ConnectionManager } from '@saga-ed/soa-rabbitmq';
+// ...
+```
+
+**Symptom of getting it wrong:** HTTP request spans appear in Jaeger / X-Ray; the event-driven hop (publish → consume) is invisible. Often mis-diagnosed as "broker not propagating context."
+
+Both rostering #138 and program-hub #60 hit this footgun and converged on the import-first pattern. See `d-consumer-resilience.md` for the broader operational pattern set.
+
 ## Why manual instrumentation over auto
 
 - ESM + tsup's `skipNodeModulesBundle: true` produces a bundle where

--- a/claude/projects/soa_75/decisions/d-preview-deploy-isolation.md
+++ b/claude/projects/soa_75/decisions/d-preview-deploy-isolation.md
@@ -1,0 +1,118 @@
+# d-preview-deploy-isolation — Two-axis isolation for shared-infra preview deploys
+
+**Status:** RESOLVED 2026-05-05 — Postgres `?schema=pr_<n>` (with libpq search_path shim) + RabbitMQ `EVENT_PREVIEW_TAG=pr-<n>` exchange/queue/consumer suffix. Lifted from rostering #138 and program-hub #60 after both adopters independently invented the same pattern.
+
+## Context
+
+The POC (soa_event_driven_example) demonstrates the event-driven primitives but only against a single dev compose stack. Real deployment introduces a constraint the POC didn't face: **multiple PR-preview environments share one Postgres instance and one RabbitMQ broker**, and each PR needs its own isolated routing island so that:
+
+- A PR-preview's outbox writes don't appear in another PR's projection
+- A PR-preview's consumer doesn't drain a queue another PR is publishing to
+- Cleanup on PR close is mechanical (no orphaned exchanges, no orphaned schema rows)
+
+iam-api in rostering #138 and programs-api / scheduling-api in program-hub #60 each independently arrived at the same two-axis isolation model. This decision codifies it as the canonical pattern for the soa fleet.
+
+## Options considered
+
+| Option | What it gives | Why not |
+|---|---|---|
+| **Schema-per-PR Postgres + tag-per-PR RabbitMQ** *(recommended — what adopters chose)* | One database, one broker, full per-PR isolation, mechanical cleanup | Requires a libpq search_path shim because node-postgres ignores Prisma's `?schema=` URL param |
+| Database-per-PR | Strong isolation, no schema leakage | Per-PR DB provisioning is slow (~1 min RDS create); shared db-host model would need many small DBs; cleanup more complex |
+| Single shared schema + row-level tenant column | No DDL per PR | Defeats the purpose — Prisma migrations would conflict between PRs; outbox rows would interleave |
+| Broker-per-PR | Trivial isolation | Cost (Amazon MQ broker per PR is wildly expensive); not viable |
+| Single shared exchange + consumer filter | Simple wiring | Cross-PR contamination if any consumer mis-binds; no broker-side enforcement |
+
+## Recommendation (resolved)
+
+**Two coordinated axes, both keyed off the same `EVENT_PREVIEW_TAG` env var:**
+
+### Axis 1 — Postgres schema-per-PR
+
+Each PR-preview deploy gets its own Postgres schema named `pr_<num>`. Migrations run scoped to the schema. Both Prisma's request-path client and the outbox relay's pg pool resolve to the same schema.
+
+**The libpq shim:** node-postgres (used by `@saga-ed/soa-event-outbox`'s OutboxRelay pool) ignores Prisma's `?schema=…` URL parameter. Translation:
+
+```typescript
+const dbUrl = new URL(databaseUrl);
+const schema = dbUrl.searchParams.get('schema');
+const pool = new Pool({
+  connectionString: databaseUrl,
+  max: 2,
+  ...(schema ? { options: `-c search_path=${schema}` } : {}),
+});
+```
+
+Without the shim, unqualified table names like `FROM outbox_event` fall through to the default search_path, miss per-PR schema tables, and the relay silently no-ops or hits the wrong schema.
+
+This helper should live in `@saga-ed/soa-event-outbox` so the next adopter doesn't reinvent it (see implementation lift in companion work).
+
+**Pool sizing:** the outbox relay pool is dedicated and small (`max=2`). It must not contend with request-path Prisma traffic, especially under preview-environment multi-tenancy where many PRs share a single Postgres instance.
+
+### Axis 2 — RabbitMQ tag-per-PR
+
+When `EVENT_PREVIEW_TAG` is set (e.g., `pr-142`), every exchange, queue, and consumer name gets the tag suffixed:
+
+```typescript
+const previewTag = (process.env.EVENT_PREVIEW_TAG ?? '').trim();
+const tagged = (name: string): string =>
+  previewTag ? `${name}.${previewTag}` : name;
+
+// Publisher side:
+new OutboxRelay({ exchange: tagged(IAM_EXCHANGE), ... });
+// → 'iam.events' in prod, 'iam.events.pr-142' in preview
+
+// Consumer side:
+new EventConsumer({
+  exchange: tagged(IAM_EXCHANGE),
+  queue: tagged(IAM_USER_PROJECTION_QUEUE),
+  consumerTag: tagged('programs-iam-projection'),
+  ...
+});
+```
+
+Both the publisher and consumer side must apply the tag. A consumer in PR-142 that binds to the un-tagged `iam.events` exchange would receive prod traffic.
+
+This helper should live in a place importable by both `@saga-ed/soa-event-outbox` and `@saga-ed/soa-event-consumer` — likely a small new utility export, or duplicated trivially in both packages.
+
+### Cleanup contract on PR close
+
+The combination requires a two-step teardown when a PR closes or merges:
+
+1. **Drop schema:** `DROP SCHEMA IF EXISTS pr_<num> CASCADE` against the shared Postgres.
+2. **Delete tagged broker objects:** for each `<name>.pr-<num>` exchange/queue, delete via the Amazon MQ management API.
+
+Without step 2, orphaned exchanges and queues accumulate on the broker, which is cheap until it isn't (Amazon MQ has resource limits). This cleanup is the responsibility of the iac repo's preview-deploy automation; it does not exist yet (see Outstanding work below).
+
+## Why both axes (not just one)
+
+- **DB-only isolation** wouldn't prevent cross-PR routing on the broker. Two PRs publishing to `iam.events` race for the same consumers.
+- **Broker-only isolation** wouldn't prevent migration conflicts. Prisma migrations would either run unconditionally (clobbering) or skip (drifting from the per-PR schema layout).
+- **Together** they make a PR-preview a fully self-contained eventing stack on shared infrastructure.
+
+## Local-vs-prod divergences
+
+- Production uses `EVENT_PREVIEW_TAG=""` (empty); the `tagged()` helper is a no-op and exchanges/queues use their canonical names.
+- Production uses the default Postgres database / public schema (no `?schema=` param). The libpq shim is also a no-op.
+- Local dev (single developer compose stack) typically uses no preview tag; behaves like prod.
+- CI integration tests can opt into a tag (e.g., `EVENT_PREVIEW_TAG=ci-${RUN_ID}`) for fully isolated runs.
+
+## Outstanding work
+
+- **iac side not yet built:** preview-deploy plumbing (per-PR ALB listener band, ephemeral target group, schema provisioning lambda, broker cleanup hook) is not in iac. Currently only the application-side plumbing exists.
+- **Cleanup automation:** application code can read `EVENT_PREVIEW_TAG` but has no responsibility for cleanup. A scheduled lambda or PR-close hook in iac will need to enumerate `*.pr-<closed-num>` exchanges and `pr_<closed-num>` schemas and tear them down.
+- **Broker-resource caps:** as PR-preview adoption grows, Amazon MQ exchange/queue counts per broker will need monitoring. Set an alert on broker resource counts; consider a max-PRs-in-preview policy.
+
+## Related artifacts
+
+**Adopter implementations (current source of truth):**
+- `apps/node/iam-api/src/inversify.config.ts` (rostering #138) — outbox pool with libpq shim, tagged exchange
+- `apps/node/programs-api/src/inversify.config.ts` (program-hub #60) — outbox pool, tagged publisher + consumer
+- `apps/node/scheduling-api/src/inversify.config.ts` (program-hub #60) — same pattern, both publisher and multi-exchange consumer
+
+**To be lifted into soa:**
+- `@saga-ed/soa-event-outbox` — `createOutboxPool(databaseUrl)` helper exporting the libpq shim
+- `@saga-ed/soa-event-outbox` and `@saga-ed/soa-event-consumer` — shared `applyPreviewTag(name)` helper
+
+**Related decisions:**
+- `d-broker-choice.md` — RabbitMQ rationale
+- `d-consumer-resilience.md` — non-fatal broker startup, idempotent handlers (companion patterns also surfaced by adopters)

--- a/claude/projects/soa_75/decisions/d-preview-deploy-isolation.md
+++ b/claude/projects/soa_75/decisions/d-preview-deploy-isolation.md
@@ -89,6 +89,22 @@ Without step 2, orphaned exchanges and queues accumulate on the broker, which is
 - **Broker-only isolation** wouldn't prevent migration conflicts. Prisma migrations would either run unconditionally (clobbering) or skip (drifting from the per-PR schema layout).
 - **Together** they make a PR-preview a fully self-contained eventing stack on shared infrastructure.
 
+`createOutboxPool` enforces this pairing as a startup invariant: it asserts that `?schema=` in `DATABASE_URL` and `EVENT_PREVIEW_TAG` are either both set or both absent, throwing with a directional error message otherwise. A half-applied state silently leaks events across PRs (broker-leak when schema-without-tag, DB-leak when tag-without-schema), and the failure mode wouldn't surface until production traffic hit it. Closing it at boot keeps misconfiguration from making it past first deploy.
+
+## Supported `DATABASE_URL` shape (createOutboxPool)
+
+The helper accepts only URL-form connection strings (`postgresql://…`). The libpq KV form (`host=… dbname=…`) is rejected with a helpful error.
+
+The optional `?schema=<name>` query parameter must match `[A-Za-z_][A-Za-z0-9_]*` — Postgres unquoted-identifier rules. Hyphenated preview identifiers like `pr-42` belong to AWS resource names; adopter pipelines convert to `pr_42` (underscore) via bash `${IDENTIFIER//-/_}` before constructing the URL. The helper's regex prevents libpq-option injection through that interpolation point.
+
+Other URL params (`?options=`, `?sslmode=`, etc.) ride along verbatim via `connectionString` and are NOT interpreted by the helper. The full adopter URL form, used by both rostering #138 and program-hub #60, looks like:
+
+```
+postgresql://u:p@host:5432/db?schema=pr_42&options=-c%20search_path%3Dpr_42
+```
+
+The helper parses `?schema=`, sets a top-level `options: '-c search_path=pr_42'` on the pg.Pool config (which overrides the URL's `?options=`), and otherwise lets the URL ride through. Adopters needing additional libpq options (e.g. `statement_timeout`) should use `opts.poolOverrides.options` to set the full string explicitly — that overrides the helper's default and is documented as the escape hatch.
+
 ## Local-vs-prod divergences
 
 - Production uses `EVENT_PREVIEW_TAG=""` (empty); the `tagged()` helper is a no-op and exchanges/queues use their canonical names.

--- a/claude/projects/soa_75/decisions/d-publisher-migration.md
+++ b/claude/projects/soa_75/decisions/d-publisher-migration.md
@@ -1,0 +1,146 @@
+# d-publisher-migration — Migration patterns for outbox publishers
+
+**Status:** RESOLVED 2026-05-05 — Interactive `$transaction` for outbox writes, wire-format enum mapping with runtime validation, dual-write coexistence path (when migrating off a legacy outbox), bulk-mutation strategy still open. Lifted from rostering #138 and program-hub #60.
+
+## Context
+
+Adding outbox publishing to an existing service is more invasive than the POC suggests. The POC's services are greenfield: every mutation already runs inside `prisma.$transaction(async (tx) => { … })` and the outbox write slots in cleanly. Real services have:
+
+- `prisma.$transaction([…])` array form (no `tx` parameter exposed)
+- Domain enums that don't match the wire format you want to publish
+- Existing legacy outbox tables / event-emitter services that must coexist during cutover
+- Bulk operations that would emit thousands of events if naively wired
+
+This doc captures the migration patterns adopters used. Treat it as a checklist for the next service onboarding to outbox publishing.
+
+## The migration patterns
+
+### 1. Array-form `$transaction` → interactive form
+
+`writeOutbox(tx, envelope)` requires the `tx` parameter from Prisma's interactive transaction. The array form doesn't expose one. Refactor every mutation that needs to publish:
+
+```typescript
+// BEFORE (array form — works with Prisma but no tx access):
+await this.prisma.$transaction([
+  this.prisma.calendarEvent.update({ where: { id }, data: { cancelled: true } }),
+  this.prisma.recurrenceRule.update({ where: { id: ruleId }, data: { exdates: { push: date } } }),
+]);
+
+// AFTER (interactive form — tx available for writeOutbox):
+await this.prisma.$transaction(async (tx) => {
+  await tx.calendarEvent.update({ where: { id }, data: { cancelled: true } });
+  await tx.recurrenceRule.update({ where: { id: ruleId }, data: { exdates: { push: date } } });
+  await writeOutbox(tx, buildEnvelope({
+    eventType: CalendarEventCancelledV1.eventType,
+    eventVersion: CalendarEventCancelledV1.eventVersion,
+    aggregateType: 'calendar_event',
+    aggregateId: id,
+    payload: CalendarEventCancelledV1.payloadSchema.parse({ id, ... }),
+  }));
+});
+```
+
+**Performance equivalence:** both forms serialize against the same row locks. The interactive form is slightly more chatty over the wire (multiple round-trips vs one batched statement) but the difference is negligible for service-layer mutations.
+
+**Source:** scheduling-api `cancelEvent` (program-hub #60).
+
+### 2. Wire-format enum mapping with runtime validation
+
+Domain enums in the database often differ from the wire format you want consumers to receive. iam-api's UserStatus is `ACTIVE | INACTIVE | DELETED` (uppercase, Prisma convention); the wire schema in `@saga-ed/iam-events` declares `'active' | 'inactive' | 'deleted'` (lowercase, JSON convention).
+
+**Convention:** a small mapping helper at the publisher edge, with a runtime fallback that throws on unknown values:
+
+```typescript
+// In rostering iam-api user.data.ts:
+function userStatusOnWire(status: string): UserStatusOnWire {
+  const lower = status.toLowerCase();
+  if (lower === 'active' || lower === 'inactive' || lower === 'deleted') {
+    return lower as UserStatusOnWire;
+  }
+  throw new Error(`Unknown user status: ${status}`);
+}
+```
+
+**Rationale:** the throw is a future-proofing tripwire. If a developer later adds `SUSPENDED` to the DB enum without updating the wire mapping or the wire schema, the *publish* fails — loudly, before a malformed event reaches the bus. The alternative (a silent string passthrough) would publish `"SUSPENDED"` to consumers who can't decode it.
+
+**Where to put it:** alongside the publisher's data layer (e.g., `*.data.ts`), not in the events package. The events package is the wire contract; the mapping is publisher-internal.
+
+### 3. Dual-write coexistence with a legacy outbox
+
+When migrating off a pre-existing outbox / event-emitter system, write to *both* tables in the same transaction until consumers have moved over:
+
+```typescript
+// In rostering iam-api (during migration window):
+await prisma.$transaction(async (tx) => {
+  // Domain mutation:
+  const created = await tx.user.create({ data: {...} });
+
+  // Legacy outbox (old in-process consumers):
+  await tx.eventOutbox.create({ data: {
+    eventName: 'user.created',
+    payload: legacyShape(created),
+  }});
+
+  // New outbox (cross-service RabbitMQ):
+  await writeOutbox(tx as unknown as SqlTagExecutor, buildEnvelope({
+    eventType: IamUserCreatedV1.eventType,
+    eventVersion: IamUserCreatedV1.eventVersion,
+    aggregateType: 'user',
+    aggregateId: created.id,
+    payload: IamUserCreatedV1.payloadSchema.parse({ id: created.id, status: created.status, createdAt: created.createdAt }),
+  }));
+});
+```
+
+**Both writes ride the same `prisma.$transaction`** so atomicity holds: either both event records are written or neither. The migration plan is then:
+
+1. Phase 1 (current — rostering #138): dual-write, no consumers cut over
+2. Phase 2: cut over consumers one-at-a-time to the new bus
+3. Phase 3: stop writing to the legacy outbox, retire it
+
+**Don't dual-write forever.** Set a target retirement date when starting Phase 1; otherwise the dual-write becomes infrastructure debt indistinguishable from a feature.
+
+### 4. Bulk-mutation strategy (OPEN)
+
+scheduling-api's `setHolidays` and `regenerate` operations modify thousands of calendar events per call. Naively emitting per-event envelopes would:
+
+- Overwhelm consumers with bursts (10k+ messages in seconds)
+- Produce huge outbox tables and slow the relay
+- Make consumer projections rebuild slowly
+
+Currently, **these bulk operations don't emit anything**. This is a deliberate deferral. Three options, all unresolved:
+
+| Option | Pro | Con |
+|---|---|---|
+| **Per-event envelopes anyway** | Consumers get full fidelity | Burst overload, large outbox |
+| **Bulk summary event** (e.g., `schedule.regenerated.v1` with `{rangeStart, rangeEnd, count}`) | Single envelope, consumers re-fetch range | Loses per-event detail; consumers need a re-fetch path |
+| **Don't emit; consumers poll** | Simplest | Stale projections; defeats the point of event-driven |
+
+**Recommendation:** when the third adopter encounters a bulk operation, design around bulk summary events with an explicit re-fetch contract (the consumer hits the publisher's read API to load affected rows). Document the pattern as `d-bulk-mutation-events.md` at that point.
+
+## Other migration considerations
+
+### OTel initialization order
+
+Already covered in `d-consumer-resilience.md`, but applies equally to publisher services: `initTracing(serviceName)` must be the first import in `main.ts`. Outbox-relay spans depend on it.
+
+### Outbox pool sizing
+
+Use a dedicated `max=2` pool for the OutboxRelay, separate from request-path Prisma. See `d-preview-deploy-isolation.md` for the helper that bundles this with the libpq schema shim.
+
+### Per-publisher event packages
+
+Each publishing service owns a per-family events package: `@saga-ed/iam-events`, `@saga-ed/programs-events`, `@saga-ed/scheduling-events`. The package declares the wire schemas (Zod), the event type constants, and the version pin. See `d-event-package-shape.md`.
+
+## Related artifacts
+
+**Adopter implementations:**
+- `apps/node/iam-api/src/sectors/user/user.data.ts` (rostering #138) — dual-write + enum mapping
+- `apps/node/scheduling-api/src/services/calendar-events.service.ts` (program-hub #60) — interactive `$transaction` refactor
+- `apps/node/programs-api/src/services/*` (program-hub #60) — greenfield publisher (no migration needed)
+
+**Related decisions:**
+- `d-preview-deploy-isolation.md` — outbox pool helper
+- `d-consumer-resilience.md` — companion consumer-side patterns
+- `d-event-package-shape.md` — events-package conventions
+- `d-event-versioning.md` — schema versioning rules that the wire mapping must respect


### PR DESCRIPTION
## Summary

Adds three new decision docs and updates three existing ones in \`claude/projects/soa_75/decisions/\` to capture the operational patterns that emerged from the first real adoptions of the event-driven packages — rostering #138 (iam-api) and program-hub #60 (programs-api, scheduling-api). The 12 existing decisions in \`soa_75\` were all written 2026-04-30 before adopter integration; this PR closes the doc-vs-reality drift.

## New decisions

- **\`d-preview-deploy-isolation.md\`** — the two-axis isolation model (Postgres schema-per-PR + RabbitMQ \`EVENT_PREVIEW_TAG\` exchange/queue suffix) that both adopters independently invented. Documents the libpq \`search_path\` shim, the cleanup contract on PR close, and the supported \`createOutboxPool\` URL shape with the bidirectional coherence assert.
- **\`d-consumer-resilience.md\`** — operational patterns: idempotent \`ON CONFLICT\` upserts (out-of-order delivery is the default), soft-delete projections when historical resolution matters, non-fatal broker startup in non-prod, and the OTel-first-import requirement that both adopters hit as a footgun.
- **\`d-publisher-migration.md\`** — migration patterns: array-form to interactive \`\$transaction\` refactor (required for \`writeOutbox(tx, ...)\`), wire-format enum mapping with runtime validation, dual-write coexistence with a legacy outbox, and the still-open bulk-mutation strategy gap.

## Updates to existing decisions

- **\`d-contract-testing.md\`** — Layers 1+2 (snapshot + CI gate) are now ✅ implemented as \`@saga-ed/soa-contract-check\` (#84). Updated status section accordingly.
- **\`d-observability.md\`** — added an \"Import-order requirement\" subsection. Both adopters hit the silent-no-op-spans footgun where outbox/consumer modules cache the no-op tracer at import time if \`initTracing\` isn't the very first statement in \`main.ts\`.
- **\`d-event-package-shape.md\`** — added an adopter package mapping table (PoC names \`@example/identity-events\` etc. → real \`@saga-ed/iam-events\`, \`@saga-ed/programs-events\`, \`@saga-ed/scheduling-events\`).

## Provenance

These docs are the deliverable from a cross-repo propagation review that compared:
- soa branch \`saga-ed/event-driven-infra\` (now merged via #78)
- the PoC reference \`soa_event_driven_example\`
- the two adopter PRs (rostering #138, program-hub #60)
- the existing 12 decision docs

The companion code lives in #83 (helpers) and #84 (contract-check).

## Test plan

- [x] Markdown only — no code changes
- [ ] Cross-link sanity: each new doc references companion docs by relative filename, all paths exist on this branch