### PR TITLE
chore(soa-event-*): bump dev versions for helpers + dispatchEnvelope

### DIFF
--- a/packages/node/event-consumer/package.json
+++ b/packages/node/event-consumer/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/soa-event-consumer",
-    "version": "0.1.0-dev.2",
+    "version": "0.1.0-dev.3",
     "private": false,
     "type": "module",
     "main": "dist/index.js",

--- a/packages/node/event-envelope/package.json
+++ b/packages/node/event-envelope/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/soa-event-envelope",
-    "version": "0.1.0-dev.2",
+    "version": "0.1.0-dev.3",
     "private": false,
     "type": "module",
     "main": "dist/index.js",

--- a/packages/node/event-outbox/package.json
+++ b/packages/node/event-outbox/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/soa-event-outbox",
-    "version": "0.1.0-dev.2",
+    "version": "0.1.0-dev.4",
     "private": false,
     "type": "module",
     "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Bumps dev versions of three published packages so the helpers shipped in #83 + the dispatchEnvelope addition in #80 reach adopters via CodeArtifact:

- `@saga-ed/soa-event-envelope`: `0.1.0-dev.2` → `0.1.0-dev.3` (adds `applyPreviewTag`)
- `@saga-ed/soa-event-outbox`: `0.1.0-dev.2` → `0.1.0-dev.4` (adds `createOutboxPool` + re-export of `applyPreviewTag` + coherence assert; skips `dev.3` which was an earlier auto-publish with a stale envelope pin and is effectively broken)
- `@saga-ed/soa-event-consumer`: `0.1.0-dev.2` → `0.1.0-dev.3` (re-export of `applyPreviewTag` + `dispatchEnvelope` already in dev.2)

## Why dev.3 / dev.4 (not dev.2)?

Audit revealed the `0.1.0-dev.2` versions were published from an earlier branch state that predated #83. They're already on CodeArtifact but missing my helpers. `dev.3` of outbox specifically was auto-published with my final code BUT pinned envelope to `0.1.0-dev.1` (which doesn't export `applyPreviewTag`) — that's broken at runtime. Skipping to `dev.4` for outbox; `dev.3` for the others.

## Already published (this PR is the package.json record)

```
@saga-ed/soa-event-envelope@0.1.0-dev.3 ✓ (published from saga-deploy-prod)
@saga-ed/soa-event-outbox@0.1.0-dev.4   ✓
@saga-ed/soa-event-consumer@0.1.0-dev.3 ✓
@saga-ed/soa-contract-check@0.1.0-dev.1 ✓ (first publish; package.json already at this version)
```

## Test plan

- [x] `pnpm turbo run build --filter=@saga-ed/soa-event-{envelope,outbox,consumer}... --filter=@saga-ed/soa-contract-check...` passes
- [x] `aws codeartifact list-package-versions` confirms all four new versions published
- [x] Manual verify of envelope dev.3 + outbox dev.4 dist via `npm pack` → `applyPreviewTag` and `createOutboxPool` exported
- [ ] Adopter follow-ups in rostering #138 and program-hub #60 to pin to these new versions and replace hand-rolled shims

## Provenance

Published manually from `saga-deploy-prod` profile per `docs/CODEARTIFACT_SETUP.md` (the canonical manual dev-version flow). Cross-account publish from `saga-deploy-dev` is blocked by the domain's resource-policy allowlist (read-only), so the prod-account profile is required.