### PR TITLE
feat(infra-compose/ec2-router): batch-b casing + batch-d describe/health

### DIFF
--- a/infra/src/ec2/ec2-router.js
+++ b/infra/src/ec2/ec2-router.js
@@ -133,6 +133,12 @@ export function create_ec2_router(config = {}) {
         next();
     });
 
+    // GET /health — liveness probe for the db-host API itself.
+    // Cheap: does not enumerate projects, query Docker, or touch S3.
+    router.get('/health', (_req, res) => {
+        res.json({ ok: true, service: 'infra-compose-ec2-router' });
+    });
+
     // GET /dbs — list all database projects with status
     router.get('/dbs', (req, res) => {
         try {
@@ -263,6 +269,32 @@ export function create_ec2_router(config = {}) {
             }
 
             res.json({ ok: true, synced });
+        } catch (err) {
+            res.status(500).json({ ok: false, error: err.message });
+        }
+    });
+
+    // GET /dbs/:name — single-DB lookup (project status + registry entry).
+    // Returns 404 if the project directory does not exist.
+    router.get('/dbs/:name', (req, res) => {
+        try {
+            const { name } = req.params;
+            const project_dir = resolve(projects_dir, name);
+            if (!existsSync(project_dir)) {
+                return res.status(404).json({ ok: false, error: `Project ${name} not found` });
+            }
+
+            const status = get_project_status(project_dir, name);
+            const ports = get_allocated_ports({ registry_path });
+            const port_entry = ports[name];
+
+            const db = {
+                ...status,
+                engine: port_entry?.engine ?? null,
+                port: port_entry?.port ?? null,
+            };
+
+            res.json({ ok: true, db });
         } catch (err) {
             res.status(500).json({ ok: false, error: err.message });
         }

--- a/infra/src/ec2/ec2-router.js
+++ b/infra/src/ec2/ec2-router.js
@@ -350,8 +350,8 @@ export function create_ec2_router(config = {}) {
                 engine,
                 version: version || engines[engine].default_version,
                 port: allocated_port,
-                volume_id,
-                db_name: effective_db_name,
+                volumeId: volume_id,
+                dbName: effective_db_name,
                 action: 'created',
             };
 
@@ -485,7 +485,7 @@ export function create_ec2_router(config = {}) {
                 engine,
                 version: version || engines[engine].default_version,
                 port,
-                db_name: db_name || name,
+                dbName: db_name || name,
                 action: 'hydrated',
             });
         } catch (err) {

--- a/infra/src/ec2/profiles.js
+++ b/infra/src/ec2/profiles.js
@@ -81,7 +81,7 @@ export function snapshot_db({ name, profile, engine, port, db_name, db_user, db_
     run('aws', ['s3', 'cp', tmp_file, s3_path]);
     console.log(`Uploaded snapshot to ${s3_path}`);
 
-    return { s3_path, size: readFileSync(tmp_file).length };
+    return { s3Path: s3_path, size: readFileSync(tmp_file).length };
 }
 
 function snapshot_mongo({ container, tmp_file, user, password }) {

--- a/infra/src/ec2/profiles.js
+++ b/infra/src/ec2/profiles.js
@@ -56,7 +56,7 @@ function get_container_name(name, projects_dir) {
 
 // --- Snapshot (dump live DB → S3) ---
 
-export function snapshot_db({ name, profile, engine, port, db_name, db_user, db_password, bucket, projects_dir }) {
+export function snapshot_db({ name, profile, engine, port: _port, db_name, db_user, db_password, bucket, projects_dir }) {
     const eng = engines[engine];
     if (!eng) throw new Error(`Unknown engine: ${engine}`);
 


### PR DESCRIPTION
## Summary

Combines Batch B (response-casing normalization) and Batch D (new
describe + health endpoints) for #332. Coordinated with hipponot/iac#338.

### Batch B — response casing -> camelCase

| Endpoint | Old key | New key |
|---|---|---|
| `POST /dbs` | `volume_id` | `volumeId` |
| `POST /dbs` | `db_name` | `dbName` |
| `POST /dbs/:name/hydrate` | `db_name` | `dbName` |
| `POST /dbs/:name/snapshot` (nested `snapshot.*`) | `s3_path` | `s3Path` |

Input destructuring in handlers (`{ db_name, volume_id }` from `req.body`)
is unchanged — orchestrator still sends snake_case in request payloads.
Request-side normalization is out of scope.

### Batch D — new actions

- `GET /health` — cheap liveness probe. Does not enumerate projects or
  touch Docker/S3. Returns `{ ok: true, service: 'infra-compose-ec2-router' }`.
- `GET /dbs/:name` — single-DB lookup. Returns `{ ok, db: { ...status,
  engine, port } }` merging project status with registry data. 404 when
  the project directory does not exist.

## Test plan

- [ ] After deploy, hit `POST /dbs` on an EC2 db-host and confirm `volumeId` / `dbName` appear in the response.
- [ ] Confirm `POST /dbs/:name/hydrate` returns `dbName` (used by the orchestrator's recovery path).
- [ ] Take a snapshot and confirm `snapshot.s3Path` is present.
- [ ] `curl /health` returns `{ ok: true, ... }`.
- [ ] `curl /dbs/<name>` for an existing DB returns the merged status payload; for a non-existent DB returns 404.
- [ ] Coordinate the deploy with hipponot/iac#338 (which expects the new keys and forwards to the new endpoints).