### PR TITLE
chore: allowlist read-only commands to reduce permission prompts

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,35 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(aws sts get-caller-identity:*)",
+      "Bash(aws cloudformation describe-stacks:*)",
+      "Bash(aws cloudformation get-template:*)",
+      "Bash(aws cloudformation describe-stack-events:*)",
+      "Bash(aws secretsmanager list-secrets:*)",
+      "Bash(aws iam list-attached-role-policies:*)",
+      "Bash(aws iam get-policy-version:*)",
+      "Bash(aws iam get-role:*)",
+      "Bash(aws iam list-role-policies:*)",
+      "Bash(aws iam simulate-principal-policy:*)",
+      "Bash(aws ecs describe-task-definition:*)",
+      "Bash(aws ecs describe-services:*)",
+      "Bash(aws ecs describe-tasks:*)",
+      "Bash(aws ecs list-clusters:*)",
+      "Bash(aws ecs list-tasks:*)",
+      "Bash(aws rds describe-db-instances:*)",
+      "Bash(aws events list-rules:*)",
+      "Bash(aws events list-event-buses:*)",
+      "Bash(aws route53 list-hosted-zones:*)",
+      "Bash(aws autoscaling describe-auto-scaling-groups:*)",
+      "Bash(aws s3 ls:*)",
+      "Bash(sam validate:*)",
+      "Bash(ruff check:*)",
+      "Bash(cfn-lint:*)",
+      "Bash(pnpm check-types:*)",
+      "mcp__datadog-mcp__search_datadog_logs",
+      "mcp__datadog-mcp__analyze_datadog_logs"
+    ]
+  },
   "hooks": {
     "PostToolUse": [
       {


### PR DESCRIPTION
## Summary

Adds read-only Bash and MCP patterns to `.claude/settings.json` `permissions.allow` to cut down on permission prompts during AWS investigation and CI/lint work. Derived from a scan of recent session transcripts.

## What's added (27 entries)
- **AWS read-only subcommands** for services not already covered by `settings.local.json`: `sts get-caller-identity`, `cloudformation describe-stacks/get-template/describe-stack-events`, `secretsmanager list-secrets`, `iam` reads, `ecs` reads, `rds describe-db-instances`, `events list-*`, `route53 list-hosted-zones`, `autoscaling describe-*`, `s3 ls`.
- **Read-only checkers**: `sam validate`, `ruff check`, `cfn-lint`, `pnpm check-types`.
- **MCP**: `mcp__datadog-mcp__search_datadog_logs`, `mcp__datadog-mcp__analyze_datadog_logs`.

## Design notes
- Uses the `:*` suffix form (matches existing `aws ec2:*` convention); Claude Code strips flags before matching.
- **Per-subcommand, not per-service** for AWS — mutations still prompt.

## Deliberately excluded
- `secretsmanager get-secret-value`, `ssm start-session`/`ssh`, `sam build/deploy`, `cloudformation deploy/delete-stack`, `pnpm install/build`, interpreters — not read-only or arbitrary code execution.

Existing `hooks` block preserved; JSON validated.