### PR TITLE
feat(rum-util): add Datadog RUM wrapper for Saga frontends

### DIFF
--- a/packages/web/CLAUDE.md
+++ b/packages/web/CLAUDE.md
@@ -17,6 +17,7 @@ See [/packages/CLAUDE.md](../CLAUDE.md) for packages overview.
 | Package | Description |
 |---------|-------------|
 | `ui/` | React component library |
+| `rum-util/` | Datadog RUM wrapper with Saga conventions (one service per app, source-tagged errors/actions, silent no-op when unconfigured). Consumed by `saga_dash`, `qboard_connectv3`, `janus_login`. |
 
 ## Browser Constraints
 

--- a/packages/web/rum-util/README.md
+++ b/packages/web/rum-util/README.md
@@ -1,29 +1,34 @@
 # @saga-ed/soa-rum-util
 
-Datadog RUM wrapper with Saga conventions. One package, three consumers:
+Datadog RUM wrapper with Saga conventions. One package, three intended consumers:
 `saga_dash`, `qboard_connectv3`, `janus_login`.
 
 ## Why a wrapper
 
 - **One service per app, source-tagged.** `addRumError` / `addRumAction` always set
-  `source: <service>` so the retention filter pattern from `saga_web`
-  (`@error.source:saga_dash`, etc.) works out of the box.
+  `source: <service>` so retention filters like `@error.source:saga_dash` work
+  out of the box.
 - **Silent no-op when unconfigured.** Pass empty `applicationId` / `clientToken`
-  (e.g. local dev with no env vars wired up) and the entire module no-ops.
-  Builds still ship.
-- **Singleton.** Second `initRum` call is ignored, so `+layout.ts` module-load
-  init is safe.
+  (e.g. local dev with no env vars wired) and the entire module no-ops. Builds
+  still ship.
+- **Singleton.** Second `initRum` call is ignored, so module-load bootstrap is
+  safe across framework re-mounts and HMR.
 - **v6 deprecation-free user updates.** `setRumUser` uses `setUserProperty`
-  under the hood so incremental patches don't clobber existing fields.
+  under the hood so incremental patches don't clobber existing fields. `null` in
+  the patch removes a field; `undefined` preserves it; a string sets it.
 
-## Usage
+## Quick start
 
 ```ts
-// app entry — runs once at module load
-import { initRum } from '@saga-ed/soa-rum-util';
+import {
+  initRum,
+  setRumUser,
+  setRumGlobalContextProperty,
+  addRumError,
+} from '@saga-ed/soa-rum-util';
 
 initRum({
-  service: 'saga_dash',
+  service: 'janus_login',
   applicationId: import.meta.env.VITE_DD_RUM_APPLICATION_ID,
   clientToken: import.meta.env.VITE_DD_RUM_CLIENT_TOKEN,
   env: import.meta.env.VITE_DD_ENV ?? 'unknown',
@@ -33,16 +38,9 @@ initRum({
   allowedTracingUrls: [/https:\/\/[^/]+\.wootdev\.com/, /https:\/\/[^/]+\.saga\.org/],
 });
 
-// later, when the user logs in
-import { setRumUser, setRumGlobalContextProperty, addRumError } from '@saga-ed/soa-rum-util';
-
 setRumUser({ id: session.user_id, name: session.screen_name, org: orgId, role: 'TUTOR' });
 setRumGlobalContextProperty('selected_program_ids', programStore.selectedIds);
 
-// reactive update — null in the patch removes the property
-setRumUser({ org: selectedOrgId }); // selectedOrgId: string | null
-
-// custom errors
 try {
   // ...
 } catch (err) {
@@ -50,16 +48,238 @@ try {
 }
 ```
 
+## Integration checklist (new consumer)
+
+Adopting this in a new app (e.g. `qboard_connectv3`, `janus_login`):
+
+1. [Install](#1-install)
+2. [Seed SSM](#2-ssm-parameter-convention) in the dev + prod accounts
+3. [CI workflow](#3-ci-workflow-github-actions) — fetch SSM into `VITE_DD_*` at build time
+4. [Vite config](#4-vite-config) — propagate `VITE_DD_*` and `__APP_VERSION__`
+5. [Ambient types](#5-ambient-types) — declare `__APP_VERSION__` and `ImportMetaEnv`
+6. [CSP](#6-csp-additions) — allow Datadog intake
+7. [Bootstrap](#7-bootstrap-pattern) — `initRum` + wrap bootstrap catches with `addRumError`
+
+Reference implementation: saga-dash —
+[`apps/web/dash/src/lib/rum.ts`](https://github.com/saga-ed/saga-dash/blob/main/apps/web/dash/src/lib/rum.ts)
+(local wrapper; will swap to this package once it lands on `soa/main`) plus the
+surrounding `+layout.ts` / `+layout.svelte` bootstrap.
+
+### 1. Install
+
+```bash
+pnpm add @saga-ed/soa-rum-util
+# or, inside a workspace that vendors soa:
+pnpm add @saga-ed/soa-rum-util@workspace:*
+```
+
+### 2. SSM parameter convention
+
+Per-app, per-account, region `us-west-2`:
+
+| Name | Value |
+|---|---|
+| `/<app>/rum/application-id` | RUM application UUID from Datadog |
+| `/<app>/rum/client-token` | RUM client token (NOT a Datadog API key) — masked in CI logs |
+| `/<app>/rum/env` | Env tag for Datadog filtering (`dev`, `prod`, ...) |
+
+`<app>` is the short app name (e.g. `dash`, `janus`, `qboard`). Leave **either**
+`application-id` or `client-token` empty to disable RUM entirely for that
+account — `initRum` returns `false` and every other call no-ops.
+
+Seed once out-of-band (or as a one-shot CFN/Terraform stack) — the values are
+account-scoped, not per-branch, so they live longer than any single deploy.
+
+### 3. CI workflow (GitHub Actions)
+
+Copy [`scripts/fetch-rum-config.sh`](scripts/fetch-rum-config.sh) into your repo's
+`.github/scripts/` directory (or wherever your workflows look). Call it from
+the build job, between AWS credential setup and `pnpm build`:
+
+```yaml
+- name: Fetch RUM config from SSM
+  env:
+    SSM_PREFIX: /janus/rum
+    RUM_ENV_DEFAULT: dev   # or 'prod' for the prod-targeting workflow
+  run: ./.github/scripts/fetch-rum-config.sh
+```
+
+The script:
+
+- Reads `${SSM_PREFIX}/application-id`, `${SSM_PREFIX}/client-token`,
+  `${SSM_PREFIX}/env` from SSM.
+- Writes them to `$GITHUB_ENV` so the next Build step picks them up via Vite's
+  `loadEnv`.
+- Uses heredoc-delimited form so a multi-line SSM value can't inject extra
+  entries into `$GITHUB_ENV`.
+- Tolerates `ParameterNotFound` (falls back to `RUM_ENV_DEFAULT` for the env
+  param; empties for app-id / token). Other AWS errors (`AccessDenied`,
+  `ThrottlingException`, wrong region) fail the build loudly — an IAM
+  regression should not silently ship prod without RUM.
+- Masks the client-token in CI logs via `::add-mask::`.
+
+### 4. Vite config
+
+```ts
+// apps/<app>/vite.config.ts
+import { defineConfig, loadEnv } from 'vite';
+import { fileURLToPath } from 'node:url';
+
+export default defineConfig(({ mode }) => {
+  // envDir relative to vite.config.ts, not the caller's cwd
+  const envDir = fileURLToPath(new URL('.', import.meta.url));
+  loadEnv(mode, envDir, 'VITE_');
+  return {
+    define: {
+      __APP_VERSION__: JSON.stringify(process.env.VITE_APP_VERSION ?? 'dev'),
+    },
+    // ...
+  };
+});
+```
+
+`VITE_DD_*` vars are read inline as `import.meta.env.VITE_DD_*` — no `define`
+block needed. `__APP_VERSION__` is a `define` substitution so it tree-shakes
+into a string literal at build time.
+
+### 5. Ambient types
+
+Add to your app's `src/app.d.ts` (SvelteKit) or `src/vite-env.d.ts` (vanilla
+Vite):
+
+```ts
+declare global {
+  // eslint-disable-next-line no-var
+  const __APP_VERSION__: string;
+}
+
+interface ImportMetaEnv {
+  readonly VITE_DD_RUM_APPLICATION_ID: string;
+  readonly VITE_DD_RUM_CLIENT_TOKEN: string;
+  readonly VITE_DD_ENV: string;
+  readonly VITE_APP_VERSION: string;
+}
+
+export {};
+```
+
+### 6. CSP additions
+
+Datadog browser RUM needs:
+
+- `connect-src` — `https://browser-intake-datadoghq.com https://*.browser-intake-datadoghq.com`.
+  The wildcard covers regional intakes (`us3`, `us5`, `eu1`, ...) without
+  pinning a specific one.
+- `worker-src 'self' blob:` — RUM session-replay constructs its worker from a
+  blob URL.
+
+Example fragment for a CloudFront `ResponseHeadersPolicy` (SAM):
+
+```yaml
+Content-Security-Policy:
+  Override: true
+  Value: >-
+    connect-src 'self'
+      https://browser-intake-datadoghq.com
+      https://*.browser-intake-datadoghq.com
+      https://*.wootdev.com
+      https://*.saga.org;
+    worker-src 'self' blob:;
+    ...
+```
+
+If you already have a `connect-src` for backend APIs, append the two Datadog
+hosts to it — don't add a second `connect-src` directive (the browser will use
+only the most restrictive intersection).
+
+### 7. Bootstrap pattern
+
+Call `initRum` once at module load — the app entry: `main.ts` for vanilla Vite,
+`+layout.ts` for SvelteKit.
+
+```ts
+// src/routes/+layout.ts (SvelteKit) — or src/main.ts (vanilla Vite)
+import { initRum, addRumError } from '@saga-ed/soa-rum-util';
+
+initRum({
+  service: 'janus_login',
+  applicationId: import.meta.env.VITE_DD_RUM_APPLICATION_ID,
+  clientToken: import.meta.env.VITE_DD_RUM_CLIENT_TOKEN,
+  env: import.meta.env.VITE_DD_ENV ?? 'unknown',
+  version: __APP_VERSION__,
+  allowedTracingUrls: [/https:\/\/[^/]+\.wootdev\.com/, /https:\/\/[^/]+\.saga\.org/],
+});
+
+// Wrap critical bootstrap paths — the user can't see a try/catch, but Datadog can.
+export async function load() {
+  try {
+    return await bootstrapCriticalData();
+  } catch (err) {
+    addRumError(err, { surface: 'bootstrap' });
+    throw err; // rethrow so the framework still sees the failure
+  }
+}
+```
+
+After login, wire user + global context — typically in an `$effect`
+(SvelteKit) or `useEffect` (React) keyed on the session store:
+
+```ts
+$effect(() => {
+  setRumUserFromSession(sessionStore.current);
+  setRumGlobalContextProperty('selected_program_ids', programStore.selectedIds);
+});
+```
+
+On logout:
+
+```ts
+addRumAction('logout');
+clearRumUser();
+removeRumGlobalContextProperty('selected_program_ids');
+```
+
+## Enable / disable
+
+### Production / CI previews
+
+SSM-managed. Set `/<app>/rum/application-id` to an empty string and redeploy —
+`initRum` returns `false` and every wrapper call short-circuits. Same path to
+re-enable: put the UUID back and redeploy.
+
+No code change is required to toggle, which makes it safe to flip during an
+incident if RUM itself starts impacting the page.
+
+### Local dev
+
+RUM is **off by default** locally — no env vars are wired in CI's preview
+deploy of your dev branch, and none are seeded in your dev shell. To turn it on
+for local debugging:
+
+1. Create `apps/<your-app>/.env.local`:
+   ```
+   VITE_DD_RUM_APPLICATION_ID=<from datadog console>
+   VITE_DD_RUM_CLIENT_TOKEN=<from datadog console>
+   VITE_DD_ENV=local
+   VITE_APP_VERSION=local
+   ```
+2. Restart `pnpm dev`.
+3. Open browser devtools — check for RUM init logs. Events appear in the
+   Datadog RUM Explorer filtered on `@env:local`.
+
+To disable, delete `.env.local` and restart. `.env.local` is in Vite's default
+gitignore — verify yours before pushing.
+
 ## API
 
 | Function | Purpose |
 |---|---|
-| `initRum(opts)` | One-shot init. Returns `false` if `applicationId`/`clientToken` empty. |
-| `setRumUser(patch)` | Incremental user updates. `null` removes, `undefined` preserves, string sets. |
+| `initRum(opts)` | One-shot init. Returns `false` if `applicationId` / `clientToken` empty. |
+| `isInitialized()` | Read-only — mostly for tests. |
+| `setRumUser(patch)` | Incremental user updates. `null` removes a field, `undefined` preserves, string sets. |
 | `removeRumUserProperty(key)` | Explicit one-off remove for a single user field. |
 | `clearRumUser()` | On logout. Clears the user object only; remove globals separately. |
 | `setRumGlobalContextProperty(k, v)` | Pass-through for app-specific context. |
 | `removeRumGlobalContextProperty(k)` | Remove a global context key. Prefer over `set(k, null)` so Datadog doesn't store literal null. |
 | `addRumError(err, ctx?)` | Auto-tags `source: <service>` (after spread — caller can't override). |
 | `addRumAction(name, ctx?)` | Auto-tags `source: <service>`. |
-| `isInitialized()` | Read-only — mostly for tests. |

--- a/packages/web/rum-util/README.md
+++ b/packages/web/rum-util/README.md
@@ -1,0 +1,58 @@
+# @saga-ed/soa-rum-util
+
+Datadog RUM wrapper with Saga conventions. One package, three consumers:
+`saga_dash`, `qboard_connectv3`, `janus_login`.
+
+## Why a wrapper
+
+- **One service per app, source-tagged.** `addRumError` / `addRumAction` always set
+  `source: <service>` so the retention filter pattern from `saga_web`
+  (`@error.source:saga_dash`, etc.) works out of the box.
+- **Silent no-op when unconfigured.** Pass empty `applicationId` / `clientToken`
+  (e.g. local dev with no env vars wired up) and the entire module no-ops.
+  Builds still ship.
+- **Singleton.** Second `initRum` call is ignored, so `+layout.ts` module-load
+  init is safe.
+- **v6 deprecation-free user updates.** `setRumUser` uses `setUserProperty`
+  under the hood so incremental patches don't clobber existing fields.
+
+## Usage
+
+```ts
+// app entry — runs once at module load
+import { initRum } from '@saga-ed/soa-rum-util';
+
+initRum({
+  service: 'saga_dash',
+  applicationId: import.meta.env.VITE_DD_RUM_APPLICATION_ID,
+  clientToken: import.meta.env.VITE_DD_RUM_CLIENT_TOKEN,
+  env: import.meta.env.VITE_DD_ENV ?? 'unknown',
+  version: __APP_VERSION__,
+  allowedTracingUrls: [/\.wootdev\.com\//, /\.sagaeducation\.org\//],
+});
+
+// later, when the user logs in
+import { setRumUser, setRumGlobalContextProperty, addRumError } from '@saga-ed/soa-rum-util';
+
+setRumUser({ id: session.user_id, name: session.screen_name, org: orgId, role: 'TUTOR' });
+setRumGlobalContextProperty('selected_program_ids', programStore.selectedIds);
+
+// custom errors
+try {
+  // ...
+} catch (err) {
+  addRumError(err, { surface: 'program-selector' });
+}
+```
+
+## API
+
+| Function | Purpose |
+|---|---|
+| `initRum(opts)` | One-shot init. Returns `false` if `applicationId`/`clientToken` empty. |
+| `setRumUser(patch)` | Incremental user updates via `setUserProperty`. |
+| `clearRumUser()` | On logout. |
+| `setRumGlobalContextProperty(k, v)` | Pass-through for app-specific context. |
+| `addRumError(err, ctx?)` | Auto-tags `source: <service>`. |
+| `addRumAction(name, ctx?)` | Auto-tags `source: <service>`. |
+| `isInitialized()` | Read-only — mostly for tests. |

--- a/packages/web/rum-util/README.md
+++ b/packages/web/rum-util/README.md
@@ -28,7 +28,9 @@ initRum({
   clientToken: import.meta.env.VITE_DD_RUM_CLIENT_TOKEN,
   env: import.meta.env.VITE_DD_ENV ?? 'unknown',
   version: __APP_VERSION__,
-  allowedTracingUrls: [/\.wootdev\.com\//, /\.sagaeducation\.org\//],
+  // Unanchored so paths and bare hosts both get tracing headers on the
+  // dev (*.wootdev.com) and prod (*.saga.org) backends.
+  allowedTracingUrls: [/https:\/\/[^/]+\.wootdev\.com/, /https:\/\/[^/]+\.saga\.org/],
 });
 
 // later, when the user logs in
@@ -36,6 +38,9 @@ import { setRumUser, setRumGlobalContextProperty, addRumError } from '@saga-ed/s
 
 setRumUser({ id: session.user_id, name: session.screen_name, org: orgId, role: 'TUTOR' });
 setRumGlobalContextProperty('selected_program_ids', programStore.selectedIds);
+
+// reactive update — null in the patch removes the property
+setRumUser({ org: selectedOrgId }); // selectedOrgId: string | null
 
 // custom errors
 try {
@@ -50,9 +55,11 @@ try {
 | Function | Purpose |
 |---|---|
 | `initRum(opts)` | One-shot init. Returns `false` if `applicationId`/`clientToken` empty. |
-| `setRumUser(patch)` | Incremental user updates via `setUserProperty`. |
-| `clearRumUser()` | On logout. |
+| `setRumUser(patch)` | Incremental user updates. `null` removes, `undefined` preserves, string sets. |
+| `removeRumUserProperty(key)` | Explicit one-off remove for a single user field. |
+| `clearRumUser()` | On logout. Clears the user object only; remove globals separately. |
 | `setRumGlobalContextProperty(k, v)` | Pass-through for app-specific context. |
-| `addRumError(err, ctx?)` | Auto-tags `source: <service>`. |
+| `removeRumGlobalContextProperty(k)` | Remove a global context key. Prefer over `set(k, null)` so Datadog doesn't store literal null. |
+| `addRumError(err, ctx?)` | Auto-tags `source: <service>` (after spread — caller can't override). |
 | `addRumAction(name, ctx?)` | Auto-tags `source: <service>`. |
 | `isInitialized()` | Read-only — mostly for tests. |

--- a/packages/web/rum-util/package.json
+++ b/packages/web/rum-util/package.json
@@ -7,8 +7,8 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
   "sideEffects": false,
@@ -18,14 +18,13 @@
     "clean": "rm -rf dist",
     "check-types": "tsc --noEmit",
     "test": "vitest run",
-    "lint": "echo 'no lint configured'"
+    "lint": "eslint src/"
   },
   "dependencies": {
     "@datadog/browser-rum": "^6.0.0"
   },
   "devDependencies": {
     "@saga-ed/soa-typescript-config": "workspace:*",
-    "@vitest/web-worker": "^1.5.0",
     "jsdom": "^25.0.0",
     "tsup": "^8.5.0",
     "typescript": "^5.8.2",

--- a/packages/web/rum-util/package.json
+++ b/packages/web/rum-util/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@saga-ed/soa-rum-util",
+  "version": "0.1.0",
+  "description": "Datadog RUM wrapper with Saga conventions: singleton init, source-tagged errors/actions, silent no-op when unconfigured.",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "clean": "rm -rf dist",
+    "check-types": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "echo 'no lint configured'"
+  },
+  "dependencies": {
+    "@datadog/browser-rum": "^6.0.0"
+  },
+  "devDependencies": {
+    "@saga-ed/soa-typescript-config": "workspace:*",
+    "@vitest/web-worker": "^1.5.0",
+    "jsdom": "^25.0.0",
+    "tsup": "^8.5.0",
+    "typescript": "^5.8.2",
+    "vitest": "^1.5.0"
+  },
+  "keywords": [
+    "datadog",
+    "rum",
+    "observability",
+    "browser",
+    "saga"
+  ],
+  "author": "Saga SOA Team",
+  "license": "MIT",
+  "publishConfig": {
+    "registry": "https://saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/saga-ed/soa.git",
+    "directory": "packages/web/rum-util"
+  }
+}

--- a/packages/web/rum-util/scripts/fetch-rum-config.sh
+++ b/packages/web/rum-util/scripts/fetch-rum-config.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# fetch-rum-config.sh
+#
+# Reads RUM SSM params and writes them to $GITHUB_ENV so the subsequent Build
+# step picks them up via vite.config.ts loadEnv.
+#
+# Copy this script into your repo's .github/scripts/ directory and call it
+# from the build job, between AWS credential setup and `pnpm build`:
+#
+#   - name: Fetch RUM config from SSM
+#     env:
+#       SSM_PREFIX: /myapp/rum
+#       RUM_ENV_DEFAULT: dev
+#     run: ./.github/scripts/fetch-rum-config.sh
+#
+# Inputs (env):
+#   SSM_PREFIX        e.g. /dash/rum, /janus/rum, /qboard/rum
+#   RUM_ENV_DEFAULT   Fallback for ${SSM_PREFIX}/env when ParameterNotFound (dev|prod)
+#   GITHUB_SHA        Used to derive VITE_APP_VERSION (short SHA)
+#   GITHUB_ENV        GitHub-provided
+#
+# Outputs (to $GITHUB_ENV):
+#   VITE_DD_RUM_APPLICATION_ID
+#   VITE_DD_RUM_CLIENT_TOKEN
+#   VITE_DD_ENV
+#   VITE_APP_VERSION
+#
+# ParameterNotFound is tolerated — initRum() no-ops on empty applicationId, so
+# a freshly bootstrapped account that hasn't seeded SSM yet still ships. Other
+# AWS errors (AccessDenied, Throttling, wrong region) fail the build loudly so
+# an IAM regression can't silently ship prod without RUM.
+#
+# Heredoc-delimiter form prevents a multi-line SSM value from injecting extra
+# entries into $GITHUB_ENV.
+
+set -euo pipefail
+
+: "${SSM_PREFIX:?SSM_PREFIX is required (e.g. /dash/rum)}"
+: "${RUM_ENV_DEFAULT:?RUM_ENV_DEFAULT is required (dev|prod)}"
+
+get_ssm() {
+  local name="$1" default="$2" value err_log
+  err_log=$(mktemp)
+  if value=$(aws ssm get-parameter --name "$name" --query Parameter.Value --output text 2>"$err_log"); then
+    rm -f "$err_log"
+    printf '%s' "$value"
+    return 0
+  fi
+  if grep -q "ParameterNotFound" "$err_log"; then
+    rm -f "$err_log"
+    printf '%s' "$default"
+    return 0
+  fi
+  cat "$err_log" >&2
+  if grep -q "AccessDenied" "$err_log"; then
+    echo "::error::AccessDenied fetching SSM $name — check the deploy role's ssm:GetParameter policy"
+  elif grep -q "ThrottlingException" "$err_log"; then
+    echo "::error::SSM throttled fetching $name — re-run the workflow"
+  else
+    echo "::error::Unexpected error fetching SSM parameter $name (see log above)"
+  fi
+  rm -f "$err_log"
+  return 1
+}
+
+APP_ID=$(get_ssm "${SSM_PREFIX}/application-id" "") || exit 1
+TOKEN=$(get_ssm "${SSM_PREFIX}/client-token" "") || exit 1
+ENV_TAG=$(get_ssm "${SSM_PREFIX}/env" "$RUM_ENV_DEFAULT") || exit 1
+
+if [ -n "$TOKEN" ]; then
+  echo "::add-mask::$TOKEN"
+fi
+
+{
+  echo "VITE_DD_RUM_APPLICATION_ID<<EOF_RUM"
+  echo "$APP_ID"
+  echo "EOF_RUM"
+  echo "VITE_DD_RUM_CLIENT_TOKEN<<EOF_RUM"
+  echo "$TOKEN"
+  echo "EOF_RUM"
+  echo "VITE_DD_ENV<<EOF_RUM"
+  echo "$ENV_TAG"
+  echo "EOF_RUM"
+  echo "VITE_APP_VERSION=${GITHUB_SHA:0:7}"
+} >> "$GITHUB_ENV"
+
+if [ -z "$APP_ID" ]; then
+  echo "::warning::Datadog RUM not configured (${SSM_PREFIX}/application-id empty) — initRum() will no-op in this build"
+fi

--- a/packages/web/rum-util/src/index.test.ts
+++ b/packages/web/rum-util/src/index.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { datadogRum } from '@datadog/browser-rum';
+import {
+  initRum,
+  setRumUser,
+  clearRumUser,
+  setRumGlobalContextProperty,
+  addRumError,
+  addRumAction,
+  isInitialized,
+  _resetForTest,
+} from './index.js';
+
+vi.mock('@datadog/browser-rum', () => ({
+  datadogRum: {
+    init: vi.fn(),
+    setUserProperty: vi.fn(),
+    clearUser: vi.fn(),
+    setGlobalContextProperty: vi.fn(),
+    addError: vi.fn(),
+    addAction: vi.fn(),
+  },
+}));
+
+afterEach(() => {
+  _resetForTest();
+  vi.clearAllMocks();
+});
+
+describe('initRum', () => {
+  it('initializes with merged defaults when applicationId + clientToken present', () => {
+    const ok = initRum({
+      service: 'test_svc',
+      applicationId: 'app-123',
+      clientToken: 'pub-abc',
+      env: 'dev',
+      version: '0.0.1',
+    });
+    expect(ok).toBe(true);
+    expect(isInitialized()).toBe(true);
+    expect(datadogRum.init).toHaveBeenCalledWith(
+      expect.objectContaining({
+        applicationId: 'app-123',
+        clientToken: 'pub-abc',
+        site: 'datadoghq.com',
+        service: 'test_svc',
+        env: 'dev',
+        version: '0.0.1',
+        sessionSampleRate: 100,
+        sessionReplaySampleRate: 5,
+        defaultPrivacyLevel: 'mask',
+      })
+    );
+  });
+
+  it('no-ops silently when applicationId is empty', () => {
+    const ok = initRum({
+      service: 'test_svc',
+      applicationId: '',
+      clientToken: 'pub-abc',
+      env: 'dev',
+      version: '0.0.1',
+    });
+    expect(ok).toBe(false);
+    expect(isInitialized()).toBe(false);
+    expect(datadogRum.init).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent — second call returns true without re-init', () => {
+    initRum({ service: 's', applicationId: 'a', clientToken: 'b', env: 'dev', version: '0' });
+    initRum({ service: 's', applicationId: 'a', clientToken: 'b', env: 'dev', version: '0' });
+    expect(datadogRum.init).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('setRumUser', () => {
+  it('calls setUserProperty per defined field, skips undefined', () => {
+    initRum({ service: 's', applicationId: 'a', clientToken: 'b', env: 'dev', version: '0' });
+    setRumUser({ id: 'u1', name: 'Alice', org: undefined, role: 'TUTOR' });
+    expect(datadogRum.setUserProperty).toHaveBeenCalledWith('id', 'u1');
+    expect(datadogRum.setUserProperty).toHaveBeenCalledWith('name', 'Alice');
+    expect(datadogRum.setUserProperty).toHaveBeenCalledWith('role', 'TUTOR');
+    expect(datadogRum.setUserProperty).not.toHaveBeenCalledWith('org', expect.anything());
+  });
+
+  it('is a no-op before init', () => {
+    setRumUser({ id: 'u1' });
+    expect(datadogRum.setUserProperty).not.toHaveBeenCalled();
+  });
+});
+
+describe('addRumError / addRumAction', () => {
+  it('tags addError with source = service', () => {
+    initRum({ service: 'saga_dash', applicationId: 'a', clientToken: 'b', env: 'dev', version: '0' });
+    addRumError(new Error('boom'), { tag: 'unit-test' });
+    expect(datadogRum.addError).toHaveBeenCalledWith(
+      expect.any(Error),
+      { source: 'saga_dash', tag: 'unit-test' }
+    );
+  });
+
+  it('tags addAction with source = service', () => {
+    initRum({ service: 'saga_dash', applicationId: 'a', clientToken: 'b', env: 'dev', version: '0' });
+    addRumAction('login_succeeded', { user_id: 'u1' });
+    expect(datadogRum.addAction).toHaveBeenCalledWith(
+      'login_succeeded',
+      { source: 'saga_dash', user_id: 'u1' }
+    );
+  });
+
+  it('caller context overrides default source if provided explicitly', () => {
+    initRum({ service: 'saga_dash', applicationId: 'a', clientToken: 'b', env: 'dev', version: '0' });
+    addRumError(new Error('x'), { source: 'override' });
+    expect(datadogRum.addError).toHaveBeenCalledWith(expect.any(Error), { source: 'override' });
+  });
+
+  it('is a no-op before init', () => {
+    addRumError(new Error('x'));
+    addRumAction('foo');
+    expect(datadogRum.addError).not.toHaveBeenCalled();
+    expect(datadogRum.addAction).not.toHaveBeenCalled();
+  });
+});
+
+describe('setRumGlobalContextProperty / clearRumUser', () => {
+  it('pass through when initialized', () => {
+    initRum({ service: 's', applicationId: 'a', clientToken: 'b', env: 'dev', version: '0' });
+    setRumGlobalContextProperty('selected_program_id', 'prog-1');
+    clearRumUser();
+    expect(datadogRum.setGlobalContextProperty).toHaveBeenCalledWith('selected_program_id', 'prog-1');
+    expect(datadogRum.clearUser).toHaveBeenCalled();
+  });
+
+  it('are no-ops before init', () => {
+    setRumGlobalContextProperty('x', 1);
+    clearRumUser();
+    expect(datadogRum.setGlobalContextProperty).not.toHaveBeenCalled();
+    expect(datadogRum.clearUser).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/rum-util/src/index.test.ts
+++ b/packages/web/rum-util/src/index.test.ts
@@ -3,8 +3,10 @@ import { datadogRum } from '@datadog/browser-rum';
 import {
   initRum,
   setRumUser,
+  removeRumUserProperty,
   clearRumUser,
   setRumGlobalContextProperty,
+  removeRumGlobalContextProperty,
   addRumError,
   addRumAction,
   isInitialized,
@@ -15,8 +17,10 @@ vi.mock('@datadog/browser-rum', () => ({
   datadogRum: {
     init: vi.fn(),
     setUserProperty: vi.fn(),
+    removeUserProperty: vi.fn(),
     clearUser: vi.fn(),
     setGlobalContextProperty: vi.fn(),
+    removeGlobalContextProperty: vi.fn(),
     addError: vi.fn(),
     addAction: vi.fn(),
   },
@@ -81,11 +85,41 @@ describe('setRumUser', () => {
     expect(datadogRum.setUserProperty).toHaveBeenCalledWith('name', 'Alice');
     expect(datadogRum.setUserProperty).toHaveBeenCalledWith('role', 'TUTOR');
     expect(datadogRum.setUserProperty).not.toHaveBeenCalledWith('org', expect.anything());
+    expect(datadogRum.removeUserProperty).not.toHaveBeenCalled();
+  });
+
+  it('removes the property when value is null', () => {
+    initRum({ service: 's', applicationId: 'a', clientToken: 'b', env: 'dev', version: '0' });
+    setRumUser({ org: null });
+    expect(datadogRum.removeUserProperty).toHaveBeenCalledWith('org');
+    expect(datadogRum.setUserProperty).not.toHaveBeenCalled();
+  });
+
+  it('mixes set and remove in a single patch', () => {
+    initRum({ service: 's', applicationId: 'a', clientToken: 'b', env: 'dev', version: '0' });
+    setRumUser({ id: 'u1', org: null, role: 'TUTOR' });
+    expect(datadogRum.setUserProperty).toHaveBeenCalledWith('id', 'u1');
+    expect(datadogRum.setUserProperty).toHaveBeenCalledWith('role', 'TUTOR');
+    expect(datadogRum.removeUserProperty).toHaveBeenCalledWith('org');
   });
 
   it('is a no-op before init', () => {
-    setRumUser({ id: 'u1' });
+    setRumUser({ id: 'u1', org: null });
     expect(datadogRum.setUserProperty).not.toHaveBeenCalled();
+    expect(datadogRum.removeUserProperty).not.toHaveBeenCalled();
+  });
+});
+
+describe('removeRumUserProperty', () => {
+  it('removes the named user property', () => {
+    initRum({ service: 's', applicationId: 'a', clientToken: 'b', env: 'dev', version: '0' });
+    removeRumUserProperty('org');
+    expect(datadogRum.removeUserProperty).toHaveBeenCalledWith('org');
+  });
+
+  it('is a no-op before init', () => {
+    removeRumUserProperty('org');
+    expect(datadogRum.removeUserProperty).not.toHaveBeenCalled();
   });
 });
 
@@ -136,5 +170,18 @@ describe('setRumGlobalContextProperty / clearRumUser', () => {
     clearRumUser();
     expect(datadogRum.setGlobalContextProperty).not.toHaveBeenCalled();
     expect(datadogRum.clearUser).not.toHaveBeenCalled();
+  });
+});
+
+describe('removeRumGlobalContextProperty', () => {
+  it('removes the named global context key', () => {
+    initRum({ service: 's', applicationId: 'a', clientToken: 'b', env: 'dev', version: '0' });
+    removeRumGlobalContextProperty('selected_program_id');
+    expect(datadogRum.removeGlobalContextProperty).toHaveBeenCalledWith('selected_program_id');
+  });
+
+  it('is a no-op before init', () => {
+    removeRumGlobalContextProperty('selected_program_id');
+    expect(datadogRum.removeGlobalContextProperty).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/rum-util/src/index.test.ts
+++ b/packages/web/rum-util/src/index.test.ts
@@ -8,7 +8,7 @@ import {
   addRumError,
   addRumAction,
   isInitialized,
-  _resetForTest,
+  __resetForTest,
 } from './index.js';
 
 vi.mock('@datadog/browser-rum', () => ({
@@ -23,7 +23,7 @@ vi.mock('@datadog/browser-rum', () => ({
 }));
 
 afterEach(() => {
-  _resetForTest();
+  __resetForTest();
   vi.clearAllMocks();
 });
 
@@ -108,10 +108,10 @@ describe('addRumError / addRumAction', () => {
     );
   });
 
-  it('caller context overrides default source if provided explicitly', () => {
+  it('caller-supplied source cannot override the service tag', () => {
     initRum({ service: 'saga_dash', applicationId: 'a', clientToken: 'b', env: 'dev', version: '0' });
     addRumError(new Error('x'), { source: 'override' });
-    expect(datadogRum.addError).toHaveBeenCalledWith(expect.any(Error), { source: 'override' });
+    expect(datadogRum.addError).toHaveBeenCalledWith(expect.any(Error), { source: 'saga_dash' });
   });
 
   it('is a no-op before init', () => {

--- a/packages/web/rum-util/src/index.ts
+++ b/packages/web/rum-util/src/index.ts
@@ -116,24 +116,26 @@ export function setRumGlobalContextProperty(key: string, value: unknown): void {
 }
 
 /** Tag every error with `source: <service>` so the existing saga_web retention
- *  filter pattern (`@error.source:saga_dash` etc.) works out of the box. */
+ *  filter pattern (`@error.source:saga_dash` etc.) works out of the box. The
+ *  service tag is applied last so it cannot be overridden by spread context. */
 export function addRumError(error: unknown, context?: Record<string, unknown>): void {
   if (!initialized) return;
-  datadogRum.addError(error, { source: service, ...context });
+  datadogRum.addError(error, { ...context, source: service });
 }
 
 export function addRumAction(name: string, context?: Record<string, unknown>): void {
   if (!initialized) return;
-  datadogRum.addAction(name, { source: service, ...context });
+  datadogRum.addAction(name, { ...context, source: service });
 }
 
-/** Whether initRum() has succeeded. Mostly for tests. */
+/** Whether initRum() has succeeded. */
 export function isInitialized(): boolean {
   return initialized;
 }
 
-/** For tests only — resets module state. Not part of the public stable API. */
-export function _resetForTest(): void {
+/** Test-only escape hatch — resets module state. Double-underscore prefix
+ *  signals "not part of the public API"; consumers should not import this. */
+export function __resetForTest(): void {
   initialized = false;
   service = '';
 }

--- a/packages/web/rum-util/src/index.ts
+++ b/packages/web/rum-util/src/index.ts
@@ -39,15 +39,16 @@ export interface InitRumOptions {
 }
 
 export interface RumUserPatch {
-  id?: string;
-  name?: string;
-  email?: string;
+  id?: string | null;
+  name?: string | null;
+  email?: string | null;
   /** Saga org / tenant id. Surfaces as `@usr.org` in the Session Explorer. */
-  org?: string;
+  org?: string | null;
   /** Saga role enum (e.g. SCHOLAR, TUTOR, SITE_DIRECTOR). Surfaces as `@usr.role`. */
-  role?: string;
-  /** Any extra fields a consumer wants on the RUM user. */
-  [key: string]: string | number | boolean | undefined;
+  role?: string | null;
+  /** Any extra fields a consumer wants on the RUM user. `null` removes the
+   *  property; `undefined` preserves the current value. */
+  [key: string]: string | number | boolean | null | undefined;
 }
 
 let initialized = false;
@@ -91,13 +92,34 @@ export function initRum(opts: InitRumOptions): boolean {
 /**
  * Incrementally merge fields into the RUM user object. Uses setUserProperty so
  * subsequent calls don't clobber earlier ones (the v6 deprecation-free path).
+ *
+ * Patch semantics per field:
+ *  - `undefined` — preserve the existing value
+ *  - `null` — remove the property (via removeUserProperty)
+ *  - any other value — set
+ *
+ * The null-as-remove path lets reactive consumers wire a nullable source
+ * straight into a setRumUser call without branching, e.g.
+ * `setRumUser({ org: selectedOrgId })` where `selectedOrgId: string | null`.
  */
 export function setRumUser(patch: RumUserPatch): void {
   if (!initialized) return;
   for (const [key, value] of Object.entries(patch)) {
     if (value === undefined) continue;
-    datadogRum.setUserProperty(key, value);
+    if (value === null) {
+      datadogRum.removeUserProperty(key);
+    } else {
+      datadogRum.setUserProperty(key, value);
+    }
   }
+}
+
+/** Remove a single field from the RUM user object. Use this when the caller
+ *  wants a one-off explicit remove rather than the patch-style null in
+ *  setRumUser. */
+export function removeRumUserProperty(key: string): void {
+  if (!initialized) return;
+  datadogRum.removeUserProperty(key);
 }
 
 export function clearRumUser(): void {
@@ -113,6 +135,15 @@ export function clearRumUser(): void {
 export function setRumGlobalContextProperty(key: string, value: unknown): void {
   if (!initialized) return;
   datadogRum.setGlobalContextProperty(key, value);
+}
+
+/** Remove a global context key entirely. Prefer this over
+ *  `setRumGlobalContextProperty(key, null)` — Datadog stores the literal null
+ *  and it surfaces in facet queries and `:*` exists matches, polluting
+ *  dashboards. removeGlobalContextProperty makes the key absent. */
+export function removeRumGlobalContextProperty(key: string): void {
+  if (!initialized) return;
+  datadogRum.removeGlobalContextProperty(key);
 }
 
 /** Tag every error with `source: <service>` so the existing saga_web retention

--- a/packages/web/rum-util/src/index.ts
+++ b/packages/web/rum-util/src/index.ts
@@ -1,0 +1,139 @@
+// Datadog RUM wrapper with Saga conventions.
+//
+// One service per app:  initRum({ service: 'saga_dash' | 'qboard_connectv3' | 'janus_login', ... })
+//
+// Singleton — only the first initRum call has any effect. Pass an empty
+// applicationId or clientToken (e.g. when env vars aren't set in local dev)
+// and the entire module silently no-ops; subsequent setRumUser / addRumError /
+// addRumAction calls return without throwing.
+
+import { datadogRum, type RumInitConfiguration } from '@datadog/browser-rum';
+
+export interface InitRumOptions {
+  /** Service tag baked into every error/action. Use `<service>` per the fleet's RUM-app strategy. */
+  service: string;
+  /** Datadog RUM application id. Empty string is treated as "not configured" and disables RUM. */
+  applicationId: string;
+  /** Datadog RUM client token (the `pub*`-prefixed bundle-safe one). Empty string disables RUM. */
+  clientToken: string;
+  /** `dev` / `staging` / `prod`. */
+  env: string;
+  /** Build version baked into every event. */
+  version: string;
+  /** Datadog site. Defaults to `datadoghq.com` (US1). */
+  site?: RumInitConfiguration['site'];
+  /** % of sessions to track. Default 100 during stabilization. */
+  sessionSampleRate?: number;
+  /** % of tracked sessions to record (session replay). Default 5. */
+  sessionReplaySampleRate?: number;
+  /** Default 'mask' to match nimbee. */
+  defaultPrivacyLevel?: RumInitConfiguration['defaultPrivacyLevel'];
+  /** Backend domains to inject `traceparent` headers into. */
+  allowedTracingUrls?: RumInitConfiguration['allowedTracingUrls'];
+  /** Default true. */
+  trackUserInteractions?: boolean;
+  /** Default true. */
+  trackResources?: boolean;
+  /** Default true. */
+  trackLongTasks?: boolean;
+}
+
+export interface RumUserPatch {
+  id?: string;
+  name?: string;
+  email?: string;
+  /** Saga org / tenant id. Surfaces as `@usr.org` in the Session Explorer. */
+  org?: string;
+  /** Saga role enum (e.g. SCHOLAR, TUTOR, SITE_DIRECTOR). Surfaces as `@usr.role`. */
+  role?: string;
+  /** Any extra fields a consumer wants on the RUM user. */
+  [key: string]: string | number | boolean | undefined;
+}
+
+let initialized = false;
+let service = '';
+
+/**
+ * Initialize Datadog RUM. Idempotent — second and subsequent calls are no-ops.
+ * Returns false (silent no-op) if applicationId or clientToken is empty so that
+ * builds without RUM env vars wired up still ship cleanly.
+ */
+export function initRum(opts: InitRumOptions): boolean {
+  if (initialized) return true;
+  if (!opts.applicationId || !opts.clientToken) return false;
+
+  try {
+    datadogRum.init({
+      applicationId: opts.applicationId,
+      clientToken: opts.clientToken,
+      site: opts.site ?? 'datadoghq.com',
+      service: opts.service,
+      env: opts.env,
+      version: opts.version,
+      sessionSampleRate: opts.sessionSampleRate ?? 100,
+      sessionReplaySampleRate: opts.sessionReplaySampleRate ?? 5,
+      trackUserInteractions: opts.trackUserInteractions ?? true,
+      trackResources: opts.trackResources ?? true,
+      trackLongTasks: opts.trackLongTasks ?? true,
+      defaultPrivacyLevel: opts.defaultPrivacyLevel ?? 'mask',
+      allowedTracingUrls: opts.allowedTracingUrls,
+    });
+    initialized = true;
+    service = opts.service;
+    return true;
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn('[rum] init failed', err);
+    return false;
+  }
+}
+
+/**
+ * Incrementally merge fields into the RUM user object. Uses setUserProperty so
+ * subsequent calls don't clobber earlier ones (the v6 deprecation-free path).
+ */
+export function setRumUser(patch: RumUserPatch): void {
+  if (!initialized) return;
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === undefined) continue;
+    datadogRum.setUserProperty(key, value);
+  }
+}
+
+export function clearRumUser(): void {
+  if (!initialized) return;
+  datadogRum.clearUser();
+}
+
+/**
+ * Pass-through to `datadogRum.setGlobalContextProperty`. Consumers add their
+ * own app-specific context here (e.g. selected_program_ids for saga-dash,
+ * doc_id + peer_count for qboard/connectv3).
+ */
+export function setRumGlobalContextProperty(key: string, value: unknown): void {
+  if (!initialized) return;
+  datadogRum.setGlobalContextProperty(key, value);
+}
+
+/** Tag every error with `source: <service>` so the existing saga_web retention
+ *  filter pattern (`@error.source:saga_dash` etc.) works out of the box. */
+export function addRumError(error: unknown, context?: Record<string, unknown>): void {
+  if (!initialized) return;
+  datadogRum.addError(error, { source: service, ...context });
+}
+
+export function addRumAction(name: string, context?: Record<string, unknown>): void {
+  if (!initialized) return;
+  datadogRum.addAction(name, { source: service, ...context });
+}
+
+/** Whether initRum() has succeeded. Mostly for tests. */
+export function isInitialized(): boolean {
+  return initialized;
+}
+
+/** For tests only — resets module state. Not part of the public stable API. */
+export function _resetForTest(): void {
+  initialized = false;
+  service = '';
+}

--- a/packages/web/rum-util/tsconfig.json
+++ b/packages/web/rum-util/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@saga-ed/soa-typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/web/rum-util/tsup.config.ts
+++ b/packages/web/rum-util/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  target: 'es2022',
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  splitting: false,
+  bundle: true,
+  minify: false,
+  external: ['@datadog/browser-rum']
+});

--- a/packages/web/rum-util/vitest.config.ts
+++ b/packages/web/rum-util/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1446,9 +1446,6 @@ importers:
       '@saga-ed/soa-typescript-config':
         specifier: workspace:*
         version: link:../../core/typescript-config
-      '@vitest/web-worker':
-        specifier: ^1.5.0
-        version: 1.6.1(vitest@1.6.1(@types/node@25.6.0)(jsdom@25.0.1))
       jsdom:
         specifier: ^25.0.0
         version: 25.0.1
@@ -4580,11 +4577,6 @@ packages:
 
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
-
-  '@vitest/web-worker@1.6.1':
-    resolution: {integrity: sha512-T3zLS/sga4z8ZqgA+iDKyiKOcL7OGG3EJ8xqXEEDuvtQELxCITehwPbDe7cGKQ+YspFsLqdNC9td30uQ1uStFg==}
-    peerDependencies:
-      vitest: ^1.0.0
 
   '@whatwg-node/disposablestack@0.0.6':
     resolution: {integrity: sha512-LOtTn+JgJvX8WfBVJtF08TGrdjuFzGJc4mkP8EdDI8ADbvO7kiexYep1o8dwnt0okb0jYclCDXF13xU7Ge4zSw==}
@@ -13701,13 +13693,6 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 1.2.0
 
-  '@vitest/web-worker@1.6.1(vitest@1.6.1(@types/node@25.6.0)(jsdom@25.0.1))':
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-      vitest: 1.6.1(@types/node@25.6.0)(jsdom@25.0.1)
-    transitivePeerDependencies:
-      - supports-color
-
   '@whatwg-node/disposablestack@0.0.6':
     dependencies:
       '@whatwg-node/promise-helpers': 1.3.2
@@ -14945,8 +14930,8 @@ snapshots:
       '@typescript-eslint/parser': 8.50.0(eslint@8.57.1)(typescript@5.8.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -14989,6 +14974,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 8.57.1
+      get-tsconfig: 4.13.0
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.15
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -15000,18 +15000,18 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.50.0(eslint@8.57.1)(typescript@5.8.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -15026,7 +15026,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -15037,7 +15037,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@25.6.0)
+        version: 1.6.1(@types/node@25.6.0)(jsdom@25.0.1)
 
   apps/node/gql-api:
     dependencies:
@@ -93,7 +93,7 @@ importers:
         version: 6.0.3
       '@vitest/coverage-v8':
         specifier: ^1.5.0
-        version: 1.6.1(vitest@1.6.1(@types/node@24.0.12))
+        version: 1.6.1(vitest@1.6.1(@types/node@24.0.12)(jsdom@25.0.1))
       supertest:
         specifier: ^7.1.1
         version: 7.1.4
@@ -105,7 +105,7 @@ importers:
         version: 4.21.0
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@24.0.12)
+        version: 1.6.1(@types/node@24.0.12)(jsdom@25.0.1)
 
   apps/node/rest-api:
     dependencies:
@@ -154,7 +154,7 @@ importers:
         version: 6.0.3
       '@vitest/coverage-v8':
         specifier: ^1.5.0
-        version: 1.6.1(vitest@1.6.1(@types/node@24.0.12))
+        version: 1.6.1(vitest@1.6.1(@types/node@24.0.12)(jsdom@25.0.1))
       supertest:
         specifier: ^7.1.1
         version: 7.1.4
@@ -163,7 +163,7 @@ importers:
         version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@24.0.12)
+        version: 1.6.1(@types/node@24.0.12)(jsdom@25.0.1)
 
   apps/node/tgql-api:
     dependencies:
@@ -233,7 +233,7 @@ importers:
         version: 6.0.3
       '@vitest/coverage-v8':
         specifier: ^1.5.0
-        version: 1.6.1(vitest@1.6.1(@types/node@24.0.12))
+        version: 1.6.1(vitest@1.6.1(@types/node@24.0.12)(jsdom@25.0.1))
       supertest:
         specifier: ^7.1.1
         version: 7.1.4
@@ -245,7 +245,7 @@ importers:
         version: 4.21.0
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@24.0.12)
+        version: 1.6.1(@types/node@24.0.12)(jsdom@25.0.1)
 
   apps/node/tgql-api/tgql-types:
     dependencies:
@@ -267,7 +267,7 @@ importers:
         version: 24.0.12
       '@vitest/coverage-v8':
         specifier: ^1.5.0
-        version: 1.6.1(vitest@1.6.1(@types/node@24.0.12))
+        version: 1.6.1(vitest@1.6.1(@types/node@24.0.12)(jsdom@25.0.1))
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.2)(yaml@2.8.2)
@@ -276,7 +276,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@24.0.12)
+        version: 1.6.1(@types/node@24.0.12)(jsdom@25.0.1)
 
   apps/node/trpc-api:
     dependencies:
@@ -358,7 +358,7 @@ importers:
         version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@24.0.12)
+        version: 1.6.1(@types/node@24.0.12)(jsdom@25.0.1)
 
   apps/node/trpc-api/trpc-types:
     dependencies:
@@ -377,7 +377,7 @@ importers:
         version: 24.0.12
       '@vitest/coverage-v8':
         specifier: ^1.5.0
-        version: 1.6.1(vitest@1.6.1(@types/node@24.0.12))
+        version: 1.6.1(vitest@1.6.1(@types/node@24.0.12)(jsdom@25.0.1))
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.2)(yaml@2.8.2)
@@ -386,7 +386,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@24.0.12)
+        version: 1.6.1(@types/node@24.0.12)(jsdom@25.0.1)
 
   apps/web/docs:
     dependencies:
@@ -497,7 +497,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.6.1
-        version: 1.6.1(@types/node@25.6.0)
+        version: 1.6.1(@types/node@25.6.0)(jsdom@25.0.1)
 
   packages/core/config:
     dependencies:
@@ -591,7 +591,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^1.6.1
-        version: 1.6.1(@types/node@24.0.12)
+        version: 1.6.1(@types/node@24.0.12)(jsdom@25.0.1)
 
   packages/core/tgql-codegen:
     dependencies:
@@ -640,7 +640,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.19.3)
+        version: 2.1.9(@types/node@22.19.3)(jsdom@25.0.1)
 
   packages/core/trpc-base:
     dependencies:
@@ -735,7 +735,7 @@ importers:
         version: 6.0.3
       '@vitest/coverage-v8':
         specifier: ^1.5.0
-        version: 1.6.1(vitest@1.6.1(@types/node@25.6.0))
+        version: 1.6.1(vitest@1.6.1(@types/node@25.6.0)(jsdom@25.0.1))
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -747,7 +747,7 @@ importers:
         version: 7.16.0
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@25.6.0)
+        version: 1.6.1(@types/node@25.6.0)(jsdom@25.0.1)
 
   packages/node/api-util:
     dependencies:
@@ -840,7 +840,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^1.6.1
-        version: 1.6.1(@types/node@24.0.12)
+        version: 1.6.1(@types/node@24.0.12)(jsdom@25.0.1)
       zod:
         specifier: 3.25.67
         version: 3.25.67
@@ -889,7 +889,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@24.0.12)
+        version: 1.6.1(@types/node@24.0.12)(jsdom@25.0.1)
 
   packages/node/event-consumer:
     dependencies:
@@ -935,7 +935,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^1.6.1
-        version: 1.6.1(@types/node@24.0.12)
+        version: 1.6.1(@types/node@24.0.12)(jsdom@25.0.1)
 
   packages/node/event-envelope:
     dependencies:
@@ -960,7 +960,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^1.6.1
-        version: 1.6.1(@types/node@24.0.12)
+        version: 1.6.1(@types/node@24.0.12)(jsdom@25.0.1)
 
   packages/node/event-integration-tests:
     dependencies:
@@ -991,7 +991,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^1.6.1
-        version: 1.6.1(@types/node@24.0.12)
+        version: 1.6.1(@types/node@24.0.12)(jsdom@25.0.1)
 
   packages/node/event-outbox:
     dependencies:
@@ -1034,7 +1034,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^1.6.1
-        version: 1.6.1(@types/node@24.0.12)
+        version: 1.6.1(@types/node@24.0.12)(jsdom@25.0.1)
 
   packages/node/event-test-harness:
     dependencies:
@@ -1068,7 +1068,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^1.6.1
-        version: 1.6.1(@types/node@24.0.12)
+        version: 1.6.1(@types/node@24.0.12)(jsdom@25.0.1)
 
   packages/node/fixture-serve:
     dependencies:
@@ -1120,7 +1120,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@25.6.0)
+        version: 1.6.1(@types/node@25.6.0)(jsdom@25.0.1)
 
   packages/node/logger:
     dependencies:
@@ -1243,7 +1243,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^1.6.1
-        version: 1.6.1(@types/node@24.0.12)
+        version: 1.6.1(@types/node@24.0.12)(jsdom@25.0.1)
 
   packages/node/pubsub-client:
     dependencies:
@@ -1295,7 +1295,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@24.0.12)
+        version: 1.6.1(@types/node@24.0.12)(jsdom@25.0.1)
 
   packages/node/pubsub-core:
     dependencies:
@@ -1320,7 +1320,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@25.6.0)
+        version: 1.6.1(@types/node@25.6.0)(jsdom@25.0.1)
 
   packages/node/pubsub-server:
     dependencies:
@@ -1363,7 +1363,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@25.6.0)
+        version: 1.6.1(@types/node@25.6.0)(jsdom@25.0.1)
 
   packages/node/rabbitmq:
     dependencies:
@@ -1388,7 +1388,7 @@ importers:
         version: 24.0.12
       '@vitest/coverage-v8':
         specifier: ^1.5.0
-        version: 1.6.1(vitest@1.6.1(@types/node@24.0.12))
+        version: 1.6.1(vitest@1.6.1(@types/node@24.0.12)(jsdom@25.0.1))
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -1397,7 +1397,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@24.0.12)
+        version: 1.6.1(@types/node@24.0.12)(jsdom@25.0.1)
 
   packages/node/redis-core:
     dependencies:
@@ -1436,6 +1436,31 @@ importers:
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+
+  packages/web/rum-util:
+    dependencies:
+      '@datadog/browser-rum':
+        specifier: ^6.0.0
+        version: 6.33.0
+    devDependencies:
+      '@saga-ed/soa-typescript-config':
+        specifier: workspace:*
+        version: link:../../core/typescript-config
+      '@vitest/web-worker':
+        specifier: ^1.5.0
+        version: 1.6.1(vitest@1.6.1(@types/node@25.6.0)(jsdom@25.0.1))
+      jsdom:
+        specifier: ^25.0.0
+        version: 25.0.1
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.8.2
+        version: 5.9.3
+      vitest:
+        specifier: ^1.5.0
+        version: 1.6.1(@types/node@25.6.0)(jsdom@25.0.1)
 
   packages/web/ui:
     dependencies:
@@ -1570,6 +1595,9 @@ packages:
     hasBin: true
     peerDependencies:
       graphql: '*'
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -2001,6 +2029,48 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
+
+  '@datadog/browser-core@6.33.0':
+    resolution: {integrity: sha512-h/xuBuY4Xi32CbBHkChMMWlOQ4al/mFF08x3o0hqrderfJvX7VO5tD3OVNwF+pfMXOGlDtBCIhwazr9sn24h3g==}
+
+  '@datadog/browser-rum-core@6.33.0':
+    resolution: {integrity: sha512-Ais4x7zQBrBI6JyILYwFAmjUsqy0iQp2C7JcEEfzU4YYYcVO3DGpyVuYYrqHT27jY1QToHY8EnQUr3Yaj6saDA==}
+
+  '@datadog/browser-rum@6.33.0':
+    resolution: {integrity: sha512-zdxs1PyKt1RQ/fdxsmaCJUeBhB+leCIaPJBcum7uDi/DL8nuu9A9NUc5qGVPlY9zc12v7t2NI8bLpOrMjv+jTg==}
+    peerDependencies:
+      '@datadog/browser-logs': 6.33.0
+    peerDependenciesMeta:
+      '@datadog/browser-logs':
+        optional: true
 
   '@emnapi/core@1.7.1':
     resolution: {integrity: sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==}
@@ -4511,6 +4581,11 @@ packages:
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
+  '@vitest/web-worker@1.6.1':
+    resolution: {integrity: sha512-T3zLS/sga4z8ZqgA+iDKyiKOcL7OGG3EJ8xqXEEDuvtQELxCITehwPbDe7cGKQ+YspFsLqdNC9td30uQ1uStFg==}
+    peerDependencies:
+      vitest: ^1.0.0
+
   '@whatwg-node/disposablestack@0.0.6':
     resolution: {integrity: sha512-LOtTn+JgJvX8WfBVJtF08TGrdjuFzGJc4mkP8EdDI8ADbvO7kiexYep1o8dwnt0okb0jYclCDXF13xU7Ge4zSw==}
     engines: {node: '>=18.0.0'}
@@ -5227,6 +5302,10 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -5240,6 +5319,10 @@ packages:
   data-uri-to-buffer@6.0.2:
     resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
     engines: {node: '>= 14'}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -5286,6 +5369,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
@@ -5478,6 +5564,10 @@ packages:
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
@@ -6211,6 +6301,10 @@ packages:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -6255,6 +6349,10 @@ packages:
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
   iconv-lite@0.7.2:
@@ -6449,6 +6547,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-property@1.0.2:
     resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
 
@@ -6603,6 +6704,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@25.0.1:
+    resolution: {integrity: sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -7173,6 +7283,9 @@ packages:
   nullthrows@1.1.1:
     resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
 
+  nwsapi@2.2.23:
+    resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -7321,6 +7434,9 @@ packages:
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -7798,6 +7914,12 @@ packages:
       class-transformer: ^0.5.1
       class-validator: ^0.14.1
 
+  rrweb-cssom@0.7.1:
+    resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-async@2.4.1:
     resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
     engines: {node: '>=0.12.0'}
@@ -7836,6 +7958,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -8194,6 +8320,9 @@ packages:
   swap-case@2.0.2:
     resolution: {integrity: sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   sync-fetch@0.6.0-2:
     resolution: {integrity: sha512-c7AfkZ9udatCuAy9RSfiGPpeOKKUAUK5e1cXadLOGUjasdxqYqAK0jTNkM/FSEyJ3a5Ra27j/tw/PS0qLmaF/A==}
     engines: {node: '>=18'}
@@ -8330,6 +8459,13 @@ packages:
   title-case@3.0.3:
     resolution: {integrity: sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
   tmp@0.0.33:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
     engines: {node: '>=0.6.0'}
@@ -8349,6 +8485,10 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
@@ -8772,6 +8912,10 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
@@ -8785,6 +8929,11 @@ packages:
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
@@ -8868,6 +9017,13 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -9064,6 +9220,14 @@ snapshots:
       signedsource: 1.0.0
     transitivePeerDependencies:
       - encoding
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -10331,6 +10495,37 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
+
+  '@datadog/browser-core@6.33.0': {}
+
+  '@datadog/browser-rum-core@6.33.0':
+    dependencies:
+      '@datadog/browser-core': 6.33.0
+
+  '@datadog/browser-rum@6.33.0':
+    dependencies:
+      '@datadog/browser-core': 6.33.0
+      '@datadog/browser-rum-core': 6.33.0
 
   '@emnapi/core@1.7.1':
     dependencies:
@@ -13399,7 +13594,7 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitest/coverage-v8@1.6.1(vitest@1.6.1(@types/node@24.0.12))':
+  '@vitest/coverage-v8@1.6.1(vitest@1.6.1(@types/node@24.0.12)(jsdom@25.0.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -13414,11 +13609,11 @@ snapshots:
       std-env: 3.10.0
       strip-literal: 2.1.1
       test-exclude: 6.0.0
-      vitest: 1.6.1(@types/node@24.0.12)
+      vitest: 1.6.1(@types/node@24.0.12)(jsdom@25.0.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@1.6.1(vitest@1.6.1(@types/node@25.6.0))':
+  '@vitest/coverage-v8@1.6.1(vitest@1.6.1(@types/node@25.6.0)(jsdom@25.0.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -13433,7 +13628,7 @@ snapshots:
       std-env: 3.10.0
       strip-literal: 2.1.1
       test-exclude: 6.0.0
-      vitest: 1.6.1(@types/node@25.6.0)
+      vitest: 1.6.1(@types/node@25.6.0)(jsdom@25.0.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -13505,6 +13700,13 @@ snapshots:
       '@vitest/pretty-format': 2.1.9
       loupe: 3.2.1
       tinyrainbow: 1.2.0
+
+  '@vitest/web-worker@1.6.1(vitest@1.6.1(@types/node@25.6.0)(jsdom@25.0.1))':
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      vitest: 1.6.1(@types/node@25.6.0)(jsdom@25.0.1)
+    transitivePeerDependencies:
+      - supports-color
 
   '@whatwg-node/disposablestack@0.0.6':
     dependencies:
@@ -14321,6 +14523,11 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
   csstype@3.2.3: {}
 
   damerau-levenshtein@1.0.8: {}
@@ -14328,6 +14535,11 @@ snapshots:
   data-uri-to-buffer@4.0.1: {}
 
   data-uri-to-buffer@6.0.2: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -14366,6 +14578,8 @@ snapshots:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 8.1.1
+
+  decimal.js@10.6.0: {}
 
   decompress-response@6.0.0:
     dependencies:
@@ -14542,6 +14756,8 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
+
+  entities@6.0.1: {}
 
   error-ex@1.3.4:
     dependencies:
@@ -14729,8 +14945,8 @@ snapshots:
       '@typescript-eslint/parser': 8.50.0(eslint@8.57.1)(typescript@5.8.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -14773,21 +14989,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 8.57.1
-      get-tsconfig: 4.13.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.15
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -14799,18 +15000,18 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.50.0(eslint@8.57.1)(typescript@5.8.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -14825,7 +15026,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -14836,7 +15037,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -15738,6 +15939,10 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-escaper@2.0.2: {}
 
   http-assert@1.5.0:
@@ -15800,6 +16005,10 @@ snapshots:
   human-signals@5.0.0: {}
 
   iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -16027,6 +16236,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-property@1.0.2: {}
 
   is-reference@1.2.1:
@@ -16175,6 +16386,34 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@25.0.1:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      form-data: 4.0.5
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.23
+      parse5: 7.3.0
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.18.3
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsesc@3.1.0: {}
 
@@ -16729,6 +16968,8 @@ snapshots:
 
   nullthrows@1.1.1: {}
 
+  nwsapi@2.2.23: {}
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -16945,6 +17186,10 @@ snapshots:
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   parseurl@1.3.3: {}
 
@@ -17485,6 +17730,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  rrweb-cssom@0.7.1: {}
+
+  rrweb-cssom@0.8.0: {}
+
   run-async@2.4.1: {}
 
   run-parallel@1.2.0:
@@ -17525,6 +17774,10 @@ snapshots:
   safe-stable-stringify@2.5.0: {}
 
   safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -17992,6 +18245,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  symbol-tree@3.2.4: {}
+
   sync-fetch@0.6.0-2:
     dependencies:
       node-fetch: 3.3.2
@@ -18167,6 +18422,12 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
   tmp@0.0.33:
     dependencies:
       os-tmpdir: 1.0.2
@@ -18184,6 +18445,10 @@ snapshots:
       is-number: 7.0.0
 
   toidentifier@1.0.1: {}
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
 
   tr46@0.0.3: {}
 
@@ -18642,7 +18907,7 @@ snapshots:
       '@types/node': 25.6.0
       fsevents: 2.3.3
 
-  vitest@1.6.1(@types/node@24.0.12):
+  vitest@1.6.1(@types/node@24.0.12)(jsdom@25.0.1):
     dependencies:
       '@vitest/expect': 1.6.1
       '@vitest/runner': 1.6.1
@@ -18666,6 +18931,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.0.12
+      jsdom: 25.0.1
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -18676,7 +18942,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@1.6.1(@types/node@25.6.0):
+  vitest@1.6.1(@types/node@25.6.0)(jsdom@25.0.1):
     dependencies:
       '@vitest/expect': 1.6.1
       '@vitest/runner': 1.6.1
@@ -18700,6 +18966,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.6.0
+      jsdom: 25.0.1
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -18710,7 +18977,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@2.1.9(@types/node@22.19.3):
+  vitest@2.1.9(@types/node@22.19.3)(jsdom@25.0.1):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.3))
@@ -18734,6 +19001,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.3
+      jsdom: 25.0.1
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -18745,6 +19013,10 @@ snapshots:
       - supports-color
       - terser
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
@@ -18754,6 +19026,10 @@ snapshots:
   webidl-conversions@3.0.1: {}
 
   webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
 
   whatwg-mimetype@3.0.0: {}
 
@@ -18853,6 +19129,10 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.18.3: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
## Summary

Adds `@saga-ed/soa-rum-util@0.1.0` — a thin Datadog RUM wrapper extracted from the saga-dash canary ([saga-dash#87](https://github.com/saga-ed/saga-dash/pull/87)) so qboard/connectv3 and janus/login can adopt the same pattern.

### Why a wrapper

- **One service tag per app, source-tagged errors.** `service` is a param to `initRum`; every `addRumError` / `addRumAction` is auto-tagged with `source: <service>` so the `@error.source:saga_dash` retention-filter pattern from `saga_web` works out of the box.
- **Silent no-op when unconfigured.** Empty `applicationId` or `clientToken` (e.g. local dev without env vars wired up) short-circuits init; later `setRumUser` / `addRumError` calls return without throwing. Local dev stays quiet, builds still ship.
- **Singleton + idempotent.** Second `initRum` call is a no-op, so module-load init in a SvelteKit `+layout.ts` is safe across HMR.
- **v6 deprecation-free user updates.** `setRumUser({...})` uses `setUserProperty` per field so incremental org/role updates don't clobber the id set earlier.
- **Patch null-as-remove + explicit remove APIs.** `setRumUser({ org: null })` removes the property (drives reactive consumers cleanly: `setRumUser({ org: selectedOrgId })` where `selectedOrgId: string | null`). `removeRumGlobalContextProperty(key)` deletes a global context key without leaving a literal `null` in Datadog facet queries.

### API

| Function | Purpose |
|---|---|
| `initRum(opts)` | One-shot init. Returns `false` if `applicationId`/`clientToken` empty. |
| `setRumUser(patch)` | Incremental user updates. `null` removes, `undefined` preserves, string sets. |
| `removeRumUserProperty(key)` | Explicit one-off remove for a single user field. |
| `clearRumUser()` | On logout. Clears the user object only; remove globals separately. |
| `setRumGlobalContextProperty(k, v)` | Pass-through for app-specific context. |
| `removeRumGlobalContextProperty(k)` | Remove a global context key. Prefer over \`set(k, null)\`. |
| `addRumError(err, ctx?)` | Auto-tags \`source: <service>\` (after the spread — caller can't override). |
| `addRumAction(name, ctx?)` | Auto-tags \`source: <service>\`. |
| `isInitialized()` | Read-only — mostly for tests. |

See \`packages/web/rum-util/README.md\` for usage.

### Consumers (post-publish)

- \`saga-dash\` — currently shipping the inline version on \`rum-canary\` ([saga-dash#87](https://github.com/saga-ed/saga-dash/pull/87)). Will swap to \`@saga-ed/soa-rum-util\` once this is published; the saga-dash side keeps a thin wrapper for \`setRumUserFromSession(session: SagaSession)\` and \`setRumProgramContext(selectedIds)\` since those depend on dash-specific types.
- \`qboard/apps/web/connectv3\` — pending (separate PR).
- \`janus/apps/web/login\` — pending (separate PR).

## Build / Test

- \`pnpm build\` → \`dist/index.js\` 2.91 KB ESM + \`dist/index.d.ts\` 4.46 KB ✓
- \`pnpm check-types\` → 0 errors ✓
- \`pnpm test\` → **17/17 pass** (vi.mock'd \`@datadog/browser-rum\`) ✓

## Test plan

- [ ] CI green (build, lint, typecheck, test, turbo cache)
- [ ] After merge: publish \`0.1.0\` to CodeArtifact (requires \`saga-platform-prod\` tier)
- [ ] After publish: open the saga-dash adoption PR — swap \`apps/web/dash/src/lib/rum.ts\` for a thin wrapper that re-exports from \`@saga-ed/soa-rum-util\` and adds the saga-dash-specific \`setRumUserFromSession\` + \`setRumProgramContext\`
- [ ] Confirm saga-dash preview still shows \`@application.name:saga_dash @env:dev\` sessions in Datadog Session Explorer

## References

- Saga-dash canary PR: https://github.com/saga-ed/saga-dash/pull/87
- Fleet RUM rollout epic: https://github.com/hipponot/iac/issues/349
- Saga-web retention-filter design (companion): \`~/.claude/plans/let-s-check-again-shiny-dolphin.md\`