### PR TITLE
tools: add synthetic-dev local stack (relocated from student-data-system)

### DIFF
--- a/tools/synthetic-dev/README.md
+++ b/tools/synthetic-dev/README.md
@@ -1,0 +1,180 @@
+# Local synthetic-dev stack (sds_92)
+
+A dockerized local stack (postgres + redis + rabbitmq + the six APIs)
+for developing **synthetic** iam rosters / programs / schedules — no
+VPN, no prod-mirror fixture. Built 2026-05-26 in response to
+`sources/prompt-3.md`.
+
+The sixth API is **sis-api** (rostering, on main as of 2026-06 — Adam's
+SIS reconciliation / CSV-roster service), added so it can be
+cross-developed against saga-dash on this stack. See
+`../decisions/d1.7`.
+
+> **New here?** Read **`getting-started.md`** — onboarding + the
+> one-command path (`./bootstrap.sh`) that lands you in the team's exact
+> state (pinned in-flight PRs via `refresh-suite.sh`, then up + seed +
+> `verify.sh`). This README is the deeper drift log + service map.
+
+## TL;DR
+
+```bash
+./up.sh           # mesh + 6 services, EMPTY
+./up.sh --reset --seed roster   # from-scratch: empty baseline, then synthetic IAM roster only (programs empty)
+./up.sh --reset --seed full     # roster + programs/periods/enrollment
+./up.sh --seed [roster|full]    # seed without resetting (roster = default; iam groups don't dedup — prefer --reset)
+./up.sh --status  # health + row counts
+./up.sh --down    # stop services (mesh stays up)
+```
+
+Branch posture (decision `../decisions/d1.1`): everything on **main**.
+sds_92 is merged, so ads-adm now runs from the canonical
+`~/dev/student-data-system` checkout (the sds_92 worktree was retired).
+
+<details>
+<summary><strong>What I need checked out</strong> — repos, branches & presumed locations</summary>
+
+All paths are relative to `$DEV` (default `~/dev`; override by exporting
+`DEV=...`). `up.sh` expects each repo cloned as a sibling under `$DEV` and
+on the branch below — `check_branches` only **warns** on a mismatch, it
+won't stop the run.
+
+| repo | presumed location | branch | provides (port) |
+|---|---|---|---|
+| **soa** | `~/dev/soa` | `main` | mesh infra (`infra/` + `projects/saga-mesh/seed`) for pg/redis/rabbitmq; shared `@saga-ed/soa-*` packages (registry mode — `soa:link:off`) |
+| **rostering** | `~/dev/rostering` | `main` | iam-api (**:3010**); **sis-api (:3100)** + sis-db prisma; iam-db / iam-pii-db prisma; the `program-hub` roster scenario (`scripts/scenarios`) |
+| **program-hub** | `~/dev/program-hub` | `main`¹ | programs-api (**:3006**) + scheduling-api (**:3008**); the `programs` scenario (`scripts/scenarios`) |
+| **student-data-system** | `~/dev/student-data-system` | `main` | ads-adm-api (**:5005**); ads-adm-db prisma. Override the path with `SDS=...` |
+| **saga-dash** | `~/dev/saga-dash` | `main` | dash web UI (**:8900**) |
+
+Mesh containers (`soa-postgres-1` / `soa-redis-1` / `soa-rabbitmq-1`) are
+brought up from `soa` by `up.sh` itself — no separate clone.
+
+¹ **program-hub** may legitimately sit on a `fix/…` branch carrying the
+drift-#8 `iam_session`-cookie patch; that's fine — `up.sh` re-applies the
+same fix idempotently. You'll just see a `⚠ … (expected 'main')` line.
+
+</details>
+
+## What's up when it's up
+
+| service | port | repo / branch |
+|---|---|---|
+| iam-api | 3010 | rostering main (moved 3000→3010 to match saga-dash main's config — d1.4) |
+| sis-api | 3100 | rostering main — SIS reconciliation / CSV-roster (d1.7); calls iam-api `service.*` (S2S, dev-bypass locally) |
+| programs-api | 3006 | program-hub main |
+| scheduling-api | 3008 | program-hub main |
+| ads-adm-api | 5005 | student-data-system **main** (canonical checkout) |
+| saga-dash | 8900 | saga-dash main |
+| postgres / redis / rabbitmq | 5432 / 6379 / 5672 (mgmt 15672) | soa-mesh (`soa-postgres-1` etc.) |
+
+Mesh rabbitmq creds: **`rabbitmq_admin:password123`** (not `saga_user`).
+Seven empty DBs: `iam_local`, `iam_pii_local`, `programs`, `scheduling`,
+`ads_adm_local`, `ledger_local`, `sis_db` (all created by the canonical
+mesh seed — `sis_db` added in soa#112; d1.7).
+
+## Status as of 2026-05-26 (after rostering + program-hub pulled to latest origin/main)
+
+- ✅ Full stack stands up healthy (rostering #294, program-hub #98).
+- ✅ **Synthetic IAM roster seeding works** — the rostering `program-hub`
+  scenario creates 5 districts, 13 schools, 28 sections, district roles,
+  6 named dev users, 168 students, 22 tutors (197 users / 46 groups /
+  593 memberships).
+- ✅ **Synthetic programs/schedules seeding now works** — the
+  `auth.resolveSession` contract drift is **RESOLVED** upstream: iam-api
+  now issues a JWT `iam_session` cookie and exposes JWKS; programs-api
+  verifies the JWT locally (`iamAuth.userFromRequest`) instead of calling
+  `resolveSession`. The program-hub `programs` scenario creates 9
+  programs + 17 periods + enrollment against the synthetic roster. See
+  `../decisions/d1.2` (RESOLVED).
+
+## Drift log — why this isn't just `./student-data-system-demo.sh up`
+
+The existing concierge predates the current mains. Every gap below is
+applied idempotently by `up.sh`; several are **latent upstream bugs**
+worth fixing in their repos.
+
+1. **`SDS` path.** sds_92 is merged to main and its worktree retired, so
+   `up.sh` now defaults `SDS=$DEV/student-data-system` (the canonical
+   checkout). Override with `SDS=…` to run ads-adm from elsewhere.
+2. **rostering main switch isn't dep-neutral.** main added
+   `@aws-sdk/client-kms/-secrets-manager/-ses/-sts` + `jose` to iam-api
+   and changed workspace-package exports → needs `pnpm install` + full
+   `pnpm build` (concierge only rebuilds *seed* packages).
+3. **iam-api dev launch lost a runtime asset — RESOLVED upstream.** The `dev`
+   script's `--onSuccess` overrode the tsup config's copy of
+   `password-blocklist.txt` (+ `clean:true` wiped `dist/`), ENOENT-ing the
+   bundle's `fs.readFileSync`. Fixed on rostering main by **PR #302** (commit
+   `bc2a2dd`, 2026-05-27); the dev script now copies the asset before `node`.
+   `up.sh` no longer patches this.
+4. **main iam-api requires new env.** `AUTH_EMAIL_LOOKUP_SECRET` /
+   `AUTH_EMAIL_VERIFICATION_SECRET` (outside `NODE_ENV=development`) —
+   absent from the concierge's `.env.local` template. Fix: add them +
+   `NODE_ENV=development`.
+5. **dev user must be a UUID.** `audit_log.actor` is `uuid`. Latest main
+   now ships a UUID `.env.example` default (`…009`), but it differs from
+   the seeder's id, so keep `AUTH_DEVUSERID=f0000004-0000-4000-8000-00000000beef`
+   (the value `iam-db/src/seed-dev-user.ts` creates) + run the dev-user seeder.
+6b. **programs-api + scheduling-api require `IAM_API_URL`.** Latest program-hub main
+   hard-requires `IAM_API_URL` at startup (both verify iam JWTs via JWKS). `up.sh`
+   launches both with `IAM_API_URL=http://localhost:3010` (the new iam port).
+9. **iam-api moved to :3010 (2026-05-26).** saga-dash main's Janus auth rewrite points
+   `static/config.json` iam at 3010; `up.sh` runs iam there (PORT in launch env + `.env`)
+   and points programs/scheduling/scenarios at it. saga-dash now authenticates via tRPC
+   (`iam.auth.whoami`/`people.me`/`groups.getByUser`) — no mock auth, no dev-login form.
+   See `../decisions/d1.4`.
+6. **rate limiter throttles bulk seeding.** `SECURITY_RATELIMITMAXREQUESTS=100`/min
+   kills the 168-student create. Fix: raise it for dev seeding.
+7. **rabbitmq port + creds mismatch.** Apps default to
+   `amqp://saga_user:password123@localhost:5673`; the mesh broker is
+   `rabbitmq_admin@:5672`. iam-api tolerates the miss (degraded);
+   programs-api/scheduling-api **circuit-break and die** after ~5 min.
+   Fix: launch them with `RABBITMQ_URL=amqp://rabbitmq_admin:password123@localhost:5672`.
+   The `config/.env.development` value is `NODE_ENV`-gated and unreliable;
+   the process-env override is authoritative.
+8. **stale scenario scripts.** rostering `demo-small` omits the now-required
+   district-membership `persona` — use the `program-hub` scenario, which sets
+   personas. (The program-hub `programs.ts` `iam_session`-cookie issue that
+   used to live here is **RESOLVED upstream** — program-hub **PR #102** (merge
+   `d85aa2d`, on main as of 2026-05-27): the scenario reads/sends the JWT
+   `iam_session` cookie natively. `up.sh` no longer patches it.)
+10. **programs/scheduling DBs are provisioned via `migrate deploy`, not `db:push`.**
+    `db:push` only mirrors `schema.prisma` and ignores `migrations/`, so
+    migration-only DDL is silently never created — e.g. `RecurrenceRule`'s
+    **partial** unique index `(scheduleId, periodId, rotationIndex) WHERE periodId
+    IS NOT NULL` (migration `20260513120000`), which `reconcileExtraRotations`'
+    `INSERT … ON CONFLICT` needs. Without it, `schedules.upsert` **500s with PG
+    `42P10`**. Fix: `up.sh prep()` runs `pnpm db:deploy` (`prisma migrate deploy`)
+    — the same command program-hub's ECS `migrate` job runs — via the `migrate_db`
+    helper. A DB still on the old `db:push` footprint (no `_prisma_migrations`
+    history) is converted once via `migrate reset` (then re-seed). See
+    **`../decisions/d1.5`**. Surfaced 2026-05-27 driving the Schedule step after
+    the program-hub main switch.
+
+## Harness caveat
+
+`up.sh` launches services with `nohup` (persists in a normal terminal).
+When standing the stack up from *inside an agent tool-call*, foreground
+`nohup`/`setsid` children get reaped on call-teardown — launch each
+server as its own background task instead. This only affects agent-run
+sessions, not you running `./up.sh` in a terminal.
+
+## Seeding synthetic data
+
+- **IAM roster:** `cd ~/dev/rostering && pnpm tsx scripts/scenarios/src/run.ts program-hub`
+  (named dev users + 5 districts/13 schools/28 sections/168 students/22 tutors).
+- **Programs/schedules:** `cd ~/dev/program-hub/scripts/scenarios && pnpm scenario:programs`
+  — works on main (runtime auth fix #96 + scenario cookie fix #102; see `../decisions/d1.2`).
+- To reset iam between runs (groups don't dedup): truncate `iam_local`
+  public tables (keep `_prisma_migrations`) + `iam_pii_local.user_pii`,
+  then re-run the dev-user seeder. `up.sh` does the dev-user seed.
+
+## Files I changed (local, uncommitted — flag for upstream)
+
+- `~/dev/rostering/apps/node/iam-api/package.json` — dev-script asset copy (drift #3)
+- `~/dev/rostering/apps/node/iam-api/.env` — `AUTH_DEVUSERID` uuid, rate limit (drift #5,6)
+- `~/dev/rostering/.env.local` — NODE_ENV + AUTH secrets + RABBITMQ_URL (drift #4,7)
+- `~/dev/program-hub/apps/node/{programs,scheduling}-api/config/.env.development` — RABBITMQ_URL (drift #7; superseded by launch-env)
+- rostering + program-hub `package.json`/`pnpm-lock.yaml` — earlier soa:link residue discarded (now registry mode against local soa main)
+
+(program-hub `scripts/scenarios/src/programs.ts` is no longer changed locally — the
+`iam_session` cookie fix landed upstream in PR #102; see drift #8.)

--- a/tools/synthetic-dev/STATUS.md
+++ b/tools/synthetic-dev/STATUS.md
@@ -1,0 +1,90 @@
+---
+purpose: First-run handoff for the synthetic-dev stack
+audience: Adam (first time standing up + cross-developing sis-api ↔ saga-dash)
+updated: 2026-06-02
+---
+
+# synthetic-dev — STATUS / first-run handoff
+
+👋 Adam — this is the local **synthetic-dev** stack: a fully-dockerized,
+six-service environment seeded with a **synthetic** roster (no PII, no VPN, no
+prod fixture). It's set up so you can **cross-develop sis-api against saga-dash**
+in the same in-flight state the rest of us run.
+
+**Read `getting-started.md` for the full picture.** This file is just the
+"you are here, do this first" version.
+
+## First run — one command
+
+```bash
+cd ~/dev/soa/tools/synthetic-dev
+./bootstrap.sh
+```
+
+`bootstrap.sh` does the whole onboarding path:
+1. `refresh-suite.sh` — sets each repo to `main` + the **pinned** in-flight PRs
+   (`integration-suite.tsv`), so you land in *exactly* the team's state.
+2. `up.sh up --reset --seed roster` — mesh + 6 services + a fresh synthetic roster.
+3. `verify.sh` — asserts everything (see "What success looks like").
+
+Then drop into the authenticated dashboard:
+
+```bash
+./up.sh --login            # mints a dev@saga.org session + opens a logged-in Chromium at :8900
+```
+
+## Prereqs (do these once, before `bootstrap.sh`)
+
+- [ ] **Docker** daemon running.
+- [ ] **Node 22+** and **pnpm**.
+- [ ] **`gh` authenticated** — `gh auth status` (refresh-suite + verify resolve pinned PRs via `gh`).
+- [ ] **CodeArtifact token** — run `pnpm co:login` in each repo (expires ~12h; a 401 on `pnpm install` means re-run it).
+- [ ] **Five sibling repos cloned under `~/dev/`**: `soa`, `rostering`, `program-hub`, `saga-dash`, `student-data-system`. One successful `pnpm install` in each.
+
+## What success looks like
+
+`verify.sh` (run by `bootstrap.sh`, or any time) prints three groups and exits 0
+only if **all green** — currently **15 checks**:
+
+- `── service health ──` — iam(:3010) · sis(:3100) · programs(:3006) · scheduling(:3008) · ads-adm(:5005) · saga-dash(:8900), all → 200
+- `── data ──` — iam roster seeded (`users=197`) · `sis_db` migrated
+- `── source posture ──` — repos on the right branches **and** the pinned PRs actually merged in
+
+If you see `✓ all 15 checks passed — stack is ready`, you're in the team's state.
+
+## Current state snapshot (2026-06-02)
+
+- **Pinned suite** (`./refresh-suite.sh --list`): **program-hub #126**, **saga-dash #136**. Everything else has landed on `main`.
+- **Branch posture** `bootstrap`/`refresh-suite` will set:
+  - `local/integration`: **program-hub**, **saga-dash** (carry the pins)
+  - `main`: **rostering**, **soa**, **student-data-system**
+  - This is correct — `up.sh`/`verify.sh` are manifest-aware and stay quiet about it. A `⚠` or posture failure means *real* drift (usually "re-run `./refresh-suite.sh`").
+- **sis-api** is the sixth service (rostering `main`), on **:3100** against `sis_db`. It calls iam-api's `service.*` over S2S and works locally with no credentials (iam dev-bypass). See `decisions/d1.7`.
+- **Heads-up:** Sean's stack may already be running on this machine. `bootstrap.sh` does a clean `--reset` restart, so it's safe to just run it — it'll give you a fresh roster (re-login after any `--reset`).
+
+## If something's red
+
+- `verify.sh` names the failing check. For a service, tail its log: `tail -f /tmp/sds-synthetic/<service>.log`.
+- iam red → usually the `AUTH_*` secrets in `~/dev/rostering/.env.local`; `up.sh apply_fixes` writes a working template if absent.
+- `pnpm install` 401 → `pnpm co:login` in that repo.
+- Posture red (a pinned PR "NOT in checkout") → `./refresh-suite.sh`.
+- Anything not covered → the **Drift log** at the bottom of `README.md`.
+
+## Steady-state loop (after the first run)
+
+```bash
+./up.sh --status              # quick health peek
+./verify.sh                   # hard check (services + data + source posture)
+./up.sh --reset --seed roster # fresh data, services stay up (re-login after)
+./refresh-suite.sh            # re-pull pinned PRs after main moves / a pin updates
+./up.sh --down                # stop services (mesh stays up)
+```
+
+## For your Claude session
+
+If you're driving this with Claude, point it at:
+- **`getting-started.md`** — full onboarding + every verb.
+- **`README.md`** — service map + the drift log (what `up.sh` patches around and why).
+- **`decisions/d1.7`** (sis-api integration) and **`decisions/d1.8`** (pinned integration suite + the source-posture assertion).
+
+— handoff from Sean's session, 2026-06-02

--- a/tools/synthetic-dev/bootstrap.sh
+++ b/tools/synthetic-dev/bootstrap.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# bootstrap.sh — one command to land in the team's exact synthetic-dev state.
+#
+# Chains the three steps a new engineer (e.g. Adam) needs:
+#   1. refresh-suite.sh   — rebuild local/integration = main + the pinned PRs
+#   2. up.sh up --reset --seed roster — mesh + 6 services, fresh synthetic roster
+#   3. verify.sh          — assert every service is green and the roster seeded
+#
+# Stops at the first failing step (so you fix it before the next). For the
+# steady-state loop afterward, use up.sh / refresh-suite.sh directly.
+#
+# Usage:
+#   ./bootstrap.sh                  full: refresh suite + up + seed + verify
+#   ./bootstrap.sh --no-refresh     skip step 1 (already on the right branches)
+#   ./bootstrap.sh --seed full      seed roster + programs/periods/enrollment
+#   DEV=~/work ./bootstrap.sh       non-default sibling-repo parent
+#
+# Prereqs (see getting-started.md): Docker running, the 5 sibling repos cloned,
+# CodeArtifact auth (`pnpm co:login`), and `gh` authenticated.
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+DO_REFRESH=1; SEED_MODE=roster
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-refresh) DO_REFRESH=0; shift ;;
+    --seed) shift; case "${1:-}" in roster|full) SEED_MODE=$1; shift ;; *) echo "--seed needs roster|full"; exit 1 ;; esac ;;
+    -h|--help) sed -n '2,28p' "$0"; exit 0 ;;
+    *) echo "unknown: $1 (use --help)"; exit 1 ;;
+  esac
+done
+
+step(){ printf "\n\033[1m\033[36m▶ %s\033[0m\n" "$*"; }
+
+if [[ $DO_REFRESH == 1 ]]; then
+  step "1/3 refresh-suite — pinned in-flight PRs onto local/integration"
+  "$DIR/refresh-suite.sh" || { echo "refresh-suite failed — resolve above, then re-run"; exit 1; }
+else
+  step "1/3 refresh-suite — SKIPPED (--no-refresh)"
+fi
+
+step "2/3 up.sh — mesh + 6 services + reset + seed $SEED_MODE"
+"$DIR/up.sh" up --reset --seed "$SEED_MODE" || { echo "up.sh failed — tail /tmp/sds-synthetic/*.log"; exit 1; }
+
+step "3/3 verify — assert all green"
+"$DIR/verify.sh" || { echo "verification failed — see reds above"; exit 1; }
+
+printf "\n\033[32m✓ bootstrap complete — you're in the team's synthetic-dev state.\033[0m\n"
+echo "  Log in: http://localhost:3010/demo#auth as dev@saga.org, then http://localhost:8900"
+echo "  Or:     ./up.sh --login   (mints a session + opens an auto-logged-in Chromium)"

--- a/tools/synthetic-dev/browser-login.mjs
+++ b/tools/synthetic-dev/browser-login.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+// ─────────────────────────────────────────────────────────────────────────────
+// browser-login.mjs — open a real Chromium already logged into the dash.
+//
+// Why this exists: up.sh's `--login` curl mints a session into a cookie JAR,
+// which is useless to your browser — HttpOnly cookies can't be transplanted
+// into a running browser, so the dash bounces to the Janus redirect. This does
+// the devLogin INSIDE a browser context (persistent profile), so the iam_session
+// cookie lands where the dash can use it, then opens the dash in that window.
+//
+// It replicates the exact manual flow (devLogin at the iam-api origin, then the
+// dash at :8900 reuses the localhost cookie) — just automated.
+//
+// Invoked by up.sh (auto-login-browser mode). Playwright is resolved from
+// saga-dash's node_modules via createRequire, so nothing needs installing here.
+//
+// Env in:
+//   IAM_URL          iam-api base       (default http://localhost:3010)
+//   DASH_URL         dash base          (default http://localhost:8900)
+//   LOGIN_EMAIL      persona to log in  (default dev@saga.org)
+//   PROFILE_DIR      persistent profile (default /tmp/sds-synthetic/browser-profile)
+//   SAGA_DASH_DASH   path to saga-dash apps/web/dash (for playwright resolution)
+//   HEADLESS=1       run headless (verification only; default headful)
+//
+// Prints one sentinel line for up.sh to grep:
+//   AUTOLOGIN_OK <email> <userId> <finalUrl>
+//   AUTOLOGIN_FAIL <reason>
+// ─────────────────────────────────────────────────────────────────────────────
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+const IAM_URL  = process.env.IAM_URL     || 'http://localhost:3010';
+const DASH_URL = process.env.DASH_URL    || 'http://localhost:8900';
+const EMAIL    = process.env.LOGIN_EMAIL || 'dev@saga.org';
+const PROFILE  = process.env.PROFILE_DIR || '/tmp/sds-synthetic/browser-profile';
+const DASH_DIR = process.env.SAGA_DASH_DASH;
+const HEADLESS = process.env.HEADLESS === '1';
+
+const fail = (reason) => { console.log(`AUTOLOGIN_FAIL ${reason}`); process.exit(1); };
+
+if (!DASH_DIR) fail('SAGA_DASH_DASH not set');
+
+let chromium;
+try {
+  const require = createRequire(path.join(DASH_DIR, 'package.json'));
+  ({ chromium } = require('playwright'));
+} catch (e) {
+  fail(`cannot load playwright from ${DASH_DIR}: ${e.message}`);
+}
+
+let ctx;
+try {
+  ctx = await chromium.launchPersistentContext(PROFILE, {
+    headless: HEADLESS,
+    viewport: null,
+    args: ['--start-maximized'],
+  });
+} catch (e) {
+  fail(`could not launch Chromium (profile in use? missing DISPLAY?): ${e.message}`);
+}
+
+// devLogin via the context's request API — it shares cookie storage with the
+// browser context, so Set-Cookie lands in the persistent profile. The Origin
+// header satisfies iam-api's pre-session origin allowlist (same check the
+// /demo page passes).
+const res = await ctx.request.post(`${IAM_URL}/trpc/auth.devLogin`, {
+  headers: { 'Content-Type': 'application/json', Origin: IAM_URL },
+  data: { email: EMAIL },
+});
+if (!res.ok()) {
+  const body = await res.text().catch(() => '');
+  await ctx.close();
+  fail(`devLogin HTTP ${res.status()} for ${EMAIL} ${body}`.trim());
+}
+
+const cookies = await ctx.cookies(IAM_URL);
+if (!cookies.some((c) => c.name === 'iam_session')) {
+  await ctx.close();
+  fail('devLogin returned 200 but no iam_session cookie was set');
+}
+
+// Prove the session actually authenticates before we hand over the window.
+const who = await ctx.request.get(`${IAM_URL}/trpc/auth.whoami`);
+let userId = 'unknown';
+try {
+  userId = (await who.json())?.result?.data?.userId ?? 'unknown';
+} catch { /* leave unknown */ }
+if (!who.ok() || userId === 'unknown') {
+  await ctx.close();
+  fail(`whoami did not confirm a session (HTTP ${who.status()})`);
+}
+
+const page = ctx.pages()[0] ?? (await ctx.newPage());
+await page.goto(DASH_URL, { waitUntil: 'domcontentloaded' }).catch(() => {});
+// Give the dash's tRPC auth probe a moment, then report where we ended up so a
+// lingering Janus redirect is visible in the log.
+await page.waitForTimeout(1500);
+const finalUrl = page.url();
+
+console.log(`AUTOLOGIN_OK ${EMAIL} ${userId} ${finalUrl}`);
+
+if (HEADLESS) {
+  await ctx.close();
+  process.exit(0);
+}
+
+// Headful: keep the process (and the window) alive until the user closes it.
+ctx.on('close', () => process.exit(0));
+await new Promise(() => {});

--- a/tools/synthetic-dev/getting-started.md
+++ b/tools/synthetic-dev/getting-started.md
@@ -1,0 +1,288 @@
+# getting-started.md — synthetic-dev stack onboarding
+
+This is the local "synthetic-dev" stack we use for the attendance-UI /
+People-step work on saga-dash, and now for **cross-developing sis-api against
+saga-dash**. It's a dockerized, fully-local **six-service** stack:
+
+| port | service | repo |
+|---|---|---|
+| 3010 | iam-api | `~/dev/rostering` |
+| 3100 | sis-api | `~/dev/rostering` |
+| 3006 | programs-api | `~/dev/program-hub` |
+| 3008 | scheduling-api | `~/dev/program-hub` |
+| 5005 | ads-adm-api | `~/dev/student-data-system` |
+| 8900 | saga-dash | `~/dev/saga-dash` |
+| 5432 | postgres (`soa-postgres-1`) | mesh, from `~/dev/soa/infra` |
+| 6379 | redis | mesh |
+| 5672 / 15672 | rabbitmq | mesh |
+
+Seeds a realistic synthetic roster: **5 districts / 13 schools / 28 sections
+/ 168 students / 22 tutors / 6 named dev personas** — no PII, no VPN, no
+prod-mirror fixture. The 6 dev personas are admin/PM accounts you log in as
+(separate from the roster).
+
+## Fastest path — land in the team's exact state
+
+The stack runs against a `local/integration` branch in each repo = `main` +
+a **pinned set of not-yet-landed PRs** (the curated subset we're all
+developing against). One command reproduces that state, brings everything up,
+seeds a roster, and verifies it's green:
+
+```bash
+cd ~/dev/soa/tools/synthetic-dev
+./bootstrap.sh                 # refresh-suite → up.sh up --reset --seed roster → verify
+```
+
+`bootstrap.sh` chains three steps (run them individually if you prefer):
+
+```bash
+./refresh-suite.sh             # rebuild local/integration = main + the pinned PRs (integration-suite.tsv)
+./up.sh up --reset --seed roster
+./verify.sh                    # asserts 6 services @ 200 + roster + sis_db + SOURCE POSTURE (right branches, pinned PRs merged); non-zero on any red
+```
+
+> **Why `refresh-suite.sh` and not `refresh-integration.sh`?**
+> `refresh-integration.sh` defaults to *your own* open PRs (`--author @me`) and
+> picks up the **full** open set — so two engineers never match, and even one
+> engineer gets WIP/prod-only branches we don't run locally. `refresh-suite.sh`
+> applies the **pinned** PR numbers in `integration-suite.tsv` (author- and
+> account-independent), so everyone lands identically. See `decisions/d1.8`.
+
+The pinned suite (snapshot — `./refresh-suite.sh --list` for the live list):
+
+| repo | pinned PRs |
+|---|---|
+| saga-dash | #136 (program-details stale-on-switch) |
+| program-hub, rostering, soa, student-data-system | none — stay on `origin/main` |
+
+**Maintenance:** when one of these PRs merges to `main`, delete its line from
+`integration-suite.tsv` — the fix then arrives via `main` (up.sh's `prep`
+pulls + builds the sibling repos), so it no longer needs replaying. If that
+was a repo's *last* pin (as rostering's #366 was), also `git checkout main`
+in that repo so it leaves `local/integration` — `refresh-suite.sh` no longer
+manages it.
+
+> `refresh-suite.sh` leaves pinned repos (program-hub, saga-dash) **on
+> `local/integration`**; unpinned ones (rostering, soa, student-data-system)
+> stay on `main`. Both `up.sh`'s `check_branches` and `verify.sh` are
+> **manifest-aware** — they expect exactly that, so the *correct* setup is
+> silent. A `⚠` (or a `verify.sh` posture failure) now means **real drift**:
+> wrong branch, or a pinned PR not actually merged into your `local/integration`
+> (usually "forgot to re-run `refresh-suite.sh`"). `verify.sh` makes this a hard,
+> exit-code check; `check_branches` stays a warning so `up` still proceeds.
+
+## TL;DR (steady-state, once you're set up)
+
+```bash
+./up.sh up --reset --seed roster   # from-scratch: roster, no programs
+./up.sh --status                   # health + row counts
+./up.sh --login                    # mint a session + open an auto-logged-in Chromium
+./up.sh --down                     # stop services (mesh left up)
+./refresh-suite.sh                 # re-pull the pinned PRs after main moves / a PR updates
+```
+
+Then open `http://localhost:3010/demo#auth` → **devLogin** as `dev@saga.org`
+(Seed District admin), then `http://localhost:8900`. Or just `./up.sh --login`,
+which mints the session and opens a Chromium already logged into the dash.
+
+## sis-api (the sixth service)
+
+sis-api (`~/dev/rostering/apps/node/sis-api`, on rostering `main`) is the SIS
+reconciliation / CSV-roster service. `up.sh` stands it up on **:3100** against
+a dedicated `sis_db`. It calls iam-api's `service.*` S2S surface — and works
+locally with **no service credentials**, because iam-api's auth middleware
+synthesizes a dev-bypass service actor when auth is disabled (which is how we
+run iam-api here). `sis_db` is created by the canonical mesh seed (soa#112)
+alongside the other app DBs. See `decisions/d1.7`.
+
+To cross-develop sis-api ↔ saga-dash: edit either repo, the dev servers
+hot-reload (sis-api via `tsup --watch`, dash via Vite HMR). The dash already
+knows where sis-api lives — `up.sh` seeds a `sis-api → :3100` entry into
+saga-dash's `static/config.json`.
+
+## Walkthrough deck (start here for the UX flow)
+
+`../training/saga-dash-walkthrough.html` — open in a browser or serve via
+`../training/serve-docs.sh` (it shells out to `python3 -m http.server` on
+`:8080`, prints the URL). The deck walks the Program Setup flow end-to-end —
+**People → Schedule → Groups → Sessions** — driven as `dev-user` against the
+synthetic Seed District roster, with collapsible **Technical notes** panels
+documenting the endpoints/tables/types behind each step. Built from PNGs
+captured by `../training/capture/capture.mjs` (regenerable; see
+`../training/GENERATION.md`).
+
+## Prereqs (one-time)
+
+1. **Docker** daemon running.
+2. **Node 22+** and **pnpm**.
+3. **`gh` CLI authenticated** (`gh auth status`) — `refresh-suite.sh` resolves
+   the pinned PR numbers to branches via `gh`.
+4. **AWS CLI** + IAM credentials with read access to Saga's CodeArtifact
+   (the npm registry for the private `@saga-ed/*` packages). Without it
+   `pnpm install` in rostering/program-hub/saga-dash will 401 on every
+   private package. Get a fresh token any time with
+   `pnpm co:login` (defined in each repo's root `package.json`).
+5. **Five sibling repos cloned under a shared parent**, by default `~/dev/`:
+   ```
+   ~/dev/
+     ├── soa                  # mesh infra (provides docker compose for pg/redis/rabbitmq)
+     ├── rostering            # iam-api + sis-api + iam-db / sis-db
+     ├── program-hub          # programs-api + scheduling-api
+     ├── saga-dash            # the dash itself
+     └── student-data-system  # ads-adm-api + this synthetic-dev tooling
+   ```
+   Override the base with `DEV=~/work ./bootstrap.sh`.
+6. Each sibling repo's `pnpm install` should succeed at least once (post-
+   token-refresh). `up.sh` reruns this idempotently for rostering on every
+   `up` because the branch switch isn't dep-neutral; for the others a one-time
+   `pnpm install` in each repo gets you started.
+
+## Does it handle a clean Docker state?
+
+**Yes.** `mesh_up()` checks for `soa-postgres-1` running; if it isn't, it
+shells out to:
+
+```bash
+( cd $SOA/infra && make up PROJECT=saga-mesh PROFILE=empty \
+    POSTGRES_PORT=5432 REDIS_PORT=6379 RABBITMQ_PORT=5672 RABBITMQ_MGMT_PORT=15672 )
+```
+
+That's the canonical soa-mesh compose definition. So with zero containers
+running and Docker just booted, `./up.sh up` does the right thing in one
+command — brings up the mesh, applies prisma schemas (via `migrate deploy`
+— matches the deployed pipeline; see `decisions/d1.5`), launches all six
+services with the right env, and reports green.
+
+## Verbs
+
+```bash
+./bootstrap.sh                   # one-shot: pinned PRs + up + seed + verify
+./refresh-suite.sh               # rebuild local/integration = main + pinned PRs (all repos)
+./refresh-suite.sh --list        # print the pinned suite, no changes
+./verify.sh                      # assert 6 services + roster + sis_db + source posture (right branches, pins merged) — exit code
+
+./up.sh up                       # bring up mesh + 6 services (empty databases)
+./up.sh up --reset --seed roster # from-scratch: empty baseline + synthetic IAM roster
+./up.sh up --reset --seed full   # roster + 9 programs + periods + enrollment
+./up.sh --reset                  # truncate synthetic data → empty baseline (services stay up)
+./up.sh --seed roster            # seed against an already-empty stack
+./up.sh --status                 # GET /health on each, iam user count
+./up.sh --login [email]          # mint a session + open an auto-logged-in Chromium
+./up.sh --down                   # stop services (mesh stays up)
+./refresh-integration.sh saga-dash         # YOUR open PRs (per-author; prefer refresh-suite for the shared set)
+./refresh-integration.sh --prs 95 saga-dash # ad-hoc: scope to specific PR numbers
+```
+
+A reset re-seeds iam users with **new UUIDs**, so any browser session you
+had will 401. Re-login at `localhost:3010/demo#auth` (or `./up.sh --login`)
+after every `--reset`.
+
+The reset is data-only — it truncates synthetic rows but **preserves
+`_prisma_migrations`**, so it doesn't re-run schema setup. Fast.
+
+## Personas (login at `localhost:3010/demo#auth`)
+
+| email | role |
+|---|---|
+| `dev@saga.org` | Seed District admin (the default — most things work) |
+| `multi@saga.org` | belongs to multiple districts |
+| `new@saga.org` | district admin for a fresh district |
+| `many@saga.org` | admin for many programs |
+| `none@saga.org` | belongs to no district |
+| `frontier@saga.org` | empty-district admin |
+
+Each persona's UUID is printed at the end of every `--seed roster` run.
+
+## What `up` actually does, step by step
+
+1. `check_branches` — **manifest-aware** branch-posture warning: pinned repos
+   are expected on `local/integration`, unpinned on `main`, so the correct
+   setup is silent; a `⚠` means real drift (warning only — `up` still proceeds;
+   `verify.sh` makes posture a hard check + confirms the pins are merged).
+2. `apply_fixes` — idempotent edits for known main-vs-tooling drifts (see
+   the **Drift log** at the bottom of `README.md`); also writes
+   `SIS_DATABASE_URL` and seeds the dash's `sis-api → :3100` config key.
+3. `mesh_up` — starts soa-mesh if not running.
+4. `prep` — `pnpm install + build` in rostering / program-hub; `prisma migrate
+   deploy` for iam / programs / scheduling / sis / ads-adm DBs (via the
+   `migrate_db` helper — matches what `_deploy-ecs-api.yml`'s migrate job runs
+   on production).
+5. `services_up` — launches the six API services / dash with the right
+   env (IAM_API_URL, RABBITMQ_URL, JWT_ACCESSTOKENTTLSECONDS, etc.) via
+   `nohup pnpm dev` per service. PID files in `/tmp/sds-synthetic/`.
+
+Logs land in `/tmp/sds-synthetic/<service>.log` — tail those when something
+goes sideways.
+
+## Common operations
+
+```bash
+# What's the state?
+./up.sh --status                          # ports + iam user count
+./verify.sh                               # same, but asserts (exit code)
+
+# Stop everything
+./up.sh --down                            # services down, mesh stays up
+docker compose -f ~/dev/soa/infra/compose/projects/saga-mesh.yml down  # mesh too
+
+# Tail a service
+tail -f /tmp/sds-synthetic/sis-api.log
+
+# Re-seed only (services already up)
+./up.sh --reset --seed roster
+
+# After ANY reset → re-login
+open http://localhost:3010/demo#auth      # or ./up.sh --login
+```
+
+## When something breaks — known caveats
+
+`README.md` has a **Drift log** explaining the historical gaps between the
+concierge and current mains and what `up.sh` patches around. The
+short-list of things to know:
+
+- **CodeArtifact tokens expire** every ~12 h. If `pnpm install` 401s,
+  `pnpm co:login` in the affected repo refreshes it.
+- **Re-login after every `--reset`** (cookie ↔ user_id mismatch).
+- **A pinned PR conflicts on refresh:** `refresh-suite.sh` aborts that one
+  merge and reports it (the rest still apply). Resolve it in the
+  `local/integration` branch, or drop the offending PR from the manifest.
+- **Vite cache stickiness:** if you ship a code change in saga-dash and
+  HMR shows it merged but the browser still behaves old, the per-package
+  `.vite` optimize-deps caches are the usual culprit. Quick recipe: kill dash,
+  `rm -rf apps/web/dash/node_modules/.vite packages/web/pages/*/node_modules/.vite`,
+  restart, "Empty Cache and Hard Reload" in DevTools (Ctrl+Shift+R alone
+  is NOT enough). `up.sh --reset` clears these for you.
+- **`up.sh` runs under `nohup`** — fine in a terminal. If you wrap it in
+  another process supervisor, the children can get reaped on parent
+  teardown. Just run it in your shell.
+
+## Where to look for more
+
+- `README.md` (this directory) — the full drift log + service map + why
+  the script exists.
+- `../decisions/` — RESOLVED decision docs that shaped the stack
+  (pinned integration suite = `d1.8`, sis-api integration = `d1.7`,
+  provisioning via migrate deploy = `d1.5`, programs↔iam auth contract
+  = `d1.2`, branch posture = `d1.1`, etc.).
+- `../plans/` — design plans (e.g. the saga-dash Internal/External-SIS
+  wiring that landed as saga-dash#97).
+- `../training/saga-dash-walkthrough.html` — the deck.
+
+## Quick sanity-check on a fresh machine
+
+After cloning the 5 sibling repos and ensuring CodeArtifact + `gh` auth work:
+
+```bash
+cd ~/dev/soa/tools/synthetic-dev
+./bootstrap.sh
+# expect: refresh-suite green → 6 services @ 200 → "all checks passed"
+```
+
+If any service is red, `verify.sh` tells you which; tail its log under
+`/tmp/sds-synthetic/`. If iam is red, 9 times out of 10 the AUTH_* env vars in
+`~/dev/rostering/.env.local` need a refresh — `up.sh apply_fixes` writes a
+working template if absent.
+
+Holler if you hit anything that isn't in the drift log — odds are you've
+found drift the rest of us haven't run into yet, and we'd rather track it.

--- a/tools/synthetic-dev/integration-suite.tsv
+++ b/tools/synthetic-dev/integration-suite.tsv
@@ -1,0 +1,24 @@
+# integration-suite.tsv — the pinned set of not-yet-landed PRs the synthetic-dev
+# stack runs against. `refresh-suite.sh` reads this and rebuilds each repo's
+# local/integration branch as origin/main + exactly these PRs (via
+# refresh-integration.sh --prs), so every engineer lands in the SAME state.
+#
+# Why pin instead of the default `gh pr list --author @me`? Two reasons:
+#   1. The default is per-author — Adam's @me ≠ Sean's @me, so they'd never
+#      match without pinning.
+#   2. Even for one author, the running stack uses a CURATED subset: snapshot-
+#      rename, prod-only caps, and WIP branches are intentionally EXCLUDED.
+#      Pinning is the only way to reproduce that exact subset.
+#
+# Format: <repo><TAB><comma-separated PR numbers>.  '#' comments + blank lines
+# ignored. Repos not listed (soa, student-data-system) stay on origin/main.
+#
+# MAINTENANCE: when a PR merges to main, delete it here (sibling repos pull main
+# in up.sh's prep, so the fix arrives via main and no longer needs replaying).
+# Snapshot as of 2026-06-02 — see decisions/d1.8.
+# (2026-06-02 landed on main, dropped: rostering #366; saga-dash #124,#130,#132,#133.)
+# (2026-06-02 saga-dash #131 dropped — PR CLOSED: #129 fixed by rostering#366;
+#  "remember district" re-homed server-side as saga-dash#138.)
+# (2026-06-02 program-hub #126 dropped — landed on main; program-hub back on main.)
+
+saga-dash	136

--- a/tools/synthetic-dev/refresh-integration.sh
+++ b/tools/synthetic-dev/refresh-integration.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# refresh-integration.sh — rebuild a local-only `local/integration` branch in
+# each named repo as `origin/main` + a merge of every open PR you author.
+#
+# Why: you can ship many small, atomic PRs (each its own branch off main) AND
+# keep your dev environment running against the union of everything in flight.
+# Run the synthetic-dev stack against `local/integration` in each repo; rerun
+# this script when main moves, when you push to a PR, or when one merges.
+#
+# Usage:
+#   ./refresh-integration.sh saga-dash                          # one repo
+#   ./refresh-integration.sh saga-dash program-hub rostering    # several
+#   ./refresh-integration.sh --prs 95,108 saga-dash             # explicit PR set
+#   ./refresh-integration.sh --prs fix/foo,fix/bar saga-dash    # explicit branches
+#   AUTHOR=someuser ./refresh-integration.sh saga-dash          # someone else's PRs
+#   BASE=develop    ./refresh-integration.sh saga-dash          # non-main base
+#   DEV=~/work      ./refresh-integration.sh saga-dash          # non-default $DEV
+#
+# Default discovery is `gh pr list --state open --author <AUTHOR>` per repo,
+# which will include stale/old open PRs. Use --prs to pin the set explicitly
+# (numbers resolve via `gh pr view` to head refs; bare names are used as-is).
+# --prs applies to ALL repos given on the line.
+#
+# Behaviour per repo:
+#   1. Skip if the working tree is dirty (commit/stash first).
+#   2. `git fetch -q origin`.
+#   3. `git checkout -B local/integration origin/<BASE>` (disposable; recreate).
+#   4. List open PRs authored by $AUTHOR (default @me), merge each origin
+#      branch in order with --no-ff. Conflicts are aborted and reported so
+#      the rest still merge (best-effort).
+#   5. Print a summary of merged / conflicted branches.
+#
+# Caveats:
+#   - `local/integration` is local-only — DO NOT push it.
+#   - If two open PRs touch the same lines you'll see a conflict here; resolve
+#     in the integration branch (the PR branches stay clean).
+#   - Requires `gh` authenticated; `gh pr list` runs in each repo dir.
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+
+DEV=${DEV:-$HOME/dev}
+AUTHOR=${AUTHOR:-@me}
+BASE=${BASE:-main}
+INT=local/integration
+
+say()  { printf "\033[34m→\033[0m %s\n" "$*"; }
+ok()   { printf "\033[32m✓\033[0m %s\n" "$*"; }
+warn() { printf "\033[33m⚠\033[0m %s\n" "$*"; }
+err()  { printf "\033[31m✗\033[0m %s\n" "$*"; }
+
+# ── arg parsing (flags then repo names) ──────────────────────────────
+PRS_OVERRIDE=""
+REPOS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --prs)      PRS_OVERRIDE="$2"; shift 2 ;;
+    --prs=*)    PRS_OVERRIDE="${1#--prs=}"; shift ;;
+    -h|--help)  sed -n '2,40p' "$0"; exit 0 ;;
+    --)         shift; while [[ $# -gt 0 ]]; do REPOS+=("$1"); shift; done ;;
+    -*)         err "unknown flag: $1"; exit 1 ;;
+    *)          REPOS+=("$1"); shift ;;
+  esac
+done
+[[ ${#REPOS[@]} -ge 1 ]] || { sed -n '2,40p' "$0"; exit 1; }
+
+# Resolve --prs (numbers → head refs via `gh pr view`, plain names kept as-is).
+# Resolution is per-repo: head-ref of PR #95 in saga-dash is not the same as in
+# program-hub, so we re-resolve inside the per-repo loop below.
+overall_failed=0
+
+for name in "${REPOS[@]}"; do
+  repo="$DEV/$name"
+  printf "\n\033[1m=== %s ===\033[0m\n" "$name"
+
+  if [[ ! -d "$repo/.git" ]]; then
+    err "$repo is not a git repo — skipping"
+    overall_failed=1
+    continue
+  fi
+
+  cd "$repo"
+
+  # Untracked files (e.g. runtime auth dirs) survive `checkout -B`; only block
+  # on tracked modifications — those a checkout could overwrite.
+  if [[ -n $(git status --porcelain | grep -v '^??' || true) ]]; then
+    warn "modified/staged changes in $name — skipping (commit/stash first)"
+    overall_failed=1
+    continue
+  fi
+
+  say "fetching origin…"
+  if ! git fetch -q origin; then
+    err "fetch failed — skipping $name"
+    overall_failed=1
+    continue
+  fi
+
+  if ! git rev-parse --verify --quiet "origin/$BASE" >/dev/null; then
+    err "origin/$BASE does not exist in $name — skipping"
+    overall_failed=1
+    continue
+  fi
+
+  say "(re)creating $INT from origin/$BASE…"
+  git checkout -B "$INT" "origin/$BASE" >/dev/null 2>&1
+
+  if [[ -n "$PRS_OVERRIDE" ]]; then
+    # Resolve each comma-separated token: numeric → PR head ref (per this repo),
+    # else used verbatim as a branch name.
+    branches=""
+    IFS=',' read -ra tokens <<<"$PRS_OVERRIDE"
+    for tok in "${tokens[@]}"; do
+      tok="${tok// /}"
+      [[ -z "$tok" ]] && continue
+      if [[ "$tok" =~ ^[0-9]+$ ]]; then
+        ref=$(gh pr view "$tok" --json headRefName --jq '.headRefName' 2>/dev/null || true)
+        if [[ -n "$ref" ]]; then branches+="$ref"$'\n'
+        else warn "PR #$tok not found in $name — skipping"; fi
+      else
+        branches+="$tok"$'\n'
+      fi
+    done
+  else
+    branches=$(gh pr list --state open --author "$AUTHOR" \
+                --json headRefName --jq '.[].headRefName' 2>/dev/null || true)
+  fi
+
+  if [[ -z "$branches" ]]; then
+    ok "no PRs to merge — $INT == origin/$BASE"
+    continue
+  fi
+
+  merged=()
+  conflicted=()
+  missing=()
+  while IFS= read -r b; do
+    [[ -z "$b" ]] && continue
+    if ! git rev-parse --verify --quiet "origin/$b" >/dev/null; then
+      missing+=("$b")
+      continue
+    fi
+    say "merging $b…"
+    if git merge --no-ff --no-edit "origin/$b" >/dev/null 2>&1; then
+      merged+=("$b")
+    else
+      git merge --abort 2>/dev/null || true
+      conflicted+=("$b")
+      warn "conflict on $b — aborted; resolve interactively with: git merge origin/$b"
+    fi
+  done <<<"$branches"
+
+  ok "merged: ${merged[*]:-(none)}"
+  [[ ${#conflicted[@]} -gt 0 ]] && { warn "conflicted: ${conflicted[*]}"; overall_failed=1; }
+  [[ ${#missing[@]}    -gt 0 ]] && { warn "missing on origin: ${missing[*]}"; overall_failed=1; }
+done
+
+printf "\n"
+if [[ $overall_failed -eq 0 ]]; then
+  ok "all repos refreshed cleanly. Dev stack should pick up changes via HMR."
+else
+  warn "completed with issues — see above."
+fi
+exit $overall_failed

--- a/tools/synthetic-dev/refresh-suite.sh
+++ b/tools/synthetic-dev/refresh-suite.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# refresh-suite.sh — reproduce the team's exact in-flight integration state.
+#
+# Reads integration-suite.tsv (the PINNED set of not-yet-landed PRs) and drives
+# refresh-integration.sh once per repo with that repo's PR numbers, so anyone
+# who runs this lands in the SAME state — independent of who authored the PRs.
+#
+# This is the author-independent companion to refresh-integration.sh: that
+# script defaults to `gh pr list --author @me` (per-author, and picks up the
+# full open set); this one pins explicit PR numbers from the manifest so the
+# curated subset is reproduced verbatim. See decisions/d1.8.
+#
+# Usage:
+#   ./refresh-suite.sh              rebuild local/integration in every manifest repo
+#   ./refresh-suite.sh --list       print the pinned suite and exit (no changes)
+#   DEV=~/work ./refresh-suite.sh   non-default sibling-repo parent
+#
+# After this, run ./up.sh up --reset --seed roster (up.sh's prep builds the
+# integration code) then ./verify.sh. Repos here end up ON local/integration —
+# up.sh's check_branches will WARN about that; it's expected for this workflow.
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MANIFEST="$SCRIPT_DIR/integration-suite.tsv"
+REFRESH="$SCRIPT_DIR/refresh-integration.sh"
+
+say()  { printf "\033[34m→\033[0m %s\n" "$*"; }
+ok()   { printf "\033[32m✓\033[0m %s\n" "$*"; }
+err()  { printf "\033[31m✗\033[0m %s\n" "$*"; }
+
+[[ -f "$MANIFEST" ]] || { err "manifest not found: $MANIFEST"; exit 1; }
+[[ -x "$REFRESH"  ]] || { err "refresh-integration.sh not found/executable: $REFRESH"; exit 1; }
+
+# Strip comments + blank lines; keep "<repo>\t<prs>" rows.
+rows="$(grep -vE '^\s*(#|$)' "$MANIFEST" || true)"
+[[ -n "$rows" ]] || { err "manifest has no repo rows"; exit 1; }
+
+if [[ "${1:-}" == "--list" ]]; then
+  printf "\033[1mPinned integration suite (%s):\033[0m\n" "$MANIFEST"
+  while IFS=$'\t' read -r repo prs; do
+    [[ -z "${repo:-}" ]] && continue
+    printf "  %-20s PRs: %s\n" "$repo" "$prs"
+  done <<<"$rows"
+  exit 0
+fi
+
+failed=0
+while IFS=$'\t' read -r repo prs; do
+  [[ -z "${repo:-}" ]] && continue
+  repo="${repo//[[:space:]]/}"; prs="${prs//[[:space:]]/}"
+  [[ -z "$prs" ]] && { say "$repo — no PRs pinned, skipping"; continue; }
+  say "refreshing $repo → origin/main + PRs $prs"
+  if "$REFRESH" --prs "$prs" "$repo"; then
+    ok "$repo refreshed"
+  else
+    err "$repo refresh reported issues (see above)"
+    failed=1
+  fi
+done <<<"$rows"
+
+printf "\n"
+if [[ $failed -eq 0 ]]; then
+  ok "suite applied — every repo on local/integration with its pinned PRs"
+  echo "  next: ./up.sh up --reset --seed roster  &&  ./verify.sh"
+else
+  err "suite applied with issues — resolve conflicts above, then re-run"
+fi
+exit $failed

--- a/tools/synthetic-dev/up.sh
+++ b/tools/synthetic-dev/up.sh
@@ -1,0 +1,452 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# synthetic-dev/up.sh — stand up the local synthetic-dev stack for sds_92.
+#
+# Goal: dockerized postgres + redis + rabbitmq + the six APIs, EMPTY, ready to
+# seed with SYNTHETIC iam rosters / programs / schedules via the scenario
+# scripts (no VPN, no prod-mirror fixture).
+#
+# The sixth API is sis-api (rostering, on main as of 2026-06 — Adam's SIS
+# reconciliation / CSV-roster service). It runs on :3100 against a dedicated
+# `sis_db`, and calls iam-api's `service.*` S2S surface. No S2S credentials are
+# needed locally: iam-api's auth.middleware synthesizes a dev-bypass service
+# actor when authEnabled=false ("for the SIS CSV pilot"), which is the mode we
+# run iam-api in here. See decisions/d1.7. Its `sis_db` is created by the
+# canonical mesh seed (soa profile-empty.sql, soa#112) like the other app DBs.
+#
+# Branch posture (see decisions/d1.1): iam/programs/scheduling/saga-dash/soa on
+# MAIN; ads-adm from the canonical ~/dev/student-data-system checkout (sds_92 is
+# merged to main; the sds_92 worktree has been retired). Override with SDS=...
+#
+# This wraps + corrects the concierge (student-data-system-demo.sh). The
+# concierge's `up` does NOT work out-of-the-box on these mains: it doesn't pass
+# RABBITMQ_URL to program-hub (apps default to :5673, mesh is :5672), its
+# .env.local template predates main's required AUTH_* secrets, and it launches
+# iam-api via `pnpm dev` which (on main) fails to copy a runtime asset. Every
+# such drift + fix is documented in README.md and applied idempotently below.
+#
+# Usage:
+#   ./up.sh                      bring up mesh + 6 services (empty)
+#   ./up.sh --seed [roster|full] seed synthetic data (default: roster)
+#                                  roster = iam roster only (programs empty → from-scratch)
+#                                  full   = iam roster + programs/periods/enrollment
+#   ./up.sh --reset              truncate synthetic data → empty baseline (keeps migrations)
+#   ./up.sh --login [email]      auto-login via iam-api devLogin (default: dev@saga.org)
+#   ./up.sh --user  [email]      alias for --login
+#   ./up.sh --down               stop services (leaves mesh up)
+#   ./up.sh --status             health + row counts
+#
+# Flags compose, applied in order up → reset → seed → login. Reproducible
+# recipes (no post-deletes — selectivity is in what you seed):
+#   ./up.sh --reset --seed roster --login  from-scratch roster + dev@saga.org session
+#   ./up.sh --reset --seed full --login    roster + 9 programs + a fresh dev@saga.org session
+# (--reset / --seed / --login against an already-running stack skip the up step.)
+#
+# IMPORTANT: the default --login persona (dev@saga.org) is the rostered Seed
+# District admin — it only exists AFTER the iam roster is seeded, so --login
+# must follow a --seed (the recipes above). A BARE `--reset --login` truncates
+# the roster and leaves only the bootstrap user (dev@example.org), so the
+# dev@saga.org default 401s; either seed first, or `--login dev@example.org`.
+#
+# --login does TWO things:
+#   1. writes a cookie jar ($STATE/cookies.txt, Netscape) for HEADLESS harnesses
+#      (Playwright storageState / curl --cookie).
+#   2. opens a real Chromium (persistent profile, via browser-login.mjs) already
+#      logged into the dash at :8900 — so you skip the Janus redirect and the
+#      manual /demo#auth step. Drive THAT window; re-run --login after a reset to
+#      refresh it. (Needs Playwright in saga-dash — if absent, half 2 is skipped
+#      with a hint and the cookie jar still works.)
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+DEV=${DEV:-$HOME/dev}
+SOA=$DEV/soa
+ROSTERING=$DEV/rostering
+PROGRAM_HUB=$DEV/program-hub
+SAGA_DASH=$DEV/saga-dash
+SDS=${SDS:-$DEV/student-data-system}         # ads-adm from the canonical checkout (sds_92 merged to main; worktree retired)
+
+IAM_PORT=3010                                               # iam-api port — matches saga-dash main's static/config.json default (post Janus auth rewrite, d1.4)
+IAM_URL="http://localhost:$IAM_PORT"
+SIS_PORT=3100                                               # sis-api port (SisConfigSchema default; rostering apps/node/sis-api)
+SIS_DB_URL="postgresql://sis:sis@localhost:5432/sis_db"     # sis-api owns a dedicated DB (read direct from SIS_DATABASE_URL; see d1.7)
+MESH_MQ="amqp://rabbitmq_admin:password123@localhost:5672"  # mesh broker creds (NOT saga_user)
+DEV_USER_UUID="f0000004-0000-4000-8000-00000000beef"        # from iam-db seed-dev-user.ts
+STATE=/tmp/sds-synthetic; mkdir -p "$STATE"
+COOKIE_JAR="$STATE/cookies.txt"                             # devLogin session jar (for headless harnesses)
+DEFAULT_LOGIN_USER="dev@saga.org"                          # --login default persona (Seed District admin)
+DASH_URL="http://localhost:8900"                           # saga-dash
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"                 # this script's dir (browser-login.mjs lives alongside)
+BROWSER_LOGIN="$SCRIPT_DIR/browser-login.mjs"              # playwright auto-login helper
+BROWSER_PROFILE="$STATE/browser-profile"                    # persistent Chromium profile for the logged-in dash
+
+PG=( postgresql://iam:iam@localhost:5432/iam_local )
+say(){ printf "\033[34m→\033[0m %s\n" "$*"; }
+ok(){ printf "\033[32m✓\033[0m %s\n" "$*"; }
+
+# ── branch posture sanity (warn only, manifest-aware) ────────────────
+# A repo with pins in integration-suite.tsv is EXPECTED on local/integration
+# (that's where refresh-suite parks it); without pins it's expected on main.
+# So we only warn on ACTUAL drift — not on the correct pinned-suite state.
+# (verify.sh turns this into a hard, exit-code check + confirms the pinned PRs
+# are merged; here it stays a warning so `up` proceeds.)
+check_branches(){
+  local MANIFEST="$SCRIPT_DIR/integration-suite.tsv" repo have want
+  declare -A PINS=()
+  if [[ -f "$MANIFEST" ]]; then
+    while IFS=$'\t' read -r repo _prs; do
+      repo="${repo//[[:space:]]/}"; [[ -z "$repo" ]] && continue
+      PINS["$repo"]="${_prs//[[:space:]]/}"
+    done < <(grep -vE '^\s*(#|$)' "$MANIFEST")
+  fi
+  for kv in "$ROSTERING:rostering" "$PROGRAM_HUB:program-hub" "$SAGA_DASH:saga-dash"; do
+    r=${kv%:*}; repo=${kv#*:}
+    want=main; [[ -n "${PINS[$repo]:-}" ]] && want=local/integration
+    have=$(git -C "$r" branch --show-current)
+    [[ "$have" == "$want" ]] || printf "\033[33m⚠\033[0m %s on '%s' (expected '%s')\n" "$repo" "$have" "$want"
+  done
+  for kv in "$SOA:soa" "$SDS:student-data-system"; do
+    r=${kv%:*}; repo=${kv#*:}; have=$(git -C "$r" branch --show-current)
+    [[ "$have" == main ]] || printf "\033[33m⚠\033[0m %s on '%s' (expected 'main')\n" "$repo" "$have"
+  done
+}
+
+# ── idempotent fixes (all the main-vs-tooling drifts) ────────────────
+apply_fixes(){
+  # 1. rostering root .env.local — main iam-api needs NODE_ENV + AUTH secrets + broker
+  local L="$ROSTERING/.env.local"
+  [[ -f "$L" ]] || cat >"$L" <<EOF
+DATABASE_URL=postgresql://iam:iam@localhost:5432/iam_local
+PII_DATABASE_URL=postgresql://iam_pii:iam_pii@localhost:5432/iam_pii_local
+PII_DEK_HEX=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+PII_HMAC_KEY_HEX=fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210
+PII_DEK_VERSION=1
+PII_CRYPTO_PIIDEKHEX=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+PII_CRYPTO_PIIHMACKEYHEX=fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210
+PII_CRYPTO_PIIDEKVERSION=1
+REDIS_URL=redis://localhost:6379
+EOF
+  grep -q '^NODE_ENV='                     "$L" || echo "NODE_ENV=development" >>"$L"
+  grep -q '^AUTH_EMAIL_LOOKUP_SECRET='     "$L" || echo "AUTH_EMAIL_LOOKUP_SECRET=$(openssl rand -hex 32)" >>"$L"
+  grep -q '^AUTH_EMAIL_VERIFICATION_SECRET=' "$L" || echo "AUTH_EMAIL_VERIFICATION_SECRET=$(openssl rand -hex 32)" >>"$L"
+  grep -q '^RABBITMQ_URL='                 "$L" || echo "RABBITMQ_URL=$MESH_MQ" >>"$L"
+  # sis-api / sis-db read SIS_DATABASE_URL directly (sis-db/prisma.config.ts
+  # loads this repo-root .env.local), so it must live here for `migrate deploy`
+  # AND the running service to see the same DB. See d1.7.
+  grep -q '^SIS_DATABASE_URL='             "$L" || echo "SIS_DATABASE_URL=$SIS_DB_URL" >>"$L"
+
+  # 2. iam-api/.env — dev user must be a UUID (audit_log.actor is uuid); raise rate limit for bulk seed
+  local IE="$ROSTERING/apps/node/iam-api/.env"
+  if [[ -f "$IE" ]]; then
+    sed -i "s|^AUTH_DEVUSERID=.*|AUTH_DEVUSERID=$DEV_USER_UUID|" "$IE"
+    # iam-api on :3010 to match saga-dash main's default (d1.4). Set in .env
+    # (authoritative) AND passed as launch env below.
+    if grep -q '^PORT=' "$IE"; then sed -i "s|^PORT=.*|PORT=$IAM_PORT|" "$IE"; else echo "PORT=$IAM_PORT" >>"$IE"; fi
+    if grep -q '^SECURITY_RATELIMITMAXREQUESTS=' "$IE"; then
+      sed -i 's|^SECURITY_RATELIMITMAXREQUESTS=.*|SECURITY_RATELIMITMAXREQUESTS=1000000|' "$IE"
+    else echo 'SECURITY_RATELIMITMAXREQUESTS=1000000' >>"$IE"; fi
+    # Longer local session: bump the access-token TTL to 8h so hand-driving the
+    # dash doesn't 401 mid-edit (the dash's refresh loop is Janus/gateway-only,
+    # not wired locally; default TTL is 15 min). DotenvConfigManager exposes the
+    # JwtConfigSchema field as JWT_ACCESSTOKENTTLSECONDS. Prod is capped at 900s
+    # by assertProductionConfig — rostering PR #310.
+    if grep -q '^JWT_ACCESSTOKENTTLSECONDS=' "$IE"; then
+      sed -i 's|^JWT_ACCESSTOKENTTLSECONDS=.*|JWT_ACCESSTOKENTTLSECONDS=28800|' "$IE"
+    else echo 'JWT_ACCESSTOKENTTLSECONDS=28800' >>"$IE"; fi
+    # Janus perimeter (rostering issue #155, @saga-ed/janus-client v0.2) is the
+    # OUTER Saga-employee gate; with it on, the local seed scenario 401s with
+    # {"realms":["janus"]}. Disable for local dev -- the documented default
+    # in iam-api's own .env.example.
+    if grep -q '^JANUS_REQUIRED=' "$IE"; then
+      sed -i 's|^JANUS_REQUIRED=.*|JANUS_REQUIRED=false|' "$IE"
+    else echo 'JANUS_REQUIRED=false' >>"$IE"; fi
+  fi
+
+  # 3. (removed) iam-api dev script password-blocklist copy — fixed upstream in
+  #    rostering PR #302 (commit bc2a2dd), on main as of 2026-05-27. No longer patched here.
+
+  # 4. (removed) program-hub programs scenario iam_session cookie patch — fixed
+  #    upstream in program-hub PR #102 (merge d85aa2d, on main as of 2026-05-27).
+  #    The scenario now reads/sends the JWT `iam_session` cookie natively. No
+  #    longer patched here.
+
+  # 5. saga-dash static/config.json — teach the dash where sis-api lives so a
+  #    dash sis-api client resolves to :3100 with no hand-editing (d1.7, dec 2).
+  #    Idempotent: only adds the `sis-api` localDefaults key if absent. NOTE:
+  #    config.json is a TRACKED file — this leaves a saga-dash working-tree edit
+  #    (expected; remove the key if you'd rather Adam own it). The key name is a
+  #    best-guess until dash sis-api code lands; rename to match if it differs.
+  local DASH_CFG="$SAGA_DASH/apps/web/dash/static/config.json"
+  if [[ -f "$DASH_CFG" ]] && ! grep -q '"sis-api"' "$DASH_CFG"; then
+    if node -e '
+      const fs=require("fs"); const [p,port]=process.argv.slice(1);
+      const c=JSON.parse(fs.readFileSync(p,"utf8"));
+      c.localDefaults=c.localDefaults||{};
+      c.localDefaults["sis-api"]={type:"localhost",port:Number(port)};
+      fs.writeFileSync(p, JSON.stringify(c,null,2)+"\n");
+    ' "$DASH_CFG" "$SIS_PORT" 2>/dev/null; then
+      ok "saga-dash config.json: sis-api → :$SIS_PORT"
+    else
+      printf "\033[33m⚠\033[0m could not patch %s (add sis-api → :%s by hand)\n" "$DASH_CFG" "$SIS_PORT"
+    fi
+  fi
+}
+
+mesh_up(){
+  if docker ps --format '{{.Names}}' | grep -q '^soa-postgres-1$'; then ok "mesh already up"; return; fi
+  say "starting mesh (postgres + redis + rabbitmq)…"
+  ( cd "$SOA/infra" && EXTRA_POSTGRES_SEED_DIR=../../projects/saga-mesh/seed \
+      make up PROJECT=saga-mesh PROFILE=empty \
+      POSTGRES_PORT=5432 REDIS_PORT=6379 RABBITMQ_PORT=5672 RABBITMQ_MGMT_PORT=15672 >"$STATE/mesh.log" 2>&1 )
+  for _ in $(seq 1 20); do docker exec soa-postgres-1 pg_isready -U postgres_admin >/dev/null 2>&1 && break; sleep 1; done
+  ok "mesh up — pg :5432  redis :6379  rabbitmq :5672"
+}
+
+# Provision an API's DB the canonical way — `prisma migrate deploy` (db:deploy),
+# exactly what program-hub's ECS `migrate` job runs. migrate deploy replays the
+# ordered migration SQL, so migration-only DDL that `schema.prisma` can't express
+# (partial unique indexes, backfills, triggers…) is created correctly — unlike
+# `db:push`, which only mirrors the schema and silently omits it. See
+# decisions/d1.5. Wrinkle: a DB previously provisioned by `db:push` has schema
+# but no `_prisma_migrations` history, so migrate deploy P3005s; detect that
+# (one-time legacy/empty case) and convert via `migrate reset` (drops + replays
+# from scratch — synthetic data is re-seeded via --seed).
+migrate_db(){ # dir db_name
+  local dir=$1 db=$2
+  if [[ "$(docker exec soa-postgres-1 psql -U postgres_admin -d "$db" -tAc \
+        "SELECT to_regclass('public._prisma_migrations') IS NOT NULL" 2>/dev/null)" == t ]]; then
+    ( cd "$dir" && pnpm db:deploy >/dev/null 2>&1 )                         # migration-managed → apply pending (non-destructive)
+  else
+    ( cd "$dir" && pnpm prisma migrate reset --force >/dev/null 2>&1 )  # unmanaged (db:push'd / empty) → drop + replay all migrations (no seed configured in prisma.config.ts)
+  fi
+}
+
+prep(){
+  say "reconciling rostering deps + workspace build (main switch is not dep-neutral)…"
+  ( cd "$ROSTERING" && pnpm install >/dev/null 2>&1 && pnpm build >/dev/null 2>&1 ) || true
+  say "reconciling program-hub deps + workspace build (new deps / stale workspace dist after a main pull)..."
+  ( cd "$PROGRAM_HUB" && pnpm install >/dev/null 2>&1 && pnpm build >/dev/null 2>&1 ) || true
+  say "applying prisma schemas (migrate deploy — canonical, see d1.5)…"
+  ( cd "$ROSTERING/packages/node/iam-db"       && pnpm prisma migrate deploy >/dev/null 2>&1 )
+  ( cd "$ROSTERING/packages/node/iam-pii-db"   && pnpm prisma db push        >/dev/null 2>&1 )
+  migrate_db "$PROGRAM_HUB/apps/node/programs-api"   programs
+  migrate_db "$PROGRAM_HUB/apps/node/scheduling-api" scheduling
+  migrate_db "$ROSTERING/packages/node/sis-db"       sis_db   # sis-api schema (d1.7)
+  ( cd "$SDS/packages/node/ads-adm-db"         && pnpm prisma migrate deploy >/dev/null 2>&1 )
+  say "seeding dev user ($DEV_USER_UUID)…"
+  ( cd "$ROSTERING/packages/node/iam-db" && env $(grep -v '^#' "$ROSTERING/.env.local" | xargs) node dist/seed-dev-user.js >/dev/null 2>&1 ) || true
+  ok "schemas + dev user ready"
+}
+
+launch(){ # name port dir extra_env...
+  local name=$1 port=$2 dir=$3; shift 3
+  [[ "$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 http://localhost:$port/health 2>/dev/null)" == 200 ]] && { ok "$name already up :$port"; return; }
+  say "starting $name on :$port…"
+  ( cd "$dir"; env "$@" nohup pnpm dev >"$STATE/$name.log" 2>&1 & echo $! >"$STATE/$name.pid" )
+  for _ in $(seq 1 40); do
+    local probe=/health; [[ "$name" == saga-dash ]] && probe=/
+    [[ "$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 http://localhost:$port$probe 2>/dev/null)" == 200 ]] && { ok "$name up :$port"; return; }
+    sleep 1
+  done
+  printf "\033[31m✗\033[0m %s failed on :%s — tail %s\n" "$name" "$port" "$STATE/$name.log"; return 1
+}
+
+services_up(){
+  launch iam-api "$IAM_PORT" "$ROSTERING/apps/node/iam-api" PORT="$IAM_PORT"
+  # sis-api → iam-api service.* over S2S; no creds locally (iam-api dev-bypass
+  # synthesizes a service actor when auth is off). IAM_BASEURL/IAM_TOKENURL must
+  # point at iam on :3010 (sis-api defaults to :3000). See d1.7.
+  launch sis-api "$SIS_PORT" "$ROSTERING/apps/node/sis-api" \
+     NODE_ENV=development PORT="$SIS_PORT" \
+     SIS_DATABASE_URL="$SIS_DB_URL" \
+     IAM_BASEURL="$IAM_URL/trpc" IAM_TOKENURL="$IAM_URL/v1/oauth/token"
+  launch programs-api 3006 "$PROGRAM_HUB/apps/node/programs-api"     NODE_ENV=development IAM_API_URL="$IAM_URL" RABBITMQ_URL="$MESH_MQ" JANUS_REQUIRED=false
+  launch scheduling-api 3008 "$PROGRAM_HUB/apps/node/scheduling-api" NODE_ENV=development IAM_API_URL="$IAM_URL" RABBITMQ_URL="$MESH_MQ" JANUS_REQUIRED=false
+  launch ads-adm-api 5005 "$SDS/apps/node/ads-adm-api" \
+     ADS_ADM_SCHEDULE_PROVIDER=mock \
+     ADS_ADM_DATABASE_URL=postgresql://ads_adm:ads_adm@localhost:5432/ads_adm_local \
+     DATABASE_URL=postgresql://ads_adm:ads_adm@localhost:5432/ads_adm_local \
+     CORS_ORIGIN=http://localhost:8900 RABBITMQ_URL="$MESH_MQ"
+  launch saga-dash 8900 "$SAGA_DASH/apps/web/dash"
+}
+
+# ── reset: truncate synthetic data to an empty baseline ──────────────
+# Not a "post-delete of seeded data" — a clean baseline BEFORE seeding, so any
+# --seed mode is reproducible regardless of prior state. Needed because iam
+# groups don't dedup (re-running the roster on a non-empty iam duplicates it).
+# Preserves _prisma_migrations so no re-migrate. Uses the mesh superuser
+# (postgres_admin) so it can truncate tables owned by iam / saga_user / etc.
+reset_data(){
+  say "resetting synthetic data → empty baseline (iam, programs, scheduling, sis)…"
+  local trunc="DO \$\$ DECLARE r RECORD; BEGIN FOR r IN SELECT tablename FROM pg_tables WHERE schemaname='public' AND tablename <> '_prisma_migrations' LOOP EXECUTE 'TRUNCATE TABLE public.'||quote_ident(r.tablename)||' RESTART IDENTITY CASCADE'; END LOOP; END \$\$;"
+  for db in iam_local iam_pii_local programs scheduling sis_db; do
+    if docker exec -i soa-postgres-1 psql -U postgres_admin -d "$db" -v ON_ERROR_STOP=1 -c "$trunc" >/dev/null 2>&1; then
+      ok "truncated $db"
+    else
+      printf "\033[33m⚠\033[0m could not truncate %s (does it exist? is mesh up?)\n" "$db"
+    fi
+  done
+  say "re-seeding dev user ($DEV_USER_UUID)…"
+  ( cd "$ROSTERING/packages/node/iam-db" && env $(grep -v '^#' "$ROSTERING/.env.local" | xargs) node dist/seed-dev-user.js >/dev/null 2>&1 ) || true
+  ok "reset complete — empty roster/programs/scheduling baseline"
+}
+
+# ── seeding ──────────────────────────────────────────────────────────
+seed_iam(){
+  say "seeding SYNTHETIC iam roster (rostering program-hub scenario)…"
+  ( cd "$ROSTERING" && pnpm tsx scripts/scenarios/src/run.ts program-hub --url "$IAM_URL" )
+  ok "synthetic roster seeded — see --status"
+}
+
+# Seeds programs/periods/enrollment against the already-seeded roster. The
+# iam↔programs auth-contract drift that used to block this is RESOLVED (d1.2):
+# iam-api issues a JWT iam_session cookie and programs-api verifies it locally.
+seed_programs(){
+  say "seeding SYNTHETIC programs (program-hub programs scenario)…"
+  ( cd "$PROGRAM_HUB/scripts/scenarios" && pnpm tsx src/run.ts programs --iam-url "$IAM_URL" --url http://localhost:3006 )
+  ok "synthetic programs seeded"
+}
+
+# roster = iam only (programs empty); full = roster + programs.
+seed_stack(){
+  local mode=${1:-roster}
+  seed_iam
+  [[ "$mode" == full ]] && seed_programs
+  return 0
+}
+
+# ── auto-login: mint a session via iam-api devLogin, then open the dash ──
+# devLogin is dev-only (FORBIDDEN when AUTH_ENABLED) and origin-checked, so we
+# send iam-api's own origin (always allowlisted — it's what the /demo page uses).
+#
+# Two halves, because a shell can't put an HttpOnly cookie in your browser:
+#   1. curl → a Netscape cookie jar ($COOKIE_JAR: iam_session JWT + iam_refresh)
+#      for HEADLESS harnesses (curl --cookie, Playwright storageState).
+#   2. browser-login.mjs → a real Chromium (persistent profile) that does the
+#      same devLogin in-browser and opens the dash already authenticated, so you
+#      don't land on the Janus redirect. Falls back gracefully if Playwright /
+#      saga-dash isn't available — the cookie jar half still succeeds.
+login_user(){
+  local email=${1:-$DEFAULT_LOGIN_USER} code
+  say "auto-login via iam-api devLogin as $email…"
+  code=$(curl -s -o "$STATE/devlogin.json" -w '%{http_code}' --max-time 10 \
+    -X POST "$IAM_URL/trpc/auth.devLogin" \
+    -H 'Content-Type: application/json' -H "Origin: $IAM_URL" \
+    -c "$COOKIE_JAR" -d "{\"email\":\"$email\"}" 2>/dev/null) || code=000
+  if [[ "$code" != 200 ]]; then
+    printf "\033[31m✗\033[0m devLogin failed (HTTP %s) for '%s'.\n" "$code" "$email"
+    if [[ "$email" == "$DEFAULT_LOGIN_USER" ]]; then
+      printf "  '%s' is the rostered Seed District admin — it only exists after a roster seed.\n" "$email"
+      printf "  Seed first, e.g.  %s --seed roster --login  (or add --seed to your reset).\n" "$0"
+      printf "  For a bare reset (no roster), the only user is the bootstrap one: %s --login dev@example.org\n" "$0"
+    else
+      printf "  Is iam-api up and is '%s' present in the seeded roster?\n" "$email"
+    fi
+    printf "  Response: %s\n" "$STATE/devlogin.json"
+    return 1
+  fi
+  ok "session minted — cookie jar → $COOKIE_JAR (headless harnesses)"
+  open_login_browser "$email"
+}
+
+# Launch a headful Chromium that's already logged into the dash. Backgrounded
+# (nohup) so the window outlives this script; pid tracked for --down. The
+# persistent profile is single-locked, so we kill any prior auto-login browser
+# first. Best-effort: a missing node / Playwright / saga-dash only warns.
+open_login_browser(){
+  local email=$1
+  [[ -f "$BROWSER_LOGIN" ]] || { printf "\033[33m⚠\033[0m %s missing — skipping browser auto-login (cookie jar is ready)\n" "$BROWSER_LOGIN"; return 0; }
+  command -v node >/dev/null 2>&1 || { printf "\033[33m⚠\033[0m node not found — skipping browser auto-login (cookie jar is ready)\n"; return 0; }
+  [[ -d "$SAGA_DASH/apps/web/dash/node_modules/playwright" ]] || { printf "\033[33m⚠\033[0m playwright not installed in saga-dash — skipping browser auto-login. Run: (cd %s/apps/web/dash && pnpm install && pnpm exec playwright install chromium)\n" "$SAGA_DASH"; return 0; }
+  if [[ -f "$STATE/browser-login.pid" ]]; then
+    kill "$(cat "$STATE/browser-login.pid")" 2>/dev/null || true; rm -f "$STATE/browser-login.pid"; sleep 1
+  fi
+  say "opening auto-logged-in dash in Chromium (profile $BROWSER_PROFILE)…"
+  ( IAM_URL="$IAM_URL" DASH_URL="$DASH_URL" LOGIN_EMAIL="$email" \
+      PROFILE_DIR="$BROWSER_PROFILE" SAGA_DASH_DASH="$SAGA_DASH/apps/web/dash" \
+      nohup node "$BROWSER_LOGIN" >"$STATE/browser-login.log" 2>&1 & echo $! >"$STATE/browser-login.pid" )
+  for _ in $(seq 1 40); do
+    if grep -q '^AUTOLOGIN_OK' "$STATE/browser-login.log" 2>/dev/null; then
+      ok "dash open + logged in as $email — use that Chromium window ($(grep -o 'http[^ ]*$' "$STATE/browser-login.log" | tail -1))"
+      return 0
+    fi
+    if grep -q '^AUTOLOGIN_FAIL' "$STATE/browser-login.log" 2>/dev/null; then
+      printf "\033[31m✗\033[0m browser auto-login failed: %s\n" "$(grep '^AUTOLOGIN_FAIL' "$STATE/browser-login.log" | head -1 | cut -d' ' -f2-)"
+      printf "  (cookie jar is still valid for harnesses.) Full log: %s\n" "$STATE/browser-login.log"
+      return 1
+    fi
+    sleep 1
+  done
+  printf "\033[33m⚠\033[0m Chromium still starting — watch %s\n" "$STATE/browser-login.log"
+}
+
+services_down(){ for n in iam-api sis-api programs-api scheduling-api ads-adm-api saga-dash; do
+  [[ -f "$STATE/$n.pid" ]] && { pkill -P "$(cat "$STATE/$n.pid")" 2>/dev/null||true; kill "$(cat "$STATE/$n.pid")" 2>/dev/null||true; rm -f "$STATE/$n.pid"; }
+done
+[[ -f "$STATE/browser-login.pid" ]] && { kill "$(cat "$STATE/browser-login.pid")" 2>/dev/null||true; rm -f "$STATE/browser-login.pid"; }
+# tsup watchers: match the real cmdline (node .../tsup/dist/cli-default.js --watch);
+# the literal "tsup --watch" never matches, so watchers used to survive --down.
+pkill -f "tsup/dist/cli-default.js --watch" 2>/dev/null||true
+# tsup's --onSuccess \`node dist/main.js\` children are orphaned by the kill above
+# and keep holding their ports; reap whatever still listens on our known ports.
+for _p in "$IAM_PORT" "$SIS_PORT" 3006 3008 5005 8900; do fuser -k "$_p/tcp" 2>/dev/null||true; done
+ok "services down (mesh left up)"; }
+
+# Remove stale Vite optimize caches so the dash serves CURRENT source after a
+# code/branch change. The dep-optimizer cache survives restarts and silently
+# serves the old program-config bundle -- the classic "fix is in the source but
+# the browser runs old JS" trap. Targets the dash app + package-level caches
+# only, never the root .pnpm vitest caches.
+nuke_vite(){
+  say "clearing dash vite caches (stale optimized bundles)..."
+  rm -rf "$SAGA_DASH/apps/web/dash/node_modules/.vite" 2>/dev/null||true
+  find "$SAGA_DASH/apps" "$SAGA_DASH/packages" -type d -name .vite -prune -exec rm -rf {} + 2>/dev/null||true
+  ok "vite caches cleared"
+}
+
+status(){
+  for kv in iam-api:$IAM_PORT sis-api:$SIS_PORT programs-api:3006 scheduling-api:3008 ads-adm-api:5005 saga-dash:8900; do
+    n=${kv%:*}; p=${kv#*:}; probe=/health; [[ "$n" == saga-dash ]] && probe=/
+    printf "  %-15s :%s → %s\n" "$n" "$p" "$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 http://localhost:$p$probe 2>/dev/null)"
+  done
+  docker exec soa-postgres-1 psql -U iam -d iam_local -tAc \
+    "SELECT 'iam users='||count(*) FROM users" 2>/dev/null | sed 's/^/  /'
+}
+
+# ── arg parsing: verbs (up/down/status/help) + composable flags ──────
+DO_UP=0; DO_RESET=0; DO_SEED=0; SEED_MODE=roster; DO_LOGIN=0; LOGIN_USER=$DEFAULT_LOGIN_USER
+case "${1:-up}" in
+  up|--up)                       DO_UP=1; shift ;;
+  --down)                        services_down; exit 0 ;;
+  --status)                      status; exit 0 ;;
+  -h|--help)                     sed -n '2,51p' "$0"; exit 0 ;;
+  --reset|--seed|--login|--user) ;;        # flag-only invocation; skip up
+  *) echo "unknown: $1 (use --help)"; exit 1 ;;
+esac
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --reset) DO_RESET=1; shift ;;
+    --seed)  DO_SEED=1; shift; case "${1:-}" in roster|full) SEED_MODE=$1; shift ;; esac ;;
+    # --login / --user [email]: optional positional email; bare or next-flag → default persona
+    --login|--user) DO_LOGIN=1; shift; case "${1:-}" in ''|--*) ;; *) LOGIN_USER=$1; shift ;; esac ;;
+    *) echo "unknown flag: $1 (use --help)"; exit 1 ;;
+  esac
+done
+
+if [[ $DO_UP == 1 ]]; then
+  check_branches; apply_fixes; mesh_up; prep
+  # With --reset, do a CLEAN restart: stop running services (incl. stale tsup /
+  # vite watchers that accumulate across runs) and clear vite caches, so
+  # services_up starts FRESH on current code rather than reusing stale
+  # "already up" processes / cached bundles.
+  if [[ $DO_RESET == 1 ]]; then
+    say "reset: clean restart — stopping running services + clearing vite caches..."
+    services_down; nuke_vite
+  fi
+  services_up
+  ok "stack up — try: $0 --status"
+fi
+[[ $DO_RESET == 1 ]] && reset_data
+[[ $DO_SEED == 1 ]]  && seed_stack "$SEED_MODE"
+[[ $DO_LOGIN == 1 ]] && login_user "$LOGIN_USER"
+exit 0

--- a/tools/synthetic-dev/verify.sh
+++ b/tools/synthetic-dev/verify.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# verify.sh — assert the synthetic-dev stack is fully up and seeded.
+#
+# Unlike `up.sh --status` (which just prints), this EXITS NON-ZERO on any red,
+# so it's a one-shot "is my setup correct?" gate for a new engineer (or CI).
+# Checks:
+#   • all six service health endpoints return 200,
+#   • the mesh Postgres is reachable + the iam roster is seeded (users > 0),
+#   • SOURCE POSTURE (manifest-aware): each sibling repo is on the branch the
+#     integration suite expects, and every pinned PR is actually merged into
+#     its local/integration. This is what makes "same state as the team" an
+#     assertion, not a hope — health alone passes even on stale/wrong code.
+#     (Caveat: it verifies the CHECKOUT; a running service built before a
+#     refresh can still lag — restart/HMR closes that. See getting-started.md.)
+#
+# Usage:  ./verify.sh        (run after ./up.sh up --reset --seed roster)
+#   DEV=~/work ./verify.sh   non-default sibling-repo parent
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MANIFEST="$SCRIPT_DIR/integration-suite.tsv"
+DEV=${DEV:-$HOME/dev}
+# Repos refresh-suite manages / up.sh builds from sibling branches. A managed
+# repo with manifest pins is expected on local/integration (with those PRs
+# merged); without pins, on main. soa + student-data-system are always on main.
+MANAGED_REPOS="rostering program-hub saga-dash"
+ALWAYS_MAIN_REPOS="soa student-data-system"
+
+pass=0; fail=0
+okline()  { printf "  \033[32m✓\033[0m %s\n" "$*"; pass=$((pass+1)); }
+badline() { printf "  \033[31m✗\033[0m %s\n" "$*"; fail=$((fail+1)); }
+
+probe(){ # name port path
+  local name=$1 port=$2 path=$3 code
+  # curl's -w always emits a code (000 on connect failure); it exits non-zero
+  # then, but we don't `set -e`, so capture it directly. ${code:-000} covers
+  # the degenerate no-curl case without doubling the 000.
+  code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 3 "http://localhost:$port$path" 2>/dev/null); code=${code:-000}
+  if [[ "$code" == 200 ]]; then okline "$(printf '%-15s :%s%s → 200' "$name" "$port" "$path")"
+  else badline "$(printf '%-15s :%s%s → %s (expected 200)' "$name" "$port" "$path" "$code")"; fi
+}
+
+printf "\033[1m── service health ──\033[0m\n"
+probe iam-api        3010 /health
+probe sis-api        3100 /health
+probe programs-api   3006 /health
+probe scheduling-api 3008 /health
+probe ads-adm-api    5005 /health
+probe saga-dash      8900 /
+
+printf "\033[1m── data ──\033[0m\n"
+users=$(docker exec soa-postgres-1 psql -U iam -d iam_local -tAc "SELECT count(*) FROM users" 2>/dev/null || echo "")
+if [[ -z "$users" ]]; then
+  badline "iam_local unreachable (is the mesh up?)"
+elif [[ "$users" -gt 0 ]]; then
+  okline "iam roster seeded — users=$users"
+else
+  badline "iam roster EMPTY (users=0) — run: ./up.sh --reset --seed roster"
+fi
+
+# sis_db schema present (sis-api's reconciliation tables)
+if docker exec soa-postgres-1 psql -U postgres_admin -d sis_db -tAc \
+     "SELECT to_regclass('public._prisma_migrations') IS NOT NULL" 2>/dev/null | grep -q t; then
+  okline "sis_db migrated"
+else
+  badline "sis_db not migrated (run ./up.sh up — prep deploys the schema)"
+fi
+
+# ── source posture (manifest-aware) ──────────────────────────────────
+# Read the pinned suite, then assert each repo's checkout matches it. A repo
+# on the wrong branch — or on local/integration but missing a pinned PR (stale,
+# forgot to re-run refresh-suite) — fails here even though health is green.
+printf "\033[1m── source posture ──\033[0m\n"
+declare -A PINS=()
+if [[ -f "$MANIFEST" ]]; then
+  while IFS=$'\t' read -r repo prs; do
+    repo="${repo//[[:space:]]/}"; [[ -z "$repo" ]] && continue
+    PINS["$repo"]="${prs//[[:space:]]/}"
+  done < <(grep -vE '^\s*(#|$)' "$MANIFEST")
+else
+  badline "manifest not found: $MANIFEST"
+fi
+
+# Flag any manifest repo we don't know how to posture-check (avoid silent skips).
+for repo in "${!PINS[@]}"; do
+  case " $MANAGED_REPOS " in *" $repo "*) ;; *) badline "manifest pins '$repo' but it's not in MANAGED_REPOS — verify can't posture-check it"; esac
+done
+
+on_branch(){ git -C "$DEV/$1" branch --show-current 2>/dev/null; }
+
+check_posture(){ # repo expected_branch
+  local repo=$1 want=$2 dir="$DEV/$repo" have
+  [[ -d "$dir/.git" ]] || { badline "$repo: not a git repo at $dir"; return; }
+  have=$(on_branch "$repo")
+  if [[ "$have" == "$want" ]]; then okline "$(printf '%-20s on %s' "$repo" "$want")"
+  else badline "$(printf '%-20s on '\''%s'\'' (expected '\''%s'\'')' "$repo" "$have" "$want")"; fi
+}
+
+# pinned PR actually merged into the current checkout? (resolve #→head SHA via gh)
+check_pin_merged(){ # repo pr#
+  local repo=$1 n=$2 dir="$DEV/$repo" oid
+  oid=$( cd "$dir" && gh pr view "$n" --json headRefOid --jq '.headRefOid' 2>/dev/null || true )
+  if [[ -z "$oid" ]]; then badline "$repo #$n: couldn't resolve head via gh (auth? PR exists?)"; return; fi
+  if git -C "$dir" merge-base --is-ancestor "$oid" HEAD 2>/dev/null; then
+    okline "$(printf '%-20s #%s merged in' "$repo" "$n")"
+  else
+    badline "$(printf '%-20s #%s NOT in checkout — run ./refresh-suite.sh' "$repo" "$n")"
+  fi
+}
+
+for repo in $MANAGED_REPOS; do
+  prs="${PINS[$repo]:-}"
+  if [[ -n "$prs" ]]; then
+    check_posture "$repo" "local/integration"
+    if [[ "$(on_branch "$repo")" == "local/integration" ]]; then   # only meaningful if branch is right
+      IFS=',' read -ra nums <<<"$prs"
+      for n in "${nums[@]}"; do [[ -n "$n" ]] && check_pin_merged "$repo" "$n"; done
+    fi
+  else
+    check_posture "$repo" "main"
+  fi
+done
+for repo in $ALWAYS_MAIN_REPOS; do check_posture "$repo" "main"; done
+
+printf "\n"
+if [[ $fail -eq 0 ]]; then
+  printf "\033[32m✓ all %d checks passed — stack is ready\033[0m\n" "$pass"; exit 0
+else
+  printf "\033[31m✗ %d/%d checks failed\033[0m — tail /tmp/sds-synthetic/<service>.log for reds\n" "$fail" "$((pass+fail))"; exit 1
+fi


### PR DESCRIPTION
## What

Relocates the **synthetic-dev** local stack into `soa/tools/synthetic-dev/`, alongside `tools/virtual-devices`.

It was previously living in `student-data-system/claude/projects/sds_92/synthetic-dev` — but it orchestrates the *full local mesh + six services across all five sibling repos* (`soa`, `rostering`, `program-hub`, `saga-dash`, `student-data-system`), seeding synthetic iam rosters / programs / schedules. That's shared dev infra, so it belongs in soa next to the other cross-cutting tooling rather than buried in one product repo's UX-initiative folder.

## Why it's safe

The scripts are **location-independent** — they locate their siblings via `SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"` and orchestrate the repos via `$DEV/<repo>` (default `~/dev`), never via their own path. So the move needed **no functional script changes**, only in-tree doc/comment path fixes.

## Verification

Full stack smoke run from the new location (`~/dev/soa/tools/synthetic-dev`):

- `./up.sh --reset --seed full --login` — clean restart, 9 programs/periods/enrollment seeded across districts, cookie jar minted, logged-in Chromium opened (exit 0).
- `./verify.sh` — **14/14 checks green** (6 services healthy, iam roster = 197 users, sis_db migrated, branch posture correct).

## Companion change

The matching reference-path updates + a `MOVED.md` tombstone in `student-data-system` are committed there separately (SDS commit `746397c`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)