### PR TITLE
fix(infra/ec2): validate POST /dbs body name against path traversal

### DIFF
--- a/infra/src/ec2/ec2-router.js
+++ b/infra/src/ec2/ec2-router.js
@@ -308,6 +308,12 @@ export function create_ec2_router(config = {}) {
             if (!name || !engine) {
                 return res.status(400).json({ ok: false, error: 'name and engine are required' });
             }
+            // Body `name` bypasses the router.param('name') guard (that only fires for
+            // path :name), so validate it here too — it feeds resolve(projects_dir/data_dir/
+            // SEEDS_BASE, name) + mkdirSync/writeFileSync below, i.e. a path-traversal sink.
+            if (!VALID_NAME.test(name)) {
+                return res.status(400).json({ ok: false, error: 'Invalid name: must be alphanumeric, hyphens, or underscores only' });
+            }
             if (!engines[engine]) {
                 return res.status(400).json({ ok: false, error: `Unknown engine: ${engine}. Use: ${Object.keys(engines).join(', ')}` });
             }


### PR DESCRIPTION
## What

`infra/src/ec2/ec2-router.js` validates the `:name` *path* parameter on all `/dbs/:name*` routes via a global `router.param('name')` allowlist (`/^[a-zA-Z0-9_-]+$/`). But `POST /dbs` (create) reads `name` from **`req.body`**, which that middleware never sees. The body `name` then flows unchecked into:

- `resolve(projects_dir, name)` → `mkdirSync(project_dir)` + `writeFileSync(resolve(project_dir, 'docker-compose.yml'))`
- `resolve(data_dir, name)` (mount path)
- `sync_seeds(name)` → `resolve(SEEDS_BASE, name)` + `mkdirSync`

A request like `{"name":"../../../../tmp/x","engine":"postgres"}` is an arbitrary-directory-create + file-write primitive outside `projects_dir`/`data_dir`. The router is mounted with **no auth** (`server.js` — `app.use(create_ec2_router(...))`), so it relies on network isolation alone; per our security-review guidance, internal-only isn't a reason to skip input validation (SSRF/IDOR targets).

This was surfaced by an automated security review that flagged the `GET /dbs/:name` line; that specific line is actually already protected by `router.param`. The real, unprotected sink is the body `name` in `POST /dbs` — fixed here.

## Fix

Apply the same `VALID_NAME` check to the body `name` in `POST /dbs`, reusing the param middleware's exact error message. One guard, no behavior change for valid names.

No command-injection vector exists: every `spawnSync` uses array args (no shell).

## Verification

- `node --check` clean.
- Confirmed `VALID_NAME` rejects `../../../../tmp/evil`, `/etc/passwd`, `foo/../bar`, `a/b`, `..`, `.`, `foo bar`, `foo;rm -rf` and accepts `mydb`, `saga-api`, `test_db`, `DB123`.

Note: the ec2-router has no existing unit-test harness (no test file references it; it'd need an express/supertest scaffold). Happy to add one if desired.