### PR TITLE
feat(infra-compose): widen postgres port range 5440 → 5499

### DIFF
--- a/infra/src/ec2/engines.js
+++ b/infra/src/ec2/engines.js
@@ -8,7 +8,7 @@ export const engines = {
         image_template: 'postgres:{version}',
         default_version: '16',
         container_data_path: '/var/lib/postgresql/data',
-        port_range: [5432, 5440],
+        port_range: [5432, 5499],
         default_port: 5432,
         seed_ext: 'sql',
         default_user: 'postgres_admin',

--- a/infra/src/ec2/volumes.js
+++ b/infra/src/ec2/volumes.js
@@ -110,7 +110,11 @@ export function attach_and_mount({ volume_id, mount_path, instance_id, region })
         '--region', region,
     ], { timeout: 180000 });
 
-    // Find next available device letter (f through p)
+    // Find next available device letter (f through z = 21 slots).
+    // t3.medium supports 27 EBS attachments and Nitro instance types
+    // support more, so the bottleneck is the device-name alphabet, not
+    // the instance limit. Was f-p (11 slots) which exhausted with one
+    // DB per main-branch service plus per-PR previews.
     const attached = JSON.parse(run('aws', [
         'ec2', 'describe-instances',
         '--instance-ids', instance_id,
@@ -120,7 +124,7 @@ export function attach_and_mount({ volume_id, mount_path, instance_id, region })
     ]));
     const used_letters = new Set(attached.map(d => d.slice(-1)));
     let device_letter = '';
-    for (const ch of 'fghijklmnop') {
+    for (const ch of 'fghijklmnopqrstuvwxyz') {
         if (!used_letters.has(ch)) { device_letter = ch; break; }
     }
     if (!device_letter) throw new Error('No available device letters for EBS attachment');


### PR DESCRIPTION
## Summary

- Widens \`engines.postgres.port_range\` in \`infra/src/ec2/engines.js\` from \`[5432, 5440]\` (9 ports) to \`[5432, 5499]\` (68 ports)

## Why

Pairs with [hipponot/iac#343](https://github.com/hipponot/iac/pull/343), which widened the matching orchestrator range (\`ENGINE_PORT_RANGES\`) and the \`dev-db-host-v2-sg\` VPC ingress rule to the same range. The 9-port pool was exhausted once \`saga-ed/program-hub#95\` (container-per-PR Postgres previews) went live: each open PR consumes 2 ports (programs-api + scheduling-api), so the pool runs out at the 4th-5th PR.

Per-service SG ingress rules already use \`5432-5499\` (transcripts, insights, chat all bound that range), so allocations past 5440 are reachable from existing consumers without further infra changes.

## Rollout

- Once this merges and a new \`@saga-ed/infra-compose\` version publishes, bump the version pin in the db-host-v2 ASG launch template user-data and do an ASG instance refresh so the wider pool is durable across instance replacement.
- Dev has been hot-patched on the running db-host-v2 instance via SSM to unblock program-hub#95 immediately; that patch reverts on instance replacement, which this PR's released version will heal.

## Test plan

- [ ] Existing unit tests cover \`allocate_port\` over the range — re-run \`infra/\` test suite
- [ ] After release, deploy + verify orchestrator can provision a 10th+ postgres DB without \`No available ports in range...\` error