### PR TITLE
ci(publish): fix single-package mode for main ruleset + bump rum-util to 0.1.1

### DIFF
--- a/.github/workflows/publish-codeartifact.yml
+++ b/.github/workflows/publish-codeartifact.yml
@@ -47,7 +47,7 @@ on:
         default: false
         type: boolean
       single_package:
-        description: "Publish ONLY this package path (e.g. packages/web/rum-util). Leave blank for the standard coordinated multi-package release."
+        description: "Publish ONLY this package path (e.g. packages/web/rum-util) at its ALREADY-COMMITTED version — bump it via a PR first, since main's ruleset blocks direct pushes. Blank = standard coordinated multi-package release."
         required: false
         default: ""
         type: string
@@ -287,29 +287,35 @@ jobs:
           PREID="${{ github.event.inputs.preid }}"
           DRY_RUN="${{ github.event.inputs.dry_run }}"
 
-          # Publishable packages (not private). In single-package mode, bump only
-          # the requested package so the other packages keep their current version.
+          # Single-package mode publishes the version ALREADY COMMITTED on main.
+          # We can't bump-and-push here: main is guarded by a repository ruleset
+          # ("changes must be made through a pull request"), so the version is
+          # bumped via a normal PR before dispatch. Just read it and move on.
           if [ -n "$SINGLE_PACKAGE" ]; then
-            PUBLISHABLE_PACKAGES=("$SINGLE_PACKAGE")
-          else
-            PUBLISHABLE_PACKAGES=(
-              "packages/core/config"
-              "packages/node/logger"
-              "packages/node/pubsub-core"
-              "packages/node/api-util"
-              "packages/core/tgql-codegen"
-              "packages/core/trpc-base"
-              "packages/node/db"
-              "packages/node/api-core"
-              "packages/node/pubsub-client"
-              "packages/node/aws-util"
-              "packages/node/rabbitmq"
-              "packages/node/redis-core"
-              "packages/node/test-util"
-              "packages/core/fixture-deidentify"
-              "packages/node/mesh-fixture-cli"
-            )
+            NEW_VERSION=$(jq -r '.version' "$SINGLE_PACKAGE/package.json")
+            echo "new-version=$NEW_VERSION" >> $GITHUB_OUTPUT
+            echo "📦 single-package mode: publishing committed version $NEW_VERSION of $SINGLE_PACKAGE (no bump/push)"
+            exit 0
           fi
+
+          # Multi-package coordinated release: bump every publishable package.
+          PUBLISHABLE_PACKAGES=(
+            "packages/core/config"
+            "packages/node/logger"
+            "packages/node/pubsub-core"
+            "packages/node/api-util"
+            "packages/core/tgql-codegen"
+            "packages/core/trpc-base"
+            "packages/node/db"
+            "packages/node/api-core"
+            "packages/node/pubsub-client"
+            "packages/node/aws-util"
+            "packages/node/rabbitmq"
+            "packages/node/redis-core"
+            "packages/node/test-util"
+            "packages/core/fixture-deidentify"
+            "packages/node/mesh-fixture-cli"
+          )
 
           # Build npm version command with preid for prerelease versions
           VERSION_CMD="npm version $VERSION_TYPE --no-git-tag-version"

--- a/packages/web/rum-util/package.json
+++ b/packages/web/rum-util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saga-ed/soa-rum-util",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Datadog RUM wrapper with Saga conventions: singleton init, source-tagged errors/actions, silent no-op when unconfigured.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Why

The first dispatch of the single-package publish (PR #110) failed at **Version Bump**: the step's \`git push\` to \`main\` was rejected by a repository **ruleset** —

> remote: GH013: Repository rule violations found for refs/heads/main.
> Changes must be made through a pull request.

So the workflow's bump-and-push-to-main can never succeed against this ruleset (this affects the multi-package path too, but that's out of scope here). Nothing was published; \`main\` was untouched.

## What

- **Single-package mode now publishes the version already committed on \`main\`** — no bump, no push. You bump the package's version via a normal PR (like this one), then dispatch. This is the only ruleset-compatible flow.
- **Bumps \`@saga-ed/soa-rum-util\` → 0.1.1** so the next dispatch publishes 0.1.1 to CodeArtifact.

Updated the \`single_package\` input help text accordingly. Multi-package coordinated-release behavior is unchanged.

## After merge

Dispatch: \`single_package=packages/web/rum-util\`, \`publish_target=codeartifact\` (version input is ignored in single-package mode) → publishes \`@saga-ed/soa-rum-util@0.1.1\` to CodeArtifact (\`saga_js\`).