### PR TITLE
feat: lift id()/UPSERT/failureMode helpers + harness docs + OTel lint rule

### DIFF
--- a/packages/core/eslint-config/base.js
+++ b/packages/core/eslint-config/base.js
@@ -3,6 +3,13 @@ import eslintConfigPrettier from "eslint-config-prettier";
 import turboPlugin from "eslint-plugin-turbo";
 import tseslint from "typescript-eslint";
 import onlyWarn from "eslint-plugin-only-warn";
+import { initTracingFirstRule } from "./rules/init-tracing-first.js";
+
+const sagaSoaPlugin = {
+  rules: {
+    "init-tracing-first": initTracingFirstRule,
+  },
+};
 
 /**
  * A shared ESLint configuration for the repository.
@@ -23,10 +30,18 @@ export const config = [
   },
   {
     plugins: {
+      "saga-soa": sagaSoaPlugin,
+    },
+    rules: {
+      "saga-soa/init-tracing-first": "error",
+    },
+  },
+  {
+    plugins: {
       onlyWarn,
     },
   },
   {
-    ignores: ["dist/**"],
+    ignores: ["dist/**", "**/__tests__/fixtures/**"],
   },
 ];

--- a/packages/core/eslint-config/package.json
+++ b/packages/core/eslint-config/package.json
@@ -24,7 +24,8 @@
     "typescript-eslint": "^8.33.0"
   },
   "scripts": {
-    "clean": ":"
+    "clean": ":",
+    "test": "node ./rules/__tests__/verify-fixture.mjs"
   },
   "publishConfig": {
     "registry": "https://saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/",

--- a/packages/core/eslint-config/rules/__tests__/fixtures/main-bad.ts
+++ b/packages/core/eslint-config/rules/__tests__/fixtures/main-bad.ts
@@ -1,0 +1,9 @@
+// Deliberately-broken fixture for the `saga-soa/init-tracing-first` rule.
+// `reflect-metadata` is imported BEFORE initTracing() — the canonical
+// footgun. ESLint MUST report a saga-soa/init-tracing-first error on
+// this file. Excluded from project-wide lint via base.js `ignores`.
+
+import 'reflect-metadata';
+import { initTracing } from '@saga-ed/soa-observability';
+
+initTracing();

--- a/packages/core/eslint-config/rules/__tests__/verify-fixture.mjs
+++ b/packages/core/eslint-config/rules/__tests__/verify-fixture.mjs
@@ -1,0 +1,42 @@
+// Verifies that `saga-soa/init-tracing-first` fires on the broken fixture.
+// Run via `pnpm --filter @saga-ed/soa-eslint-config test`. Exits non-zero
+// if the rule fails to flag the fixture.
+
+import { Linter } from "eslint";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { initTracingFirstRule } from "../init-tracing-first.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturePath = resolve(__dirname, "fixtures/main-bad.ts");
+
+const linter = new Linter();
+linter.defineRule("saga-soa/init-tracing-first", initTracingFirstRule);
+
+const code = readFileSync(fixturePath, "utf8");
+const messages = linter.verify(
+    code,
+    {
+        parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+        rules: { "saga-soa/init-tracing-first": "error" },
+    },
+    { filename: "main.ts" },
+);
+
+const flagged = messages.find(
+    (m) =>
+        m.ruleId === "saga-soa/init-tracing-first" &&
+        m.messageId === "importBeforeInit",
+);
+
+if (!flagged) {
+    console.error(
+        "FAIL: saga-soa/init-tracing-first did not fire on broken fixture.",
+    );
+    console.error(JSON.stringify(messages, null, 2));
+    process.exit(1);
+}
+
+console.log("OK: saga-soa/init-tracing-first flagged the broken fixture.");
+console.log(`  ${flagged.message}`);

--- a/packages/core/eslint-config/rules/init-tracing-first.js
+++ b/packages/core/eslint-config/rules/init-tracing-first.js
@@ -1,0 +1,93 @@
+/**
+ * `saga-soa/init-tracing-first` — entrypoint files (`main.ts`) must call
+ * `initTracing()` before any import that could load tracer-using modules.
+ *
+ * The footgun: OpenTelemetry's tracer-provider singleton is patched in
+ * place by `initTracing()`. Any module loaded *before* `initTracing()` runs
+ * captures the no-op tracer at module-load time and silently emits zero
+ * spans for its lifetime. Both `rostering` (PR #138) and `program-hub`
+ * (PRs #60/#62) hit this; this rule catches it at lint time.
+ *
+ * Allowed: `import { initTracing } from '@saga-ed/soa-observability'`
+ * before the call (you can't call what you haven't imported).
+ *
+ * Disallowed: any other import before the call. Convert them to dynamic
+ * `await import(...)` after `initTracing()`, or move the side-effecting
+ * setup into observability so it runs as part of `initTracing()`.
+ *
+ * The rule only fires on files literally named `main.ts` so adopter app
+ * code (handlers, sectors, etc.) isn't constrained.
+ *
+ * @type {import('eslint').Rule.RuleModule}
+ */
+export const initTracingFirstRule = {
+    meta: {
+        type: 'problem',
+        docs: {
+            description:
+                'Require initTracing() to be called before any non-observability import in main.ts entrypoints.',
+        },
+        schema: [],
+        messages: {
+            importBeforeInit:
+                "Import '{{source}}' precedes initTracing() call. Move it to a dynamic import after initTracing() — modules loaded before tracing init capture the no-op tracer and emit zero spans.",
+            missingInitCall:
+                "main.ts must call initTracing() before any non-observability import. No initTracing() call found.",
+        },
+    },
+    create(context) {
+        const filename = context.getFilename ? context.getFilename() : (context.filename ?? '');
+        if (!/(^|[\\/])main\.ts$/.test(filename)) {
+            return {};
+        }
+
+        const imports = [];
+        let initCallNode = null;
+
+        function isObservabilitySource(source) {
+            return (
+                source === '@saga-ed/soa-observability' ||
+                source.startsWith('@saga-ed/soa-observability/')
+            );
+        }
+
+        return {
+            ImportDeclaration(node) {
+                if (initCallNode !== null) return;
+                imports.push(node);
+            },
+            CallExpression(node) {
+                if (initCallNode !== null) return;
+                const callee = node.callee;
+                const isInitTracing =
+                    (callee.type === 'Identifier' && callee.name === 'initTracing') ||
+                    (callee.type === 'MemberExpression' &&
+                        callee.property.type === 'Identifier' &&
+                        callee.property.name === 'initTracing');
+                if (isInitTracing) {
+                    initCallNode = node;
+                }
+            },
+            'Program:exit'() {
+                if (initCallNode === null) {
+                    if (imports.length > 0) {
+                        context.report({
+                            node: imports[0],
+                            messageId: 'missingInitCall',
+                        });
+                    }
+                    return;
+                }
+                for (const importNode of imports) {
+                    if (!isObservabilitySource(importNode.source.value)) {
+                        context.report({
+                            node: importNode,
+                            messageId: 'importBeforeInit',
+                            data: { source: importNode.source.value },
+                        });
+                    }
+                }
+            },
+        };
+    },
+};

--- a/packages/node/event-consumer/README.md
+++ b/packages/node/event-consumer/README.md
@@ -1,0 +1,127 @@
+# @saga-ed/soa-event-consumer
+
+Idempotent RabbitMQ consumer with a `consumed_events` dedup table, Zod-
+validated handlers, OTel trace propagation, and DLQ wiring. Pairs with
+`@saga-ed/soa-event-outbox` on the publisher side and
+`@saga-ed/soa-event-envelope` for the on-wire schema.
+
+```typescript
+import { EventConsumer, type EventHandler } from '@saga-ed/soa-event-consumer';
+```
+
+## Queue topology — one consumer per event family
+
+**Rule:** if a service consumes more than one event family (e.g. `iam.*`
+and `programs.*`), bind one `EventConsumer` per family to a separate
+queue. Don't multiplex families on a single queue.
+
+A poison message in family A — a payload that fails validation, a handler
+that throws on every retry, a malformed envelope — backs up against the
+queue's prefetch. Anything else on that queue waits behind it. If `iam.*`
+and `programs.*` share a queue, an `iam.*` poison stalls `programs.*`
+projections too.
+
+Splitting per family bounds the blast radius: a poison in `iam.*` blocks
+only `iam.*` consumption; the `programs.*` projection keeps converging.
+Each `EventConsumer` holds its own `consumed_events` row range and
+prefetch budget, so the per-queue retry storm doesn't bleed into the
+other family.
+
+```typescript
+const iamConsumer = new EventConsumer({
+    queueName: 'programs-api.iam-projection',
+    handlers: iamProjectionHandlers,
+    /* … */
+});
+const programsConsumer = new EventConsumer({
+    queueName: 'programs-api.programs-projection',
+    handlers: programsProjectionHandlers,
+    /* … */
+});
+```
+
+Canonical example: `program-hub` PR #62, which split
+`GroupProjectionConsumer` from `IamProjectionConsumer` after a poison
+message in one family stalled the other.
+
+The decision-doc rule lives in
+[`d-consumer-resilience.md`](../../../claude/projects/soa_75/decisions/d-consumer-resilience.md)
+pattern 5.
+
+## Idempotent UPSERT handlers — projection pattern
+
+**Rule:** every projection handler must use `INSERT … ON CONFLICT DO UPDATE`
+(or equivalent UPSERT). Never blind `INSERT` followed by `UPDATE`.
+
+Event ordering is **not guaranteed**, even within a single source aggregate:
+
+- The outbox relay batches writes; second-batch rows can ack before a
+  first-batch row stuck on a transient broker error.
+- Multiple `OutboxRelay` instances during a deploy can race.
+- A consumer's retry queue can deliver an old envelope after a newer one
+  was already processed.
+
+UPSERT lets the projection converge regardless of arrival order. The
+`consumed_events` dedup table guarantees each event applies at most
+once; UPSERT guarantees the *resulting state* is correct even when events
+arrive out of order.
+
+### Worked example
+
+```typescript
+const iamUserUpdatedHandler: EventHandler<IamUserUpdatedV1Payload> = {
+    eventType: IamUserUpdatedV1.eventType,
+    eventVersion: IamUserUpdatedV1.eventVersion,
+    payloadSchema: IamUserUpdatedV1.payloadSchema,
+    async handle(_envelope, payload, tx) {
+        // UPSERT: if `user.updated` arrives before `user.created` (rare
+        // but possible under broker retries), insert a skeleton row with
+        // the most recent `updated_at`. The later `user.created` event's
+        // ON CONFLICT will fix `created_at` without clobbering `updated_at`.
+        await tx.query(
+            `INSERT INTO user_projection (id, status, created_at, updated_at)
+             VALUES ($1::uuid, $2, $3::timestamptz, $3::timestamptz)
+             ON CONFLICT (id) DO UPDATE SET
+                 status = EXCLUDED.status,
+                 updated_at = EXCLUDED.updated_at`,
+            [payload.id, payload.status, payload.updatedAt],
+        );
+    },
+};
+```
+
+### Anti-pattern
+
+```typescript
+// DON'T: brittle on out-of-order delivery and produces partial state.
+async handle(_envelope, payload, tx) {
+    const existing = await tx.query('SELECT 1 FROM user_projection WHERE id = $1', [payload.id]);
+    if (existing.rowCount === 0) {
+        await tx.query('INSERT INTO user_projection (...) VALUES (...)', [...]);
+    } else {
+        await tx.query('UPDATE user_projection SET ... WHERE id = $1', [...]);
+    }
+}
+```
+
+### A note on column choice in `ON CONFLICT DO UPDATE`
+
+Per-handler, set only the columns that handler *owns*. A `*.updated`
+handler should not overwrite `created_at`; a `*.created` handler should
+not overwrite a more recent `updated_at`. The convergent steady state is
+each event leaving its imprint and nothing more.
+
+For soft-delete vs hard-delete projection rows on `*.deleted` events,
+see
+[`d-consumer-resilience.md`](../../../claude/projects/soa_75/decisions/d-consumer-resilience.md)
+pattern 2 (decision matrix + worked examples).
+
+## See also
+
+- `@saga-ed/soa-event-outbox` — transactional outbox + relay.
+- `@saga-ed/soa-event-envelope` — Zod envelope schema (`type`, `version`,
+  `traceparent`, `payload`).
+- `@saga-ed/soa-event-test-harness` — Postgres + RabbitMQ container helpers
+  + `id()` UUID-shaped seed for fixture IDs.
+- `@saga-ed/soa-rabbitmq` — `ConnectionManager` with `failureMode` for
+  broker-startup behavior.

--- a/packages/node/event-consumer/package.json
+++ b/packages/node/event-consumer/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/soa-event-consumer",
-    "version": "0.1.0-dev.3",
+    "version": "0.1.0-dev.4",
     "private": false,
     "type": "module",
     "main": "dist/index.js",

--- a/packages/node/event-outbox/package.json
+++ b/packages/node/event-outbox/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/soa-event-outbox",
-    "version": "0.1.0-dev.4",
+    "version": "0.1.0-dev.5",
     "private": false,
     "type": "module",
     "main": "dist/index.js",

--- a/packages/node/event-outbox/src/__tests__/create-pool.unit.test.ts
+++ b/packages/node/event-outbox/src/__tests__/create-pool.unit.test.ts
@@ -42,9 +42,9 @@ describe('createOutboxPool — production-shape URLs (no schema, no tag)', () =>
         expect(getOpts(pool).connectionString).toBe(url);
     });
 
-    it('defaults max to 2', () => {
+    it('defaults max to 4', () => {
         const pool = createOutboxPool('postgresql://u:p@h:5432/db');
-        expect(getOpts(pool).max).toBe(2);
+        expect(getOpts(pool).max).toBe(4);
     });
 
     it('respects an explicit max', () => {

--- a/packages/node/event-outbox/src/create-pool.ts
+++ b/packages/node/event-outbox/src/create-pool.ts
@@ -2,10 +2,15 @@ import { Pool, type PoolConfig } from 'pg';
 
 export interface CreateOutboxPoolOpts {
     /**
-     * Max connections in the dedicated relay pool. Defaults to 2 — the relay
-     * needs only one for the polling tick + one spare for liveness checks. Keep
-     * it small so it cannot starve request-path Prisma traffic, especially in
-     * preview environments where many PRs share a single Postgres instance.
+     * Max connections in the dedicated relay pool. Defaults to 4 — enough
+     * headroom for the polling tick, a concurrent retry of a failed batch,
+     * and a liveness probe without queuing. Keep it small so it cannot
+     * starve request-path Prisma traffic, especially in preview environments
+     * where many PRs share a single Postgres instance; outbox traffic is
+     * bursty and short-lived, so 4 saturates rare bursts without holding
+     * connections idle. program-hub's programs-api uses this value in
+     * production; rostering's iam-api leaves it at the default. Bump only
+     * if relay-tick latency shows actual queue depth on the pool.
      */
     max?: number;
     /**
@@ -37,7 +42,7 @@ const SCHEMA_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
  *
  * The helper is intentionally production-safe: when neither `?schema=` nor
  * `EVENT_PREVIEW_TAG` are set, it's equivalent to
- * `new Pool({ connectionString, max: 2 })`. The startup coherence assert
+ * `new Pool({ connectionString, max: 4 })`. The startup coherence assert
  * (below) ensures preview state can't leak in by accident — that's what
  * makes a single helper safe across both environments.
  *
@@ -115,7 +120,7 @@ export function createOutboxPool(
 
     return new Pool({
         connectionString: databaseUrl,
-        max: opts.max ?? 2,
+        max: opts.max ?? 4,
         ...(schema ? { options: `-c search_path=${schema}` } : {}),
         ...opts.poolOverrides,
     });

--- a/packages/node/event-test-harness/README.md
+++ b/packages/node/event-test-harness/README.md
@@ -1,0 +1,192 @@
+# @saga-ed/soa-event-test-harness
+
+Testcontainers helpers for integration-testing the event-driven stack:
+spin up real Postgres + RabbitMQ in parallel, apply migrations, and assert
+end-to-end roundtrips through `@saga-ed/soa-event-outbox` →
+`@saga-ed/soa-rabbitmq` → bound queues. Plus a deterministic UUID-shaped
+ID helper for fixture data that satisfies `z.string().uuid()` payload
+schemas.
+
+```typescript
+import { startInfra, id, type InfraHandle } from '@saga-ed/soa-event-test-harness';
+```
+
+## API
+
+### `startInfra(opts?): Promise<InfraHandle>`
+
+Starts a Postgres container and a RabbitMQ container in parallel. Uses
+`Promise.allSettled` internally so a partial-start failure stops the
+other container — testcontainers leaks Docker resources otherwise.
+
+Default images: `postgres:17-alpine` and `rabbitmq:3.13-management-alpine`.
+Override per call via `opts.postgresImage` / `opts.rabbitmqImage`.
+
+### `InfraHandle`
+
+| member             | purpose                                                                                                              |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| `postgresAdminUrl` | URL pointing at the default `test` admin database. Use only for `createDatabase`.                                    |
+| `rabbitmqUrl`      | AMQP URL with credentials. Pass to `new ConnectionManager({ url })`.                                                 |
+| `createDatabase(name, opts?)` | Provision a fresh database in the running Postgres container; returns the URL. `dropIfExists` for idempotency. |
+| `runSql(url, sql)` | Apply arbitrary SQL — use to install the outbox / consumer migrations + your service's projection tables.            |
+| `stop()`           | Stop both containers. Call in `afterAll`.                                                                            |
+
+### `id(seed: string): string`
+
+Deterministic UUID-v4-shaped string from a memorable seed. Lifted from
+the canonical adopter helper in `rostering` (PR #138).
+
+```typescript
+id('mem-child');           // e.g. '8f3e9b21-…' — stable across runs
+id('mem-child') === id('mem-child');  // true (deterministic)
+id('mem-child') !== id('parent');     // true (distinct seeds)
+```
+
+Use this anywhere a test fixture needs a string that satisfies
+`z.string().uuid()`. The seed makes cross-fixture references readable
+(e.g. `id('mem-child')` referenced both in `User` and `Pod` fixtures
+resolves to the same UUID without bookkeeping).
+
+## Worked example — outbox roundtrip
+
+Full integration pattern: write an event through `writeOutbox`, tick the
+relay, assert the message arrives on a bound queue. Mirrors
+`apps/node/iam-api/src/__tests__/integration/outbox-roundtrip.int.test.ts`
+in rostering (PR #138).
+
+```typescript
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { startInfra, id, type InfraHandle } from '@saga-ed/soa-event-test-harness';
+import { OUTBOX_EVENT_SQL, OutboxRelay, writeOutbox } from '@saga-ed/soa-event-outbox';
+import { ConnectionManager } from '@saga-ed/soa-rabbitmq';
+import { buildEnvelope } from '@saga-ed/soa-event-envelope';
+import { IAM_EXCHANGE, IamUserCreatedV1 } from '@saga-ed/iam-events';
+import { Pool } from 'pg';
+
+const skip = process.env.SKIP_INT === '1';
+
+const noopLogger = {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+};
+
+describe.skipIf(skip)('outbox -> RabbitMQ roundtrip', () => {
+    let infra: InfraHandle;
+    let pool: Pool;
+    let connectionManager: ConnectionManager;
+    let relay: OutboxRelay;
+    const TEST_QUEUE = 'iam.events.test.consumer';
+    const collected: Array<{ routingKey: string; body: unknown }> = [];
+
+    beforeAll(async () => {
+        // (a) Postgres + RabbitMQ container spin-up.
+        infra = await startInfra();
+        const dbUrl = await infra.createDatabase('iam_outbox_int');
+        await infra.runSql(dbUrl, OUTBOX_EVENT_SQL);
+        pool = new Pool({ connectionString: dbUrl, max: 4 });
+
+        connectionManager = new ConnectionManager(noopLogger as never, {
+            url: infra.rabbitmqUrl,
+            reconnect: { enabled: false },
+            failureMode: 'fatal',  // tests should fail loud on broker issues
+        });
+        await connectionManager.connect();
+
+        // Bind a transient test queue so we can observe published messages.
+        const channel = await connectionManager.newChannel();
+        await channel.assertExchange(IAM_EXCHANGE, 'topic', { durable: true });
+        await channel.assertQueue(TEST_QUEUE, { durable: false, autoDelete: true });
+        await channel.bindQueue(TEST_QUEUE, IAM_EXCHANGE, 'iam.user.*');
+        await channel.consume(TEST_QUEUE, (msg) => {
+            if (!msg) return;
+            collected.push({
+                routingKey: msg.fields.routingKey,
+                body: JSON.parse(msg.content.toString()),
+            });
+            channel.ack(msg);
+        });
+
+        relay = new OutboxRelay({
+            pool,
+            connectionManager,
+            exchange: IAM_EXCHANGE,
+            logger: noopLogger as never,
+        });
+    }, 120_000);
+
+    afterAll(async () => {
+        await relay?.stop().catch(() => {});
+        await pool?.end().catch(() => {});
+        await infra?.stop().catch(() => {});
+    }, 30_000);
+
+    it('publishes an envelope written to outbox_event', async () => {
+        // (b) `id()` helper produces a UUID-shaped string that the
+        // payload schema's `z.string().uuid()` accepts.
+        const userId = id('mem-child');
+        const envelope = buildEnvelope({
+            eventType: IamUserCreatedV1.eventType,
+            eventVersion: IamUserCreatedV1.eventVersion,
+            aggregateType: 'user',
+            aggregateId: userId,
+            payload: IamUserCreatedV1.payloadSchema.parse({
+                id: userId,
+                status: 'active',
+                createdAt: new Date().toISOString(),
+            }),
+        });
+
+        await writeOutbox(makeTxShim(pool), envelope);
+
+        // (c) Tick the relay manually for determinism, then assert the
+        // bound queue received the published envelope.
+        await (relay as unknown as { tick: () => Promise<void> }).tick();
+        await new Promise((resolve) => setTimeout(resolve, 250));
+
+        expect(collected).toHaveLength(1);
+        expect(collected[0].routingKey).toBe('iam.user.created');
+    });
+});
+
+// `writeOutbox` accepts a Prisma-tx-shaped object. The pg Pool exposes
+// $executeRaw via a thin shim that mimics the tagged-template signature.
+function makeTxShim(pool: Pool) {
+    return {
+        async $executeRaw(strings: TemplateStringsArray, ...values: unknown[]) {
+            let sql = strings[0];
+            for (let i = 0; i < values.length; i++) {
+                sql += `$${i + 1}` + strings[i + 1];
+            }
+            const res = await pool.query(sql, values);
+            return res.rowCount ?? 0;
+        },
+    };
+}
+```
+
+## When to skip
+
+- `SKIP_INT=1` — explicit skip, e.g. in CI lanes that don't provision
+  Docker.
+- Sandboxed runners without a Docker daemon — tests will fail at
+  `startInfra()`. Either install Docker in the runner or set `SKIP_INT=1`.
+
+## Container lifecycle
+
+`startInfra()` is intentionally per-suite, not per-test: container
+startup is ~5–10s and dominates a per-test cost. Use one
+`startInfra → afterAll(stop)` cycle per integration suite, with
+`createDatabase` for per-test isolation inside that suite.
+
+## See also
+
+- `@saga-ed/soa-event-outbox` — `OUTBOX_EVENT_SQL` migration,
+  `writeOutbox`, `OutboxRelay`.
+- `@saga-ed/soa-event-consumer` — projection consumer with
+  `consumed_events` dedup; queue-topology + UPSERT-handler pattern docs.
+- `@saga-ed/soa-rabbitmq` — `ConnectionManager` with `failureMode`
+  control.
+- `@saga-ed/soa-event-envelope` — Zod envelope, `buildEnvelope`.

--- a/packages/node/event-test-harness/package.json
+++ b/packages/node/event-test-harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/soa-event-test-harness",
-    "version": "0.1.0-dev.1",
+    "version": "0.1.0-dev.2",
     "private": false,
     "type": "module",
     "main": "dist/index.js",

--- a/packages/node/event-test-harness/src/__tests__/uuid.unit.test.ts
+++ b/packages/node/event-test-harness/src/__tests__/uuid.unit.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { id } from '../uuid.js';
+
+describe('id()', () => {
+    it('produces UUID-v4-shaped output', () => {
+        const out = id('mem-child');
+        expect(out).toMatch(
+            /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-8[0-9a-f]{3}-[0-9a-f]{12}$/,
+        );
+    });
+
+    it('is deterministic for the same seed', () => {
+        expect(id('foo')).toBe(id('foo'));
+    });
+
+    it('produces distinct values for distinct seeds', () => {
+        expect(id('a')).not.toBe(id('b'));
+    });
+});

--- a/packages/node/event-test-harness/src/index.ts
+++ b/packages/node/event-test-harness/src/index.ts
@@ -1,3 +1,5 @@
+export { id } from './uuid.js';
+
 import {
     PostgreSqlContainer,
     type StartedPostgreSqlContainer,

--- a/packages/node/event-test-harness/src/uuid.ts
+++ b/packages/node/event-test-harness/src/uuid.ts
@@ -1,0 +1,14 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * Deterministic UUID-v4-shaped string from a memorable seed.
+ *
+ * Used in unit tests so fixture IDs satisfy event-payload schema validation
+ * (`z.string().uuid()`) while keeping the source readable: `id('mem-child')`
+ * instead of an opaque hex literal. Same seed always returns the same UUID
+ * so cross-references between fixtures stay coherent.
+ */
+export const id = (seed: string): string => {
+    const h = createHash('md5').update(seed).digest('hex');
+    return `${h.slice(0, 8)}-${h.slice(8, 12)}-4${h.slice(13, 16)}-8${h.slice(17, 20)}-${h.slice(20, 32)}`;
+};

--- a/packages/node/observability/README.md
+++ b/packages/node/observability/README.md
@@ -1,0 +1,55 @@
+# @saga-ed/soa-observability
+
+OpenTelemetry tracing setup, Prometheus metrics for outbox/consumer, and an
+Express error-classifier middleware for Saga services.
+
+```typescript
+import { initTracing } from '@saga-ed/soa-observability';
+```
+
+> **⚠️ FOOTGUN — `initTracing()` MUST run before any tracer-using import.**
+>
+> OpenTelemetry's tracer-provider singleton is patched in place by
+> `initTracing()`. Any module loaded *before* the call captures the
+> **no-op tracer** at module-load time and silently emits **zero spans**
+> for its lifetime. The service still runs; you just have no traces.
+>
+> Both `rostering` and `program-hub` hit this. The `saga-soa/init-tracing-first`
+> ESLint rule (in `@saga-ed/soa-eslint-config/base`) catches it at lint time.
+>
+> ### ✅ Correct
+>
+> ```typescript
+> // main.ts
+> import { initTracing } from '@saga-ed/soa-observability';
+> initTracing({ serviceName: 'iam-api' });
+>
+> // Dynamic import AFTER tracing is initialized:
+> const { startServer } = await import('./server.js');
+> await startServer();
+> ```
+>
+> ### ❌ Wrong — `reflect-metadata` precedes `initTracing()`
+>
+> ```typescript
+> import 'reflect-metadata';            // captures no-op tracer at load
+> import { container } from './ioc.js'; // same — silent dead spans
+> import { initTracing } from '@saga-ed/soa-observability';
+> initTracing();                         // too late
+> ```
+>
+> ### ❌ Wrong — static import of app code before init
+>
+> ```typescript
+> import { initTracing } from '@saga-ed/soa-observability';
+> import { startServer } from './server.js';  // hoists; loads before initTracing() runs
+> initTracing();
+> await startServer();
+> ```
+
+## See also
+
+- `@saga-ed/soa-eslint-config` — the `saga-soa/init-tracing-first` lint
+  rule wires this into CI; runs against any file named `main.ts`.
+- `claude/projects/soa_75/decisions/d-consumer-resilience.md` pattern 4 —
+  decision-doc rationale.

--- a/packages/node/observability/package.json
+++ b/packages/node/observability/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/soa-observability",
-    "version": "0.1.0-dev.1",
+    "version": "0.1.0-dev.2",
     "private": false,
     "type": "module",
     "main": "dist/index.js",

--- a/packages/node/rabbitmq/README.md
+++ b/packages/node/rabbitmq/README.md
@@ -1,0 +1,43 @@
+# @saga-ed/soa-rabbitmq
+
+RabbitMQ connection management, channel helpers, queue assertions, and
+publisher-confirms for Saga services.
+
+```typescript
+import { ConnectionManager } from '@saga-ed/soa-rabbitmq';
+```
+
+## Connection failure semantics
+
+`ConnectionManager.connect()` retries with exponential backoff up to
+`reconnect.maxRetries`. When retries are exhausted the circuit breaker
+trips. What happens *next* depends on `failureMode`:
+
+| `failureMode`       | Behavior on circuit-trip               | Use when                                                                                            |
+| ------------------- | -------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `'fatal'`           | throws — host process crashes          | production. Soft-failing event publication accumulates outbox debt invisibly; the crash is the alert. |
+| `'log-and-continue'`| logs warn, returns; state stays open   | dev / test / preview. Request-path mutations still succeed via the outbox table; the relay reconnects when the broker returns. |
+
+**Default:** `'fatal'` when `process.env.NODE_ENV === 'production'`,
+`'log-and-continue'` otherwise. Set explicitly to override — e.g. a
+staging environment that should fail loud:
+
+```typescript
+new ConnectionManager(logger, {
+    url: process.env.RABBITMQ_URL!,
+    failureMode: 'fatal',
+});
+```
+
+Rationale and the full pattern set (idempotent UPSERT handlers, soft-delete
+projections, OTel `initTracing` ordering, queue-per-event-family) are
+captured in
+[`d-consumer-resilience.md`](../../../claude/projects/soa_75/decisions/d-consumer-resilience.md)
+on `soa_75`.
+
+## See also
+
+- `@saga-ed/soa-event-outbox` — relay that publishes outbox rows.
+- `@saga-ed/soa-event-consumer` — idempotent consumer with `consumed_events`
+  dedup.
+- `@saga-ed/soa-observability` — OpenTelemetry + Prometheus wiring.

--- a/packages/node/rabbitmq/__tests__/connection-manager.unit.test.ts
+++ b/packages/node/rabbitmq/__tests__/connection-manager.unit.test.ts
@@ -4,9 +4,16 @@
 // can verify the manager delegates to createConfirmChannel() and surfaces
 // the same not-initialized error contract as newChannel().
 
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ChannelModel } from 'amqplib';
 import { ConnectionManager } from '../src/connection-manager.js';
+
+vi.mock('amqplib', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('amqplib')>();
+    return { ...actual, connect: vi.fn() };
+});
+
+const { connect: mockConnect } = await import('amqplib');
 
 const NOOP_LOGGER = {
     info: vi.fn(),
@@ -66,5 +73,56 @@ describe('ConnectionManager.newConfirmChannel', () => {
         expect(confirm).toEqual({ kind: 'confirm' });
         expect(createChannel).toHaveBeenCalledOnce();
         expect(createConfirmChannel).toHaveBeenCalledOnce();
+    });
+});
+
+describe('ConnectionManager.connect — failureMode', () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+
+    beforeEach(() => {
+        // Force `connect` to exhaust retries quickly: stub amqplib.connect so
+        // it always rejects, and use a tiny `initialDelay` so the backoff
+        // doesn't drag the test out.
+        vi.mocked(mockConnect).mockRejectedValue(new Error('boom'));
+    });
+
+    afterEach(() => {
+        vi.mocked(mockConnect).mockReset();
+        (process.env as Record<string, string | undefined>).NODE_ENV = originalNodeEnv;
+    });
+
+    function makeFailingManager(failureMode?: 'fatal' | 'log-and-continue') {
+        return new ConnectionManager(NOOP_LOGGER as never, {
+            url: 'amqp://localhost',
+            failureMode,
+            reconnect: { enabled: true, maxRetries: 1, initialDelay: 1, maxDelay: 1 },
+        });
+    }
+
+    it('throws when failureMode=fatal after retries exhaust', async () => {
+        const cm = makeFailingManager('fatal');
+        await expect(cm.connect()).rejects.toThrow(/circuit breaker opened/);
+        expect(cm.state()).toBe('CIRCUIT_OPEN');
+    });
+
+    it('returns + logs warn when failureMode=log-and-continue', async () => {
+        const cm = makeFailingManager('log-and-continue');
+        await expect(cm.connect()).resolves.toBeUndefined();
+        expect(cm.state()).toBe('CIRCUIT_OPEN');
+        expect(NOOP_LOGGER.warn).toHaveBeenCalledWith(
+            expect.stringMatching(/log-and-continue/),
+        );
+    });
+
+    it("defaults to 'fatal' when NODE_ENV=production", async () => {
+        (process.env as Record<string, string | undefined>).NODE_ENV = 'production';
+        const cm = makeFailingManager();
+        await expect(cm.connect()).rejects.toThrow(/circuit breaker opened/);
+    });
+
+    it("defaults to 'log-and-continue' when NODE_ENV is not production", async () => {
+        (process.env as Record<string, string | undefined>).NODE_ENV = 'test';
+        const cm = makeFailingManager();
+        await expect(cm.connect()).resolves.toBeUndefined();
     });
 });

--- a/packages/node/rabbitmq/package.json
+++ b/packages/node/rabbitmq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saga-ed/soa-rabbitmq",
-  "version": "1.2.0",
+  "version": "1.3.0-dev.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/node/rabbitmq/src/connection-manager.ts
+++ b/packages/node/rabbitmq/src/connection-manager.ts
@@ -6,10 +6,33 @@ import { QueueDefinition } from './queue';
 
 export interface RabbitMQConfig {
   url: string; // eg. amqp://user:password@host:port
-  
+
   reconnect?: ReconnectConfig;
-  
+
   heartbeat?: number; // seconds
+
+  /**
+   * What to do when initial `connect()` exhausts retries and trips the
+   * circuit breaker:
+   *
+   * - `'fatal'`: throw, so the host process can crash and surface a clear
+   *   alert. Correct in production — a service that "soft fails" event
+   *   publication accumulates outbox debt invisibly until alerting catches
+   *   it.
+   * - `'log-and-continue'`: log a warning and return without throwing, so
+   *   the service can still serve request-path traffic while the broker is
+   *   unreachable. The outbox table absorbs the writes; the relay reconnects
+   *   when the broker returns. Correct in dev/test where the broker is more
+   *   flaky than the service itself.
+   *
+   * Default: `'fatal'` when `process.env.NODE_ENV === 'production'`,
+   * `'log-and-continue'` otherwise. Set explicitly to override that default
+   * — e.g. a CI/staging environment where you want fail-loud behavior.
+   *
+   * See `claude/projects/soa_75/decisions/d-consumer-resilience.md` pattern
+   * 3 ("non-fatal broker startup") for the rationale.
+   */
+  failureMode?: 'fatal' | 'log-and-continue';
 }
 
 export interface ReconnectConfig {
@@ -28,7 +51,7 @@ export type ConnectionState =
   | "RECONNECTING"
   | "CIRCUIT_OPEN";
 
-const DEFAULT_CONNECTION_CONFIG: Required<Omit<RabbitMQConfig, 'url'> & { reconnect: Required<ReconnectConfig> }> = {
+const DEFAULT_CONNECTION_CONFIG: Required<Omit<RabbitMQConfig, 'url' | 'failureMode'> & { reconnect: Required<ReconnectConfig> }> = {
   reconnect: {
     enabled: true,
     maxRetries: 10,
@@ -40,7 +63,7 @@ const DEFAULT_CONNECTION_CONFIG: Required<Omit<RabbitMQConfig, 'url'> & { reconn
 
 @injectable()
 export class ConnectionManager {
-  private config: Required<RabbitMQConfig & { reconnect: Required<ReconnectConfig> }>;
+  private config: Required<Omit<RabbitMQConfig, 'failureMode'> & { reconnect: Required<ReconnectConfig> }> & { failureMode?: 'fatal' | 'log-and-continue' };
   private channelModel: ChannelModel | null = null;
 
   private currentState: ConnectionState = "DISCONNECTED";
@@ -242,6 +265,20 @@ export class ConnectionManager {
     this.circuitOpenTimestamp = Date.now();
     this.circuitOpen = true;
     this.setState("CIRCUIT_OPEN");
-    throw new Error("RabbitMQ connection failed: circuit breaker opened");
+    const mode = this.resolveFailureMode();
+    const message = "RabbitMQ connection failed: circuit breaker opened";
+    if (mode === 'log-and-continue') {
+      this.logger.warn(
+        `[MQConnectionManager] ${message} — failureMode='log-and-continue', not throwing. ` +
+          'Outbox writes will accumulate; the relay will reconnect on the next attempt.',
+      );
+      return;
+    }
+    throw new Error(message);
+  }
+
+  private resolveFailureMode(): 'fatal' | 'log-and-continue' {
+    if (this.config.failureMode) return this.config.failureMode;
+    return process.env.NODE_ENV === 'production' ? 'fatal' : 'log-and-continue';
   }
 }


### PR DESCRIPTION
## Summary

Lateral-propagation pass per [`claude/projects/soa_75/tasks/lateral-propagation.md`](https://github.com/saga-ed/soa/blob/soa_75/claude/projects/soa_75/tasks/lateral-propagation.md) on `soa_75`. Lifts patterns the event-driven adopters (rostering #138, program-hub #60/#62) discovered into the shared `@saga-ed/soa-*` packages so future adopters inherit them.

## What lands

| Item | Item title | Where |
| --- | --- | --- |
| 1.1 P1 | `id(seed)` UUID-shaped helper | `@saga-ed/soa-event-test-harness` (new `id` export + unit tests) |
| 1.2 P1 | OTel `initTracing` import-order check | new `saga-soa/init-tracing-first` ESLint rule in `@saga-ed/soa-eslint-config`, plus loud banner in `@saga-ed/soa-observability/README.md` |
| 1.3 P2 | `createOutboxPool` `max` default 2 → 4 | `@saga-ed/soa-event-outbox` |
| 1.5 P2 | Queue-topology rule | `@saga-ed/soa-event-consumer/README.md` |
| 1.6 P2 | UPSERT-handler pattern | `@saga-ed/soa-event-consumer/README.md` (documented pattern; per briefing, equivalent to a generic helper given per-table SQL specificity) |
| 1.8 P2 | `failureMode` on `ConnectionManager` | `@saga-ed/soa-rabbitmq` (new option + matrix in new `README.md`) |
| 2.3 P2 | Harness README + worked example | `@saga-ed/soa-event-test-harness/README.md` mirroring rostering `outbox-roundtrip.int.test.ts` |

## Coordinated dev-tag bumps

| package | from | to |
| --- | --- | --- |
| `@saga-ed/soa-event-test-harness` | `0.1.0-dev.1` | `0.1.0-dev.2` |
| `@saga-ed/soa-event-consumer`     | `0.1.0-dev.3` | `0.1.0-dev.4` |
| `@saga-ed/soa-event-outbox`       | `0.1.0-dev.4` | `0.1.0-dev.5` |
| `@saga-ed/soa-rabbitmq`           | `1.2.0`       | `1.3.0-dev.1` |
| `@saga-ed/soa-observability`      | `0.1.0-dev.1` | `0.1.0-dev.2` |

Sessions B (rostering) and C (program-hub) are running in parallel on
pre-bump tags and will not pick these up until directed (Session D).
None of the prior tags are reused or broken.

## Verification

- `pnpm -r --filter <each-touched-pkg> build` ✓
- `pnpm -r --filter <each-touched-pkg> test` ✓ (adds 3 `id()` unit tests, 4 `failureMode` unit tests; existing 20 outbox tests updated to expect `max=4`)
- ESLint rule: `pnpm --filter @saga-ed/soa-eslint-config test` runs `verify-fixture.mjs`, which lints `main-bad.ts` and asserts the rule fires (`importBeforeInit` on `import 'reflect-metadata'`).

## Out of scope

- Adopter cleanup (Session D — swaps in-tree copies for the shared helpers).
- Decision-doc edits on `soa_75` (Session A2).
- Bulk-mutation strategy (1.4 — blocked on Seth).
- Soft-/hard-delete projection guidance (1.7 — Session A2 docs).

## Post-merge follow-up

Tick items 1.1, 1.2 (lint portion), 1.3, 1.5, 1.6, 1.8, 2.3 in
`claude/projects/soa_75/tasks/lateral-propagation.md` on `soa_75` (separate
commit; lateral-propagation lives only on the planning branch).

## Test plan

- [ ] CI green
- [ ] Publish workflow produces the dev-tag set above against CodeArtifact
- [ ] Smoke: `npm view @saga-ed/soa-event-test-harness@0.1.0-dev.2` resolves once published