### PR TITLE
feat(saga-mesh): add sis_db + role to the empty seed profile

### DIFF
--- a/infra/compose/projects/saga-mesh/seed/profile-empty.sql
+++ b/infra/compose/projects/saga-mesh/seed/profile-empty.sql
@@ -1,6 +1,6 @@
 -- saga-mesh / profile=empty
 --
--- Creates the six per-app databases and owners for the SDS fixture mesh.
+-- Creates the seven per-app databases and owners for the SDS fixture mesh.
 -- No application data is seeded here — each app runs its own prisma
 -- migrations into its database after this file executes.
 --
@@ -16,6 +16,7 @@ CREATE USER iam_pii        WITH PASSWORD 'iam_pii';
 CREATE USER saga_user      WITH PASSWORD 'password123';
 CREATE USER ads_adm        WITH PASSWORD 'ads_adm';
 CREATE USER ledger         WITH PASSWORD 'ledger';
+CREATE USER sis            WITH PASSWORD 'sis';
 
 -- ── Databases ───────────────────────────────────────────────────────
 -- Owner set at creation time so prisma migrate deploy can CREATE SCHEMA.
@@ -25,6 +26,7 @@ CREATE DATABASE programs        OWNER saga_user;
 CREATE DATABASE scheduling      OWNER saga_user;
 CREATE DATABASE ads_adm_local   OWNER ads_adm;
 CREATE DATABASE ledger_local    OWNER ledger;
+CREATE DATABASE sis_db          OWNER sis;
 
 -- ── Grants (belt-and-suspenders; owner already has these) ──────────
 GRANT ALL PRIVILEGES ON DATABASE iam_local     TO iam;
@@ -33,6 +35,7 @@ GRANT ALL PRIVILEGES ON DATABASE programs      TO saga_user;
 GRANT ALL PRIVILEGES ON DATABASE scheduling    TO saga_user;
 GRANT ALL PRIVILEGES ON DATABASE ads_adm_local TO ads_adm;
 GRANT ALL PRIVILEGES ON DATABASE ledger_local  TO ledger;
+GRANT ALL PRIVILEGES ON DATABASE sis_db        TO sis;
 
 -- The sentinel row in _profile_meta.seeded is written by
 -- services/postgres/seed/init-and-seed.sh after this file completes.


### PR DESCRIPTION
## What

Add the `sis` role + `sis_db` database (with grant) to the saga-mesh
`profile-empty.sql` seed, mirroring the existing per-app role/db/grant
pattern for iam/programs/scheduling/ads_adm/ledger.

## Why

Adam's **sis-api** landed in `rostering` on `main` (2026-06). It owns a
dedicated `sis_db` and needs the role/database to exist before its prisma
migrations deploy. The sds_92 synthetic-dev stack currently provisions
this with a **local idempotent guard** (`up.sh`'s `ensure_sis_db`); this
PR adds it to the canonical seed so every mesh consumer gets it without
the guard. Once this is on main, the local guard can be dropped.

## Verification

Applied the equivalent role+db SQL against a live `soa-postgres-1` mesh,
deployed the sis-db init migration into `sis_db`, and booted sis-api:
`/health/ready` → 200 `{"status":"ready","sisDb":"connected"}`.

Tracking: saga-ed/student-data-system sds_92 decision `d1.7`.