### PR TITLE
api-core: configurable ExpressServer CORS allowedHeaders + Datadog RUM by default

### DIFF
--- a/packages/node/api-core/package.json
+++ b/packages/node/api-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saga-ed/soa-api-core",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "private": false,
   "type": "module",
   "main": "dist/rest-controller.js",
@@ -68,6 +68,7 @@
   "dependencies": {
     "@apollo/server": "^4.10.0",
     "@graphql-tools/schema": "^10.0.0",
+    "@saga-ed/soa-api-util": "workspace:*",
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "fast-glob": "^3.3.3",

--- a/packages/node/api-core/src/__tests__/express-server.int.test.ts
+++ b/packages/node/api-core/src/__tests__/express-server.int.test.ts
@@ -7,6 +7,7 @@ import { TestSector } from './test-sector.js';
 import { fetch } from 'undici';
 import { useContainer, createExpressServer } from 'routing-controllers';
 import { ExpressServer } from '../express-server.js';
+import { DATADOG_RUM_TRACING_HEADERS } from '@saga-ed/soa-api-util';
 import { JsonController, Get, Post, Body } from 'routing-controllers';
 
 function getRandomPort() {
@@ -183,6 +184,7 @@ describe('ExpressServer (integration)', () => {
     async function withCorsServer(
       domains: string[] | undefined,
       fn: (port: number, warnings: string[]) => Promise<void>,
+      extraConfig: Record<string, unknown> = {},
     ) {
       const container = new Container();
       const warnings: string[] = [];
@@ -199,6 +201,7 @@ describe('ExpressServer (integration)', () => {
         logLevel: 'info' as const,
         name: 'CORS Test Server',
         ...(domains !== undefined ? { corsAllowedDomains: domains } : {}),
+        ...extraConfig,
       };
 
       container.bind('ExpressServerConfig').toConstantValue(config);
@@ -277,6 +280,49 @@ describe('ExpressServer (integration)', () => {
         expect(res.headers.get('access-control-allow-origin')).toBe('https://coach.saga.org');
         expect(res.headers.get('access-control-allow-credentials')).toBe('true');
         expect(res.headers.get('access-control-allow-methods')).toContain('POST');
+      });
+    });
+
+    describe('allowed headers (Datadog RUM)', () => {
+      it('default allow-headers include the baseline + every Datadog RUM tracing header', async () => {
+        await withCorsServer(['saga.org'], async (port) => {
+          const res = await fetch(`http://localhost:${port}/simple/`, {
+            method: 'OPTIONS',
+            headers: {
+              Origin: 'https://coach.saga.org',
+              'Access-Control-Request-Method': 'GET',
+              'Access-Control-Request-Headers': 'x-datadog-trace-id',
+            },
+          });
+          const allow = res.headers.get('access-control-allow-headers') ?? '';
+          expect(allow).toContain('Content-Type');
+          expect(allow).toContain('Authorization');
+          for (const header of DATADOG_RUM_TRACING_HEADERS) {
+            expect(allow).toContain(header);
+          }
+        });
+      });
+
+      it('config.allowedHeaders overrides the default (replaces, not merges)', async () => {
+        await withCorsServer(
+          ['saga.org'],
+          async (port) => {
+            const res = await fetch(`http://localhost:${port}/simple/`, {
+              method: 'OPTIONS',
+              headers: {
+                Origin: 'https://coach.saga.org',
+                'Access-Control-Request-Method': 'GET',
+                'Access-Control-Request-Headers': 'x-custom-header',
+              },
+            });
+            const allow = res.headers.get('access-control-allow-headers') ?? '';
+            expect(allow).toContain('X-Custom-Header');
+            // A caller-supplied list fully replaces the default — Datadog headers
+            // are not auto-merged, so a service overriding must spread them itself.
+            expect(allow).not.toContain('x-datadog-trace-id');
+          },
+          { allowedHeaders: ['Content-Type', 'X-Custom-Header'] },
+        );
       });
     });
   });

--- a/packages/node/api-core/src/express-server-schema.ts
+++ b/packages/node/api-core/src/express-server-schema.ts
@@ -21,6 +21,13 @@ export const ExpressServerSchema = z.object({
   corsAllowedDomains: z
     .array(z.string())
     .optional(),
+  // CORS `Access-Control-Allow-Headers`. When omitted, defaults to the baseline
+  // request headers plus the Datadog RUM tracing headers (see ExpressServer).
+  // Set this to override — spread `DATADOG_RUM_TRACING_HEADERS` from
+  // `@saga-ed/soa-api-util` to keep Datadog browser RUM working.
+  allowedHeaders: z
+    .array(z.string())
+    .optional(),
 });
 
 export type ExpressServerConfig = z.infer<typeof ExpressServerSchema>;

--- a/packages/node/api-core/src/express-server.ts
+++ b/packages/node/api-core/src/express-server.ts
@@ -1,11 +1,22 @@
 import express, { Application } from 'express';
 import cors from 'cors';
 import { injectable, inject } from 'inversify';
+import { DATADOG_RUM_TRACING_HEADERS } from '@saga-ed/soa-api-util';
 import type { ExpressServerConfig } from './express-server-schema.js';
 import type { ILogger } from '@saga-ed/soa-logger';
 import { useContainer, useExpressServer, getMetadataArgsStorage } from 'routing-controllers';
 import { Container } from 'inversify';
 import { SectorsController } from './sectors-controller.js';
+
+// Default CORS `Access-Control-Allow-Headers`: the baseline request headers
+// every Saga API accepts, plus the Datadog browser-RUM distributed-tracing
+// headers. Once a frontend enables RUM, those headers ride on every cross-origin
+// request and the browser fails the preflight if any one is missing — so
+// allowing them by default keeps RUM-instrumented frontends working with no
+// per-service config. Services needing extra headers set `allowedHeaders` in
+// their ExpressServerConfig (spread `DATADOG_RUM_TRACING_HEADERS` to keep RUM
+// working). See hipponot/iac#358.
+const DEFAULT_ALLOWED_HEADERS: string[] = ['Content-Type', 'Authorization', ...DATADOG_RUM_TRACING_HEADERS];
 
 @injectable()
 export class ExpressServer {
@@ -29,12 +40,14 @@ export class ExpressServer {
     //   any exact match or subdomain of a listed domain is allowed.
     // When omitted/empty, defaults to origin: true (reflect any origin) for backward compatibility.
     // credentials is always true — Saga apps use cross-origin cookie auth.
+    // allowedHeaders defaults to DEFAULT_ALLOWED_HEADERS (baseline + Datadog RUM);
+    // services override via the `allowedHeaders` config field.
     const domains = this.config.corsAllowedDomains ?? [];
 
     const corsOptions: cors.CorsOptions = {
       credentials: true,
       methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
-      allowedHeaders: ['Content-Type', 'Authorization'],
+      allowedHeaders: this.config.allowedHeaders ?? DEFAULT_ALLOWED_HEADERS,
     };
 
     if (domains.length > 0) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -675,6 +675,9 @@ importers:
       '@graphql-tools/schema':
         specifier: ^10.0.0
         version: 10.0.30(graphql@16.12.0)
+      '@saga-ed/soa-api-util':
+        specifier: workspace:*
+        version: link:../api-util
       cors:
         specifier: ^2.8.5
         version: 2.8.5


### PR DESCRIPTION
## What

`@saga-ed/soa-api-core`'s `ExpressServer` hardcoded `allowedHeaders: ['Content-Type', 'Authorization']` with no way to override it. Any service that relies on the built-in CORS (instead of a hand-rolled `app.use(cors(...))` before `init()`) therefore can't clear the browser preflight for Datadog browser-RUM's cross-origin tracing headers (`traceparent`, `tracestate`, `x-datadog-*`). Confirmed inheritors of the default: **coach-api**, **saga-sm** (+ the saga-soa examples).

This closes that gap fleet-wide and makes the list configurable.

## Changes

- **Default `allowedHeaders` is now `['Content-Type', 'Authorization', ...DATADOG_RUM_TRACING_HEADERS]`** — the canonical set from `@saga-ed/soa-api-util`. Inheriting services get Datadog RUM support automatically, no config needed.
- **New optional `allowedHeaders` field on `ExpressServerConfig`.** When set, it **replaces** the default (standard `cors` semantics). This lets the services that currently hand-roll a `cors()` override before `init()` retire that boilerplate and the `// TODO: remove when SOA ExpressServer supports configurable allowedHeaders` comment (thrive iam-api, etc.).
- Adds `@saga-ed/soa-api-util` (`workspace:*`) as an api-core dependency for the shared constant.
- Version bump `api-core` 1.1.4 → 1.2.0 (additive, backward-compatible).

## Design note (wants a 👍)

A caller-supplied `allowedHeaders` **replaces** the default rather than merging the Datadog headers in. That's the predictable `cors` semantic and matches the existing per-service override lists (which already spread the constant), but it means an overriding service that forgets to spread `DATADOG_RUM_TRACING_HEADERS` loses RUM support. If we'd prefer Datadog headers always-on (merge), it's a one-line change — flagging for a decision.

## Verification

- `turbo run build --filter=@saga-ed/soa-api-core` green (tsup DTS type-check passes).
- `pnpm --filter @saga-ed/soa-api-core test` → **33/33**, including 2 new integration tests in `express-server.int.test.ts`:
  - default preflight `Access-Control-Allow-Headers` admits the baseline + every Datadog header;
  - an explicit `allowedHeaders` config replaces the default (Datadog not auto-merged).

## Rollout

Backward-compatible — the default only *adds* allowed request headers (strictly more permissive, no security change). Consumers pick it up when they bump `@saga-ed/soa-api-core`. No required follow-up; services that hand-roll CORS overrides can now drop them.

Context: this came out of adding Datadog RUM header allows across the APIs (rtsm was the trigger — rtsm itself hand-rolls CORS and doesn't use ExpressServer, so it's handled separately). See hipponot/iac#358.
