### PR TITLE
tools: add vdev — virtual cameras + mics for local media testing

### DIFF
--- a/tools/virtual-devices/.gitignore
+++ b/tools/virtual-devices/.gitignore
@@ -1,0 +1,4 @@
+# Generated synthetic clips (regenerate with: ./vdev gen). Never commit binaries.
+assets/
+# A local working copy of the device map.
+devices.conf

--- a/tools/virtual-devices/README.md
+++ b/tools/virtual-devices/README.md
@@ -21,10 +21,12 @@ PipeWire/PulseAudio (`pactl`). On Ubuntu: `apt install ffmpeg v4l-utils
 v4l2loopback-dkms`. The **only** privileged operation is loading the kernel
 module (`sudo modprobe v4l2loopback`), which `vdev up`/`vdev down` invoke for
 you; everything else runs as your user. Pass `--skip-modprobe` if the module is
-already loaded (e.g. persisted at boot) to run `vdev up` without sudo — note
-that `vdev down` still unloads the module and will prompt for sudo, so with a
-boot-persisted module you'd typically stop the feeders (`vdev down` will warn it
-can't unload, or just leave them) rather than expect a fully sudo-free teardown.
+already loaded (e.g. persisted at boot) to run `vdev up` without sudo. Note that
+`vdev down` always tries to unload the module (`sudo modprobe -r`) and will
+prompt for sudo — so on a boot-persisted setup, `vdev down` will actually unload
+the module (defeating the persistence until the next boot). If you only want to
+stop the feeders without unloading, kill the ffmpeg feeders yourself instead of
+running `vdev down`.
 
 ## Usage
 

--- a/tools/virtual-devices/README.md
+++ b/tools/virtual-devices/README.md
@@ -21,7 +21,10 @@ PipeWire/PulseAudio (`pactl`). On Ubuntu: `apt install ffmpeg v4l-utils
 v4l2loopback-dkms`. The **only** privileged operation is loading the kernel
 module (`sudo modprobe v4l2loopback`), which `vdev up`/`vdev down` invoke for
 you; everything else runs as your user. Pass `--skip-modprobe` if the module is
-already loaded (e.g. persisted at boot) to run entirely without sudo.
+already loaded (e.g. persisted at boot) to run `vdev up` without sudo — note
+that `vdev down` still unloads the module and will prompt for sudo, so with a
+boot-persisted module you'd typically stop the feeders (`vdev down` will warn it
+can't unload, or just leave them) rather than expect a fully sudo-free teardown.
 
 ## Usage
 
@@ -80,11 +83,14 @@ VDEV_WIDTH=640 VDEV_HEIGHT=480 VDEV_FPS=15 ./vdev gen --force
 | `VDEV_VIDEO_NR_BASE` | `10` | first `/dev/videoN` (avoids real `/dev/video0,1`) |
 | `VDEV_WIDTH`/`VDEV_HEIGHT`/`VDEV_FPS` | `1280`/`720`/`30` | camera caps |
 | `VDEV_PIXFMT` | `yuv420p` | set to `yuyv422` if an app rejects the format |
+| `VDEV_AUDIO_RATE` | `48000` | virtual-mic sample rate (Hz) |
 | `VDEV_CLIP_SECONDS` | `60` | generated clip length (looped at playback) |
 | `VDEV_COUNT_DEFAULT` | `2` | devices when `--count` omitted |
+| `VDEV_FEEDER_SETTLE` | `0.4` | seconds `up` waits to confirm a feeder stayed alive |
 
 State (PIDs, logs, pulse module ids) lives in `~/.local/state/vdev/`
-(`$XDG_STATE_HOME/vdev`); override with `VDEV_STATE`.
+(`$XDG_STATE_HOME/vdev`); override with `VDEV_STATE`. Clips default to `assets/`;
+override the directory with `VDEV_ASSETS`.
 
 ## Troubleshooting
 
@@ -93,6 +99,9 @@ State (PIDs, logs, pulse module ids) lives in `~/.local/state/vdev/`
   capture-only; confirm with `v4l2-ctl --list-devices`.
 - **`vdev down` says "device busy"** — a reader (browser tab, OBS) still holds the
   device. Close it and re-run `vdev down`.
+- **`vdev status` shows `feeder: dead`** — the ffmpeg feeder for that device
+  exited (often because a reader closed the loopback). Check its log under
+  `~/.local/state/vdev/logs/cam{N}.log` (or `mic{N}.log`) and re-run `vdev up`.
 - **Mic shows as "Monitor of …"** — `vdev` uses `module-remap-source` to expose a
   clean `Virtual Mic N` capture source; if your app only lists monitors, select
   `vmicN` / "Virtual Mic N" explicitly.

--- a/tools/virtual-devices/README.md
+++ b/tools/virtual-devices/README.md
@@ -1,0 +1,103 @@
+# vdev — virtual cameras & mics
+
+OS-level synthetic capture devices for testing conferencing/recording flows
+without real hardware. Unlike Chrome's `--use-file-for-fake-video-capture` flag
+(browser-only, single static file) or the LiveKit SDK publisher (in-memory, no
+device node), these are **real V4L2 + PulseAudio devices**: any app — a browser
+conferencing client, OBS, ffmpeg — sees them in its device picker, you can run
+several at once, and each plays a looping, moving synthetic clip.
+
+Each "device" N is a pair:
+
+| | name | node |
+|---|---|---|
+| camera | `Virtual Cam N` | `/dev/video$((10 + N - 1))` |
+| mic | `Virtual Mic N` | pulse source `vmicN` |
+
+## Requirements
+
+Linux with `ffmpeg`, `v4l-utils`, the `v4l2loopback` kernel module, and
+PipeWire/PulseAudio (`pactl`). On Ubuntu: `apt install ffmpeg v4l-utils
+v4l2loopback-dkms`. The **only** privileged operation is loading the kernel
+module (`sudo modprobe v4l2loopback`), which `vdev up`/`vdev down` invoke for
+you; everything else runs as your user. Pass `--skip-modprobe` if the module is
+already loaded (e.g. persisted at boot) to run entirely without sudo.
+
+## Usage
+
+```bash
+cd tools/virtual-devices
+
+./vdev up              # 2 cams + 2 mics (auto-generates clips on first run)
+./vdev up --count 4    # 4 of each
+./vdev up --cams 3 --no-audio
+./vdev status          # what's running
+./vdev attach cam1 ~/clips/demo.mp4   # swap one camera's source (loops the file)
+./vdev attach mic2 ~/audio/voice.wav
+./vdev down            # stop feeders, remove mics, unload module
+```
+
+Pin specific clips per device with a config file:
+
+```bash
+cp devices.conf.example devices.conf   # edit paths
+./vdev up --config devices.conf
+```
+
+### Verify it in a browser
+
+```bash
+python3 -m http.server 8099            # from this directory
+# open http://localhost:8099/webcam-test.html, pick "Virtual Cam 1" / "Virtual Mic 1"
+```
+
+The picker should list the virtual devices; selecting one shows the looping clip
+and the audio meter moves with the synthetic tone.
+
+## Synthetic media
+
+`./vdev gen` (run automatically by `up` when clips are missing) writes one clip
+per slot to `assets/`:
+
+- **video** `cam{N}.mp4` — a distinct base pattern (testsrc2 / smptebars /
+  rgbtestsrc / mandelbrot) overlaid with a `CAM N` label, a running clock, and a
+  frame counter, so feeds are clearly **non-static** and easy to tell apart.
+- **audio** `mic{N}.wav` — a distinct per-mic tone, pulsed so it's audible.
+
+Regenerate or resize:
+
+```bash
+./vdev gen --count 4 --force
+VDEV_WIDTH=640 VDEV_HEIGHT=480 VDEV_FPS=15 ./vdev gen --force
+```
+
+`assets/` is git-ignored — clips are regenerable, never committed.
+
+## Tuning (env vars)
+
+| var | default | meaning |
+|---|---|---|
+| `VDEV_VIDEO_NR_BASE` | `10` | first `/dev/videoN` (avoids real `/dev/video0,1`) |
+| `VDEV_WIDTH`/`VDEV_HEIGHT`/`VDEV_FPS` | `1280`/`720`/`30` | camera caps |
+| `VDEV_PIXFMT` | `yuv420p` | set to `yuyv422` if an app rejects the format |
+| `VDEV_CLIP_SECONDS` | `60` | generated clip length (looped at playback) |
+| `VDEV_COUNT_DEFAULT` | `2` | devices when `--count` omitted |
+
+State (PIDs, logs, pulse module ids) lives in `~/.local/state/vdev/`
+(`$XDG_STATE_HOME/vdev`); override with `VDEV_STATE`.
+
+## Troubleshooting
+
+- **Camera missing from a browser picker** — the `exclusive_caps=1` modprobe
+  option (set by `vdev up`) is what makes Chrome/Firefox treat the device as
+  capture-only; confirm with `v4l2-ctl --list-devices`.
+- **`vdev down` says "device busy"** — a reader (browser tab, OBS) still holds the
+  device. Close it and re-run `vdev down`.
+- **Mic shows as "Monitor of …"** — `vdev` uses `module-remap-source` to expose a
+  clean `Virtual Mic N` capture source; if your app only lists monitors, select
+  `vmicN` / "Virtual Mic N" explicitly.
+- **No text on the video** — install a TTF font (e.g. `fonts-dejavu-core`); motion
+  still works without it.
+- **Persist across reboots (optional)** — drop a `/etc/modules-load.d/` +
+  `/etc/modprobe.d/` config for `v4l2loopback` so the devices come up at boot.
+  Not done by default to keep the tool side-effect-free.

--- a/tools/virtual-devices/devices.conf.example
+++ b/tools/virtual-devices/devices.conf.example
@@ -1,0 +1,20 @@
+# vdev device map — pass with: vdev up --config devices.conf
+#
+# One device per non-comment line. Line order = device index (1, 2, ...).
+# Columns are whitespace-separated:
+#
+#     [index]   <video-clip>            <audio-clip>
+#
+# - A leading numeric index column is optional (it's just a readable label;
+#   the actual /dev/video number is VDEV_VIDEO_NR_BASE + index - 1).
+# - Relative paths resolve against THIS file's directory.
+# - The video device is "Virtual Cam <index>"; the mic is pulse source "vmic<index>".
+#
+# Example: two cameras, the second reusing a real recorded audio file.
+
+1   assets/cam1.mp4   assets/mic1.wav
+2   assets/cam2.mp4   assets/mic2.wav
+
+# To feed real recorded audio instead of a synthetic tone, point the audio
+# column at any WAV, e.g.:
+#   2  assets/cam2.mp4  /path/to/voice.wav

--- a/tools/virtual-devices/generate-clips.sh
+++ b/tools/virtual-devices/generate-clips.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Generate the default synthetic clip library: one distinct, MOVING, labeled
+# video clip per camera plus one distinct-tone audio clip per mic.
+#
+# Usage: generate-clips.sh [--count N] [--out DIR] [--force]
+# Also callable via `vdev gen`.
+set -euo pipefail
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+source "$SELF_DIR/lib/common.sh"
+
+COUNT="$VDEV_COUNT_DEFAULT"
+OUT="$VDEV_ASSETS"
+FORCE=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --count) COUNT="$2"; shift 2;;
+    --out)   OUT="$2"; shift 2;;
+    --force) FORCE=1; shift;;
+    -h|--help) awk 'NR==1{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "$0"; exit 0;;
+    *) die "unknown arg: $1";;
+  esac
+done
+
+require_cmd ffmpeg
+mkdir -p "$OUT"
+
+# A bold font for the on-screen labels; motion comes from the live clock +
+# frame counter overlays, so a missing font only drops the text, not the motion.
+find_font() {
+  local f
+  for f in \
+    /usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf \
+    /usr/share/fonts/truetype/dejavu/DejaVuSans.ttf \
+    /usr/share/fonts/truetype/liberation/LiberationSans-Bold.ttf \
+    /usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf; do
+    [[ -f "$f" ]] && { echo "$f"; return 0; }
+  done
+  return 1
+}
+FONT="$(find_font || true)"
+[[ -n "$FONT" ]] || warn "no TTF font found; clips will have motion but no text labels"
+
+# Visually distinct base patterns, cycled per camera.
+SOURCES=(testsrc2 smptebars rgbtestsrc mandelbrot)
+
+gen_video() {
+  local idx="$1" out="$2"
+  local src="${SOURCES[$(( (idx - 1) % ${#SOURCES[@]} ))]}"
+  local vf="format=${VDEV_PIXFMT}"
+  if [[ -n "$FONT" ]]; then
+    local label
+    vf="drawtext=fontfile=${FONT}:text='CAM ${idx}':fontcolor=white:fontsize=110:box=1:boxcolor=black@0.55:boxborderw=16:x=40:y=40"
+    vf+=",drawtext=fontfile=${FONT}:text='%{pts\\:hms}':fontcolor=yellow:fontsize=72:box=1:boxcolor=black@0.55:boxborderw=10:x=40:y=h-120"
+    vf+=",drawtext=fontfile=${FONT}:text='frame %{n}':fontcolor=cyan:fontsize=44:box=1:boxcolor=black@0.45:boxborderw=8:x=40:y=h-220"
+    vf+=",format=${VDEV_PIXFMT}"
+  fi
+  log "generating $out  (source=$src, ${VDEV_WIDTH}x${VDEV_HEIGHT}@${VDEV_FPS}, ${VDEV_CLIP_SECONDS}s)"
+  ffmpeg -y -hide_banner -loglevel error \
+    -f lavfi -t "$VDEV_CLIP_SECONDS" -i "${src}=size=${VDEV_WIDTH}x${VDEV_HEIGHT}:rate=${VDEV_FPS}" \
+    -vf "$vf" \
+    -c:v libx264 -preset veryfast -pix_fmt "$VDEV_PIXFMT" \
+    "$out"
+}
+
+gen_audio() {
+  local idx="$1" out="$2"
+  # Distinct, identifiable per-mic tone with a 1 Hz pulse so it's clearly audible.
+  local freq=$(( 220 + idx * 110 ))
+  log "generating $out  (tone ${freq}Hz, ${VDEV_CLIP_SECONDS}s)"
+  ffmpeg -y -hide_banner -loglevel error \
+    -f lavfi -t "$VDEV_CLIP_SECONDS" \
+    -i "sine=frequency=${freq}:sample_rate=${VDEV_AUDIO_RATE}" \
+    -af "tremolo=f=2:d=0.8,volume=0.5" \
+    -ac 1 -ar "$VDEV_AUDIO_RATE" \
+    "$out"
+}
+
+for ((i = 1; i <= COUNT; i++)); do
+  v="$OUT/cam${i}.mp4"
+  a="$OUT/mic${i}.wav"
+  if [[ -f "$v" && $FORCE -eq 0 ]]; then dim "skip $v (exists; --force to regenerate)"; else gen_video "$i" "$v"; fi
+  if [[ -f "$a" && $FORCE -eq 0 ]]; then dim "skip $a (exists; --force to regenerate)"; else gen_audio "$i" "$a"; fi
+done
+
+ok "clip library ready in $OUT ($COUNT camera(s) + $COUNT mic(s))"

--- a/tools/virtual-devices/generate-clips.sh
+++ b/tools/virtual-devices/generate-clips.sh
@@ -19,7 +19,7 @@ while [[ $# -gt 0 ]]; do
     --count) [[ $# -ge 2 ]] || die "--count requires a value"; COUNT="$2"; shift 2;;
     --out)   [[ $# -ge 2 ]] || die "--out requires a value";   OUT="$2"; shift 2;;
     --force) FORCE=1; shift;;
-    -h|--help) awk 'NR==1{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "$0"; exit 0;;
+    -h|--help) usage; exit 0;;
     *) die "unknown arg: $1";;
   esac
 done

--- a/tools/virtual-devices/generate-clips.sh
+++ b/tools/virtual-devices/generate-clips.sh
@@ -16,14 +16,15 @@ FORCE=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --count) COUNT="$2"; shift 2;;
-    --out)   OUT="$2"; shift 2;;
+    --count) [[ $# -ge 2 ]] || die "--count requires a value"; COUNT="$2"; shift 2;;
+    --out)   [[ $# -ge 2 ]] || die "--out requires a value";   OUT="$2"; shift 2;;
     --force) FORCE=1; shift;;
     -h|--help) awk 'NR==1{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "$0"; exit 0;;
     *) die "unknown arg: $1";;
   esac
 done
 
+require_uint --count "$COUNT"
 require_cmd ffmpeg
 mkdir -p "$OUT"
 
@@ -57,11 +58,18 @@ gen_video() {
     vf+=",format=${VDEV_PIXFMT}"
   fi
   log "generating $out  (source=$src, ${VDEV_WIDTH}x${VDEV_HEIGHT}@${VDEV_FPS}, ${VDEV_CLIP_SECONDS}s)"
-  ffmpeg -y -hide_banner -loglevel error \
+  # Write to a sibling temp (keeps the .mp4 extension so ffmpeg picks the muxer)
+  # and only move into place on success — a Ctrl-C'd run leaves no half-written clip.
+  local tmp; tmp="$(dirname "$out")/.tmp.$(basename "$out")"
+  if ffmpeg -y -hide_banner -loglevel error \
     -f lavfi -t "$VDEV_CLIP_SECONDS" -i "${src}=size=${VDEV_WIDTH}x${VDEV_HEIGHT}:rate=${VDEV_FPS}" \
     -vf "$vf" \
     -c:v libx264 -preset veryfast -pix_fmt "$VDEV_PIXFMT" \
-    "$out"
+    "$tmp"; then
+    mv -f "$tmp" "$out"
+  else
+    rm -f "$tmp"; die "ffmpeg failed generating $out"
+  fi
 }
 
 gen_audio() {
@@ -69,19 +77,24 @@ gen_audio() {
   # Distinct, identifiable per-mic tone with a 1 Hz pulse so it's clearly audible.
   local freq=$(( 220 + idx * 110 ))
   log "generating $out  (tone ${freq}Hz, ${VDEV_CLIP_SECONDS}s)"
-  ffmpeg -y -hide_banner -loglevel error \
+  local tmp; tmp="$(dirname "$out")/.tmp.$(basename "$out")"
+  if ffmpeg -y -hide_banner -loglevel error \
     -f lavfi -t "$VDEV_CLIP_SECONDS" \
     -i "sine=frequency=${freq}:sample_rate=${VDEV_AUDIO_RATE}" \
     -af "tremolo=f=2:d=0.8,volume=0.5" \
     -ac 1 -ar "$VDEV_AUDIO_RATE" \
-    "$out"
+    "$tmp"; then
+    mv -f "$tmp" "$out"
+  else
+    rm -f "$tmp"; die "ffmpeg failed generating $out"
+  fi
 }
 
 for ((i = 1; i <= COUNT; i++)); do
   v="$OUT/cam${i}.mp4"
   a="$OUT/mic${i}.wav"
-  if [[ -f "$v" && $FORCE -eq 0 ]]; then dim "skip $v (exists; --force to regenerate)"; else gen_video "$i" "$v"; fi
-  if [[ -f "$a" && $FORCE -eq 0 ]]; then dim "skip $a (exists; --force to regenerate)"; else gen_audio "$i" "$a"; fi
+  if [[ -s "$v" && $FORCE -eq 0 ]]; then dim "skip $v (exists; --force to regenerate)"; else gen_video "$i" "$v"; fi
+  if [[ -s "$a" && $FORCE -eq 0 ]]; then dim "skip $a (exists; --force to regenerate)"; else gen_audio "$i" "$a"; fi
 done
 
 ok "clip library ready in $OUT ($COUNT camera(s) + $COUNT mic(s))"

--- a/tools/virtual-devices/generate-clips.sh
+++ b/tools/virtual-devices/generate-clips.sh
@@ -51,7 +51,6 @@ gen_video() {
   local src="${SOURCES[$(( (idx - 1) % ${#SOURCES[@]} ))]}"
   local vf="format=${VDEV_PIXFMT}"
   if [[ -n "$FONT" ]]; then
-    local label
     vf="drawtext=fontfile=${FONT}:text='CAM ${idx}':fontcolor=white:fontsize=110:box=1:boxcolor=black@0.55:boxborderw=16:x=40:y=40"
     vf+=",drawtext=fontfile=${FONT}:text='%{pts\\:hms}':fontcolor=yellow:fontsize=72:box=1:boxcolor=black@0.55:boxborderw=10:x=40:y=h-120"
     vf+=",drawtext=fontfile=${FONT}:text='frame %{n}':fontcolor=cyan:fontsize=44:box=1:boxcolor=black@0.45:boxborderw=8:x=40:y=h-220"

--- a/tools/virtual-devices/lib/audio.sh
+++ b/tools/virtual-devices/lib/audio.sh
@@ -99,6 +99,14 @@ audio_start_feeder() {
   require_cmd ffmpeg
   [[ -f "$audio" ]] || { err "mic$idx: audio not found: $audio"; return 1; }
 
+  # ffmpeg keeps running even if -device names a sink that doesn't exist, so a
+  # feeder pointed at a missing sink would survive the liveness check and falsely
+  # report "playing". Require the sink up front (e.g. `attach` before `up`).
+  if ! pactl list short sinks 2>/dev/null | awk '{print $2}' | grep -qx "$sink"; then
+    err "mic$idx: pulse sink '$sink' not found — create the mic first (run 'vdev up')"
+    return 1
+  fi
+
   audio_stop_feeder "$idx"
 
   log "mic$idx <- $audio  (sink $sink)"
@@ -115,7 +123,8 @@ audio_start_feeder() {
   fi
 
   # The source exists as soon as the modules load, so a dead feeder would look
-  # healthy — verify ffmpeg is actually feeding the sink before claiming up.
+  # healthy. We can't cheaply confirm audio is truly flowing, so settle briefly
+  # and require the ffmpeg process to still be alive before claiming the mic is up.
   sleep "$VDEV_FEEDER_SETTLE"
   if ! pid_is_feeder "$pid"; then
     rm -f "$pidf"
@@ -123,7 +132,9 @@ audio_start_feeder() {
     tail -n 12 "$logf" >&2 || true
     return 1
   fi
-  meta_set "mic${idx}_audio" "$audio"
+  # Feeder is up; don't let a metadata-write failure flip that verdict (see video.sh).
+  meta_set "mic${idx}_audio" "$audio" || warn "mic$idx: feeder up but could not record audio metadata"
+  return 0
 }
 
 audio_stop_feeder() {

--- a/tools/virtual-devices/lib/audio.sh
+++ b/tools/virtual-devices/lib/audio.sh
@@ -137,30 +137,7 @@ audio_start_feeder() {
   return 0
 }
 
-audio_stop_feeder() {
-  local idx="$1" pid
-  local pidf="$VDEV_PIDS/mic${idx}.pid"
-  [[ -f "$pidf" ]] || return 0
-  pid="$(cat "$pidf" 2>/dev/null || true)"
-  if pid_is_feeder "$pid"; then
-    kill "$pid" 2>/dev/null || true
-  fi
-  rm -f "$pidf"
-}
-
-audio_stop_all() {
-  local pidf idx
-  for pidf in "$VDEV_PIDS"/mic*.pid; do
-    [[ -e "$pidf" ]] || continue
-    idx="$(basename "$pidf" .pid)"; idx="${idx#mic}"
-    audio_stop_feeder "$idx"
-  done
-}
-
-audio_feeder_state() {
-  local idx="$1" pid
-  local pidf="$VDEV_PIDS/mic${idx}.pid"
-  [[ -f "$pidf" ]] || { echo "stopped"; return; }
-  pid="$(cat "$pidf" 2>/dev/null || true)"
-  if pid_is_feeder "$pid"; then echo "alive ($pid)"; else echo "dead"; fi
-}
+# Mic feeder lifecycle — thin wrappers over the shared helpers in common.sh.
+audio_stop_feeder()  { feeder_stop mic "$1"; }
+audio_stop_all()     { feeder_stop_all mic; }
+audio_feeder_state() { feeder_state mic "$1"; }

--- a/tools/virtual-devices/lib/audio.sh
+++ b/tools/virtual-devices/lib/audio.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Audio plane: PipeWire/PulseAudio virtual mics (null-sink + remap-source) and
+# per-mic ffmpeg feeders. No root required — runs against the user's pulse/pw
+# session. Assumes lib/common.sh is already sourced.
+#
+# Per mic N:
+#   - module-null-sink   sink_name=vmicN_sink   (audio played here)
+#   - module-remap-source master=vmicN_sink.monitor source_name=vmicN
+#     (the selectable "Virtual Mic N" capture device apps see)
+# Module ids are tracked in $VDEV_PULSE_MODULES as: "micN <sinkid> <srcid>".
+
+audio_available() { command -v pactl >/dev/null 2>&1 && pactl info >/dev/null 2>&1; }
+
+# audio_create_mic INDEX
+audio_create_mic() {
+  local idx="$1" sink_id src_id
+  local sink_name="vmic${idx}_sink" src_name="vmic${idx}"
+
+  # Tear down a stale instance with the same name first (idempotent).
+  audio_destroy_mic "$idx" >/dev/null 2>&1 || true
+
+  sink_id="$(pactl load-module module-null-sink \
+    sink_name="$sink_name" \
+    "sink_properties=device.description='Virtual Mic ${idx} sink'")" \
+    || die "failed to create null sink for mic$idx"
+
+  src_id="$(pactl load-module module-remap-source \
+    master="${sink_name}.monitor" \
+    source_name="$src_name" \
+    "source_properties=device.description='Virtual Mic ${idx}'")" \
+    || { pactl unload-module "$sink_id" 2>/dev/null || true
+         die "failed to create remap source for mic$idx"; }
+
+  ensure_state_dirs
+  # replace any existing line for this mic
+  local tmp; tmp="$(mktemp)"
+  grep -v "^mic${idx} " "$VDEV_PULSE_MODULES" 2>/dev/null > "$tmp" || true
+  echo "mic${idx} ${sink_id} ${src_id}" >> "$tmp"
+  mv "$tmp" "$VDEV_PULSE_MODULES"
+  log "mic$idx created: source '$src_name' (sink module $sink_id, source module $src_id)"
+}
+
+# audio_destroy_mic INDEX
+audio_destroy_mic() {
+  local idx="$1" line sink_id src_id
+  [[ -f "$VDEV_PULSE_MODULES" ]] || return 0
+  line="$(grep "^mic${idx} " "$VDEV_PULSE_MODULES" 2>/dev/null | tail -1)" || return 0
+  [[ -n "$line" ]] || return 0
+  read -r _ sink_id src_id <<<"$line"
+  [[ -n "$src_id"  ]] && pactl unload-module "$src_id"  2>/dev/null || true
+  [[ -n "$sink_id" ]] && pactl unload-module "$sink_id" 2>/dev/null || true
+  local tmp; tmp="$(mktemp)"
+  grep -v "^mic${idx} " "$VDEV_PULSE_MODULES" 2>/dev/null > "$tmp" || true
+  mv "$tmp" "$VDEV_PULSE_MODULES"
+}
+
+audio_destroy_all() {
+  [[ -f "$VDEV_PULSE_MODULES" ]] || return 0
+  local idx
+  # collect indices first; audio_destroy_mic rewrites the file as it goes
+  while read -r tag _; do
+    [[ "$tag" == mic* ]] || continue
+    idx="${tag#mic}"
+    audio_destroy_mic "$idx"
+  done < <(cat "$VDEV_PULSE_MODULES")
+  : > "$VDEV_PULSE_MODULES"
+}
+
+# audio_start_feeder INDEX AUDIOFILE
+audio_start_feeder() {
+  local idx="$1" audio="$2"
+  local sink="vmic${idx}_sink" pidf logf
+  pidf="$VDEV_PIDS/mic${idx}.pid"
+  logf="$VDEV_LOGS/mic${idx}.log"
+  require_cmd ffmpeg
+  [[ -f "$audio" ]] || die "audio not found for mic$idx: $audio"
+
+  audio_stop_feeder "$idx"
+
+  log "mic$idx <- $audio  (sink $sink)"
+  nohup ffmpeg -hide_banner -loglevel warning -nostdin \
+    -re -stream_loop -1 -i "$audio" \
+    -ac 1 -ar "$VDEV_AUDIO_RATE" \
+    -f pulse -device "$sink" "vmic${idx}-feed" \
+    >"$logf" 2>&1 &
+  echo $! > "$pidf"
+  meta_set "mic${idx}_audio" "$audio"
+}
+
+audio_stop_feeder() {
+  local idx="$1" pid
+  local pidf="$VDEV_PIDS/mic${idx}.pid"
+  [[ -f "$pidf" ]] || return 0
+  pid="$(cat "$pidf" 2>/dev/null || true)"
+  if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null || true
+  fi
+  rm -f "$pidf"
+}
+
+audio_stop_all() {
+  local pidf idx
+  for pidf in "$VDEV_PIDS"/mic*.pid; do
+    [[ -e "$pidf" ]] || continue
+    idx="$(basename "$pidf" .pid)"; idx="${idx#mic}"
+    audio_stop_feeder "$idx"
+  done
+}
+
+audio_feeder_state() {
+  local idx="$1" pid
+  local pidf="$VDEV_PIDS/mic${idx}.pid"
+  [[ -f "$pidf" ]] || { echo "stopped"; return; }
+  pid="$(cat "$pidf" 2>/dev/null || true)"
+  if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then echo "alive ($pid)"; else echo "dead"; fi
+}

--- a/tools/virtual-devices/lib/audio.sh
+++ b/tools/virtual-devices/lib/audio.sh
@@ -11,7 +11,16 @@
 
 audio_available() { command -v pactl >/dev/null 2>&1 && pactl info >/dev/null 2>&1; }
 
+# Unload a pactl module by id and report success if it's gone afterward —
+# treats an already-absent (stale) id as success rather than a failure.
+audio_unload_gone() {
+  local id="$1"
+  pactl unload-module "$id" 2>/dev/null || true
+  ! pactl list short modules 2>/dev/null | awk '{print $1}' | grep -qx "$id"
+}
+
 # audio_create_mic INDEX
+# Returns non-zero (without exiting) on failure so callers can aggregate.
 audio_create_mic() {
   local idx="$1" sink_id src_id
   local sink_name="vmic${idx}_sink" src_name="vmic${idx}"
@@ -22,14 +31,14 @@ audio_create_mic() {
   sink_id="$(pactl load-module module-null-sink \
     sink_name="$sink_name" \
     "sink_properties=device.description='Virtual Mic ${idx} sink'")" \
-    || die "failed to create null sink for mic$idx"
+    || { err "mic$idx: failed to create null sink"; return 1; }
 
   src_id="$(pactl load-module module-remap-source \
     master="${sink_name}.monitor" \
     source_name="$src_name" \
     "source_properties=device.description='Virtual Mic ${idx}'")" \
     || { pactl unload-module "$sink_id" 2>/dev/null || true
-         die "failed to create remap source for mic$idx"; }
+         err "mic$idx: failed to create remap source"; return 1; }
 
   ensure_state_dirs
   # replace any existing line for this mic
@@ -41,39 +50,54 @@ audio_create_mic() {
 }
 
 # audio_destroy_mic INDEX
+# Returns non-zero if a module could not be unloaded; in that case the tracking
+# line is kept so a later teardown can retry instead of orphaning the sink.
 audio_destroy_mic() {
-  local idx="$1" line sink_id src_id
+  local idx="$1" line sink_id src_id rc=0
   [[ -f "$VDEV_PULSE_MODULES" ]] || return 0
   line="$(grep "^mic${idx} " "$VDEV_PULSE_MODULES" 2>/dev/null | tail -1)" || return 0
   [[ -n "$line" ]] || return 0
   read -r _ sink_id src_id <<<"$line"
-  [[ -n "$src_id"  ]] && pactl unload-module "$src_id"  2>/dev/null || true
-  [[ -n "$sink_id" ]] && pactl unload-module "$sink_id" 2>/dev/null || true
-  local tmp; tmp="$(mktemp)"
-  grep -v "^mic${idx} " "$VDEV_PULSE_MODULES" 2>/dev/null > "$tmp" || true
-  mv "$tmp" "$VDEV_PULSE_MODULES"
+  # remap-source first, then the null-sink it depends on.
+  if [[ -n "$src_id" ]] && ! audio_unload_gone "$src_id"; then
+    warn "mic$idx: could not unload remap-source module $src_id"; rc=1
+  fi
+  if [[ -n "$sink_id" ]] && ! audio_unload_gone "$sink_id"; then
+    warn "mic$idx: could not unload null-sink module $sink_id"; rc=1
+  fi
+  if [[ $rc -eq 0 ]]; then
+    local tmp; tmp="$(mktemp)"
+    grep -v "^mic${idx} " "$VDEV_PULSE_MODULES" 2>/dev/null > "$tmp" || true
+    mv "$tmp" "$VDEV_PULSE_MODULES"
+  fi
+  return $rc
 }
 
+# Returns non-zero if any mic could not be fully removed.
 audio_destroy_all() {
   [[ -f "$VDEV_PULSE_MODULES" ]] || return 0
-  local idx
-  # collect indices first; audio_destroy_mic rewrites the file as it goes
+  local idx rc=0 indices=()
+  # snapshot indices first; audio_destroy_mic rewrites the file as it goes
   while read -r tag _; do
     [[ "$tag" == mic* ]] || continue
-    idx="${tag#mic}"
-    audio_destroy_mic "$idx"
-  done < <(cat "$VDEV_PULSE_MODULES")
-  : > "$VDEV_PULSE_MODULES"
+    indices+=("${tag#mic}")
+  done < "$VDEV_PULSE_MODULES"
+  for idx in "${indices[@]}"; do
+    audio_destroy_mic "$idx" || rc=1
+  done
+  return $rc
 }
 
 # audio_start_feeder INDEX AUDIOFILE
+# Returns non-zero (without exiting) if the feeder can't be started or dies
+# immediately, so callers can aggregate per-device failures.
 audio_start_feeder() {
   local idx="$1" audio="$2"
-  local sink="vmic${idx}_sink" pidf logf
+  local sink="vmic${idx}_sink" pidf logf pid
   pidf="$VDEV_PIDS/mic${idx}.pid"
   logf="$VDEV_LOGS/mic${idx}.log"
   require_cmd ffmpeg
-  [[ -f "$audio" ]] || die "audio not found for mic$idx: $audio"
+  [[ -f "$audio" ]] || { err "mic$idx: audio not found: $audio"; return 1; }
 
   audio_stop_feeder "$idx"
 
@@ -83,7 +107,22 @@ audio_start_feeder() {
     -ac 1 -ar "$VDEV_AUDIO_RATE" \
     -f pulse -device "$sink" "vmic${idx}-feed" \
     >"$logf" 2>&1 &
-  echo $! > "$pidf"
+  pid=$!
+  if ! echo "$pid" > "$pidf"; then
+    kill "$pid" 2>/dev/null || true
+    err "mic$idx: could not record pid (state dir $VDEV_PIDS not writable?)"
+    return 1
+  fi
+
+  # The source exists as soon as the modules load, so a dead feeder would look
+  # healthy — verify ffmpeg is actually feeding the sink before claiming up.
+  sleep "$VDEV_FEEDER_SETTLE"
+  if ! pid_is_feeder "$pid"; then
+    rm -f "$pidf"
+    err "mic$idx feeder died immediately (audio=$audio sink=$sink) — last log lines:"
+    tail -n 12 "$logf" >&2 || true
+    return 1
+  fi
   meta_set "mic${idx}_audio" "$audio"
 }
 
@@ -92,7 +131,7 @@ audio_stop_feeder() {
   local pidf="$VDEV_PIDS/mic${idx}.pid"
   [[ -f "$pidf" ]] || return 0
   pid="$(cat "$pidf" 2>/dev/null || true)"
-  if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+  if pid_is_feeder "$pid"; then
     kill "$pid" 2>/dev/null || true
   fi
   rm -f "$pidf"
@@ -112,5 +151,5 @@ audio_feeder_state() {
   local pidf="$VDEV_PIDS/mic${idx}.pid"
   [[ -f "$pidf" ]] || { echo "stopped"; return; }
   pid="$(cat "$pidf" 2>/dev/null || true)"
-  if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then echo "alive ($pid)"; else echo "dead"; fi
+  if pid_is_feeder "$pid"; then echo "alive ($pid)"; else echo "dead"; fi
 }

--- a/tools/virtual-devices/lib/common.sh
+++ b/tools/virtual-devices/lib/common.sh
@@ -25,6 +25,7 @@ VDEV_PIXFMT="${VDEV_PIXFMT:-yuv420p}"            # YU12; set to yuyv422 as fallb
 VDEV_COUNT_DEFAULT="${VDEV_COUNT_DEFAULT:-2}"
 VDEV_CLIP_SECONDS="${VDEV_CLIP_SECONDS:-60}"
 VDEV_AUDIO_RATE="${VDEV_AUDIO_RATE:-48000}"
+VDEV_FEEDER_SETTLE="${VDEV_FEEDER_SETTLE:-0.4}"  # seconds to wait before confirming a feeder stayed up
 
 # ---- logging -------------------------------------------------------------
 if [[ -t 2 ]]; then
@@ -48,6 +49,16 @@ ensure_state_dirs() {
 
 require_cmd() {
   command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+# True if PID is alive AND looks like one of our ffmpeg feeders. Guards against
+# killing an unrelated process that has since inherited a recycled PID.
+pid_is_feeder() {
+  local pid="$1"
+  [[ -n "$pid" ]] || return 1
+  kill -0 "$pid" 2>/dev/null || return 1
+  # /proc/PID/cmdline is NUL-separated; -a treats it as text.
+  grep -qa ffmpeg "/proc/$pid/cmdline" 2>/dev/null
 }
 
 # Map a 1-based device index to its /dev/video number.

--- a/tools/virtual-devices/lib/common.sh
+++ b/tools/virtual-devices/lib/common.sh
@@ -51,6 +51,13 @@ require_cmd() {
   command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
 }
 
+# require_uint NAME VALUE — die with a usage hint unless VALUE is a non-negative
+# integer. Guards arithmetic contexts (for (( )) bounds) from set -u crashes and
+# from bash silently evaluating expressions like '1+1'.
+require_uint() {
+  [[ "$2" =~ ^[0-9]+$ ]] || die "$1 must be a non-negative integer, got: '$2'"
+}
+
 # True if PID is alive AND looks like one of our ffmpeg feeders. Guards against
 # killing an unrelated process that has since inherited a recycled PID.
 pid_is_feeder() {

--- a/tools/virtual-devices/lib/common.sh
+++ b/tools/virtual-devices/lib/common.sh
@@ -42,6 +42,12 @@ err()  { printf '%s[vdev] error:%s %s\n' "$_c_red" "$_c_rst" "$*" >&2; }
 die()  { err "$*"; exit 1; }
 dim()  { printf '%s%s%s\n' "$_c_dim" "$*" "$_c_rst" >&2; }
 
+# Print a script's leading comment block as usage text: skip the shebang, strip
+# the "# " prefix from each comment line, stop at the first code line. Uses $0,
+# which (sourcing doesn't change it) is the running script — vdev or
+# generate-clips.sh — so each prints its own header.
+usage() { awk 'NR==1{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "$0"; }
+
 ensure_state_dirs() {
   mkdir -p "$VDEV_PIDS" "$VDEV_LOGS"
   touch "$VDEV_PULSE_MODULES" "$VDEV_META"
@@ -66,6 +72,44 @@ pid_is_feeder() {
   kill -0 "$pid" 2>/dev/null || return 1
   # /proc/PID/cmdline is NUL-separated; -a treats it as text.
   grep -qa ffmpeg "/proc/$pid/cmdline" 2>/dev/null
+}
+
+# ---- feeder process lifecycle ----------------------------------------------
+# Cameras and mics track their ffmpeg feeders the same way: one pidfile per
+# device at $VDEV_PIDS/<kind><idx>.pid. These helpers take the kind prefix
+# ("cam"/"mic") so both planes share one implementation; only the per-plane
+# start_feeder (the ffmpeg invocation) genuinely differs and stays in video.sh/audio.sh.
+
+# feeder_stop KIND IDX — kill this device's feeder (only if it's really ours)
+# and drop its pidfile. No-op if not running.
+feeder_stop() {
+  local kind="$1" idx="$2" pid
+  local pidf="$VDEV_PIDS/${kind}${idx}.pid"
+  [[ -f "$pidf" ]] || return 0
+  pid="$(cat "$pidf" 2>/dev/null || true)"
+  if pid_is_feeder "$pid"; then
+    kill "$pid" 2>/dev/null || true
+  fi
+  rm -f "$pidf"
+}
+
+# feeder_stop_all KIND — stop every feeder of this kind.
+feeder_stop_all() {
+  local kind="$1" pidf idx
+  for pidf in "$VDEV_PIDS/${kind}"*.pid; do
+    [[ -e "$pidf" ]] || continue
+    idx="$(basename "$pidf" .pid)"; idx="${idx#"$kind"}"
+    feeder_stop "$kind" "$idx"
+  done
+}
+
+# feeder_state KIND IDX — print stopped | alive (pid) | dead for status output.
+feeder_state() {
+  local kind="$1" idx="$2" pid
+  local pidf="$VDEV_PIDS/${kind}${idx}.pid"
+  [[ -f "$pidf" ]] || { echo "stopped"; return; }
+  pid="$(cat "$pidf" 2>/dev/null || true)"
+  if pid_is_feeder "$pid"; then echo "alive ($pid)"; else echo "dead"; fi
 }
 
 # Map a 1-based device index to its /dev/video number.

--- a/tools/virtual-devices/lib/common.sh
+++ b/tools/virtual-devices/lib/common.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Shared helpers, paths, and defaults for the vdev virtual-device tooling.
+# Sourced by vdev, generate-clips.sh, and the lib/*.sh modules.
+
+# Resolve repo-relative paths from this file's location (lib/ -> parent).
+VDEV_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VDEV_ROOT="$(dirname "$VDEV_LIB_DIR")"
+
+# Where generated clips live (override with VDEV_ASSETS).
+VDEV_ASSETS="${VDEV_ASSETS:-$VDEV_ROOT/assets}"
+
+# Runtime state (PIDs, logs, pulse module ids). XDG state dir; override w/ VDEV_STATE.
+VDEV_STATE="${VDEV_STATE:-${XDG_STATE_HOME:-$HOME/.local/state}/vdev}"
+VDEV_PIDS="$VDEV_STATE/pids"
+VDEV_LOGS="$VDEV_STATE/logs"
+VDEV_PULSE_MODULES="$VDEV_STATE/pulse-modules"   # one pactl module id per line
+VDEV_META="$VDEV_STATE/meta"                     # key=value runtime facts
+
+# Device defaults (all overridable via env).
+VDEV_VIDEO_NR_BASE="${VDEV_VIDEO_NR_BASE:-10}"   # first /dev/videoN for cam 1
+VDEV_WIDTH="${VDEV_WIDTH:-1280}"
+VDEV_HEIGHT="${VDEV_HEIGHT:-720}"
+VDEV_FPS="${VDEV_FPS:-30}"
+VDEV_PIXFMT="${VDEV_PIXFMT:-yuv420p}"            # YU12; set to yuyv422 as fallback
+VDEV_COUNT_DEFAULT="${VDEV_COUNT_DEFAULT:-2}"
+VDEV_CLIP_SECONDS="${VDEV_CLIP_SECONDS:-60}"
+VDEV_AUDIO_RATE="${VDEV_AUDIO_RATE:-48000}"
+
+# ---- logging -------------------------------------------------------------
+if [[ -t 2 ]]; then
+  _c_red=$'\033[31m'; _c_grn=$'\033[32m'; _c_ylw=$'\033[33m'
+  _c_blu=$'\033[34m'; _c_dim=$'\033[2m'; _c_rst=$'\033[0m'
+else
+  _c_red=; _c_grn=; _c_ylw=; _c_blu=; _c_dim=; _c_rst=
+fi
+
+log()  { printf '%s[vdev]%s %s\n'      "$_c_blu" "$_c_rst" "$*" >&2; }
+ok()   { printf '%s[vdev]%s %s\n'      "$_c_grn" "$_c_rst" "$*" >&2; }
+warn() { printf '%s[vdev] warn:%s %s\n' "$_c_ylw" "$_c_rst" "$*" >&2; }
+err()  { printf '%s[vdev] error:%s %s\n' "$_c_red" "$_c_rst" "$*" >&2; }
+die()  { err "$*"; exit 1; }
+dim()  { printf '%s%s%s\n' "$_c_dim" "$*" "$_c_rst" >&2; }
+
+ensure_state_dirs() {
+  mkdir -p "$VDEV_PIDS" "$VDEV_LOGS"
+  touch "$VDEV_PULSE_MODULES" "$VDEV_META"
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+# Map a 1-based device index to its /dev/video number.
+video_nr_for() { echo $(( VDEV_VIDEO_NR_BASE + $1 - 1 )); }
+video_dev_for() { echo "/dev/video$(video_nr_for "$1")"; }
+
+# meta_set KEY VALUE / meta_get KEY
+meta_set() {
+  ensure_state_dirs
+  local key="$1" val="$2" tmp
+  tmp="$(mktemp)"
+  grep -v "^${key}=" "$VDEV_META" 2>/dev/null > "$tmp" || true
+  echo "${key}=${val}" >> "$tmp"
+  mv "$tmp" "$VDEV_META"
+}
+meta_get() {
+  [[ -f "$VDEV_META" ]] || return 1
+  local line
+  line="$(grep "^${1}=" "$VDEV_META" 2>/dev/null | tail -1)" || return 1
+  [[ -n "$line" ]] || return 1
+  echo "${line#*=}"
+}

--- a/tools/virtual-devices/lib/video.sh
+++ b/tools/virtual-devices/lib/video.sh
@@ -58,16 +58,18 @@ video_unload_module() {
 }
 
 # video_start_feeder INDEX CLIP
+# Returns non-zero (without exiting) if the feeder can't be started or dies
+# immediately, so callers can aggregate per-device failures.
 video_start_feeder() {
   local idx="$1" clip="$2"
-  local dev pidf logf
+  local dev pidf logf pid
   dev="$(video_dev_for "$idx")"
   pidf="$VDEV_PIDS/cam${idx}.pid"
   logf="$VDEV_LOGS/cam${idx}.log"
   require_cmd ffmpeg
 
-  [[ -e "$dev" ]] || die "device $dev does not exist (load the module first)"
-  [[ -f "$clip" ]] || die "clip not found for cam$idx: $clip"
+  [[ -e "$dev" ]] || { err "cam$idx: device $dev does not exist (load the module first)"; return 1; }
+  [[ -f "$clip" ]] || { err "cam$idx: clip not found: $clip"; return 1; }
 
   video_stop_feeder "$idx"  # no-op if not running
 
@@ -77,7 +79,24 @@ video_start_feeder() {
     -an -vf "scale=${VDEV_WIDTH}:${VDEV_HEIGHT},fps=${VDEV_FPS},format=${VDEV_PIXFMT}" \
     -f v4l2 "$dev" \
     >"$logf" 2>&1 &
-  echo $! > "$pidf"
+  pid=$!
+  if ! echo "$pid" > "$pidf"; then
+    kill "$pid" 2>/dev/null || true
+    err "cam$idx: could not record pid (state dir $VDEV_PIDS not writable?)"
+    return 1
+  fi
+
+  # ffmpeg often dies within milliseconds for runtime reasons the pre-flight
+  # checks can't catch (pixfmt the device rejects, device already held by a
+  # reader, undecodable clip). Settle, then confirm it's still serving before
+  # we claim the camera is up.
+  sleep "$VDEV_FEEDER_SETTLE"
+  if ! pid_is_feeder "$pid"; then
+    rm -f "$pidf"
+    err "cam$idx feeder died immediately (clip=$clip dev=$dev pixfmt=$VDEV_PIXFMT) — last log lines:"
+    tail -n 12 "$logf" >&2 || true
+    return 1
+  fi
   meta_set "cam${idx}_clip" "$clip"
 }
 
@@ -86,7 +105,7 @@ video_stop_feeder() {
   local pidf="$VDEV_PIDS/cam${idx}.pid"
   [[ -f "$pidf" ]] || return 0
   pid="$(cat "$pidf" 2>/dev/null || true)"
-  if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+  if pid_is_feeder "$pid"; then
     kill "$pid" 2>/dev/null || true
   fi
   rm -f "$pidf"
@@ -107,5 +126,5 @@ video_feeder_state() {
   local pidf="$VDEV_PIDS/cam${idx}.pid"
   [[ -f "$pidf" ]] || { echo "stopped"; return; }
   pid="$(cat "$pidf" 2>/dev/null || true)"
-  if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then echo "alive ($pid)"; else echo "dead"; fi
+  if pid_is_feeder "$pid"; then echo "alive ($pid)"; else echo "dead"; fi
 }

--- a/tools/virtual-devices/lib/video.sh
+++ b/tools/virtual-devices/lib/video.sh
@@ -97,7 +97,10 @@ video_start_feeder() {
     tail -n 12 "$logf" >&2 || true
     return 1
   fi
-  meta_set "cam${idx}_clip" "$clip"
+  # The feeder is up; a metadata-write failure must not flip that verdict (which
+  # would mark a live feeder "failed" and orphan its ffmpeg). Warn, don't fail.
+  meta_set "cam${idx}_clip" "$clip" || warn "cam$idx: feeder up but could not record clip metadata"
+  return 0
 }
 
 video_stop_feeder() {

--- a/tools/virtual-devices/lib/video.sh
+++ b/tools/virtual-devices/lib/video.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Video plane: v4l2loopback module + per-camera ffmpeg feeders.
+# Assumes lib/common.sh is already sourced.
+
+# Check /sys/module directly: avoids the `set -o pipefail` + `grep -q` pitfall
+# where grep exits early, lsmod gets SIGPIPE, and the pipeline reports failure.
+video_module_loaded() { [[ -d /sys/module/v4l2loopback ]]; }
+
+# video_load_module COUNT
+# Idempotent: if already loaded with the same device count, reuse it.
+# If loaded with a different count, unload and reload (caller must have
+# stopped any feeders first, or modprobe -r will fail with "device busy").
+video_load_module() {
+  local count="$1"
+  require_cmd modprobe
+
+  if video_module_loaded; then
+    local cur; cur="$(meta_get video_count 2>/dev/null || echo '')"
+    if [[ "$cur" == "$count" ]]; then
+      log "v4l2loopback already loaded for $count device(s); reusing"
+      return 0
+    fi
+    warn "v4l2loopback loaded for '${cur:-unknown}' device(s); reloading for $count"
+    video_unload_module || die "could not unload v4l2loopback (a device is busy?)"
+  fi
+
+  local nrs=() labels=() excl=() i nr
+  for ((i = 1; i <= count; i++)); do
+    nr="$(video_nr_for "$i")"
+    nrs+=("$nr")
+    labels+=("Virtual Cam $i")
+    excl+=("1")
+  done
+  local nr_csv label_csv excl_csv
+  nr_csv="$(IFS=,; echo "${nrs[*]}")"
+  label_csv="$(IFS=,; echo "${labels[*]}")"
+  excl_csv="$(IFS=,; echo "${excl[*]}")"
+
+  log "loading v4l2loopback (devices=$count video_nr=$nr_csv) — sudo required"
+  sudo modprobe v4l2loopback \
+    devices="$count" \
+    video_nr="$nr_csv" \
+    card_label="$label_csv" \
+    exclusive_caps="$excl_csv" \
+    || die "modprobe v4l2loopback failed"
+
+  meta_set video_count "$count"
+  meta_set video_nr_base "$VDEV_VIDEO_NR_BASE"
+  ok "v4l2loopback loaded: $count virtual camera(s)"
+}
+
+video_unload_module() {
+  video_module_loaded || { meta_set video_count 0; return 0; }
+  log "unloading v4l2loopback — sudo required"
+  sudo modprobe -r v4l2loopback || return 1
+  meta_set video_count 0
+  return 0
+}
+
+# video_start_feeder INDEX CLIP
+video_start_feeder() {
+  local idx="$1" clip="$2"
+  local dev pidf logf
+  dev="$(video_dev_for "$idx")"
+  pidf="$VDEV_PIDS/cam${idx}.pid"
+  logf="$VDEV_LOGS/cam${idx}.log"
+  require_cmd ffmpeg
+
+  [[ -e "$dev" ]] || die "device $dev does not exist (load the module first)"
+  [[ -f "$clip" ]] || die "clip not found for cam$idx: $clip"
+
+  video_stop_feeder "$idx"  # no-op if not running
+
+  log "cam$idx <- $clip  ($dev)"
+  nohup ffmpeg -hide_banner -loglevel warning -nostdin \
+    -stream_loop -1 -re -i "$clip" \
+    -an -vf "scale=${VDEV_WIDTH}:${VDEV_HEIGHT},fps=${VDEV_FPS},format=${VDEV_PIXFMT}" \
+    -f v4l2 "$dev" \
+    >"$logf" 2>&1 &
+  echo $! > "$pidf"
+  meta_set "cam${idx}_clip" "$clip"
+}
+
+video_stop_feeder() {
+  local idx="$1" pid
+  local pidf="$VDEV_PIDS/cam${idx}.pid"
+  [[ -f "$pidf" ]] || return 0
+  pid="$(cat "$pidf" 2>/dev/null || true)"
+  if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null || true
+  fi
+  rm -f "$pidf"
+}
+
+video_stop_all() {
+  local pidf idx
+  for pidf in "$VDEV_PIDS"/cam*.pid; do
+    [[ -e "$pidf" ]] || continue
+    idx="$(basename "$pidf" .pid)"; idx="${idx#cam}"
+    video_stop_feeder "$idx"
+  done
+}
+
+# Print "alive"/"dead" for a cam index based on its pid file.
+video_feeder_state() {
+  local idx="$1" pid
+  local pidf="$VDEV_PIDS/cam${idx}.pid"
+  [[ -f "$pidf" ]] || { echo "stopped"; return; }
+  pid="$(cat "$pidf" 2>/dev/null || true)"
+  if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then echo "alive ($pid)"; else echo "dead"; fi
+}

--- a/tools/virtual-devices/lib/video.sh
+++ b/tools/virtual-devices/lib/video.sh
@@ -103,31 +103,7 @@ video_start_feeder() {
   return 0
 }
 
-video_stop_feeder() {
-  local idx="$1" pid
-  local pidf="$VDEV_PIDS/cam${idx}.pid"
-  [[ -f "$pidf" ]] || return 0
-  pid="$(cat "$pidf" 2>/dev/null || true)"
-  if pid_is_feeder "$pid"; then
-    kill "$pid" 2>/dev/null || true
-  fi
-  rm -f "$pidf"
-}
-
-video_stop_all() {
-  local pidf idx
-  for pidf in "$VDEV_PIDS"/cam*.pid; do
-    [[ -e "$pidf" ]] || continue
-    idx="$(basename "$pidf" .pid)"; idx="${idx#cam}"
-    video_stop_feeder "$idx"
-  done
-}
-
-# Print "alive"/"dead" for a cam index based on its pid file.
-video_feeder_state() {
-  local idx="$1" pid
-  local pidf="$VDEV_PIDS/cam${idx}.pid"
-  [[ -f "$pidf" ]] || { echo "stopped"; return; }
-  pid="$(cat "$pidf" 2>/dev/null || true)"
-  if pid_is_feeder "$pid"; then echo "alive ($pid)"; else echo "dead"; fi
-}
+# Camera feeder lifecycle — thin wrappers over the shared helpers in common.sh.
+video_stop_feeder()  { feeder_stop cam "$1"; }
+video_stop_all()     { feeder_stop_all cam; }
+video_feeder_state() { feeder_state cam "$1"; }

--- a/tools/virtual-devices/vdev
+++ b/tools/virtual-devices/vdev
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# vdev — spin up OS-level virtual cameras + mics that any app can select,
+# each playing looping synthetic media. App-agnostic dev tooling.
+#
+#   vdev up   [--count N] [--cams N] [--mics N] [--config FILE] [--no-audio] [--skip-modprobe]
+#   vdev down
+#   vdev status | list
+#   vdev gen  [--count N] [--out DIR] [--force]
+#   vdev attach <camN|micN> <file>
+#
+# A "device" N = Virtual Cam N (/dev/video1{N}) + Virtual Mic N (pulse source vmicN).
+# The only privileged step is loading/unloading the v4l2loopback kernel module
+# (sudo modprobe); everything else runs as your normal user.
+set -euo pipefail
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+source "$SELF_DIR/lib/common.sh"
+# shellcheck source=lib/video.sh
+source "$SELF_DIR/lib/video.sh"
+# shellcheck source=lib/audio.sh
+source "$SELF_DIR/lib/audio.sh"
+
+# Print the leading comment block (skip shebang, stop at first code line).
+usage() { awk 'NR==1{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "$0"; }
+
+# Resolve a path relative to a base dir (absolute paths pass through).
+resolve_path() {
+  local p="$1" base="$2"
+  case "$p" in
+    /*) echo "$p";;
+    *)  echo "$base/$p";;
+  esac
+}
+
+# Parse a --config file into the CLIPS/AUDIOS arrays (line order = device index).
+# Columns (whitespace): [index] <video-clip> <audio-clip>; '#' comments allowed.
+# A leading purely-numeric column is treated as the index label and skipped.
+parse_config() {
+  local file="$1" base
+  base="$(cd "$(dirname "$file")" && pwd)"
+  CLIPS=(); AUDIOS=()
+  local a b c
+  while read -r a b c _; do
+    [[ -z "$a" || "$a" == \#* ]] && continue
+    if [[ "$a" =~ ^[0-9]+$ && -n "$b" ]]; then
+      CLIPS+=("$(resolve_path "$b" "$base")")
+      AUDIOS+=("$(resolve_path "${c:-}" "$base")")
+    else
+      CLIPS+=("$(resolve_path "$a" "$base")")
+      AUDIOS+=("$(resolve_path "${b:-}" "$base")")
+    fi
+  done < "$file"
+  [[ ${#CLIPS[@]} -gt 0 ]] || die "config $file has no device entries"
+}
+
+cmd_up() {
+  local count="" cams="" mics="" config="" want_audio=1 skip_modprobe=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --count) count="$2"; shift 2;;
+      --cams)  cams="$2";  shift 2;;
+      --mics)  mics="$2";  shift 2;;
+      --config) config="$2"; shift 2;;
+      --no-audio) want_audio=0; shift;;
+      --skip-modprobe) skip_modprobe=1; shift;;
+      -h|--help) usage; return 0;;
+      *) die "unknown arg to up: $1";;
+    esac
+  done
+  ensure_state_dirs
+
+  CLIPS=(); AUDIOS=()
+  if [[ -n "$config" ]]; then
+    [[ -f "$config" ]] || die "config not found: $config"
+    parse_config "$config"
+    cams="${#CLIPS[@]}"
+    mics="$cams"
+  else
+    count="${count:-$VDEV_COUNT_DEFAULT}"
+    cams="${cams:-$count}"
+    mics="${mics:-$count}"
+    # default media library; auto-generate whatever is missing
+    local need_gen=0 i
+    for ((i = 1; i <= cams; i++)); do [[ -f "$VDEV_ASSETS/cam${i}.mp4" ]] || need_gen=1; done
+    if [[ $want_audio -eq 1 ]]; then
+      for ((i = 1; i <= mics; i++)); do [[ -f "$VDEV_ASSETS/mic${i}.wav" ]] || need_gen=1; done
+    fi
+    if [[ $need_gen -eq 1 ]]; then
+      log "generating missing default clips"
+      "$SELF_DIR/generate-clips.sh" --count "$(( cams > mics ? cams : mics ))"
+    fi
+    for ((i = 1; i <= cams; i++)); do CLIPS+=("$VDEV_ASSETS/cam${i}.mp4"); done
+    for ((i = 1; i <= mics; i++)); do AUDIOS+=("$VDEV_ASSETS/mic${i}.wav"); done
+  fi
+
+  # ---- video ----
+  if [[ $skip_modprobe -eq 1 ]]; then
+    video_module_loaded || die "--skip-modprobe given but v4l2loopback is not loaded (run: sudo modprobe v4l2loopback exclusive_caps=1 devices=$cams video_nr=$(seq -s, "$VDEV_VIDEO_NR_BASE" $((VDEV_VIDEO_NR_BASE + cams - 1))))"
+    meta_set video_count "$cams"
+  else
+    video_load_module "$cams"
+  fi
+  local i
+  for ((i = 1; i <= cams; i++)); do
+    video_start_feeder "$i" "${CLIPS[$((i-1))]}"
+  done
+
+  # ---- audio ----
+  if [[ $want_audio -eq 1 ]]; then
+    if audio_available; then
+      for ((i = 1; i <= mics; i++)); do
+        [[ -n "${AUDIOS[$((i-1))]:-}" ]] || continue
+        audio_create_mic "$i"
+        audio_start_feeder "$i" "${AUDIOS[$((i-1))]}"
+      done
+    else
+      warn "pactl/pulse not available — skipping virtual mics (cameras only)"
+    fi
+  fi
+
+  meta_set cams "$cams"
+  meta_set mics "$([[ $want_audio -eq 1 ]] && echo "$mics" || echo 0)"
+  echo
+  cmd_status
+}
+
+cmd_down() {
+  ensure_state_dirs
+  log "stopping feeders"
+  video_stop_all
+  audio_stop_all
+  log "removing virtual mics"
+  audio_destroy_all
+  # give the kernel a moment to release the loopback devices, then unload
+  local tries=0
+  until video_unload_module; do
+    tries=$((tries + 1))
+    [[ $tries -ge 4 ]] && { err "v4l2loopback still busy; check for stray readers (browsers/OBS) and retry 'vdev down'"; break; }
+    sleep 0.4
+  done
+  meta_set cams 0; meta_set mics 0
+  ok "all virtual devices torn down"
+}
+
+cmd_status() {
+  ensure_state_dirs
+  local cams mics
+  cams="$(meta_get cams 2>/dev/null || echo 0)"
+  mics="$(meta_get mics 2>/dev/null || echo 0)"
+
+  printf '%s== virtual cameras ==%s\n' "$_c_grn" "$_c_rst" >&2
+  if video_module_loaded; then
+    if command -v v4l2-ctl >/dev/null 2>&1; then
+      v4l2-ctl --list-devices 2>/dev/null | grep -A1 -i 'Virtual Cam' >&2 || dim "(module loaded; no Virtual Cam entries)"
+    fi
+    local i
+    for ((i = 1; i <= ${cams:-0}; i++)); do
+      printf '  cam%-2s %-13s feeder: %s  clip: %s\n' \
+        "$i" "$(video_dev_for "$i")" "$(video_feeder_state "$i")" \
+        "$(meta_get "cam${i}_clip" 2>/dev/null || echo '-')" >&2
+    done
+  else
+    dim "  v4l2loopback not loaded" >&2
+  fi
+
+  echo >&2
+  printf '%s== virtual mics ==%s\n' "$_c_grn" "$_c_rst" >&2
+  if [[ "${mics:-0}" -gt 0 ]] && audio_available; then
+    pactl list sources short 2>/dev/null | grep -E '[[:space:]]vmic[0-9]' >&2 || dim "  (no vmic sources found)"
+    local i
+    for ((i = 1; i <= mics; i++)); do
+      printf '  mic%-2s source: vmic%-2s feeder: %s  audio: %s\n' \
+        "$i" "$i" "$(audio_feeder_state "$i")" \
+        "$(meta_get "mic${i}_audio" 2>/dev/null || echo '-')" >&2
+    done
+  else
+    dim "  no virtual mics active" >&2
+  fi
+}
+
+cmd_attach() {
+  local target="${1:-}" file="${2:-}"
+  [[ -n "$target" && -n "$file" ]] || die "usage: vdev attach <camN|micN> <file>"
+  file="$(resolve_path "$file" "$PWD")"
+  [[ -f "$file" ]] || die "file not found: $file"
+  case "$target" in
+    cam*|[0-9]*)
+      local idx="${target#cam}"
+      [[ -e "$(video_dev_for "$idx")" ]] || die "cam$idx device missing — run 'vdev up' first"
+      video_start_feeder "$idx" "$file"
+      ok "cam$idx now playing $file";;
+    mic*)
+      local idx="${target#mic}"
+      audio_available || die "pulse not available"
+      audio_start_feeder "$idx" "$file"
+      ok "mic$idx now playing $file";;
+    *) die "target must be camN or micN, got: $target";;
+  esac
+}
+
+main() {
+  local sub="${1:-}"; shift || true
+  case "$sub" in
+    up)            cmd_up "$@";;
+    down|stop)     cmd_down "$@";;
+    status|list)   cmd_status "$@";;
+    gen|generate)  "$SELF_DIR/generate-clips.sh" "$@";;
+    attach)        cmd_attach "$@";;
+    -h|--help|help|"") usage;;
+    *) die "unknown command: $sub (try: vdev --help)";;
+  esac
+}
+main "$@"

--- a/tools/virtual-devices/vdev
+++ b/tools/virtual-devices/vdev
@@ -22,9 +22,6 @@ source "$SELF_DIR/lib/video.sh"
 # shellcheck source=lib/audio.sh
 source "$SELF_DIR/lib/audio.sh"
 
-# Print the leading comment block (skip shebang, stop at first code line).
-usage() { awk 'NR==1{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "$0"; }
-
 # Resolve a path relative to a base dir (absolute paths pass through).
 # Empty input stays empty so an omitted column doesn't resolve to the base dir.
 resolve_path() {

--- a/tools/virtual-devices/vdev
+++ b/tools/virtual-devices/vdev
@@ -62,10 +62,10 @@ cmd_up() {
   local count="" cams="" mics="" config="" want_audio=1 skip_modprobe=0
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --count) count="$2"; shift 2;;
-      --cams)  cams="$2";  shift 2;;
-      --mics)  mics="$2";  shift 2;;
-      --config) config="$2"; shift 2;;
+      --count) [[ $# -ge 2 ]] || die "--count requires a value"; count="$2"; shift 2;;
+      --cams)  [[ $# -ge 2 ]] || die "--cams requires a value";  cams="$2";  shift 2;;
+      --mics)  [[ $# -ge 2 ]] || die "--mics requires a value";  mics="$2";  shift 2;;
+      --config) [[ $# -ge 2 ]] || die "--config requires a value"; config="$2"; shift 2;;
       --no-audio) want_audio=0; shift;;
       --skip-modprobe) skip_modprobe=1; shift;;
       -h|--help) usage; return 0;;
@@ -84,13 +84,15 @@ cmd_up() {
     mics="$cams"
   else
     count="${count:-$VDEV_COUNT_DEFAULT}"
-    cams="${cams:-$count}"
-    mics="${mics:-$count}"
-    # default media library; auto-generate whatever is missing
+    require_uint --count "$count"
+    cams="${cams:-$count}"; require_uint --cams "$cams"
+    mics="${mics:-$count}"; require_uint --mics "$mics"
+    # default media library; auto-generate whatever is missing or empty (-s, not
+    # -f, so a leftover zero-byte clip from an interrupted run gets regenerated).
     local need_gen=0 i
-    for ((i = 1; i <= cams; i++)); do [[ -f "$VDEV_ASSETS/cam${i}.mp4" ]] || need_gen=1; done
+    for ((i = 1; i <= cams; i++)); do [[ -s "$VDEV_ASSETS/cam${i}.mp4" ]] || need_gen=1; done
     if [[ $want_audio -eq 1 ]]; then
-      for ((i = 1; i <= mics; i++)); do [[ -f "$VDEV_ASSETS/mic${i}.wav" ]] || need_gen=1; done
+      for ((i = 1; i <= mics; i++)); do [[ -s "$VDEV_ASSETS/mic${i}.wav" ]] || need_gen=1; done
     fi
     if [[ $need_gen -eq 1 ]]; then
       log "generating missing default clips"
@@ -101,8 +103,16 @@ cmd_up() {
   fi
 
   # ---- video ----
+  # Stop any feeders left from a previous run first: reloading v4l2loopback for a
+  # changed device count needs `modprobe -r`, which fails "device busy" while an
+  # ffmpeg feeder still holds a /dev/videoN. Makes `vdev up` safely re-runnable.
+  video_stop_all
+
   local i
-  if [[ $skip_modprobe -eq 1 ]]; then
+  if (( cams == 0 )); then
+    dim "  no cameras requested (cams=0); skipping v4l2loopback"
+    meta_set video_count 0
+  elif [[ $skip_modprobe -eq 1 ]]; then
     video_module_loaded || die "--skip-modprobe given but v4l2loopback is not loaded (run: sudo modprobe v4l2loopback exclusive_caps=1 devices=$cams video_nr=$(seq -s, "$VDEV_VIDEO_NR_BASE" $((VDEV_VIDEO_NR_BASE + cams - 1))))"
     # The pre-loaded module may have fewer devices than requested; fail early
     # with a clear message rather than dying mid-feeder on a missing node.

--- a/tools/virtual-devices/vdev
+++ b/tools/virtual-devices/vdev
@@ -8,7 +8,8 @@
 #   vdev gen  [--count N] [--out DIR] [--force]
 #   vdev attach <camN|micN> <file>
 #
-# A "device" N = Virtual Cam N (/dev/video1{N}) + Virtual Mic N (pulse source vmicN).
+# A "device" N = Virtual Cam N (/dev/video<10+N-1>, e.g. cam1 -> /dev/video10)
+# + Virtual Mic N (pulse source vmicN).
 # The only privileged step is loading/unloading the v4l2loopback kernel module
 # (sudo modprobe); everything else runs as your normal user.
 set -euo pipefail
@@ -25,8 +26,10 @@ source "$SELF_DIR/lib/audio.sh"
 usage() { awk 'NR==1{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "$0"; }
 
 # Resolve a path relative to a base dir (absolute paths pass through).
+# Empty input stays empty so an omitted column doesn't resolve to the base dir.
 resolve_path() {
   local p="$1" base="$2"
+  [[ -n "$p" ]] || return 0
   case "$p" in
     /*) echo "$p";;
     *)  echo "$base/$p";;
@@ -38,10 +41,11 @@ resolve_path() {
 # A leading purely-numeric column is treated as the index label and skipped.
 parse_config() {
   local file="$1" base
-  base="$(cd "$(dirname "$file")" && pwd)"
+  base="$(cd "$(dirname "$file")" && pwd)" || die "cannot resolve directory of config $file"
   CLIPS=(); AUDIOS=()
   local a b c
-  while read -r a b c _; do
+  # `|| [[ -n "$a" ]]` keeps the final line when the file lacks a trailing newline.
+  while read -r a b c _ || [[ -n "$a" ]]; do
     [[ -z "$a" || "$a" == \#* ]] && continue
     if [[ "$a" =~ ^[0-9]+$ && -n "$b" ]]; then
       CLIPS+=("$(resolve_path "$b" "$base")")
@@ -73,6 +77,8 @@ cmd_up() {
   CLIPS=(); AUDIOS=()
   if [[ -n "$config" ]]; then
     [[ -f "$config" ]] || die "config not found: $config"
+    [[ -z "$count$cams$mics" ]] || \
+      warn "--config given; device count comes from $config (ignoring --count/--cams/--mics)"
     parse_config "$config"
     cams="${#CLIPS[@]}"
     mics="$cams"
@@ -95,15 +101,24 @@ cmd_up() {
   fi
 
   # ---- video ----
+  local i
   if [[ $skip_modprobe -eq 1 ]]; then
     video_module_loaded || die "--skip-modprobe given but v4l2loopback is not loaded (run: sudo modprobe v4l2loopback exclusive_caps=1 devices=$cams video_nr=$(seq -s, "$VDEV_VIDEO_NR_BASE" $((VDEV_VIDEO_NR_BASE + cams - 1))))"
+    # The pre-loaded module may have fewer devices than requested; fail early
+    # with a clear message rather than dying mid-feeder on a missing node.
+    local missing=()
+    for ((i = 1; i <= cams; i++)); do
+      [[ -e "$(video_dev_for "$i")" ]] || missing+=("$(video_dev_for "$i")")
+    done
+    (( ${#missing[@]} == 0 )) || die "--skip-modprobe: v4l2loopback is loaded but these nodes are missing: ${missing[*]} — the loaded module has fewer than $cams devices. Reload it with devices=$cams, or lower --count/--cams."
     meta_set video_count "$cams"
   else
     video_load_module "$cams"
   fi
-  local i
+
+  local failed=()
   for ((i = 1; i <= cams; i++)); do
-    video_start_feeder "$i" "${CLIPS[$((i-1))]}"
+    video_start_feeder "$i" "${CLIPS[$((i-1))]}" || failed+=("cam$i")
   done
 
   # ---- audio ----
@@ -111,8 +126,11 @@ cmd_up() {
     if audio_available; then
       for ((i = 1; i <= mics; i++)); do
         [[ -n "${AUDIOS[$((i-1))]:-}" ]] || continue
-        audio_create_mic "$i"
-        audio_start_feeder "$i" "${AUDIOS[$((i-1))]}"
+        if audio_create_mic "$i"; then
+          audio_start_feeder "$i" "${AUDIOS[$((i-1))]}" || failed+=("mic$i")
+        else
+          failed+=("mic$i")
+        fi
       done
     else
       warn "pactl/pulse not available — skipping virtual mics (cameras only)"
@@ -123,6 +141,11 @@ cmd_up() {
   meta_set mics "$([[ $want_audio -eq 1 ]] && echo "$mics" || echo 0)"
   echo
   cmd_status
+
+  if (( ${#failed[@]} )); then
+    err "these devices failed to start: ${failed[*]} (logs in $VDEV_LOGS)"
+    return 1
+  fi
 }
 
 cmd_down() {
@@ -131,16 +154,26 @@ cmd_down() {
   video_stop_all
   audio_stop_all
   log "removing virtual mics"
-  audio_destroy_all
+  local audio_ok=1
+  audio_destroy_all || audio_ok=0
+  [[ $audio_ok -eq 1 ]] && meta_set mics 0
+
   # give the kernel a moment to release the loopback devices, then unload
-  local tries=0
+  local tries=0 unloaded=1
   until video_unload_module; do
     tries=$((tries + 1))
-    [[ $tries -ge 4 ]] && { err "v4l2loopback still busy; check for stray readers (browsers/OBS) and retry 'vdev down'"; break; }
+    if [[ $tries -ge 4 ]]; then unloaded=0; break; fi
     sleep 0.4
   done
-  meta_set cams 0; meta_set mics 0
-  ok "all virtual devices torn down"
+  [[ $unloaded -eq 1 ]] && meta_set cams 0
+
+  if [[ $unloaded -eq 1 && $audio_ok -eq 1 ]]; then
+    ok "all virtual devices torn down"
+  else
+    [[ $unloaded -eq 0 ]] && err "v4l2loopback still busy after $tries tries; module NOT unloaded — close stray readers (browser tabs, OBS) and retry 'vdev down'."
+    [[ $audio_ok -eq 0 ]] && err "some virtual mics could not be removed — retry 'vdev down', or unload manually with 'pactl unload-module'."
+    return 1
+  fi
 }
 
 cmd_status() {
@@ -185,7 +218,7 @@ cmd_attach() {
   file="$(resolve_path "$file" "$PWD")"
   [[ -f "$file" ]] || die "file not found: $file"
   case "$target" in
-    cam*|[0-9]*)
+    cam*)
       local idx="${target#cam}"
       [[ -e "$(video_dev_for "$idx")" ]] || die "cam$idx device missing — run 'vdev up' first"
       video_start_feeder "$idx" "$file"

--- a/tools/virtual-devices/webcam-test.html
+++ b/tools/virtual-devices/webcam-test.html
@@ -1,0 +1,93 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>vdev — virtual device check</title>
+<style>
+  body { font: 15px/1.4 system-ui, sans-serif; margin: 2rem; background:#111; color:#eee; }
+  h1 { font-size: 1.2rem; }
+  label { display:inline-block; min-width: 5rem; }
+  select, button { font: inherit; padding: .3rem .5rem; margin: .2rem 0; }
+  video { width: 640px; max-width: 100%; background:#000; border-radius:6px; margin-top:1rem; }
+  .row { margin: .4rem 0; }
+  #meter { width: 640px; height: 14px; background:#222; border-radius:7px; overflow:hidden; }
+  #meterfill { height:100%; width:0; background:#3c6; }
+  #log { white-space: pre-wrap; color:#9ab; margin-top:1rem; font-size:13px; }
+</style>
+<h1>vdev — virtual camera / mic check</h1>
+<p>Pick a device below. Virtual ones appear as <b>Virtual Cam N</b> / <b>Virtual Mic N</b>
+once <code>vdev up</code> is running. Serve this file over http (browsers gate device
+labels behind a secure/localhost context):</p>
+<pre style="color:#7a8">  cd tools/virtual-devices &amp;&amp; python3 -m http.server 8099
+  # then open http://localhost:8099/webcam-test.html</pre>
+
+<div class="row"><label>Camera</label><select id="cam"></select></div>
+<div class="row"><label>Mic</label><select id="mic"></select></div>
+<div class="row"><button id="start">Start</button> <button id="stop">Stop</button>
+  <button id="refresh">Refresh devices</button></div>
+<div id="meter"><div id="meterfill"></div></div>
+<video id="preview" autoplay playsinline muted></video>
+<div id="log"></div>
+
+<script>
+const $ = id => document.getElementById(id);
+const logEl = $('log');
+const log = m => { logEl.textContent += m + "\n"; };
+let stream = null, audioCtx = null, raf = null;
+
+async function listDevices() {
+  const devs = await navigator.mediaDevices.enumerateDevices();
+  for (const [kind, sel] of [['videoinput', $('cam')], ['audioinput', $('mic')]]) {
+    sel.innerHTML = '';
+    devs.filter(d => d.kind === kind).forEach(d => {
+      const o = document.createElement('option');
+      o.value = d.deviceId;
+      o.textContent = d.label || `(${kind} ${d.deviceId.slice(0,8)})`;
+      sel.appendChild(o);
+    });
+  }
+  log(`found ${devs.filter(d=>d.kind==='videoinput').length} cameras, ` +
+      `${devs.filter(d=>d.kind==='audioinput').length} mics`);
+}
+
+function stop() {
+  if (raf) cancelAnimationFrame(raf), raf = null;
+  if (audioCtx) audioCtx.close(), audioCtx = null;
+  if (stream) stream.getTracks().forEach(t => t.stop()), stream = null;
+  $('preview').srcObject = null;
+  $('meterfill').style.width = '0';
+}
+
+async function start() {
+  stop();
+  const camId = $('cam').value, micId = $('mic').value;
+  try {
+    stream = await navigator.mediaDevices.getUserMedia({
+      video: camId ? { deviceId: { exact: camId } } : true,
+      audio: micId ? { deviceId: { exact: micId } } : true,
+    });
+  } catch (e) { log('getUserMedia failed: ' + e); return; }
+  $('preview').srcObject = stream;
+  log('streaming: ' + stream.getTracks().map(t => t.kind + ':' + t.label).join(', '));
+  // simple audio level meter to confirm the mic carries the synthetic tone
+  const aTrack = stream.getAudioTracks()[0];
+  if (aTrack) {
+    audioCtx = new AudioContext();
+    const src = audioCtx.createMediaStreamSource(stream);
+    const an = audioCtx.createAnalyser(); an.fftSize = 512;
+    src.connect(an);
+    const buf = new Uint8Array(an.frequencyBinCount);
+    const tick = () => {
+      an.getByteTimeDomainData(buf);
+      let peak = 0; for (const v of buf) peak = Math.max(peak, Math.abs(v - 128));
+      $('meterfill').style.width = Math.min(100, peak / 128 * 100 * 2) + '%';
+      raf = requestAnimationFrame(tick);
+    };
+    tick();
+  }
+  await listDevices(); // labels populate after permission is granted
+}
+
+$('start').onclick = start;
+$('stop').onclick = stop;
+$('refresh').onclick = listDevices;
+listDevices();
+</script>


### PR DESCRIPTION
## Summary

Adds `tools/virtual-devices/` — `vdev`, an app-agnostic CLI that creates **OS-level virtual cameras and microphones** on Linux so any application (browser conferencing client, OBS, ffmpeg) can select them from its normal device picker. Each device plays a looping, moving, labeled synthetic clip. Built for testing video/recording flows without real hardware, and more general than Chrome's `--use-file-for-fake-video-capture` flag (browser-only, single static file) or an SDK-level publisher (no real device node).

A "device" N pairs:
- **Virtual Cam N** → `/dev/video$((10+N-1))` via `v4l2loopback`
- **Virtual Mic N** → PipeWire/PulseAudio source `vmicN` (null-sink + remap-source)

## How it works

- `vdev up [--count N] [--cams N] [--mics N] [--config FILE] [--no-audio] [--skip-modprobe]`, plus `down`, `status`, `gen`, `attach <camN|micN> <file>`.
- Video: per-cam `ffmpeg` loops a clip into the loopback device (`exclusive_caps=1` so browsers list it).
- Audio: per-mic `ffmpeg` feeds a null-sink whose monitor is remapped to a clean capture source — **fully user-space, no sudo**.
- `generate-clips.sh` produces distinct moving test patterns (testsrc2/smptebars/rgbtestsrc/mandelbrot) with a `CAM N` label + live clock, and per-mic tones. Clips are git-ignored (regenerable).
- The **only** privileged step is `sudo modprobe v4l2loopback` (done by `up`/`down`); `--skip-modprobe` runs entirely without sudo against an already-loaded module.
- Runtime state in `$XDG_STATE_HOME/vdev`.

## Test plan

- [x] `vdev gen` produces 1280x720 yuv420p clips; frames differ over time (motion) with correct labels
- [x] `vdev up` loads the module; `v4l2-ctl --list-devices` shows Virtual Cam 1/2; `vmic1/2` appear as sources
- [x] Live frame grabbed off `/dev/video10` shows advancing clock (device serves looping content)
- [x] Audio path: feeders feed the sinks; `vdev down` tears down cleanly (no stray processes/modules/pidfiles)
- [x] `--skip-modprobe` reuses a loaded module with no sudo
- [ ] Select Virtual Cam/Mic in a browser via `webcam-test.html` and confirm live preview + level meter
- [ ] Select them in the connect/conferencing client and confirm a recording captures the synthetic feed