### PR TITLE
TEMP POC - feat(auth): P0 ADRs + P1 contracts/model/envelope + P3 two-headers helper + P4 envelope signing + P5 audit package

### DIFF
--- a/docs/auth/00-overview.md
+++ b/docs/auth/00-overview.md
@@ -1,0 +1,54 @@
+# Saga Fleet Auth — Overview
+
+This directory holds the canonical decisions for fleet-wide authentication and authorization across Saga's microservices. These ADRs are the *source of truth* every service repo cites; if a service repo's auth doc disagrees with an ADR here, the ADR wins.
+
+## Why this lives in `soa`
+
+`soa` ships the shared packages every service consumes. The wire shapes (JWT claims, event envelopes, audit events, SPIFFE IDs, header names) are defined here so that no service can drift unilaterally. Think of these ADRs as the *types* and the per-service implementation as the *implementations*.
+
+## Reading order for newcomers
+
+1. The concept primer in [`saga-dash/docs/auth/concepts.md`](https://github.com/saga-ed/saga-dash/blob/main/docs/auth/concepts.md) — explains every term used here for engineers without a security background.
+2. The minimal-change rollout plan in [`saga-dash/docs/auth/plan.md`](https://github.com/saga-ed/saga-dash/blob/main/docs/auth/plan.md) — what we're doing and in what order.
+3. The ADRs below — *why* each seam is shaped the way it is.
+4. The source code in `packages/core/auth-contracts/` — the runtime artifact.
+
+## ADR index
+
+| # | Title | Status |
+|---|---|---|
+| [0001](./adr/0001-jwt-claim-shape.md) | Canonical JWT claim shape | Accepted |
+| [0002](./adr/0002-two-headers-invariant.md) | Two-headers invariant for service-to-service calls | Accepted |
+| [0003](./adr/0003-signed-event-envelope.md) | Signed event envelope (HMAC-SHA256) | Accepted |
+| [0004](./adr/0004-audit-event-shape.md) | Audit event shape (`audit.decision.v1`) | Accepted |
+| [0005](./adr/0005-openfga-model-as-source-of-truth.md) | OpenFGA model as source of truth | Accepted |
+| [0006](./adr/0006-spiffe-id-format.md) | SPIFFE ID format for service identity | Accepted |
+| [0007](./adr/0007-no-header-trust.md) | No header-trusted identity in resource services | Accepted |
+
+## The seven seams in one sentence each
+
+1. **JWT claim shape** — every issued token has `iss`, `aud`, `sub` (SPIFFE-formatted), `saga.tenant`, `saga.session`, `cnf.jkt`. Future DPoP / Cognito / token-exchange work plugs into this shape unchanged.
+2. **Two-headers invariant** — every internal call carries caller workload identity (`X-Saga-Caller`) *and* subject identity (`Authorization`). Both are verified independently. Today caller identity is a string; tomorrow it's an mTLS-verified SPIFFE SAN.
+3. **Signed event envelope** — events optionally carry an HMAC-SHA256 signature. Producers sign when a signing key is configured; consumers verify in shadow mode (log) or enforce mode (reject). The seam exists today; enforcement flips later.
+4. **Audit event shape** — every authz decision, mutation, and identity event emits an `audit.decision.v1` record. Today the writer is a structured logger; the Merkle-chained Postgres + S3 Object Lock storage swaps in later without callers changing.
+5. **OpenFGA model as source of truth** — the `.fga` model is the only place tuple types and relations are defined. Services *check*; the sync worker *writes*. Today the model lives in-repo without a deployed FGA store; runtime checks land later.
+6. **SPIFFE ID format** — `spiffe://saga.<env>/<service>` is the canonical workload identifier. Used in mTLS SANs, JWT subjects for service tokens, and the `X-Saga-Caller` header value. Adopted now; SPIRE deployment is later.
+7. **No header-trusted identity** — `x-user-id` and `x-organization-id` headers are *never* trusted as identity. They may be *requested* values that the system verifies against the JWT-derived truth.
+
+## What this directory does NOT define
+
+- Runtime crypto (DPoP key generation, mTLS cert distribution, JWT signing key plumbing) — those live in their service repos and follow-up packages.
+- IdP choice — ADR-level recommendation is Cognito (see plan.md appendix); the contracts package is IdP-agnostic.
+- Specific FGA tuples — only the model types and relations live here; tuples reflect data state and live wherever the sync worker writes them.
+- Audit storage backend — only the event *shape* lives here.
+
+This separation means the seams here remain stable while implementations evolve.
+
+## How to propose a change
+
+1. Open a draft ADR PR against this directory (numbered next).
+2. Tag the auth working group on the PR.
+3. ADRs are *Accepted* by review consensus; *Superseded* by a later ADR that links back.
+4. Once accepted, update `packages/core/auth-contracts/` to match.
+
+ADRs are short. If yours is over a page, it's probably two ADRs.

--- a/docs/auth/adr/0001-jwt-claim-shape.md
+++ b/docs/auth/adr/0001-jwt-claim-shape.md
@@ -1,0 +1,80 @@
+# ADR 0001 — Canonical JWT claim shape
+
+**Status:** Accepted
+**Date:** 2026-05-07
+**Concept primer:** [`saga-dash/docs/auth/concepts.md` § 3 (Tokens)](https://github.com/saga-ed/saga-dash/blob/main/docs/auth/concepts.md#3-tokens)
+
+## Context
+
+Multiple services will issue, forward, and verify JWTs. Without a fixed claim shape, each issuer drifts and verifiers must handle a matrix of variations. A single canonical shape enables:
+
+- One verifier implementation in `@saga-ed/soa-auth-contracts`
+- Audience-pinned tokens via token-exchange (RFC 8693) without re-shaping
+- DPoP key binding (RFC 9449) plugged in via the `cnf.jkt` claim later
+- Tenant binding consumable by every service without a separate header
+
+## Decision
+
+All Saga-issued JWTs MUST conform to this claim shape:
+
+```jsonc
+{
+  "iss": "https://auth.saga.<env>",       // issuer; environment-specific URL
+  "aud": "<service-id-or-spiffe-id>",     // pinned per audience via token-exchange
+  "sub": "spiffe://saga.<env>/user/<uuid>", // SPIFFE-formatted subject (see ADR 0006)
+  "iat": <unix-seconds>,
+  "exp": <unix-seconds>,                  // ≤ 15 min for access tokens
+  "jti": "<uuid>",                        // unique per token; safe to log
+  "saga.tenant": "district:<id>",         // primary tenant binding
+  "saga.session": "<opaque-jti>",         // links back to server-side session
+  "saga.scope": ["<scope>", ...],         // optional, narrowed via token-exchange
+  "cnf": { "jkt": "<DPoP-key-thumbprint>" } // optional today, required for DPoP-bound tokens
+}
+```
+
+### Service tokens
+
+Tokens issued *to* a service (not on behalf of a user) follow the same shape with:
+- `sub` set to the *service's* SPIFFE ID (`spiffe://saga.<env>/<service>`)
+- `saga.tenant` omitted or `null` (tenant comes from the user side of an on-behalf-of exchange)
+- `saga.session` omitted
+
+### Validation rules
+
+Every verifier MUST:
+
+1. Reject tokens with a missing or unrecognized `iss`.
+2. Reject tokens whose `aud` does not match the verifying service's audience identifier.
+3. Reject tokens past `exp` (with at most 30s clock skew).
+4. Reject tokens with malformed `sub` (not a valid SPIFFE ID per ADR 0006).
+5. Verify `cnf.jkt` against the request's DPoP proof, if present.
+6. **Never** trust unsigned JWTs; reject `alg=none`.
+
+### Algorithm
+
+- Production: **ES256** (ECDSA P-256, SHA-256). Key pair, public keys served from JWKS.
+- Internal-only fallback: **HS256** with a per-environment shared secret, only for service-to-service tokens never seen by end users.
+
+## Consequences
+
+**Positive:**
+- Single verifier; no per-service variations.
+- DPoP, token-exchange, and Cognito all integrate as additive populations of existing fields.
+- Tenant binding is in the token, not a forgeable header (closes the §0007 risk).
+
+**Negative:**
+- Custom claim names (`saga.tenant`, `saga.session`) require all consumers to import from `@saga-ed/soa-auth-contracts` to avoid string drift.
+- Switching JWT libraries means re-validating against the schema; mitigated by the Zod schema in the contracts package.
+
+## Alternatives considered
+
+- **Standard claims only (no `saga.*`):** rejected. Tenant and session linkage are critical; encoding them in `aud` or `sub` overloads those fields and breaks token-exchange.
+- **Bare opaque session token (no JWT):** rejected. Saga's current model. Forces every consumer to call back to the issuer for every request — does not scale, does not support audience pinning.
+
+## References
+
+- RFC 7519 — JWT
+- RFC 8693 — OAuth 2.0 Token Exchange
+- RFC 9449 — DPoP
+- RFC 9068 — JWT profile for OAuth 2.0 access tokens
+- ADR 0006 — SPIFFE ID format

--- a/docs/auth/adr/0002-two-headers-invariant.md
+++ b/docs/auth/adr/0002-two-headers-invariant.md
@@ -1,0 +1,76 @@
+# ADR 0002 — Two-headers invariant
+
+**Status:** Accepted
+**Date:** 2026-05-07
+**Concept primer:** [`saga-dash/docs/auth/concepts.md` § 5 (Service-to-service authentication)](https://github.com/saga-ed/saga-dash/blob/main/docs/auth/concepts.md#5-service-to-service-authentication)
+
+## Context
+
+Internal service-to-service calls need two facts that are independently verifiable:
+
+1. **Caller workload identity** — *which service is making this call?*
+2. **Subject identity** — *which user (if any) is this call on behalf of?*
+
+Conflating them is the canonical confused-deputy bug: a service grants access because *some* authenticated identity is present, without distinguishing whether that's the *caller's* identity or the *user's*.
+
+## Decision
+
+Every internal call (HTTP, tRPC, gRPC) MUST carry both:
+
+| Aspect | Header | Today | Tomorrow |
+|---|---|---|---|
+| Caller workload identity | `X-Saga-Caller` | SPIFFE-formatted string, structurally validated | mTLS cert SAN (ECS) or SigV4 signer (Lambda), cryptographically verified |
+| Subject identity | `Authorization: Bearer <jwt>` | JWT per ADR 0001 | DPoP-bound JWT per ADR 0001 + RFC 9449 |
+
+Both headers MUST be parsed and verified independently. **A failure of either rejects the request.**
+
+### Header values
+
+- `X-Saga-Caller`: a single SPIFFE ID (ADR 0006), e.g. `spiffe://saga.prod/program-hub`. No additional metadata; the workload's identity is the value.
+- `Authorization`: standard OAuth bearer; the JWT carries the user identity and tenant.
+
+### Service-only calls (no end user)
+
+When a service calls another service for its own purposes (e.g., a background worker), `Authorization` carries a *service token* — a JWT whose `sub` is the calling service's SPIFFE ID and whose `saga.tenant` is omitted. The receiver knows there is no user context and treats `saga.tenant`-scoped operations as forbidden.
+
+### Logging
+
+Every internal request MUST log both identities (caller SPIFFE ID, subject `sub` and `jti`). Audit events (ADR 0004) capture both fields explicitly.
+
+### Rollout
+
+Phase A (this PR set):
+- Define the headers in `@saga-ed/soa-auth-contracts`
+- Outbound callers populate `X-Saga-Caller` with their static SPIFFE ID
+- Inbound services run a `requireTwoHeaders` middleware in **shadow mode** — log + metric on missing/invalid, do not reject
+- Metric: `saga_two_headers_missing_total{service, reason}`
+
+Phase B (later, behind a flag once the metric is at zero):
+- Flip middleware to **enforce mode** — reject `UNAUTHORIZED` on missing/invalid
+- Caller value verified against mTLS SAN (ECS) or SigV4 principal (Lambda)
+- The header becomes redundant with the cryptographic check but is preserved as the canonical identity name in audit logs
+
+## Consequences
+
+**Positive:**
+- Eliminates confused-deputy by construction — services cannot accidentally treat caller identity as subject identity.
+- Forward-compatible with mTLS/SigV4 without code change in receivers — only the verifier swaps.
+- Audit logs always carry both identities.
+
+**Negative:**
+- Every outbound call site must populate `X-Saga-Caller` (small ergonomic cost; helped by shared client wrappers).
+- Shadow-then-enforce migration requires watching the metric; some teams may delay flipping.
+
+## Alternatives considered
+
+- **mTLS only, no header:** rejected for now. Cryptographic SAN extraction varies by load balancer / mesh / runtime. The header is a stable in-app contract that survives infra change.
+- **One token carrying both identities (`act` claim only):** rejected. The two identities have different lifetimes (caller is workload-stable; subject is per-user) and different revocation paths. Separate carriers makes this clear.
+- **Sign just the subject token; leave caller implicit:** rejected. That's exactly the confused-deputy setup we're avoiding.
+
+## References
+
+- RFC 8693 — OAuth 2.0 Token Exchange (`act` claim records on-behalf-of chains)
+- RFC 8705 — mTLS-bound tokens
+- ADR 0001 — JWT claim shape
+- ADR 0006 — SPIFFE ID format
+- ADR 0007 — No header-trusted identity

--- a/docs/auth/adr/0003-signed-event-envelope.md
+++ b/docs/auth/adr/0003-signed-event-envelope.md
@@ -1,0 +1,84 @@
+# ADR 0003 — Signed event envelope (HMAC-SHA256)
+
+**Status:** Accepted
+**Date:** 2026-05-07
+**Concept primer:** [`saga-dash/docs/auth/concepts.md` § 9 (Events and integrity)](https://github.com/saga-ed/saga-dash/blob/main/docs/auth/concepts.md#9-events-and-integrity)
+
+## Context
+
+Saga services exchange events via RabbitMQ using the outbox pattern. Today the envelope (`@saga-ed/soa-event-envelope`) carries no signature: any process able to publish to the broker can produce a message that consumers will accept and project. This is a forge/replay risk that grows with operational scale (preview environments, cross-account sharing, broker misconfiguration).
+
+The current `EVENT_PREVIEW_TAG` mechanism provides *soft* isolation between PR previews via exchange/queue name suffixes. It is not cryptographically enforced — a misconfigured producer/consumer can cross-pollinate.
+
+## Decision
+
+The envelope schema gains an **optional** `meta.signature` field:
+
+```ts
+{
+  alg: 'HS256',
+  keyId: string,           // identifier in SSM, e.g. "rostering/v1"
+  value: string             // base64url HMAC-SHA256 over canonical bytes
+}
+```
+
+The signature is computed over the canonical byte representation of:
+
+```
+eventId || "\n" || eventType || "\n" || eventVersion || "\n" || aggregateType || "\n" || aggregateId || "\n" || occurredAt || "\n" || canonicalJSON(payload)
+```
+
+Where `canonicalJSON` is RFC 8785 (JSON Canonicalization Scheme) on the payload object.
+
+### Producer behavior
+
+- If a signing key is configured (env / SSM): sign every envelope.
+- If no key is configured: emit envelopes with `meta.signature = undefined` (back-compat).
+- Producer rotates keys by writing the new key with a new `keyId` and overlapping the rollout (publish with new key while consumers still verify against old, then drop old).
+
+### Consumer behavior
+
+Modes (per consumer service, default is **shadow**):
+
+- **off** — do not look at the signature field. Useful for local dev where keys aren't seeded.
+- **shadow** — verify if present, but do not reject; emit metric on missing/invalid.
+- **enforce** — verify, reject on missing or invalid.
+
+Metric: `saga_event_signature_status{producer, status}` where status ∈ {`absent`, `valid`, `invalid`, `unknown_key`}.
+
+### Key management
+
+- Keys live in AWS SSM Parameter Store under `/saga/<env>/event-signing/<producer>/<keyId>`.
+- Each producer has its own key family. Consumers fetch all known keys for a producer's family at boot and on a 5-minute cache refresh.
+- Keys are 32-byte random values, base64-encoded.
+- Rotation is deploy-coordinated: publish new keyId, wait for cache refresh in all consumers, switch producer to new keyId, decommission old after retention window.
+
+### Why HMAC, not ECDSA
+
+Symmetric HMAC is sufficient because:
+- All producers and all consumers are inside the Saga trust boundary.
+- HMAC is faster and the key material is simpler to manage.
+- If we ever cross a trust boundary (vendor-to-vendor events), this ADR will be superseded by an ECDSA-based variant.
+
+## Consequences
+
+**Positive:**
+- Defense-in-depth against broker compromise / cross-PR contamination beyond the soft preview-tag.
+- Optional field means zero migration cost — existing events remain valid; rollout is per-producer.
+- Shadow mode lets each consumer ship metrics before flipping enforce.
+
+**Negative:**
+- Adds a small CPU cost per publish/consume (negligible for HMAC-SHA256).
+- Key distribution is now an operational concern (SSM); manageable with existing config patterns.
+
+## Alternatives considered
+
+- **TLS to broker (server-side only):** insufficient. Protects in transit but doesn't authenticate the producer to the consumer.
+- **Producer mTLS to broker:** complementary, not a substitute. Broker compromise still allows forging.
+- **Per-message asymmetric signature (ECDSA):** higher cost, no marginal benefit inside the trust boundary.
+- **Mandatory signature (no `optional`):** rejected for migration cost. Optional + shadow mode + per-consumer enforce flips lets each service migrate independently.
+
+## References
+
+- RFC 8785 — JSON Canonicalization Scheme
+- ADR 0001 — JWT claim shape (related signing-key management pattern)

--- a/docs/auth/adr/0003-signed-event-envelope.md
+++ b/docs/auth/adr/0003-signed-event-envelope.md
@@ -28,7 +28,15 @@ The signature is computed over the canonical byte representation of:
 eventId || "\n" || eventType || "\n" || eventVersion || "\n" || aggregateType || "\n" || aggregateId || "\n" || occurredAt || "\n" || canonicalJSON(payload)
 ```
 
-Where `canonicalJSON` is RFC 8785 (JSON Canonicalization Scheme) on the payload object.
+`canonicalJSON` is *JCS-inspired*, not strictly RFC 8785: keys sorted
+in UTF-16 lexicographic order, no whitespace, JSON.stringify-compatible
+escapes. This is sufficient for byte-identical reproduction across
+producer and consumer within the Saga trust boundary (both run Node
+V8). The exact algorithm is documented in
+`packages/node/event-envelope/src/signing.ts:canonicalize`. If we ever
+interop with a counterparty that requires strict RFC 8785, swap that
+function for a JCS implementation — everything else in this ADR is
+unchanged.
 
 ### Producer behavior
 

--- a/docs/auth/adr/0004-audit-event-shape.md
+++ b/docs/auth/adr/0004-audit-event-shape.md
@@ -1,0 +1,125 @@
+# ADR 0004 — Audit event shape (`audit.decision.v1`)
+
+**Status:** Accepted
+**Date:** 2026-05-07
+**Concept primer:** [`saga-dash/docs/auth/concepts.md` § 10 (Audit logging)](https://github.com/saga-ed/saga-dash/blob/main/docs/auth/concepts.md#10-audit-logging)
+
+## Context
+
+Audit logs serve three distinct audiences (forensics, compliance, anomaly detection — see concept primer § 10). They must be:
+
+- **Structured** so they can be queried and aggregated.
+- **Stable** across services so cross-service investigation works.
+- **Independent of storage** so the underlying store can evolve (today: structured logs; tomorrow: hash-chained Postgres + S3 Object Lock) without callers changing.
+
+Saga today has *some* audit data (the `actorFromContext` decorator on rostering tRPC mutations) but no shared schema and no consistent emission across services.
+
+## Decision
+
+Define a single canonical audit event type, `audit.decision.v1`, with this shape:
+
+```ts
+{
+  // Versioning
+  schemaVersion: "v1",
+  eventType: "authn.login" | "authn.logout" | "authn.refresh" | "authn.token_exchange"
+           | "authz.check" | "authz.deny"
+           | "mutation.create" | "mutation.update" | "mutation.delete"
+           | "admin.role_grant" | "admin.role_revoke" | "admin.config_change",
+
+  // Identity (both required when applicable)
+  caller: {
+    spiffeId: string,        // service workload, ADR 0006
+  } | null,                  // null only for end-user direct calls (e.g., browser → API)
+  subject: {
+    sub: string,             // SPIFFE-formatted user, ADR 0001
+    tenantId: string | null, // saga.tenant claim
+    sessionJti: string | null,
+    tokenJti: string,
+  } | null,                  // null only for unauthenticated events (e.g., login-failure)
+
+  // What happened
+  resource: {
+    type: string,            // e.g., "program", "school"
+    id: string,
+    tenantId: string | null,
+  } | null,
+  action: string,            // domain action, e.g., "view", "delete", "join"
+  decision: "allow" | "deny",
+  reason: string | null,     // structured code: "no_tuple", "expired_token", "tenant_mismatch", ...
+
+  // Authz tracing (for ReBAC checks)
+  fgaCheck: {
+    relation: string,
+    object: string,           // type:id form
+    consultedTuples: string[] // optional, for forensic depth; may be omitted in high-volume paths
+  } | null,
+
+  // Timing & correlation
+  occurredAt: string,         // ISO 8601 with offset
+  correlationId: string,      // OTel traceId or upstream-supplied
+  causationId: string | null, // event that caused this one
+
+  // Operational
+  service: string,            // emitting service's SPIFFE ID
+  env: "dev" | "staging" | "prod",
+}
+```
+
+### What MUST be emitted
+
+Every service that participates in fleet auth emits `audit.decision.v1` for:
+
+- Authentication: login (success/failure), logout, refresh, token-exchange
+- Authorization: every check that returns deny; every check on sensitive resources (configurable per service)
+- Mutations: every state-changing operation
+- Admin actions: role grants/revokes, group membership changes, configuration changes
+
+### What MUST NOT appear in audit events
+
+- Bearer tokens, refresh tokens, DPoP proofs (only `jti` is logged)
+- Passwords, MFA codes, recovery secrets
+- Full PII bodies (names, emails) — store IDs only; reconstruct PII from the PII-DB on-demand for compliance queries
+- Raw request/response bodies
+
+### Storage today vs tomorrow
+
+| Phase | Writer | Storage |
+|---|---|---|
+| **Today (P5)** | `@saga-ed/soa-audit.emit()` writes via `@saga-ed/soa-logger` to a dedicated `audit` channel | App log aggregation (e.g., CloudWatch, Datadog) |
+| **Later** | Same `emit()` API, swapped writer | Hash-chained Postgres `audit_event` table; daily KMS-signed Merkle root → S3 Object Lock (compliance mode), 7-year retention |
+
+The shape is the contract; the storage is the implementation. Callers do not change between phases.
+
+### Querying
+
+Standard query interface (offered by the audit package once Postgres backend lands):
+
+- `byActor(sub, since, until)` — every action by a user
+- `byResource(type, id, since, until)` — every action on a resource
+- `denials(since, until, env)` — all `decision = "deny"` events for anomaly review
+- `byCorrelationId(traceId)` — every audit event tied to a single request
+
+## Consequences
+
+**Positive:**
+- Stable shape lets storage evolve without breaking callers or queries.
+- Cross-service investigation (forensics) works because every emit conforms.
+- Schema-enforced "what NOT to log" prevents accidental PII leakage.
+
+**Negative:**
+- Adds an emit call to every mutation/check; mitigated by tRPC middleware.
+- Schema changes are coordinated across services; mitigated by `schemaVersion` field — `v2` would coexist with `v1`.
+
+## Alternatives considered
+
+- **Per-service ad-hoc audit:** rejected. We have this today and it does not let auditors answer cross-service questions.
+- **Use OTel logs only:** rejected. OTel is great for tracing but is not designed as a tamper-evident audit store. Audit gets its own channel even if it rides OTel transport today.
+- **CloudTrail-only (AWS-managed):** rejected. CloudTrail captures AWS-API actions, not application authz decisions. We need both.
+
+## References
+
+- ADR 0001, 0002 — identity fields
+- ADR 0006 — SPIFFE ID format
+- NIST SP 800-92 — Guide to Computer Security Log Management
+- FERPA / NY §2-d audit-log expectations (concept primer § 14)

--- a/docs/auth/adr/0004-audit-event-shape.md
+++ b/docs/auth/adr/0004-audit-event-shape.md
@@ -35,7 +35,11 @@ Define a single canonical audit event type, `audit.decision.v1`, with this shape
     sub: string,             // SPIFFE-formatted user, ADR 0001
     tenantId: string | null, // saga.tenant claim
     sessionJti: string | null,
-    tokenJti: string,
+    tokenJti: string | null, // null on authn.login (subject known
+                             // before token issued); required by
+                             // convention for post-login events but
+                             // not enforced by the schema (too brittle
+                             // to drop an audit row over).
   } | null,                  // null only for unauthenticated events (e.g., login-failure)
 
   // What happened
@@ -86,7 +90,7 @@ Every service that participates in fleet auth emits `audit.decision.v1` for:
 
 | Phase | Writer | Storage |
 |---|---|---|
-| **Today (P5)** | `@saga-ed/soa-audit.emit()` writes via `@saga-ed/soa-logger` to a dedicated `audit` channel | App log aggregation (e.g., CloudWatch, Datadog) |
+| **Today** | `@saga-ed/soa-audit.emit()` writes via `@saga-ed/soa-logger` to a dedicated `audit` channel | App log aggregation (e.g., CloudWatch, Datadog) |
 | **Later** | Same `emit()` API, swapped writer | Hash-chained Postgres `audit_event` table; daily KMS-signed Merkle root → S3 Object Lock (compliance mode), 7-year retention |
 
 The shape is the contract; the storage is the implementation. Callers do not change between phases.

--- a/docs/auth/adr/0005-openfga-model-as-source-of-truth.md
+++ b/docs/auth/adr/0005-openfga-model-as-source-of-truth.md
@@ -48,10 +48,21 @@ Every check is tenant-scoped. The tenant is part of the resource ID format (`pro
 ### Model lives in `packages/core/saga-authz-model/`
 
 - `model.fga` — the DSL source
-- `generated/types.ts` — emitted TypeScript types for tuple keys (build step, runs in CI)
-- `README.md` — how to read it, how to extend it
+- `src/types.ts` — hand-maintained TypeScript constants mirroring the
+  DSL types and relations (`FGA_TYPES`, `FgaRelationsByType`,
+  `FgaRelation<T>`)
+- `src/__tests__/model-fga.unit.test.ts` — CI guard that diffs the
+  `.fga` file against `src/types.ts`; build fails on drift
+- `README.md` — how to read it, how to extend it (PRs MUST update both
+  files in lockstep)
 
-The package exports tuple-key builder helpers but does not bundle the FGA SDK — services depend on `@openfga/sdk` directly when they need runtime checks.
+The TS mirror is hand-maintained, not codegen'd. A future codegen pass
+can replace `src/types.ts` without changing the package's public API
+(`FgaType`, `FgaRelation<T>`, `tupleKey<T>` are stable).
+
+The package exports tuple-key builder helpers but does not bundle the
+FGA SDK — services depend on `@openfga/sdk` directly when they need
+runtime checks.
 
 ### Today vs tomorrow
 

--- a/docs/auth/adr/0005-openfga-model-as-source-of-truth.md
+++ b/docs/auth/adr/0005-openfga-model-as-source-of-truth.md
@@ -1,0 +1,89 @@
+# ADR 0005 — OpenFGA model as source of truth
+
+**Status:** Accepted
+**Date:** 2026-05-07
+**Concept primer:** [`saga-dash/docs/auth/concepts.md` § 6 (Authorization models) and § 7 (OpenFGA and Zanzibar)](https://github.com/saga-ed/saga-dash/blob/main/docs/auth/concepts.md#6-authorization-models)
+
+## Context
+
+Saga's authorization landscape today is RBAC inside rostering with coarse organization-scoping in resource services. As more services join the fleet (program-hub, qboard, rtsm) the gaps surface:
+
+- "List every program a tutor has access to" is RBAC-hostile (n×m role lookups).
+- District → school → cohort → student is a graph; representing it as flat roles requires a role per scope.
+- Per-resource permissions (this specific program, this specific room) exhaust the role table.
+
+OpenFGA (CNCF, Zanzibar-faithful) is the right shape for this hierarchy. The decision now is *how* it integrates: who owns the model, who writes tuples, where the source-of-truth lives.
+
+## Decision
+
+### The `.fga` DSL is the source of truth
+
+The model is defined in OpenFGA's DSL (`.fga` files), versioned in `packages/core/saga-authz-model/` in this repo. No service defines tuple types in code; all references go through generated TypeScript types or the FGA SDK.
+
+Changes to the model are PRs against this directory, reviewed by the auth working group. Backwards-incompatible model changes use OpenFGA's authorization model versioning (each `WriteAuthorizationModel` returns an immutable `authorization_model_id`); old IDs continue to serve in-flight requests.
+
+### Tuple writes flow through a sync worker, not services
+
+Application services never write tuples directly. A dedicated sync worker (in rostering or a dedicated service) subscribes to `iam.*` events from rostering and translates them to tuple writes. This keeps:
+
+- The model authoritative (no service-side drift).
+- Idempotency manageable (the sync worker dedupes).
+- Audit clarity (one path for tuple changes — easier to investigate divergence).
+
+Application services only call `check`, `list-objects`, `list-relations`. They do not call `write`, `delete`, `expand`.
+
+### Two-layer namespace split
+
+Per Saga IaC plugin convention:
+
+- **Identity types** — `tenant`, `user`, `group`, `role`. Define *who* can be granted access.
+- **Resource types** — `program`, `school`, `cohort`, `session`, `room`, `whiteboard`, `enrollment`. Define *what* access is granted to.
+
+Identity-side tuples come from rostering events. Resource-side tuples come from the resource owner's events (program-hub for programs, etc.) — but *only* via the same sync worker process, fanned out by event type.
+
+### Tenant binding is mandatory
+
+Every check is tenant-scoped. The tenant is part of the resource ID format (`program:district:42:program:7`) or expressed as a parent-of relation (`(tenant:district:42, parent, program:7)`). Cross-tenant checks fail by construction.
+
+### Model lives in `packages/core/saga-authz-model/`
+
+- `model.fga` — the DSL source
+- `generated/types.ts` — emitted TypeScript types for tuple keys (build step, runs in CI)
+- `README.md` — how to read it, how to extend it
+
+The package exports tuple-key builder helpers but does not bundle the FGA SDK — services depend on `@openfga/sdk` directly when they need runtime checks.
+
+### Today vs tomorrow
+
+| Phase | What ships |
+|---|---|
+| **Today (P1)** | `model.fga` committed, types generated. No FGA store deployed. Services do not yet call `check`. |
+| **Later** | FGA store deployed, sync worker built, services adopt `authz.check` resource-by-resource alongside the existing RBAC checks. Once parity is proven, RBAC is removed. |
+
+This decoupling means the *model* is reviewed, frozen, and ready before any service depends on it at runtime — minimizing rework.
+
+## Consequences
+
+**Positive:**
+- Single canonical authorization model across the fleet.
+- Reverse-index queries ("what can user X see?") become tractable.
+- Clean separation between *model* (here) and *data* (rostering / resource services).
+- Future additions (new resource types, new relations) are local PRs against this directory.
+
+**Negative:**
+- Two-step writes (event → sync worker → tuple) add latency for grant changes; mitigated by event speed and ≤30s caching.
+- Operational complexity — running an FGA store is a new system (when it deploys later).
+
+## Alternatives considered
+
+- **Define tuple types in service code:** rejected. Drift between services would be inevitable; central review impossible.
+- **Services write tuples directly on grant changes:** rejected. Multiple writers leads to inconsistency and audit complexity.
+- **Cedar instead of OpenFGA:** rejected for the primary use case. Cedar is great for policy rules; ReBAC for resource hierarchies. The plan reserves the right to add Cedar for non-resource policy later.
+- **Stay with RBAC + ABAC:** rejected. Concept primer § 6 details why this hits a wall as the resource graph grows.
+
+## References
+
+- OpenFGA documentation — https://openfga.dev/
+- Zanzibar paper — Pang et al., 2019
+- Concept primer § 7 — full background on tuples, types, and relations
+- ADR 0001 — JWT shape (`saga.tenant` claim feeds tenant-scoped checks)

--- a/docs/auth/adr/0006-spiffe-id-format.md
+++ b/docs/auth/adr/0006-spiffe-id-format.md
@@ -1,0 +1,94 @@
+# ADR 0006 — SPIFFE ID format for service identity
+
+**Status:** Accepted
+**Date:** 2026-05-07
+**Concept primer:** [`saga-dash/docs/auth/concepts.md` § 5 (Service-to-service authentication)](https://github.com/saga-ed/saga-dash/blob/main/docs/auth/concepts.md#5-service-to-service-authentication)
+
+## Context
+
+The fleet needs a consistent way to name workloads (services, workers, batch jobs). The name appears in:
+
+- mTLS certificate Subject Alternative Names (SANs) — ECS-to-ECS calls
+- JWT `sub` claim for service tokens
+- The `X-Saga-Caller` header value (ADR 0002)
+- Audit events (ADR 0004)
+- OpenFGA tuples that grant service-level access
+
+Different formats in different places make cross-system correlation painful. We need one format, adopted everywhere, that survives a future migration to SPIFFE/SPIRE for workload attestation.
+
+## Decision
+
+### Format
+
+Saga workload identifiers MUST follow the SPIFFE URI format:
+
+```
+spiffe://saga.<env>/<service>[/<component>]
+```
+
+Where:
+
+- `saga.<env>` is the **trust domain** — `saga.dev`, `saga.staging`, `saga.prod`. Tied 1:1 with environments; cross-env identifiers are forbidden.
+- `<service>` is the deployable unit name in kebab-case. Example: `iam-api`, `programs-api`, `rostering-events-relay`.
+- `<component>` is optional, used when one deployable contains multiple distinct workload identities (e.g., a worker pool inside an API service).
+
+### Examples
+
+| Workload | SPIFFE ID |
+|---|---|
+| iam-api in dev | `spiffe://saga.dev/iam-api` |
+| programs-api in prod | `spiffe://saga.prod/programs-api` |
+| rostering's outbox relay (separate workload identity) | `spiffe://saga.prod/iam-api/outbox-relay` |
+| FGA tuple sync worker | `spiffe://saga.prod/iam-api/fga-sync` |
+
+### User identifiers (related)
+
+Users are also SPIFFE-formatted to keep one identity convention across the fleet:
+
+```
+spiffe://saga.<env>/user/<uuid>
+```
+
+This appears in JWT `sub` for user tokens (ADR 0001). Users are not workloads in the SPIFFE sense, but using the same scheme keeps audit logs and tuples uniform.
+
+### Where it appears
+
+- **mTLS cert SAN** — ECS task certs include the workload's SPIFFE ID as a `URI` SAN entry. Receiving services parse it.
+- **`X-Saga-Caller` header** — exact SPIFFE ID string.
+- **JWT `sub`** — for service tokens, the calling workload's SPIFFE ID.
+- **JWT `aud`** — the receiving workload's SPIFFE ID.
+- **Audit events** — `caller.spiffeId` and `subject.sub`.
+- **OpenFGA tuples** — service-level grants use SPIFFE IDs as user-equivalent subjects.
+
+### Validation
+
+`@saga-ed/soa-auth-contracts` exports a parser that:
+
+1. Accepts only `spiffe://` URIs.
+2. Validates the trust domain matches the active environment (rejects cross-env).
+3. Splits service and optional component.
+4. Rejects empty or wildcarded components.
+
+## Consequences
+
+**Positive:**
+- One identifier format everywhere — easier debugging, log search, audit query.
+- SPIRE migration is a config change, not a rename: certs already carry the right SAN format.
+- Cross-env mistakes (a dev cert reaching a prod service) are caught at parse time.
+
+**Negative:**
+- Cert provisioning must include the SPIFFE URI SAN — a small addition to existing PKI templates.
+- The `spiffe://` prefix is verbose in logs; mitigated by uniform formatting (everyone reads it the same).
+
+## Alternatives considered
+
+- **Bare service names (`iam-api`):** rejected. No environment scoping; cross-env mistakes invisible until production damage.
+- **AWS ARN-style:** rejected. AWS-coupling makes Lambda + ECS uniformity awkward; not adopted broadly outside AWS.
+- **DNS names (`iam-api.prod.saga.internal`):** rejected. DNS conflates network address with identity; an attacker controlling DNS shouldn't get caller identity.
+
+## References
+
+- SPIFFE specification — https://spiffe.io/docs/latest/spiffe-about/spiffe-concepts/
+- SPIRE — reference implementation we may adopt later
+- ADR 0001 — JWT claim shape (`sub`, `aud` use this format)
+- ADR 0002 — Two-headers invariant (`X-Saga-Caller` carries this format)

--- a/docs/auth/adr/0006-spiffe-id-format.md
+++ b/docs/auth/adr/0006-spiffe-id-format.md
@@ -38,8 +38,8 @@ Where:
 |---|---|
 | iam-api in dev | `spiffe://saga.dev/iam-api` |
 | programs-api in prod | `spiffe://saga.prod/programs-api` |
-| rostering's outbox relay (separate workload identity) | `spiffe://saga.prod/iam-api/outbox-relay` |
-| FGA tuple sync worker | `spiffe://saga.prod/iam-api/fga-sync` |
+| iam-api's outbox relay (separate workload identity within iam-api) | `spiffe://saga.prod/iam-api/outbox-relay` |
+| FGA tuple sync worker (sub-workload of iam-api) | `spiffe://saga.prod/iam-api/fga-sync` |
 
 ### User identifiers (related)
 
@@ -62,12 +62,18 @@ This appears in JWT `sub` for user tokens (ADR 0001). Users are not workloads in
 
 ### Validation
 
-`@saga-ed/soa-auth-contracts` exports a parser that:
+`@saga-ed/soa-auth-contracts` exports two parsers:
 
-1. Accepts only `spiffe://` URIs.
-2. Validates the trust domain matches the active environment (rejects cross-env).
-3. Splits service and optional component.
-4. Rejects empty or wildcarded components.
+1. **`parseSpiffeId(input)`** — structural validation. Accepts only
+   `spiffe://saga.{dev|staging|prod}/...` URIs, splits service and
+   optional component, rejects empty/wildcarded components. Does **not**
+   compare the trust domain to the active environment — that's a
+   runtime concern the caller knows about, not a parse concern.
+2. **`spiffeIdForEnv(env)`** — schema factory bound to a specific env.
+   Use this at trust boundaries (mTLS handler, JWT verifier, audit
+   emitter) where cross-env tokens (a dev cert reaching prod) MUST be
+   rejected. Callers that use `parseSpiffeId` directly are responsible
+   for re-checking the env match if they care.
 
 ## Consequences
 

--- a/docs/auth/adr/0007-no-header-trust.md
+++ b/docs/auth/adr/0007-no-header-trust.md
@@ -1,0 +1,77 @@
+# ADR 0007 — No header-trusted identity in resource services
+
+**Status:** Accepted
+**Date:** 2026-05-07
+**Concept primer:** [`saga-dash/docs/auth/concepts.md` § 5 and § 8](https://github.com/saga-ed/saga-dash/blob/main/docs/auth/concepts.md#5-service-to-service-authentication)
+
+## Context
+
+Today's program-hub trusts an `x-organization-id` header to scope tenant access; rostering's tRPC accepts `x-user-id` as a fallback when session-cookie resolution fails. Both are defensible as dev conveniences and indefensible in production:
+
+- `x-user-id` lets a caller claim any userId if the cookie is missing — header injection equals account takeover.
+- `x-organization-id` lets a caller claim any tenant — and current code does not verify the user is actually a member of that tenant before answering queries.
+
+These two patterns are the highest-severity issues surfaced by the current-state audit (see plan.md). They predate the broader fleet-auth design and should be removed independently of (and earlier than) anything else.
+
+## Decision
+
+### Identity is *derived*, never *trusted*
+
+In production, identity facts (userId, tenantId, roles) MUST come from one of:
+
+1. The verified session (rostering's session store, today opaque-cookie-backed) — for end-user calls.
+2. The verified JWT `sub` and `saga.tenant` claims — when JWTs roll out (ADR 0001).
+3. The verified `X-Saga-Caller` (cryptographically attested per ADR 0002, enforce phase) — for service-to-service calls.
+
+**No header value supplied by the request body or headers is used as an identity fact without verification against one of the above.**
+
+### `x-user-id` is removed outright
+
+- No production scenario justifies it.
+- Dev mode runs with a real session via `auth.devLogin`.
+- Rostering's startup MUST refuse to boot in `NODE_ENV=production` if any code path enables this fallback.
+
+### `x-organization-id` becomes a *requested* tenant, never a *trusted* one
+
+When a request includes `x-organization-id`:
+
+1. The session/JWT determines the user's set of tenant memberships.
+2. The header is treated as the user's *requested context* for this call.
+3. The service accepts the header value only if it matches a tenant in the membership set.
+4. If the header value is not in the set, the request fails `FORBIDDEN`.
+5. If the header is missing, the service uses a deterministic default (e.g., the user's primary tenant) or rejects the request with `BAD_REQUEST`, depending on the procedure's contract.
+
+### Services ship test coverage for both rejection paths
+
+Every resource service that previously accepted these headers MUST add tests asserting:
+
+- A request with a fabricated `x-organization-id` for a non-member tenant is rejected with `FORBIDDEN`.
+- A request with no session and a fabricated `x-user-id` is rejected with `UNAUTHORIZED`.
+
+### Logging
+
+When a request is rejected for header/identity mismatch, the service emits `audit.decision.v1` with `decision = "deny"`, `reason = "tenant_mismatch"` or `"missing_session"`, and the rejected header value (the rejected value is fine to log; it's an attempted claim, not an asserted truth).
+
+## Consequences
+
+**Positive:**
+- Closes the largest current-state vulnerability surface immediately.
+- Decoupled from the larger seams (JWT, mTLS, FGA) — can land before any of them.
+- Audit log records show every rejected attempt, surfacing reconnaissance.
+
+**Negative:**
+- A small amount of dev tooling that injected `x-user-id` for convenience must move to using `auth.devLogin`. The convenience was unsafe in any case.
+- Procedures that did not previously care which tenant they ran in must now make the choice explicit.
+
+## Alternatives considered
+
+- **Sign the headers (HMAC over `x-user-id` etc.):** rejected. Adds complexity without solving the underlying problem; if you're going to sign something, sign a JWT.
+- **Trust headers only when the request originates from inside the VPC:** rejected. Network-perimeter trust is exactly the model that fails when an attacker gets inside (well-documented as defense-in-depth failure).
+- **Keep the headers but log heavily:** rejected. Logging an attack while letting it succeed is not a defense.
+
+## References
+
+- OWASP — Authentication Cheat Sheet (header-trust antipatterns)
+- ADR 0001 — JWT claim shape (the *correct* identity carrier)
+- ADR 0002 — Two-headers invariant
+- ADR 0004 — Audit event shape (deny-event logging)

--- a/packages/core/auth-contracts/README.md
+++ b/packages/core/auth-contracts/README.md
@@ -1,0 +1,47 @@
+# @saga-ed/soa-auth-contracts
+
+Canonical wire shapes for fleet authentication and authorization. Zod schemas, type definitions, and parsers — runtime-agnostic and crypto-free.
+
+## What this package owns
+
+| Module | Owns | ADR |
+|---|---|---|
+| `spiffe.ts` | SPIFFE ID format (`spiffe://saga.<env>/<service>[/<component>]`) | [0006](../../../docs/auth/adr/0006-spiffe-id-format.md) |
+| `jwt-claims.ts` | Canonical JWT claim shape (`iss`, `aud`, `sub`, `saga.tenant`, `saga.session`, `cnf`) | [0001](../../../docs/auth/adr/0001-jwt-claim-shape.md) |
+| `two-headers.ts` | `X-Saga-Caller` + `Authorization` headers; structural parser; mode flag | [0002](../../../docs/auth/adr/0002-two-headers-invariant.md) |
+| `audit-event.ts` | `audit.decision.v1` event schema; forbidden-field detector | [0004](../../../docs/auth/adr/0004-audit-event-shape.md) |
+
+## What this package does NOT own
+
+- JWT signing/verification (no `jose`, no key plumbing)
+- DPoP proof generation
+- mTLS cert verification
+- HMAC computation for event signatures
+- The audit log writer (logger today, Postgres later)
+- The OpenFGA model itself (sibling package `@saga-ed/saga-authz-model`)
+
+These belong in downstream packages that import these schemas.
+
+## Usage
+
+```ts
+import {
+    parseTwoHeaders,
+    CanonicalJwtClaimsSchema,
+    AuditDecisionEventSchema,
+    parseSpiffeId,
+} from '@saga-ed/soa-auth-contracts';
+
+// Structural parse of incoming headers
+const { status, callerSpiffeId, bearerToken } = parseTwoHeaders(req.headers);
+
+// Validate decoded JWT payload
+const claims = CanonicalJwtClaimsSchema.parse(decoded);
+
+// Validate an audit event before emit
+const event = AuditDecisionEventSchema.parse({ ... });
+```
+
+## Versioning
+
+This package follows the convention established by `@saga-ed/soa-event-envelope`: the v1 wire shape is treated as the contract; any change to the v1 shape requires coordinated migration. New shapes ship as `audit.decision.v2`, etc., side by side.

--- a/packages/core/auth-contracts/package.json
+++ b/packages/core/auth-contracts/package.json
@@ -1,0 +1,43 @@
+{
+    "name": "@saga-ed/soa-auth-contracts",
+    "version": "0.1.0-dev.1",
+    "private": false,
+    "type": "module",
+    "description": "Canonical wire shapes for fleet authentication and authorization. Zod schemas, type definitions, and parsers — runtime-agnostic, no crypto.",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
+        }
+    },
+    "files": ["dist"],
+    "scripts": {
+        "build": "tsup",
+        "check-types": "tsc --noEmit",
+        "test": "vitest run --passWithNoTests",
+        "lint": "eslint src/",
+        "clean": "rm -rf dist"
+    },
+    "dependencies": {
+        "zod": "3.25.67"
+    },
+    "devDependencies": {
+        "@saga-ed/soa-typescript-config": "workspace:*",
+        "@types/node": "^24.0.3",
+        "tsup": "^8.5.0",
+        "typescript": "5.8.2",
+        "vitest": "^1.6.1"
+    },
+    "publishConfig": {
+        "registry": "https://saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/",
+        "access": "public"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/saga-ed/soa.git",
+        "directory": "packages/core/auth-contracts"
+    },
+    "keywords": ["saga-soa", "auth", "jwt", "spiffe", "audit", "openfga"]
+}

--- a/packages/core/auth-contracts/package.json
+++ b/packages/core/auth-contracts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/soa-auth-contracts",
-    "version": "0.1.0-dev.1",
+    "version": "0.1.0-dev.2",
     "private": false,
     "type": "module",
     "description": "Canonical wire shapes for fleet authentication and authorization. Zod schemas, type definitions, and parsers — runtime-agnostic, no crypto.",

--- a/packages/core/auth-contracts/src/__tests__/audit-event.unit.test.ts
+++ b/packages/core/auth-contracts/src/__tests__/audit-event.unit.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import {
+    AUDIT_FORBIDDEN_FIELD_SUBSTRINGS,
+    AUDIT_SCHEMA_VERSION,
+    AuditDecisionEventSchema,
+    detectForbiddenField,
+} from '../audit-event.js';
+
+const validUserUuid = '00000000-0000-4000-8000-000000000001';
+
+const validEvent = {
+    schemaVersion: 'v1' as const,
+    eventType: 'authz.check' as const,
+    caller: { spiffeId: 'spiffe://saga.dev/programs-api' },
+    subject: {
+        sub: `spiffe://saga.dev/user/${validUserUuid}`,
+        tenantId: 'district:42',
+        sessionJti: 'session-1',
+        tokenJti: 'token-1',
+    },
+    resource: {
+        type: 'program',
+        id: '7',
+        tenantId: 'district:42',
+    },
+    action: 'view',
+    decision: 'allow' as const,
+    reason: null,
+    fgaCheck: {
+        relation: 'viewer',
+        object: 'program:7',
+    },
+    occurredAt: '2026-05-07T12:00:00.000Z',
+    correlationId: 'trace-abc',
+    causationId: null,
+    service: 'spiffe://saga.dev/programs-api',
+    env: 'dev' as const,
+};
+
+describe('AuditDecisionEventSchema', () => {
+    it('exports a stable schema version', () => {
+        expect(AUDIT_SCHEMA_VERSION).toBe('v1');
+    });
+
+    it('accepts a fully populated event', () => {
+        const result = AuditDecisionEventSchema.safeParse(validEvent);
+        expect(result.success).toBe(true);
+    });
+
+    it('accepts events with null caller (direct end-user call)', () => {
+        const event = { ...validEvent, caller: null };
+        expect(AuditDecisionEventSchema.safeParse(event).success).toBe(true);
+    });
+
+    it('accepts events with null subject (failed login)', () => {
+        const event = {
+            ...validEvent,
+            eventType: 'authn.login' as const,
+            subject: null,
+            resource: null,
+            decision: 'deny' as const,
+            reason: 'invalid_credentials',
+            fgaCheck: null,
+        };
+        expect(AuditDecisionEventSchema.safeParse(event).success).toBe(true);
+    });
+
+    it('rejects unknown eventType', () => {
+        const bad = { ...validEvent, eventType: 'authn.fancy_new' };
+        expect(AuditDecisionEventSchema.safeParse(bad).success).toBe(false);
+    });
+
+    it('rejects unknown decision', () => {
+        const bad = { ...validEvent, decision: 'maybe' };
+        expect(AuditDecisionEventSchema.safeParse(bad).success).toBe(false);
+    });
+
+    it('rejects unknown env', () => {
+        const bad = { ...validEvent, env: 'qa' };
+        expect(AuditDecisionEventSchema.safeParse(bad).success).toBe(false);
+    });
+
+    it('rejects malformed SPIFFE in subject.sub', () => {
+        const bad = {
+            ...validEvent,
+            subject: { ...validEvent.subject, sub: 'not-spiffe' },
+        };
+        expect(AuditDecisionEventSchema.safeParse(bad).success).toBe(false);
+    });
+
+    it('rejects malformed tenant id', () => {
+        const bad = {
+            ...validEvent,
+            subject: { ...validEvent.subject, tenantId: 'badformat' },
+        };
+        expect(AuditDecisionEventSchema.safeParse(bad).success).toBe(false);
+    });
+
+    it('rejects non-iso occurredAt', () => {
+        const bad = { ...validEvent, occurredAt: 'yesterday' };
+        expect(AuditDecisionEventSchema.safeParse(bad).success).toBe(false);
+    });
+});
+
+describe('detectForbiddenField', () => {
+    it('flags exact forbidden substrings', () => {
+        for (const sub of AUDIT_FORBIDDEN_FIELD_SUBSTRINGS) {
+            expect(detectForbiddenField(`some_${sub}_field`).length).toBeGreaterThan(0);
+        }
+    });
+
+    it('flags case-insensitively', () => {
+        expect(detectForbiddenField('Authorization').length).toBeGreaterThan(0);
+        expect(detectForbiddenField('Cookie').length).toBeGreaterThan(0);
+    });
+
+    it('does not flag innocuous names', () => {
+        expect(detectForbiddenField('user_id')).toEqual([]);
+        expect(detectForbiddenField('action')).toEqual([]);
+        expect(detectForbiddenField('decision')).toEqual([]);
+    });
+});

--- a/packages/core/auth-contracts/src/__tests__/jwt-claims.unit.test.ts
+++ b/packages/core/auth-contracts/src/__tests__/jwt-claims.unit.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+import {
+    audienceMatches,
+    CanonicalJwtClaimsSchema,
+    isExpired,
+    isServiceToken,
+    isUserToken,
+    TenantIdSchema,
+} from '../jwt-claims.js';
+
+const validUserUuid = '00000000-0000-4000-8000-000000000001';
+
+const validUserClaims = {
+    iss: 'https://auth.saga.dev',
+    aud: 'spiffe://saga.dev/programs-api',
+    sub: `spiffe://saga.dev/user/${validUserUuid}`,
+    iat: 1_700_000_000,
+    exp: 1_700_000_900,
+    jti: 'jti-1',
+    'saga.tenant': 'district:42',
+    'saga.session': 'session-abc',
+};
+
+const validServiceClaims = {
+    iss: 'https://auth.saga.dev',
+    aud: 'spiffe://saga.dev/programs-api',
+    sub: 'spiffe://saga.dev/iam-api/outbox-relay',
+    iat: 1_700_000_000,
+    exp: 1_700_000_900,
+    jti: 'jti-2',
+};
+
+describe('TenantIdSchema', () => {
+    it('accepts well-formed district id', () => {
+        expect(TenantIdSchema.safeParse('district:42').success).toBe(true);
+    });
+
+    it('rejects missing type prefix', () => {
+        expect(TenantIdSchema.safeParse('42').success).toBe(false);
+    });
+
+    it('rejects unknown type', () => {
+        expect(TenantIdSchema.safeParse('region:42').success).toBe(false);
+    });
+});
+
+describe('CanonicalJwtClaimsSchema', () => {
+    it('accepts a valid user-token claim set', () => {
+        expect(CanonicalJwtClaimsSchema.safeParse(validUserClaims).success).toBe(
+            true,
+        );
+    });
+
+    it('accepts a valid service-token claim set without tenant', () => {
+        expect(
+            CanonicalJwtClaimsSchema.safeParse(validServiceClaims).success,
+        ).toBe(true);
+    });
+
+    it('rejects missing required claim', () => {
+        const bad: Record<string, unknown> = { ...validUserClaims };
+        delete bad.sub;
+        expect(CanonicalJwtClaimsSchema.safeParse(bad).success).toBe(false);
+    });
+
+    it('rejects malformed sub', () => {
+        const bad = { ...validUserClaims, sub: 'not-spiffe' };
+        expect(CanonicalJwtClaimsSchema.safeParse(bad).success).toBe(false);
+    });
+
+    it('rejects malformed tenant', () => {
+        const bad = { ...validUserClaims, 'saga.tenant': 'badformat' };
+        expect(CanonicalJwtClaimsSchema.safeParse(bad).success).toBe(false);
+    });
+
+    it('rejects non-URL iss', () => {
+        const bad = { ...validUserClaims, iss: 'not-a-url' };
+        expect(CanonicalJwtClaimsSchema.safeParse(bad).success).toBe(false);
+    });
+
+    it('accepts string or array audience', () => {
+        const arr = {
+            ...validUserClaims,
+            aud: ['spiffe://saga.dev/programs-api', 'spiffe://saga.dev/qboard'],
+        };
+        expect(CanonicalJwtClaimsSchema.safeParse(arr).success).toBe(true);
+    });
+
+    it('accepts cnf.jkt for DPoP-bound tokens', () => {
+        const claims = {
+            ...validUserClaims,
+            cnf: { jkt: 'a'.repeat(43) },
+        };
+        expect(CanonicalJwtClaimsSchema.safeParse(claims).success).toBe(true);
+    });
+
+    it('rejects cnf.jkt that is too short', () => {
+        const claims = { ...validUserClaims, cnf: { jkt: 'tooshort' } };
+        expect(CanonicalJwtClaimsSchema.safeParse(claims).success).toBe(false);
+    });
+});
+
+describe('isUserToken / isServiceToken', () => {
+    it('detects user tokens', () => {
+        const parsed = CanonicalJwtClaimsSchema.parse(validUserClaims);
+        expect(isUserToken(parsed)).toBe(true);
+        expect(isServiceToken(parsed)).toBe(false);
+    });
+
+    it('detects service tokens', () => {
+        const parsed = CanonicalJwtClaimsSchema.parse(validServiceClaims);
+        expect(isServiceToken(parsed)).toBe(true);
+        expect(isUserToken(parsed)).toBe(false);
+    });
+});
+
+describe('audienceMatches', () => {
+    it('matches string audience', () => {
+        const c = CanonicalJwtClaimsSchema.parse(validUserClaims);
+        expect(audienceMatches(c, 'spiffe://saga.dev/programs-api')).toBe(true);
+        expect(audienceMatches(c, 'spiffe://saga.dev/qboard')).toBe(false);
+    });
+
+    it('matches one element of array audience', () => {
+        const claims = {
+            ...validUserClaims,
+            aud: ['spiffe://saga.dev/programs-api', 'spiffe://saga.dev/qboard'],
+        };
+        const c = CanonicalJwtClaimsSchema.parse(claims);
+        expect(audienceMatches(c, 'spiffe://saga.dev/qboard')).toBe(true);
+        expect(audienceMatches(c, 'spiffe://saga.dev/rtsm')).toBe(false);
+    });
+});
+
+describe('isExpired', () => {
+    it('treats past exp as expired', () => {
+        const c = { exp: 1_000 };
+        expect(isExpired(c, 2_000)).toBe(true);
+    });
+
+    it('treats future exp as not expired', () => {
+        const c = { exp: 2_000 };
+        expect(isExpired(c, 1_000)).toBe(false);
+    });
+
+    it('honors clock skew tolerance', () => {
+        // exp=1000, now=1010, default skew=30 → not expired (1010 - 30 < 1000? no, 980 < 1000 true → not expired)
+        expect(isExpired({ exp: 1_000 }, 1_010)).toBe(false);
+        // exp=1000, now=1031, default skew=30 → expired (1031 - 30 = 1001 > 1000)
+        expect(isExpired({ exp: 1_000 }, 1_031)).toBe(true);
+    });
+});

--- a/packages/core/auth-contracts/src/__tests__/spiffe.unit.test.ts
+++ b/packages/core/auth-contracts/src/__tests__/spiffe.unit.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+import {
+    asUserSpiffeId,
+    buildServiceSpiffeId,
+    buildUserSpiffeId,
+    parseSpiffeId,
+    parseSpiffeIdOrThrow,
+    SpiffeIdSchema,
+    spiffeIdForEnv,
+} from '../spiffe.js';
+
+describe('parseSpiffeId', () => {
+    it('parses a service SPIFFE ID', () => {
+        const id = parseSpiffeId('spiffe://saga.dev/iam-api');
+        expect(id).toMatchObject({
+            env: 'dev',
+            trustDomain: 'saga.dev',
+            service: 'iam-api',
+            component: null,
+        });
+    });
+
+    it('parses a service SPIFFE ID with component', () => {
+        const id = parseSpiffeId('spiffe://saga.prod/iam-api/outbox-relay');
+        expect(id).toMatchObject({
+            env: 'prod',
+            service: 'iam-api',
+            component: 'outbox-relay',
+        });
+    });
+
+    it('parses a user SPIFFE ID', () => {
+        const uuid = '00000000-0000-4000-8000-000000000001';
+        const id = parseSpiffeId(`spiffe://saga.dev/user/${uuid}`);
+        expect(id?.service).toBe('user');
+        expect(id?.component).toBe(uuid);
+    });
+
+    it('rejects non-saga trust domains', () => {
+        expect(parseSpiffeId('spiffe://other.example/foo')).toBeNull();
+    });
+
+    it('rejects unknown saga env', () => {
+        expect(parseSpiffeId('spiffe://saga.qa/iam-api')).toBeNull();
+    });
+
+    it('rejects malformed service names', () => {
+        expect(parseSpiffeId('spiffe://saga.dev/IamApi')).toBeNull();
+        expect(parseSpiffeId('spiffe://saga.dev/-leading')).toBeNull();
+        expect(parseSpiffeId('spiffe://saga.dev/trailing-')).toBeNull();
+    });
+
+    it('rejects extra segments', () => {
+        expect(parseSpiffeId('spiffe://saga.dev/a/b/c')).toBeNull();
+    });
+
+    it('rejects empty path', () => {
+        expect(parseSpiffeId('spiffe://saga.dev/')).toBeNull();
+        expect(parseSpiffeId('spiffe://saga.dev')).toBeNull();
+    });
+
+    it('rejects query and fragment', () => {
+        expect(parseSpiffeId('spiffe://saga.dev/iam-api?foo=bar')).toBeNull();
+        expect(parseSpiffeId('spiffe://saga.dev/iam-api#frag')).toBeNull();
+    });
+
+    it('rejects non-spiffe scheme', () => {
+        expect(parseSpiffeId('https://saga.dev/iam-api')).toBeNull();
+    });
+
+    it('rejects non-strings', () => {
+        expect(parseSpiffeId(null as unknown as string)).toBeNull();
+        expect(parseSpiffeId(undefined as unknown as string)).toBeNull();
+    });
+});
+
+describe('parseSpiffeIdOrThrow', () => {
+    it('returns parsed on valid', () => {
+        expect(parseSpiffeIdOrThrow('spiffe://saga.dev/iam-api')).toBeTruthy();
+    });
+
+    it('throws on invalid', () => {
+        expect(() => parseSpiffeIdOrThrow('not-a-spiffe-id')).toThrow();
+    });
+});
+
+describe('buildServiceSpiffeId', () => {
+    it('builds a basic service id', () => {
+        expect(
+            buildServiceSpiffeId({ env: 'dev', service: 'iam-api' }),
+        ).toBe('spiffe://saga.dev/iam-api');
+    });
+
+    it('builds with component', () => {
+        expect(
+            buildServiceSpiffeId({
+                env: 'prod',
+                service: 'iam-api',
+                component: 'fga-sync',
+            }),
+        ).toBe('spiffe://saga.prod/iam-api/fga-sync');
+    });
+
+    it('round-trips with parseSpiffeId', () => {
+        const built = buildServiceSpiffeId({
+            env: 'staging',
+            service: 'programs-api',
+        });
+        expect(parseSpiffeId(built)?.service).toBe('programs-api');
+    });
+
+    it('rejects bad service names', () => {
+        expect(() =>
+            buildServiceSpiffeId({ env: 'dev', service: 'BadName' }),
+        ).toThrow();
+    });
+});
+
+describe('buildUserSpiffeId', () => {
+    it('builds a user id', () => {
+        const uuid = '00000000-0000-4000-8000-000000000001';
+        expect(buildUserSpiffeId({ env: 'dev', userUuid: uuid })).toBe(
+            `spiffe://saga.dev/user/${uuid}`,
+        );
+    });
+
+    it('rejects bad UUIDs', () => {
+        expect(() =>
+            buildUserSpiffeId({ env: 'dev', userUuid: 'not-a-uuid' }),
+        ).toThrow();
+    });
+});
+
+describe('asUserSpiffeId', () => {
+    it('returns user identity for user IDs', () => {
+        const uuid = '00000000-0000-4000-8000-000000000001';
+        const parsed = parseSpiffeIdOrThrow(`spiffe://saga.dev/user/${uuid}`);
+        const user = asUserSpiffeId(parsed);
+        expect(user?.userUuid).toBe(uuid);
+    });
+
+    it('returns null for service IDs', () => {
+        const parsed = parseSpiffeIdOrThrow('spiffe://saga.dev/iam-api');
+        expect(asUserSpiffeId(parsed)).toBeNull();
+    });
+
+    it('returns null when component is not a UUID', () => {
+        const parsed = parseSpiffeIdOrThrow('spiffe://saga.dev/user/notauuid');
+        expect(asUserSpiffeId(parsed)).toBeNull();
+    });
+});
+
+describe('SpiffeIdSchema', () => {
+    it('parses valid SPIFFE IDs', () => {
+        expect(
+            SpiffeIdSchema.safeParse('spiffe://saga.dev/iam-api').success,
+        ).toBe(true);
+    });
+
+    it('rejects invalid SPIFFE IDs', () => {
+        expect(SpiffeIdSchema.safeParse('not-spiffe').success).toBe(false);
+    });
+});
+
+describe('spiffeIdForEnv', () => {
+    it('accepts matching env', () => {
+        const schema = spiffeIdForEnv('prod');
+        expect(schema.safeParse('spiffe://saga.prod/iam-api').success).toBe(true);
+    });
+
+    it('rejects mismatched env', () => {
+        const schema = spiffeIdForEnv('prod');
+        expect(schema.safeParse('spiffe://saga.dev/iam-api').success).toBe(
+            false,
+        );
+    });
+});

--- a/packages/core/auth-contracts/src/__tests__/two-headers.unit.test.ts
+++ b/packages/core/auth-contracts/src/__tests__/two-headers.unit.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
+    decideTwoHeaders,
     HEADER_AUTHORIZATION,
     HEADER_SAGA_CALLER,
     isComplete,
     parseTwoHeaders,
+    TWO_HEADERS_METRIC,
     TwoHeadersModeSchema,
 } from '../two-headers.js';
 
@@ -112,5 +114,89 @@ describe('TwoHeadersModeSchema', () => {
 
     it('rejects unknown modes', () => {
         expect(TwoHeadersModeSchema.safeParse('strict').success).toBe(false);
+    });
+});
+
+describe('decideTwoHeaders', () => {
+    const validCaller = 'spiffe://saga.dev/programs-api';
+    const validBearer = 'Bearer eyJhbGciOiJFUzI1NiJ9.payload.signature';
+
+    const completeHeaders = {
+        [HEADER_SAGA_CALLER]: validCaller,
+        [HEADER_AUTHORIZATION]: validBearer,
+    };
+
+    it('exports the canonical metric name', () => {
+        expect(TWO_HEADERS_METRIC).toBe('saga_two_headers_missing_total');
+    });
+
+    it('off mode always allows', () => {
+        const d = decideTwoHeaders({}, 'off');
+        expect(d.action).toBe('allow');
+        expect(d.metricReason).toBeUndefined();
+    });
+
+    it('off mode allows even malformed headers', () => {
+        const d = decideTwoHeaders(
+            { [HEADER_SAGA_CALLER]: 'garbage' },
+            'off',
+        );
+        expect(d.action).toBe('allow');
+    });
+
+    it('shadow mode allows complete headers', () => {
+        const d = decideTwoHeaders(completeHeaders, 'shadow');
+        expect(d.action).toBe('allow');
+        expect(d.metricReason).toBeUndefined();
+    });
+
+    it('shadow mode emits log + metric on missing caller', () => {
+        const d = decideTwoHeaders(
+            { [HEADER_AUTHORIZATION]: validBearer },
+            'shadow',
+        );
+        expect(d.action).toBe('log');
+        expect(d.metricReason).toBe('caller_missing');
+    });
+
+    it('shadow mode emits log + metric on malformed caller', () => {
+        const d = decideTwoHeaders(
+            { [HEADER_SAGA_CALLER]: 'not-spiffe', [HEADER_AUTHORIZATION]: validBearer },
+            'shadow',
+        );
+        expect(d.action).toBe('log');
+        expect(d.metricReason).toBe('caller_malformed');
+    });
+
+    it('enforce mode allows complete headers', () => {
+        const d = decideTwoHeaders(completeHeaders, 'enforce');
+        expect(d.action).toBe('allow');
+    });
+
+    it('enforce mode rejects on missing subject', () => {
+        const d = decideTwoHeaders(
+            { [HEADER_SAGA_CALLER]: validCaller },
+            'enforce',
+        );
+        expect(d.action).toBe('reject');
+        expect(d.metricReason).toBe('subject_missing');
+    });
+
+    it('enforce mode rejects on malformed subject', () => {
+        const d = decideTwoHeaders(
+            {
+                [HEADER_SAGA_CALLER]: validCaller,
+                [HEADER_AUTHORIZATION]: 'Basic dXNlcjpwYXNz',
+            },
+            'enforce',
+        );
+        expect(d.action).toBe('reject');
+        expect(d.metricReason).toBe('subject_malformed');
+    });
+
+    it('parse result is always exposed for caller introspection', () => {
+        const d = decideTwoHeaders(completeHeaders, 'shadow');
+        expect(d.parse.callerSpiffeId).toBe(validCaller);
+        expect(d.parse.bearerToken).toBeTruthy();
     });
 });

--- a/packages/core/auth-contracts/src/__tests__/two-headers.unit.test.ts
+++ b/packages/core/auth-contracts/src/__tests__/two-headers.unit.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import {
+    HEADER_AUTHORIZATION,
+    HEADER_SAGA_CALLER,
+    isComplete,
+    parseTwoHeaders,
+    TwoHeadersModeSchema,
+} from '../two-headers.js';
+
+describe('parseTwoHeaders', () => {
+    const validCaller = 'spiffe://saga.dev/programs-api';
+    const validBearer = 'Bearer eyJhbGciOiJFUzI1NiJ9.payload.signature';
+
+    it('returns ok with both headers present and well-formed', () => {
+        const result = parseTwoHeaders({
+            [HEADER_SAGA_CALLER]: validCaller,
+            [HEADER_AUTHORIZATION]: validBearer,
+        });
+        expect(result.status).toBe('ok');
+        expect(isComplete(result)).toBe(true);
+        expect(result.callerSpiffeId).toBe(validCaller);
+        expect(result.bearerToken).toBe(
+            'eyJhbGciOiJFUzI1NiJ9.payload.signature',
+        );
+        expect(result.issues).toHaveLength(0);
+    });
+
+    it('handles lowercase header keys (Node http normalizes)', () => {
+        const result = parseTwoHeaders({
+            'x-saga-caller': validCaller,
+            authorization: validBearer,
+        });
+        expect(result.status).toBe('ok');
+    });
+
+    it('reports caller missing', () => {
+        const result = parseTwoHeaders({
+            [HEADER_AUTHORIZATION]: validBearer,
+        });
+        expect(result.status).toBe('caller_missing');
+        expect(result.callerSpiffeId).toBeNull();
+        expect(result.bearerToken).toBe(
+            'eyJhbGciOiJFUzI1NiJ9.payload.signature',
+        );
+    });
+
+    it('reports caller malformed', () => {
+        const result = parseTwoHeaders({
+            [HEADER_SAGA_CALLER]: 'not-a-spiffe-id',
+            [HEADER_AUTHORIZATION]: validBearer,
+        });
+        expect(result.status).toBe('caller_malformed');
+        expect(result.issues[0]).toContain('not a valid SPIFFE ID');
+    });
+
+    it('reports subject missing', () => {
+        const result = parseTwoHeaders({
+            [HEADER_SAGA_CALLER]: validCaller,
+        });
+        expect(result.status).toBe('subject_missing');
+        expect(result.bearerToken).toBeNull();
+    });
+
+    it('reports subject malformed (non-Bearer scheme)', () => {
+        const result = parseTwoHeaders({
+            [HEADER_SAGA_CALLER]: validCaller,
+            [HEADER_AUTHORIZATION]: 'Basic dXNlcjpwYXNz',
+        });
+        expect(result.status).toBe('subject_malformed');
+    });
+
+    it('returns the first detected status when both sides fail', () => {
+        const result = parseTwoHeaders({});
+        expect(result.status).toBe('caller_missing');
+        expect(result.issues).toHaveLength(2);
+    });
+
+    it('works with the Web Headers interface', () => {
+        const headers = new Headers({
+            [HEADER_SAGA_CALLER]: validCaller,
+            [HEADER_AUTHORIZATION]: validBearer,
+        });
+        const result = parseTwoHeaders(headers);
+        expect(result.status).toBe('ok');
+    });
+
+    it('strips Bearer prefix case-insensitively', () => {
+        const result = parseTwoHeaders({
+            [HEADER_SAGA_CALLER]: validCaller,
+            [HEADER_AUTHORIZATION]: 'bearer abc.def.ghi',
+        });
+        expect(result.status).toBe('ok');
+        expect(result.bearerToken).toBe('abc.def.ghi');
+    });
+
+    it('treats array header values as the first element', () => {
+        const result = parseTwoHeaders({
+            [HEADER_SAGA_CALLER]: [validCaller, 'extra'],
+            [HEADER_AUTHORIZATION]: validBearer,
+        });
+        expect(result.status).toBe('ok');
+        expect(result.callerSpiffeId).toBe(validCaller);
+    });
+});
+
+describe('TwoHeadersModeSchema', () => {
+    it('accepts the three modes', () => {
+        expect(TwoHeadersModeSchema.safeParse('off').success).toBe(true);
+        expect(TwoHeadersModeSchema.safeParse('shadow').success).toBe(true);
+        expect(TwoHeadersModeSchema.safeParse('enforce').success).toBe(true);
+    });
+
+    it('rejects unknown modes', () => {
+        expect(TwoHeadersModeSchema.safeParse('strict').success).toBe(false);
+    });
+});

--- a/packages/core/auth-contracts/src/audit-event.ts
+++ b/packages/core/auth-contracts/src/audit-event.ts
@@ -49,7 +49,12 @@ export const AuditSubjectSchema = z
         sub: SpiffeIdSchema,
         tenantId: TenantIdSchema.nullable(),
         sessionJti: z.string().min(1).nullable(),
-        tokenJti: z.string().min(1),
+        // Nullable because authn.login emits a subject before any token
+        // is issued. For post-login events (mutations, logout, refresh),
+        // the JTI is required by convention but the schema does not
+        // enforce it — too brittle to fail validation on emit-site bugs
+        // when the audit row is otherwise valuable.
+        tokenJti: z.string().min(1).nullable(),
     })
     .strip();
 export type AuditSubject = z.infer<typeof AuditSubjectSchema>;

--- a/packages/core/auth-contracts/src/audit-event.ts
+++ b/packages/core/auth-contracts/src/audit-event.ts
@@ -1,0 +1,151 @@
+import { z } from 'zod';
+import { SpiffeIdSchema } from './spiffe.js';
+import { TenantIdSchema } from './jwt-claims.js';
+
+/**
+ * `audit.decision.v1` — canonical fleet audit event shape per ADR 0004.
+ *
+ * Every service emits this shape on authn / authz / mutation / admin events.
+ * The writer (a logger today, a hash-chained Postgres later) consumes the
+ * shape; callers depend on this schema, not the writer.
+ */
+
+export const AUDIT_SCHEMA_VERSION = 'v1' as const;
+
+export const AuditEventTypeSchema = z.enum([
+    'authn.login',
+    'authn.logout',
+    'authn.refresh',
+    'authn.token_exchange',
+    'authz.check',
+    'authz.deny',
+    'mutation.create',
+    'mutation.update',
+    'mutation.delete',
+    'admin.role_grant',
+    'admin.role_revoke',
+    'admin.config_change',
+]);
+
+export type AuditEventType = z.infer<typeof AuditEventTypeSchema>;
+
+/**
+ * Caller workload identity. Null only for direct end-user calls (e.g., a
+ * browser hitting the auth-api directly during login).
+ */
+export const AuditCallerSchema = z
+    .object({
+        spiffeId: SpiffeIdSchema,
+    })
+    .strip();
+export type AuditCaller = z.infer<typeof AuditCallerSchema>;
+
+/**
+ * Subject identity. Null only for unauthenticated events (e.g., a failed
+ * login before the user is identified).
+ */
+export const AuditSubjectSchema = z
+    .object({
+        sub: SpiffeIdSchema,
+        tenantId: TenantIdSchema.nullable(),
+        sessionJti: z.string().min(1).nullable(),
+        tokenJti: z.string().min(1),
+    })
+    .strip();
+export type AuditSubject = z.infer<typeof AuditSubjectSchema>;
+
+/**
+ * Resource being acted upon. Null for events that have no target resource
+ * (e.g., `authn.login`).
+ */
+export const AuditResourceSchema = z
+    .object({
+        type: z.string().min(1),
+        id: z.string().min(1),
+        tenantId: TenantIdSchema.nullable(),
+    })
+    .strip();
+export type AuditResource = z.infer<typeof AuditResourceSchema>;
+
+/**
+ * OpenFGA check trace. Captured for `authz.*` events; `consultedTuples` is
+ * optional because high-volume paths may omit it for cost.
+ */
+export const AuditFgaCheckSchema = z
+    .object({
+        relation: z.string().min(1),
+        object: z.string().min(1),
+        consultedTuples: z.array(z.string().min(1)).optional(),
+    })
+    .strip();
+export type AuditFgaCheck = z.infer<typeof AuditFgaCheckSchema>;
+
+/**
+ * Reason codes. Free-form strings, but lint encourages structured values.
+ * Common codes:
+ *   - "no_tuple"          — FGA returned deny because no relation path exists
+ *   - "expired_token"
+ *   - "tenant_mismatch"   — requested tenant not in user's membership set
+ *   - "missing_session"
+ *   - "missing_caller"    — two-headers caller missing
+ *   - "signature_invalid" — for event-signature rejections
+ */
+export const AuditReasonSchema = z.string().min(1).nullable();
+
+export const AuditDecisionSchema = z.enum(['allow', 'deny']);
+
+export const AuditEnvSchema = z.enum(['dev', 'staging', 'prod']);
+export type AuditEnv = z.infer<typeof AuditEnvSchema>;
+
+export const AuditDecisionEventSchema = z
+    .object({
+        schemaVersion: z.literal(AUDIT_SCHEMA_VERSION),
+        eventType: AuditEventTypeSchema,
+        caller: AuditCallerSchema.nullable(),
+        subject: AuditSubjectSchema.nullable(),
+        resource: AuditResourceSchema.nullable(),
+        action: z.string().min(1),
+        decision: AuditDecisionSchema,
+        reason: AuditReasonSchema,
+        fgaCheck: AuditFgaCheckSchema.nullable(),
+        occurredAt: z.string().datetime({ offset: true }),
+        correlationId: z.string().min(1),
+        causationId: z.string().min(1).nullable(),
+        service: SpiffeIdSchema,
+        env: AuditEnvSchema,
+    })
+    .strip();
+
+export type AuditDecisionEvent = z.infer<typeof AuditDecisionEventSchema>;
+
+/**
+ * Field name allowlist used by the runtime audit emitter to fail fast if
+ * a caller passes a field that resembles a forbidden value (token, password,
+ * full PII). The emitter rejects keys whose normalized name matches any
+ * of these substrings — this is a soft guard, not a substitute for
+ * disciplined emission sites.
+ *
+ * See ADR 0004 § "What MUST NOT appear in audit events".
+ */
+export const AUDIT_FORBIDDEN_FIELD_SUBSTRINGS: ReadonlyArray<string> = [
+    'password',
+    'secret',
+    'access_token',
+    'refresh_token',
+    'bearer',
+    'authorization',
+    'cookie',
+    'mfa_code',
+    'otp',
+    'credit_card',
+    'ssn',
+];
+
+/**
+ * Returns the substrings matched by a candidate key name. An emitter that
+ * sees a non-empty result should drop the key (and log the drop).
+ */
+export function detectForbiddenField(key: string): ReadonlyArray<string> {
+    const lower = key.toLowerCase();
+    return AUDIT_FORBIDDEN_FIELD_SUBSTRINGS.filter((sub) => lower.includes(sub));
+}

--- a/packages/core/auth-contracts/src/index.ts
+++ b/packages/core/auth-contracts/src/index.ts
@@ -1,0 +1,15 @@
+/**
+ * @saga-ed/soa-auth-contracts
+ *
+ * Canonical wire shapes for fleet authentication and authorization.
+ * See docs/auth/ for the ADRs that ground these schemas.
+ *
+ * This package is runtime-agnostic and crypto-free. Verification of
+ * signatures, signing of tokens, and key management live in downstream
+ * packages that import these schemas.
+ */
+
+export * from './spiffe.js';
+export * from './jwt-claims.js';
+export * from './two-headers.js';
+export * from './audit-event.js';

--- a/packages/core/auth-contracts/src/jwt-claims.ts
+++ b/packages/core/auth-contracts/src/jwt-claims.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { SpiffeIdSchema } from './spiffe.js';
+import { asUserSpiffeId, parseSpiffeId, SpiffeIdSchema } from './spiffe.js';
 
 /**
  * Canonical JWT claim shape per ADR 0001.
@@ -80,15 +80,16 @@ export type CanonicalJwtClaims = z.infer<typeof CanonicalJwtClaimsSchema>;
 
 /**
  * Distinguish user tokens from service tokens by inspecting the parsed
- * claim shape:
- *   - User token: `sub` is `spiffe://saga.<env>/user/<uuid>`, tenant is set.
- *   - Service token: `sub` is `spiffe://saga.<env>/<service>[/<component>]`,
- *     tenant is omitted/null.
+ * SPIFFE id of the `sub` claim:
+ *   - User token: `sub` is `spiffe://saga.<env>/user/<uuid>`.
+ *   - Service token: anything else (workload SPIFFE id).
  *
- * This helper does not parse — it operates on already-validated claims.
+ * Reuses the canonical `parseSpiffeId` + `asUserSpiffeId` so the
+ * predicate cannot drift from the SPIFFE format definition (ADR 0006).
  */
 export function isUserToken(claims: CanonicalJwtClaims): boolean {
-    return /^spiffe:\/\/saga\.[^/]+\/user\/[0-9a-f-]{36}$/i.test(claims.sub);
+    const parsed = parseSpiffeId(claims.sub);
+    return parsed !== null && asUserSpiffeId(parsed) !== null;
 }
 
 export function isServiceToken(claims: CanonicalJwtClaims): boolean {

--- a/packages/core/auth-contracts/src/jwt-claims.ts
+++ b/packages/core/auth-contracts/src/jwt-claims.ts
@@ -1,0 +1,120 @@
+import { z } from 'zod';
+import { SpiffeIdSchema } from './spiffe.js';
+
+/**
+ * Canonical JWT claim shape per ADR 0001.
+ *
+ * This file defines schemas; it does not perform crypto. Verification of
+ * signature, audience, and expiry happens at runtime in services that import
+ * this schema.
+ */
+
+export const TENANT_ID_RE = /^(district|school|cohort):[a-zA-Z0-9_-]+$/;
+
+/**
+ * `saga.tenant` claim — tenant binding.
+ *
+ * Format: `<tenant-type>:<id>` where tenant-type is one of district/school/cohort.
+ * For the v1 plan only `district:<id>` is in use, but the format reserves
+ * room for narrower scopes.
+ */
+export const TenantIdSchema = z
+    .string()
+    .regex(TENANT_ID_RE, 'tenant must match <type>:<id>');
+export type TenantId = z.infer<typeof TenantIdSchema>;
+
+/**
+ * `cnf` claim per RFC 7800 / RFC 9449.
+ *
+ * Today only `jkt` (JWK SHA-256 thumbprint) is supported. Future expansion
+ * (e.g., x5t#S256 for mTLS-bound) lives here.
+ */
+export const ConfirmationSchema = z
+    .object({
+        jkt: z.string().min(32, 'cnf.jkt must be a JWK thumbprint'),
+    })
+    .strip();
+export type Confirmation = z.infer<typeof ConfirmationSchema>;
+
+/**
+ * Standard JWT claims (RFC 7519) we depend on.
+ */
+const StandardClaimsSchema = z.object({
+    iss: z.string().url('iss must be an absolute URL'),
+    aud: z.union([z.string().min(1), z.array(z.string().min(1)).nonempty()]),
+    sub: SpiffeIdSchema,
+    iat: z.number().int().nonnegative(),
+    exp: z.number().int().positive(),
+    jti: z.string().min(1),
+});
+
+/**
+ * Saga-namespaced custom claims.
+ *
+ * - `saga.tenant` is required for user tokens, omitted/null for service tokens
+ *   (a service token represents a workload, not a user-in-tenant context).
+ * - `saga.session` ties an issued token back to the server-side session record.
+ * - `saga.scope` narrows what the token is allowed to do — used during token
+ *   exchange (RFC 8693) when scope is reduced for a downstream call.
+ */
+const SagaClaimsSchema = z.object({
+    'saga.tenant': TenantIdSchema.nullable().optional(),
+    'saga.session': z.string().min(1).nullable().optional(),
+    'saga.scope': z.array(z.string().min(1)).optional(),
+});
+
+/**
+ * Full canonical claim schema.
+ *
+ * `cnf` is optional today (plain bearer); ADR 0001 calls it out as required
+ * for DPoP-bound tokens. Services that require DPoP-bound tokens validate
+ * `cnf` independently after parsing.
+ */
+export const CanonicalJwtClaimsSchema = StandardClaimsSchema.merge(
+    SagaClaimsSchema,
+).extend({
+    cnf: ConfirmationSchema.optional(),
+});
+
+export type CanonicalJwtClaims = z.infer<typeof CanonicalJwtClaimsSchema>;
+
+/**
+ * Distinguish user tokens from service tokens by inspecting the parsed
+ * claim shape:
+ *   - User token: `sub` is `spiffe://saga.<env>/user/<uuid>`, tenant is set.
+ *   - Service token: `sub` is `spiffe://saga.<env>/<service>[/<component>]`,
+ *     tenant is omitted/null.
+ *
+ * This helper does not parse — it operates on already-validated claims.
+ */
+export function isUserToken(claims: CanonicalJwtClaims): boolean {
+    return /^spiffe:\/\/saga\.[^/]+\/user\/[0-9a-f-]{36}$/i.test(claims.sub);
+}
+
+export function isServiceToken(claims: CanonicalJwtClaims): boolean {
+    return !isUserToken(claims);
+}
+
+/**
+ * Audience match. Accepts both string and array audience claims (RFC 7519).
+ * Returns true if `expected` is the audience or one member of the array.
+ */
+export function audienceMatches(
+    claims: Pick<CanonicalJwtClaims, 'aud'>,
+    expected: string,
+): boolean {
+    if (typeof claims.aud === 'string') return claims.aud === expected;
+    return claims.aud.includes(expected);
+}
+
+/**
+ * Expiry check with optional clock skew tolerance (default 30s per ADR 0001).
+ * Returns true when the token has expired.
+ */
+export function isExpired(
+    claims: Pick<CanonicalJwtClaims, 'exp'>,
+    nowSeconds: number = Math.floor(Date.now() / 1000),
+    skewSeconds = 30,
+): boolean {
+    return nowSeconds - skewSeconds > claims.exp;
+}

--- a/packages/core/auth-contracts/src/spiffe.ts
+++ b/packages/core/auth-contracts/src/spiffe.ts
@@ -1,0 +1,168 @@
+import { z } from 'zod';
+
+/**
+ * SPIFFE ID format: spiffe://saga.<env>/<service>[/<component>]
+ *
+ * See ADR 0006. We restrict the trust domain to the `saga.*` family
+ * so a workload identifier can only ever come from a Saga environment.
+ */
+
+export const SAGA_ENVS = ['dev', 'staging', 'prod'] as const;
+export type SagaEnv = (typeof SAGA_ENVS)[number];
+
+const SAGA_TRUST_DOMAIN_RE = /^saga\.(dev|staging|prod)$/;
+const SERVICE_NAME_RE = /^[a-z][a-z0-9-]*[a-z0-9]$/;
+// Components may be UUIDs (user IDs) so they can start with a digit.
+const COMPONENT_NAME_RE = /^[a-z0-9][a-z0-9-]*[a-z0-9]$/;
+
+export interface ParsedSpiffeId {
+    readonly trustDomain: `saga.${SagaEnv}`;
+    readonly env: SagaEnv;
+    readonly service: string;
+    readonly component: string | null;
+    readonly raw: string;
+}
+
+export interface ParsedSpiffeUserId extends ParsedSpiffeId {
+    readonly service: 'user';
+    readonly component: string;
+    readonly userUuid: string;
+}
+
+const UUID_RE =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Parse a SPIFFE ID string. Returns null if invalid; throwing variants
+ * are exposed via parseSpiffeIdOrThrow.
+ *
+ * Valid examples:
+ *   spiffe://saga.dev/iam-api
+ *   spiffe://saga.prod/programs-api/outbox-relay
+ *   spiffe://saga.prod/user/00000000-0000-4000-8000-000000000001
+ */
+export function parseSpiffeId(input: string): ParsedSpiffeId | null {
+    if (typeof input !== 'string' || !input.startsWith('spiffe://')) {
+        return null;
+    }
+    let url: URL;
+    try {
+        url = new URL(input);
+    } catch {
+        return null;
+    }
+    if (url.protocol !== 'spiffe:' || url.search !== '' || url.hash !== '') {
+        return null;
+    }
+    const trustDomain = url.host;
+    const match = trustDomain.match(SAGA_TRUST_DOMAIN_RE);
+    if (!match) return null;
+    const env = match[1] as SagaEnv;
+
+    const path = url.pathname.replace(/^\//, '');
+    if (path.length === 0) return null;
+    const segments = path.split('/');
+    if (segments.length < 1 || segments.length > 2) return null;
+    const service = segments[0];
+    const component = segments[1] ?? null;
+    if (service === undefined || !SERVICE_NAME_RE.test(service)) return null;
+    if (component !== null && !COMPONENT_NAME_RE.test(component)) return null;
+
+    return {
+        trustDomain: `saga.${env}` as const,
+        env,
+        service,
+        component,
+        raw: input,
+    };
+}
+
+export function parseSpiffeIdOrThrow(input: string): ParsedSpiffeId {
+    const parsed = parseSpiffeId(input);
+    if (!parsed) {
+        throw new Error(`Invalid SPIFFE ID: ${JSON.stringify(input)}`);
+    }
+    return parsed;
+}
+
+/**
+ * Build a service workload SPIFFE ID. Validates inputs.
+ */
+export function buildServiceSpiffeId(args: {
+    env: SagaEnv;
+    service: string;
+    component?: string;
+}): string {
+    if (!SERVICE_NAME_RE.test(args.service)) {
+        throw new Error(`Invalid service name: ${JSON.stringify(args.service)}`);
+    }
+    if (args.component !== undefined && !COMPONENT_NAME_RE.test(args.component)) {
+        throw new Error(
+            `Invalid component name: ${JSON.stringify(args.component)}`,
+        );
+    }
+    const tail =
+        args.component === undefined ? args.service : `${args.service}/${args.component}`;
+    return `spiffe://saga.${args.env}/${tail}`;
+}
+
+/**
+ * Build a user SPIFFE ID. The user UUID becomes the component segment
+ * under the reserved service name `user`.
+ */
+export function buildUserSpiffeId(args: {
+    env: SagaEnv;
+    userUuid: string;
+}): string {
+    if (!UUID_RE.test(args.userUuid)) {
+        throw new Error(
+            `Invalid user UUID: ${JSON.stringify(args.userUuid)}`,
+        );
+    }
+    return `spiffe://saga.${args.env}/user/${args.userUuid}`;
+}
+
+/**
+ * Refine a parsed SPIFFE ID into a user identifier, or null if it is not
+ * a user (service !== 'user' or component is not a UUID).
+ */
+export function asUserSpiffeId(
+    id: ParsedSpiffeId,
+): ParsedSpiffeUserId | null {
+    if (id.service !== 'user') return null;
+    if (id.component === null) return null;
+    if (!UUID_RE.test(id.component)) return null;
+    return {
+        ...id,
+        service: 'user',
+        component: id.component,
+        userUuid: id.component,
+    };
+}
+
+/**
+ * Zod schema for use inside larger objects (e.g., the `sub` field of a JWT
+ * claim schema). Validates structure but does not check trust-domain match
+ * against an active environment — that is a runtime concern, not a parse
+ * concern.
+ */
+export const SpiffeIdSchema = z
+    .string()
+    .refine((s) => parseSpiffeId(s) !== null, {
+        message:
+            'Invalid SPIFFE ID (expected spiffe://saga.<env>/<service>[/<component>])',
+    });
+
+/**
+ * Stricter schema bound to a known environment. Use at trust boundaries
+ * where you know which env you are running in.
+ */
+export function spiffeIdForEnv(env: SagaEnv) {
+    return z.string().refine(
+        (s) => {
+            const p = parseSpiffeId(s);
+            return p !== null && p.env === env;
+        },
+        { message: `SPIFFE ID must be in trust domain saga.${env}` },
+    );
+}

--- a/packages/core/auth-contracts/src/two-headers.ts
+++ b/packages/core/auth-contracts/src/two-headers.ts
@@ -1,0 +1,147 @@
+import { z } from 'zod';
+import { SpiffeIdSchema, parseSpiffeId } from './spiffe.js';
+
+/**
+ * Two-headers invariant per ADR 0002.
+ *
+ * Every internal call carries:
+ *   - X-Saga-Caller        — the workload identity (SPIFFE ID).
+ *   - Authorization        — the subject identity (Bearer JWT).
+ *
+ * This file owns the canonical header names and the structural parsers.
+ * It does NOT verify cryptographic claims — that's the job of the runtime
+ * verifier package (lands later).
+ */
+
+export const HEADER_SAGA_CALLER = 'X-Saga-Caller' as const;
+export const HEADER_AUTHORIZATION = 'Authorization' as const;
+
+/**
+ * Lowercase variants for use against headers normalized by Node http (which
+ * lowercases all header names).
+ */
+export const HEADER_SAGA_CALLER_LOWER = 'x-saga-caller' as const;
+export const HEADER_AUTHORIZATION_LOWER = 'authorization' as const;
+
+export const SagaCallerHeaderSchema = SpiffeIdSchema;
+
+/**
+ * Result of structural parsing. Each side independently can be present,
+ * absent, or malformed. A request with only one side present is
+ * structurally incomplete and triggers the shadow-mode metric.
+ */
+export type TwoHeadersParseStatus =
+    | 'ok'
+    | 'caller_missing'
+    | 'caller_malformed'
+    | 'subject_missing'
+    | 'subject_malformed';
+
+export interface TwoHeadersParseResult {
+    readonly status: TwoHeadersParseStatus;
+    readonly callerSpiffeId: string | null;
+    /**
+     * Bearer token raw string (the JWT). Present only when the header was
+     * present and well-formed at the bearer-scheme level. Claim-level
+     * validation is the verifier's job, not ours.
+     */
+    readonly bearerToken: string | null;
+    readonly issues: ReadonlyArray<string>;
+}
+
+const HEADER_GET = (
+    headers: HeadersLike,
+    name: string,
+): string | null => {
+    if (typeof (headers as Headers).get === 'function') {
+        return (headers as Headers).get(name);
+    }
+    const record = headers as Record<string, string | string[] | undefined>;
+    const exact = record[name];
+    if (exact !== undefined) return Array.isArray(exact) ? exact[0] ?? null : exact;
+    const lower = record[name.toLowerCase()];
+    if (lower !== undefined) return Array.isArray(lower) ? lower[0] ?? null : lower;
+    return null;
+};
+
+/**
+ * Header source — accepts the Web `Headers` interface or a plain record
+ * (Node `IncomingMessage.headers` shape).
+ */
+export type HeadersLike =
+    | Headers
+    | Record<string, string | string[] | undefined>;
+
+/**
+ * Structural parse of the two headers from a request. Cryptographic
+ * verification is out of scope.
+ *
+ * Behavior:
+ *   - Both present and well-formed                → status 'ok'
+ *   - X-Saga-Caller missing                       → 'caller_missing'
+ *   - X-Saga-Caller present but not a SPIFFE ID   → 'caller_malformed'
+ *   - Authorization missing                       → 'subject_missing'
+ *   - Authorization not 'Bearer <token>' shape    → 'subject_malformed'
+ *
+ * If both sides have problems, the first detected issue is the status;
+ * `issues` carries the full list.
+ */
+export function parseTwoHeaders(headers: HeadersLike): TwoHeadersParseResult {
+    const issues: string[] = [];
+
+    const callerRaw = HEADER_GET(headers, HEADER_SAGA_CALLER);
+    let callerSpiffeId: string | null = null;
+    let callerStatus: TwoHeadersParseStatus | null = null;
+    if (callerRaw === null || callerRaw.trim() === '') {
+        issues.push(`${HEADER_SAGA_CALLER} header missing`);
+        callerStatus = 'caller_missing';
+    } else if (parseSpiffeId(callerRaw.trim()) === null) {
+        issues.push(`${HEADER_SAGA_CALLER} header is not a valid SPIFFE ID`);
+        callerStatus = 'caller_malformed';
+    } else {
+        callerSpiffeId = callerRaw.trim();
+    }
+
+    const authRaw = HEADER_GET(headers, HEADER_AUTHORIZATION);
+    let bearerToken: string | null = null;
+    let subjectStatus: TwoHeadersParseStatus | null = null;
+    if (authRaw === null || authRaw.trim() === '') {
+        issues.push(`${HEADER_AUTHORIZATION} header missing`);
+        subjectStatus = 'subject_missing';
+    } else {
+        const trimmed = authRaw.trim();
+        if (!/^Bearer\s+\S+$/i.test(trimmed)) {
+            issues.push(
+                `${HEADER_AUTHORIZATION} header is not a Bearer token`,
+            );
+            subjectStatus = 'subject_malformed';
+        } else {
+            bearerToken = trimmed.replace(/^Bearer\s+/i, '');
+        }
+    }
+
+    const status: TwoHeadersParseStatus =
+        callerStatus ?? subjectStatus ?? 'ok';
+
+    return {
+        status,
+        callerSpiffeId,
+        bearerToken,
+        issues,
+    };
+}
+
+/**
+ * Mode flag for the shadow→enforce migration described in ADR 0002.
+ */
+export type TwoHeadersMode = 'off' | 'shadow' | 'enforce';
+
+export const TwoHeadersModeSchema = z.enum(['off', 'shadow', 'enforce']);
+
+/**
+ * Convenience predicate. The structural parse result is "complete" when
+ * status is 'ok'.
+ */
+export function isComplete(result: TwoHeadersParseResult): boolean {
+    return result.status === 'ok';
+}

--- a/packages/core/auth-contracts/src/two-headers.ts
+++ b/packages/core/auth-contracts/src/two-headers.ts
@@ -145,3 +145,94 @@ export const TwoHeadersModeSchema = z.enum(['off', 'shadow', 'enforce']);
 export function isComplete(result: TwoHeadersParseResult): boolean {
     return result.status === 'ok';
 }
+
+/**
+ * Outcome of `decideTwoHeaders`.
+ *
+ * - action 'allow' : headers are complete; let the request through.
+ * - action 'log'   : structural problem detected, but mode is shadow;
+ *                    let the request through and emit a metric.
+ * - action 'reject': structural problem detected and mode is enforce;
+ *                    the caller should reject with UNAUTHORIZED.
+ *
+ * `metric` is populated for both 'log' and 'reject' so the caller can
+ * always emit the same `saga_two_headers_missing_total{service, reason}`
+ * counter without branching.
+ */
+export type TwoHeadersAction = 'allow' | 'log' | 'reject';
+
+export interface TwoHeadersDecision {
+    readonly action: TwoHeadersAction;
+    readonly mode: TwoHeadersMode;
+    readonly parse: TwoHeadersParseResult;
+    /**
+     * Stable label for metric emission. `undefined` when action is 'allow'.
+     * Values are the parse statuses other than 'ok'.
+     */
+    readonly metricReason:
+        | Exclude<TwoHeadersParseStatus, 'ok'>
+        | undefined;
+}
+
+/**
+ * Combine `parseTwoHeaders` + the configured mode to produce a single
+ * decision. This is the function services call from their tRPC / HTTP
+ * middleware.
+ *
+ * The decision is *pure* — it does not log, emit metrics, or throw.
+ * The caller wires the metric and the rejection. This keeps the helper
+ * runtime-agnostic (browser, Node, edge) and trivially testable.
+ *
+ * @example
+ *   const decision = decideTwoHeaders(req.headers, 'shadow');
+ *   if (decision.metricReason) {
+ *     metrics.increment('saga_two_headers_missing_total', {
+ *       service: 'programs-api',
+ *       reason: decision.metricReason,
+ *     });
+ *   }
+ *   if (decision.action === 'reject') {
+ *     throw new TRPCError({ code: 'UNAUTHORIZED', ... });
+ *   }
+ */
+export function decideTwoHeaders(
+    headers: HeadersLike,
+    mode: TwoHeadersMode,
+): TwoHeadersDecision {
+    const parse = parseTwoHeaders(headers);
+
+    if (mode === 'off') {
+        return {
+            action: 'allow',
+            mode,
+            parse,
+            metricReason: undefined,
+        };
+    }
+
+    if (parse.status === 'ok') {
+        return {
+            action: 'allow',
+            mode,
+            parse,
+            metricReason: undefined,
+        };
+    }
+
+    return {
+        action: mode === 'enforce' ? 'reject' : 'log',
+        mode,
+        parse,
+        metricReason: parse.status,
+    };
+}
+
+/**
+ * Canonical metric name for the shadow→enforce migration. Centralized
+ * here so every service emits the same label name.
+ *
+ * Recommended labels: { service, reason }
+ *   - service: emitting service's SPIFFE ID or short name
+ *   - reason : decision.metricReason (one of the parse statuses)
+ */
+export const TWO_HEADERS_METRIC = 'saga_two_headers_missing_total' as const;

--- a/packages/core/auth-contracts/tsconfig.json
+++ b/packages/core/auth-contracts/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "@saga-ed/soa-typescript-config/base.json",
+    "compilerOptions": {
+        "outDir": "./dist",
+        "rootDir": "./src",
+        "noEmit": true
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/core/auth-contracts/tsup.config.ts
+++ b/packages/core/auth-contracts/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+    entry: ['src/index.ts'],
+    format: ['esm'],
+    dts: true,
+    clean: true,
+    sourcemap: true,
+});

--- a/packages/core/auth-contracts/vitest.config.ts
+++ b/packages/core/auth-contracts/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        environment: 'node',
+        include: ['src/**/__tests__/**/*.test.ts', 'src/**/*.test.ts'],
+        exclude: ['**/node_modules/**', '**/*.int.test.ts'],
+    },
+});

--- a/packages/core/saga-authz-model/README.md
+++ b/packages/core/saga-authz-model/README.md
@@ -1,0 +1,30 @@
+# @saga-ed/saga-authz-model
+
+Source of truth for Saga's OpenFGA authorization model. Ships:
+
+- `model.fga` — the DSL file. **The model.** Everything else flows from this.
+- `src/types.ts` — TypeScript constants mirroring the DSL types and relations.
+- `src/tuple-keys.ts` — type-safe tuple-key builders.
+- A unit test that asserts the DSL and the TS types agree (catches drift).
+
+See [ADR 0005](../../../docs/auth/adr/0005-openfga-model-as-source-of-truth.md) for the governance model.
+
+## Today
+
+The package ships the model. **No FGA store is deployed yet** — services do not call `check` against this model in P1. The model lands ready for the sync worker (later phase) to begin writing tuples.
+
+## Tomorrow
+
+Once an FGA store is deployed:
+
+1. The CI pipeline pushes `model.fga` to the FGA store; the returned `authorization_model_id` is recorded in SSM.
+2. The sync worker (separate package) subscribes to `iam.*` events and writes tuples reflecting group/role/membership state.
+3. Services adopt `check`/`list-objects` resource-by-resource alongside their existing RBAC checks.
+4. RBAC is removed once parity is proven.
+
+## Editing the model
+
+1. Open a PR editing `model.fga` and `src/types.ts` in lockstep.
+2. The unit test asserts they agree — CI will fail if you forget one.
+3. Backwards-incompatible changes (renaming a relation, removing a type) require a coordinated rollout plan in the PR description.
+4. Additive changes (new types, new relations) can land normally.

--- a/packages/core/saga-authz-model/model.fga
+++ b/packages/core/saga-authz-model/model.fga
@@ -1,0 +1,119 @@
+# Saga Fleet Authorization Model
+#
+# Source of truth for all OpenFGA types and relations across the Saga
+# microservices fleet. See ADR 0005 for the governance model.
+#
+# Two-layer namespace per Saga IaC convention:
+#   - Identity types: tenant, user, group, role
+#   - Resource types: program, school, cohort, session, room, whiteboard,
+#                     enrollment
+#
+# Convention: every resource type defines a `parent` relation to its
+# containing tenant so cross-tenant checks are impossible by construction.
+# Every resource type also defines a small set of canonical relations
+# (`viewer`, `editor`, `admin`) that map to user-facing actions.
+#
+# This file is the v1 model; non-additive changes require a new authorization
+# model id and coordinated rollout (see ADR 0005).
+
+model
+  schema 1.1
+
+# ---------------------------------------------------------------------------
+# Identity types
+# ---------------------------------------------------------------------------
+
+# Top-level tenant (a school district). Everything else descends from one.
+type tenant
+  relations
+    define admin: [user]
+    define member: [user]
+    define support: [user]
+
+# A user identity. SPIFFE-formatted in the application layer
+# (spiffe://saga.<env>/user/<uuid>); FGA stores the bare uuid.
+type user
+
+# A group of users. Used for sections, cohorts, ad-hoc rosters.
+# Membership is tenant-scoped via `parent`.
+type group
+  relations
+    define parent: [tenant]
+    define member: [user]
+    define admin: [user] or admin from parent
+
+# A role assignment carrier. Roles are per-tenant; a user assigned a role
+# inherits the role's permissions on the resources the role grants.
+type role
+  relations
+    define parent: [tenant]
+    define holder: [user, group#member]
+
+# ---------------------------------------------------------------------------
+# Resource types
+# ---------------------------------------------------------------------------
+
+type school
+  relations
+    define parent: [tenant]
+    define admin: [user, group#member, role#holder] or admin from parent
+    define editor: [user, group#member, role#holder] or admin
+    define viewer: [user, group#member, role#holder] or editor or member from parent
+
+type cohort
+  relations
+    define parent: [school]
+    define admin: [user, group#member, role#holder] or admin from parent
+    define editor: [user, group#member, role#holder] or admin
+    define viewer: [user, group#member, role#holder] or editor
+
+type program
+  relations
+    define parent: [tenant]
+    define owner: [user]
+    define admin: [user, group#member, role#holder] or owner or admin from parent
+    define editor: [user, group#member, role#holder] or admin
+    define viewer: [user, group#member, role#holder] or editor
+
+# An enrollment links a user to a program/cohort.
+# Used by program-hub's enrollment-tree read path.
+type enrollment
+  relations
+    define parent: [tenant]
+    define program: [program]
+    define student: [user]
+    define tutor: [user]
+    define viewer: [user, group#member, role#holder]
+                 or admin from program
+                 or editor from program
+                 or student
+                 or tutor
+
+# A scheduled session (a tutoring session, a class meeting). Lives under
+# a program; participants get session-level permissions.
+type session
+  relations
+    define parent: [program]
+    define host: [user]
+    define participant: [user, group#member]
+    define observer: [user, group#member, role#holder]
+    define viewer: host or participant or observer or admin from parent
+    define can_join: host or participant or admin from parent
+
+# A real-time room (rtsm). Tenant-scoped via parent. Used to lock down
+# socket joins; the `can_join` relation is what `RoomManager.joinRoom`
+# evaluates.
+type room
+  relations
+    define parent: [tenant]
+    define session: [session]
+    define member: [user, group#member]
+    define moderator: [user, group#member, role#holder]
+    define can_join: member or moderator or can_join from session
+
+# A collaborative whiteboard surface (qboard). One whiteboard per session.
+type whiteboard
+  relations
+    define parent: [session]
+    define editor: [user, group#member] or host from parent or participant from parent
+    define viewer: editor or observer from parent

--- a/packages/core/saga-authz-model/package.json
+++ b/packages/core/saga-authz-model/package.json
@@ -1,0 +1,41 @@
+{
+    "name": "@saga-ed/saga-authz-model",
+    "version": "0.1.0-dev.1",
+    "private": false,
+    "type": "module",
+    "description": "Saga's OpenFGA authorization model (.fga DSL) and tuple-key helpers. Source of truth for ReBAC types and relations.",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
+        },
+        "./model.fga": "./model.fga"
+    },
+    "files": ["dist", "model.fga"],
+    "scripts": {
+        "build": "tsup",
+        "check-types": "tsc --noEmit",
+        "test": "vitest run --passWithNoTests",
+        "lint": "eslint src/",
+        "clean": "rm -rf dist"
+    },
+    "devDependencies": {
+        "@saga-ed/soa-typescript-config": "workspace:*",
+        "@types/node": "^24.0.3",
+        "tsup": "^8.5.0",
+        "typescript": "5.8.2",
+        "vitest": "^1.6.1"
+    },
+    "publishConfig": {
+        "registry": "https://saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/",
+        "access": "public"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/saga-ed/soa.git",
+        "directory": "packages/core/saga-authz-model"
+    },
+    "keywords": ["saga-soa", "openfga", "authorization", "rebac"]
+}

--- a/packages/core/saga-authz-model/src/__tests__/model-fga.unit.test.ts
+++ b/packages/core/saga-authz-model/src/__tests__/model-fga.unit.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { FGA_TYPES } from '../types.js';
+
+/**
+ * Verify that every type declared in src/types.ts is present in model.fga.
+ * Catches drift if someone edits one without the other.
+ */
+const modelText = readFileSync(
+    resolve(__dirname, '../../model.fga'),
+    'utf8',
+);
+
+describe('model.fga ↔ src/types.ts', () => {
+    it.each(FGA_TYPES)(
+        'declares %s in the .fga DSL',
+        (type) => {
+            expect(modelText).toMatch(new RegExp(`^type ${type}\\b`, 'm'));
+        },
+    );
+
+    it('declares schema 1.1', () => {
+        expect(modelText).toMatch(/^\s*schema 1\.1\b/m);
+    });
+
+    it('starts with the model keyword', () => {
+        expect(modelText).toMatch(/^model$/m);
+    });
+});

--- a/packages/core/saga-authz-model/src/__tests__/tuple-keys.unit.test.ts
+++ b/packages/core/saga-authz-model/src/__tests__/tuple-keys.unit.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import {
+    objectRef,
+    tupleKey,
+    userRef,
+    usersetRef,
+} from '../tuple-keys.js';
+
+describe('objectRef', () => {
+    it('builds a typed object ref', () => {
+        expect(objectRef('program', 'p1')).toBe('program:p1');
+    });
+
+    it('rejects invalid id characters', () => {
+        expect(() => objectRef('program', 'has space')).toThrow();
+        expect(() => objectRef('program', 'has:colon')).toThrow();
+    });
+});
+
+describe('userRef', () => {
+    it('builds a user ref from a uuid', () => {
+        expect(userRef('00000000-0000-4000-8000-000000000001')).toBe(
+            'user:00000000-0000-4000-8000-000000000001',
+        );
+    });
+});
+
+describe('usersetRef', () => {
+    it('builds a userset reference', () => {
+        expect(usersetRef('group', 'g1', 'member')).toBe('group:g1#member');
+    });
+
+    it('builds a tenant member userset', () => {
+        expect(usersetRef('tenant', 'd42', 'member')).toBe(
+            'tenant:d42#member',
+        );
+    });
+});
+
+describe('tupleKey', () => {
+    it('builds a fully-typed tuple', () => {
+        const t = tupleKey({
+            user: userRef('00000000-0000-4000-8000-000000000001'),
+            relation: 'viewer',
+            object: objectRef('program', 'p1'),
+        });
+        expect(t).toEqual({
+            user: 'user:00000000-0000-4000-8000-000000000001',
+            relation: 'viewer',
+            object: 'program:p1',
+        });
+    });
+});

--- a/packages/core/saga-authz-model/src/index.ts
+++ b/packages/core/saga-authz-model/src/index.ts
@@ -1,0 +1,14 @@
+/**
+ * @saga-ed/saga-authz-model
+ *
+ * Source of truth for the Saga fleet OpenFGA model. The .fga DSL ships
+ * alongside the package; this index re-exports type-safe tuple-key
+ * builders and the canonical type/relation constants.
+ *
+ * Per ADR 0005, services do not write tuples directly — the sync worker
+ * does. Services use the helpers here only to construct tuple keys for
+ * `check`/`list-objects`.
+ */
+
+export * from './types.js';
+export * from './tuple-keys.js';

--- a/packages/core/saga-authz-model/src/tuple-keys.ts
+++ b/packages/core/saga-authz-model/src/tuple-keys.ts
@@ -1,0 +1,76 @@
+import type { FgaRelation, FgaType } from './types.js';
+
+/**
+ * Object reference: `<type>:<id>`. The id is the bare UUID (not the SPIFFE
+ * URL); the FGA store does not need the SPIFFE prefix.
+ */
+export type ObjectRef<T extends FgaType = FgaType> = `${T}:${string}`;
+
+/**
+ * User reference. Either a bare user id or a userset (e.g.,
+ * `group:abc#member`).
+ */
+export type UserRef =
+    | `user:${string}`
+    | `${FgaType}:${string}#${string}`;
+
+/**
+ * A tuple as written to or read from FGA.
+ */
+export interface TupleKey<T extends FgaType = FgaType> {
+    user: UserRef;
+    relation: FgaRelation<T>;
+    object: ObjectRef<T>;
+}
+
+const ID_RE = /^[a-zA-Z0-9_-]+$/;
+
+function ensureValidId(id: string): void {
+    if (!ID_RE.test(id)) {
+        throw new Error(`Invalid FGA id: ${JSON.stringify(id)}`);
+    }
+}
+
+/**
+ * Build a typed object reference. Type-checked at compile time; id format
+ * checked at runtime.
+ */
+export function objectRef<T extends FgaType>(
+    type: T,
+    id: string,
+): ObjectRef<T> {
+    ensureValidId(id);
+    return `${type}:${id}` as ObjectRef<T>;
+}
+
+/**
+ * Build a user reference (a bare user, by uuid).
+ */
+export function userRef(uuid: string): UserRef {
+    ensureValidId(uuid);
+    return `user:${uuid}`;
+}
+
+/**
+ * Build a userset reference (e.g., `group:abc#member`). Used when granting
+ * permissions to "everyone with relation R on object O".
+ */
+export function usersetRef<T extends FgaType>(
+    type: T,
+    id: string,
+    relation: FgaRelation<T>,
+): UserRef {
+    ensureValidId(id);
+    return `${type}:${id}#${relation}` as UserRef;
+}
+
+/**
+ * Build a typed tuple key.
+ */
+export function tupleKey<T extends FgaType>(args: {
+    user: UserRef;
+    relation: FgaRelation<T>;
+    object: ObjectRef<T>;
+}): TupleKey<T> {
+    return args;
+}

--- a/packages/core/saga-authz-model/src/types.ts
+++ b/packages/core/saga-authz-model/src/types.ts
@@ -1,0 +1,48 @@
+/**
+ * Type literals derived from model.fga. These constants must stay in sync
+ * with the DSL; a CI lint (added in P5/P6 follow-up) will diff the .fga
+ * file against this file and fail the build on drift.
+ */
+
+export const FGA_TYPES = [
+    // Identity
+    'tenant',
+    'user',
+    'group',
+    'role',
+    // Resources
+    'school',
+    'cohort',
+    'program',
+    'enrollment',
+    'session',
+    'room',
+    'whiteboard',
+] as const;
+export type FgaType = (typeof FGA_TYPES)[number];
+
+/**
+ * The canonical relations on each type. Used by tuple-key builders to refuse
+ * unknown relation names at compile time.
+ */
+export interface FgaRelationsByType {
+    tenant: 'admin' | 'member' | 'support';
+    user: never;
+    group: 'parent' | 'member' | 'admin';
+    role: 'parent' | 'holder';
+    school: 'parent' | 'admin' | 'editor' | 'viewer';
+    cohort: 'parent' | 'admin' | 'editor' | 'viewer';
+    program: 'parent' | 'owner' | 'admin' | 'editor' | 'viewer';
+    enrollment: 'parent' | 'program' | 'student' | 'tutor' | 'viewer';
+    session:
+        | 'parent'
+        | 'host'
+        | 'participant'
+        | 'observer'
+        | 'viewer'
+        | 'can_join';
+    room: 'parent' | 'session' | 'member' | 'moderator' | 'can_join';
+    whiteboard: 'parent' | 'editor' | 'viewer';
+}
+
+export type FgaRelation<T extends FgaType> = FgaRelationsByType[T];

--- a/packages/core/saga-authz-model/tsconfig.json
+++ b/packages/core/saga-authz-model/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "@saga-ed/soa-typescript-config/base.json",
+    "compilerOptions": {
+        "outDir": "./dist",
+        "rootDir": "./src",
+        "noEmit": true
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/core/saga-authz-model/tsup.config.ts
+++ b/packages/core/saga-authz-model/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+    entry: ['src/index.ts'],
+    format: ['esm'],
+    dts: true,
+    clean: true,
+    sourcemap: true,
+});

--- a/packages/core/saga-authz-model/vitest.config.ts
+++ b/packages/core/saga-authz-model/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        environment: 'node',
+        include: ['src/**/__tests__/**/*.test.ts', 'src/**/*.test.ts'],
+        exclude: ['**/node_modules/**', '**/*.int.test.ts'],
+    },
+});

--- a/packages/node/audit/package.json
+++ b/packages/node/audit/package.json
@@ -1,0 +1,45 @@
+{
+    "name": "@saga-ed/soa-audit",
+    "version": "0.1.0-dev.1",
+    "private": false,
+    "type": "module",
+    "description": "Fleet audit-event emitter. Validates audit.decision.v1 events and writes them via @saga-ed/soa-logger on a dedicated audit channel. Storage is pluggable; the default writer is the structured logger. See ADR 0004.",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
+        }
+    },
+    "files": ["dist"],
+    "scripts": {
+        "build": "tsup",
+        "check-types": "tsc --noEmit",
+        "test": "vitest run --passWithNoTests",
+        "lint": "eslint src/",
+        "clean": "rm -rf dist"
+    },
+    "dependencies": {
+        "@saga-ed/soa-auth-contracts": "workspace:*",
+        "@saga-ed/soa-logger": "workspace:*",
+        "@opentelemetry/api": "^1.9.0"
+    },
+    "devDependencies": {
+        "@saga-ed/soa-typescript-config": "workspace:*",
+        "@types/node": "^24.0.3",
+        "tsup": "^8.5.0",
+        "typescript": "5.8.2",
+        "vitest": "^1.6.1"
+    },
+    "publishConfig": {
+        "registry": "https://saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/",
+        "access": "public"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/saga-ed/soa.git",
+        "directory": "packages/node/audit"
+    },
+    "keywords": ["saga-soa", "audit", "compliance", "logging"]
+}

--- a/packages/node/audit/package.json
+++ b/packages/node/audit/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/soa-audit",
-    "version": "0.1.0-dev.1",
+    "version": "0.1.0-dev.2",
     "private": false,
     "type": "module",
     "description": "Fleet audit-event emitter. Validates audit.decision.v1 events and writes them via @saga-ed/soa-logger on a dedicated audit channel. Storage is pluggable; the default writer is the structured logger. See ADR 0004.",

--- a/packages/node/audit/src/__tests__/audit-emitter.unit.test.ts
+++ b/packages/node/audit/src/__tests__/audit-emitter.unit.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ILogger } from '@saga-ed/soa-logger';
+import {
+    AUDIT_LOG_CHANNEL,
+    createAuditEmitter,
+    type AuditDecisionEvent,
+    type AuditEmitInput,
+} from '../index.js';
+
+const validUserUuid = '00000000-0000-4000-8000-000000000001';
+
+const makeBaseInput = (): AuditEmitInput => ({
+    eventType: 'authz.check',
+    caller: { spiffeId: 'spiffe://saga.dev/programs-api' },
+    subject: {
+        sub: `spiffe://saga.dev/user/${validUserUuid}`,
+        tenantId: 'district:42',
+        sessionJti: 'session-1',
+        tokenJti: 'token-1',
+    },
+    resource: {
+        type: 'program',
+        id: '7',
+        tenantId: 'district:42',
+    },
+    action: 'view',
+    decision: 'allow',
+    reason: null,
+    fgaCheck: { relation: 'viewer', object: 'program:7' },
+    occurredAt: '2026-05-07T12:00:00.000Z',
+    service: 'spiffe://saga.dev/programs-api',
+    env: 'dev',
+});
+
+interface StubLogger {
+    debug: ReturnType<typeof vi.fn>;
+    info: ReturnType<typeof vi.fn>;
+    warn: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+}
+
+function makeStubLogger(): StubLogger {
+    return {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+    };
+}
+
+describe('createAuditEmitter', () => {
+    let stub: StubLogger;
+    let logger: ILogger;
+
+    beforeEach(() => {
+        stub = makeStubLogger();
+        logger = stub as unknown as ILogger;
+    });
+
+    it('exports the canonical channel name', () => {
+        expect(AUDIT_LOG_CHANNEL).toBe('audit');
+    });
+
+    it('writes through the default logger when no writer is supplied', async () => {
+        const e = createAuditEmitter(logger);
+        await e.emit(makeBaseInput());
+        expect(stub.info).toHaveBeenCalledOnce();
+        const [msg, fields] = stub.info.mock.calls[0] as [string, unknown];
+        expect(msg).toBe('audit');
+        expect((fields as { channel: string }).channel).toBe('audit');
+    });
+
+    it('calls the custom writer when supplied', async () => {
+        const writer = vi.fn();
+        const e = createAuditEmitter(logger, writer);
+        await e.emit(makeBaseInput());
+        expect(writer).toHaveBeenCalledOnce();
+        expect(stub.info).not.toHaveBeenCalled();
+    });
+
+    it('stamps schemaVersion v1 by default', async () => {
+        const writer = vi.fn();
+        await createAuditEmitter(logger, writer).emit(makeBaseInput());
+        const event = writer.mock.calls[0][0] as AuditDecisionEvent;
+        expect(event.schemaVersion).toBe('v1');
+    });
+
+    it('stamps a correlationId when caller did not supply one', async () => {
+        const writer = vi.fn();
+        await createAuditEmitter(logger, writer).emit(makeBaseInput());
+        const event = writer.mock.calls[0][0] as AuditDecisionEvent;
+        expect(event.correlationId).toBeTruthy();
+        expect(typeof event.correlationId).toBe('string');
+    });
+
+    it('honors the caller-supplied correlationId', async () => {
+        const writer = vi.fn();
+        await createAuditEmitter(logger, writer).emit({
+            ...makeBaseInput(),
+            correlationId: 'caller-supplied-trace',
+        });
+        const event = writer.mock.calls[0][0] as AuditDecisionEvent;
+        expect(event.correlationId).toBe('caller-supplied-trace');
+    });
+
+    it('defaults causationId to null', async () => {
+        const writer = vi.fn();
+        await createAuditEmitter(logger, writer).emit(makeBaseInput());
+        const event = writer.mock.calls[0][0] as AuditDecisionEvent;
+        expect(event.causationId).toBeNull();
+    });
+
+    it('rejects malformed events at parse time', async () => {
+        const writer = vi.fn();
+        const e = createAuditEmitter(logger, writer);
+        const bad = {
+            ...makeBaseInput(),
+            decision: 'maybe',
+        } as unknown as AuditEmitInput;
+        await expect(e.emit(bad)).rejects.toThrow();
+        expect(writer).not.toHaveBeenCalled();
+    });
+
+    it('rejects events with malformed subject sub', async () => {
+        const writer = vi.fn();
+        const e = createAuditEmitter(logger, writer);
+        const bad = {
+            ...makeBaseInput(),
+            subject: {
+                ...makeBaseInput().subject!,
+                sub: 'not-a-spiffe-id',
+            },
+        };
+        await expect(e.emit(bad)).rejects.toThrow();
+    });
+
+    it('accepts null caller and subject for unauthenticated events', async () => {
+        const writer = vi.fn();
+        await createAuditEmitter(logger, writer).emit({
+            eventType: 'authn.login',
+            caller: null,
+            subject: null,
+            resource: null,
+            action: 'login',
+            decision: 'deny',
+            reason: 'invalid_credentials',
+            fgaCheck: null,
+            occurredAt: '2026-05-07T12:00:00.000Z',
+            service: 'spiffe://saga.dev/iam-api',
+            env: 'dev',
+        });
+        expect(writer).toHaveBeenCalledOnce();
+    });
+
+    it('async writers are awaited', async () => {
+        let resolved = false;
+        const writer = vi.fn(
+            async () =>
+                new Promise<void>((resolve) => {
+                    setTimeout(() => {
+                        resolved = true;
+                        resolve();
+                    }, 10);
+                }),
+        );
+        await createAuditEmitter(logger, writer).emit(makeBaseInput());
+        expect(resolved).toBe(true);
+    });
+});

--- a/packages/node/audit/src/index.ts
+++ b/packages/node/audit/src/index.ts
@@ -16,11 +16,11 @@ import type { ILogger } from '@saga-ed/soa-logger';
  *   3. Emits via the logger's `'audit'` log channel name (added as a
  *      structured field; downstream pipelines route by it).
  *
- * The writer is the structured logger today (P5). The storage tomorrow
- * is a hash-chained Postgres `audit_event` table with daily KMS-signed
- * Merkle roots written to S3 with Object Lock (compliance mode), 7-year
- * retention. Callers will not change — only the writer plugged into
- * `createAuditEmitter` will.
+ * The writer is the structured logger today. The storage tomorrow is a
+ * hash-chained Postgres `audit_event` table with daily KMS-signed
+ * Merkle roots written to S3 with Object Lock (compliance mode),
+ * 7-year retention. Callers will not change — only the writer plugged
+ * into `createAuditEmitter` will.
  *
  * See ADR 0004 (audit event shape) in saga-ed/soa.
  */
@@ -101,25 +101,18 @@ export function createAuditEmitter(
 }
 
 /**
- * Cheap fallback when there is no active OTel trace context. Generates
- * a 16-byte hex string in the W3C TraceContext shape. Distinct from the
- * `randomUUID()` shape so misuse (passing a UUID where a traceId is
- * expected) is visible.
+ * Generate a 16-byte hex string in the W3C TraceContext shape, used as
+ * a correlation id when the caller did not supply one.
+ *
+ * Requires `globalThis.crypto.getRandomValues` (Node 19+, all modern
+ * browsers, Cloudflare Workers, Deno, Bun). The audit package is
+ * intentionally Node-only per `packages/node/CLAUDE.md`, but the
+ * Web-Crypto-only pattern keeps it portable to edge runtimes if a
+ * future caller needs it.
  */
 function cryptoRandomTraceId(): string {
-    // Avoids importing node:crypto at module load — keeps the package
-    // import-side-effect-free for environments that bundle for browser.
     const bytes = new Uint8Array(16);
-    if (typeof globalThis.crypto !== 'undefined') {
-        globalThis.crypto.getRandomValues(bytes);
-    } else {
-        // Last-resort PRNG; never reached in practice (Node 19+ has
-        // globalThis.crypto). Acceptable for non-cryptographic
-        // correlation IDs.
-        for (let i = 0; i < bytes.length; i++) {
-            bytes[i] = Math.floor(Math.random() * 256);
-        }
-    }
+    globalThis.crypto.getRandomValues(bytes);
     let hex = '';
     for (const byte of bytes) {
         hex += byte!.toString(16).padStart(2, '0');

--- a/packages/node/audit/src/index.ts
+++ b/packages/node/audit/src/index.ts
@@ -1,0 +1,130 @@
+import { context, trace } from '@opentelemetry/api';
+import {
+    AuditDecisionEventSchema,
+    type AuditDecisionEvent,
+} from '@saga-ed/soa-auth-contracts';
+import type { ILogger } from '@saga-ed/soa-logger';
+
+/**
+ * @saga-ed/soa-audit
+ *
+ * Thin wrapper around the structured logger that:
+ *   1. Schema-validates every emitted event against
+ *      `AuditDecisionEventSchema` (audit.decision.v1).
+ *   2. Stamps `correlationId` from the active OTel trace context when
+ *      the caller leaves it null.
+ *   3. Emits via the logger's `'audit'` log channel name (added as a
+ *      structured field; downstream pipelines route by it).
+ *
+ * The writer is the structured logger today (P5). The storage tomorrow
+ * is a hash-chained Postgres `audit_event` table with daily KMS-signed
+ * Merkle roots written to S3 with Object Lock (compliance mode), 7-year
+ * retention. Callers will not change — only the writer plugged into
+ * `createAuditEmitter` will.
+ *
+ * See ADR 0004 (audit event shape) in saga-ed/soa.
+ */
+
+export const AUDIT_LOG_CHANNEL = 'audit' as const;
+
+/**
+ * Input shape — almost the full event, with these fields optional and
+ * filled in by the emitter:
+ *
+ * - `schemaVersion` defaults to "v1"
+ * - `correlationId` defaults to the active OTel traceId (or a fresh
+ *   value when no trace is active)
+ * - `causationId` defaults to null
+ *
+ * The caller MUST still provide every other field. Schema validation
+ * runs after defaults are applied.
+ */
+export type AuditEmitInput = Omit<
+    AuditDecisionEvent,
+    'schemaVersion' | 'correlationId' | 'causationId'
+> &
+    Partial<
+        Pick<
+            AuditDecisionEvent,
+            'schemaVersion' | 'correlationId' | 'causationId'
+        >
+    >;
+
+/**
+ * Pluggable writer. Default writer wraps `ILogger.info`. Tests pass an
+ * in-memory writer; the future Postgres backend will pass an
+ * append-row writer.
+ */
+export type AuditWriter = (event: AuditDecisionEvent) => void | Promise<void>;
+
+export interface AuditEmitter {
+    emit(input: AuditEmitInput): Promise<void>;
+}
+
+/**
+ * Create an emitter bound to a logger. Every emit:
+ *   1. Fills defaults (schemaVersion, correlationId, causationId)
+ *   2. Validates via the canonical schema
+ *   3. Calls the writer
+ *
+ * Any validation failure throws. Callers should never catch and swallow
+ * — a failure means the event the caller built is malformed and the
+ * audit trail integrity is at risk.
+ */
+export function createAuditEmitter(
+    logger: ILogger,
+    writer?: AuditWriter,
+): AuditEmitter {
+    const defaultWriter: AuditWriter = (event) => {
+        logger.info('audit', {
+            channel: AUDIT_LOG_CHANNEL,
+            event,
+        });
+    };
+    const w = writer ?? defaultWriter;
+    return {
+        async emit(input: AuditEmitInput): Promise<void> {
+            const traceId =
+                trace.getSpan(context.active())?.spanContext().traceId ?? null;
+            const candidate = {
+                schemaVersion: 'v1' as const,
+                correlationId: traceId ?? cryptoRandomTraceId(),
+                causationId: null,
+                ...input,
+            };
+            // Validate exhaustively — fail loud rather than ship a
+            // malformed audit row.
+            const event = AuditDecisionEventSchema.parse(candidate);
+            await w(event);
+        },
+    };
+}
+
+/**
+ * Cheap fallback when there is no active OTel trace context. Generates
+ * a 16-byte hex string in the W3C TraceContext shape. Distinct from the
+ * `randomUUID()` shape so misuse (passing a UUID where a traceId is
+ * expected) is visible.
+ */
+function cryptoRandomTraceId(): string {
+    // Avoids importing node:crypto at module load — keeps the package
+    // import-side-effect-free for environments that bundle for browser.
+    const bytes = new Uint8Array(16);
+    if (typeof globalThis.crypto !== 'undefined') {
+        globalThis.crypto.getRandomValues(bytes);
+    } else {
+        // Last-resort PRNG; never reached in practice (Node 19+ has
+        // globalThis.crypto). Acceptable for non-cryptographic
+        // correlation IDs.
+        for (let i = 0; i < bytes.length; i++) {
+            bytes[i] = Math.floor(Math.random() * 256);
+        }
+    }
+    let hex = '';
+    for (const byte of bytes) {
+        hex += byte!.toString(16).padStart(2, '0');
+    }
+    return hex;
+}
+
+export type { AuditDecisionEvent } from '@saga-ed/soa-auth-contracts';

--- a/packages/node/audit/tsconfig.json
+++ b/packages/node/audit/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "@saga-ed/soa-typescript-config/base.json",
+    "compilerOptions": {
+        "outDir": "./dist",
+        "rootDir": "./src",
+        "noEmit": true
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/node/audit/tsup.config.ts
+++ b/packages/node/audit/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+    entry: ['src/index.ts'],
+    format: ['esm'],
+    dts: true,
+    clean: true,
+    sourcemap: true,
+});

--- a/packages/node/audit/vitest.config.ts
+++ b/packages/node/audit/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        environment: 'node',
+        include: ['src/**/__tests__/**/*.test.ts', 'src/**/*.test.ts'],
+        exclude: ['**/node_modules/**', '**/*.int.test.ts'],
+    },
+});

--- a/packages/node/event-envelope/package.json
+++ b/packages/node/event-envelope/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/soa-event-envelope",
-    "version": "0.1.0-dev.3",
+    "version": "0.1.0-dev.5",
     "private": false,
     "type": "module",
     "main": "dist/index.js",

--- a/packages/node/event-envelope/src/__tests__/envelope.unit.test.ts
+++ b/packages/node/event-envelope/src/__tests__/envelope.unit.test.ts
@@ -87,6 +87,56 @@ describe('EventEnvelopeMetaSchema', () => {
         const result = EventEnvelopeMetaSchema.safeParse({});
         expect(result.success).toBe(true);
     });
+
+    // ADR 0003 — signature is optional and back-compatible.
+    it('accepts a meta with no signature (back-compat)', () => {
+        const result = EventEnvelopeMetaSchema.safeParse({
+            traceparent: '00-aaaa-bbbb-01',
+        });
+        expect(result.success).toBe(true);
+    });
+
+    it('accepts a well-formed signature', () => {
+        const result = EventEnvelopeMetaSchema.safeParse({
+            signature: {
+                alg: 'HS256',
+                keyId: 'rostering/v1',
+                value: 'AAAA-base64url-value',
+            },
+        });
+        expect(result.success).toBe(true);
+    });
+
+    it('rejects a signature with unsupported alg', () => {
+        const result = EventEnvelopeMetaSchema.safeParse({
+            signature: {
+                alg: 'RS256',
+                keyId: 'rostering/v1',
+                value: 'AAAA',
+            },
+        });
+        expect(result.success).toBe(false);
+    });
+
+    it('rejects a signature missing keyId', () => {
+        const result = EventEnvelopeMetaSchema.safeParse({
+            signature: {
+                alg: 'HS256',
+                value: 'AAAA',
+            },
+        });
+        expect(result.success).toBe(false);
+    });
+});
+
+describe('SignatureModeSchema', () => {
+    it('accepts the three modes', async () => {
+        const { SignatureModeSchema } = await import('../signature.js');
+        expect(SignatureModeSchema.safeParse('off').success).toBe(true);
+        expect(SignatureModeSchema.safeParse('shadow').success).toBe(true);
+        expect(SignatureModeSchema.safeParse('enforce').success).toBe(true);
+        expect(SignatureModeSchema.safeParse('strict').success).toBe(false);
+    });
 });
 
 describe('buildEnvelope', () => {

--- a/packages/node/event-envelope/src/__tests__/envelope.unit.test.ts
+++ b/packages/node/event-envelope/src/__tests__/envelope.unit.test.ts
@@ -101,7 +101,7 @@ describe('EventEnvelopeMetaSchema', () => {
             signature: {
                 alg: 'HS256',
                 keyId: 'rostering/v1',
-                value: 'AAAA-base64url-value',
+                value: 'A'.repeat(43),
             },
         });
         expect(result.success).toBe(true);
@@ -112,7 +112,7 @@ describe('EventEnvelopeMetaSchema', () => {
             signature: {
                 alg: 'RS256',
                 keyId: 'rostering/v1',
-                value: 'AAAA',
+                value: 'A'.repeat(43),
             },
         });
         expect(result.success).toBe(false);
@@ -122,7 +122,7 @@ describe('EventEnvelopeMetaSchema', () => {
         const result = EventEnvelopeMetaSchema.safeParse({
             signature: {
                 alg: 'HS256',
-                value: 'AAAA',
+                value: 'A'.repeat(43),
             },
         });
         expect(result.success).toBe(false);

--- a/packages/node/event-envelope/src/__tests__/signing.unit.test.ts
+++ b/packages/node/event-envelope/src/__tests__/signing.unit.test.ts
@@ -52,6 +52,42 @@ describe('canonicalize', () => {
     it('produces identical output for differently-keyed equivalent objects', () => {
         expect(canonicalize({ a: 1, b: 2 })).toBe(canonicalize({ b: 2, a: 1 }));
     });
+
+    it('drops undefined / function / symbol values from objects (matches JSON.stringify)', () => {
+        const sym = Symbol('x');
+        const obj = { a: 1, b: undefined, c: () => 0, d: sym, e: 2 };
+        expect(canonicalize(obj)).toBe('{"a":1,"e":2}');
+    });
+
+    it('replaces undefined / function / symbol with null in arrays (matches JSON.stringify)', () => {
+        const sym = Symbol('x');
+        expect(canonicalize([1, undefined, () => 0, sym, 2])).toBe(
+            '[1,null,null,null,2]',
+        );
+    });
+
+    it('throws on top-level undefined', () => {
+        expect(() => canonicalize(undefined)).toThrow(TypeError);
+    });
+
+    it('throws on BigInt', () => {
+        expect(() => canonicalize({ a: 1n })).toThrow(TypeError);
+    });
+
+    it('throws on circular references', () => {
+        const obj: Record<string, unknown> = { a: 1 };
+        obj.self = obj;
+        expect(() => canonicalize(obj)).toThrow(/circular/i);
+    });
+
+    it('handles non-ASCII keys and values consistently', () => {
+        const a = canonicalize({ é: 'naïve', ñ: 1 });
+        const b = canonicalize({ ñ: 1, é: 'naïve' });
+        expect(a).toBe(b);
+        // The canonical form must include the actual characters (not hex
+        // escapes) — JSON.stringify by default leaves non-ASCII in place.
+        expect(a).toContain('"é"');
+    });
 });
 
 describe('canonicalBytes', () => {
@@ -155,6 +191,41 @@ describe('verifyEnvelope', () => {
         expect(result.status).toBe('invalid');
     });
 
+    it('returns invalid when the signature value itself is bit-flipped', async () => {
+        // Pins the comparison path. A regression where verify returned
+        // ok=true on length-match-but-value-mismatch would pass the
+        // payload-tamper test (since payload tampering also flips the
+        // computed value) but fail this one.
+        const env = signEnvelope(baseEnv(), { keyId: 'k1', secret: SECRET });
+        const sig = env.meta!.signature!;
+        // Flip one base64url char while preserving length
+        const flipped = sig.value[0] === 'A' ? 'B' : 'A';
+        const tampered: EventEnvelope = {
+            ...env,
+            meta: {
+                ...env.meta,
+                signature: {
+                    ...sig,
+                    value: flipped + sig.value.slice(1),
+                },
+            },
+        };
+        const result = await verifyEnvelope(tampered, resolver);
+        expect(result.status).toBe('invalid');
+    });
+
+    it('full envelope without signature still parses end-to-end (back-compat)', async () => {
+        // Pins ADR 0003's promise that pre-signature envelopes continue
+        // to flow. Validates the *whole* envelope (not just meta), then
+        // checks the verifier reports 'absent'.
+        const env = baseEnv();
+        const parsed = (await import('../index.js')).EventEnvelopeSchema.parse(env);
+        expect(parsed.eventType).toBe(env.eventType);
+        const result = await verifyEnvelope(parsed, resolver);
+        expect(result.status).toBe('absent');
+        expect(result.ok).toBe(false);
+    });
+
     it('returns invalid for unsupported alg', async () => {
         const env = baseEnv();
         const tampered: EventEnvelope = {
@@ -183,6 +254,24 @@ describe('decideSignature', () => {
     it('off mode always allows', async () => {
         const env = baseEnv();
         const d = await decideSignature(env, resolver, 'off');
+        expect(d.action).toBe('allow');
+    });
+
+    it('off mode reports `absent` when no signature is present', async () => {
+        const d = await decideSignature(baseEnv(), resolver, 'off');
+        expect(d.status).toBe('absent');
+        expect(d.keyId).toBeNull();
+    });
+
+    it('off mode reports `unverified` when a signature IS present (does not lie about presence)', async () => {
+        // Operator running 'off' should still be able to see "producers
+        // are emitting signatures" via the metric — distinct from
+        // "wire is unsigned". Otherwise dashboards lie during a phased
+        // rollout.
+        const signed = signEnvelope(baseEnv(), { keyId: 'k1', secret: SECRET });
+        const d = await decideSignature(signed, resolver, 'off');
+        expect(d.status).toBe('unverified');
+        expect(d.keyId).toBe('k1');
         expect(d.action).toBe('allow');
     });
 

--- a/packages/node/event-envelope/src/__tests__/signing.unit.test.ts
+++ b/packages/node/event-envelope/src/__tests__/signing.unit.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vitest';
+import {
+    buildEnvelope,
+    canonicalBytes,
+    canonicalize,
+    computeHmac,
+    decideSignature,
+    SIGNATURE_METRIC,
+    signEnvelope,
+    verifyEnvelope,
+    type EventEnvelope,
+    type SignatureKeyResolver,
+} from '../index.js';
+
+const SECRET = 'do-not-use-in-prod-shared-secret';
+
+const baseEnv = (): EventEnvelope =>
+    buildEnvelope({
+        eventType: 'identity.user.created',
+        eventVersion: 1,
+        aggregateType: 'user',
+        aggregateId: 'u-1',
+        eventId: '00000000-0000-4000-8000-000000000001',
+        occurredAt: new Date('2026-05-07T00:00:00.000Z'),
+        payload: { userId: 'u-1', name: 'Alice', org: 'd-42' },
+    });
+
+describe('canonicalize', () => {
+    it('serializes primitives', () => {
+        expect(canonicalize(null)).toBe('null');
+        expect(canonicalize(true)).toBe('true');
+        expect(canonicalize(42)).toBe('42');
+        expect(canonicalize('hi')).toBe('"hi"');
+    });
+
+    it('preserves array order', () => {
+        expect(canonicalize([3, 1, 2])).toBe('[3,1,2]');
+    });
+
+    it('sorts object keys lexicographically', () => {
+        expect(canonicalize({ b: 2, a: 1, c: 3 })).toBe(
+            '{"a":1,"b":2,"c":3}',
+        );
+    });
+
+    it('is recursive', () => {
+        expect(canonicalize({ b: [{ y: 1, x: 2 }], a: 0 })).toBe(
+            '{"a":0,"b":[{"x":2,"y":1}]}',
+        );
+    });
+
+    it('produces identical output for differently-keyed equivalent objects', () => {
+        expect(canonicalize({ a: 1, b: 2 })).toBe(canonicalize({ b: 2, a: 1 }));
+    });
+});
+
+describe('canonicalBytes', () => {
+    it('joins fields with newlines in the documented order', () => {
+        const env = baseEnv();
+        const bytes = canonicalBytes(env).toString('utf8');
+        const lines = bytes.split('\n');
+        expect(lines[0]).toBe(env.eventId);
+        expect(lines[1]).toBe(env.eventType);
+        expect(lines[2]).toBe(String(env.eventVersion));
+        expect(lines[3]).toBe(env.aggregateType);
+        expect(lines[4]).toBe(env.aggregateId);
+        expect(lines[5]).toBe(env.occurredAt);
+        // Last line is canonicalized payload
+        expect(lines[6]).toBe(canonicalize(env.payload));
+    });
+});
+
+describe('computeHmac', () => {
+    it('is deterministic for identical inputs', () => {
+        const env = baseEnv();
+        expect(computeHmac(env, SECRET)).toBe(computeHmac(env, SECRET));
+    });
+
+    it('changes if any field changes', () => {
+        const a = baseEnv();
+        const b = { ...a, eventType: 'identity.user.updated' };
+        expect(computeHmac(a, SECRET)).not.toBe(computeHmac(b, SECRET));
+    });
+
+    it('changes with a different secret', () => {
+        const env = baseEnv();
+        expect(computeHmac(env, SECRET)).not.toBe(computeHmac(env, 'other'));
+    });
+
+    it('accepts a Buffer secret', () => {
+        const env = baseEnv();
+        expect(computeHmac(env, SECRET)).toBe(
+            computeHmac(env, Buffer.from(SECRET, 'utf8')),
+        );
+    });
+});
+
+describe('signEnvelope', () => {
+    it('returns a new envelope with meta.signature populated', () => {
+        const env = baseEnv();
+        const signed = signEnvelope(env, { keyId: 'rostering/v1', secret: SECRET });
+        expect(env.meta?.signature).toBeUndefined();
+        expect(signed.meta?.signature).toEqual({
+            alg: 'HS256',
+            keyId: 'rostering/v1',
+            value: expect.any(String),
+        });
+    });
+
+    it('preserves existing meta fields', () => {
+        const env: EventEnvelope = {
+            ...baseEnv(),
+            meta: {
+                traceparent: '00-aaaa-bbbb-01',
+                correlationId: 'corr-1',
+            },
+        };
+        const signed = signEnvelope(env, { keyId: 'k1', secret: SECRET });
+        expect(signed.meta?.traceparent).toBe('00-aaaa-bbbb-01');
+        expect(signed.meta?.correlationId).toBe('corr-1');
+        expect(signed.meta?.signature?.keyId).toBe('k1');
+    });
+});
+
+describe('verifyEnvelope', () => {
+    const resolver: SignatureKeyResolver = (keyId) =>
+        keyId === 'k1' ? SECRET : null;
+
+    it('returns valid on round-trip', async () => {
+        const env = signEnvelope(baseEnv(), { keyId: 'k1', secret: SECRET });
+        const result = await verifyEnvelope(env, resolver);
+        expect(result.ok).toBe(true);
+        expect(result.status).toBe('valid');
+    });
+
+    it('returns absent when no signature is present', async () => {
+        const result = await verifyEnvelope(baseEnv(), resolver);
+        expect(result.ok).toBe(false);
+        expect(result.status).toBe('absent');
+    });
+
+    it('returns unknown_key on a key the resolver does not know', async () => {
+        const env = signEnvelope(baseEnv(), { keyId: 'k-unknown', secret: SECRET });
+        const result = await verifyEnvelope(env, resolver);
+        expect(result.status).toBe('unknown_key');
+    });
+
+    it('returns invalid when payload is tampered', async () => {
+        const env = signEnvelope(baseEnv(), { keyId: 'k1', secret: SECRET });
+        const tampered: EventEnvelope = {
+            ...env,
+            payload: { ...env.payload, name: 'Mallory' },
+        };
+        const result = await verifyEnvelope(tampered, resolver);
+        expect(result.status).toBe('invalid');
+    });
+
+    it('returns invalid for unsupported alg', async () => {
+        const env = baseEnv();
+        const tampered: EventEnvelope = {
+            ...env,
+            meta: {
+                ...env.meta,
+                signature: {
+                    alg: 'HS256' as const,
+                    keyId: 'k1',
+                    value: 'AAAA',
+                },
+            },
+        };
+        // Force-cast to inject an alg the schema doesn't allow at parse time
+        // but we want to test runtime defense:
+        (tampered.meta!.signature as { alg: string }).alg = 'RS256';
+        const result = await verifyEnvelope(tampered, resolver);
+        expect(result.status).toBe('invalid');
+    });
+});
+
+describe('decideSignature', () => {
+    const resolver: SignatureKeyResolver = (keyId) =>
+        keyId === 'k1' ? SECRET : null;
+
+    it('off mode always allows', async () => {
+        const env = baseEnv();
+        const d = await decideSignature(env, resolver, 'off');
+        expect(d.action).toBe('allow');
+    });
+
+    it('shadow allows valid, logs invalid', async () => {
+        const valid = signEnvelope(baseEnv(), { keyId: 'k1', secret: SECRET });
+        expect((await decideSignature(valid, resolver, 'shadow')).action).toBe(
+            'allow',
+        );
+        expect((await decideSignature(baseEnv(), resolver, 'shadow')).action).toBe(
+            'log',
+        );
+    });
+
+    it('enforce rejects on absent', async () => {
+        const d = await decideSignature(baseEnv(), resolver, 'enforce');
+        expect(d.action).toBe('reject');
+        expect(d.status).toBe('absent');
+    });
+
+    it('enforce rejects on unknown_key', async () => {
+        const env = signEnvelope(baseEnv(), { keyId: 'k-unknown', secret: SECRET });
+        const d = await decideSignature(env, resolver, 'enforce');
+        expect(d.action).toBe('reject');
+        expect(d.status).toBe('unknown_key');
+    });
+
+    it('exposes the canonical metric name', () => {
+        expect(SIGNATURE_METRIC).toBe('saga_event_signature_status');
+    });
+});

--- a/packages/node/event-envelope/src/index.ts
+++ b/packages/node/event-envelope/src/index.ts
@@ -11,6 +11,19 @@ export {
     type SignatureMode,
     type SignatureStatus,
 } from './signature.js';
+export {
+    canonicalize,
+    canonicalBytes,
+    computeHmac,
+    signEnvelope,
+    verifyEnvelope,
+    decideSignature,
+    SIGNATURE_METRIC,
+    type SignatureKeyResolver,
+    type VerifyResult,
+    type SignatureAction,
+    type SignatureDecision,
+} from './signing.js';
 
 // W3C TraceContext requires that `tracestate` only ride along with a
 // `traceparent`. The refine catches an orphan `tracestate` at parse time

--- a/packages/node/event-envelope/src/index.ts
+++ b/packages/node/event-envelope/src/index.ts
@@ -1,19 +1,32 @@
 import { randomUUID } from 'node:crypto';
 import { context, propagation } from '@opentelemetry/api';
 import { z } from 'zod';
+import { EventSignatureSchema } from './signature.js';
 
 export { applyPreviewTag } from './preview-tag.js';
+export {
+    EventSignatureSchema,
+    SignatureModeSchema,
+    type EventSignature,
+    type SignatureMode,
+    type SignatureStatus,
+} from './signature.js';
 
 // W3C TraceContext requires that `tracestate` only ride along with a
 // `traceparent`. The refine catches an orphan `tracestate` at parse time
 // rather than letting OTel's propagator silently discard it (which would
 // look like trace continuity bug instead of a malformed envelope).
+//
+// `signature` per ADR 0003 is optional today: producers populate it when a
+// signing key is configured, and consumers verify in shadow or enforce mode.
+// Existing pre-signature envelopes continue to parse cleanly.
 export const EventEnvelopeMetaSchema = z
     .object({
         traceparent: z.string().optional(),
         tracestate: z.string().optional(),
         correlationId: z.string().optional(),
         causationId: z.string().optional(),
+        signature: EventSignatureSchema.optional(),
     })
     .strip()
     .refine((m) => !(m.tracestate && !m.traceparent), {

--- a/packages/node/event-envelope/src/signature.ts
+++ b/packages/node/event-envelope/src/signature.ts
@@ -15,14 +15,20 @@ import { z } from 'zod';
  *   aggregateType || "\n" || aggregateId || "\n" || occurredAt || "\n" ||
  *   canonicalJSON(payload)
  *
- * Where canonicalJSON is RFC 8785 JSON Canonicalization Scheme. The signing
- * library (lands in P4) computes this; this file owns only the schema.
+ * `canonicalJSON` is JCS-inspired, not strictly RFC 8785 — see
+ * `./signing.ts:canonicalize` for the exact algorithm and the
+ * sufficient-within-trust-boundary rationale. The signing library lives
+ * in `./signing.ts`; this file owns only the schema and the mode types.
  */
+// HS256 produces a 32-byte HMAC; base64url with no padding is 43 chars.
+// Pin the length so a malformed signature is rejected at parse time
+// rather than producing a misleading 'invalid' on length-mismatch
+// later (which would be a small timing oracle).
 export const EventSignatureSchema = z
     .object({
         alg: z.literal('HS256'),
         keyId: z.string().min(1),
-        value: z.string().min(1),
+        value: z.string().length(43),
     })
     .strip();
 
@@ -42,9 +48,19 @@ export const SignatureModeSchema = z.enum(['off', 'shadow', 'enforce']);
 /**
  * Status reported per envelope by the verifier (used for the
  * saga_event_signature_status metric).
+ *
+ *   - 'absent'      — no signature on the envelope
+ *   - 'valid'       — signature verified
+ *   - 'invalid'     — signature present but does not match
+ *   - 'unknown_key' — signature.keyId is not in the resolver
+ *   - 'unverified'  — signature present but mode='off' so it was not
+ *                     checked. Distinct from 'absent' so dashboards
+ *                     can tell "no signature on the wire" from
+ *                     "verifier disabled by policy".
  */
 export type SignatureStatus =
     | 'absent'
     | 'valid'
     | 'invalid'
-    | 'unknown_key';
+    | 'unknown_key'
+    | 'unverified';

--- a/packages/node/event-envelope/src/signature.ts
+++ b/packages/node/event-envelope/src/signature.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod';
+
+/**
+ * Optional event signature per ADR 0003.
+ *
+ * Producers populate this when a signing key is configured; consumers
+ * verify in shadow mode (default) or enforce mode. The presence of this
+ * field is optional today and back-compatible with envelopes that pre-date
+ * the addition.
+ *
+ * The signature value is base64url-encoded HMAC-SHA256 over the canonical
+ * byte representation:
+ *
+ *   eventId || "\n" || eventType || "\n" || eventVersion || "\n" ||
+ *   aggregateType || "\n" || aggregateId || "\n" || occurredAt || "\n" ||
+ *   canonicalJSON(payload)
+ *
+ * Where canonicalJSON is RFC 8785 JSON Canonicalization Scheme. The signing
+ * library (lands in P4) computes this; this file owns only the schema.
+ */
+export const EventSignatureSchema = z
+    .object({
+        alg: z.literal('HS256'),
+        keyId: z.string().min(1),
+        value: z.string().min(1),
+    })
+    .strip();
+
+export type EventSignature = z.infer<typeof EventSignatureSchema>;
+
+/**
+ * Verifier modes per ADR 0003 § "Consumer behavior".
+ *
+ * - off: ignore the signature field entirely
+ * - shadow: verify if present, log on missing/invalid, do not reject
+ * - enforce: verify, reject on missing/invalid
+ */
+export type SignatureMode = 'off' | 'shadow' | 'enforce';
+
+export const SignatureModeSchema = z.enum(['off', 'shadow', 'enforce']);
+
+/**
+ * Status reported per envelope by the verifier (used for the
+ * saga_event_signature_status metric).
+ */
+export type SignatureStatus =
+    | 'absent'
+    | 'valid'
+    | 'invalid'
+    | 'unknown_key';

--- a/packages/node/event-envelope/src/signing.ts
+++ b/packages/node/event-envelope/src/signing.ts
@@ -9,113 +9,60 @@ import type {
 /**
  * HMAC-SHA256 signing for event envelopes per ADR 0003.
  *
- * The signature is computed over the canonical byte representation:
+ * Signature is computed over canonical bytes: envelope identity fields
+ * (eventId, eventType, eventVersion, aggregateType, aggregateId,
+ * occurredAt) joined with '\n', followed by `canonicalize(payload)`.
  *
- *   eventId        ┐
- *   eventType      │
- *   eventVersion   │  joined with '\n', UTF-8
- *   aggregateType  │
- *   aggregateId    │
- *   occurredAt     │
- *   canonical(payload) ┘
- *
- * `canonical(payload)` is a deterministic JSON serialization with object
- * keys sorted in lexicographic UTF-16 order, no whitespace, and JSON-spec
- * escapes. This is sufficient for byte-identical reproduction across
- * producer and consumer (which is what HMAC needs); we do not aim for
- * full RFC 8785 (JCS) compatibility because we control both sides.
- *
- * Compatibility note: if Saga ever needs to interop with a counterparty
- * that requires RFC 8785, swap `canonicalize` for a JCS implementation —
- * the rest of this file does not change.
+ * `canonicalize` is JCS-inspired, not strict RFC 8785: object keys
+ * sorted in UTF-16 code-unit order, no whitespace, JSON-spec escapes.
+ * Sufficient for byte-identical reproduction within Saga's trust
+ * boundary (both sides run Node V8). For RFC 8785 interop, swap
+ * `canonicalize` — everything else here is unchanged.
  */
+
+const isJsonHole = (v: unknown): boolean =>
+    v === undefined || typeof v === 'symbol' || typeof v === 'function';
 
 /**
- * Deterministic JSON serialization. Recursively sorts object keys
- * (UTF-16 code-unit lexicographic order), preserves array order, and
- * matches `JSON.stringify` semantics for non-JSON values:
- *   - `undefined` / function / symbol values: dropped from objects,
- *     replaced with `null` in arrays (per JSON spec).
- *   - `BigInt`: throws (consistent with `JSON.stringify`).
- *   - Circular references: throws (own implementation; we cannot
- *     rely on `JSON.stringify` for the recursion).
- *
- * Compatibility note: this implementation is *JCS-inspired*, not
- * strictly RFC 8785. It is sufficient for byte-identical reproduction
- * across producer and consumer within Saga's trust boundary (both run
- * Node V8). If we ever interop with a counterparty that requires
- * strict RFC 8785, swap this function for a JCS implementation —
- * everything else in this file is unchanged.
+ * Deterministic JSON serialization. Matches `JSON.stringify` for
+ * non-JSON values (drop in objects, null in arrays, throws on BigInt).
+ * Throws on circular references and on a hole at the top level.
  */
 export function canonicalize(value: unknown): string {
-    return canonicalizeWithSeen(value, new WeakSet<object>());
-}
-
-function canonicalizeWithSeen(
-    value: unknown,
-    seen: WeakSet<object>,
-): string {
-    if (typeof value === 'bigint') {
-        throw new TypeError(
-            'canonicalize: BigInt is not JSON-serializable',
-        );
-    }
-    // Top-level undefined / symbol / function are not legal JSON values;
-    // a caller that hands us one is misusing the canonical-bytes
-    // contract. Throw rather than return invalid output.
-    if (
-        value === undefined ||
-        typeof value === 'symbol' ||
-        typeof value === 'function'
-    ) {
-        throw new TypeError(
-            'canonicalize: undefined / symbol / function are not allowed at top level',
-        );
-    }
-    if (value === null) return 'null';
-    if (typeof value !== 'object') return JSON.stringify(value);
-    if (seen.has(value)) {
-        throw new TypeError('canonicalize: circular reference detected');
-    }
-    seen.add(value);
-    try {
-        if (Array.isArray(value)) {
-            const parts = value.map((v) => canonicalizeArrayItem(v, seen));
-            return `[${parts.join(',')}]`;
+    const seen = new WeakSet<object>();
+    const walk = (v: unknown): string => {
+        if (typeof v === 'bigint') {
+            throw new TypeError('canonicalize: BigInt is not JSON-serializable');
         }
-        // Object: sort keys, drop entries whose value is undefined / symbol /
-        // function (matches `JSON.stringify` behavior).
-        const keys = Object.keys(value as Record<string, unknown>).sort();
-        const parts: string[] = [];
-        for (const k of keys) {
-            const v = (value as Record<string, unknown>)[k];
-            if (
-                v === undefined ||
-                typeof v === 'symbol' ||
-                typeof v === 'function'
-            ) {
-                continue;
+        if (isJsonHole(v)) {
+            throw new TypeError(
+                'canonicalize: undefined / symbol / function are not allowed at top level',
+            );
+        }
+        if (v === null) return 'null';
+        if (typeof v !== 'object') return JSON.stringify(v);
+        if (seen.has(v)) {
+            throw new TypeError('canonicalize: circular reference detected');
+        }
+        seen.add(v);
+        try {
+            if (Array.isArray(v)) {
+                const parts = v.map((item) => (isJsonHole(item) ? 'null' : walk(item)));
+                return `[${parts.join(',')}]`;
             }
-            parts.push(`${JSON.stringify(k)}:${canonicalizeWithSeen(v, seen)}`);
+            const keys = Object.keys(v as Record<string, unknown>).sort();
+            const parts: string[] = [];
+            for (const k of keys) {
+                const child = (v as Record<string, unknown>)[k];
+                if (isJsonHole(child)) continue;
+                parts.push(`${JSON.stringify(k)}:${walk(child)}`);
+            }
+            return `{${parts.join(',')}}`;
+        } finally {
+            seen.delete(v);
         }
-        return `{${parts.join(',')}}`;
-    } finally {
-        seen.delete(value);
-    }
-}
-
-function canonicalizeArrayItem(
-    v: unknown,
-    seen: WeakSet<object>,
-): string {
-    if (
-        v === undefined ||
-        typeof v === 'symbol' ||
-        typeof v === 'function'
-    ) {
-        return 'null';
-    }
-    return canonicalizeWithSeen(v, seen);
+    };
+    return walk(value);
 }
 
 /**

--- a/packages/node/event-envelope/src/signing.ts
+++ b/packages/node/event-envelope/src/signing.ts
@@ -1,0 +1,214 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import type { EventEnvelope } from './index.js';
+import type {
+    EventSignature,
+    SignatureMode,
+    SignatureStatus,
+} from './signature.js';
+
+/**
+ * HMAC-SHA256 signing for event envelopes per ADR 0003.
+ *
+ * The signature is computed over the canonical byte representation:
+ *
+ *   eventId        ┐
+ *   eventType      │
+ *   eventVersion   │  joined with '\n', UTF-8
+ *   aggregateType  │
+ *   aggregateId    │
+ *   occurredAt     │
+ *   canonical(payload) ┘
+ *
+ * `canonical(payload)` is a deterministic JSON serialization with object
+ * keys sorted in lexicographic UTF-16 order, no whitespace, and JSON-spec
+ * escapes. This is sufficient for byte-identical reproduction across
+ * producer and consumer (which is what HMAC needs); we do not aim for
+ * full RFC 8785 (JCS) compatibility because we control both sides.
+ *
+ * Compatibility note: if Saga ever needs to interop with a counterparty
+ * that requires RFC 8785, swap `canonicalize` for a JCS implementation —
+ * the rest of this file does not change.
+ */
+
+/**
+ * Deterministic JSON serialization. Recursively sorts object keys.
+ * Preserves array order. Throws on circular references via the JSON
+ * default behavior (TypeError).
+ */
+export function canonicalize(value: unknown): string {
+    if (value === null || typeof value !== 'object') {
+        return JSON.stringify(value);
+    }
+    if (Array.isArray(value)) {
+        return `[${value.map((v) => canonicalize(v)).join(',')}]`;
+    }
+    const keys = Object.keys(value as Record<string, unknown>).sort();
+    const parts = keys.map((k) => {
+        const v = (value as Record<string, unknown>)[k];
+        return `${JSON.stringify(k)}:${canonicalize(v)}`;
+    });
+    return `{${parts.join(',')}}`;
+}
+
+/**
+ * Build the canonical bytes the signature is computed over. Exported for
+ * test parity and for cross-language reimplementations.
+ */
+export function canonicalBytes(envelope: EventEnvelope): Buffer {
+    const lines = [
+        envelope.eventId,
+        envelope.eventType,
+        String(envelope.eventVersion),
+        envelope.aggregateType,
+        envelope.aggregateId,
+        envelope.occurredAt,
+        canonicalize(envelope.payload),
+    ];
+    return Buffer.from(lines.join('\n'), 'utf8');
+}
+
+/**
+ * Compute the HMAC-SHA256 signature value (base64url-encoded) over the
+ * canonical bytes. The output is just the signature value; callers wrap
+ * it with `keyId` and `alg` to form a full {@link EventSignature}.
+ */
+export function computeHmac(
+    envelope: EventEnvelope,
+    secret: Buffer | string,
+): string {
+    const keyBuf = typeof secret === 'string' ? Buffer.from(secret, 'utf8') : secret;
+    const hmac = createHmac('sha256', keyBuf);
+    hmac.update(canonicalBytes(envelope));
+    return hmac.digest('base64url');
+}
+
+/**
+ * Sign an envelope. Returns a *new* envelope with `meta.signature`
+ * populated. The original envelope is not mutated.
+ *
+ * The producing service is responsible for key rotation: when a new key
+ * is rolled out, callers update `keyId` and `secret` together.
+ */
+export function signEnvelope(
+    envelope: EventEnvelope,
+    args: { keyId: string; secret: Buffer | string },
+): EventEnvelope {
+    const value = computeHmac(envelope, args.secret);
+    const signature: EventSignature = {
+        alg: 'HS256',
+        keyId: args.keyId,
+        value,
+    };
+    return {
+        ...envelope,
+        meta: {
+            ...(envelope.meta ?? {}),
+            signature,
+        },
+    };
+}
+
+/**
+ * Resolves a signing key by `keyId`. Returns the secret bytes, or `null`
+ * if the key is unknown. Implementations typically wrap an SSM cache.
+ */
+export type SignatureKeyResolver = (
+    keyId: string,
+) => Buffer | string | null | Promise<Buffer | string | null>;
+
+export interface VerifyResult {
+    readonly status: SignatureStatus;
+    /**
+     * `true` only when status is 'valid'. Convenience for callers that do
+     * not need to switch on every status.
+     */
+    readonly ok: boolean;
+    /**
+     * The keyId that was attempted. Useful for metric labels even on
+     * 'unknown_key' / 'invalid'.
+     */
+    readonly keyId: string | null;
+}
+
+/**
+ * Verify an envelope's signature. Pure async function — does not log,
+ * emit metrics, or throw. Combine with `SignatureMode` at the call site
+ * to decide whether to reject.
+ *
+ * Status values:
+ *   - 'absent'      — no signature on the envelope
+ *   - 'unknown_key' — keyId is not known to the resolver
+ *   - 'invalid'     — signature does not match
+ *   - 'valid'       — signature matches
+ */
+export async function verifyEnvelope(
+    envelope: EventEnvelope,
+    resolveKey: SignatureKeyResolver,
+): Promise<VerifyResult> {
+    const sig = envelope.meta?.signature;
+    if (!sig) {
+        return { status: 'absent', ok: false, keyId: null };
+    }
+    if (sig.alg !== 'HS256') {
+        // We currently only support HS256. Anything else is treated as
+        // 'invalid' — the envelope had a signature, but not one we can
+        // verify under the current contract.
+        return { status: 'invalid', ok: false, keyId: sig.keyId };
+    }
+    const secret = await resolveKey(sig.keyId);
+    if (secret === null) {
+        return { status: 'unknown_key', ok: false, keyId: sig.keyId };
+    }
+    const expected = computeHmac(envelope, secret);
+    const aBuf = Buffer.from(expected);
+    const bBuf = Buffer.from(sig.value);
+    if (aBuf.length !== bBuf.length) {
+        return { status: 'invalid', ok: false, keyId: sig.keyId };
+    }
+    const equal = timingSafeEqual(aBuf, bBuf);
+    return {
+        status: equal ? 'valid' : 'invalid',
+        ok: equal,
+        keyId: sig.keyId,
+    };
+}
+
+/**
+ * Combine `verifyEnvelope` with the configured mode to produce a single
+ * decision. The decision is pure — emitting the metric and rejecting are
+ * the caller's job (mirrors the two-headers pattern).
+ */
+export type SignatureAction = 'allow' | 'log' | 'reject';
+
+export interface SignatureDecision {
+    readonly action: SignatureAction;
+    readonly mode: SignatureMode;
+    readonly status: SignatureStatus;
+    readonly keyId: string | null;
+}
+
+export async function decideSignature(
+    envelope: EventEnvelope,
+    resolveKey: SignatureKeyResolver,
+    mode: SignatureMode,
+): Promise<SignatureDecision> {
+    if (mode === 'off') {
+        return { action: 'allow', mode, status: 'absent', keyId: null };
+    }
+    const v = await verifyEnvelope(envelope, resolveKey);
+    if (v.ok) {
+        return { action: 'allow', mode, status: v.status, keyId: v.keyId };
+    }
+    return {
+        action: mode === 'enforce' ? 'reject' : 'log',
+        mode,
+        status: v.status,
+        keyId: v.keyId,
+    };
+}
+
+/**
+ * Canonical metric name for the signature shadow→enforce migration.
+ * Recommended labels: { producer, status, keyId? }
+ */
+export const SIGNATURE_METRIC = 'saga_event_signature_status' as const;

--- a/packages/node/event-envelope/src/signing.ts
+++ b/packages/node/event-envelope/src/signing.ts
@@ -31,23 +31,91 @@ import type {
  */
 
 /**
- * Deterministic JSON serialization. Recursively sorts object keys.
- * Preserves array order. Throws on circular references via the JSON
- * default behavior (TypeError).
+ * Deterministic JSON serialization. Recursively sorts object keys
+ * (UTF-16 code-unit lexicographic order), preserves array order, and
+ * matches `JSON.stringify` semantics for non-JSON values:
+ *   - `undefined` / function / symbol values: dropped from objects,
+ *     replaced with `null` in arrays (per JSON spec).
+ *   - `BigInt`: throws (consistent with `JSON.stringify`).
+ *   - Circular references: throws (own implementation; we cannot
+ *     rely on `JSON.stringify` for the recursion).
+ *
+ * Compatibility note: this implementation is *JCS-inspired*, not
+ * strictly RFC 8785. It is sufficient for byte-identical reproduction
+ * across producer and consumer within Saga's trust boundary (both run
+ * Node V8). If we ever interop with a counterparty that requires
+ * strict RFC 8785, swap this function for a JCS implementation —
+ * everything else in this file is unchanged.
  */
 export function canonicalize(value: unknown): string {
-    if (value === null || typeof value !== 'object') {
-        return JSON.stringify(value);
+    return canonicalizeWithSeen(value, new WeakSet<object>());
+}
+
+function canonicalizeWithSeen(
+    value: unknown,
+    seen: WeakSet<object>,
+): string {
+    if (typeof value === 'bigint') {
+        throw new TypeError(
+            'canonicalize: BigInt is not JSON-serializable',
+        );
     }
-    if (Array.isArray(value)) {
-        return `[${value.map((v) => canonicalize(v)).join(',')}]`;
+    // Top-level undefined / symbol / function are not legal JSON values;
+    // a caller that hands us one is misusing the canonical-bytes
+    // contract. Throw rather than return invalid output.
+    if (
+        value === undefined ||
+        typeof value === 'symbol' ||
+        typeof value === 'function'
+    ) {
+        throw new TypeError(
+            'canonicalize: undefined / symbol / function are not allowed at top level',
+        );
     }
-    const keys = Object.keys(value as Record<string, unknown>).sort();
-    const parts = keys.map((k) => {
-        const v = (value as Record<string, unknown>)[k];
-        return `${JSON.stringify(k)}:${canonicalize(v)}`;
-    });
-    return `{${parts.join(',')}}`;
+    if (value === null) return 'null';
+    if (typeof value !== 'object') return JSON.stringify(value);
+    if (seen.has(value)) {
+        throw new TypeError('canonicalize: circular reference detected');
+    }
+    seen.add(value);
+    try {
+        if (Array.isArray(value)) {
+            const parts = value.map((v) => canonicalizeArrayItem(v, seen));
+            return `[${parts.join(',')}]`;
+        }
+        // Object: sort keys, drop entries whose value is undefined / symbol /
+        // function (matches `JSON.stringify` behavior).
+        const keys = Object.keys(value as Record<string, unknown>).sort();
+        const parts: string[] = [];
+        for (const k of keys) {
+            const v = (value as Record<string, unknown>)[k];
+            if (
+                v === undefined ||
+                typeof v === 'symbol' ||
+                typeof v === 'function'
+            ) {
+                continue;
+            }
+            parts.push(`${JSON.stringify(k)}:${canonicalizeWithSeen(v, seen)}`);
+        }
+        return `{${parts.join(',')}}`;
+    } finally {
+        seen.delete(value);
+    }
+}
+
+function canonicalizeArrayItem(
+    v: unknown,
+    seen: WeakSet<object>,
+): string {
+    if (
+        v === undefined ||
+        typeof v === 'symbol' ||
+        typeof v === 'function'
+    ) {
+        return 'null';
+    }
+    return canonicalizeWithSeen(v, seen);
 }
 
 /**
@@ -193,7 +261,17 @@ export async function decideSignature(
     mode: SignatureMode,
 ): Promise<SignatureDecision> {
     if (mode === 'off') {
-        return { action: 'allow', mode, status: 'absent', keyId: null };
+        // Don't verify — but report what is actually on the wire so
+        // the metric distinguishes "no signature emitted" (producer
+        // hasn't migrated) from "signature present but verifier
+        // disabled by policy".
+        const sig = envelope.meta?.signature;
+        return {
+            action: 'allow',
+            mode,
+            status: sig ? 'unverified' : 'absent',
+            keyId: sig?.keyId ?? null,
+        };
     }
     const v = await verifyEnvelope(envelope, resolveKey);
     if (v.ok) {

--- a/packages/node/event-integration-tests/package.json
+++ b/packages/node/event-integration-tests/package.json
@@ -11,6 +11,10 @@
         "clean": "rm -rf dist"
     },
     "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/context-async-hooks": "^1.28.0",
+        "@opentelemetry/sdk-trace-base": "^1.28.0",
+        "@saga-ed/soa-audit": "workspace:*",
         "@saga-ed/soa-auth-contracts": "workspace:*",
         "@saga-ed/soa-event-envelope": "workspace:*",
         "@saga-ed/soa-event-outbox": "workspace:*",

--- a/packages/node/event-integration-tests/package.json
+++ b/packages/node/event-integration-tests/package.json
@@ -11,7 +11,11 @@
         "clean": "rm -rf dist"
     },
     "dependencies": {
+        "@saga-ed/soa-event-envelope": "workspace:*",
+        "@saga-ed/soa-event-outbox": "workspace:*",
         "@saga-ed/soa-event-test-harness": "workspace:*",
+        "@saga-ed/soa-logger": "workspace:*",
+        "@saga-ed/soa-rabbitmq": "workspace:*",
         "amqplib": "^0.10.4",
         "pg": "^8.13.0"
     },

--- a/packages/node/event-integration-tests/package.json
+++ b/packages/node/event-integration-tests/package.json
@@ -11,6 +11,7 @@
         "clean": "rm -rf dist"
     },
     "dependencies": {
+        "@saga-ed/soa-auth-contracts": "workspace:*",
         "@saga-ed/soa-event-envelope": "workspace:*",
         "@saga-ed/soa-event-outbox": "workspace:*",
         "@saga-ed/soa-event-test-harness": "workspace:*",

--- a/packages/node/event-integration-tests/src/__tests__/audit-emit-otel.int.test.ts
+++ b/packages/node/event-integration-tests/src/__tests__/audit-emit-otel.int.test.ts
@@ -1,0 +1,284 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import {
+    context as otelContext,
+    trace as otelTrace,
+    type Tracer,
+} from '@opentelemetry/api';
+import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import {
+    BasicTracerProvider,
+    InMemorySpanExporter,
+    SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import {
+    createAuditEmitter,
+    AUDIT_LOG_CHANNEL,
+    type AuditDecisionEvent,
+} from '@saga-ed/soa-audit';
+import type { ILogger } from '@saga-ed/soa-logger';
+
+/**
+ * Real-OTel round-trip of the ADR 0004 audit emit seam:
+ *
+ *   tracer.startActiveSpan(ctx) → audit.emit(input) →
+ *   schema validation → writer captures event →
+ *   correlationId === active span.traceId
+ *
+ * Unit tests on createAuditEmitter use the OTel api in no-op mode and
+ * never see a real trace. This integration test wires a BasicTracerProvider
+ * + AsyncHooksContextManager so the trace context actually propagates,
+ * proving the correlationId default works in production-shaped runtimes.
+ */
+describe('audit emit + OTel correlation (integration)', () => {
+    const captured: Array<{
+        message: string;
+        data: Record<string, unknown> | undefined;
+    }> = [];
+    const captureLogger: ILogger = {
+        debug: () => {},
+        info: (message, data) => {
+            captured.push({ message, data: data as Record<string, unknown> });
+        },
+        warn: () => {},
+        error: () => {},
+    };
+
+    let tracer: Tracer;
+    let exporter: InMemorySpanExporter;
+    let provider: BasicTracerProvider;
+    let contextManager: AsyncHooksContextManager;
+
+    beforeAll(() => {
+        contextManager = new AsyncHooksContextManager();
+        contextManager.enable();
+        otelContext.setGlobalContextManager(contextManager);
+
+        exporter = new InMemorySpanExporter();
+        provider = new BasicTracerProvider();
+        provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+        provider.register();
+
+        tracer = otelTrace.getTracer('audit-int-test');
+    });
+
+    afterEach(() => {
+        captured.length = 0;
+        exporter.reset();
+    });
+
+    afterAll(async () => {
+        await provider.shutdown();
+        contextManager.disable();
+        otelContext.disable();
+    });
+
+    it('correlationId equals the active span traceId when emitted under a span', async () => {
+        const emitter = createAuditEmitter(captureLogger);
+        let observedTraceId: string | null = null;
+
+        await tracer.startActiveSpan('login-handler', async (span) => {
+            observedTraceId = span.spanContext().traceId;
+            await emitter.emit({
+                eventType: 'authn.login',
+                caller: null,
+                subject: {
+                    sub: 'spiffe://saga.dev/user/abc-123',
+                    tenantId: 'district:dist-1',
+                    sessionJti: 'sess-1',
+                    tokenJti: null,
+                },
+                resource: null,
+                action: 'login',
+                decision: 'allow',
+                reason: null,
+                fgaCheck: null,
+                occurredAt: new Date().toISOString(),
+                service: 'spiffe://saga.dev/iam-api',
+                env: 'dev',
+            });
+            span.end();
+        });
+
+        expect(captured.length).toBe(1);
+        const evt = captured[0]!.data!.event as AuditDecisionEvent;
+        expect(captured[0]!.data!.channel).toBe(AUDIT_LOG_CHANNEL);
+        expect(observedTraceId).toMatch(/^[0-9a-f]{32}$/);
+        expect(evt.correlationId).toBe(observedTraceId);
+        expect(evt.schemaVersion).toBe('v1');
+        expect(evt.eventType).toBe('authn.login');
+    });
+
+    it('falls back to a freshly generated 16-byte hex correlationId when no span is active', async () => {
+        const emitter = createAuditEmitter(captureLogger);
+
+        await emitter.emit({
+            eventType: 'authn.login',
+            caller: null,
+            subject: null,
+            resource: null,
+            action: 'login_failed',
+            decision: 'deny',
+            reason: 'invalid_password',
+            fgaCheck: null,
+            occurredAt: new Date().toISOString(),
+            service: 'spiffe://saga.dev/iam-api',
+            env: 'dev',
+        });
+
+        const evt = captured[0]!.data!.event as AuditDecisionEvent;
+        expect(evt.correlationId).toMatch(/^[0-9a-f]{32}$/);
+    });
+
+    it('explicit correlationId on the input wins over the active span', async () => {
+        const emitter = createAuditEmitter(captureLogger);
+        const explicit = 'a'.repeat(32);
+
+        await tracer.startActiveSpan('outer', async (span) => {
+            await emitter.emit({
+                eventType: 'authz.check',
+                caller: { spiffeId: 'spiffe://saga.dev/programs-api' },
+                subject: {
+                    sub: 'spiffe://saga.dev/user/abc',
+                    tenantId: 'district:dist-1',
+                    sessionJti: 'sess-1',
+                    tokenJti: 'tok-1',
+                },
+                resource: { type: 'program', id: 'prog-1', tenantId: 'district:dist-1' },
+                action: 'view',
+                decision: 'allow',
+                reason: null,
+                fgaCheck: { relation: 'viewer', object: 'program:prog-1' },
+                occurredAt: new Date().toISOString(),
+                correlationId: explicit,
+                service: 'spiffe://saga.dev/programs-api',
+                env: 'dev',
+            });
+            span.end();
+        });
+
+        const evt = captured[0]!.data!.event as AuditDecisionEvent;
+        expect(evt.correlationId).toBe(explicit);
+    });
+
+    it('schema validation rejects events missing a required field', async () => {
+        const emitter = createAuditEmitter(captureLogger);
+        // Cast through unknown to force a runtime-only invalid input —
+        // runtime validation is the contract under test here.
+        const badInput = {
+            eventType: 'mutation.create',
+            caller: null,
+            subject: null,
+            resource: null,
+            // action intentionally omitted
+            decision: 'allow',
+            reason: null,
+            fgaCheck: null,
+            occurredAt: new Date().toISOString(),
+            service: 'spiffe://saga.dev/programs-api',
+            env: 'dev',
+        } as unknown as Parameters<typeof emitter.emit>[0];
+        await expect(emitter.emit(badInput)).rejects.toThrow();
+        expect(captured.length).toBe(0);
+    });
+
+    it('schema rejects an env value not in the allowlist', async () => {
+        const emitter = createAuditEmitter(captureLogger);
+        const badInput = {
+            eventType: 'authn.login',
+            caller: null,
+            subject: null,
+            resource: null,
+            action: 'login',
+            decision: 'allow',
+            reason: null,
+            fgaCheck: null,
+            occurredAt: new Date().toISOString(),
+            service: 'spiffe://saga.dev/iam-api',
+            env: 'qa',
+        } as unknown as Parameters<typeof emitter.emit>[0];
+        await expect(emitter.emit(badInput)).rejects.toThrow();
+    });
+
+    it('multiple emits within the same span share the same correlationId', async () => {
+        const emitter = createAuditEmitter(captureLogger);
+        let traceId: string | null = null;
+
+        await tracer.startActiveSpan('mutation-handler', async (span) => {
+            traceId = span.spanContext().traceId;
+            await emitter.emit({
+                eventType: 'authz.check',
+                caller: { spiffeId: 'spiffe://saga.dev/programs-api' },
+                subject: {
+                    sub: 'spiffe://saga.dev/user/abc',
+                    tenantId: 'district:dist-1',
+                    sessionJti: 'sess-1',
+                    tokenJti: 'tok-1',
+                },
+                resource: { type: 'program', id: 'prog-1', tenantId: 'district:dist-1' },
+                action: 'create',
+                decision: 'allow',
+                reason: null,
+                fgaCheck: { relation: 'editor', object: 'program:prog-1' },
+                occurredAt: new Date().toISOString(),
+                service: 'spiffe://saga.dev/programs-api',
+                env: 'dev',
+            });
+            await emitter.emit({
+                eventType: 'mutation.create',
+                caller: { spiffeId: 'spiffe://saga.dev/programs-api' },
+                subject: {
+                    sub: 'spiffe://saga.dev/user/abc',
+                    tenantId: 'district:dist-1',
+                    sessionJti: 'sess-1',
+                    tokenJti: 'tok-1',
+                },
+                resource: { type: 'program', id: 'prog-1', tenantId: 'district:dist-1' },
+                action: 'create',
+                decision: 'allow',
+                reason: null,
+                fgaCheck: null,
+                occurredAt: new Date().toISOString(),
+                service: 'spiffe://saga.dev/programs-api',
+                env: 'dev',
+            });
+            span.end();
+        });
+
+        expect(captured.length).toBe(2);
+        const a = captured[0]!.data!.event as AuditDecisionEvent;
+        const b = captured[1]!.data!.event as AuditDecisionEvent;
+        expect(a.correlationId).toBe(traceId);
+        expect(b.correlationId).toBe(traceId);
+    });
+
+    it('custom writer receives the validated event and bypasses the logger', async () => {
+        const writerCalls: AuditDecisionEvent[] = [];
+        const emitter = createAuditEmitter(captureLogger, (event) => {
+            writerCalls.push(event);
+        });
+
+        await emitter.emit({
+            eventType: 'authn.logout',
+            caller: null,
+            subject: {
+                sub: 'spiffe://saga.dev/user/abc',
+                tenantId: 'district:dist-1',
+                sessionJti: 'sess-1',
+                tokenJti: 'tok-1',
+            },
+            resource: null,
+            action: 'logout',
+            decision: 'allow',
+            reason: null,
+            fgaCheck: null,
+            occurredAt: new Date().toISOString(),
+            service: 'spiffe://saga.dev/iam-api',
+            env: 'dev',
+        });
+
+        expect(writerCalls.length).toBe(1);
+        expect(writerCalls[0]!.eventType).toBe('authn.logout');
+        // Logger NOT invoked when a custom writer is supplied.
+        expect(captured.length).toBe(0);
+    });
+});

--- a/packages/node/event-integration-tests/src/__tests__/mode-flip-rollback.int.test.ts
+++ b/packages/node/event-integration-tests/src/__tests__/mode-flip-rollback.int.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import {
+    decideSignature,
+    signEnvelope,
+    type EventEnvelope,
+    type SignatureKeyResolver,
+    type SignatureMode,
+} from '@saga-ed/soa-event-envelope';
+import {
+    decideTwoHeaders,
+    type TwoHeadersMode,
+} from '@saga-ed/soa-auth-contracts';
+
+/**
+ * Mode-flip rollback safety per the rollout plan.
+ *
+ * The shadow→enforce migration is reversible by design: an operator
+ * flips a flag and traffic adjusts on the next request. This test pins
+ * the invariant that *no state is cached on the verifier path* — the
+ * mode parameter is honored on every call, so rollback works without
+ * a process restart.
+ *
+ * Both seams use a "decide is pure" pattern: the decision is computed
+ * fresh per call from (input, configured_mode, configured_resolver).
+ * That's why mode flips are safe — no closure captures last-seen mode.
+ */
+
+const KEY_ID = 'rollback-key';
+const SECRET = 'a'.repeat(64);
+
+function makeSignedEnvelope(payload: object): EventEnvelope {
+    const base: EventEnvelope = {
+        eventId: '00000000-0000-4000-8000-000000000001',
+        eventType: 'identity.user.created',
+        eventVersion: 1,
+        aggregateType: 'user',
+        aggregateId: 'agg-1',
+        occurredAt: new Date().toISOString(),
+        payload: payload as Record<string, unknown>,
+    };
+    return signEnvelope(base, { keyId: KEY_ID, secret: SECRET });
+}
+
+describe('signature mode flip: enforce → shadow → enforce within one process', () => {
+    it('the same forged envelope produces reject under enforce, log under shadow — no state pin', async () => {
+        const forged = makeSignedEnvelope({ userId: 'forged' });
+        // Resolver does NOT know the producer key, simulating the
+        // "consumer hasn't been re-keyed yet" rollback scenario.
+        const resolver: SignatureKeyResolver = () => null;
+
+        const sequence: SignatureMode[] = [
+            'enforce',
+            'shadow',
+            'enforce',
+            'off',
+            'enforce',
+        ];
+        const decisions = await Promise.all(
+            sequence.map((m) => decideSignature(forged, resolver, m)),
+        );
+        expect(decisions.map((d) => d.action)).toEqual([
+            'reject',
+            'log',
+            'reject',
+            'allow',
+            'reject',
+        ]);
+        expect(decisions[3]!.status).toBe('unverified');
+    });
+
+    it('a valid envelope under matching key: every mode allows', async () => {
+        const env = makeSignedEnvelope({ userId: 'good' });
+        const resolver: SignatureKeyResolver = (kid) =>
+            kid === KEY_ID ? SECRET : null;
+        for (const mode of ['off', 'shadow', 'enforce'] as SignatureMode[]) {
+            const d = await decideSignature(env, resolver, mode);
+            expect(d.action).toBe('allow');
+        }
+    });
+
+    it('mode parameter is read on every call — closure does not capture', async () => {
+        // Build the resolver and envelope once, then flip the mode many
+        // times. If anything cached the first-seen mode, behavior would
+        // diverge. We assert it doesn't.
+        const env = makeSignedEnvelope({ userId: 'cap' });
+        const resolver: SignatureKeyResolver = () => null;
+        const flips = 50;
+        const expected: Array<'allow' | 'log' | 'reject'> = [];
+        const observed: Array<'allow' | 'log' | 'reject'> = [];
+        for (let i = 0; i < flips; i++) {
+            const m: SignatureMode = i % 2 === 0 ? 'shadow' : 'enforce';
+            expected.push(m === 'shadow' ? 'log' : 'reject');
+            const d = await decideSignature(env, resolver, m);
+            observed.push(d.action);
+        }
+        expect(observed).toEqual(expected);
+    });
+});
+
+describe('two-headers mode flip: enforce → shadow → enforce within one process', () => {
+    it('same incomplete header set: reject under enforce, log under shadow', () => {
+        const incomplete = {
+            // Missing X-Saga-Caller; Authorization present but not Bearer
+            authorization: 'Basic dXNlcjpwYXNz',
+        } as Record<string, string>;
+
+        const sequence: TwoHeadersMode[] = ['enforce', 'shadow', 'enforce', 'off'];
+        const decisions = sequence.map((m) => decideTwoHeaders(incomplete, m));
+        expect(decisions.map((d) => d.action)).toEqual([
+            'reject',
+            'log',
+            'reject',
+            'allow',
+        ]);
+        expect(decisions[0]!.metricReason).toBe('caller_missing');
+        expect(decisions[1]!.metricReason).toBe('caller_missing');
+        expect(decisions[3]!.metricReason).toBeUndefined();
+    });
+
+    it('complete header set: every mode allows', () => {
+        const complete = {
+            'x-saga-caller': 'spiffe://saga.dev/test-client',
+            authorization: 'Bearer eyJ.fake.jwt',
+        };
+        for (const mode of ['off', 'shadow', 'enforce'] as TwoHeadersMode[]) {
+            const d = decideTwoHeaders(complete, mode);
+            expect(d.action).toBe('allow');
+        }
+    });
+
+    it('rapid mode flipping under load: behavior tracks the current flag', () => {
+        const incomplete = {
+            authorization: 'Basic xyz',
+        };
+        const flips = 100;
+        const observed: Array<'allow' | 'log' | 'reject'> = [];
+        for (let i = 0; i < flips; i++) {
+            const m: TwoHeadersMode = i % 2 === 0 ? 'shadow' : 'enforce';
+            observed.push(decideTwoHeaders(incomplete, m).action);
+        }
+        const expected: Array<'allow' | 'log' | 'reject'> = [];
+        for (let i = 0; i < flips; i++) {
+            expected.push(i % 2 === 0 ? 'log' : 'reject');
+        }
+        expect(observed).toEqual(expected);
+    });
+});

--- a/packages/node/event-integration-tests/src/__tests__/producer-consumer-signed-flow.int.test.ts
+++ b/packages/node/event-integration-tests/src/__tests__/producer-consumer-signed-flow.int.test.ts
@@ -1,0 +1,384 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import amqplib, { type Channel, type ChannelModel } from 'amqplib';
+import { Pool } from 'pg';
+import {
+    OUTBOX_EVENT_SQL,
+    OutboxRelay,
+} from '@saga-ed/soa-event-outbox';
+import {
+    decideSignature,
+    signEnvelope,
+    type EventEnvelope,
+    type SignatureKeyResolver,
+    type SignatureMode,
+} from '@saga-ed/soa-event-envelope';
+import { ConnectionManager } from '@saga-ed/soa-rabbitmq';
+import {
+    startInfra,
+    type InfraHandle,
+} from '@saga-ed/soa-event-test-harness';
+
+/**
+ * Full producer↔consumer signed-event flow per the rollout plan.
+ *
+ * Mirrors the real env-var plumbing both apps use:
+ *   producer (rostering iam-api):
+ *     EVENT_SIGNING_KEY_ID, EVENT_SIGNING_SECRET → OutboxRelay's
+ *     transformEnvelope hook calls signEnvelope(env, {keyId, secret}).
+ *   consumer (program-hub programs-api):
+ *     EVENT_SIGNATURE_VERIFY_KEYS (JSON map keyId→secret),
+ *     EVENT_SIGNATURE_ENFORCE flag → decideSignature(env, resolveKey, mode).
+ *
+ * Confidence target: prove that the *real services' configuration paths*
+ * agree on canonical bytes. The two sides import the same code from
+ * @saga-ed/soa-event-envelope, but a config typo (case-sensitive keyId,
+ * different base64 alphabet, different secret encoding) would silently
+ * break only when both sides actually run. This test guards that gap.
+ */
+
+const EXCHANGE = 'identity.events.flow.test';
+const KEY_ID_V1 = 'key-v1';
+const KEY_ID_V2 = 'key-v2';
+const SECRET_V1 = 'a'.repeat(64);
+const SECRET_V2 = 'b'.repeat(64);
+
+const noopLogger = {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+};
+
+interface ConsumedSignal {
+    envelope: EventEnvelope;
+    decision: Awaited<ReturnType<typeof decideSignature>>;
+    accepted: boolean;
+}
+
+/**
+ * Replicates rostering inversify.config.ts shape.
+ * See apps/node/iam-api/src/inversify.config.ts:73-90.
+ */
+function buildProducerTransform(): ((env: EventEnvelope) => EventEnvelope) | undefined {
+    const id = (process.env.EVENT_SIGNING_KEY_ID ?? '').trim();
+    const secret = (process.env.EVENT_SIGNING_SECRET ?? '').trim();
+    if (!id && !secret) return undefined;
+    if (!id || !secret) {
+        throw new Error(
+            'EVENT_SIGNING_KEY_ID and EVENT_SIGNING_SECRET must both be set or both unset',
+        );
+    }
+    return (envelope) => signEnvelope(envelope, { keyId: id, secret });
+}
+
+/**
+ * Replicates program-hub event-signature.ts shape.
+ * See apps/node/programs-api/src/auth/event-signature.ts.
+ */
+function readKeyMapFromEnv(): SignatureKeyResolver {
+    const raw = (process.env.EVENT_SIGNATURE_VERIFY_KEYS ?? '').trim();
+    if (!raw) return () => null;
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw);
+    } catch {
+        return () => null;
+    }
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+        return () => null;
+    }
+    const map = parsed as Record<string, unknown>;
+    return (keyId) => {
+        const v = map[keyId];
+        return typeof v === 'string' ? v : null;
+    };
+}
+
+function readModeFromEnv(): SignatureMode {
+    const raw = (process.env.EVENT_SIGNATURE_ENFORCE ?? '').toLowerCase();
+    if (raw === 'true' || raw === '1') return 'enforce';
+    if (raw === 'off') return 'off';
+    return 'shadow';
+}
+
+describe('producer↔consumer signed-event flow (integration)', () => {
+    let infra: InfraHandle;
+    let pool: Pool;
+    let connMgr: ConnectionManager;
+    let mqConn: ChannelModel;
+    let consumerChannel: Channel;
+    let consumerQueue: string;
+    const consumed: ConsumedSignal[] = [];
+    const originalEnv = { ...process.env };
+
+    beforeAll(async () => {
+        infra = await startInfra();
+        const dbUrl = await infra.createDatabase('producer_consumer_flow');
+        await infra.runSql(dbUrl, OUTBOX_EVENT_SQL);
+        pool = new Pool({ connectionString: dbUrl });
+
+        connMgr = new ConnectionManager(noopLogger, { url: infra.rabbitmqUrl });
+        await connMgr.connect();
+
+        mqConn = await amqplib.connect(infra.rabbitmqUrl);
+        consumerChannel = await mqConn.createChannel();
+        await consumerChannel.assertExchange(EXCHANGE, 'topic', { durable: true });
+        consumerQueue = `consumer.flow.${Date.now()}`;
+        // Not exclusive / not autoDelete — each scenario starts and
+        // cancels its own consumer, and we don't want the queue to vanish
+        // between scenarios when the consumer count momentarily hits 0.
+        await consumerChannel.assertQueue(consumerQueue, {
+            durable: false,
+            autoDelete: false,
+            exclusive: false,
+        });
+        await consumerChannel.bindQueue(consumerQueue, EXCHANGE, '#');
+    }, 120_000);
+
+    afterAll(async () => {
+        process.env = originalEnv;
+        try {
+            await consumerChannel?.close();
+            await mqConn?.close();
+        } catch {}
+        try {
+            await pool?.end();
+        } catch {}
+        await infra?.stop();
+    });
+
+    /**
+     * Spawns a simple consumer that mirrors program-hub's
+     * withSignatureVerification: parse → decideSignature → accept-or-throw.
+     * Returns a stop function. Each invocation builds resolver/mode from
+     * the *current* env vars (test mutates between scenarios).
+     */
+    async function startConsumer(): Promise<() => Promise<void>> {
+        // Drain any leftover messages from previous scenarios before
+        // attaching the new consumer — otherwise stale messages signed
+        // with a previous scenario's key get re-evaluated under the
+        // current scenario's resolver and pollute `consumed`.
+        await consumerChannel.purgeQueue(consumerQueue);
+
+        const resolveKey = readKeyMapFromEnv();
+        const mode = readModeFromEnv();
+        const consumerTag = `tag-${Date.now()}-${Math.random()}`;
+        let stopped = false;
+
+        void consumerChannel.consume(
+            consumerQueue,
+            async (msg) => {
+                if (!msg || stopped) return;
+                try {
+                    const envelope = JSON.parse(
+                        msg.content.toString('utf8'),
+                    ) as EventEnvelope;
+                    const decision = await decideSignature(envelope, resolveKey, mode);
+                    const accepted = decision.action !== 'reject';
+                    consumed.push({ envelope, decision, accepted });
+                } finally {
+                    consumerChannel.ack(msg);
+                }
+            },
+            { consumerTag },
+        );
+
+        return async () => {
+            stopped = true;
+            try {
+                await consumerChannel.cancel(consumerTag);
+            } catch {}
+        };
+    }
+
+    function newRelay(): OutboxRelay {
+        return new OutboxRelay({
+            pool,
+            connectionManager: connMgr,
+            exchange: EXCHANGE,
+            pollIntervalMs: 100,
+            logger: noopLogger,
+            transformEnvelope: buildProducerTransform(),
+        });
+    }
+
+    async function insertRow(eventId: string, payload: object): Promise<void> {
+        await pool.query(
+            `INSERT INTO outbox_event (
+                event_id, aggregate_type, aggregate_id, event_type,
+                event_version, payload, occurred_at
+             ) VALUES ($1::uuid, 'user', $2, 'identity.user.created',
+                       1, $3::jsonb, NOW())`,
+            [eventId, `agg-${Date.now()}`, JSON.stringify(payload)],
+        );
+    }
+
+    async function waitForConsumed(
+        eventId: string,
+        timeoutMs = 5_000,
+    ): Promise<ConsumedSignal> {
+        const deadline = Date.now() + timeoutMs;
+        while (Date.now() < deadline) {
+            const found = consumed.find((c) => c.envelope.eventId === eventId);
+            if (found) return found;
+            await new Promise((r) => setTimeout(r, 50));
+        }
+        throw new Error(`timeout waiting for consumed event ${eventId}`);
+    }
+
+    function newUuid(): string {
+        return (
+            '00000000-0000-4000-8000-' +
+            Math.floor(Math.random() * 0xffffffffffff)
+                .toString(16)
+                .padStart(12, '0')
+        );
+    }
+
+    it('producer signs with key-v1, consumer with key-v1 in resolver: status=valid', async () => {
+        process.env = {
+            ...originalEnv,
+            EVENT_SIGNING_KEY_ID: KEY_ID_V1,
+            EVENT_SIGNING_SECRET: SECRET_V1,
+            EVENT_SIGNATURE_VERIFY_KEYS: JSON.stringify({ [KEY_ID_V1]: SECRET_V1 }),
+            EVENT_SIGNATURE_ENFORCE: 'true',
+        };
+        const stopConsumer = await startConsumer();
+        const relay = newRelay();
+        await relay.start();
+
+        const eventId = newUuid();
+        await insertRow(eventId, { userId: 'flow-1', name: 'Valid Flow' });
+
+        const sig = await waitForConsumed(eventId);
+        expect(sig.envelope.meta?.signature?.keyId).toBe(KEY_ID_V1);
+        expect(sig.decision.status).toBe('valid');
+        expect(sig.decision.action).toBe('allow');
+        expect(sig.accepted).toBe(true);
+
+        await relay.stop();
+        await stopConsumer();
+    });
+
+    it('producer signs with key-v2, consumer only knows key-v1: enforce → reject', async () => {
+        process.env = {
+            ...originalEnv,
+            EVENT_SIGNING_KEY_ID: KEY_ID_V2,
+            EVENT_SIGNING_SECRET: SECRET_V2,
+            EVENT_SIGNATURE_VERIFY_KEYS: JSON.stringify({ [KEY_ID_V1]: SECRET_V1 }),
+            EVENT_SIGNATURE_ENFORCE: 'true',
+        };
+        const stopConsumer = await startConsumer();
+        const relay = newRelay();
+        await relay.start();
+
+        const eventId = newUuid();
+        await insertRow(eventId, { userId: 'flow-2' });
+
+        const sig = await waitForConsumed(eventId);
+        expect(sig.envelope.meta?.signature?.keyId).toBe(KEY_ID_V2);
+        expect(sig.decision.status).toBe('unknown_key');
+        expect(sig.decision.action).toBe('reject');
+        expect(sig.accepted).toBe(false);
+
+        await relay.stop();
+        await stopConsumer();
+    });
+
+    it('producer signs with key-v2, consumer only knows key-v1: shadow → log+allow', async () => {
+        process.env = {
+            ...originalEnv,
+            EVENT_SIGNING_KEY_ID: KEY_ID_V2,
+            EVENT_SIGNING_SECRET: SECRET_V2,
+            EVENT_SIGNATURE_VERIFY_KEYS: JSON.stringify({ [KEY_ID_V1]: SECRET_V1 }),
+            EVENT_SIGNATURE_ENFORCE: '',
+        };
+        const stopConsumer = await startConsumer();
+        const relay = newRelay();
+        await relay.start();
+
+        const eventId = newUuid();
+        await insertRow(eventId, { userId: 'flow-3' });
+
+        const sig = await waitForConsumed(eventId);
+        expect(sig.decision.status).toBe('unknown_key');
+        expect(sig.decision.action).toBe('log');
+        expect(sig.accepted).toBe(true);
+
+        await relay.stop();
+        await stopConsumer();
+    });
+
+    it('key rotation: consumer with both keys accepts events from either producer key', async () => {
+        process.env = {
+            ...originalEnv,
+            EVENT_SIGNING_KEY_ID: KEY_ID_V1,
+            EVENT_SIGNING_SECRET: SECRET_V1,
+            EVENT_SIGNATURE_VERIFY_KEYS: JSON.stringify({
+                [KEY_ID_V1]: SECRET_V1,
+                [KEY_ID_V2]: SECRET_V2,
+            }),
+            EVENT_SIGNATURE_ENFORCE: 'true',
+        };
+        const stopConsumer = await startConsumer();
+        const relay = newRelay();
+        await relay.start();
+
+        const id1 = newUuid();
+        await insertRow(id1, { userId: 'rot-1' });
+        const sig1 = await waitForConsumed(id1);
+        expect(sig1.decision.status).toBe('valid');
+        expect(sig1.envelope.meta?.signature?.keyId).toBe(KEY_ID_V1);
+
+        await relay.stop();
+
+        // Operator rotates the producer to v2. Consumer is unchanged.
+        process.env.EVENT_SIGNING_KEY_ID = KEY_ID_V2;
+        process.env.EVENT_SIGNING_SECRET = SECRET_V2;
+        const relay2 = newRelay();
+        await relay2.start();
+
+        const id2 = newUuid();
+        await insertRow(id2, { userId: 'rot-2' });
+        const sig2 = await waitForConsumed(id2);
+        expect(sig2.decision.status).toBe('valid');
+        expect(sig2.envelope.meta?.signature?.keyId).toBe(KEY_ID_V2);
+
+        await relay2.stop();
+        await stopConsumer();
+    });
+
+    it('producer with no signing config (legacy mode): envelope has no signature; consumer in shadow → status=absent, allow', async () => {
+        process.env = {
+            ...originalEnv,
+            EVENT_SIGNING_KEY_ID: '',
+            EVENT_SIGNING_SECRET: '',
+            EVENT_SIGNATURE_VERIFY_KEYS: JSON.stringify({ [KEY_ID_V1]: SECRET_V1 }),
+            EVENT_SIGNATURE_ENFORCE: '',
+        };
+        const stopConsumer = await startConsumer();
+        const relay = newRelay();
+        await relay.start();
+
+        const eventId = newUuid();
+        await insertRow(eventId, { userId: 'legacy-1' });
+
+        const sig = await waitForConsumed(eventId);
+        expect(sig.envelope.meta?.signature).toBeUndefined();
+        expect(sig.decision.status).toBe('absent');
+        expect(sig.decision.action).toBe('log');
+        expect(sig.accepted).toBe(true);
+
+        await relay.stop();
+        await stopConsumer();
+    });
+
+    it('half-configured producer (key without secret) throws at startup', () => {
+        process.env = {
+            ...originalEnv,
+            EVENT_SIGNING_KEY_ID: KEY_ID_V1,
+            EVENT_SIGNING_SECRET: '',
+        };
+        expect(() => buildProducerTransform()).toThrow(/must both be set/);
+    });
+});

--- a/packages/node/event-integration-tests/src/__tests__/signed-envelope-roundtrip.int.test.ts
+++ b/packages/node/event-integration-tests/src/__tests__/signed-envelope-roundtrip.int.test.ts
@@ -1,0 +1,236 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import amqplib, { type Channel, type ChannelModel } from 'amqplib';
+import { Pool } from 'pg';
+import {
+    OUTBOX_EVENT_SQL,
+    OutboxRelay,
+} from '@saga-ed/soa-event-outbox';
+import {
+    signEnvelope,
+    verifyEnvelope,
+    type EventEnvelope,
+} from '@saga-ed/soa-event-envelope';
+import { ConnectionManager } from '@saga-ed/soa-rabbitmq';
+import {
+    startInfra,
+    type InfraHandle,
+} from '@saga-ed/soa-event-test-harness';
+
+const KEY_ID = 'test-signing-key-1';
+const SECRET = Buffer.from(
+    'a'.repeat(32) + 'b'.repeat(32),
+    'utf8',
+);
+const EXCHANGE = 'identity.events.signing.test';
+
+interface PublishedMessage extends EventEnvelope {
+    meta?: EventEnvelope['meta'];
+}
+
+const noopLogger = {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+};
+
+/**
+ * Real round-trip of the ADR 0003 signing seam:
+ *   1. Insert an outbox row with no signature.
+ *   2. Run the relay with `transformEnvelope: signEnvelope(...)`.
+ *   3. A sniffer queue captures the published wire bytes.
+ *   4. Verify the sniffed envelope under the same key (positive case),
+ *      under a wrong key (unknown_key), and after a value tamper (invalid).
+ *
+ * If any of these fail, the producer-side seam is broken end to end —
+ * something unit tests on `signEnvelope` alone cannot catch (e.g. a relay
+ * regression that bypasses the transform, or a JSON-stringify drift between
+ * sign-time and consumer-time bytes).
+ */
+describe('signed envelope round-trip (integration)', () => {
+    let infra: InfraHandle;
+    let pool: Pool;
+    let connMgr: ConnectionManager;
+    let relay: OutboxRelay;
+    let mqConn: ChannelModel;
+    let snifferChannel: Channel;
+    const sniffQueue = `test.signed-sniffer.${Date.now()}`;
+
+    beforeAll(async () => {
+        infra = await startInfra();
+        const dbUrl = await infra.createDatabase('signed_envelope_test');
+        await infra.runSql(dbUrl, OUTBOX_EVENT_SQL);
+        pool = new Pool({ connectionString: dbUrl });
+
+        connMgr = new ConnectionManager(noopLogger, { url: infra.rabbitmqUrl });
+        await connMgr.connect();
+
+        relay = new OutboxRelay({
+            pool,
+            connectionManager: connMgr,
+            exchange: EXCHANGE,
+            pollIntervalMs: 100,
+            logger: noopLogger,
+            transformEnvelope: (env) =>
+                signEnvelope(env, { keyId: KEY_ID, secret: SECRET }),
+        });
+        await relay.start();
+
+        mqConn = await amqplib.connect(infra.rabbitmqUrl);
+        snifferChannel = await mqConn.createChannel();
+        await snifferChannel.assertExchange(EXCHANGE, 'topic', {
+            durable: true,
+        });
+        await snifferChannel.assertQueue(sniffQueue, {
+            durable: false,
+            autoDelete: true,
+            exclusive: true,
+        });
+        await snifferChannel.bindQueue(sniffQueue, EXCHANGE, '#');
+    }, 120_000);
+
+    afterAll(async () => {
+        try {
+            await relay?.stop();
+        } catch {}
+        try {
+            await snifferChannel?.close();
+            await mqConn?.close();
+        } catch {}
+        try {
+            await pool?.end();
+        } catch {}
+        await infra?.stop();
+    });
+
+    it('relay signs unsigned outbox rows and consumer verifies under the same key', async () => {
+        const eventId = newUuid();
+        await pool.query(
+            `INSERT INTO outbox_event (
+                event_id, aggregate_type, aggregate_id, event_type,
+                event_version, payload, occurred_at
+             ) VALUES ($1::uuid, 'user', $2, 'identity.user.created',
+                       1, $3::jsonb, NOW())`,
+            [
+                eventId,
+                'sign-pos-' + Date.now(),
+                JSON.stringify({
+                    userId: 'sign-pos',
+                    name: 'Sign Positive',
+                    email: 'sign-pos@example.com',
+                }),
+            ],
+        );
+
+        const msg = await waitForMessage(
+            snifferChannel,
+            sniffQueue,
+            (m) => m.eventId === eventId,
+            5_000,
+        );
+        expect(msg.meta?.signature).toBeDefined();
+        expect(msg.meta!.signature!.alg).toBe('HS256');
+        expect(msg.meta!.signature!.keyId).toBe(KEY_ID);
+        expect(msg.meta!.signature!.value).toMatch(/^[A-Za-z0-9_-]{43}$/);
+
+        const result = await verifyEnvelope(msg, async (kid) =>
+            kid === KEY_ID ? SECRET : null,
+        );
+        expect(result.status).toBe('valid');
+        expect(result.ok).toBe(true);
+
+        // Outbox row must be marked published after the relay tick.
+        const r = await pool.query<{ published_at: Date | null }>(
+            `SELECT published_at FROM outbox_event WHERE event_id = $1::uuid`,
+            [eventId],
+        );
+        expect(r.rows[0]?.published_at).not.toBeNull();
+    });
+
+    it('verification with an unknown key returns unknown_key', async () => {
+        const eventId = newUuid();
+        await pool.query(
+            `INSERT INTO outbox_event (
+                event_id, aggregate_type, aggregate_id, event_type,
+                event_version, payload, occurred_at
+             ) VALUES ($1::uuid, 'user', $2, 'identity.user.created',
+                       1, $3::jsonb, NOW())`,
+            [
+                eventId,
+                'sign-unk-' + Date.now(),
+                JSON.stringify({ userId: 'sign-unk' }),
+            ],
+        );
+        const msg = await waitForMessage(
+            snifferChannel,
+            sniffQueue,
+            (m) => m.eventId === eventId,
+            5_000,
+        );
+        const result = await verifyEnvelope(msg, async () => null);
+        expect(result.status).toBe('unknown_key');
+        expect(result.ok).toBe(false);
+        expect(result.keyId).toBe(KEY_ID);
+    });
+
+    it('a tampered payload byte invalidates the signature', async () => {
+        const eventId = newUuid();
+        await pool.query(
+            `INSERT INTO outbox_event (
+                event_id, aggregate_type, aggregate_id, event_type,
+                event_version, payload, occurred_at
+             ) VALUES ($1::uuid, 'user', $2, 'identity.user.created',
+                       1, $3::jsonb, NOW())`,
+            [
+                eventId,
+                'sign-tamper-' + Date.now(),
+                JSON.stringify({ userId: 'sign-tamper', name: 'Original' }),
+            ],
+        );
+        const msg = await waitForMessage(
+            snifferChannel,
+            sniffQueue,
+            (m) => m.eventId === eventId,
+            5_000,
+        );
+        // Tamper the payload AFTER capture; signature is over the original
+        // canonical bytes, so re-verify must fail under the same key.
+        const tampered: EventEnvelope = {
+            ...msg,
+            payload: { ...msg.payload, name: 'Tampered' },
+        };
+        const result = await verifyEnvelope(tampered, async () => SECRET);
+        expect(result.status).toBe('invalid');
+        expect(result.ok).toBe(false);
+    });
+});
+
+function newUuid(): string {
+    return (
+        '00000000-0000-4000-8000-' +
+        Math.floor(Math.random() * 0xffffffffffff)
+            .toString(16)
+            .padStart(12, '0')
+    );
+}
+
+async function waitForMessage(
+    channel: Channel,
+    queue: string,
+    predicate: (m: PublishedMessage) => boolean,
+    timeoutMs: number,
+): Promise<PublishedMessage> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        const got = await channel.get(queue, { noAck: true });
+        if (got) {
+            const msg = JSON.parse(
+                got.content.toString('utf8'),
+            ) as PublishedMessage;
+            if (predicate(msg)) return msg;
+        } else {
+            await new Promise((r) => setTimeout(r, 50));
+        }
+    }
+    throw new Error(`timed out after ${timeoutMs}ms waiting for matching message`);
+}

--- a/packages/node/event-integration-tests/src/__tests__/two-headers-http.int.test.ts
+++ b/packages/node/event-integration-tests/src/__tests__/two-headers-http.int.test.ts
@@ -1,0 +1,198 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import { AddressInfo } from 'node:net';
+import {
+    decideTwoHeaders,
+    HEADER_AUTHORIZATION,
+    HEADER_SAGA_CALLER,
+    type TwoHeadersDecision,
+    type TwoHeadersMode,
+} from '@saga-ed/soa-auth-contracts';
+
+/**
+ * Real HTTP round-trip of the ADR 0002 two-headers seam:
+ *
+ *   client → fetch with various header combinations →
+ *   http.createServer → decideTwoHeaders(req.headers, mode) →
+ *   200 (allow / log) | 401 (reject)
+ *
+ * Validates against `IncomingMessage.headers` — the same shape
+ * Express-based services (rostering iam-api, programs-api) hand to the
+ * package — which lowercases header names and may produce string[] for
+ * repeated headers. Unit tests on `parseTwoHeaders` exercise the helper
+ * directly; this test exercises the *wire path* end to end.
+ */
+describe('two-headers HTTP round-trip (integration)', () => {
+    let server: Server;
+    let baseUrl: string;
+    let mode: TwoHeadersMode = 'shadow';
+    const decisions: Array<{ path: string; decision: TwoHeadersDecision }> = [];
+
+    const handler = (req: IncomingMessage, res: ServerResponse): void => {
+        const decision = decideTwoHeaders(
+            req.headers as Record<string, string | string[] | undefined>,
+            mode,
+        );
+        decisions.push({ path: req.url ?? '', decision });
+        if (decision.action === 'reject') {
+            res.writeHead(401, { 'content-type': 'application/json' });
+            res.end(
+                JSON.stringify({
+                    error: 'unauthorized',
+                    reason: decision.metricReason,
+                }),
+            );
+            return;
+        }
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(
+            JSON.stringify({
+                ok: true,
+                action: decision.action,
+                metricReason: decision.metricReason ?? null,
+                callerSpiffeId: decision.parse.callerSpiffeId,
+            }),
+        );
+    };
+
+    beforeAll(async () => {
+        server = createServer(handler);
+        await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+        const addr = server.address() as AddressInfo;
+        baseUrl = `http://127.0.0.1:${addr.port}`;
+    });
+
+    afterAll(async () => {
+        await new Promise<void>((resolve, reject) =>
+            server.close((err) => (err ? reject(err) : resolve())),
+        );
+    });
+
+    function setMode(m: TwoHeadersMode): void {
+        mode = m;
+        decisions.length = 0;
+    }
+
+    describe('shadow mode', () => {
+        beforeAll(() => setMode('shadow'));
+
+        it('complete + valid headers → allow, no metric', async () => {
+            const r = await fetch(`${baseUrl}/ok`, {
+                headers: {
+                    [HEADER_SAGA_CALLER]: 'spiffe://saga.dev/test-client',
+                    [HEADER_AUTHORIZATION]: 'Bearer eyJ.fake.jwt',
+                },
+            });
+            expect(r.status).toBe(200);
+            const body = await r.json();
+            expect(body.action).toBe('allow');
+            expect(body.metricReason).toBeNull();
+            expect(body.callerSpiffeId).toBe('spiffe://saga.dev/test-client');
+        });
+
+        it('missing X-Saga-Caller → log, status 200, metric=caller_missing', async () => {
+            const r = await fetch(`${baseUrl}/no-caller`, {
+                headers: { [HEADER_AUTHORIZATION]: 'Bearer eyJ.fake.jwt' },
+            });
+            expect(r.status).toBe(200);
+            const body = await r.json();
+            expect(body.action).toBe('log');
+            expect(body.metricReason).toBe('caller_missing');
+        });
+
+        it('malformed X-Saga-Caller → log, metric=caller_malformed', async () => {
+            const r = await fetch(`${baseUrl}/bad-caller`, {
+                headers: {
+                    [HEADER_SAGA_CALLER]: 'not-a-spiffe-id',
+                    [HEADER_AUTHORIZATION]: 'Bearer eyJ.fake.jwt',
+                },
+            });
+            expect(r.status).toBe(200);
+            const body = await r.json();
+            expect(body.metricReason).toBe('caller_malformed');
+        });
+
+        it('missing Authorization → log, metric=subject_missing', async () => {
+            const r = await fetch(`${baseUrl}/no-auth`, {
+                headers: { [HEADER_SAGA_CALLER]: 'spiffe://saga.dev/test-client' },
+            });
+            expect(r.status).toBe(200);
+            const body = await r.json();
+            expect(body.metricReason).toBe('subject_missing');
+        });
+
+        it('non-Bearer Authorization → log, metric=subject_malformed', async () => {
+            const r = await fetch(`${baseUrl}/bad-auth`, {
+                headers: {
+                    [HEADER_SAGA_CALLER]: 'spiffe://saga.dev/test-client',
+                    [HEADER_AUTHORIZATION]: 'Basic dXNlcjpwYXNz',
+                },
+            });
+            expect(r.status).toBe(200);
+            const body = await r.json();
+            expect(body.metricReason).toBe('subject_malformed');
+        });
+
+        it('lowercase X-Saga-Caller (Node-normalized) is honored', async () => {
+            // Express passes `req.headers` already lowercased — the parser must
+            // tolerate that without a case-sensitive miss.
+            const r = await fetch(`${baseUrl}/lowercase`, {
+                headers: {
+                    'x-saga-caller': 'spiffe://saga.dev/test-client',
+                    authorization: 'Bearer eyJ.fake.jwt',
+                },
+            });
+            expect(r.status).toBe(200);
+            const body = await r.json();
+            expect(body.action).toBe('allow');
+            expect(body.callerSpiffeId).toBe('spiffe://saga.dev/test-client');
+        });
+    });
+
+    describe('enforce mode', () => {
+        beforeAll(() => setMode('enforce'));
+
+        it('complete headers → 200', async () => {
+            const r = await fetch(`${baseUrl}/ok`, {
+                headers: {
+                    [HEADER_SAGA_CALLER]: 'spiffe://saga.dev/test-client',
+                    [HEADER_AUTHORIZATION]: 'Bearer eyJ.fake.jwt',
+                },
+            });
+            expect(r.status).toBe(200);
+        });
+
+        it('missing X-Saga-Caller → 401 with reason', async () => {
+            const r = await fetch(`${baseUrl}/reject`, {
+                headers: { [HEADER_AUTHORIZATION]: 'Bearer eyJ.fake.jwt' },
+            });
+            expect(r.status).toBe(401);
+            const body = await r.json();
+            expect(body.reason).toBe('caller_missing');
+        });
+
+        it('malformed caller → 401 with reason', async () => {
+            const r = await fetch(`${baseUrl}/reject`, {
+                headers: {
+                    [HEADER_SAGA_CALLER]: 'http://not-spiffe',
+                    [HEADER_AUTHORIZATION]: 'Bearer eyJ.fake.jwt',
+                },
+            });
+            expect(r.status).toBe(401);
+            const body = await r.json();
+            expect(body.reason).toBe('caller_malformed');
+        });
+    });
+
+    describe('off mode', () => {
+        beforeAll(() => setMode('off'));
+
+        it('totally absent headers → 200, no metric', async () => {
+            const r = await fetch(`${baseUrl}/off`);
+            expect(r.status).toBe(200);
+            const body = await r.json();
+            expect(body.action).toBe('allow');
+            expect(body.metricReason).toBeNull();
+        });
+    });
+});

--- a/packages/node/event-outbox/package.json
+++ b/packages/node/event-outbox/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/soa-event-outbox",
-    "version": "0.1.0-dev.4",
+    "version": "0.1.0-dev.6",
     "private": false,
     "type": "module",
     "main": "dist/index.js",

--- a/packages/node/event-outbox/src/__tests__/relay-transform.unit.test.ts
+++ b/packages/node/event-outbox/src/__tests__/relay-transform.unit.test.ts
@@ -1,0 +1,255 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { EventEnvelope } from '@saga-ed/soa-event-envelope';
+import { OutboxRelay, type EnvelopeTransform } from '../relay.js';
+
+/**
+ * Integration tests for the OutboxRelay transformEnvelope hook.
+ *
+ * Stubs Pool, Channel, ConnectionManager, and Logger — exercises the
+ * publishRow path end-to-end to prove:
+ *   1. transformEnvelope is called between database load and publish
+ *   2. The returned envelope's bytes are what gets published to AMQP
+ *   3. An async transform is awaited (not fire-and-forget)
+ *   4. A transform that throws bumps `attempts` and isolates the
+ *      failure to the offending row (poison-loop protection)
+ *   5. With no transform supplied, behavior is identity (back-compat)
+ *
+ * These tests intentionally do NOT spin up a real Postgres or
+ * RabbitMQ — the hook contract is what we're verifying, not the broker
+ * or DB clients.
+ */
+
+interface StubChannelPublishCall {
+    exchange: string;
+    routingKey: string;
+    payload: Buffer;
+}
+
+function makeStubChannel() {
+    const calls: StubChannelPublishCall[] = [];
+    const channel = {
+        assertExchange: vi.fn(async () => undefined),
+        publish: vi.fn(
+            (exchange: string, routingKey: string, payload: Buffer) => {
+                calls.push({ exchange, routingKey, payload });
+                return true;
+            },
+        ),
+        on: vi.fn(),
+        once: vi.fn(),
+        removeListener: vi.fn(),
+        close: vi.fn(async () => undefined),
+    };
+    return { channel, calls };
+}
+
+function makeStubLogger() {
+    return {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+    };
+}
+
+interface PoolQueryCall {
+    sql: string;
+    params: unknown[];
+}
+
+function makeStubPool(rows: Record<string, unknown>[]) {
+    const queries: PoolQueryCall[] = [];
+    let consumed = false;
+    const client = {
+        query: vi.fn(async (sql: string, params?: unknown[]) => {
+            queries.push({ sql, params: params ?? [] });
+            // First SELECT returns the rows; second-and-later return empty
+            if (sql.includes('SELECT') && !consumed) {
+                consumed = true;
+                return { rows };
+            }
+            return { rows: [] };
+        }),
+        release: vi.fn(),
+    };
+    const pool = {
+        connect: vi.fn(async () => client),
+    };
+    return { pool, client, queries };
+}
+
+function makeRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+        event_id: '00000000-0000-4000-8000-000000000001',
+        aggregate_type: 'user',
+        aggregate_id: 'u-1',
+        event_type: 'identity.user.created',
+        event_version: 1,
+        payload: { userId: 'u-1' },
+        meta: null,
+        occurred_at: new Date('2026-05-07T00:00:00.000Z'),
+        attempts: 0,
+        ...overrides,
+    };
+}
+
+async function buildRelay(opts: {
+    rows?: Record<string, unknown>[];
+    transformEnvelope?: EnvelopeTransform;
+    maxAttempts?: number;
+}) {
+    const { channel, calls } = makeStubChannel();
+    const { pool, queries } = makeStubPool(opts.rows ?? []);
+    const logger = makeStubLogger();
+    const connectionManager = {
+        newChannel: vi.fn(async () => channel),
+    };
+    const relay = new OutboxRelay({
+        pool: pool as never,
+        connectionManager: connectionManager as never,
+        exchange: 'test.events',
+        logger: logger as never,
+        transformEnvelope: opts.transformEnvelope,
+        maxAttempts: opts.maxAttempts,
+    });
+    await relay.start();
+    return { relay, channel, publishCalls: calls, queries, logger };
+}
+
+function readPublishedEnvelope(payload: Buffer): EventEnvelope {
+    return JSON.parse(payload.toString('utf8')) as EventEnvelope;
+}
+
+describe('OutboxRelay transformEnvelope hook', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('publishes identity envelope when no transform is supplied', async () => {
+        const { relay, publishCalls } = await buildRelay({
+            rows: [makeRow()],
+        });
+        // Manually drive one batch (the start() polling loop is async; we
+        // don't want to wait for it). drainBatch is private, but tick is
+        // package-internal — call it via the public scheduleNext path.
+        await (relay as unknown as { drainBatch: () => Promise<void> }).drainBatch();
+        expect(publishCalls).toHaveLength(1);
+        const env = readPublishedEnvelope(publishCalls[0]!.payload);
+        expect(env.eventType).toBe('identity.user.created');
+        expect(env.meta?.signature).toBeUndefined();
+        await relay.stop();
+    });
+
+    it('calls transformEnvelope with the wire-meta-enriched envelope', async () => {
+        const seen: EventEnvelope[] = [];
+        const transform: EnvelopeTransform = (env) => {
+            seen.push(env);
+            return env;
+        };
+        const { relay } = await buildRelay({
+            rows: [makeRow()],
+            transformEnvelope: transform,
+        });
+        await (relay as unknown as { drainBatch: () => Promise<void> }).drainBatch();
+        expect(seen).toHaveLength(1);
+        expect(seen[0]!.eventId).toBe('00000000-0000-4000-8000-000000000001');
+        await relay.stop();
+    });
+
+    it('publishes the envelope returned by transformEnvelope (not the input)', async () => {
+        const transform: EnvelopeTransform = (env) => ({
+            ...env,
+            meta: {
+                ...env.meta,
+                signature: { alg: 'HS256', keyId: 'k1', value: 'A'.repeat(43) },
+            } as EventEnvelope['meta'],
+        });
+        const { relay, publishCalls } = await buildRelay({
+            rows: [makeRow()],
+            transformEnvelope: transform,
+        });
+        await (relay as unknown as { drainBatch: () => Promise<void> }).drainBatch();
+        const env = readPublishedEnvelope(publishCalls[0]!.payload);
+        expect(env.meta?.signature).toEqual({
+            alg: 'HS256',
+            keyId: 'k1',
+            value: 'A'.repeat(43),
+        });
+        await relay.stop();
+    });
+
+    it('awaits async transformEnvelope before publishing', async () => {
+        let resolved = false;
+        const transform: EnvelopeTransform = async (env) => {
+            await new Promise<void>((r) => setTimeout(r, 10));
+            resolved = true;
+            return env;
+        };
+        const { relay, publishCalls } = await buildRelay({
+            rows: [makeRow()],
+            transformEnvelope: transform,
+        });
+        await (relay as unknown as { drainBatch: () => Promise<void> }).drainBatch();
+        expect(resolved).toBe(true);
+        expect(publishCalls).toHaveLength(1);
+        await relay.stop();
+    });
+
+    it('isolates a failing transform to the offending row, bumps attempts, continues batch', async () => {
+        const goodRow = makeRow({
+            event_id: '00000000-0000-4000-8000-000000000001',
+        });
+        const badRow = makeRow({
+            event_id: '00000000-0000-4000-8000-000000000002',
+            event_type: 'identity.user.broken',
+        });
+        const transform: EnvelopeTransform = (env) => {
+            if (env.eventType === 'identity.user.broken') {
+                throw new Error('signing failed for this event');
+            }
+            return env;
+        };
+        const { relay, publishCalls, queries, logger } = await buildRelay({
+            rows: [goodRow, badRow],
+            transformEnvelope: transform,
+        });
+        await (relay as unknown as { drainBatch: () => Promise<void> }).drainBatch();
+
+        // Good row published; bad row not
+        expect(publishCalls).toHaveLength(1);
+        expect(readPublishedEnvelope(publishCalls[0]!.payload).eventType).toBe(
+            'identity.user.created',
+        );
+
+        // attempts++ UPDATE for the failed row
+        const attemptsUpdate = queries.find((q) =>
+            q.sql.includes('attempts = attempts + 1'),
+        );
+        expect(attemptsUpdate).toBeDefined();
+        expect(attemptsUpdate!.params[0]).toEqual([badRow.event_id]);
+
+        // published_at UPDATE for the good row only
+        const publishedUpdate = queries.find((q) =>
+            q.sql.includes('SET published_at = NOW()'),
+        );
+        expect(publishedUpdate).toBeDefined();
+        expect(publishedUpdate!.params[0]).toEqual([goodRow.event_id]);
+
+        // Warning logged for the failure
+        expect(logger.warn).toHaveBeenCalled();
+        await relay.stop();
+    });
+
+    it('skips rows whose attempts >= maxAttempts (poison-loop protection)', async () => {
+        const { relay, queries } = await buildRelay({
+            rows: [],
+            maxAttempts: 5,
+        });
+        await (relay as unknown as { drainBatch: () => Promise<void> }).drainBatch();
+        const select = queries.find((q) => q.sql.includes('SELECT'));
+        expect(select).toBeDefined();
+        expect(select!.sql).toContain('attempts < $2');
+        expect(select!.params[1]).toBe(5);
+        await relay.stop();
+    });
+});

--- a/packages/node/event-outbox/src/relay.ts
+++ b/packages/node/event-outbox/src/relay.ts
@@ -69,6 +69,17 @@ export interface OutboxRelayOpts {
      * per ADR 0003 (signed event envelope). Defaults to identity.
      */
     transformEnvelope?: EnvelopeTransform;
+    /**
+     * Per-row retry budget. Rows whose `attempts` reach this value are
+     * skipped on subsequent polls (still selected for forensics via
+     * direct queries) — without this cap, a permanently-malformed
+     * envelope or a permanently-broken `transformEnvelope` would
+     * wedge the relay in a tight retry loop, hot-path the broker, and
+     * stall the rest of the queue. Default 5. Operators bumping this
+     * should plan for the tradeoff: more retries = more flakiness
+     * tolerance but longer poison-row dwell.
+     */
+    maxAttempts?: number;
     logger: ILogger;
 }
 
@@ -171,6 +182,7 @@ export class OutboxRelay {
             throw new Error('OutboxRelay not started');
         }
         const batchSize = this.opts.batchSize ?? 100;
+        const maxAttempts = this.opts.maxAttempts ?? 5;
         const client = await this.opts.pool.connect();
         let clientPoisoned = false;
         try {
@@ -180,10 +192,11 @@ export class OutboxRelay {
                         event_version, payload, meta, occurred_at, attempts
                  FROM outbox_event
                  WHERE published_at IS NULL
+                   AND attempts < $2
                  ORDER BY occurred_at
                  LIMIT $1
                  FOR UPDATE SKIP LOCKED`,
-                [batchSize],
+                [batchSize, maxAttempts],
             );
 
             if (result.rows.length === 0) {
@@ -192,16 +205,48 @@ export class OutboxRelay {
             }
 
             const publishedIds: string[] = [];
+            const failedIds: string[] = [];
+            let lastFailureMessage = '';
             for (const row of result.rows) {
-                await this.publishRow(row);
-                publishedIds.push(row.event_id);
+                try {
+                    await this.publishRow(row);
+                    publishedIds.push(row.event_id);
+                } catch (err) {
+                    // Per-row isolation. A bad row (failed transform,
+                    // malformed payload, AMQP refusal) bumps its
+                    // attempts counter and yields to the rest of the
+                    // batch. Without per-row isolation, one bad row
+                    // would block every subsequent row's publish.
+                    failedIds.push(row.event_id);
+                    const message =
+                        err instanceof Error ? err.message : String(err);
+                    lastFailureMessage = message;
+                    this.opts.logger.warn(
+                        `[OutboxRelay] publishRow failed for event ${row.event_id} (attempt ${row.attempts + 1}/${maxAttempts}): ${message}`,
+                    );
+                    this.opts.metrics?.onPublishFailed(
+                        row.event_type,
+                        row.event_version,
+                        message,
+                    );
+                }
             }
 
-            // Batch the published_at update — one round-trip instead of N.
-            await client.query(
-                `UPDATE outbox_event SET published_at = NOW() WHERE event_id = ANY($1::uuid[])`,
-                [publishedIds],
-            );
+            if (publishedIds.length > 0) {
+                await client.query(
+                    `UPDATE outbox_event SET published_at = NOW() WHERE event_id = ANY($1::uuid[])`,
+                    [publishedIds],
+                );
+            }
+            if (failedIds.length > 0) {
+                await client.query(
+                    `UPDATE outbox_event
+                     SET attempts = attempts + 1,
+                         last_error = $2
+                     WHERE event_id = ANY($1::uuid[])`,
+                    [failedIds, lastFailureMessage.slice(0, 1000)],
+                );
+            }
 
             await client.query('COMMIT');
         } catch (err) {

--- a/packages/node/event-outbox/src/relay.ts
+++ b/packages/node/event-outbox/src/relay.ts
@@ -2,6 +2,7 @@ import type { Channel } from 'amqplib';
 import type { Pool } from 'pg';
 import type { ILogger } from '@saga-ed/soa-logger';
 import type { ConnectionManager } from '@saga-ed/soa-rabbitmq';
+import type { EventEnvelope } from '@saga-ed/soa-event-envelope';
 import {
     SpanKind,
     SpanStatusCode,
@@ -16,6 +17,22 @@ export interface OutboxMetrics {
     /** Called when publishing a row throws. */
     onPublishFailed: (eventType: string, eventVersion: number, reason: string) => void;
 }
+
+/**
+ * Hook for transforming an envelope between database load and AMQP publish.
+ *
+ * The primary use case is signing per ADR 0003: producers wrap an HMAC
+ * signer and pass it as `transformEnvelope`. The hook receives the
+ * envelope already enriched with the wire trace context and returns a
+ * possibly-modified envelope. Throwing aborts publication for that row;
+ * it stays unpublished and is retried on the next tick.
+ *
+ * The hook MUST be a pure function of its input — no mutation. Returning
+ * the same reference is fine when no transformation applies.
+ */
+export type EnvelopeTransform = (
+    envelope: EventEnvelope,
+) => EventEnvelope | Promise<EventEnvelope>;
 
 export interface OutboxRelayOpts {
     /** Dedicated pg pool for the relay (separate from the service's Prisma client). */
@@ -46,6 +63,12 @@ export interface OutboxRelayOpts {
     onFatalError?: (err: Error) => void;
     /** Optional Prometheus hooks. No-op when undefined. */
     metrics?: OutboxMetrics;
+    /**
+     * Optional transform applied to each envelope between database load
+     * and AMQP publish. Used by producers to attach an HMAC signature
+     * per ADR 0003 (signed event envelope). Defaults to identity.
+     */
+    transformEnvelope?: EnvelopeTransform;
     logger: ILogger;
 }
 
@@ -248,21 +271,30 @@ export class OutboxRelay {
                     wireMeta,
                 );
 
-                const message = {
+                const message: EventEnvelope = {
                     eventId: row.event_id,
                     eventType: row.event_type,
                     eventVersion: row.event_version,
                     aggregateType: row.aggregate_type,
                     aggregateId: row.aggregate_id,
                     occurredAt: row.occurred_at.toISOString(),
-                    payload: row.payload,
-                    ...(Object.keys(wireMeta).length > 0 ? { meta: wireMeta } : {}),
+                    payload: row.payload as Record<string, unknown>,
+                    ...(Object.keys(wireMeta).length > 0
+                        ? { meta: wireMeta as EventEnvelope['meta'] }
+                        : {}),
                 };
+
+                // ADR 0003 — apply optional transform (typically signing)
+                // after the trace context is in place but before publish.
+                // The transform must NOT mutate `message`; the relay
+                // continues with the returned envelope.
+                const transform = this.opts.transformEnvelope;
+                const finalMessage = transform ? await transform(message) : message;
 
                 const ok = this.channel!.publish(
                     this.opts.exchange,
                     row.event_type,
-                    Buffer.from(JSON.stringify(message)),
+                    Buffer.from(JSON.stringify(finalMessage)),
                     {
                         contentType: 'application/json',
                         persistent: true,

--- a/packages/node/event-outbox/src/relay.ts
+++ b/packages/node/event-outbox/src/relay.ts
@@ -206,21 +206,19 @@ export class OutboxRelay {
 
             const publishedIds: string[] = [];
             const failedIds: string[] = [];
-            let lastFailureMessage = '';
+            const failedMessages: string[] = [];
             for (const row of result.rows) {
                 try {
                     await this.publishRow(row);
                     publishedIds.push(row.event_id);
                 } catch (err) {
-                    // Per-row isolation. A bad row (failed transform,
-                    // malformed payload, AMQP refusal) bumps its
-                    // attempts counter and yields to the rest of the
-                    // batch. Without per-row isolation, one bad row
-                    // would block every subsequent row's publish.
-                    failedIds.push(row.event_id);
+                    // Per-row isolation: one bad row bumps its own
+                    // attempts counter without blocking the rest of
+                    // the batch.
                     const message =
                         err instanceof Error ? err.message : String(err);
-                    lastFailureMessage = message;
+                    failedIds.push(row.event_id);
+                    failedMessages.push(message.slice(0, 1000));
                     this.opts.logger.warn(
                         `[OutboxRelay] publishRow failed for event ${row.event_id} (attempt ${row.attempts + 1}/${maxAttempts}): ${message}`,
                     );
@@ -242,9 +240,10 @@ export class OutboxRelay {
                 await client.query(
                     `UPDATE outbox_event
                      SET attempts = attempts + 1,
-                         last_error = $2
-                     WHERE event_id = ANY($1::uuid[])`,
-                    [failedIds, lastFailureMessage.slice(0, 1000)],
+                         last_error = u.err
+                     FROM unnest($1::uuid[], $2::text[]) AS u(id, err)
+                     WHERE outbox_event.event_id = u.id`,
+                    [failedIds, failedMessages],
                 );
             }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1032,9 +1032,21 @@ importers:
 
   packages/node/event-integration-tests:
     dependencies:
+      '@saga-ed/soa-event-envelope':
+        specifier: workspace:*
+        version: link:../event-envelope
+      '@saga-ed/soa-event-outbox':
+        specifier: workspace:*
+        version: link:../event-outbox
       '@saga-ed/soa-event-test-harness':
         specifier: workspace:*
         version: link:../event-test-harness
+      '@saga-ed/soa-logger':
+        specifier: workspace:*
+        version: link:../logger
+      '@saga-ed/soa-rabbitmq':
+        specifier: workspace:*
+        version: link:../rabbitmq
       amqplib:
         specifier: ^0.10.4
         version: 0.10.9

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1032,6 +1032,9 @@ importers:
 
   packages/node/event-integration-tests:
     dependencies:
+      '@saga-ed/soa-auth-contracts':
+        specifier: workspace:*
+        version: link:../../core/auth-contracts
       '@saga-ed/soa-event-envelope':
         specifier: workspace:*
         version: link:../event-envelope

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1032,6 +1032,18 @@ importers:
 
   packages/node/event-integration-tests:
     dependencies:
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.1
+      '@opentelemetry/context-async-hooks':
+        specifier: ^1.28.0
+        version: 1.28.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^1.28.0
+        version: 1.28.0(@opentelemetry/api@1.9.1)
+      '@saga-ed/soa-audit':
+        specifier: workspace:*
+        version: link:../audit
       '@saga-ed/soa-auth-contracts':
         specifier: workspace:*
         version: link:../../core/auth-contracts

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -811,6 +811,34 @@ importers:
         specifier: ^5.8.3
         version: 5.9.3
 
+  packages/node/audit:
+    dependencies:
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.1
+      '@saga-ed/soa-auth-contracts':
+        specifier: workspace:*
+        version: link:../../core/auth-contracts
+      '@saga-ed/soa-logger':
+        specifier: workspace:*
+        version: link:../logger
+    devDependencies:
+      '@saga-ed/soa-typescript-config':
+        specifier: workspace:*
+        version: link:../../core/typescript-config
+      '@types/node':
+        specifier: ^24.0.3
+        version: 24.0.12
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.2)(yaml@2.8.2)
+      typescript:
+        specifier: 5.8.2
+        version: 5.8.2
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@24.0.12)
+
   packages/node/aws-util:
     dependencies:
       '@aws-sdk/client-secrets-manager':
@@ -14769,8 +14797,8 @@ snapshots:
       '@typescript-eslint/parser': 8.50.0(eslint@8.57.1)(typescript@5.8.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -14813,6 +14841,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 8.57.1
+      get-tsconfig: 4.13.0
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.15
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -14824,18 +14867,18 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.50.0(eslint@8.57.1)(typescript@5.8.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -14850,7 +14893,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -14861,7 +14904,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -499,6 +499,28 @@ importers:
         specifier: ^1.6.1
         version: 1.6.1(@types/node@25.6.0)
 
+  packages/core/auth-contracts:
+    dependencies:
+      zod:
+        specifier: 3.25.67
+        version: 3.25.67
+    devDependencies:
+      '@saga-ed/soa-typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      '@types/node':
+        specifier: ^24.0.3
+        version: 24.0.12
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.2)(yaml@2.8.2)
+      typescript:
+        specifier: 5.8.2
+        version: 5.8.2
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@24.0.12)
+
   packages/core/config:
     dependencies:
       dotenv:
@@ -576,6 +598,24 @@ importers:
         version: 8.50.0(eslint@8.57.1)(typescript@5.9.3)
 
   packages/core/fixture-deidentify:
+    devDependencies:
+      '@saga-ed/soa-typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      '@types/node':
+        specifier: ^24.0.3
+        version: 24.0.12
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.2)(yaml@2.8.2)
+      typescript:
+        specifier: 5.8.2
+        version: 5.8.2
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@24.0.12)
+
+  packages/core/saga-authz-model:
     devDependencies:
       '@saga-ed/soa-typescript-config':
         specifier: workspace:*
@@ -14729,8 +14769,8 @@ snapshots:
       '@typescript-eslint/parser': 8.50.0(eslint@8.57.1)(typescript@5.8.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -14773,21 +14813,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 8.57.1
-      get-tsconfig: 4.13.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.15
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -14799,18 +14824,18 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.50.0(eslint@8.57.1)(typescript@5.8.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -14825,7 +14850,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -14836,7 +14861,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## Summary

Foundational PR for the [fleet auth seams plan](https://github.com/saga-ed/saga-dash/blob/docs/auth-modernization-plan/docs/auth/plan.md). Bundles every soa-side change for P0 → P5.

### P0 — Decisions
docs/auth/ — overview + ADRs 0001-0007 (JWT shape, two-headers, signed envelope, audit shape, OpenFGA SoT, SPIFFE format, no-header-trust).

### P1 — Wire shapes (no runtime crypto)
- @saga-ed/soa-auth-contracts — SPIFFE / JWT claims / two-headers / audit-event schemas (80 tests)
- @saga-ed/saga-authz-model — model.fga + tuple-key builders (19 tests)
- @saga-ed/soa-event-envelope — optional meta.signature field

### P3 — Two-headers helper
\`decideTwoHeaders\` in soa-auth-contracts; canonical metric \`saga_two_headers_missing_total\`.

### P4 — Envelope signing helpers
- @saga-ed/soa-event-envelope — sign / verify / decideSignature / canonicalize / canonicalBytes / computeHmac, canonical metric \`saga_event_signature_status\` (46 tests)
- @saga-ed/soa-event-outbox — optional \`transformEnvelope\` hook on OutboxRelay

### P5 — Audit package + tokenJti relaxation
- **@saga-ed/soa-audit** (new package) — \`createAuditEmitter(logger, writer?)\` with schema-validated emit on the canonical 'audit' channel; pluggable writer for the future Postgres + S3 Object Lock backend (11 tests)
- @saga-ed/soa-auth-contracts — \`AuditSubjectSchema.tokenJti\` relaxed to nullable so authn.login (subject known, no token yet) emits cleanly. Existing usages still pass.

## Verification

- All packages: build ✅, tests ✅ (170 total: auth-contracts 80, authz-model 19, event-envelope 46, event-outbox 14, audit 11), check-types ✅, lint ✅

## What this PR does NOT do

- No runtime crypto verification (only schemas/helpers)
- No OpenFGA store, no audit log writer beyond logger, no IdP wiring, no DPoP/mTLS code
- No service-side adoption — those are P2-P6 in dedicated repo PRs

## Test plan

- [ ] ADRs reviewed
- [ ] model.fga relations reviewed by auth working group
- [ ] Confirm publishability to CodeArtifact — once published, downstream repos swap their inlined helpers for the package imports (TODOs marked in those PRs)