### PR TITLE
feat: add @saga-ed/soa-postgres + redis/mongo loaders for 3-env mirror tier

### DIFF
--- a/packages/node/db/src/__tests__/connection-string.unit.test.ts
+++ b/packages/node/db/src/__tests__/connection-string.unit.test.ts
@@ -118,4 +118,17 @@ describe('MongoProvider._buildConnectionString', () => {
     const caFile = params.get('tlsCAFile');
     expect(caFile).toMatch(/saga-mongodb-ca-cert-from-content-test\.pem$/);
   });
+
+  it('re-writing the CA file is idempotent across constructions (restart-safe)', () => {
+    const cfg = {
+      ...baseConfig,
+      instanceName: 'restart-safe-test',
+      tls: true,
+      tlsCAContent: '-----BEGIN CERTIFICATE-----\nidempotent\n-----END CERTIFICATE-----\n',
+    };
+    // The first write leaves the file mode 0o400; constructing again (as a
+    // restarted process would) must not fail with EACCES.
+    new MongoProvider(cfg);
+    expect(() => new MongoProvider(cfg)).not.toThrow();
+  });
 });

--- a/packages/node/db/src/__tests__/mirror-alias.unit.test.ts
+++ b/packages/node/db/src/__tests__/mirror-alias.unit.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mockClient } from 'aws-sdk-client-mock';
+import {
+  GetParameterCommand,
+  SSMClient,
+} from '@aws-sdk/client-ssm';
+import {
+  GetSecretValueCommand,
+  SecretsManagerClient,
+} from '@aws-sdk/client-secrets-manager';
+import { loadMongoConfigFromAws } from '../aws-mongo-loader.js';
+
+const ssmMock = mockClient(SSMClient);
+const smMock = mockClient(SecretsManagerClient);
+
+beforeEach(() => {
+  ssmMock.reset();
+  smMock.reset();
+});
+
+/**
+ * The plan locks `mirror` as the canonical env name for all engines, with
+ * `staging` kept as a deprecated alias for one cycle. Both names resolve
+ * to the same underlying SSM/secret paths today because the IaC rename
+ * hasn't shipped yet; when it does, this test will be updated to point
+ * mirror at /shared/infra/mirror/* and the staging path will be removed.
+ */
+
+function stubStagingPaths() {
+  ssmMock
+    .on(GetParameterCommand, { Name: '/shared/infra/staging/mongodb-hosts' })
+    .resolves({ Parameter: { Value: 'h1:27017' } })
+    .on(GetParameterCommand, { Name: '/shared/infra/staging/mongodb-replica-set-name' })
+    .resolves({ Parameter: { Value: 'saga-rs' } })
+    .on(GetParameterCommand, { Name: '/shared/infra/staging/mongodb-ca-secret-arn' })
+    .resolves({ Parameter: { Value: 'arn:ca' } });
+  smMock
+    .on(GetSecretValueCommand, { SecretId: 'arn:ca' })
+    .resolves({ SecretString: JSON.stringify({ ca_cert: 'CA' }) })
+    .on(GetSecretValueCommand, { SecretId: 'staging/mongodb-shared/sds-api-password' })
+    .resolves({ SecretString: JSON.stringify({ username: 'sds_app', password: 'pw' }) });
+}
+
+describe("env='mirror' alias", () => {
+  it("resolves env='mirror' against the staging SSM/secret paths", async () => {
+    stubStagingPaths();
+
+    const config = await loadMongoConfigFromAws({
+      scope: 'shared',
+      env: 'mirror',
+      project: 'sds-api',
+      instanceName: 'sds-mirror',
+    });
+
+    expect(config.username).toBe('sds_app');
+    expect(config.hosts).toEqual(['h1:27017']);
+  });
+
+  it("env='staging' still works but emits a deprecation warning", async () => {
+    stubStagingPaths();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await loadMongoConfigFromAws({
+      scope: 'shared',
+      env: 'staging',
+      project: 'sds-api',
+      instanceName: 'sds-staging',
+    });
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("env='staging' is deprecated"),
+    );
+    warn.mockRestore();
+  });
+
+  it("env='prod' is unaffected and uses /shared/infra/prod/* paths", async () => {
+    ssmMock
+      .on(GetParameterCommand, { Name: '/shared/infra/prod/mongodb-hosts' })
+      .resolves({ Parameter: { Value: 'p1:27017' } })
+      .on(GetParameterCommand, { Name: '/shared/infra/prod/mongodb-replica-set-name' })
+      .resolves({ Parameter: { Value: 'saga-rs' } })
+      .on(GetParameterCommand, { Name: '/shared/infra/prod/mongodb-ca-secret-arn' })
+      .resolves({ Parameter: { Value: 'arn:prod-ca' } });
+    smMock
+      .on(GetSecretValueCommand, { SecretId: 'arn:prod-ca' })
+      .resolves({ SecretString: JSON.stringify({ ca_cert: 'PROD-CA' }) })
+      .on(GetSecretValueCommand, { SecretId: 'prod/mongodb-shared/sds-api-password' })
+      .resolves({ SecretString: JSON.stringify({ username: 'sds_app', password: 'pw' }) });
+
+    const config = await loadMongoConfigFromAws({
+      scope: 'shared',
+      env: 'prod',
+      project: 'sds-api',
+      instanceName: 'sds-prod',
+    });
+
+    expect(config.hosts).toEqual(['p1:27017']);
+  });
+
+  it('rejects unknown envs', async () => {
+    await expect(
+      loadMongoConfigFromAws({
+        scope: 'shared',
+        // @ts-expect-error — testing runtime validation of invalid env
+        env: 'preprod',
+        project: 'sds-api',
+        instanceName: 'i',
+      }),
+    ).rejects.toThrow(/scope='shared'/);
+  });
+});

--- a/packages/node/db/src/__tests__/mirror-alias.unit.test.ts
+++ b/packages/node/db/src/__tests__/mirror-alias.unit.test.ts
@@ -19,31 +19,74 @@ beforeEach(() => {
 });
 
 /**
- * The plan locks `mirror` as the canonical env name for all engines, with
- * `staging` kept as a deprecated alias for one cycle. Both names resolve
- * to the same underlying SSM/secret paths today because the IaC rename
- * hasn't shipped yet; when it does, this test will be updated to point
- * mirror at /shared/infra/mirror/* and the staging path will be removed.
+ * Mirror reads from the existing refresh workflow's per-service paths:
+ *   SSM:    /mirror/current/mongodb-shared/{endpoint,port,replica-set-name,ca-secret-arn}
+ *   Secret: /mirror/current/{project}-mongo-password
+ *
+ * This unifies the daily refresh workflow's rotation and consumer reads
+ * into a single source of truth instead of two parallel universes.
+ *
+ * The legacy ``env='staging'`` path is kept for one deprecation cycle —
+ * resolves to /shared/infra/staging/* and staging/mongodb-shared/* with a
+ * console.warn.
  */
+
+function stubMirrorPaths() {
+  ssmMock
+    .on(GetParameterCommand, {
+      Name: '/mirror/current/mongodb-shared/endpoint',
+    })
+    .resolves({ Parameter: { Value: 'mirror-mongo.dev.internal' } })
+    .on(GetParameterCommand, { Name: '/mirror/current/mongodb-shared/port' })
+    .resolves({ Parameter: { Value: '27017' } })
+    .on(GetParameterCommand, {
+      Name: '/mirror/current/mongodb-shared/replica-set-name',
+    })
+    .resolves({ Parameter: { Value: 'saga-rs' } })
+    .on(GetParameterCommand, {
+      Name: '/mirror/current/mongodb-shared/ca-secret-arn',
+    })
+    .resolves({ Parameter: { Value: 'arn:mirror-ca' } });
+  smMock
+    .on(GetSecretValueCommand, { SecretId: 'arn:mirror-ca' })
+    .resolves({ SecretString: JSON.stringify({ ca_cert: 'MIRROR-CA' }) })
+    .on(GetSecretValueCommand, {
+      SecretId: '/mirror/current/sds-api-mongo-password',
+    })
+    .resolves({
+      SecretString: JSON.stringify({
+        username: 'sds_api_app',
+        password: 'mirror-pw',
+      }),
+    });
+}
 
 function stubStagingPaths() {
   ssmMock
     .on(GetParameterCommand, { Name: '/shared/infra/staging/mongodb-hosts' })
     .resolves({ Parameter: { Value: 'h1:27017' } })
-    .on(GetParameterCommand, { Name: '/shared/infra/staging/mongodb-replica-set-name' })
+    .on(GetParameterCommand, {
+      Name: '/shared/infra/staging/mongodb-replica-set-name',
+    })
     .resolves({ Parameter: { Value: 'saga-rs' } })
-    .on(GetParameterCommand, { Name: '/shared/infra/staging/mongodb-ca-secret-arn' })
+    .on(GetParameterCommand, {
+      Name: '/shared/infra/staging/mongodb-ca-secret-arn',
+    })
     .resolves({ Parameter: { Value: 'arn:ca' } });
   smMock
     .on(GetSecretValueCommand, { SecretId: 'arn:ca' })
     .resolves({ SecretString: JSON.stringify({ ca_cert: 'CA' }) })
-    .on(GetSecretValueCommand, { SecretId: 'staging/mongodb-shared/sds-api-password' })
-    .resolves({ SecretString: JSON.stringify({ username: 'sds_app', password: 'pw' }) });
+    .on(GetSecretValueCommand, {
+      SecretId: 'staging/mongodb-shared/sds-api-password',
+    })
+    .resolves({
+      SecretString: JSON.stringify({ username: 'sds_app', password: 'pw' }),
+    });
 }
 
-describe("env='mirror' alias", () => {
-  it("resolves env='mirror' against the staging SSM/secret paths", async () => {
-    stubStagingPaths();
+describe("env='mirror' reads from refresh workflow paths", () => {
+  it('uses /mirror/current/* SSM + /mirror/current/{project}-mongo-password secret', async () => {
+    stubMirrorPaths();
 
     const config = await loadMongoConfigFromAws({
       scope: 'shared',
@@ -52,8 +95,13 @@ describe("env='mirror' alias", () => {
       instanceName: 'sds-mirror',
     });
 
-    expect(config.username).toBe('sds_app');
-    expect(config.hosts).toEqual(['h1:27017']);
+    expect(config.username).toBe('sds_api_app');
+    expect(config.password).toBe('mirror-pw');
+    expect(config.hosts).toEqual(['mirror-mongo.dev.internal:27017']);
+    expect(config.replicaSet).toBe('saga-rs');
+    expect(config.authSource).toBe('sds_api_db');
+    expect(config.tls).toBe(true);
+    expect(config.tlsCAContent).toBe('MIRROR-CA');
   });
 
   it("env='staging' still works but emits a deprecation warning", async () => {
@@ -73,19 +121,27 @@ describe("env='mirror' alias", () => {
     warn.mockRestore();
   });
 
-  it("env='prod' is unaffected and uses /shared/infra/prod/* paths", async () => {
+  it("env='prod' uses /shared/infra/prod/* paths unchanged", async () => {
     ssmMock
       .on(GetParameterCommand, { Name: '/shared/infra/prod/mongodb-hosts' })
       .resolves({ Parameter: { Value: 'p1:27017' } })
-      .on(GetParameterCommand, { Name: '/shared/infra/prod/mongodb-replica-set-name' })
+      .on(GetParameterCommand, {
+        Name: '/shared/infra/prod/mongodb-replica-set-name',
+      })
       .resolves({ Parameter: { Value: 'saga-rs' } })
-      .on(GetParameterCommand, { Name: '/shared/infra/prod/mongodb-ca-secret-arn' })
+      .on(GetParameterCommand, {
+        Name: '/shared/infra/prod/mongodb-ca-secret-arn',
+      })
       .resolves({ Parameter: { Value: 'arn:prod-ca' } });
     smMock
       .on(GetSecretValueCommand, { SecretId: 'arn:prod-ca' })
       .resolves({ SecretString: JSON.stringify({ ca_cert: 'PROD-CA' }) })
-      .on(GetSecretValueCommand, { SecretId: 'prod/mongodb-shared/sds-api-password' })
-      .resolves({ SecretString: JSON.stringify({ username: 'sds_app', password: 'pw' }) });
+      .on(GetSecretValueCommand, {
+        SecretId: 'prod/mongodb-shared/sds-api-password',
+      })
+      .resolves({
+        SecretString: JSON.stringify({ username: 'sds_app', password: 'pw' }),
+      });
 
     const config = await loadMongoConfigFromAws({
       scope: 'shared',

--- a/packages/node/db/src/__tests__/mongo-provider.unit.test.ts
+++ b/packages/node/db/src/__tests__/mongo-provider.unit.test.ts
@@ -1,0 +1,138 @@
+import 'reflect-metadata';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock the mongodb driver so we can drive connect()/ping() without a real DB.
+// `new MongoClient(...)` returns a single shared `instance`; its connect/db/
+// close are individually controllable mocks.
+// ---------------------------------------------------------------------------
+const { MongoClientMock, connectMock, commandMock, closeMock, instance } =
+  vi.hoisted(() => {
+    const commandMock = vi.fn();
+    const closeMock = vi.fn();
+    const connectMock = vi.fn();
+    const instance = {
+      connect: connectMock,
+      close: closeMock,
+      db: vi.fn(() => ({ command: commandMock })),
+    };
+    const MongoClientMock = vi.fn(() => instance);
+    return { MongoClientMock, connectMock, commandMock, closeMock, instance };
+  });
+
+vi.mock('mongodb', () => ({ MongoClient: MongoClientMock }));
+
+// vi.mock/vi.hoisted are hoisted above these imports.
+import { MongoProvider } from '../mongo-provider.js';
+import type { MongoProviderConfig } from '../mongo-provider-config.js';
+
+const baseConfig: MongoProviderConfig = {
+  configType: 'MONGO',
+  instanceName: 'unit',
+  hosts: ['localhost:27017'],
+  database: 'app_db',
+};
+
+const authError = (code: number) => Object.assign(new Error('auth failed'), { code });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  MongoClientMock.mockReset();
+  connectMock.mockReset();
+  commandMock.mockReset();
+  closeMock.mockReset();
+  MongoClientMock.mockReturnValue(instance);
+  connectMock.mockResolvedValue(instance);
+  commandMock.mockResolvedValue({ ok: 1 });
+  closeMock.mockResolvedValue(undefined);
+});
+
+describe('MongoProvider lifecycle', () => {
+  it('tracks isConnected across connect/disconnect via a flag (not a private driver field)', async () => {
+    const provider = new MongoProvider(baseConfig);
+    expect(provider.isConnected()).toBe(false);
+
+    await provider.connect();
+    expect(provider.isConnected()).toBe(true);
+
+    await provider.disconnect();
+    expect(provider.isConnected()).toBe(false);
+  });
+
+  it('connect() is idempotent', async () => {
+    const provider = new MongoProvider(baseConfig);
+    await provider.connect();
+    await provider.connect();
+    expect(MongoClientMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('MongoProvider.ping', () => {
+  it('returns false before connect', async () => {
+    expect(await new MongoProvider(baseConfig).ping()).toBe(false);
+  });
+
+  it('returns true when admin.ping succeeds', async () => {
+    const provider = new MongoProvider(baseConfig);
+    await provider.connect();
+    expect(await provider.ping()).toBe(true);
+    expect(commandMock).toHaveBeenCalledWith({ ping: 1 });
+  });
+
+  it('returns false (does not throw) when the server is unreachable', async () => {
+    const provider = new MongoProvider(baseConfig);
+    await provider.connect();
+    commandMock.mockRejectedValueOnce(new Error('no primary available'));
+    expect(await provider.ping()).toBe(false);
+  });
+});
+
+describe('MongoProvider.connect retry', () => {
+  it('retries a transient failure and succeeds on a later attempt', async () => {
+    vi.useFakeTimers();
+    connectMock
+      .mockRejectedValueOnce(new Error('ETIMEDOUT'))
+      .mockResolvedValueOnce(instance);
+
+    const provider = new MongoProvider(baseConfig);
+    const connecting = provider.connect();
+    await vi.runAllTimersAsync();
+    await connecting;
+
+    expect(provider.isConnected()).toBe(true);
+    expect(MongoClientMock).toHaveBeenCalledTimes(2); // a fresh client per attempt
+    vi.useRealTimers();
+  });
+
+  it('gives up after maxRetries and rethrows', async () => {
+    vi.useFakeTimers();
+    connectMock.mockRejectedValue(new Error('cluster down'));
+
+    const provider = new MongoProvider(baseConfig);
+    const captured = provider.connect().catch((e: unknown) => e);
+    await vi.runAllTimersAsync();
+    const err = await captured;
+
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toBe('cluster down');
+    expect(provider.isConnected()).toBe(false);
+    expect(MongoClientMock).toHaveBeenCalledTimes(3);
+    vi.useRealTimers();
+  });
+
+  it('does NOT retry a non-retryable auth error (AuthenticationFailed=18)', async () => {
+    connectMock.mockRejectedValue(authError(18));
+
+    const provider = new MongoProvider(baseConfig);
+    await expect(provider.connect()).rejects.toThrow('auth failed');
+    expect(MongoClientMock).toHaveBeenCalledTimes(1); // failed fast, no retry
+  });
+
+  it('does NOT retry Unauthorized=13 either', async () => {
+    connectMock.mockRejectedValue(authError(13));
+
+    const provider = new MongoProvider(baseConfig);
+    await expect(provider.connect()).rejects.toThrow('auth failed');
+    expect(MongoClientMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/node/db/src/aws-mongo-loader.ts
+++ b/packages/node/db/src/aws-mongo-loader.ts
@@ -88,10 +88,41 @@ export async function loadMongoConfigFromAws(
       );
     }
 
-    // 'mirror' is the canonical name but the underlying SSM/secret paths
-    // are still under '/shared/infra/staging/*' and 'staging/mongodb-shared/*'
-    // until the IaC rename ships. Map both new and deprecated names to
-    // the same paths.
+    // env='mirror' reads from the daily-refresh workflow's paths:
+    //   SSM:    /mirror/current/mongodb-shared/{endpoint,port,replica-set-name,ca-secret-arn}
+    //   Secret: /mirror/current/{project}-mongo-password
+    // env='prod' uses the canonical prod paths.
+    // env='staging' (deprecated) keeps the legacy paths under /shared/infra/staging/*.
+    if (env === 'mirror') {
+      const [endpoint, port, replicaSetName, caSecretArn] = await Promise.all([
+        readSsm(ssm, '/mirror/current/mongodb-shared/endpoint'),
+        readSsm(ssm, '/mirror/current/mongodb-shared/port'),
+        readSsm(ssm, '/mirror/current/mongodb-shared/replica-set-name'),
+        readSsm(ssm, '/mirror/current/mongodb-shared/ca-secret-arn'),
+      ]);
+
+      const [caBundle, projectCreds] = await Promise.all([
+        readSecretJson<{ ca_cert: string }>(sm, caSecretArn),
+        readSecretJson<{ username: string; password: string }>(
+          sm,
+          `/mirror/current/${project}-mongo-password`,
+        ),
+      ]);
+
+      return {
+        configType: 'MONGO',
+        instanceName,
+        hosts: [`${endpoint}:${port}`],
+        database: dbName,
+        username: projectCreds.username,
+        password: projectCreds.password,
+        replicaSet: replicaSetName,
+        authSource: dbName,
+        tls: true,
+        tlsCAContent: caBundle.ca_cert,
+      };
+    }
+
     const pathSegment = env === 'prod' ? 'prod' : 'staging';
 
     const [hostsCsv, replicaSetName, caSecretArn] = await Promise.all([

--- a/packages/node/db/src/aws-mongo-loader.ts
+++ b/packages/node/db/src/aws-mongo-loader.ts
@@ -35,10 +35,21 @@ import type { MongoProviderConfig } from './mongo-provider-config.js';
  * env vars or static wiring.
  */
 export interface LoadMongoConfigParams {
-  /** Mirror-current is the dev-account mirror; shared is staging/prod. */
+  /** Mirror-current is the dev-account mirror (admin); shared is mirror/prod. */
   scope?: 'shared' | 'mirror-current';
-  /** Required when scope is 'shared'. Ignored for 'mirror-current'. */
-  env?: 'staging' | 'prod';
+  /**
+   * Required when scope is 'shared'. Ignored for 'mirror-current'.
+   *
+   * - `'mirror'` — canonical name for the prod-shape RDS-managed mirror.
+   * - `'prod'`   — production.
+   * - `'staging'` — deprecated alias for `'mirror'`; emits a warning.
+   *                 Removed in next major.
+   *
+   * Until the SSM/Secrets-Manager rename ships, `'mirror'` resolves to
+   * the same underlying paths as `'staging'` ({@link _STAGING_PATH_PREFIX}
+   * below). This is a one-cycle compat shim.
+   */
+  env?: 'mirror' | 'prod' | 'staging';
   /** Project name (e.g. 'ledger-api'). Hyphens become underscores in db/user names. */
   project: string;
   /** Name to give the MongoProvider instance. */
@@ -63,21 +74,37 @@ export async function loadMongoConfigFromAws(
 
   if (scope === 'shared') {
     const env = params.env;
-    if (env !== 'staging' && env !== 'prod') {
-      throw new Error(`scope='shared' requires env='staging'|'prod', got: ${String(env)}`);
+    if (env !== 'mirror' && env !== 'prod' && env !== 'staging') {
+      throw new Error(
+        `scope='shared' requires env='mirror'|'prod' (or deprecated 'staging'), got: ${String(env)}`,
+      );
     }
 
+    if (env === 'staging') {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[@saga-ed/soa-db] env='staging' is deprecated; use env='mirror'. " +
+          "Will be removed in next major.",
+      );
+    }
+
+    // 'mirror' is the canonical name but the underlying SSM/secret paths
+    // are still under '/shared/infra/staging/*' and 'staging/mongodb-shared/*'
+    // until the IaC rename ships. Map both new and deprecated names to
+    // the same paths.
+    const pathSegment = env === 'prod' ? 'prod' : 'staging';
+
     const [hostsCsv, replicaSetName, caSecretArn] = await Promise.all([
-      readSsm(ssm, `/shared/infra/${env}/mongodb-hosts`),
-      readSsm(ssm, `/shared/infra/${env}/mongodb-replica-set-name`),
-      readSsm(ssm, `/shared/infra/${env}/mongodb-ca-secret-arn`),
+      readSsm(ssm, `/shared/infra/${pathSegment}/mongodb-hosts`),
+      readSsm(ssm, `/shared/infra/${pathSegment}/mongodb-replica-set-name`),
+      readSsm(ssm, `/shared/infra/${pathSegment}/mongodb-ca-secret-arn`),
     ]);
 
     const [caBundle, projectCreds] = await Promise.all([
       readSecretJson<{ ca_cert: string }>(sm, caSecretArn),
       readSecretJson<{ username: string; password: string }>(
         sm,
-        `${env}/mongodb-shared/${project}-password`,
+        `${pathSegment}/mongodb-shared/${project}-password`,
       ),
     ]);
 

--- a/packages/node/db/src/i-mongo-conn-mgr.ts
+++ b/packages/node/db/src/i-mongo-conn-mgr.ts
@@ -4,6 +4,12 @@ export interface IMongoConnMgr {
   readonly instanceName: string;
   connect(): Promise<void>;
   disconnect(): Promise<void>;
+  /** Cheap sync flag: connect() succeeded and disconnect() hasn't run. */
   isConnected(): boolean;
+  /**
+   * Optional real liveness probe (admin.ping). Returns false rather than
+   * throwing. Optional so existing implementers aren't forced to add it.
+   */
+  ping?(): Promise<boolean>;
   getClient(): MongoClient;
 }

--- a/packages/node/db/src/mocks/mock-mongo-provider.ts
+++ b/packages/node/db/src/mocks/mock-mongo-provider.ts
@@ -5,6 +5,7 @@ import { IMongoConnMgr } from '../i-mongo-conn-mgr.js';
 export class MockMongoProvider implements IMongoConnMgr {
   public readonly instanceName: string;
   private client: MongoClient | null = null;
+  private _connected = false;
   private mongoServer: MongoMemoryServer | null = null;
 
   constructor(instanceName: string = 'MockMongoDB') {
@@ -16,6 +17,7 @@ export class MockMongoProvider implements IMongoConnMgr {
     const uri = this.mongoServer.getUri();
     this.client = new MongoClient(uri);
     await this.client.connect();
+    this._connected = true;
   }
 
   async disconnect(): Promise<void> {
@@ -27,10 +29,21 @@ export class MockMongoProvider implements IMongoConnMgr {
       await this.mongoServer.stop();
       this.mongoServer = null;
     }
+    this._connected = false;
   }
 
   isConnected(): boolean {
-    return !!this.client && !(this.client as any).closed;
+    return this._connected;
+  }
+
+  async ping(): Promise<boolean> {
+    if (!this.client) return false;
+    try {
+      await this.client.db().command({ ping: 1 });
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   getClient(): MongoClient {

--- a/packages/node/db/src/mongo-provider.ts
+++ b/packages/node/db/src/mongo-provider.ts
@@ -1,4 +1,4 @@
-import { writeFileSync } from 'node:fs';
+import { rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { injectable } from 'inversify';
@@ -157,6 +157,12 @@ export class MongoProvider implements IMongoConnMgr {
     if (tlsCAContent) {
       const safeName = instanceName.replace(/[^a-zA-Z0-9_-]/g, '_');
       const path = join(tmpdir(), `saga-mongodb-ca-${safeName}.pem`);
+      // Idempotent across restarts: the previous run leaves this file mode
+      // 0o400 (read-only), so a plain writeFileSync would fail EACCES on the
+      // next boot (or whenever a provider with this instanceName is rebuilt).
+      // Remove any stale copy first, then write fresh. rmSync needs write
+      // perms on the dir (tmpdir), not the file, so the 0o400 mode is fine.
+      rmSync(path, { force: true });
       writeFileSync(path, tlsCAContent, { mode: 0o400 });
       return path;
     }

--- a/packages/node/db/src/mongo-provider.ts
+++ b/packages/node/db/src/mongo-provider.ts
@@ -10,6 +10,7 @@ import { IMongoConnMgr } from './i-mongo-conn-mgr.js';
 export class MongoProvider implements IMongoConnMgr {
   public readonly instanceName: string;
   private client: MongoClient | null = null;
+  private _connected = false;
   private config: MongoProviderConfig;
   // Resolved CA path — either the caller-provided tlsCAFile, or a tmp path
   // we wrote tlsCAContent to. Computed once at construction so writes don't
@@ -25,8 +26,32 @@ export class MongoProvider implements IMongoConnMgr {
   async connect(): Promise<void> {
     if (this.isConnected()) return;
     const uri = this._buildConnectionString();
-    this.client = null;
-    this.client = await new MongoClient(uri, this.config.options).connect();
+
+    const maxRetries = 3;
+    const baseDelayMs = 1000;
+
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      try {
+        this.client = await new MongoClient(uri, this.config.options).connect();
+        this._connected = true;
+        return;
+      } catch (err) {
+        this.client = null;
+        this._connected = false;
+        // The driver's own server selection (serverSelectionTimeoutMS,
+        // default ~30s) already absorbs transient unavailability within a
+        // single connect(). This loop adds coverage for connects that fail
+        // fast and then recover (e.g. a brief DNS/RS-election blip at boot).
+        // Auth/authz failures are NOT transient — retrying just burns
+        // another full server-selection window, so fail fast on those.
+        if (MongoProvider.isNonRetryableAuthError(err) || attempt === maxRetries) {
+          throw err;
+        }
+        await new Promise((resolve) =>
+          setTimeout(resolve, baseDelayMs * Math.pow(2, attempt - 1)),
+        );
+      }
+    }
   }
 
   async disconnect(): Promise<void> {
@@ -34,10 +59,32 @@ export class MongoProvider implements IMongoConnMgr {
       await this.client.close();
       this.client = null;
     }
+    this._connected = false;
   }
 
+  /**
+   * Whether connect() has succeeded and disconnect() hasn't run. This is a
+   * cheap synchronous flag, not a live reachability check — the driver can
+   * lose every server while this still reads true. For a real probe (e.g.
+   * a readiness endpoint) use {@link ping}.
+   */
   isConnected(): boolean {
-    return !!this.client && !(this.client as any).closed;
+    return this._connected;
+  }
+
+  /**
+   * Real liveness probe: issues an ``admin.ping`` against the current
+   * topology, confirming a server is reachable right now. Returns false
+   * instead of throwing so it's safe to call from health checks.
+   */
+  async ping(): Promise<boolean> {
+    if (!this.client) return false;
+    try {
+      await this.client.db().command({ ping: 1 });
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   getClient(): MongoClient {
@@ -45,6 +92,15 @@ export class MongoProvider implements IMongoConnMgr {
       throw new Error('MongoClient is not connected');
     }
     return this.client;
+  }
+
+  /**
+   * MongoServerError auth/authz failures (AuthenticationFailed=18,
+   * Unauthorized=13) won't fix themselves on retry.
+   */
+  private static isNonRetryableAuthError(err: unknown): boolean {
+    const code = (err as { code?: number | string } | null)?.code;
+    return code === 18 || code === 13 || code === '18' || code === '13';
   }
 
   /**

--- a/packages/node/logger/package.json
+++ b/packages/node/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saga-ed/soa-logger",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "private": false,
   "scripts": {
     "dev": "tsup --watch",

--- a/packages/node/logger/src/__tests__/pino-logger.unit.test.ts
+++ b/packages/node/logger/src/__tests__/pino-logger.unit.test.ts
@@ -51,11 +51,13 @@ describe('PinoLogger', () => {
     });
   });
 
-  it('should throw if logFile is missing in production Express context', () => {
+  it('should default to stdout (fd 1) in production Express context without logFile', () => {
+    // No longer throws: a missing logFile now means "log structured JSON to
+    // stdout via a direct pino.destination stream" (CloudWatch via awslogs).
     const config: PinoLoggerConfig = { ...baseConfig, isExpressContext: true };
     process.env.NODE_ENV = 'production';
-    withTTY(true, () => {
-      expect(() => new PinoLogger(config)).toThrow(/logFile must be specified/);
+    withTTY(false, () => {
+      expect(() => new PinoLogger(config)).not.toThrow();
     });
   });
 

--- a/packages/node/logger/src/pino-logger.ts
+++ b/packages/node/logger/src/pino-logger.ts
@@ -12,12 +12,27 @@ export class PinoLogger implements ILogger {
     const isForeground = Boolean(process.stdout.isTTY);
     const isExpressContext = config.isExpressContext;
     const logFile = config.logFile;
-    const targets: TransportTargetOptions[] = [];
 
-    // Enforce production Express context rule
-    if (env === 'production' && isExpressContext && !logFile) {
-      throw new Error('In production Express context, logFile must be specified for the logger.');
+    // pino's ESM default interop (CJS package, ESM consumer).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pinoFn: any = (pino as any).default ?? pino;
+
+    // Production Express context (e.g. ECS/Fargate): write structured JSON
+    // straight to a file descriptor via a direct pino.destination stream
+    // (default fd 1 = stdout; an explicit logFile overrides). pino's
+    // transport mechanism runs in a worker thread that crashes on process
+    // fds (/dev/stdout, /proc/1/fd/1) in Fargate, so the previous workaround
+    // logged to a /tmp file that never reached CloudWatch. A main-thread
+    // SonicBoom stream on stdout is reliable and is captured by the awslogs
+    // driver → CloudWatch.
+    if (env === 'production' && isExpressContext) {
+      const dest = pinoFn.destination({ dest: logFile ?? 1, sync: false });
+      this.logger = pinoFn({ level: config.level }, dest);
+      this.logger.info(`Logger initialized with level ${config.level}`);
+      return;
     }
+
+    const targets: TransportTargetOptions[] = [];
 
     // NODE_ENV=local
     if (env === 'local') {
@@ -61,28 +76,9 @@ export class PinoLogger implements ILogger {
         });
       }
     }
-    // NODE_ENV=production
-    else if (env === 'production') {
-      if (isExpressContext) {
-        // Always file logger (already enforced above)
-        targets.push({
-          target: 'pino/file',
-          options: { destination: logFile! },
-        });
-        if (isForeground) {
-          targets.push({
-            target: config.prettyPrint ? 'pino-pretty' : 'pino/file',
-            options: config.prettyPrint
-              ? {
-                  colorize: true,
-                  levelFirst: true,
-                  translateTime: 'SYS:standard',
-                }
-              : { destination: 1 },
-          });
-        }
-      }
-    }
+    // NODE_ENV=production + Express context is handled by the early-return
+    // above (direct stdout destination). Production without Express context
+    // falls through to the console fallback below.
     // Fallback/default: always log to console
     if (targets.length === 0) {
       targets.push({
@@ -97,21 +93,12 @@ export class PinoLogger implements ILogger {
       });
     }
 
-    // Use pino.default if available (ESM interop), otherwise pino (CJS)
-    // @ts-ignore
-    this.logger = (pino as any).default
-      ? (pino as any).default({
-          level: config.level,
-          transport: {
-            targets,
-          },
-        })
-      : (pino as any)({
-          level: config.level,
-          transport: {
-            targets,
-          },
-        });
+    this.logger = pinoFn({
+      level: config.level,
+      transport: {
+        targets,
+      },
+    });
 
     this.logger.info(`Logger initialized with level ${config.level}`);
   }

--- a/packages/node/postgres/package.json
+++ b/packages/node/postgres/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@saga-ed/soa-postgres",
   "type": "module",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "scripts": {
     "dev": "tsup --watch",
     "build": "tsup",

--- a/packages/node/postgres/package.json
+++ b/packages/node/postgres/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.968.0",
     "@aws-sdk/client-ssm": "^3.968.0",
+    "@aws-sdk/rds-signer": "^3.968.0",
     "inversify": "^6.2.2",
     "pg": "^8.13.1",
     "reflect-metadata": "^0.2.2",

--- a/packages/node/postgres/package.json
+++ b/packages/node/postgres/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "@saga-ed/soa-db",
+  "name": "@saga-ed/soa-postgres",
   "type": "module",
+  "version": "0.1.0",
   "scripts": {
     "dev": "tsup --watch",
     "build": "tsup",
@@ -10,30 +11,24 @@
   "devDependencies": {
     "@saga-ed/soa-typescript-config": "workspace:*",
     "@types/node": "^24.0.3",
+    "@types/pg": "^8.11.10",
     "aws-sdk-client-mock": "^4.1.0",
     "tsup": "^8.5.0",
     "typescript": "^5.8.3",
-    "vitest": "^1.5.0",
-    "@saga-ed/soa-config": "workspace:*"
+    "vitest": "^1.5.0"
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.968.0",
     "@aws-sdk/client-ssm": "^3.968.0",
     "inversify": "^6.2.2",
-    "mongodb": "^6.12.0",
-    "mongodb-memory-server": "^10.1.4",
+    "pg": "^8.13.1",
     "reflect-metadata": "^0.2.2",
     "zod": "3.25.67"
   },
-  "version": "1.2.0",
   "exports": {
     ".": {
       "import": "./dist/index.js",
       "require": "./dist/index.js"
-    },
-    "./mocks/mock-mongo-provider": {
-      "import": "./dist/mocks/mock-mongo-provider.js",
-      "require": "./dist/mocks/mock-mongo-provider.js"
     }
   },
   "publishConfig": {
@@ -43,6 +38,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/saga-ed/soa.git",
-    "directory": "packages/node/db"
+    "directory": "packages/node/postgres"
   }
 }

--- a/packages/node/postgres/src/__tests__/aws-postgres-loader.unit.test.ts
+++ b/packages/node/postgres/src/__tests__/aws-postgres-loader.unit.test.ts
@@ -4,7 +4,10 @@ import {
   GetSecretValueCommand,
   SecretsManagerClient,
 } from '@aws-sdk/client-secrets-manager';
-import { loadPostgresConfigFromAws } from '../aws-postgres-loader.js';
+import {
+  loadPostgresConfigFromAws,
+  postgresServiceSecretName,
+} from '../aws-postgres-loader.js';
 
 const smMock = mockClient(SecretsManagerClient);
 
@@ -12,18 +15,51 @@ beforeEach(() => {
   smMock.reset();
 });
 
+describe('postgresServiceSecretName', () => {
+  it('uses workflow path shape for mirror (leading slash, -postgres-password suffix)', () => {
+    expect(postgresServiceSecretName('mirror', 'sds-api')).toBe(
+      '/mirror/current/sds-api-postgres-password',
+    );
+  });
+
+  it('inserts dbId before -postgres-password for multi-DB mirror', () => {
+    expect(postgresServiceSecretName('mirror', 'iam-api', 'pii')).toBe(
+      '/mirror/current/iam-api-pii-postgres-password',
+    );
+    expect(postgresServiceSecretName('mirror', 'iam-api', 'main')).toBe(
+      '/mirror/current/iam-api-main-postgres-password',
+    );
+  });
+
+  it('uses prod/postgres-shared/{service} for prod single-DB', () => {
+    expect(postgresServiceSecretName('prod', 'sds-api')).toBe(
+      'prod/postgres-shared/sds-api',
+    );
+  });
+
+  it('appends -{dbId} for prod multi-DB', () => {
+    expect(postgresServiceSecretName('prod', 'iam-api', 'main')).toBe(
+      'prod/postgres-shared/iam-api-main',
+    );
+    expect(postgresServiceSecretName('prod', 'iam-api', 'pii')).toBe(
+      'prod/postgres-shared/iam-api-pii',
+    );
+  });
+});
+
 describe('loadPostgresConfigFromAws', () => {
-  it('reads from the canonical {env}/postgres-shared/{service} path for mirror', async () => {
+  it('reads mirror from the workflow path with SSL=true', async () => {
     smMock
-      .on(GetSecretValueCommand, { SecretId: 'mirror/postgres-shared/sds-api' })
+      .on(GetSecretValueCommand, {
+        SecretId: '/mirror/current/sds-api-postgres-password',
+      })
       .resolves({
         SecretString: JSON.stringify({
-          username: 'sds_mirror',
-          password: 'pw-from-sm',
+          username: 'sds_api_app',
+          password: 'pw-from-mirror',
           host: 'saga-postgres-mirror.rds.amazonaws.com',
           port: 5432,
-          database: 'sds',
-          engine: 'postgres',
+          dbname: 'sds_api', // mirror workflow uses 'dbname'
         }),
       });
 
@@ -38,23 +74,24 @@ describe('loadPostgresConfigFromAws', () => {
       instanceName: 'sds-mirror',
       host: 'saga-postgres-mirror.rds.amazonaws.com',
       port: 5432,
-      database: 'sds',
-      username: 'sds_mirror',
-      password: 'pw-from-sm',
-      ssl: true, // mirror is managed RDS — SSL required
+      database: 'sds_api',
+      username: 'sds_api_app',
+      password: 'pw-from-mirror',
+      ssl: true,
     });
   });
 
-  it('reads from prod path with ssl=true', async () => {
+  it('reads prod from prod/postgres-shared/{service} with SSL=true', async () => {
     smMock
       .on(GetSecretValueCommand, { SecretId: 'prod/postgres-shared/sds-api' })
       .resolves({
         SecretString: JSON.stringify({
-          username: 'sds_prod',
+          username: 'sds_api_app',
           password: 'pw',
           host: 'saga-postgres-prod.rds.amazonaws.com',
           port: 5432,
-          database: 'sds',
+          database: 'sds_api',
+          engine: 'postgres',
         }),
       });
 
@@ -73,11 +110,11 @@ describe('loadPostgresConfigFromAws', () => {
       .on(GetSecretValueCommand, { SecretId: 'dev/postgres-shared/sds-api' })
       .resolves({
         SecretString: JSON.stringify({
-          username: 'sds_dev',
+          username: 'sds_api_app',
           password: 'dev-password-sds-api',
           host: 'db-host.dbs',
           port: 5432,
-          database: 'sds',
+          database: 'sds_api',
         }),
       });
 
@@ -90,16 +127,66 @@ describe('loadPostgresConfigFromAws', () => {
     expect(config.ssl).toBe(false);
   });
 
+  it('supports multi-DB via dbId — rostering iam-api PII isolation', async () => {
+    smMock
+      .on(GetSecretValueCommand, {
+        SecretId: 'prod/postgres-shared/iam-api-pii',
+      })
+      .resolves({
+        SecretString: JSON.stringify({
+          username: 'iam_api_pii_app',
+          password: 'pw',
+          host: 'h',
+          port: 5432,
+          database: 'iam_pii_db',
+        }),
+      });
+
+    const config = await loadPostgresConfigFromAws({
+      env: 'prod',
+      service: 'iam-api',
+      dbId: 'pii',
+      instanceName: 'iam-pii',
+    });
+
+    expect(config.database).toBe('iam_pii_db');
+    expect(config.username).toBe('iam_api_pii_app');
+  });
+
+  it('accepts dbname (mirror workflow) or database (CLI) interchangeably', async () => {
+    smMock
+      .on(GetSecretValueCommand, { SecretId: 'prod/postgres-shared/sds-api' })
+      .resolves({
+        SecretString: JSON.stringify({
+          username: 'u',
+          password: 'p',
+          host: 'h',
+          port: 5432,
+          database: 'd_from_database_field',
+        }),
+      });
+
+    const config = await loadPostgresConfigFromAws({
+      env: 'prod',
+      service: 'sds-api',
+      instanceName: 'i',
+    });
+
+    expect(config.database).toBe('d_from_database_field');
+  });
+
   it('accepts string ports for SM payloads serialized that way', async () => {
     smMock
-      .on(GetSecretValueCommand, { SecretId: 'mirror/postgres-shared/sds-api' })
+      .on(GetSecretValueCommand, {
+        SecretId: '/mirror/current/sds-api-postgres-password',
+      })
       .resolves({
         SecretString: JSON.stringify({
           username: 'u',
           password: 'p',
           host: 'h',
           port: '5432',
-          database: 'd',
+          dbname: 'd',
         }),
       });
 
@@ -112,9 +199,32 @@ describe('loadPostgresConfigFromAws', () => {
     expect(config.port).toBe(5432);
   });
 
+  it('throws when both database and dbname are missing', async () => {
+    smMock
+      .on(GetSecretValueCommand, { SecretId: 'prod/postgres-shared/sds-api' })
+      .resolves({
+        SecretString: JSON.stringify({
+          username: 'u',
+          password: 'p',
+          host: 'h',
+          port: 5432,
+        }),
+      });
+
+    await expect(
+      loadPostgresConfigFromAws({
+        env: 'prod',
+        service: 'sds-api',
+        instanceName: 'i',
+      }),
+    ).rejects.toThrow(/missing both 'database' and 'dbname'/);
+  });
+
   it('throws when the secret is missing', async () => {
     smMock
-      .on(GetSecretValueCommand, { SecretId: 'mirror/postgres-shared/sds-api' })
+      .on(GetSecretValueCommand, {
+        SecretId: '/mirror/current/sds-api-postgres-password',
+      })
       .resolves({});
 
     await expect(

--- a/packages/node/postgres/src/__tests__/aws-postgres-loader.unit.test.ts
+++ b/packages/node/postgres/src/__tests__/aws-postgres-loader.unit.test.ts
@@ -24,14 +24,14 @@ beforeEach(() => {
 });
 
 describe('path helpers', () => {
-  it('iamHostSsmPath: mirror uses /mirror/current/*, prod uses /shared/infra/prod/*', () => {
+  it('iamHostSsmPath: mirror uses /mirror/current/*, prod uses /prod/postgres-rds/*', () => {
     expect(iamHostSsmPath('mirror')).toBe('/mirror/current/postgres-rds/endpoint');
-    expect(iamHostSsmPath('prod')).toBe('/shared/infra/prod/postgres-host');
+    expect(iamHostSsmPath('prod')).toBe('/prod/postgres-rds/endpoint');
   });
 
   it('iamPortSsmPath: same split by env', () => {
     expect(iamPortSsmPath('mirror')).toBe('/mirror/current/postgres-rds/port');
-    expect(iamPortSsmPath('prod')).toBe('/shared/infra/prod/postgres-port');
+    expect(iamPortSsmPath('prod')).toBe('/prod/postgres-rds/port');
   });
 
   it('devSecretName: nests role under service (single-DB)', () => {
@@ -50,9 +50,9 @@ describe('path helpers', () => {
 describe('loadPostgresConfigFromAws — prod (IAM auth)', () => {
   it('reads coords from SSM and returns config with async password callback', async () => {
     ssmMock
-      .on(GetParameterCommand, { Name: '/shared/infra/prod/postgres-host' })
+      .on(GetParameterCommand, { Name: '/prod/postgres-rds/endpoint' })
       .resolves({ Parameter: { Value: 'saga-postgres-prod.rds.amazonaws.com' } })
-      .on(GetParameterCommand, { Name: '/shared/infra/prod/postgres-port' })
+      .on(GetParameterCommand, { Name: '/prod/postgres-rds/port' })
       .resolves({ Parameter: { Value: '5432' } });
 
     const config = await loadPostgresConfigFromAws({
@@ -75,7 +75,7 @@ describe('loadPostgresConfigFromAws — prod (IAM auth)', () => {
       .on(GetParameterCommand)
       .resolves({ Parameter: { Value: '5432' } });
     ssmMock
-      .on(GetParameterCommand, { Name: '/shared/infra/prod/postgres-host' })
+      .on(GetParameterCommand, { Name: '/prod/postgres-rds/endpoint' })
       .resolves({ Parameter: { Value: 'h' } });
 
     const config = await loadPostgresConfigFromAws({
@@ -92,7 +92,7 @@ describe('loadPostgresConfigFromAws — prod (IAM auth)', () => {
       .on(GetParameterCommand)
       .resolves({ Parameter: { Value: '5432' } });
     ssmMock
-      .on(GetParameterCommand, { Name: '/shared/infra/prod/postgres-host' })
+      .on(GetParameterCommand, { Name: '/prod/postgres-rds/endpoint' })
       .resolves({ Parameter: { Value: 'h' } });
 
     const config = await loadPostgresConfigFromAws({
@@ -110,7 +110,7 @@ describe('loadPostgresConfigFromAws — prod (IAM auth)', () => {
       .on(GetParameterCommand)
       .resolves({ Parameter: { Value: '5432' } });
     ssmMock
-      .on(GetParameterCommand, { Name: '/shared/infra/prod/postgres-host' })
+      .on(GetParameterCommand, { Name: '/prod/postgres-rds/endpoint' })
       .resolves({ Parameter: { Value: 'h' } });
 
     const config = await loadPostgresConfigFromAws({
@@ -128,7 +128,7 @@ describe('loadPostgresConfigFromAws — prod (IAM auth)', () => {
       .on(GetParameterCommand)
       .resolves({ Parameter: { Value: '5432' } });
     ssmMock
-      .on(GetParameterCommand, { Name: '/shared/infra/prod/postgres-host' })
+      .on(GetParameterCommand, { Name: '/prod/postgres-rds/endpoint' })
       .resolves({ Parameter: { Value: 'h' } });
 
     const config = await loadPostgresConfigFromAws({
@@ -148,7 +148,7 @@ describe('loadPostgresConfigFromAws — prod (IAM auth)', () => {
       .on(GetParameterCommand)
       .resolves({ Parameter: { Value: '5432' } });
     ssmMock
-      .on(GetParameterCommand, { Name: '/shared/infra/prod/postgres-host' })
+      .on(GetParameterCommand, { Name: '/prod/postgres-rds/endpoint' })
       .resolves({ Parameter: { Value: 'h' } });
 
     const config = await loadPostgresConfigFromAws({

--- a/packages/node/postgres/src/__tests__/aws-postgres-loader.unit.test.ts
+++ b/packages/node/postgres/src/__tests__/aws-postgres-loader.unit.test.ts
@@ -5,232 +5,254 @@ import {
   SecretsManagerClient,
 } from '@aws-sdk/client-secrets-manager';
 import {
+  GetParameterCommand,
+  SSMClient,
+} from '@aws-sdk/client-ssm';
+import {
   loadPostgresConfigFromAws,
-  postgresServiceSecretName,
+  iamHostSsmPath,
+  iamPortSsmPath,
+  devSecretName,
 } from '../aws-postgres-loader.js';
 
 const smMock = mockClient(SecretsManagerClient);
+const ssmMock = mockClient(SSMClient);
 
 beforeEach(() => {
   smMock.reset();
+  ssmMock.reset();
 });
 
-describe('postgresServiceSecretName', () => {
-  it('uses workflow path shape for mirror (leading slash, -postgres-password suffix)', () => {
-    expect(postgresServiceSecretName('mirror', 'sds-api')).toBe(
-      '/mirror/current/sds-api-postgres-password',
-    );
+describe('path helpers', () => {
+  it('iamHostSsmPath: mirror uses /mirror/current/*, prod uses /shared/infra/prod/*', () => {
+    expect(iamHostSsmPath('mirror')).toBe('/mirror/current/postgres-rds/endpoint');
+    expect(iamHostSsmPath('prod')).toBe('/shared/infra/prod/postgres-host');
   });
 
-  it('inserts dbId before -postgres-password for multi-DB mirror', () => {
-    expect(postgresServiceSecretName('mirror', 'iam-api', 'pii')).toBe(
-      '/mirror/current/iam-api-pii-postgres-password',
-    );
-    expect(postgresServiceSecretName('mirror', 'iam-api', 'main')).toBe(
-      '/mirror/current/iam-api-main-postgres-password',
-    );
+  it('iamPortSsmPath: same split by env', () => {
+    expect(iamPortSsmPath('mirror')).toBe('/mirror/current/postgres-rds/port');
+    expect(iamPortSsmPath('prod')).toBe('/shared/infra/prod/postgres-port');
   });
 
-  it('uses prod/postgres-shared/{service} for prod single-DB', () => {
-    expect(postgresServiceSecretName('prod', 'sds-api')).toBe(
-      'prod/postgres-shared/sds-api',
-    );
+  it('devSecretName: nests role under service (single-DB)', () => {
+    expect(devSecretName('chat-api', 'app')).toBe('dev/postgres-shared/chat-api/app');
+    expect(devSecretName('chat-api', 'owner')).toBe('dev/postgres-shared/chat-api/owner');
+    expect(devSecretName('chat-api', 'ro')).toBe('dev/postgres-shared/chat-api/ro');
   });
 
-  it('appends -{dbId} for prod multi-DB', () => {
-    expect(postgresServiceSecretName('prod', 'iam-api', 'main')).toBe(
-      'prod/postgres-shared/iam-api-main',
-    );
-    expect(postgresServiceSecretName('prod', 'iam-api', 'pii')).toBe(
-      'prod/postgres-shared/iam-api-pii',
+  it('devSecretName: nests dbId between service and role (multi-DB)', () => {
+    expect(devSecretName('iam-api', 'owner', 'pii')).toBe(
+      'dev/postgres-shared/iam-api/pii/owner',
     );
   });
 });
 
-describe('loadPostgresConfigFromAws', () => {
-  it('reads mirror from the workflow path with SSL=true', async () => {
-    smMock
-      .on(GetSecretValueCommand, {
-        SecretId: '/mirror/current/sds-api-postgres-password',
-      })
-      .resolves({
-        SecretString: JSON.stringify({
-          username: 'sds_api_app',
-          password: 'pw-from-mirror',
-          host: 'saga-postgres-mirror.rds.amazonaws.com',
-          port: 5432,
-          dbname: 'sds_api', // mirror workflow uses 'dbname'
-        }),
-      });
+describe('loadPostgresConfigFromAws — prod (IAM auth)', () => {
+  it('reads coords from SSM and returns config with async password callback', async () => {
+    ssmMock
+      .on(GetParameterCommand, { Name: '/shared/infra/prod/postgres-host' })
+      .resolves({ Parameter: { Value: 'saga-postgres-prod.rds.amazonaws.com' } })
+      .on(GetParameterCommand, { Name: '/shared/infra/prod/postgres-port' })
+      .resolves({ Parameter: { Value: '5432' } });
 
     const config = await loadPostgresConfigFromAws({
-      env: 'mirror',
-      service: 'sds-api',
-      instanceName: 'sds-mirror',
+      env: 'prod',
+      service: 'chat-api',
+      role: 'app',
+      instanceName: 'ChatDB-prod',
     });
 
-    expect(config).toMatchObject({
-      configType: 'POSTGRES',
-      instanceName: 'sds-mirror',
-      host: 'saga-postgres-mirror.rds.amazonaws.com',
-      port: 5432,
-      database: 'sds_api',
-      username: 'sds_api_app',
-      password: 'pw-from-mirror',
-      ssl: true,
-    });
+    expect(config.host).toBe('saga-postgres-prod.rds.amazonaws.com');
+    expect(config.port).toBe(5432);
+    expect(config.database).toBe('chat_api');
+    expect(config.user).toBe('chat_api_app');
+    expect(config.ssl).toBe(true);
+    expect(typeof config.password).toBe('function');
   });
 
-  it('reads prod from prod/postgres-shared/{service} with SSL=true', async () => {
-    smMock
-      .on(GetSecretValueCommand, { SecretId: 'prod/postgres-shared/sds-api' })
-      .resolves({
-        SecretString: JSON.stringify({
-          username: 'sds_api_app',
-          password: 'pw',
-          host: 'saga-postgres-prod.rds.amazonaws.com',
-          port: 5432,
-          database: 'sds_api',
-          engine: 'postgres',
-        }),
-      });
+  it("defaults role to 'app' when omitted", async () => {
+    ssmMock
+      .on(GetParameterCommand)
+      .resolves({ Parameter: { Value: '5432' } });
+    ssmMock
+      .on(GetParameterCommand, { Name: '/shared/infra/prod/postgres-host' })
+      .resolves({ Parameter: { Value: 'h' } });
+
+    const config = await loadPostgresConfigFromAws({
+      env: 'prod',
+      service: 'chat-api',
+      instanceName: 'i',
+    });
+
+    expect(config.user).toBe('chat_api_app');
+  });
+
+  it('uses owner role for AppInfra / migration workloads', async () => {
+    ssmMock
+      .on(GetParameterCommand)
+      .resolves({ Parameter: { Value: '5432' } });
+    ssmMock
+      .on(GetParameterCommand, { Name: '/shared/infra/prod/postgres-host' })
+      .resolves({ Parameter: { Value: 'h' } });
+
+    const config = await loadPostgresConfigFromAws({
+      env: 'prod',
+      service: 'chat-api',
+      role: 'owner',
+      instanceName: 'i',
+    });
+
+    expect(config.user).toBe('chat_api_owner');
+  });
+
+  it('uses ro role for read-only workloads', async () => {
+    ssmMock
+      .on(GetParameterCommand)
+      .resolves({ Parameter: { Value: '5432' } });
+    ssmMock
+      .on(GetParameterCommand, { Name: '/shared/infra/prod/postgres-host' })
+      .resolves({ Parameter: { Value: 'h' } });
+
+    const config = await loadPostgresConfigFromAws({
+      env: 'prod',
+      service: 'chat-api',
+      role: 'ro',
+      instanceName: 'i',
+    });
+
+    expect(config.user).toBe('chat_api_ro');
+  });
+
+  it('multi-DB: dbId nests into the derived database name', async () => {
+    ssmMock
+      .on(GetParameterCommand)
+      .resolves({ Parameter: { Value: '5432' } });
+    ssmMock
+      .on(GetParameterCommand, { Name: '/shared/infra/prod/postgres-host' })
+      .resolves({ Parameter: { Value: 'h' } });
+
+    const config = await loadPostgresConfigFromAws({
+      env: 'prod',
+      service: 'iam-api',
+      role: 'app',
+      dbId: 'pii',
+      instanceName: 'iam-pii',
+    });
+
+    expect(config.database).toBe('iam_api_pii_db');
+    expect(config.user).toBe('iam_api_app');
+  });
+
+  it('username and database can be explicitly overridden', async () => {
+    ssmMock
+      .on(GetParameterCommand)
+      .resolves({ Parameter: { Value: '5432' } });
+    ssmMock
+      .on(GetParameterCommand, { Name: '/shared/infra/prod/postgres-host' })
+      .resolves({ Parameter: { Value: 'h' } });
 
     const config = await loadPostgresConfigFromAws({
       env: 'prod',
       service: 'sds-api',
-      instanceName: 'sds-prod',
+      role: 'app',
+      username: 'ledger_writer',         // legacy override
+      database: 'ledger',
+      instanceName: 'i',
     });
 
-    expect(config.ssl).toBe(true);
-    expect(config.host).toBe('saga-postgres-prod.rds.amazonaws.com');
+    expect(config.user).toBe('ledger_writer');
+    expect(config.database).toBe('ledger');
   });
+});
 
-  it('disables SSL for dev (db-host has no TLS)', async () => {
+describe('loadPostgresConfigFromAws — mirror (IAM auth, dev account)', () => {
+  it('reads coords from /mirror/current/* SSM paths', async () => {
+    ssmMock
+      .on(GetParameterCommand, { Name: '/mirror/current/postgres-rds/endpoint' })
+      .resolves({ Parameter: { Value: 'mirror-pg.dev.internal' } })
+      .on(GetParameterCommand, { Name: '/mirror/current/postgres-rds/port' })
+      .resolves({ Parameter: { Value: '5432' } });
+
+    const config = await loadPostgresConfigFromAws({
+      env: 'mirror',
+      service: 'chat-api',
+      role: 'app',
+      instanceName: 'ChatDB-mirror',
+    });
+
+    expect(config.host).toBe('mirror-pg.dev.internal');
+    expect(config.port).toBe(5432);
+    expect(config.user).toBe('chat_api_app');
+    expect(config.ssl).toBe(true);
+    expect(typeof config.password).toBe('function');
+  });
+});
+
+describe('loadPostgresConfigFromAws — dev (static password from parity secret)', () => {
+  it('reads the per-role parity secret and returns config with static password', async () => {
     smMock
-      .on(GetSecretValueCommand, { SecretId: 'dev/postgres-shared/sds-api' })
+      .on(GetSecretValueCommand, {
+        SecretId: 'dev/postgres-shared/chat-api/app',
+      })
       .resolves({
         SecretString: JSON.stringify({
-          username: 'sds_api_app',
-          password: 'dev-password-sds-api',
+          username: 'chat_api_app',
+          password: 'dev-password-chat-api',
           host: 'db-host.dbs',
           port: 5432,
-          database: 'sds_api',
+          database: 'chat_api',
+        }),
+      });
+
+    const config = await loadPostgresConfigFromAws({
+      env: 'dev',
+      service: 'chat-api',
+      role: 'app',
+      instanceName: 'ChatDB-dev',
+    });
+
+    expect(config.host).toBe('db-host.dbs');
+    expect(config.user).toBe('chat_api_app');
+    expect(config.password).toBe('dev-password-chat-api');
+    expect(config.ssl).toBe(false);
+  });
+
+  it('accepts dbname as an alternate field (mirror-workflow legacy compat)', async () => {
+    smMock
+      .on(GetSecretValueCommand, {
+        SecretId: 'dev/postgres-shared/sds-api/ro',
+      })
+      .resolves({
+        SecretString: JSON.stringify({
+          password: 'dev-password-sds-api',
+          host: 'db-host.dbs',
+          port: '5432',
+          dbname: 'sds_api',
         }),
       });
 
     const config = await loadPostgresConfigFromAws({
       env: 'dev',
       service: 'sds-api',
-      instanceName: 'sds-dev',
-    });
-
-    expect(config.ssl).toBe(false);
-  });
-
-  it('supports multi-DB via dbId — rostering iam-api PII isolation', async () => {
-    smMock
-      .on(GetSecretValueCommand, {
-        SecretId: 'prod/postgres-shared/iam-api-pii',
-      })
-      .resolves({
-        SecretString: JSON.stringify({
-          username: 'iam_api_pii_app',
-          password: 'pw',
-          host: 'h',
-          port: 5432,
-          database: 'iam_pii_db',
-        }),
-      });
-
-    const config = await loadPostgresConfigFromAws({
-      env: 'prod',
-      service: 'iam-api',
-      dbId: 'pii',
-      instanceName: 'iam-pii',
-    });
-
-    expect(config.database).toBe('iam_pii_db');
-    expect(config.username).toBe('iam_api_pii_app');
-  });
-
-  it('accepts dbname (mirror workflow) or database (CLI) interchangeably', async () => {
-    smMock
-      .on(GetSecretValueCommand, { SecretId: 'prod/postgres-shared/sds-api' })
-      .resolves({
-        SecretString: JSON.stringify({
-          username: 'u',
-          password: 'p',
-          host: 'h',
-          port: 5432,
-          database: 'd_from_database_field',
-        }),
-      });
-
-    const config = await loadPostgresConfigFromAws({
-      env: 'prod',
-      service: 'sds-api',
+      role: 'ro',
       instanceName: 'i',
     });
 
-    expect(config.database).toBe('d_from_database_field');
-  });
-
-  it('accepts string ports for SM payloads serialized that way', async () => {
-    smMock
-      .on(GetSecretValueCommand, {
-        SecretId: '/mirror/current/sds-api-postgres-password',
-      })
-      .resolves({
-        SecretString: JSON.stringify({
-          username: 'u',
-          password: 'p',
-          host: 'h',
-          port: '5432',
-          dbname: 'd',
-        }),
-      });
-
-    const config = await loadPostgresConfigFromAws({
-      env: 'mirror',
-      service: 'sds-api',
-      instanceName: 'i',
-    });
-
+    expect(config.database).toBe('sds_api');
     expect(config.port).toBe(5432);
+    expect(config.user).toBe('sds_api_ro');   // derived; secret had no username field
   });
 
-  it('throws when both database and dbname are missing', async () => {
+  it('throws when the dev parity secret is missing', async () => {
     smMock
-      .on(GetSecretValueCommand, { SecretId: 'prod/postgres-shared/sds-api' })
-      .resolves({
-        SecretString: JSON.stringify({
-          username: 'u',
-          password: 'p',
-          host: 'h',
-          port: 5432,
-        }),
-      });
-
-    await expect(
-      loadPostgresConfigFromAws({
-        env: 'prod',
-        service: 'sds-api',
-        instanceName: 'i',
-      }),
-    ).rejects.toThrow(/missing both 'database' and 'dbname'/);
-  });
-
-  it('throws when the secret is missing', async () => {
-    smMock
-      .on(GetSecretValueCommand, {
-        SecretId: '/mirror/current/sds-api-postgres-password',
-      })
+      .on(GetSecretValueCommand)
       .resolves({});
 
     await expect(
       loadPostgresConfigFromAws({
-        env: 'mirror',
-        service: 'sds-api',
+        env: 'dev',
+        service: 'chat-api',
+        role: 'app',
         instanceName: 'i',
       }),
     ).rejects.toThrow(/no SecretString/);

--- a/packages/node/postgres/src/__tests__/aws-postgres-loader.unit.test.ts
+++ b/packages/node/postgres/src/__tests__/aws-postgres-loader.unit.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mockClient } from 'aws-sdk-client-mock';
+import {
+  GetSecretValueCommand,
+  SecretsManagerClient,
+} from '@aws-sdk/client-secrets-manager';
+import { loadPostgresConfigFromAws } from '../aws-postgres-loader.js';
+
+const smMock = mockClient(SecretsManagerClient);
+
+beforeEach(() => {
+  smMock.reset();
+});
+
+describe('loadPostgresConfigFromAws', () => {
+  it('reads from the canonical {env}/postgres-shared/{service} path for mirror', async () => {
+    smMock
+      .on(GetSecretValueCommand, { SecretId: 'mirror/postgres-shared/sds-api' })
+      .resolves({
+        SecretString: JSON.stringify({
+          username: 'sds_mirror',
+          password: 'pw-from-sm',
+          host: 'saga-postgres-mirror.rds.amazonaws.com',
+          port: 5432,
+          database: 'sds',
+          engine: 'postgres',
+        }),
+      });
+
+    const config = await loadPostgresConfigFromAws({
+      env: 'mirror',
+      service: 'sds-api',
+      instanceName: 'sds-mirror',
+    });
+
+    expect(config).toMatchObject({
+      configType: 'POSTGRES',
+      instanceName: 'sds-mirror',
+      host: 'saga-postgres-mirror.rds.amazonaws.com',
+      port: 5432,
+      database: 'sds',
+      username: 'sds_mirror',
+      password: 'pw-from-sm',
+      ssl: true, // mirror is managed RDS — SSL required
+    });
+  });
+
+  it('reads from prod path with ssl=true', async () => {
+    smMock
+      .on(GetSecretValueCommand, { SecretId: 'prod/postgres-shared/sds-api' })
+      .resolves({
+        SecretString: JSON.stringify({
+          username: 'sds_prod',
+          password: 'pw',
+          host: 'saga-postgres-prod.rds.amazonaws.com',
+          port: 5432,
+          database: 'sds',
+        }),
+      });
+
+    const config = await loadPostgresConfigFromAws({
+      env: 'prod',
+      service: 'sds-api',
+      instanceName: 'sds-prod',
+    });
+
+    expect(config.ssl).toBe(true);
+    expect(config.host).toBe('saga-postgres-prod.rds.amazonaws.com');
+  });
+
+  it('disables SSL for dev (db-host has no TLS)', async () => {
+    smMock
+      .on(GetSecretValueCommand, { SecretId: 'dev/postgres-shared/sds-api' })
+      .resolves({
+        SecretString: JSON.stringify({
+          username: 'sds_dev',
+          password: 'dev-password-sds-api',
+          host: 'db-host.dbs',
+          port: 5432,
+          database: 'sds',
+        }),
+      });
+
+    const config = await loadPostgresConfigFromAws({
+      env: 'dev',
+      service: 'sds-api',
+      instanceName: 'sds-dev',
+    });
+
+    expect(config.ssl).toBe(false);
+  });
+
+  it('accepts string ports for SM payloads serialized that way', async () => {
+    smMock
+      .on(GetSecretValueCommand, { SecretId: 'mirror/postgres-shared/sds-api' })
+      .resolves({
+        SecretString: JSON.stringify({
+          username: 'u',
+          password: 'p',
+          host: 'h',
+          port: '5432',
+          database: 'd',
+        }),
+      });
+
+    const config = await loadPostgresConfigFromAws({
+      env: 'mirror',
+      service: 'sds-api',
+      instanceName: 'i',
+    });
+
+    expect(config.port).toBe(5432);
+  });
+
+  it('throws when the secret is missing', async () => {
+    smMock
+      .on(GetSecretValueCommand, { SecretId: 'mirror/postgres-shared/sds-api' })
+      .resolves({});
+
+    await expect(
+      loadPostgresConfigFromAws({
+        env: 'mirror',
+        service: 'sds-api',
+        instanceName: 'i',
+      }),
+    ).rejects.toThrow(/no SecretString/);
+  });
+});

--- a/packages/node/postgres/src/__tests__/postgres-provider-config.unit.test.ts
+++ b/packages/node/postgres/src/__tests__/postgres-provider-config.unit.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { PostgresProviderSchema } from '../postgres-provider-config.js';
+
+describe('PostgresProviderSchema', () => {
+  it('accepts the minimal payload from saga-provision-credentials', () => {
+    const config = PostgresProviderSchema.parse({
+      instanceName: 'sds-mirror',
+      host: 'rds.example.com',
+      port: 5432,
+      database: 'sds',
+      username: 'sds_mirror',
+      password: 'pw',
+    });
+    expect(config).toMatchObject({
+      configType: 'POSTGRES',
+      instanceName: 'sds-mirror',
+      host: 'rds.example.com',
+      port: 5432,
+      database: 'sds',
+      username: 'sds_mirror',
+      password: 'pw',
+      ssl: false,
+      poolSize: 10,
+      idleTimeoutMs: 30_000,
+      connectionTimeoutMs: 10_000,
+      statementTimeoutMs: 0,
+      lockTimeoutMs: 0,
+    });
+  });
+
+  it('preserves pool tuning when provided', () => {
+    const config = PostgresProviderSchema.parse({
+      instanceName: 'sds-mirror',
+      host: 'h',
+      port: 5432,
+      database: 'd',
+      username: 'u',
+      password: 'p',
+      poolSize: 25,
+      statementTimeoutMs: 5_000,
+    });
+    expect(config.poolSize).toBe(25);
+    expect(config.statementTimeoutMs).toBe(5_000);
+  });
+
+  it('rejects missing required fields', () => {
+    expect(() =>
+      PostgresProviderSchema.parse({
+        instanceName: 'x',
+        host: '',
+        port: 5432,
+        database: 'd',
+        username: 'u',
+        password: 'p',
+      }),
+    ).toThrow();
+  });
+
+  it('rejects non-positive port', () => {
+    expect(() =>
+      PostgresProviderSchema.parse({
+        instanceName: 'x',
+        host: 'h',
+        port: 0,
+        database: 'd',
+        username: 'u',
+        password: 'p',
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/node/postgres/src/__tests__/postgres-provider.unit.test.ts
+++ b/packages/node/postgres/src/__tests__/postgres-provider.unit.test.ts
@@ -156,3 +156,54 @@ describe('PostgresProvider resilience', () => {
     vi.useRealTimers();
   });
 });
+
+describe('PostgresProvider config sources', () => {
+  it('accepts a PostgresPoolConfig with an async password callback (IAM/RDS path)', async () => {
+    const tokenFn = vi.fn(async () => 'iam-token');
+    const provider = new PostgresProvider({
+      instanceName: 'IamDB',
+      host: 'rds.example',
+      port: 5432,
+      database: 'chat',
+      user: 'chat_app',
+      password: tokenFn,
+      ssl: true,
+    });
+    await provider.connect();
+
+    expect(provider.instanceName).toBe('IamDB');
+    // Discrete options (no connectionString) so pg honors the callback —
+    // it is passed through untouched and invoked per new connection by pg.
+    expect(state.options?.password).toBe(tokenFn);
+    expect(state.options?.user).toBe('chat_app');
+    expect(state.options?.host).toBe('rds.example');
+    expect(state.options?.ssl).toBe(true);
+    expect(state.options?.keepAlive).toBe(true);
+    expect(state.options).not.toHaveProperty('connectionString');
+  });
+
+  it('applies pool-tuning defaults when a PostgresPoolConfig omits them', async () => {
+    await new PostgresProvider({
+      instanceName: 'D',
+      host: 'h',
+      port: 5432,
+      database: 'd',
+      user: 'u',
+      password: 'p',
+      ssl: false,
+    }).connect();
+
+    expect(state.options?.max).toBe(10);
+    expect(state.options?.idleTimeoutMillis).toBe(30_000);
+    expect(state.options?.connectionTimeoutMillis).toBe(10_000);
+  });
+
+  it('maps the static schema config (username + string password) onto pool options', async () => {
+    await new PostgresProvider(baseConfig({ ssl: true, poolSize: 7 })).connect();
+
+    expect(state.options?.user).toBe('tester'); // schema `username` -> pg `user`
+    expect(state.options?.password).toBe('secret');
+    expect(state.options?.ssl).toBe(true);
+    expect(state.options?.max).toBe(7);
+  });
+});

--- a/packages/node/postgres/src/__tests__/postgres-provider.unit.test.ts
+++ b/packages/node/postgres/src/__tests__/postgres-provider.unit.test.ts
@@ -1,0 +1,158 @@
+import 'reflect-metadata';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock `pg` so we can drive Pool lifecycle/event callbacks without a real DB.
+// A single shared poolInstance is returned for every `new Pool(...)`; the
+// constructor options and registered event handlers are captured in `state`.
+// ---------------------------------------------------------------------------
+const { PoolMock, poolInstance, state } = vi.hoisted(() => {
+  const state: {
+    options?: Record<string, unknown>;
+    handlers: Record<string, (...args: unknown[]) => void>;
+  } = { handlers: {} };
+
+  const poolInstance = {
+    on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+      state.handlers[event] = cb;
+      return poolInstance;
+    }),
+    connect: vi.fn(),
+    end: vi.fn(),
+  };
+
+  const PoolMock = vi.fn((options: Record<string, unknown>) => {
+    state.options = options;
+    return poolInstance;
+  });
+
+  return { PoolMock, poolInstance, state };
+});
+
+vi.mock('pg', () => ({ Pool: PoolMock }));
+
+// vi.mock + vi.hoisted are hoisted above these imports, so PostgresProvider
+// picks up the mocked `pg`.
+import { PostgresProvider } from '../postgres-provider.js';
+import {
+  PostgresProviderSchema,
+  type PostgresProviderConfig,
+} from '../postgres-provider-config.js';
+
+const baseConfig = (
+  overrides: Record<string, unknown> = {},
+): PostgresProviderConfig =>
+  PostgresProviderSchema.parse({
+    instanceName: 'TestDB',
+    host: 'localhost',
+    database: 'testdb',
+    username: 'tester',
+    password: 'secret',
+    ...overrides,
+  });
+
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.handlers = {};
+  state.options = undefined;
+  poolInstance.connect.mockResolvedValue({ release: vi.fn() });
+  poolInstance.end.mockResolvedValue(undefined);
+  errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  errorSpy.mockRestore();
+});
+
+describe('PostgresProvider resilience', () => {
+  it('registers an idle-client error handler so an RDS drop cannot crash the process', async () => {
+    const provider = new PostgresProvider(baseConfig());
+    await provider.connect();
+
+    expect(provider.isConnected()).toBe(true);
+    expect(state.handlers.error).toBeTypeOf('function');
+
+    // Simulate an idle client error (e.g. RDS failover). Emitting an
+    // 'error' event with no listener would throw; ours must not.
+    expect(() =>
+      state.handlers.error(new Error('Connection terminated unexpectedly')),
+    ).not.toThrow();
+
+    // Provider reports unhealthy, but the pool is retained so it can
+    // self-heal on the next acquire.
+    expect(provider.isConnected()).toBe(false);
+    expect(() => provider.getPool()).not.toThrow();
+    expect(errorSpy).toHaveBeenCalledOnce();
+  });
+
+  it('enables TCP keepAlive on the pool', async () => {
+    await new PostgresProvider(baseConfig()).connect();
+    expect(state.options?.keepAlive).toBe(true);
+  });
+
+  it('does not let a failing session-timeout SET become an unhandled rejection', async () => {
+    const provider = new PostgresProvider(
+      baseConfig({ statementTimeoutMs: 5000, lockTimeoutMs: 2000 }),
+    );
+    await provider.connect();
+
+    expect(state.handlers.connect).toBeTypeOf('function');
+
+    const failingClient = {
+      query: vi.fn().mockRejectedValue(new Error('backend gone')),
+    };
+    // Invoking the per-connection setup must not throw, and the rejected
+    // SET must be swallowed (the .catch handles it).
+    expect(() => state.handlers.connect(failingClient)).not.toThrow();
+    expect(failingClient.query).toHaveBeenCalledWith('SET statement_timeout = 5000');
+    expect(failingClient.query).toHaveBeenCalledWith('SET lock_timeout = 2000');
+
+    // Let the swallowed rejections settle; an unhandled one would surface
+    // as a test failure.
+    await new Promise((r) => setTimeout(r, 0));
+  });
+
+  it('does not register a connect handler when no session timeouts are set', async () => {
+    await new PostgresProvider(baseConfig()).connect();
+    expect(state.handlers.connect).toBeUndefined();
+  });
+
+  it('connect() is idempotent — a second call does not create a second pool', async () => {
+    const provider = new PostgresProvider(baseConfig());
+    await provider.connect();
+    await provider.connect();
+    expect(PoolMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('an idle error does not let a follow-up connect() leak a second pool', async () => {
+    const provider = new PostgresProvider(baseConfig());
+    await provider.connect();
+
+    state.handlers.error(new Error('drop'));
+    expect(provider.isConnected()).toBe(false);
+
+    // Even though the health flag is false, the live pool guards against
+    // building (and leaking) a replacement.
+    await provider.connect();
+    expect(PoolMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries connect with backoff and ends the failed attempt’s pool', async () => {
+    vi.useFakeTimers();
+    poolInstance.connect
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce({ release: vi.fn() });
+
+    const provider = new PostgresProvider(baseConfig());
+    const connecting = provider.connect();
+    await vi.runAllTimersAsync();
+    await connecting;
+
+    expect(provider.isConnected()).toBe(true);
+    expect(PoolMock).toHaveBeenCalledTimes(2); // a fresh pool per attempt
+    expect(poolInstance.end).toHaveBeenCalledTimes(1); // failed pool torn down
+    vi.useRealTimers();
+  });
+});

--- a/packages/node/postgres/src/aws-postgres-loader.ts
+++ b/packages/node/postgres/src/aws-postgres-loader.ts
@@ -7,34 +7,44 @@ import type { PostgresProviderConfig } from './postgres-provider-config.js';
 
 /**
  * Build a fully-resolved {@link PostgresProviderConfig} by reading the
- * Secrets Manager payload written by ``saga-provision-credentials``.
+ * Secrets Manager payload written by ``saga-provision-credentials`` (prod)
+ * or by the daily mirror refresh workflow (mirror).
  *
- * The CLI writes one secret per service per env at
- * ``{env}/postgres-shared/{service}`` with shape
- * ``{username, password, host, port, database, engine}``. That's the
- * full set of fields we need — no SSM read is required for postgres
- * (host is in the secret, port is in the secret, no TLS CA needed
- * because RDS uses public trust anchors).
+ * Secret paths are env-specific:
  *
- * Env mapping:
+ * - `'dev'`   — db-host container in dev account. CLI's ``--insecure-dev``
+ *               writes a parity secret with trivial password and ``host: db-host.dbs``.
+ *               Path: ``dev/postgres-shared/{service}[-{dbId}]``.
+ * - `'mirror'` — prod-shape RDS in dev account, refreshed daily from a prod
+ *                snapshot. Path matches the existing refresh workflow:
+ *                ``/mirror/current/{service}-postgres-password`` (leading slash;
+ *                ``-postgres-password`` suffix). For multi-DB services the
+ *                ``dbId`` goes BEFORE the suffix:
+ *                ``/mirror/current/{service}-{dbId}-postgres-password``.
+ * - `'prod'`   — prod RDS in account 531. SSL required.
+ *                Path: ``prod/postgres-shared/{service}[-{dbId}]``.
  *
- * - `'dev'`   — db-host container in dev account. The CLI's
- *               ``--insecure-dev`` mode writes a parity secret with
- *               trivial password and ``host: db-host.dbs``.
- * - `'mirror'` — prod-shape RDS in dev account (account 396).
- *                ``ssl: true`` always (managed RDS).
- * - `'prod'`   — prod RDS in account 531. ``ssl: true`` always.
+ * Payload shape (both workflow and CLI write the same fields, with one
+ * legacy quirk — the mirror workflow uses ``dbname`` while the CLI uses
+ * ``database``. Loader accepts either.)
  *
- * For dev (where the local container is unauthenticated), callers
- * can construct {@link PostgresProviderConfig} directly from env vars
- * if the parity secret hasn't been provisioned.
+ *   { username, password, host, port, database (or dbname), engine? }
+ *
+ * Multi-DB postgres services (e.g., rostering's iam-api with iam_db +
+ * iam_pii_db) pass ``dbId`` to address each DB's credential separately.
  */
 export interface LoadPostgresConfigParams {
   env: 'dev' | 'mirror' | 'prod';
-  /** Service name as it appears in `db-access.yaml` (e.g. 'sds-api'). */
+  /** Service name as it appears in `db-access.yaml` (e.g. 'iam-api'). */
   service: string;
   /** Name to give the PostgresProvider instance. */
   instanceName: string;
+  /**
+   * For multi-DB services, the database id from db-access.yaml (e.g. 'main',
+   * 'pii'). Omit for single-DB services — the secret path uses the bare
+   * service name with no suffix.
+   */
+  dbId?: string;
   /** Override AWS region. Defaults to us-west-2. */
   region?: string;
 }
@@ -47,13 +57,14 @@ export async function loadPostgresConfigFromAws(
   const region = params.region ?? DEFAULT_REGION;
   const sm = new SecretsManagerClient({ region });
 
-  const secretId = `${params.env}/postgres-shared/${params.service}`;
+  const secretId = postgresServiceSecretName(params.env, params.service, params.dbId);
   const raw = await readSecretJson<{
     username: string;
     password: string;
     host: string;
     port: number | string;
-    database: string;
+    database?: string;
+    dbname?: string;
     engine?: string;
   }>(sm, secretId);
 
@@ -61,15 +72,50 @@ export async function loadPostgresConfigFromAws(
   // dev is the db-host container with no TLS.
   const ssl = params.env !== 'dev';
 
+  // Accept either `database` (CLI / prod) or `dbname` (mirror refresh workflow).
+  const database = raw.database ?? raw.dbname;
+  if (!database) {
+    throw new Error(
+      `Secret ${secretId} is missing both 'database' and 'dbname' fields`,
+    );
+  }
+
   return PostgresProviderSchema.parse({
     instanceName: params.instanceName,
     host: raw.host,
     port: typeof raw.port === 'string' ? parseInt(raw.port, 10) : raw.port,
-    database: raw.database,
+    database,
     username: raw.username,
     password: raw.password,
     ssl,
   });
+}
+
+/**
+ * Compute the canonical SM secret name for a postgres service / env / dbId.
+ *
+ * Mirror paths align with the existing refresh workflow shape so the CLI
+ * and the workflow write to the same location:
+ *
+ *   single-DB:  /mirror/current/{service}-postgres-password
+ *   multi-DB:   /mirror/current/{service}-{dbId}-postgres-password
+ *
+ * Prod/dev use our CLI's path shape:
+ *
+ *   single-DB:  {env}/postgres-shared/{service}
+ *   multi-DB:   {env}/postgres-shared/{service}-{dbId}
+ */
+export function postgresServiceSecretName(
+  env: 'dev' | 'mirror' | 'prod',
+  service: string,
+  dbId?: string,
+): string {
+  if (env === 'mirror') {
+    const idPart = dbId ? `-${dbId}` : '';
+    return `/mirror/current/${service}${idPart}-postgres-password`;
+  }
+  const idPart = dbId ? `-${dbId}` : '';
+  return `${env}/postgres-shared/${service}${idPart}`;
 }
 
 async function readSecretJson<T>(

--- a/packages/node/postgres/src/aws-postgres-loader.ts
+++ b/packages/node/postgres/src/aws-postgres-loader.ts
@@ -104,6 +104,16 @@ export interface PostgresPoolConfig {
   user: string;
   password: string | (() => Promise<string>);
   ssl: boolean;
+
+  // Optional pool tuning. `PostgresProvider` applies conservative defaults
+  // (matching `PostgresProviderSchema`) when these are omitted, so the
+  // loader output can be handed straight to the provider — including the
+  // IAM mirror/prod shape whose `password` is the async token callback.
+  poolSize?: number;
+  idleTimeoutMs?: number;
+  connectionTimeoutMs?: number;
+  statementTimeoutMs?: number;
+  lockTimeoutMs?: number;
 }
 
 const DEFAULT_REGION = 'us-west-2';

--- a/packages/node/postgres/src/aws-postgres-loader.ts
+++ b/packages/node/postgres/src/aws-postgres-loader.ts
@@ -2,120 +2,268 @@ import {
   GetSecretValueCommand,
   SecretsManagerClient,
 } from '@aws-sdk/client-secrets-manager';
-import { PostgresProviderSchema } from './postgres-provider-config.js';
-import type { PostgresProviderConfig } from './postgres-provider-config.js';
+import {
+  GetParameterCommand,
+  SSMClient,
+} from '@aws-sdk/client-ssm';
+import { Signer } from '@aws-sdk/rds-signer';
 
 /**
- * Build a fully-resolved {@link PostgresProviderConfig} by reading the
- * Secrets Manager payload written by ``saga-provision-credentials`` (prod)
- * or by the daily mirror refresh workflow (mirror).
+ * Build a ready-to-use ``pg.Pool``-compatible config for a Saga service's
+ * Postgres connection. Handles all three envs via the same call:
  *
- * Secret paths are env-specific:
+ *   loadPostgresConfigFromAws({ env: 'prod', service: 'chat-api', role: 'app',
+ *                               instanceName: 'ChatDB' })
  *
- * - `'dev'`   — db-host container in dev account. CLI's ``--insecure-dev``
- *               writes a parity secret with trivial password and ``host: db-host.dbs``.
- *               Path: ``dev/postgres-shared/{service}[-{dbId}]``.
- * - `'mirror'` — prod-shape RDS in dev account, refreshed daily from a prod
- *                snapshot. Path matches the existing refresh workflow:
- *                ``/mirror/current/{service}-postgres-password`` (leading slash;
- *                ``-postgres-password`` suffix). For multi-DB services the
- *                ``dbId`` goes BEFORE the suffix:
- *                ``/mirror/current/{service}-{dbId}-postgres-password``.
- * - `'prod'`   — prod RDS in account 531. SSL required.
- *                Path: ``prod/postgres-shared/{service}[-{dbId}]``.
+ * **Env behavior:**
  *
- * Payload shape (both workflow and CLI write the same fields, with one
- * legacy quirk — the mirror workflow uses ``dbname`` while the CLI uses
- * ``database``. Loader accepts either.)
+ * - `'prod'`   — IAM-auth against shared RDS in prod account. Coords
+ *                (host/port) come from SSM `/shared/infra/prod/postgres-{host,port}`.
+ *                Database is derived as ``{service_snake}`` unless overridden
+ *                in the per-service spec (multi-DB services pass ``dbId`` to
+ *                pick the right one). Password is an async callback that
+ *                mints a 15-min IAM token via ``@aws-sdk/rds-signer`` on
+ *                every new pool connection.
  *
- *   { username, password, host, port, database (or dbname), engine? }
+ * - `'mirror'` — Same as prod but coords come from
+ *                ``/mirror/current/postgres-rds/{endpoint,port}``. Mirror is
+ *                in the dev account but otherwise prod-shape.
  *
- * Multi-DB postgres services (e.g., rostering's iam-api with iam_db +
- * iam_pii_db) pass ``dbId`` to address each DB's credential separately.
+ * - `'dev'`    — Local docker / db-host container. No IAM. Reads the
+ *                parity secret written by ``saga-provision-credentials
+ *                create --env dev --insecure-dev`` at
+ *                ``dev/postgres-shared/{service}/{role}``. Returns
+ *                a static password string. For services not using the
+ *                parity flow, this loader isn't the right tool — construct
+ *                config directly from env vars.
+ *
+ * **Naming convention** (derived; spec-overridable in iac):
+ *
+ *   username = `{service_snake}_{role}`   (e.g. chat_app)
+ *   database = `{service_snake}`           (e.g. chat)
+ *
+ * Where `service_snake = service.replace(/-/g, '_')` so spec ids with
+ * hyphens (`chat-api`) become valid Postgres identifiers (`chat_api`).
+ *
+ * **Multi-DB postgres** (rostering iam-api → iam_db + iam_pii_db):
+ * pass ``dbId`` to select; the database becomes ``{service_snake}_{dbId}_db``
+ * or whatever the spec declares.
  */
 export interface LoadPostgresConfigParams {
   env: 'dev' | 'mirror' | 'prod';
-  /** Service name as it appears in `db-access.yaml` (e.g. 'iam-api'). */
+
+  /** Service name as it appears in `db-access.yaml` (e.g. 'chat-api'). */
   service: string;
-  /** Name to give the PostgresProvider instance. */
-  instanceName: string;
+
   /**
-   * For multi-DB services, the database id from db-access.yaml (e.g. 'main',
-   * 'pii'). Omit for single-DB services — the secret path uses the bare
-   * service name with no suffix.
+   * Postgres role suffix. Maps onto the per-service role triplet:
+   *   'owner' — DDL / migrations (AppInfra tier or owner-only contexts)
+   *   'app'   — DML runtime (the most common case; default)
+   *   'ro'    — SELECT only (reports, debugging)
+   */
+  role?: 'owner' | 'app' | 'ro';
+
+  /** Name to give the resulting PostgresProvider / pool. */
+  instanceName: string;
+
+  /**
+   * For multi-DB services (e.g. rostering iam-api with iam_db + iam_pii_db),
+   * the database id from db-access.yaml. Omit for single-DB services.
    */
   dbId?: string;
-  /** Override AWS region. Defaults to us-west-2. */
+
+  /**
+   * Override the auto-derived database name. Defaults to
+   * ``{service_snake}`` (or ``{service_snake}_{dbId}`` for multi-DB).
+   * Use this for legacy schemas that don't follow the convention.
+   */
+  database?: string;
+
+  /**
+   * Override the auto-derived username. Defaults to
+   * ``{service_snake}_{role}``. Use for services whose role names
+   * predate this convention (e.g. `saga_api` writers).
+   */
+  username?: string;
+
+  /** AWS region. Defaults to us-west-2 (Saga's only region today). */
   region?: string;
+}
+
+/**
+ * `pg.Pool`-compatible config returned by the loader. The `password`
+ * field is a union: a static string for dev (parity secret) or an
+ * async callback for mirror/prod (mints IAM token per new pool
+ * connection). `pg.Pool` natively accepts both shapes.
+ */
+export interface PostgresPoolConfig {
+  instanceName: string;
+  host: string;
+  port: number;
+  database: string;
+  user: string;
+  password: string | (() => Promise<string>);
+  ssl: boolean;
 }
 
 const DEFAULT_REGION = 'us-west-2';
 
 export async function loadPostgresConfigFromAws(
   params: LoadPostgresConfigParams,
-): Promise<PostgresProviderConfig> {
+): Promise<PostgresPoolConfig> {
   const region = params.region ?? DEFAULT_REGION;
-  const sm = new SecretsManagerClient({ region });
+  const role = params.role ?? 'app';
+  const serviceSnake = params.service.replace(/-/g, '_');
 
-  const secretId = postgresServiceSecretName(params.env, params.service, params.dbId);
-  const raw = await readSecretJson<{
-    username: string;
-    password: string;
-    host: string;
-    port: number | string;
-    database?: string;
-    dbname?: string;
-    engine?: string;
-  }>(sm, secretId);
+  const username =
+    params.username ?? `${serviceSnake}_${role}`;
+  const database =
+    params.database ?? (params.dbId ? `${serviceSnake}_${params.dbId}_db` : serviceSnake);
 
-  // mirror + prod are always managed RDS — SSL required.
-  // dev is the db-host container with no TLS.
-  const ssl = params.env !== 'dev';
-
-  // Accept either `database` (CLI / prod) or `dbname` (mirror refresh workflow).
-  const database = raw.database ?? raw.dbname;
-  if (!database) {
-    throw new Error(
-      `Secret ${secretId} is missing both 'database' and 'dbname' fields`,
-    );
+  if (params.env === 'dev') {
+    return loadDevConfig({
+      service: params.service,
+      role,
+      instanceName: params.instanceName,
+      dbId: params.dbId,
+      username,
+      database,
+      region,
+    });
   }
 
-  return PostgresProviderSchema.parse({
+  return loadIamConfig({
+    env: params.env,
     instanceName: params.instanceName,
-    host: raw.host,
-    port: typeof raw.port === 'string' ? parseInt(raw.port, 10) : raw.port,
+    username,
     database,
-    username: raw.username,
-    password: raw.password,
-    ssl,
+    region,
   });
 }
 
 /**
- * Compute the canonical SM secret name for a postgres service / env / dbId.
- *
- * Mirror paths align with the existing refresh workflow shape so the CLI
- * and the workflow write to the same location:
- *
- *   single-DB:  /mirror/current/{service}-postgres-password
- *   multi-DB:   /mirror/current/{service}-{dbId}-postgres-password
- *
- * Prod/dev use our CLI's path shape:
- *
- *   single-DB:  {env}/postgres-shared/{service}
- *   multi-DB:   {env}/postgres-shared/{service}-{dbId}
+ * Dev path: read the parity SM secret + return config with the static
+ * password. The parity entry is written by
+ * ``saga-provision-credentials create --env dev --insecure-dev`` and
+ * contains the role's hardcoded local-docker password.
  */
-export function postgresServiceSecretName(
-  env: 'dev' | 'mirror' | 'prod',
+async function loadDevConfig(args: {
+  service: string;
+  role: 'owner' | 'app' | 'ro';
+  instanceName: string;
+  dbId?: string;
+  username: string;
+  database: string;
+  region: string;
+}): Promise<PostgresPoolConfig> {
+  const sm = new SecretsManagerClient({ region: args.region });
+  const secretId = devSecretName(args.service, args.role, args.dbId);
+  const raw = await readSecretJson<DevSecretPayload>(sm, secretId);
+  return {
+    instanceName: args.instanceName,
+    host: raw.host,
+    port: typeof raw.port === 'string' ? parseInt(raw.port, 10) : raw.port,
+    database: raw.database ?? raw.dbname ?? args.database,
+    user: raw.username ?? args.username,
+    password: raw.password,
+    ssl: false,
+  };
+}
+
+/**
+ * Mirror/prod path: IAM auth. Coords from SSM; password is an async
+ * callback that mints a fresh 15-min token per new pool connection.
+ *
+ * `pg.Pool` calls the password callback once per connection establishment
+ * (not once per query). Long-lived pooled connections survive past the
+ * 15-min token TTL because Postgres only validates the token at connect
+ * time. New connections (pool refill, scale-out) get fresh tokens.
+ */
+async function loadIamConfig(args: {
+  env: 'mirror' | 'prod';
+  instanceName: string;
+  username: string;
+  database: string;
+  region: string;
+}): Promise<PostgresPoolConfig> {
+  const ssm = new SSMClient({ region: args.region });
+  const [host, portRaw] = await Promise.all([
+    readSsm(ssm, iamHostSsmPath(args.env)),
+    readSsm(ssm, iamPortSsmPath(args.env)),
+  ]);
+  const port = parseInt(portRaw, 10);
+
+  // Critical: the Signer must use the REAL RDS hostname + port (5432).
+  // RDS validates the token against the actual listener, not against the
+  // local tunnel port (15432) when running over SSM port-forwarding.
+  // pg.Pool can connect to localhost:tunnelPort if desired — but the
+  // Signer always signs for the real endpoint.
+  const signer = new Signer({
+    hostname: host,
+    port,
+    username: args.username,
+    region: args.region,
+  });
+
+  return {
+    instanceName: args.instanceName,
+    host,
+    port,
+    database: args.database,
+    user: args.username,
+    ssl: true,
+    password: async () => signer.getAuthToken(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Path helpers (exported for consumers that need to compute the same paths
+// in IAM policies, deploy scripts, etc.)
+// ---------------------------------------------------------------------------
+
+/**
+ * SSM path for the shared Postgres host. Distinct per env because mirror
+ * lives in the dev account under `/mirror/current/*` (the daily refresh
+ * workflow's path namespace).
+ */
+export function iamHostSsmPath(env: 'mirror' | 'prod'): string {
+  return env === 'mirror'
+    ? '/mirror/current/postgres-rds/endpoint'
+    : '/shared/infra/prod/postgres-host';
+}
+
+export function iamPortSsmPath(env: 'mirror' | 'prod'): string {
+  return env === 'mirror'
+    ? '/mirror/current/postgres-rds/port'
+    : '/shared/infra/prod/postgres-port';
+}
+
+/**
+ * Dev parity SM secret name (one per service per role, optionally per dbId
+ * for multi-DB services). Written by ``saga-provision-credentials --env
+ * dev --insecure-dev``.
+ */
+export function devSecretName(
   service: string,
+  role: 'owner' | 'app' | 'ro',
   dbId?: string,
 ): string {
-  if (env === 'mirror') {
-    const idPart = dbId ? `-${dbId}` : '';
-    return `/mirror/current/${service}${idPart}-postgres-password`;
-  }
-  const idPart = dbId ? `-${dbId}` : '';
-  return `${env}/postgres-shared/${service}${idPart}`;
+  const idPart = dbId ? `${service}/${dbId}/${role}` : `${service}/${role}`;
+  return `dev/postgres-shared/${idPart}`;
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+interface DevSecretPayload {
+  username?: string;
+  password: string;
+  host: string;
+  port: number | string;
+  database?: string;
+  /** Mirror refresh workflow legacy alias; not used in dev but tolerated. */
+  dbname?: string;
 }
 
 async function readSecretJson<T>(
@@ -127,4 +275,13 @@ async function readSecretJson<T>(
     throw new Error(`Secret ${secretId} has no SecretString`);
   }
   return JSON.parse(out.SecretString) as T;
+}
+
+async function readSsm(client: SSMClient, name: string): Promise<string> {
+  const out = await client.send(new GetParameterCommand({ Name: name }));
+  const value = out.Parameter?.Value;
+  if (!value) {
+    throw new Error(`SSM parameter ${name} has no value`);
+  }
+  return value;
 }

--- a/packages/node/postgres/src/aws-postgres-loader.ts
+++ b/packages/node/postgres/src/aws-postgres-loader.ts
@@ -1,0 +1,84 @@
+import {
+  GetSecretValueCommand,
+  SecretsManagerClient,
+} from '@aws-sdk/client-secrets-manager';
+import { PostgresProviderSchema } from './postgres-provider-config.js';
+import type { PostgresProviderConfig } from './postgres-provider-config.js';
+
+/**
+ * Build a fully-resolved {@link PostgresProviderConfig} by reading the
+ * Secrets Manager payload written by ``saga-provision-credentials``.
+ *
+ * The CLI writes one secret per service per env at
+ * ``{env}/postgres-shared/{service}`` with shape
+ * ``{username, password, host, port, database, engine}``. That's the
+ * full set of fields we need — no SSM read is required for postgres
+ * (host is in the secret, port is in the secret, no TLS CA needed
+ * because RDS uses public trust anchors).
+ *
+ * Env mapping:
+ *
+ * - `'dev'`   — db-host container in dev account. The CLI's
+ *               ``--insecure-dev`` mode writes a parity secret with
+ *               trivial password and ``host: db-host.dbs``.
+ * - `'mirror'` — prod-shape RDS in dev account (account 396).
+ *                ``ssl: true`` always (managed RDS).
+ * - `'prod'`   — prod RDS in account 531. ``ssl: true`` always.
+ *
+ * For dev (where the local container is unauthenticated), callers
+ * can construct {@link PostgresProviderConfig} directly from env vars
+ * if the parity secret hasn't been provisioned.
+ */
+export interface LoadPostgresConfigParams {
+  env: 'dev' | 'mirror' | 'prod';
+  /** Service name as it appears in `db-access.yaml` (e.g. 'sds-api'). */
+  service: string;
+  /** Name to give the PostgresProvider instance. */
+  instanceName: string;
+  /** Override AWS region. Defaults to us-west-2. */
+  region?: string;
+}
+
+const DEFAULT_REGION = 'us-west-2';
+
+export async function loadPostgresConfigFromAws(
+  params: LoadPostgresConfigParams,
+): Promise<PostgresProviderConfig> {
+  const region = params.region ?? DEFAULT_REGION;
+  const sm = new SecretsManagerClient({ region });
+
+  const secretId = `${params.env}/postgres-shared/${params.service}`;
+  const raw = await readSecretJson<{
+    username: string;
+    password: string;
+    host: string;
+    port: number | string;
+    database: string;
+    engine?: string;
+  }>(sm, secretId);
+
+  // mirror + prod are always managed RDS — SSL required.
+  // dev is the db-host container with no TLS.
+  const ssl = params.env !== 'dev';
+
+  return PostgresProviderSchema.parse({
+    instanceName: params.instanceName,
+    host: raw.host,
+    port: typeof raw.port === 'string' ? parseInt(raw.port, 10) : raw.port,
+    database: raw.database,
+    username: raw.username,
+    password: raw.password,
+    ssl,
+  });
+}
+
+async function readSecretJson<T>(
+  client: SecretsManagerClient,
+  secretId: string,
+): Promise<T> {
+  const out = await client.send(new GetSecretValueCommand({ SecretId: secretId }));
+  if (!out.SecretString) {
+    throw new Error(`Secret ${secretId} has no SecretString`);
+  }
+  return JSON.parse(out.SecretString) as T;
+}

--- a/packages/node/postgres/src/aws-postgres-loader.ts
+++ b/packages/node/postgres/src/aws-postgres-loader.ts
@@ -222,20 +222,21 @@ async function loadIamConfig(args: {
 // ---------------------------------------------------------------------------
 
 /**
- * SSM path for the shared Postgres host. Distinct per env because mirror
- * lives in the dev account under `/mirror/current/*` (the daily refresh
- * workflow's path namespace).
+ * SSM path for the shared Postgres host. Canonical pattern is
+ * `/{tier}/postgres-rds/{coord}` for both mirror and prod — they share
+ * the same shape; mirror's "tier" is `mirror/current` because the daily
+ * refresh workflow rolls instances under that namespace.
  */
 export function iamHostSsmPath(env: 'mirror' | 'prod'): string {
   return env === 'mirror'
     ? '/mirror/current/postgres-rds/endpoint'
-    : '/shared/infra/prod/postgres-host';
+    : '/prod/postgres-rds/endpoint';
 }
 
 export function iamPortSsmPath(env: 'mirror' | 'prod'): string {
   return env === 'mirror'
     ? '/mirror/current/postgres-rds/port'
-    : '/shared/infra/prod/postgres-port';
+    : '/prod/postgres-rds/port';
 }
 
 /**

--- a/packages/node/postgres/src/index.ts
+++ b/packages/node/postgres/src/index.ts
@@ -1,7 +1,10 @@
 export { PostgresProvider } from './postgres-provider.js';
 export { PostgresProviderSchema } from './postgres-provider-config.js';
 export type { PostgresProviderConfig } from './postgres-provider-config.js';
-export { loadPostgresConfigFromAws } from './aws-postgres-loader.js';
+export {
+  loadPostgresConfigFromAws,
+  postgresServiceSecretName,
+} from './aws-postgres-loader.js';
 export type { LoadPostgresConfigParams } from './aws-postgres-loader.js';
 
 export const POSTGRES_PROVIDER = Symbol.for('PostgresProvider');

--- a/packages/node/postgres/src/index.ts
+++ b/packages/node/postgres/src/index.ts
@@ -3,8 +3,13 @@ export { PostgresProviderSchema } from './postgres-provider-config.js';
 export type { PostgresProviderConfig } from './postgres-provider-config.js';
 export {
   loadPostgresConfigFromAws,
-  postgresServiceSecretName,
+  iamHostSsmPath,
+  iamPortSsmPath,
+  devSecretName,
 } from './aws-postgres-loader.js';
-export type { LoadPostgresConfigParams } from './aws-postgres-loader.js';
+export type {
+  LoadPostgresConfigParams,
+  PostgresPoolConfig,
+} from './aws-postgres-loader.js';
 
 export const POSTGRES_PROVIDER = Symbol.for('PostgresProvider');

--- a/packages/node/postgres/src/index.ts
+++ b/packages/node/postgres/src/index.ts
@@ -1,0 +1,7 @@
+export { PostgresProvider } from './postgres-provider.js';
+export { PostgresProviderSchema } from './postgres-provider-config.js';
+export type { PostgresProviderConfig } from './postgres-provider-config.js';
+export { loadPostgresConfigFromAws } from './aws-postgres-loader.js';
+export type { LoadPostgresConfigParams } from './aws-postgres-loader.js';
+
+export const POSTGRES_PROVIDER = Symbol.for('PostgresProvider');

--- a/packages/node/postgres/src/postgres-provider-config.ts
+++ b/packages/node/postgres/src/postgres-provider-config.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+
+/**
+ * Config schema for {@link PostgresProvider}.
+ *
+ * Matches the secret payload written by ``saga-provision-credentials``
+ * for the postgres engine: `{username, password, host, port, database, engine}`.
+ * The `engine` discriminator lets a shared secret store distinguish
+ * engine types when consumers fetch by ARN.
+ *
+ * Pool tuning fields are provider-side knobs that don't belong in the
+ * Secrets Manager payload — they're set per-consumer and default to
+ * conservative values suitable for a typical API service.
+ */
+export const PostgresProviderSchema = z.object({
+  configType: z.literal('POSTGRES').default('POSTGRES'),
+  instanceName: z.string().min(1),
+
+  // Connection target — matches the SM payload shape from
+  // saga-provision-credentials: {username, password, host, port, database}.
+  host: z.string().min(1),
+  port: z.number().int().positive().default(5432),
+  database: z.string().min(1),
+  username: z.string().min(1),
+  password: z.string().min(1),
+
+  // TLS toggle. Required for managed RDS / RDS Proxy connections.
+  // Dev db-host containers can leave this off.
+  ssl: z.boolean().default(false),
+
+  // Optional pool tuning. Sensible defaults for an API service.
+  poolSize: z.number().int().positive().default(10),
+  idleTimeoutMs: z.number().int().nonnegative().default(30_000),
+  connectionTimeoutMs: z.number().int().positive().default(10_000),
+
+  // Per-connection session-level timeouts. 0 disables.
+  // Default 0 (disabled) — services that want statement deadlines
+  // should set these explicitly.
+  statementTimeoutMs: z.number().int().nonnegative().default(0),
+  lockTimeoutMs: z.number().int().nonnegative().default(0),
+});
+
+export type PostgresProviderConfig = z.infer<typeof PostgresProviderSchema>;

--- a/packages/node/postgres/src/postgres-provider.ts
+++ b/packages/node/postgres/src/postgres-provider.ts
@@ -1,0 +1,108 @@
+import 'reflect-metadata';
+import { injectable } from 'inversify';
+import { Pool, type PoolClient } from 'pg';
+import type { PostgresProviderConfig } from './postgres-provider-config.js';
+
+/**
+ * Manages a single ``pg.Pool`` for one logical database. Provider is
+ * ORM-agnostic — consumers wrap the pool with Prisma (``PrismaPg``),
+ * Drizzle, or use it directly.
+ *
+ * Lifted from student-data-system/packages/node/ads-adm-db with the
+ * Prisma coupling removed so this package stays a thin postgres-only
+ * library. Consumers that want Prisma adapt the pool themselves:
+ *
+ *   const provider = new PostgresProvider(config);
+ *   await provider.connect();
+ *   const adapter = new PrismaPg(provider.getPool());
+ *   const client = new PrismaClient({ adapter });
+ *
+ * Connection failures retry with exponential backoff (3 attempts, 1s
+ * base) — matches the original implementation.
+ */
+@injectable()
+export class PostgresProvider {
+  public readonly instanceName: string;
+  private pool: Pool | null = null;
+  private _isConnected = false;
+
+  constructor(private readonly config: PostgresProviderConfig) {
+    this.instanceName = config.instanceName;
+  }
+
+  async connect(): Promise<void> {
+    if (this._isConnected) return;
+
+    const maxRetries = 3;
+    const baseDelayMs = 1000;
+
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      try {
+        this.pool = new Pool({
+          connectionString: this.buildConnectionString(),
+          max: this.config.poolSize,
+          idleTimeoutMillis: this.config.idleTimeoutMs,
+          connectionTimeoutMillis: this.config.connectionTimeoutMs,
+        });
+
+        if (this.config.statementTimeoutMs > 0 || this.config.lockTimeoutMs > 0) {
+          this.pool.on('connect', (client: PoolClient) => {
+            if (this.config.statementTimeoutMs > 0) {
+              client.query(`SET statement_timeout = ${this.config.statementTimeoutMs}`);
+            }
+            if (this.config.lockTimeoutMs > 0) {
+              client.query(`SET lock_timeout = ${this.config.lockTimeoutMs}`);
+            }
+          });
+        }
+
+        // Validate by acquiring + releasing one connection. We do this
+        // rather than relying on Pool's lazy connect so a bad
+        // host/credential fails fast at connect() rather than on the
+        // first query.
+        const probe = await this.pool.connect();
+        probe.release();
+
+        this._isConnected = true;
+        return;
+      } catch (err) {
+        if (this.pool) {
+          await this.pool.end().catch(() => {});
+          this.pool = null;
+        }
+        if (attempt === maxRetries) throw err;
+        await new Promise((resolve) =>
+          setTimeout(resolve, baseDelayMs * Math.pow(2, attempt - 1)),
+        );
+      }
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.pool) {
+      await this.pool.end();
+      this.pool = null;
+    }
+    this._isConnected = false;
+  }
+
+  isConnected(): boolean {
+    return this._isConnected;
+  }
+
+  /** Returns the underlying ``Pool``. Throws if not connected. */
+  getPool(): Pool {
+    if (!this.pool) {
+      throw new Error('PostgresProvider is not connected. Call connect() first.');
+    }
+    return this.pool;
+  }
+
+  /** Build the postgres:// connection string from config. */
+  private buildConnectionString(): string {
+    const { host, port, database, username, password, ssl } = this.config;
+    const auth = `${encodeURIComponent(username)}:${encodeURIComponent(password)}@`;
+    const sslParam = ssl ? '?sslmode=require' : '';
+    return `postgresql://${auth}${host}:${port}/${database}${sslParam}`;
+  }
+}

--- a/packages/node/postgres/src/postgres-provider.ts
+++ b/packages/node/postgres/src/postgres-provider.ts
@@ -2,39 +2,85 @@ import 'reflect-metadata';
 import { injectable } from 'inversify';
 import { Pool, type PoolClient } from 'pg';
 import type { PostgresProviderConfig } from './postgres-provider-config.js';
+import type { PostgresPoolConfig } from './aws-postgres-loader.js';
 
 /**
  * Manages a single ``pg.Pool`` for one logical database. Provider is
  * ORM-agnostic — consumers wrap the pool with Prisma (``PrismaPg``),
  * Drizzle, or use it directly.
  *
- * Lifted from student-data-system/packages/node/ads-adm-db with the
- * Prisma coupling removed so this package stays a thin postgres-only
- * library. Consumers that want Prisma adapt the pool themselves:
+ * Accepts either config shape, so the same provider serves every env:
  *
- *   const provider = new PostgresProvider(config);
+ *   - a static {@link PostgresProviderConfig} (validated via
+ *     ``PostgresProviderSchema``) for dev/local or any static-credential DB;
+ *   - a {@link PostgresPoolConfig} straight from
+ *     {@link loadPostgresConfigFromAws}, **including the mirror/prod IAM
+ *     shape** whose ``password`` is an async callback that mints a fresh
+ *     15-min RDS auth token. ``pg`` invokes the callback once per new
+ *     physical connection, so pooled connections re-authenticate with a
+ *     fresh token automatically.
+ *
+ * Routing the IAM path through the provider (rather than a hand-rolled
+ * ``new Pool(...)`` per call site) is what lets RDS consumers inherit the
+ * resilience below for free:
+ *
+ *   const provider = new PostgresProvider(
+ *     await loadPostgresConfigFromAws({ env: 'prod', service: 'chat-api', ... }),
+ *   );
  *   await provider.connect();
  *   const adapter = new PrismaPg(provider.getPool());
  *   const client = new PrismaClient({ adapter });
  *
- * Connection failures retry with exponential backoff (3 attempts, 1s
- * base) — matches the original implementation.
+ * Connection failures retry with exponential backoff (3 attempts, 1s base).
  *
- * Resilience: TCP keepAlive is enabled so half-open sockets (RDS
- * failover, NAT/LB idle drops) are detected proactively, and an
- * ``'error'`` listener is attached to the pool so an error on an *idle*
- * pooled client cannot bubble out as an uncaught exception and crash the
- * process. The pool self-heals — it discards the dead client and opens a
- * fresh one on the next acquire — so no manual reconnect is required.
+ * Resilience: TCP keepAlive is enabled so half-open sockets (RDS failover,
+ * NAT/LB idle drops) are detected proactively, and an ``'error'`` listener
+ * is attached so an error on an *idle* pooled client cannot bubble out as an
+ * uncaught exception and crash the process. The pool self-heals — it
+ * discards the dead client and opens a fresh one (re-running the password
+ * callback for a fresh IAM token) on the next acquire — so no manual
+ * reconnect is required.
  */
+
+/**
+ * Pool-tuning defaults applied when a {@link PostgresPoolConfig} omits them.
+ * Mirror ``PostgresProviderSchema``'s defaults so the static and AWS-loader
+ * paths behave identically.
+ */
+const POOL_DEFAULTS = {
+  poolSize: 10,
+  idleTimeoutMs: 30_000,
+  connectionTimeoutMs: 10_000,
+  statementTimeoutMs: 0,
+  lockTimeoutMs: 0,
+} as const;
+
+/** Internal canonical shape both accepted configs normalize into. */
+interface NormalizedConfig {
+  instanceName: string;
+  host: string;
+  port: number;
+  database: string;
+  user: string;
+  password: string | (() => Promise<string>);
+  ssl: boolean;
+  poolSize: number;
+  idleTimeoutMs: number;
+  connectionTimeoutMs: number;
+  statementTimeoutMs: number;
+  lockTimeoutMs: number;
+}
+
 @injectable()
 export class PostgresProvider {
   public readonly instanceName: string;
   private pool: Pool | null = null;
   private _isConnected = false;
+  private readonly cfg: NormalizedConfig;
 
-  constructor(private readonly config: PostgresProviderConfig) {
-    this.instanceName = config.instanceName;
+  constructor(config: PostgresProviderConfig | PostgresPoolConfig) {
+    this.cfg = PostgresProvider.normalize(config);
+    this.instanceName = this.cfg.instanceName;
   }
 
   async connect(): Promise<void> {
@@ -50,10 +96,22 @@ export class PostgresProvider {
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       try {
         this.pool = new Pool({
-          connectionString: this.buildConnectionString(),
-          max: this.config.poolSize,
-          idleTimeoutMillis: this.config.idleTimeoutMs,
-          connectionTimeoutMillis: this.config.connectionTimeoutMs,
+          host: this.cfg.host,
+          port: this.cfg.port,
+          database: this.cfg.database,
+          user: this.cfg.user,
+          // Static string (dev) or async token callback (mirror/prod IAM).
+          // Built from discrete options rather than a connection string
+          // specifically because pg ignores a discrete password when a
+          // connectionString is also present — the callback would be lost.
+          password: this.cfg.password,
+          // ssl:true => full cert verification, equivalent to the previous
+          // `sslmode=require` (which pg maps to {}). RDS certs chain to the
+          // Amazon roots in Node's CA bundle. ssl:false for local dev.
+          ssl: this.cfg.ssl,
+          max: this.cfg.poolSize,
+          idleTimeoutMillis: this.cfg.idleTimeoutMs,
+          connectionTimeoutMillis: this.cfg.connectionTimeoutMs,
           // Detect half-open sockets (RDS failover, NAT/LB idle drops)
           // proactively instead of only on the next query.
           keepAlive: true,
@@ -73,19 +131,19 @@ export class PostgresProvider {
           );
         });
 
-        if (this.config.statementTimeoutMs > 0 || this.config.lockTimeoutMs > 0) {
+        if (this.cfg.statementTimeoutMs > 0 || this.cfg.lockTimeoutMs > 0) {
           this.pool.on('connect', (client: PoolClient) => {
             // Fire-and-forget, but swallow rejections: an unhandled
             // rejection here (SET against a dying backend) is another
             // uncaught-exception path.
-            if (this.config.statementTimeoutMs > 0) {
+            if (this.cfg.statementTimeoutMs > 0) {
               client
-                .query(`SET statement_timeout = ${this.config.statementTimeoutMs}`)
+                .query(`SET statement_timeout = ${this.cfg.statementTimeoutMs}`)
                 .catch(() => {});
             }
-            if (this.config.lockTimeoutMs > 0) {
+            if (this.cfg.lockTimeoutMs > 0) {
               client
-                .query(`SET lock_timeout = ${this.config.lockTimeoutMs}`)
+                .query(`SET lock_timeout = ${this.cfg.lockTimeoutMs}`)
                 .catch(() => {});
             }
           });
@@ -133,11 +191,47 @@ export class PostgresProvider {
     return this.pool;
   }
 
-  /** Build the postgres:// connection string from config. */
-  private buildConnectionString(): string {
-    const { host, port, database, username, password, ssl } = this.config;
-    const auth = `${encodeURIComponent(username)}:${encodeURIComponent(password)}@`;
-    const sslParam = ssl ? '?sslmode=require' : '';
-    return `postgresql://${auth}${host}:${port}/${database}${sslParam}`;
+  /**
+   * Normalize either accepted config shape into the internal canonical form.
+   * {@link PostgresPoolConfig} (loader output) uses ``user`` and may omit
+   * pool tuning; {@link PostgresProviderConfig} (zod schema) uses
+   * ``username`` and always carries tuning (via schema defaults).
+   */
+  private static normalize(
+    config: PostgresProviderConfig | PostgresPoolConfig,
+  ): NormalizedConfig {
+    if ('user' in config) {
+      return {
+        instanceName: config.instanceName,
+        host: config.host,
+        port: config.port,
+        database: config.database,
+        user: config.user,
+        password: config.password,
+        ssl: config.ssl,
+        poolSize: config.poolSize ?? POOL_DEFAULTS.poolSize,
+        idleTimeoutMs: config.idleTimeoutMs ?? POOL_DEFAULTS.idleTimeoutMs,
+        connectionTimeoutMs:
+          config.connectionTimeoutMs ?? POOL_DEFAULTS.connectionTimeoutMs,
+        statementTimeoutMs:
+          config.statementTimeoutMs ?? POOL_DEFAULTS.statementTimeoutMs,
+        lockTimeoutMs: config.lockTimeoutMs ?? POOL_DEFAULTS.lockTimeoutMs,
+      };
+    }
+
+    return {
+      instanceName: config.instanceName,
+      host: config.host,
+      port: config.port,
+      database: config.database,
+      user: config.username,
+      password: config.password,
+      ssl: config.ssl,
+      poolSize: config.poolSize,
+      idleTimeoutMs: config.idleTimeoutMs,
+      connectionTimeoutMs: config.connectionTimeoutMs,
+      statementTimeoutMs: config.statementTimeoutMs,
+      lockTimeoutMs: config.lockTimeoutMs,
+    };
   }
 }

--- a/packages/node/postgres/src/postgres-provider.ts
+++ b/packages/node/postgres/src/postgres-provider.ts
@@ -19,6 +19,13 @@ import type { PostgresProviderConfig } from './postgres-provider-config.js';
  *
  * Connection failures retry with exponential backoff (3 attempts, 1s
  * base) — matches the original implementation.
+ *
+ * Resilience: TCP keepAlive is enabled so half-open sockets (RDS
+ * failover, NAT/LB idle drops) are detected proactively, and an
+ * ``'error'`` listener is attached to the pool so an error on an *idle*
+ * pooled client cannot bubble out as an uncaught exception and crash the
+ * process. The pool self-heals — it discards the dead client and opens a
+ * fresh one on the next acquire — so no manual reconnect is required.
  */
 @injectable()
 export class PostgresProvider {
@@ -31,7 +38,11 @@ export class PostgresProvider {
   }
 
   async connect(): Promise<void> {
-    if (this._isConnected) return;
+    // Guard on the pool itself, not _isConnected. An idle-client error
+    // flips _isConnected to false (see the 'error' handler below) while
+    // the pool stays alive and self-heals; keying off _isConnected here
+    // would let a second connect() build a new pool and leak the first.
+    if (this.pool) return;
 
     const maxRetries = 3;
     const baseDelayMs = 1000;
@@ -43,15 +54,39 @@ export class PostgresProvider {
           max: this.config.poolSize,
           idleTimeoutMillis: this.config.idleTimeoutMs,
           connectionTimeoutMillis: this.config.connectionTimeoutMs,
+          // Detect half-open sockets (RDS failover, NAT/LB idle drops)
+          // proactively instead of only on the next query.
+          keepAlive: true,
+        });
+
+        // Without this listener, an error on an *idle* pooled client
+        // (RDS reboot/failover, network partition) is emitted on the Pool
+        // with no handler — Node re-throws it as an uncaught exception and
+        // crashes the process. Handle it: mark unhealthy + log. The pool
+        // discards the dead client and reconnects on the next acquire.
+        this.pool.on('error', (err: Error) => {
+          this._isConnected = false;
+          console.error(
+            `[PostgresProvider:${this.instanceName}] idle client error; ` +
+              `pool will reconnect on next use:`,
+            err,
+          );
         });
 
         if (this.config.statementTimeoutMs > 0 || this.config.lockTimeoutMs > 0) {
           this.pool.on('connect', (client: PoolClient) => {
+            // Fire-and-forget, but swallow rejections: an unhandled
+            // rejection here (SET against a dying backend) is another
+            // uncaught-exception path.
             if (this.config.statementTimeoutMs > 0) {
-              client.query(`SET statement_timeout = ${this.config.statementTimeoutMs}`);
+              client
+                .query(`SET statement_timeout = ${this.config.statementTimeoutMs}`)
+                .catch(() => {});
             }
             if (this.config.lockTimeoutMs > 0) {
-              client.query(`SET lock_timeout = ${this.config.lockTimeoutMs}`);
+              client
+                .query(`SET lock_timeout = ${this.config.lockTimeoutMs}`)
+                .catch(() => {});
             }
           });
         }

--- a/packages/node/postgres/tsconfig.json
+++ b/packages/node/postgres/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@saga-ed/soa-typescript-config/base.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "types": ["node", "vitest"],
+    "noEmit": false,
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__/**"]
+}

--- a/packages/node/postgres/tsup.config.ts
+++ b/packages/node/postgres/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  outDir: 'dist',
+  splitting: false,
+  skipNodeModulesBundle: true,
+  target: 'node22',
+});

--- a/packages/node/postgres/vitest.config.ts
+++ b/packages/node/postgres/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/__tests__/**/*.unit.test.ts', 'src/__tests__/**/*.int.test.ts'],
+    coverage: {
+      reporter: ['text', 'html'],
+      exclude: ['**/node_modules/**', '**/dist/**', '**/test/**', '**/__tests__/**/mocks/**'],
+    },
+  },
+});

--- a/packages/node/redis-core/package.json
+++ b/packages/node/redis-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saga-ed/soa-redis-core",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "private": false,
   "type": "module",
   "main": "dist/index.js",
@@ -18,6 +18,8 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@aws-sdk/client-secrets-manager": "^3.968.0",
+    "@aws-sdk/client-ssm": "^3.968.0",
     "@saga-ed/soa-api-util": "workspace:*",
     "@saga-ed/soa-logger": "workspace:*",
     "inversify": "^6.2.2",
@@ -25,7 +27,9 @@
   },
   "devDependencies": {
     "@saga-ed/soa-typescript-config": "workspace:*",
-    "tsup": "^8.5.1"
+    "aws-sdk-client-mock": "^4.1.0",
+    "tsup": "^8.5.1",
+    "vitest": "^1.5.0"
   },
   "publishConfig": {
     "registry": "https://saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/",

--- a/packages/node/redis-core/src/__tests__/aws-redis-loader.unit.test.ts
+++ b/packages/node/redis-core/src/__tests__/aws-redis-loader.unit.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mockClient } from 'aws-sdk-client-mock';
+import {
+  GetSecretValueCommand,
+  SecretsManagerClient,
+} from '@aws-sdk/client-secrets-manager';
+import {
+  GetParameterCommand,
+  SSMClient,
+} from '@aws-sdk/client-ssm';
+import { loadRedisConfigFromAws } from '../aws-redis-loader.js';
+
+const smMock = mockClient(SecretsManagerClient);
+const ssmMock = mockClient(SSMClient);
+
+beforeEach(() => {
+  smMock.reset();
+  ssmMock.reset();
+});
+
+describe('loadRedisConfigFromAws', () => {
+  it('reads endpoint from the secret when present', async () => {
+    smMock
+      .on(GetSecretValueCommand, { SecretId: 'prod/redis/sds-api' })
+      .resolves({
+        SecretString: JSON.stringify({
+          username: 'sds-api-prod',
+          password: 'pw',
+          endpoint: 'master.prod-redis.cache.amazonaws.com',
+          port: 6379,
+          tls: true,
+          user_group_id: 'cache-prod',
+        }),
+      });
+
+    const config = await loadRedisConfigFromAws({
+      env: 'prod',
+      service: 'sds-api',
+    });
+
+    expect(config).toEqual({
+      url: 'master.prod-redis.cache.amazonaws.com',
+      username: 'sds-api-prod',
+      password: 'pw',
+      tls: true,
+    });
+  });
+
+  it('falls back to SSM /shared/infra/{env}/redis-endpoint when secret omits endpoint', async () => {
+    smMock
+      .on(GetSecretValueCommand, { SecretId: 'mirror/redis/sds-api' })
+      .resolves({
+        SecretString: JSON.stringify({
+          username: 'sds-api-mirror',
+          password: 'pw',
+        }),
+      });
+
+    ssmMock
+      .on(GetParameterCommand, { Name: '/shared/infra/mirror/redis-endpoint' })
+      .resolves({ Parameter: { Value: 'master.mirror-redis.cache.amazonaws.com' } });
+
+    const config = await loadRedisConfigFromAws({
+      env: 'mirror',
+      service: 'sds-api',
+    });
+
+    expect(config.url).toBe('master.mirror-redis.cache.amazonaws.com');
+    expect(config.tls).toBe(true); // default for non-dev
+  });
+
+  it('defaults tls=false for dev', async () => {
+    smMock
+      .on(GetSecretValueCommand, { SecretId: 'dev/redis/sds-api' })
+      .resolves({
+        SecretString: JSON.stringify({
+          username: 'sds-api-dev',
+          password: 'dev-password-sds-api',
+          endpoint: 'localhost',
+        }),
+      });
+
+    const config = await loadRedisConfigFromAws({
+      env: 'dev',
+      service: 'sds-api',
+    });
+
+    expect(config.tls).toBe(false);
+  });
+
+  it('respects explicit tls=false from secret even on mirror/prod', async () => {
+    smMock
+      .on(GetSecretValueCommand, { SecretId: 'mirror/redis/sds-api' })
+      .resolves({
+        SecretString: JSON.stringify({
+          username: 'u',
+          password: 'p',
+          endpoint: 'h',
+          tls: false,
+        }),
+      });
+
+    const config = await loadRedisConfigFromAws({
+      env: 'mirror',
+      service: 'sds-api',
+    });
+
+    expect(config.tls).toBe(false);
+  });
+});

--- a/packages/node/redis-core/src/aws-redis-loader.ts
+++ b/packages/node/redis-core/src/aws-redis-loader.ts
@@ -1,0 +1,97 @@
+import {
+  GetSecretValueCommand,
+  SecretsManagerClient,
+} from '@aws-sdk/client-secrets-manager';
+import {
+  GetParameterCommand,
+  SSMClient,
+} from '@aws-sdk/client-ssm';
+import type { RedisConfig } from './redis-connection-manager.js';
+
+/**
+ * Build a {@link RedisConfig} for a per-service ElastiCache user.
+ *
+ * Reads the secret written by ``saga-provision-credentials`` at
+ * ``{env}/redis/{service}`` (shape:
+ * ``{username, password, endpoint, port, tls, user_group_id}``).
+ * The endpoint may also be sourced from SSM
+ * ``/shared/infra/{env}/redis-endpoint`` if the secret omits it, but in
+ * practice the CLI writes it into the secret so SSM is a fallback.
+ *
+ * Per-service users are attached to the env's user group
+ * (``cache-{env}``) which is bound to the replication group at the
+ * IaC level. Each user has a key-pattern-scoped AccessString (e.g.,
+ * ``on ~{service}:* +@read +@write -@dangerous``) so server-side
+ * enforcement prevents cross-service reads/writes.
+ *
+ * Env support:
+ *
+ * - `'dev'`    — local container or `cache-dev` if it ever comes back.
+ *                Today most dev usage skips authentication and goes
+ *                through SG membership only; the CLI's `--insecure-dev`
+ *                path writes a parity secret so consumers can construct
+ *                this config uniformly across envs.
+ * - `'mirror'` — `cache-mirror` user group in account 396.
+ * - `'prod'`   — `cache-prod` user group in account 531.
+ */
+export interface LoadRedisConfigParams {
+  env: 'dev' | 'mirror' | 'prod';
+  /** Service name as in `db-access.yaml` (e.g. 'sds-api'). */
+  service: string;
+  /** Override AWS region. Defaults to us-west-2. */
+  region?: string;
+}
+
+const DEFAULT_REGION = 'us-west-2';
+
+interface RedisSecretPayload {
+  username: string;
+  password: string;
+  endpoint?: string;
+  port?: number | string;
+  tls?: boolean;
+  user_group_id?: string;
+}
+
+export async function loadRedisConfigFromAws(
+  params: LoadRedisConfigParams,
+): Promise<RedisConfig> {
+  const region = params.region ?? DEFAULT_REGION;
+  const sm = new SecretsManagerClient({ region });
+  const ssm = new SSMClient({ region });
+
+  const secretId = `${params.env}/redis/${params.service}`;
+  const raw = await readSecretJson<RedisSecretPayload>(sm, secretId);
+
+  // Endpoint is normally in the secret; fall back to SSM if not (older
+  // provisioning runs predate that field).
+  let endpoint = raw.endpoint;
+  if (!endpoint) {
+    endpoint = await readSsm(ssm, `/shared/infra/${params.env}/redis-endpoint`);
+  }
+
+  return {
+    url: endpoint,
+    username: raw.username,
+    password: raw.password,
+    tls: raw.tls ?? params.env !== 'dev',
+  };
+}
+
+async function readSecretJson<T>(
+  client: SecretsManagerClient,
+  secretId: string,
+): Promise<T> {
+  const out = await client.send(new GetSecretValueCommand({ SecretId: secretId }));
+  if (!out.SecretString) {
+    throw new Error(`Secret ${secretId} has no SecretString`);
+  }
+  return JSON.parse(out.SecretString) as T;
+}
+
+async function readSsm(client: SSMClient, name: string): Promise<string> {
+  const out = await client.send(new GetParameterCommand({ Name: name }));
+  const value = out.Parameter?.Value;
+  if (!value) throw new Error(`SSM parameter ${name} has no value`);
+  return value;
+}

--- a/packages/node/redis-core/src/index.ts
+++ b/packages/node/redis-core/src/index.ts
@@ -1,1 +1,3 @@
 export { RedisConnectionManager, type RedisConfig } from './redis-connection-manager.js';
+export { loadRedisConfigFromAws } from './aws-redis-loader.js';
+export type { LoadRedisConfigParams } from './aws-redis-loader.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,7 +53,7 @@ importers:
         version: link:../../../packages/node/logger
       '@types/mongodb':
         specifier: ^4.0.7
-        version: 4.0.7(socks@2.8.7)
+        version: 4.0.7(@aws-sdk/credential-providers@3.1054.0)(socks@2.8.7)
       express:
         specifier: ^4.18.2
         version: 4.22.1
@@ -68,7 +68,7 @@ importers:
         version: 6.2.2(reflect-metadata@0.2.2)
       mongodb:
         specifier: ^5.7.0
-        version: 5.9.2
+        version: 5.9.2(@aws-sdk/credential-providers@3.1054.0)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -120,7 +120,7 @@ importers:
         version: link:../../../packages/node/logger
       '@types/mongodb':
         specifier: ^4.0.7
-        version: 4.0.7(socks@2.8.7)
+        version: 4.0.7(@aws-sdk/credential-providers@3.1054.0)(socks@2.8.7)
       express:
         specifier: ^4.18.2
         version: 4.22.1
@@ -132,7 +132,7 @@ importers:
         version: 6.2.2(reflect-metadata@0.2.2)
       mongodb:
         specifier: ^5.7.0
-        version: 5.9.2
+        version: 5.9.2(@aws-sdk/credential-providers@3.1054.0)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -181,7 +181,7 @@ importers:
         version: link:../../../packages/node/logger
       '@types/mongodb':
         specifier: ^4.0.7
-        version: 4.0.7(socks@2.8.7)
+        version: 4.0.7(@aws-sdk/credential-providers@3.1054.0)(socks@2.8.7)
       express:
         specifier: ^4.18.2
         version: 4.22.1
@@ -196,7 +196,7 @@ importers:
         version: 6.2.2(reflect-metadata@0.2.2)
       mongodb:
         specifier: ^5.7.0
-        version: 5.9.2
+        version: 5.9.2(@aws-sdk/credential-providers@3.1054.0)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -309,7 +309,7 @@ importers:
         version: 11.8.0(typescript@5.9.3)
       '@types/mongodb':
         specifier: ^4.0.7
-        version: 4.0.7(socks@2.8.7)
+        version: 4.0.7(@aws-sdk/credential-providers@3.1054.0)(socks@2.8.7)
       express:
         specifier: ^4.18.2
         version: 4.22.1
@@ -321,7 +321,7 @@ importers:
         version: 6.2.2(reflect-metadata@0.2.2)
       mongodb:
         specifier: ^5.7.0
-        version: 5.9.2
+        version: 5.9.2(@aws-sdk/credential-providers@3.1054.0)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -481,7 +481,7 @@ importers:
         version: 4.22.1
       mongodb:
         specifier: ^6.0.0
-        version: 6.21.0(socks@2.8.7)
+        version: 6.21.0(@aws-sdk/credential-providers@3.1054.0)(socks@2.8.7)
       mysql2:
         specifier: ^3.0.0
         version: 3.20.0(@types/node@25.9.1)
@@ -858,10 +858,10 @@ importers:
         version: 6.2.2(reflect-metadata@0.2.2)
       mongodb:
         specifier: ^6.12.0
-        version: 6.21.0(socks@2.8.7)
+        version: 6.21.0(@aws-sdk/credential-providers@3.1054.0)(socks@2.8.7)
       mongodb-memory-server:
         specifier: ^10.1.4
-        version: 10.4.2(socks@2.8.7)
+        version: 10.4.2(@aws-sdk/credential-providers@3.1054.0)(socks@2.8.7)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -1080,7 +1080,7 @@ importers:
         version: 6.2.2(reflect-metadata@0.2.2)
       mongodb:
         specifier: ^6.0.0
-        version: 6.21.0(socks@2.8.7)
+        version: 6.21.0(@aws-sdk/credential-providers@3.1054.0)(socks@2.8.7)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -1253,6 +1253,9 @@ importers:
       '@aws-sdk/client-ssm':
         specifier: ^3.968.0
         version: 3.1040.0
+      '@aws-sdk/rds-signer':
+        specifier: ^3.968.0
+        version: 3.1054.0
       inversify:
         specifier: ^6.2.2
         version: 6.2.2(reflect-metadata@0.2.2)
@@ -1653,6 +1656,10 @@ packages:
     resolution: {integrity: sha512-KRac+gkuj3u49IyWkrudHRlP/q/faTto+1xRS7Aj6cDGewMIzgdQArrdZEJoVntbaVZHLM5s/NVmWORzBWNcSw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-cognito-identity@3.1054.0':
+    resolution: {integrity: sha512-B3R1BnF9MtyAyIhI875geixK4SJ1dXwWjf8McBMyMkctaXdvGx5O4YD7MPxGPtbmExrW4tDp6h4wQbDJDLZumw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-s3@3.1014.0':
     resolution: {integrity: sha512-0XLrOT4Cm3NEhhiME7l/8LbTXS4KdsbR4dSrY207KNKTcHLLTZ9EXt4ZpgnTfLvWQF3pGP2us4Zi1fYLo0N+Ow==}
     engines: {node: '>=20.0.0'}
@@ -1677,6 +1684,10 @@ packages:
     resolution: {integrity: sha512-u4lIpvGqMMHZN523/RxW70xNoVXHBXucIWZsxFKc373E6TWYEb16ddFhXTELioS5TU93qkd/6yDQZzI6AAhbkw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/core@3.974.14':
+    resolution: {integrity: sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/core@3.974.5':
     resolution: {integrity: sha512-lMPlYlYfQdNZhlkJgnkmESwrY+hNh3PljmZ+37oAqLNdJ6rnILAwFSyc6B3bJeDOtMORNnMQIej0aTRuOlDyhQ==}
     engines: {node: '>=20.0.0'}
@@ -1687,6 +1698,10 @@ packages:
 
   '@aws-sdk/crc64-nvme@3.972.7':
     resolution: {integrity: sha512-QUagVVBbC8gODCF6e1aV0mE2TXWB9Opz4k8EJFdNrujUVQm5R4AjJa1mpOqzwOuROBzqJU9zawzig7M96L8Ejg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-cognito-identity@3.972.37':
+    resolution: {integrity: sha512-f8ZRPoATqSVS1LW19KwiWn2/BSTdylXPznAjDI2r7d3+RT880/yRT9uBQhPE+Ba986LiMRvg1AhmFYDwNLk/0A==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-env@3.968.0':
@@ -1701,6 +1716,10 @@ packages:
     resolution: {integrity: sha512-bJV7eViSJV6GSuuN+VIdNVPdwPsNSf75BiC2v5alPrjR/OCcqgKwSZInKbDFz9mNeizldsyf67jt6YSIiv53Cw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-env@3.972.40':
+    resolution: {integrity: sha512-jjT0p0Y7KZtcvExYiPCLJnqM9lkXDV1KBEg/13OE2DXv/9batzlyJHVKUEnRNJccY0O2Sul17E1su38CgdBhGQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-http@3.968.0':
     resolution: {integrity: sha512-79teHBx/EtsNRR3Bq8fQdmMHtUcYwvohm9EwXXFt2Jd3BEOBH872IjIlfKdAvdkM+jW1QeeWOZBAxXGPir7GcQ==}
     engines: {node: '>=20.0.0'}
@@ -1711,6 +1730,10 @@ packages:
 
   '@aws-sdk/credential-provider-http@3.972.35':
     resolution: {integrity: sha512-x/BQGEIdq0oI+4WxLjKmnQvT7CnF9r8ezdGt7wXwxb7ckHXQz0Zmgxt8v3Ne0JaT3R5YefmuybHX6E8EnsDXyA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.42':
+    resolution: {integrity: sha512-+3fsKtWybe5BjKEUA3/07oh7Ayfd82IED2+gyyaVfS/4PU78E3TaOQxSGOJ1t7Imefoidw/ne9QA7apX8wEnJg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.968.0':
@@ -1725,16 +1748,20 @@ packages:
     resolution: {integrity: sha512-eUTpmWfd/BKsq9medhCRcu+GRAhFP2Zrn7/2jKDHHOOjCkhrMoTp/t4cEthqFoG7gE0VGp5wUxrXTdvBCmSmJg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-ini@3.972.44':
+    resolution: {integrity: sha512-gZFw5wBefCIPg9vpT+gV5FdhfNKhYTVDZa1IsZCcn3SRoYUOJ/E05vwIogkJoonqBL0ttBGi5vhthX7xceekRg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-login@3.968.0':
     resolution: {integrity: sha512-YxBaR0IMuHPOVTG+73Ve0QfllweN+EdwBRnHFhUGnahMGAcTmcaRdotqwqWfiws+9ud44IFKjxXR3t8jaGpFnQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-login@3.972.35':
-    resolution: {integrity: sha512-5oa3j0cA50jPqgNhZ9XdJVopuzUf1klRb28/2MfLYWWiPi9DRVvbrBWT+DidbHTT36520VuXZJahQwR+YgSjrg==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-login@3.972.37':
     resolution: {integrity: sha512-Ty68y8ISSC+g5Q3D0K8uAaoINwvfaOslnNpsF/LgVUxyosYXHawcK2yV4HLXDVugiTTYLQfJfcw0ce5meAGkKw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.44':
+    resolution: {integrity: sha512-QqEGHfQeZgUDqh7zpqHufrZ8T644ELEWvB+4gUdewLyRw4IRF+6CJqeQuRWqucZdQzoQeMh7fNAD9BWxFAdNig==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.968.0':
@@ -1749,6 +1776,10 @@ packages:
     resolution: {integrity: sha512-BQ9XYnBDVxR2HuV5huXYQYF/PZMTsY+EnwfGnCU2cA8Zw63XpkOtPY8WqiMIZMQCrKPQQEiFURS/o9CIolRLqg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-node@3.972.45':
+    resolution: {integrity: sha512-3YCv52ExXIRz3LAVNysevd+s7akSpg9dl39v9LJ7dOQH+s5rHi3jMZYQyxwMmglxQGMuzYRfQ0o1VSP2UOlIRw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-process@3.968.0':
     resolution: {integrity: sha512-my9M/ijRyEACoyeEWiC2sTVM3+eck5IWPGTPQrlYMKivy4LLlZchohtIopuqTom+JZzLZD508j1s9aDvl7BA0w==}
     engines: {node: '>=20.0.0'}
@@ -1759,6 +1790,10 @@ packages:
 
   '@aws-sdk/credential-provider-process@3.972.33':
     resolution: {integrity: sha512-yfjGksI9WQbdMObb0VeLXqzTLI+a0qXLJT9gCDiv0+X/xjPpI3mTz6a5FibrhpuEKIe0gSgvs3MaoFZy5cx4WA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.40':
+    resolution: {integrity: sha512-cXaozlgJCOwmE6D7x4npcPdyk7kiFZdrGjN3D6tXXtItJJMNGPafDfAJn4YQmciMooG/X+b0Y6RTqdVVMx26jg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.968.0':
@@ -1773,6 +1808,10 @@ packages:
     resolution: {integrity: sha512-fpwE+20ntpp3i9Xb9vUuQfXLDKYHH+5I2V+ZG96SX1nBzrruhy10RXDgmN7t1etOz3c55stlA3TeQASUA451NQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.972.44':
+    resolution: {integrity: sha512-YePoj5kQuPmE0MHnyftXCfsO8ZSBd2kDr50XEIUrdejSbGFlayYvUuCohdb8drhGhPm6b65o7H1eC26EZhwUvA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.968.0':
     resolution: {integrity: sha512-9HNAP6mx2jsBW4moWnRg5ycyZ0C1EbtMIegIHa93ga13B/8VZF9Y0iDnwW73yQYzCEt9UrDiFeRck/ChZup3rA==}
     engines: {node: '>=20.0.0'}
@@ -1783,6 +1822,14 @@ packages:
 
   '@aws-sdk/credential-provider-web-identity@3.972.37':
     resolution: {integrity: sha512-aryawqyebf+3WhAFNHfF62rekFpYtVcVN7dQ89qnAWsa4n5hJst8qBG6gXC24WHtW7Nnhkf9ScYnjwo0Brn3bw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.44':
+    resolution: {integrity: sha512-Ys/JJe++8Z2Y5meR1taMBaVcrGBA0/XsVTQR+qOKZbdNyg+8Jlv5rYZSwh8SqEHY00goSOZy7PHzZ2rLNQxDLg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-providers@3.1054.0':
+    resolution: {integrity: sha512-/tK0QmOL1vUqOgqRMLTJlvHRAp+7GTfdPgrfgD5T0WBmExdlaFsVwzR7mUQlmYoY8mExqoRH4UEt2I3snsMLrg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-bucket-endpoint@3.972.10':
@@ -1853,12 +1900,16 @@ packages:
     resolution: {integrity: sha512-LLppm+8MzD3afD2IA/tYDp5AoVPOybK7MHQz5DVB4HsZ+fHvwYlvau2ZUK8nKwJSk5c1kWcxCZkyuJQjFu37ng==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/nested-clients@3.997.3':
-    resolution: {integrity: sha512-SivE6GP228IVgfsrr2c/vqTg95X0Qj39Yw4uIrcddpkUzIltNMoNOR62leHOLhODfjv9K8X2mPTwS69A5kT0nQ==}
+  '@aws-sdk/nested-clients@3.997.12':
+    resolution: {integrity: sha512-Js2VYaCM269feB0cs0cGmlIhdOgT9aMqzdBx68lCy6kVCYfzr0T36ovUFDvfUmatkuBeyBJhCwaLBh7P8meH5Q==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/nested-clients@3.997.5':
     resolution: {integrity: sha512-jGFr6DxtcMTmzOkG/a0jCZYv4BBDmeNYVeO+/memSoDkYCJu4Y58xviYmzwJfYyIVSts+X/BVjJm1uGBnwHEMg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/rds-signer@3.1054.0':
+    resolution: {integrity: sha512-ibadZVtLI0BaHhWJAh3YbYL0RC0BGE1UWjUbQU0Hd/1O/sARc/iLsNLGo3+UKEP426gx9wS4PAorH1dkRCR+aA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/region-config-resolver@3.968.0':
@@ -1877,12 +1928,20 @@ packages:
     resolution: {integrity: sha512-amP7tLikppN940wbBFISYqiuzVmpzMS9U3mcgtmVLjX4fdWI/SNCvrXv6ZxfVzTT4cT0rPKOLhFah2xLwzREWw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/signature-v4-multi-region@3.996.29':
+    resolution: {integrity: sha512-Few9FoQqOt/0KSvZYP+qdW0dfOhfQ9N+gl2UUDvCPW6mkPKHli9LMbKxWj+wZ5zKPaOoqxuR3Hhy3OTpndkfSw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/token-providers@3.1036.0':
     resolution: {integrity: sha512-aNSJ6jjDYayxN9ZA1JpycVScX93Lx03kKZ1EXt3DGOTahcWVLJj3oLAlop0xKP+vP2Ga2t49p1tEaMkTbCCaZA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1039.0':
     resolution: {integrity: sha512-NMSFL2HwkAOoCeLCQiqoOq5pT3vVbSjww2QZTuYgYknVwhhv125PSDzZIcL5EYnlxuPWjEOdauZK+FspkZDVdw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1054.0':
+    resolution: {integrity: sha512-hG9YKApmZOw+drJ9Nuoaf/OvC8e5W1+3eoLeN5p2uVCZRWsv27teIS0b4kiH6Sfv3WMmamqYJxmE2WMwyp/L/A==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.968.0':
@@ -1895,6 +1954,10 @@ packages:
 
   '@aws-sdk/types@3.973.8':
     resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.9':
+    resolution: {integrity: sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-arn-parser@3.972.3':
@@ -1956,6 +2019,10 @@ packages:
 
   '@aws-sdk/xml-builder@3.972.22':
     resolution: {integrity: sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.26':
+    resolution: {integrity: sha512-cDbrqvDS73whl6YAPSPq0U6whzG6UWI9PuWh0wrUuGoZexhWEqhdunbukV7iBoaWnFV1AODutM5hOD6rtn439g==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.3':
@@ -3682,12 +3749,20 @@ packages:
     resolution: {integrity: sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.24.4':
+    resolution: {integrity: sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.2.14':
     resolution: {integrity: sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/credential-provider-imds@4.2.8':
     resolution: {integrity: sha512-FNT0xHS1c/CPN8upqbMFP83+ul5YgdisfCfkZ86Jh2NSmnqw/AJ6x5pEogVCTVvSm7j9MopRU89bmDelxuDMYw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.3.4':
+    resolution: {integrity: sha512-vKW0MEFRU4Y3MkVZUkpJm+g9qyPGLCXhc0YLggUdSdBB4g7IaSSsCE75P9rBXyWHrXY1UYSQUl8/DwsTR7QciA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/eventstream-codec@4.2.14':
@@ -3716,6 +3791,10 @@ packages:
 
   '@smithy/fetch-http-handler@5.3.9':
     resolution: {integrity: sha512-I4UhmcTYXBrct03rwzQX1Y/iqQlzVQaPxWjCjula++5EmWq9YGBrx6bbGqluGc1f0XEfhSkiY4jhLgbsJUMKRA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.4.4':
+    resolution: {integrity: sha512-qM7AUKI4G6d7lNgaZD3lA1tWSolh5r6gcixfTZAPstVURfjIbvreVTPz+994M0yC3HbX4YYhDRgr31Xy3XwWOQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/hash-blob-browser@4.2.15':
@@ -3818,6 +3897,10 @@ packages:
     resolution: {integrity: sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/node-http-handler@4.7.4':
+    resolution: {integrity: sha512-HIeF+1vrDGzPkkv39Hj2vlHSXHY3p958jd/8ZnePIY6+ZOsQX8coyEUKO5yQu4r0bQIVsbpotVIrXXwyycMStQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/property-provider@4.2.14':
     resolution: {integrity: sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==}
     engines: {node: '>=18.0.0'}
@@ -3874,6 +3957,10 @@ packages:
     resolution: {integrity: sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/signature-v4@5.4.4':
+    resolution: {integrity: sha512-e5UtkMvsatzBfbeBZjEOt0k0Z3BEsjTFL/n6fdO5vtBLe67tdy0dX7xw2DU7uZ3acwoHyeCqpU2Fzb7pxwHb6Q==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/smithy-client@4.10.7':
     resolution: {integrity: sha512-Uznt0I9z3os3Z+8pbXrOSCTXCA6vrjyN7Ub+8l2pRDum44vLv8qw0qGVkJN0/tZBZotaEFHrDPKUoPNueTr5Vg==}
     engines: {node: '>=18.0.0'}
@@ -3888,6 +3975,10 @@ packages:
 
   '@smithy/types@4.14.1':
     resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.2':
+    resolution: {integrity: sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/url-parser@4.2.14':
@@ -5862,6 +5953,9 @@ packages:
   fast-xml-builder@1.1.5:
     resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
 
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
   fast-xml-parser@5.2.5:
     resolution: {integrity: sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==}
     hasBin: true
@@ -5872,6 +5966,10 @@ packages:
 
   fast-xml-parser@5.7.2:
     resolution: {integrity: sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==}
+    hasBin: true
+
+  fast-xml-parser@5.7.3:
+    resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
     hasBin: true
 
   fastest-levenshtein@1.0.16:
@@ -8927,6 +9025,10 @@ packages:
       utf-8-validate:
         optional: true
 
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -9216,6 +9318,19 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/client-cognito-identity@3.1054.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/credential-provider-node': 3.972.45
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/fetch-http-handler': 5.4.4
+      '@smithy/node-http-handler': 4.7.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/client-s3@3.1014.0':
     dependencies:
       '@aws-crypto/sha1-browser': 5.2.0
@@ -9468,6 +9583,17 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.974.14':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/xml-builder': 3.972.26
+      '@aws/lambda-invoke-store': 0.2.3
+      '@smithy/core': 3.24.4
+      '@smithy/signature-v4': 5.4.4
+      '@smithy/types': 4.14.2
+      bowser: 2.13.1
+      tslib: 2.8.1
+
   '@aws-sdk/core@3.974.5':
     dependencies:
       '@aws-sdk/types': 3.973.8
@@ -9507,6 +9633,14 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-cognito-identity@3.972.37':
+    dependencies:
+      '@aws-sdk/nested-clients': 3.997.12
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-env@3.968.0':
     dependencies:
       '@aws-sdk/core': 3.968.0
@@ -9517,7 +9651,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-env@3.972.31':
     dependencies:
-      '@aws-sdk/core': 3.974.5
+      '@aws-sdk/core': 3.974.7
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/types': 4.14.1
@@ -9529,6 +9663,14 @@ snapshots:
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.40':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-http@3.968.0':
@@ -9546,7 +9688,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-http@3.972.33':
     dependencies:
-      '@aws-sdk/core': 3.974.5
+      '@aws-sdk/core': 3.974.7
       '@aws-sdk/types': 3.973.8
       '@smithy/fetch-http-handler': 5.3.17
       '@smithy/node-http-handler': 4.6.1
@@ -9570,6 +9712,16 @@ snapshots:
       '@smithy/util-stream': 4.5.25
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-http@3.972.42':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/fetch-http-handler': 5.4.4
+      '@smithy/node-http-handler': 4.7.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-ini@3.968.0':
     dependencies:
       '@aws-sdk/core': 3.968.0
@@ -9591,14 +9743,14 @@ snapshots:
 
   '@aws-sdk/credential-provider-ini@3.972.35':
     dependencies:
-      '@aws-sdk/core': 3.974.5
-      '@aws-sdk/credential-provider-env': 3.972.31
-      '@aws-sdk/credential-provider-http': 3.972.33
-      '@aws-sdk/credential-provider-login': 3.972.35
-      '@aws-sdk/credential-provider-process': 3.972.31
-      '@aws-sdk/credential-provider-sso': 3.972.35
-      '@aws-sdk/credential-provider-web-identity': 3.972.35
-      '@aws-sdk/nested-clients': 3.997.3
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/credential-provider-env': 3.972.33
+      '@aws-sdk/credential-provider-http': 3.972.35
+      '@aws-sdk/credential-provider-login': 3.972.37
+      '@aws-sdk/credential-provider-process': 3.972.33
+      '@aws-sdk/credential-provider-sso': 3.972.37
+      '@aws-sdk/credential-provider-web-identity': 3.972.37
+      '@aws-sdk/nested-clients': 3.997.5
       '@aws-sdk/types': 3.973.8
       '@smithy/credential-provider-imds': 4.2.14
       '@smithy/property-provider': 4.2.14
@@ -9627,24 +9779,27 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-ini@3.972.44':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/credential-provider-env': 3.972.40
+      '@aws-sdk/credential-provider-http': 3.972.42
+      '@aws-sdk/credential-provider-login': 3.972.44
+      '@aws-sdk/credential-provider-process': 3.972.40
+      '@aws-sdk/credential-provider-sso': 3.972.44
+      '@aws-sdk/credential-provider-web-identity': 3.972.44
+      '@aws-sdk/nested-clients': 3.997.12
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/credential-provider-imds': 4.3.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.968.0':
     dependencies:
       '@aws-sdk/core': 3.968.0
       '@aws-sdk/nested-clients': 3.968.0
       '@aws-sdk/types': 3.968.0
-      '@smithy/property-provider': 4.2.14
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/credential-provider-login@3.972.35':
-    dependencies:
-      '@aws-sdk/core': 3.974.5
-      '@aws-sdk/nested-clients': 3.997.3
-      '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/protocol-http': 5.3.14
       '@smithy/shared-ini-file-loader': 4.4.9
@@ -9665,6 +9820,15 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.44':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/nested-clients': 3.997.12
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
 
   '@aws-sdk/credential-provider-node@3.968.0':
     dependencies:
@@ -9717,6 +9881,20 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-node@3.972.45':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.40
+      '@aws-sdk/credential-provider-http': 3.972.42
+      '@aws-sdk/credential-provider-ini': 3.972.44
+      '@aws-sdk/credential-provider-process': 3.972.40
+      '@aws-sdk/credential-provider-sso': 3.972.44
+      '@aws-sdk/credential-provider-web-identity': 3.972.44
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/credential-provider-imds': 4.3.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.968.0':
     dependencies:
       '@aws-sdk/core': 3.968.0
@@ -9728,7 +9906,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-process@3.972.31':
     dependencies:
-      '@aws-sdk/core': 3.974.5
+      '@aws-sdk/core': 3.974.7
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
@@ -9742,6 +9920,14 @@ snapshots:
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
       '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.40':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-sso@3.968.0':
@@ -9759,8 +9945,8 @@ snapshots:
 
   '@aws-sdk/credential-provider-sso@3.972.35':
     dependencies:
-      '@aws-sdk/core': 3.974.5
-      '@aws-sdk/nested-clients': 3.997.3
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/nested-clients': 3.997.5
       '@aws-sdk/token-providers': 3.1036.0
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
@@ -9783,6 +9969,16 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-sso@3.972.44':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/nested-clients': 3.997.12
+      '@aws-sdk/token-providers': 3.1054.0
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.968.0':
     dependencies:
       '@aws-sdk/core': 3.968.0
@@ -9797,8 +9993,8 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.972.35':
     dependencies:
-      '@aws-sdk/core': 3.974.5
-      '@aws-sdk/nested-clients': 3.997.3
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/nested-clients': 3.997.5
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
@@ -9818,6 +10014,35 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.44':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/nested-clients': 3.997.12
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-providers@3.1054.0':
+    dependencies:
+      '@aws-sdk/client-cognito-identity': 3.1054.0
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/credential-provider-cognito-identity': 3.972.37
+      '@aws-sdk/credential-provider-env': 3.972.40
+      '@aws-sdk/credential-provider-http': 3.972.42
+      '@aws-sdk/credential-provider-ini': 3.972.44
+      '@aws-sdk/credential-provider-login': 3.972.44
+      '@aws-sdk/credential-provider-node': 3.972.45
+      '@aws-sdk/credential-provider-process': 3.972.40
+      '@aws-sdk/credential-provider-sso': 3.972.44
+      '@aws-sdk/credential-provider-web-identity': 3.972.44
+      '@aws-sdk/nested-clients': 3.997.12
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/credential-provider-imds': 4.3.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
 
   '@aws-sdk/middleware-bucket-endpoint@3.972.10':
     dependencies:
@@ -9841,7 +10066,7 @@ snapshots:
       '@aws-crypto/crc32': 5.2.0
       '@aws-crypto/crc32c': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/core': 3.974.5
+      '@aws-sdk/core': 3.974.7
       '@aws-sdk/crc64-nvme': 3.972.7
       '@aws-sdk/types': 3.973.8
       '@smithy/is-array-buffer': 4.2.2
@@ -9903,7 +10128,7 @@ snapshots:
 
   '@aws-sdk/middleware-sdk-s3@3.972.34':
     dependencies:
-      '@aws-sdk/core': 3.974.5
+      '@aws-sdk/core': 3.974.7
       '@aws-sdk/types': 3.973.8
       '@aws-sdk/util-arn-parser': 3.972.3
       '@smithy/core': 3.23.17
@@ -9953,7 +10178,7 @@ snapshots:
 
   '@aws-sdk/middleware-user-agent@3.972.35':
     dependencies:
-      '@aws-sdk/core': 3.974.5
+      '@aws-sdk/core': 3.974.7
       '@aws-sdk/types': 3.973.8
       '@aws-sdk/util-endpoints': 3.996.8
       '@smithy/core': 3.23.17
@@ -10016,49 +10241,18 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/nested-clients@3.997.3':
+  '@aws-sdk/nested-clients@3.997.12':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.5
-      '@aws-sdk/middleware-host-header': 3.972.10
-      '@aws-sdk/middleware-logger': 3.972.10
-      '@aws-sdk/middleware-recursion-detection': 3.972.11
-      '@aws-sdk/middleware-user-agent': 3.972.35
-      '@aws-sdk/region-config-resolver': 3.972.13
-      '@aws-sdk/signature-v4-multi-region': 3.996.22
-      '@aws-sdk/types': 3.973.8
-      '@aws-sdk/util-endpoints': 3.996.8
-      '@aws-sdk/util-user-agent-browser': 3.972.10
-      '@aws-sdk/util-user-agent-node': 3.973.21
-      '@smithy/config-resolver': 4.4.17
-      '@smithy/core': 3.23.17
-      '@smithy/fetch-http-handler': 5.3.17
-      '@smithy/hash-node': 4.2.14
-      '@smithy/invalid-dependency': 4.2.14
-      '@smithy/middleware-content-length': 4.2.14
-      '@smithy/middleware-endpoint': 4.4.32
-      '@smithy/middleware-retry': 4.5.5
-      '@smithy/middleware-serde': 4.2.20
-      '@smithy/middleware-stack': 4.2.14
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/node-http-handler': 4.6.1
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/smithy-client': 4.12.13
-      '@smithy/types': 4.14.1
-      '@smithy/url-parser': 4.2.14
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-body-length-browser': 4.2.2
-      '@smithy/util-body-length-node': 4.2.3
-      '@smithy/util-defaults-mode-browser': 4.3.49
-      '@smithy/util-defaults-mode-node': 4.2.54
-      '@smithy/util-endpoints': 3.4.2
-      '@smithy/util-middleware': 4.2.14
-      '@smithy/util-retry': 4.3.4
-      '@smithy/util-utf8': 4.2.2
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/signature-v4-multi-region': 3.996.29
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/fetch-http-handler': 5.4.4
+      '@smithy/node-http-handler': 4.7.4
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
 
   '@aws-sdk/nested-clients@3.997.5':
     dependencies:
@@ -10104,6 +10298,17 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/rds-signer@3.1054.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/credential-providers': 3.1054.0
+      '@smithy/core': 3.24.4
+      '@smithy/signature-v4': 5.4.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/region-config-resolver@3.968.0':
     dependencies:
       '@aws-sdk/types': 3.968.0
@@ -10138,10 +10343,17 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/signature-v4-multi-region@3.996.29':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@smithy/signature-v4': 5.4.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/token-providers@3.1036.0':
     dependencies:
-      '@aws-sdk/core': 3.974.5
-      '@aws-sdk/nested-clients': 3.997.3
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/nested-clients': 3.997.5
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
@@ -10161,6 +10373,15 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+
+  '@aws-sdk/token-providers@3.1054.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/nested-clients': 3.997.12
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.968.0':
     dependencies:
@@ -10182,6 +10403,11 @@ snapshots:
   '@aws-sdk/types@3.973.8':
     dependencies:
       '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.9':
+    dependencies:
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@aws-sdk/util-arn-parser@3.972.3':
@@ -10265,6 +10491,12 @@ snapshots:
       '@nodable/entities': 2.1.0
       '@smithy/types': 4.14.1
       fast-xml-parser: 5.7.2
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.26':
+    dependencies:
+      '@smithy/types': 4.14.2
+      fast-xml-parser: 5.7.3
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.3': {}
@@ -12276,6 +12508,12 @@ snapshots:
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
+  '@smithy/core@3.24.4':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.2.14':
     dependencies:
       '@smithy/node-config-provider': 4.3.14
@@ -12290,6 +12528,12 @@ snapshots:
       '@smithy/property-provider': 4.2.14
       '@smithy/types': 4.14.1
       '@smithy/url-parser': 4.2.14
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.3.4':
+    dependencies:
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@smithy/eventstream-codec@4.2.14':
@@ -12336,6 +12580,12 @@ snapshots:
       '@smithy/querystring-builder': 4.2.8
       '@smithy/types': 4.14.1
       '@smithy/util-base64': 4.3.2
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.4.4':
+    dependencies:
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@smithy/hash-blob-browser@4.2.15':
@@ -12517,6 +12767,12 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@smithy/node-http-handler@4.7.4':
+    dependencies:
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@smithy/property-provider@4.2.14':
     dependencies:
       '@smithy/types': 4.14.1
@@ -12592,6 +12848,12 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
+  '@smithy/signature-v4@5.4.4':
+    dependencies:
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@smithy/smithy-client@4.10.7':
     dependencies:
       '@smithy/core': 3.23.17
@@ -12617,6 +12879,10 @@ snapshots:
       tslib: 2.8.1
 
   '@smithy/types@4.14.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.2':
     dependencies:
       tslib: 2.8.1
 
@@ -13087,9 +13353,9 @@ snapshots:
     dependencies:
       minimatch: 10.2.5
 
-  '@types/mongodb@4.0.7(socks@2.8.7)':
+  '@types/mongodb@4.0.7(@aws-sdk/credential-providers@3.1054.0)(socks@2.8.7)':
     dependencies:
-      mongodb: 6.21.0(socks@2.8.7)
+      mongodb: 6.21.0(@aws-sdk/credential-providers@3.1054.0)(socks@2.8.7)
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
       - '@mongodb-js/zstd'
@@ -14807,7 +15073,7 @@ snapshots:
       '@typescript-eslint/parser': 8.50.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
@@ -14831,7 +15097,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
@@ -14846,21 +15112,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 8.57.1
-      get-tsconfig: 4.13.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.15
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
@@ -14872,14 +15123,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.50.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -14923,7 +15174,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -15312,6 +15563,11 @@ snapshots:
     dependencies:
       path-expression-matcher: 1.5.0
 
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
   fast-xml-parser@5.2.5:
     dependencies:
       strnum: 2.2.3
@@ -15327,6 +15583,13 @@ snapshots:
     dependencies:
       '@nodable/entities': 2.1.0
       fast-xml-builder: 1.1.5
+      path-expression-matcher: 1.5.0
+      strnum: 2.2.3
+
+  fast-xml-parser@5.7.3:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.2.0
       path-expression-matcher: 1.5.0
       strnum: 2.2.3
 
@@ -16563,7 +16826,7 @@ snapshots:
       '@types/whatwg-url': 11.0.5
       whatwg-url: 14.2.0
 
-  mongodb-memory-server-core@10.4.2(socks@2.8.7):
+  mongodb-memory-server-core@10.4.2(@aws-sdk/credential-providers@3.1054.0)(socks@2.8.7):
     dependencies:
       async-mutex: 0.5.0
       camelcase: 6.3.0
@@ -16571,7 +16834,7 @@ snapshots:
       find-cache-dir: 3.3.2
       follow-redirects: 1.15.11(debug@4.4.3)
       https-proxy-agent: 7.0.6
-      mongodb: 6.21.0(socks@2.8.7)
+      mongodb: 6.21.0(@aws-sdk/credential-providers@3.1054.0)(socks@2.8.7)
       new-find-package-json: 2.0.0
       semver: 7.7.3
       tar-stream: 3.1.7
@@ -16589,9 +16852,9 @@ snapshots:
       - socks
       - supports-color
 
-  mongodb-memory-server@10.4.2(socks@2.8.7):
+  mongodb-memory-server@10.4.2(@aws-sdk/credential-providers@3.1054.0)(socks@2.8.7):
     dependencies:
-      mongodb-memory-server-core: 10.4.2(socks@2.8.7)
+      mongodb-memory-server-core: 10.4.2(@aws-sdk/credential-providers@3.1054.0)(socks@2.8.7)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
@@ -16605,20 +16868,22 @@ snapshots:
       - socks
       - supports-color
 
-  mongodb@5.9.2:
+  mongodb@5.9.2(@aws-sdk/credential-providers@3.1054.0):
     dependencies:
       bson: 5.5.1
       mongodb-connection-string-url: 2.6.0
       socks: 2.8.7
     optionalDependencies:
+      '@aws-sdk/credential-providers': 3.1054.0
       '@mongodb-js/saslprep': 1.4.4
 
-  mongodb@6.21.0(socks@2.8.7):
+  mongodb@6.21.0(@aws-sdk/credential-providers@3.1054.0)(socks@2.8.7):
     dependencies:
       '@mongodb-js/saslprep': 1.4.4
       bson: 6.10.4
       mongodb-connection-string-url: 3.0.2
     optionalDependencies:
+      '@aws-sdk/credential-providers': 3.1054.0
       socks: 2.8.7
 
   ms@2.0.0: {}
@@ -18911,6 +19176,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.18.3: {}
+
+  xml-naming@0.1.0: {}
 
   xtend@4.0.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@25.6.0)
+        version: 1.6.1(@types/node@25.9.1)
 
   apps/node/gql-api:
     dependencies:
@@ -484,7 +484,7 @@ importers:
         version: 6.21.0(socks@2.8.7)
       mysql2:
         specifier: ^3.0.0
-        version: 3.20.0(@types/node@25.6.0)
+        version: 3.20.0(@types/node@25.9.1)
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -497,7 +497,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.6.1
-        version: 1.6.1(@types/node@25.6.0)
+        version: 1.6.1(@types/node@25.9.1)
 
   packages/core/config:
     dependencies:
@@ -729,13 +729,13 @@ importers:
         version: 14.5.0
       '@types/node':
         specifier: latest
-        version: 25.6.0
+        version: 25.9.1
       '@types/supertest':
         specifier: ^6.0.3
         version: 6.0.3
       '@vitest/coverage-v8':
         specifier: ^1.5.0
-        version: 1.6.1(vitest@1.6.1(@types/node@25.6.0))
+        version: 1.6.1(vitest@1.6.1(@types/node@25.9.1))
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -747,7 +747,7 @@ importers:
         version: 7.16.0
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@25.6.0)
+        version: 1.6.1(@types/node@25.9.1)
 
   packages/node/api-util:
     dependencies:
@@ -763,7 +763,7 @@ importers:
         version: link:../../core/typescript-config
       '@types/node':
         specifier: latest
-        version: 25.6.0
+        version: 25.9.1
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -800,7 +800,7 @@ importers:
         version: link:../../core/typescript-config
       '@types/node':
         specifier: latest
-        version: 25.6.0
+        version: 25.9.1
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -1111,7 +1111,7 @@ importers:
         version: 5.0.6
       '@types/node':
         specifier: latest
-        version: 25.6.0
+        version: 25.9.1
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -1120,7 +1120,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@25.6.0)
+        version: 1.6.1(@types/node@25.9.1)
 
   packages/node/logger:
     dependencies:
@@ -1148,7 +1148,7 @@ importers:
         version: link:../../core/typescript-config
       '@types/node':
         specifier: latest
-        version: 25.6.0
+        version: 25.9.1
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -1176,13 +1176,13 @@ importers:
         version: link:../../core/typescript-config
       '@types/node':
         specifier: latest
-        version: 25.6.0
+        version: 25.9.1
       '@types/uuid':
         specifier: ^10.0.0
         version: 10.0.0
       oclif:
         specifier: ^4.22.93
-        version: 4.23.0(@types/node@25.6.0)
+        version: 4.23.0(@types/node@25.9.1)
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
@@ -1243,6 +1243,49 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^1.6.1
+        version: 1.6.1(@types/node@24.0.12)
+
+  packages/node/postgres:
+    dependencies:
+      '@aws-sdk/client-secrets-manager':
+        specifier: ^3.968.0
+        version: 3.968.0
+      '@aws-sdk/client-ssm':
+        specifier: ^3.968.0
+        version: 3.1040.0
+      inversify:
+        specifier: ^6.2.2
+        version: 6.2.2(reflect-metadata@0.2.2)
+      pg:
+        specifier: ^8.13.1
+        version: 8.20.0
+      reflect-metadata:
+        specifier: ^0.2.2
+        version: 0.2.2
+      zod:
+        specifier: 3.25.67
+        version: 3.25.67
+    devDependencies:
+      '@saga-ed/soa-typescript-config':
+        specifier: workspace:*
+        version: link:../../core/typescript-config
+      '@types/node':
+        specifier: ^24.0.3
+        version: 24.0.12
+      '@types/pg':
+        specifier: ^8.11.10
+        version: 8.20.0
+      aws-sdk-client-mock:
+        specifier: ^4.1.0
+        version: 4.1.0
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      vitest:
+        specifier: ^1.5.0
         version: 1.6.1(@types/node@24.0.12)
 
   packages/node/pubsub-client:
@@ -1320,7 +1363,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@25.6.0)
+        version: 1.6.1(@types/node@25.9.1)
 
   packages/node/pubsub-server:
     dependencies:
@@ -1354,7 +1397,7 @@ importers:
         version: link:../../core/typescript-config
       '@types/node':
         specifier: latest
-        version: 25.6.0
+        version: 25.9.1
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -1363,7 +1406,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@25.6.0)
+        version: 1.6.1(@types/node@25.9.1)
 
   packages/node/rabbitmq:
     dependencies:
@@ -1401,6 +1444,12 @@ importers:
 
   packages/node/redis-core:
     dependencies:
+      '@aws-sdk/client-secrets-manager':
+        specifier: ^3.968.0
+        version: 3.968.0
+      '@aws-sdk/client-ssm':
+        specifier: ^3.968.0
+        version: 3.1040.0
       '@saga-ed/soa-api-util':
         specifier: workspace:*
         version: link:../api-util
@@ -1417,9 +1466,15 @@ importers:
       '@saga-ed/soa-typescript-config':
         specifier: workspace:*
         version: link:../../core/typescript-config
+      aws-sdk-client-mock:
+        specifier: ^4.1.0
+        version: 4.1.0
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      vitest:
+        specifier: ^1.5.0
+        version: 1.6.1(@types/node@25.9.1)
 
   packages/node/test-util:
     dependencies:
@@ -3938,6 +3993,7 @@ packages:
   '@smithy/util-retry@4.3.6':
     resolution: {integrity: sha512-p6/FO1n2KxMeQyna067i0uJ6TSbb165ZhnRtCpWh4Foxqbfc6oW+XITaL8QkFJj3KFnDe2URt4gOhgU06EP9ew==}
     engines: {node: '>=18.0.0'}
+    deprecated: '@smithy/util-retry v4.3.6 contains a bug in Adaptive Retry, see https://github.com/smithy-lang/smithy-typescript/issues/1993. Upgrade to 4.3.7+'
 
   '@smithy/util-stream@4.5.10':
     resolution: {integrity: sha512-jbqemy51UFSZSp2y0ZmRfckmrzuKww95zT9BYMmuJ8v3altGcqjwoV1tzpOwuHaKrwQrCjIzOib499ymr2f98g==}
@@ -4216,8 +4272,8 @@ packages:
   '@types/node@24.0.12':
     resolution: {integrity: sha512-LtOrbvDf5ndC9Xi+4QZjVL0woFymF/xSTKZKPgrrl7H7XoeDvnD+E2IclKVDyaK9UM756W/3BXqSU+JEHopA9g==}
 
-  '@types/node@25.6.0':
-    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+  '@types/node@25.9.1':
+    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
 
   '@types/pg@8.20.0':
     resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
@@ -4366,6 +4422,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -4816,7 +4873,7 @@ packages:
   basic-ftp@5.0.5:
     resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
     engines: {node: '>=10.0.0'}
-    deprecated: Security vulnerability fixed in 5.2.0, please upgrade
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
@@ -8576,8 +8633,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici-types@7.19.2:
-    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
   undici-types@7.8.0:
     resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
@@ -8657,6 +8714,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -11376,40 +11434,40 @@ snapshots:
 
   '@inquirer/ansi@1.0.2': {}
 
-  '@inquirer/checkbox@4.3.2(@types/node@25.6.0)':
+  '@inquirer/checkbox@4.3.2(@types/node@25.9.1)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@25.6.0)
+      '@inquirer/core': 10.3.2(@types/node@25.9.1)
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@25.6.0)
+      '@inquirer/type': 3.0.10(@types/node@25.9.1)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.1
 
   '@inquirer/confirm@3.2.0':
     dependencies:
       '@inquirer/core': 9.2.1
       '@inquirer/type': 1.5.5
 
-  '@inquirer/confirm@5.1.21(@types/node@25.6.0)':
+  '@inquirer/confirm@5.1.21(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.6.0)
-      '@inquirer/type': 3.0.10(@types/node@25.6.0)
+      '@inquirer/core': 10.3.2(@types/node@25.9.1)
+      '@inquirer/type': 3.0.10(@types/node@25.9.1)
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.1
 
-  '@inquirer/core@10.3.2(@types/node@25.6.0)':
+  '@inquirer/core@10.3.2(@types/node@25.9.1)':
     dependencies:
       '@inquirer/ansi': 1.0.2
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@25.6.0)
+      '@inquirer/type': 3.0.10(@types/node@25.9.1)
       cli-width: 4.1.0
       mute-stream: 2.0.0
       signal-exit: 4.1.0
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.1
 
   '@inquirer/core@9.2.1':
     dependencies:
@@ -11426,21 +11484,21 @@ snapshots:
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.3
 
-  '@inquirer/editor@4.2.23(@types/node@25.6.0)':
+  '@inquirer/editor@4.2.23(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.6.0)
-      '@inquirer/external-editor': 1.0.3(@types/node@25.6.0)
-      '@inquirer/type': 3.0.10(@types/node@25.6.0)
+      '@inquirer/core': 10.3.2(@types/node@25.9.1)
+      '@inquirer/external-editor': 1.0.3(@types/node@25.9.1)
+      '@inquirer/type': 3.0.10(@types/node@25.9.1)
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.1
 
-  '@inquirer/expand@4.0.23(@types/node@25.6.0)':
+  '@inquirer/expand@4.0.23(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.6.0)
-      '@inquirer/type': 3.0.10(@types/node@25.6.0)
+      '@inquirer/core': 10.3.2(@types/node@25.9.1)
+      '@inquirer/type': 3.0.10(@types/node@25.9.1)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.1
 
   '@inquirer/external-editor@1.0.3(@types/node@22.19.3)':
     dependencies:
@@ -11456,12 +11514,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.0.12
 
-  '@inquirer/external-editor@1.0.3(@types/node@25.6.0)':
+  '@inquirer/external-editor@1.0.3(@types/node@25.9.1)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.1
 
   '@inquirer/figures@1.0.15': {}
 
@@ -11470,59 +11528,59 @@ snapshots:
       '@inquirer/core': 9.2.1
       '@inquirer/type': 1.5.5
 
-  '@inquirer/input@4.3.1(@types/node@25.6.0)':
+  '@inquirer/input@4.3.1(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.6.0)
-      '@inquirer/type': 3.0.10(@types/node@25.6.0)
+      '@inquirer/core': 10.3.2(@types/node@25.9.1)
+      '@inquirer/type': 3.0.10(@types/node@25.9.1)
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.1
 
-  '@inquirer/number@3.0.23(@types/node@25.6.0)':
+  '@inquirer/number@3.0.23(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.6.0)
-      '@inquirer/type': 3.0.10(@types/node@25.6.0)
+      '@inquirer/core': 10.3.2(@types/node@25.9.1)
+      '@inquirer/type': 3.0.10(@types/node@25.9.1)
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.1
 
-  '@inquirer/password@4.0.23(@types/node@25.6.0)':
+  '@inquirer/password@4.0.23(@types/node@25.9.1)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@25.6.0)
-      '@inquirer/type': 3.0.10(@types/node@25.6.0)
+      '@inquirer/core': 10.3.2(@types/node@25.9.1)
+      '@inquirer/type': 3.0.10(@types/node@25.9.1)
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.1
 
-  '@inquirer/prompts@7.10.1(@types/node@25.6.0)':
+  '@inquirer/prompts@7.10.1(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/checkbox': 4.3.2(@types/node@25.6.0)
-      '@inquirer/confirm': 5.1.21(@types/node@25.6.0)
-      '@inquirer/editor': 4.2.23(@types/node@25.6.0)
-      '@inquirer/expand': 4.0.23(@types/node@25.6.0)
-      '@inquirer/input': 4.3.1(@types/node@25.6.0)
-      '@inquirer/number': 3.0.23(@types/node@25.6.0)
-      '@inquirer/password': 4.0.23(@types/node@25.6.0)
-      '@inquirer/rawlist': 4.1.11(@types/node@25.6.0)
-      '@inquirer/search': 3.2.2(@types/node@25.6.0)
-      '@inquirer/select': 4.4.2(@types/node@25.6.0)
+      '@inquirer/checkbox': 4.3.2(@types/node@25.9.1)
+      '@inquirer/confirm': 5.1.21(@types/node@25.9.1)
+      '@inquirer/editor': 4.2.23(@types/node@25.9.1)
+      '@inquirer/expand': 4.0.23(@types/node@25.9.1)
+      '@inquirer/input': 4.3.1(@types/node@25.9.1)
+      '@inquirer/number': 3.0.23(@types/node@25.9.1)
+      '@inquirer/password': 4.0.23(@types/node@25.9.1)
+      '@inquirer/rawlist': 4.1.11(@types/node@25.9.1)
+      '@inquirer/search': 3.2.2(@types/node@25.9.1)
+      '@inquirer/select': 4.4.2(@types/node@25.9.1)
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.1
 
-  '@inquirer/rawlist@4.1.11(@types/node@25.6.0)':
+  '@inquirer/rawlist@4.1.11(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.6.0)
-      '@inquirer/type': 3.0.10(@types/node@25.6.0)
+      '@inquirer/core': 10.3.2(@types/node@25.9.1)
+      '@inquirer/type': 3.0.10(@types/node@25.9.1)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.1
 
-  '@inquirer/search@3.2.2(@types/node@25.6.0)':
+  '@inquirer/search@3.2.2(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.6.0)
+      '@inquirer/core': 10.3.2(@types/node@25.9.1)
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@25.6.0)
+      '@inquirer/type': 3.0.10(@types/node@25.9.1)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.1
 
   '@inquirer/select@2.5.0':
     dependencies:
@@ -11532,15 +11590,15 @@ snapshots:
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.3
 
-  '@inquirer/select@4.4.2(@types/node@25.6.0)':
+  '@inquirer/select@4.4.2(@types/node@25.9.1)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@25.6.0)
+      '@inquirer/core': 10.3.2(@types/node@25.9.1)
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@25.6.0)
+      '@inquirer/type': 3.0.10(@types/node@25.9.1)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.1
 
   '@inquirer/type@1.5.5':
     dependencies:
@@ -11550,9 +11608,9 @@ snapshots:
     dependencies:
       mute-stream: 1.0.0
 
-  '@inquirer/type@3.0.10(@types/node@25.6.0)':
+  '@inquirer/type@3.0.10(@types/node@25.9.1)':
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.1
 
   '@inversifyjs/common@1.4.0': {}
 
@@ -11728,9 +11786,9 @@ snapshots:
     dependencies:
       '@oclif/core': 4.10.5
 
-  '@oclif/plugin-not-found@3.2.80(@types/node@25.6.0)':
+  '@oclif/plugin-not-found@3.2.80(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/prompts': 7.10.1(@types/node@25.6.0)
+      '@inquirer/prompts': 7.10.1(@types/node@25.9.1)
       '@oclif/core': 4.10.5
       ansis: 3.17.0
       fast-levenshtein: 3.0.0
@@ -13062,9 +13120,9 @@ snapshots:
     dependencies:
       undici-types: 7.8.0
 
-  '@types/node@25.6.0':
+  '@types/node@25.9.1':
     dependencies:
-      undici-types: 7.19.2
+      undici-types: 7.24.6
 
   '@types/pg@8.20.0':
     dependencies:
@@ -13418,7 +13476,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@1.6.1(vitest@1.6.1(@types/node@25.6.0))':
+  '@vitest/coverage-v8@1.6.1(vitest@1.6.1(@types/node@25.9.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -13433,7 +13491,7 @@ snapshots:
       std-env: 3.10.0
       strip-literal: 2.1.1
       test-exclude: 6.0.0
-      vitest: 1.6.1(@types/node@25.6.0)
+      vitest: 1.6.1(@types/node@25.9.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -14729,8 +14787,8 @@ snapshots:
       '@typescript-eslint/parser': 8.50.0(eslint@8.57.1)(typescript@5.8.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -14749,7 +14807,7 @@ snapshots:
       '@typescript-eslint/parser': 8.50.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
@@ -14773,22 +14831,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 8.57.1
-      get-tsconfig: 4.13.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.15
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
@@ -14803,29 +14846,44 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 8.57.1
+      get-tsconfig: 4.13.0
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.15
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.50.0(eslint@8.57.1)(typescript@5.8.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.50.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -14836,7 +14894,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -14865,7 +14923,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -16584,9 +16642,9 @@ snapshots:
 
   mute-stream@2.0.0: {}
 
-  mysql2@3.20.0(@types/node@25.6.0):
+  mysql2@3.20.0(@types/node@25.9.1):
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.1
       aws-ssl-profiles: 1.1.2
       denque: 2.1.0
       generate-function: 2.3.1
@@ -16771,7 +16829,7 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
-  oclif@4.23.0(@types/node@25.6.0):
+  oclif@4.23.0(@types/node@25.9.1):
     dependencies:
       '@aws-sdk/client-cloudfront': 3.1009.0
       '@aws-sdk/client-s3': 3.1014.0
@@ -16780,7 +16838,7 @@ snapshots:
       '@inquirer/select': 2.5.0
       '@oclif/core': 4.9.0
       '@oclif/plugin-help': 6.2.44
-      '@oclif/plugin-not-found': 3.2.80(@types/node@25.6.0)
+      '@oclif/plugin-not-found': 3.2.80(@types/node@25.9.1)
       '@oclif/plugin-warn-if-update-available': 3.1.60
       ansis: 3.17.0
       async-retry: 1.3.3
@@ -18456,7 +18514,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici-types@7.19.2: {}
+  undici-types@7.24.6: {}
 
   undici-types@7.8.0: {}
 
@@ -18579,13 +18637,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@1.6.1(@types/node@25.6.0):
+  vite-node@1.6.1(@types/node@25.9.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3(supports-color@8.1.1)
       pathe: 1.1.2
       picocolors: 1.1.1
-      vite: 5.4.21(@types/node@25.6.0)
+      vite: 5.4.21(@types/node@25.9.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -18633,13 +18691,13 @@ snapshots:
       '@types/node': 24.0.12
       fsevents: 2.3.3
 
-  vite@5.4.21(@types/node@25.6.0):
+  vite@5.4.21(@types/node@25.9.1):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
       rollup: 4.53.5
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.1
       fsevents: 2.3.3
 
   vitest@1.6.1(@types/node@24.0.12):
@@ -18676,7 +18734,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@1.6.1(@types/node@25.6.0):
+  vitest@1.6.1(@types/node@25.9.1):
     dependencies:
       '@vitest/expect': 1.6.1
       '@vitest/runner': 1.6.1
@@ -18695,11 +18753,11 @@ snapshots:
       strip-literal: 2.1.1
       tinybench: 2.9.0
       tinypool: 0.8.4
-      vite: 5.4.21(@types/node@25.6.0)
-      vite-node: 1.6.1(@types/node@25.6.0)
+      vite: 5.4.21(@types/node@25.9.1)
+      vite-node: 1.6.1(@types/node@25.9.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.1
     transitivePeerDependencies:
       - less
       - lightningcss


### PR DESCRIPTION
## Summary

Companion to **iac PR [hipponot/iac#352](https://github.com/hipponot/iac/pull/352)** (\`saga-provision-credentials\` + \`saga-verify-credentials\`). Together they enable the *"roles in code, identities at provision time"* DB access pattern across the 7 services being stood up in prod (saga-dash, qboard, coach, program-hub, rostering, student-data-system, janus).

The iac CLI writes per-service secrets at canonical SM paths; these soa libraries read those secrets and assemble typed provider configs.

## New package

**\`@saga-ed/soa-postgres\`** (\`packages/node/postgres\`)
- \`PostgresProvider\` — single \`pg.Pool\` per logical DB, exponential-backoff retry on connect, lazy probe to fail fast on bad creds
- \`PostgresProviderConfig\` — zod schema matching the SM payload shape (\`{username, password, host, port, database}\`) plus pool tuning fields
- \`loadPostgresConfigFromAws\` — reads \`{env}/postgres-shared/{service}\`, infers SSL from env (dev=off, mirror/prod=on)

Lifted from \`student-data-system/packages/node/ads-adm-db\` with the Prisma coupling removed so the package stays a thin pg-only library. Consumers wrap the pool with PrismaPg themselves:

\`\`\`ts
const provider = new PostgresProvider(await loadPostgresConfigFromAws({...}));
await provider.connect();
const adapter = new PrismaPg(provider.getPool());
const client = new PrismaClient({ adapter });
\`\`\`

## Extended packages

**\`@saga-ed/soa-redis-core\`** — new \`loadRedisConfigFromAws\` reads \`{env}/redis/{service}\` from SM with an SSM fallback for the endpoint. Returns the existing \`RedisConfig\` shape unchanged so \`RedisConnectionManager\` works without modification. Per-service users are server-side enforced via ElastiCache User Management AccessStrings provisioned by the iac CLI.

**\`@saga-ed/soa-db\`** — \`aws-mongo-loader\` now accepts \`env='mirror'\` as the canonical name. \`env='staging'\` is kept as a deprecated alias for one cycle (emits a \`console.warn\`) so existing callers don't break. Both names resolve to the same SSM/secret paths today; will switch \`mirror\` to \`/shared/infra/mirror/*\` when the IaC rename ships.

## Tests

| Package | Tests | What's covered |
|---|---|---|
| @saga-ed/soa-postgres | 9 | Config validation, loader env mapping, SSL defaults per env, SM payload shape compatibility, error paths |
| @saga-ed/soa-redis-core | 4 | Endpoint from secret vs SSM fallback, TLS defaults per env, explicit overrides |
| @saga-ed/soa-db | 4 | Mirror alias works, staging deprecation warning emitted, prod path unaffected, unknown envs rejected |

All 32 tests pass. All 3 packages build clean.

## Versions

- \`@saga-ed/soa-postgres\` — \`0.1.0\` (new)
- \`@saga-ed/soa-redis-core\` — \`1.1.1\` → \`1.2.0\`
- \`@saga-ed/soa-db\` — \`1.1.3\` → \`1.2.0\`

## Test plan

- [x] Unit tests pass (32/32)
- [x] All 3 packages build
- [x] No regressions in existing tests
- [ ] First real run on mirror tier against sds-api — pairs with iac CLI smoke test (next workstream)