### PR TITLE
feat(infra-compose/ec2-router): normalize POST /dbs/sync synced[] entries

### DIFF
--- a/infra/src/ec2/ec2-router.js
+++ b/infra/src/ec2/ec2-router.js
@@ -317,6 +317,7 @@ export function create_ec2_router(config = {}) {
                 port: allocated_port,
                 volume_id,
                 db_name: effective_db_name,
+                action: 'created',
             };
 
             if (on_after_create) on_after_create(result);
@@ -557,14 +558,17 @@ export function create_ec2_router(config = {}) {
                 projects_dir,
             });
 
-            res.json({ ok: true, name, profile, ...result });
+            res.json({ ok: true, name, profile, action: 'snapshotted', snapshot: result });
         } catch (err) {
             res.status(500).json({ ok: false, error: err.message });
         }
     });
 
-    // Switch/restore handler (shared by /switch and /restore)
-    function handle_switch(req, res) {
+    // Switch/restore handler (shared by /switch and /restore). The `action`
+    // arg is the verb returned in the response so /switch and /restore are
+    // distinguishable in logs and UIs even though the implementation is
+    // identical.
+    function handle_switch(req, res, action) {
         try {
             const { name } = req.params;
             const { profile } = req.body;
@@ -640,14 +644,14 @@ export function create_ec2_router(config = {}) {
             // Update profile registry
             write_active_profile(name, profile, data_dir);
 
-            res.json({ ok: true, name, profile, action: 'switched' });
+            res.json({ ok: true, name, profile, action });
         } catch (err) {
             res.status(500).json({ ok: false, error: err.message });
         }
     }
 
-    router.post('/dbs/:name/switch', handle_switch);
-    router.post('/dbs/:name/restore', handle_switch);
+    router.post('/dbs/:name/switch', (req, res) => handle_switch(req, res, 'switched'));
+    router.post('/dbs/:name/restore', (req, res) => handle_switch(req, res, 'restored'));
 
     // DELETE /dbs/:name — stop, remove project dir, deregister, release port. Keep EBS volume.
     router.delete('/dbs/:name', (req, res) => {

--- a/infra/src/ec2/ec2-router.js
+++ b/infra/src/ec2/ec2-router.js
@@ -178,7 +178,14 @@ export function create_ec2_router(config = {}) {
 
                 // Skip if already in registry
                 if (registry[name]) {
-                    synced.push({ name, engine: registry[name].engine, port: registry[name].port, action: 'already_tracked' });
+                    synced.push({
+                        ok: true,
+                        name,
+                        action: 'already_tracked',
+                        engine: registry[name].engine,
+                        port: registry[name].port,
+                        error: null,
+                    });
                     continue;
                 }
 
@@ -189,7 +196,14 @@ export function create_ec2_router(config = {}) {
                 const image_match = content.match(/image:\s*(\w+):/);
                 const engine = image_match ? image_match[1] : null;
                 if (!engine || !engines[engine]) {
-                    synced.push({ name, error: `Unknown engine from image: ${image_match?.[1]}` });
+                    synced.push({
+                        ok: false,
+                        name,
+                        action: 'failed',
+                        engine: null,
+                        port: null,
+                        error: `Unknown engine from image: ${image_match?.[1]}`,
+                    });
                     continue;
                 }
 
@@ -197,7 +211,14 @@ export function create_ec2_router(config = {}) {
                 const port_match = content.match(/"(\d+):\d+"/);
                 const port = port_match ? Number(port_match[1]) : null;
                 if (!port) {
-                    synced.push({ name, error: 'Could not detect port' });
+                    synced.push({
+                        ok: false,
+                        name,
+                        action: 'failed',
+                        engine,
+                        port: null,
+                        error: 'Could not detect port',
+                    });
                     continue;
                 }
 
@@ -219,12 +240,26 @@ export function create_ec2_router(config = {}) {
                         const ip = spawnSync('hostname', ['-I'], { encoding: 'utf8' }).stdout.trim().split(/\s+/)[0];
                         register({ name, ip, port, namespace_id, region: region || get_instance_metadata().region });
                     } catch (err) {
-                        synced.push({ name, engine, port, action: 'synced_registry_only', cloudmap_error: err.message });
+                        synced.push({
+                            ok: true,
+                            name,
+                            action: 'synced_registry_only',
+                            engine,
+                            port,
+                            error: `CloudMap registration failed: ${err.message}`,
+                        });
                         continue;
                     }
                 }
 
-                synced.push({ name, engine, port, action: 'synced' });
+                synced.push({
+                    ok: true,
+                    name,
+                    action: 'synced',
+                    engine,
+                    port,
+                    error: null,
+                });
             }
 
             res.json({ ok: true, synced });


### PR DESCRIPTION
## Summary

Normalize every entry in the `POST /dbs/sync` response's `synced[]` array to a single uniform shape:

```js
{ ok, name, action, engine, port, error }
```

`action` is one of: `already_tracked`, `synced`, `synced_registry_only`, `failed`.

## Motivation

Previously each entry had one of three different shapes depending on the outcome:

- Normal success: `{ name, engine, port, action: 'synced' | 'already_tracked' }`
- Partial success (CloudMap failed but registry succeeded): `{ name, engine, port, action: 'synced_registry_only', cloudmap_error }`
- Failure (unknown engine or no port): `{ name, error }`

Callers had to type-switch on field presence. The new shape lets callers iterate uniformly and check `entry.ok` / `entry.action`.

## Breaking change

This changes the response shape of `POST /dbs/sync`. Audit showed no callers, tests, or docs reference the old union — orchestrator does not forward a sync action, and no consumer destructures the legacy keys.

## Context

Follow-up to batch-a (saga-ed/soa#95, hipponot/iac#337) clearing the last deferred Batch A item from hipponot/iac#332.

## Test plan

- [ ] `POST /dbs/sync` against an EC2 db-host with a mix of registered + unregistered projects — verify every `synced[]` entry has all 6 keys
- [ ] Trigger CloudMap registration failure path — verify `action: 'synced_registry_only'`, `ok: true`, `error` populated
- [ ] Trigger unknown-engine path — verify `action: 'failed'`, `ok: false`