### PR TITLE
chore(infra-compose): bump version to 1.3.1

### DIFF
--- a/infra/package.json
+++ b/infra/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/infra-compose",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "description": "Composable Docker service templates for Saga platform local development",
     "bin": {
         "infra-compose": "bin/infra-compose"


### PR DESCRIPTION
## Summary

Bumps \`@saga-ed/infra-compose\` from 1.3.0 → 1.3.1 to release the port-range and EBS device-letter widenings already on main from #98:

- \`engines.js\`: postgres \`port_range\` \`[5432, 5440]\` → \`[5432, 5499]\` (68 ports vs 9)
- \`volumes.js\`: device-letter alphabet \`f-p\` → \`f-z\` (21 slots vs 11)

## Why

Dev was hot-patched to unblock \`saga-ed/program-hub#95\` (container-per-PR Postgres previews), but the patch reverts on EC2 instance replacement. Publishing 1.3.1 + bumping the iac launch-template version pin makes the widenings durable.

## Test plan

- [ ] PR CI green
- [ ] After merge, \`cd infra && npm publish\` from a workstation with CodeArtifact write access
- [ ] Open follow-up iac PR bumping \`InfraComposeVersion\` from \`1.3.0\` to \`1.3.1\` in \`db_host_v2/asg/samconfig.yaml\`
- [ ] Deploy iac stack + instance-refresh dev ASG to verify hydrate flow restores existing DBs cleanly