### PR TITLE
soa-api-util: cut stable 1.2.0

### DIFF
--- a/packages/node/api-util/package.json
+++ b/packages/node/api-util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saga-ed/soa-api-util",
-  "version": "1.2.0-dev.0",
+  "version": "1.2.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Promote `@saga-ed/soa-api-util` 1.2.0-dev.0 → **1.2.0** stable. The prerelease was vetted end-to-end: connectv3-api consumes `DATADOG_RUM_TRACING_HEADERS` (qboard#127) and programs-api/scheduling-api consume `buildSagaOriginAllowlist` + the header constant (program-hub#135) — both install from CodeArtifact and build green. Code unchanged from 1.2.0-dev.0; version-only bump. Re hipponot/iac#358.