### PR TITLE
feat(seed-ids-kit): shared opt-in mechanism for the *-seed-ids contract

### DIFF
--- a/packages/core/seed-ids-kit/README.md
+++ b/packages/core/seed-ids-kit/README.md
@@ -29,6 +29,12 @@ import { checkSeedIdContract } from '@saga-ed/seed-ids-kit/contract';
 ```
 
 - **`uuidv5(name, namespace)`** — RFC 4122 v5 (SHA-1) UUID, browser-safe.
+  **Deterministic** — same input, same id. The basis of the seed-ids contract.
+- **`uuidv7()`** — RFC 9562 v7, **time-ordered** (48-bit ms timestamp + random).
+  For **runtime-generated primary keys**, where time-ordering improves DB index
+  locality. **Not** for seed ids — it is non-deterministic (no name input), so
+  independent services can't reproduce the same id. `uuidv7(timestamp?)` exposes
+  the timestamp only for testing/backfill.
 - **`makeHashDeriver(rootNamespace)`** — the **hash** strategy. `derive(key)` is
   order-independent; any service computes the same id from a stable key. Use for
   **new** domains. `rootNamespace` is the contract — never change it.

--- a/packages/core/seed-ids-kit/README.md
+++ b/packages/core/seed-ids-kit/README.md
@@ -1,0 +1,70 @@
+# @saga-ed/seed-ids-kit
+
+The shared mechanism behind the `*-seed-ids` contract: canonical, deterministic
+entity UUIDs that independent service seeds agree on **without a shared database**.
+
+Each domain already owns a `*-seed-ids` package (`iam-seed-ids`,
+`program-seed-ids`, `content-seed-ids`, …). They were hand-rolling the same
+pieces — a derivation function, a drift test, sometimes a frozen `ids.ts` plus
+codegen. This kit factors out the parts that are genuinely identical so a new
+domain writes only its **catalog** and picks a **strategy**. It is **opt-in**:
+add it as a dependency when convenient. It owns **no** catalog and **no** id
+values — those stay in each domain's repo.
+
+## Why a browser-safe hash matters
+
+The original `iam-seed-ids` used `node:crypto`, which can't run in a browser, so
+it had to pre-compute ("freeze") its ids into a committed `ids.ts` and ship a
+separate node-only `derive` entry plus a codegen script. This kit's `uuidv5`
+uses [`@noble/hashes`](https://github.com/paulmillr/noble-hashes) (audited,
+zero-dependency, isomorphic) and is **byte-identical** to the `node:crypto`
+output — so a package can compute ids on demand in any runtime and drop the
+freeze/codegen entirely, with **zero id change**.
+
+## API
+
+```ts
+import { uuidv5, makeHashDeriver, makePositionDeriver } from '@saga-ed/seed-ids-kit';
+import { checkSeedIdContract } from '@saga-ed/seed-ids-kit/contract';
+```
+
+- **`uuidv5(name, namespace)`** — RFC 4122 v5 (SHA-1) UUID, browser-safe.
+- **`makeHashDeriver(rootNamespace)`** — the **hash** strategy. `derive(key)` is
+  order-independent; any service computes the same id from a stable key. Use for
+  **new** domains. `rootNamespace` is the contract — never change it.
+- **`makePositionDeriver(namespacePrefix, padWidth = 12)`** — the **position-suffix**
+  strategy. `derive(n)` = `` `${namespacePrefix}${pad(n)}` ``. Pure formatting; use
+  **only** to preserve an existing hand-assigned scheme so persisted data isn't
+  orphaned.
+- **`checkSeedIdContract(collections)`** — framework-agnostic drift / value-lock
+  test helper. Returns `{ ok, failures, checked }`; assert `failures` is empty.
+
+> The two strategies are **not** interchangeable and must not be unified — each
+> encodes ids already persisted in a domain's database.
+
+## Recipe — a new `*-seed-ids` domain (opt-in)
+
+```ts
+// catalog.ts — pure data, no ids
+export const WIDGETS = [{ slug: 'alpha' }, { slug: 'beta' }] as const;
+export const WIDGET_SLUGS = WIDGETS.map((w) => w.slug);
+
+// index.ts — pick a strategy, compute on demand
+import { makeHashDeriver } from '@saga-ed/seed-ids-kit';
+const ROOT = '…fixed-namespace-uuid…';
+const deriveWidgetId = makeHashDeriver(ROOT);
+export const widgetId = (slug: string) => deriveWidgetId(`widget:${slug}`);
+
+// index.test.ts — one call locks the contract
+import { checkSeedIdContract } from '@saga-ed/seed-ids-kit/contract';
+import { WIDGET_SLUGS } from './catalog.js';
+import { widgetId } from './index.js';
+it('contract holds', () => {
+  const r = checkSeedIdContract([{ name: 'widget', slugs: WIDGET_SLUGS, id: widgetId }]);
+  expect(r.failures).toEqual([]);
+});
+```
+
+When migrating an **existing** package, pass `expect:` with the current ids as
+pinned literals — `checkSeedIdContract` then proves the migration changed none of
+them. The full narrative recipe lives in the saga-iac plugin's `seed-fixtures.md`.

--- a/packages/core/seed-ids-kit/package.json
+++ b/packages/core/seed-ids-kit/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@saga-ed/seed-ids-kit",
+  "version": "0.1.0-dev.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./uuid": {
+      "types": "./dist/uuid.d.ts",
+      "import": "./dist/uuid.js"
+    },
+    "./derivers": {
+      "types": "./dist/derivers.d.ts",
+      "import": "./dist/derivers.js"
+    },
+    "./contract": {
+      "types": "./dist/contract.d.ts",
+      "import": "./dist/contract.js"
+    }
+  },
+  "publishConfig": {
+    "registry": "https://saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/"
+  },
+  "scripts": {
+    "build": "tsup",
+    "check-types": "tsc --noEmit",
+    "lint": "eslint src/",
+    "test": "vitest run",
+    "prepublishOnly": "pnpm run build",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@noble/hashes": "^1.8.0"
+  },
+  "devDependencies": {
+    "@saga-ed/soa-typescript-config": "workspace:*",
+    "@types/node": "24.0.12",
+    "tsup": "^8.5.0",
+    "typescript": "^5.8.3",
+    "vitest": "^1.6.1"
+  }
+}

--- a/packages/core/seed-ids-kit/src/__tests__/seed-ids-kit.unit.test.ts
+++ b/packages/core/seed-ids-kit/src/__tests__/seed-ids-kit.unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { uuidv5, makeHashDeriver, makePositionDeriver, checkSeedIdContract } from '../index.js';
+import { uuidv5, uuidv7, makeHashDeriver, makePositionDeriver, checkSeedIdContract } from '../index.js';
 
 // The root namespace + known literals from rostering's iam-seed-ids, frozen on
 // origin/main. These are the regression oracle: if the browser-safe uuidv5 here
@@ -31,6 +31,30 @@ describe('uuidv5 (browser-safe v5)', () => {
     expect(uuidv5('x:y', IAM_ROOT)).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
     );
+  });
+});
+
+describe('uuidv7 (time-ordered)', () => {
+  it('emits a well-formed v7 UUID', () => {
+    expect(uuidv7()).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it('encodes the 48-bit millisecond timestamp big-endian', () => {
+    // 0x0123456789ab -> first 12 hex are the timestamp, then the version nibble
+    expect(uuidv7(0x0123456789ab).startsWith('01234567-89ab-7')).toBe(true);
+  });
+
+  it('sorts lexicographically by time', () => {
+    const ts = [1_700_000_000_000, 1_700_000_000_001, 1_700_000_005_000, 1_700_001_000_000];
+    const ids = ts.map((t) => uuidv7(t));
+    expect([...ids].sort()).toEqual(ids);
+  });
+
+  it('is unique within the same millisecond (random low bits)', () => {
+    const t = 1_700_000_000_000;
+    expect(uuidv7(t)).not.toBe(uuidv7(t));
   });
 });
 

--- a/packages/core/seed-ids-kit/src/__tests__/seed-ids-kit.unit.test.ts
+++ b/packages/core/seed-ids-kit/src/__tests__/seed-ids-kit.unit.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { uuidv5, makeHashDeriver, makePositionDeriver, checkSeedIdContract } from '../index.js';
+
+// The root namespace + known literals from rostering's iam-seed-ids, frozen on
+// origin/main. These are the regression oracle: if the browser-safe uuidv5 here
+// reproduces them byte-for-byte, then iam-seed-ids can adopt this kit with ZERO
+// id change. (Verified independently against node:crypto.)
+const IAM_ROOT = 'b2c4f1a0-5e3d-4c9a-8f6b-1d2e3f4a5b6c';
+const IAM_KNOWN: Record<string, string> = {
+  'group:seed': '71698462-2be8-5eb8-9d7c-443bd59d0c3f',
+  'group:riverside': '0adcbddd-7406-545e-ba75-ef195181145a',
+  'group:metro': '4cedce5b-9173-57c2-8f10-72f8ce4a0509',
+  'group:lincoln': '92c6c9f4-c764-519f-9873-7df7b77f5410',
+};
+
+describe('uuidv5 (browser-safe v5)', () => {
+  it('reproduces iam-seed-ids frozen literals byte-for-byte', () => {
+    for (const [name, want] of Object.entries(IAM_KNOWN)) {
+      expect(uuidv5(name, IAM_ROOT)).toBe(want);
+    }
+  });
+
+  it('is deterministic and namespace-sensitive', () => {
+    expect(uuidv5('group:lincoln', IAM_ROOT)).toBe(uuidv5('group:lincoln', IAM_ROOT));
+    expect(uuidv5('group:lincoln', IAM_ROOT)).not.toBe(
+      uuidv5('group:lincoln', 'a1b2c3d4-0001-4000-8000-000000000000'),
+    );
+  });
+
+  it('emits a well-formed v5 UUID', () => {
+    expect(uuidv5('x:y', IAM_ROOT)).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  });
+});
+
+describe('makeHashDeriver', () => {
+  const derive = makeHashDeriver(IAM_ROOT);
+  it('matches uuidv5 for the same key (order-independent)', () => {
+    expect(derive('group:seed')).toBe(IAM_KNOWN['group:seed']);
+    expect(derive('group:metro')).toBe(uuidv5('group:metro', IAM_ROOT));
+  });
+});
+
+describe('makePositionDeriver', () => {
+  it('reproduces the program-seed-ids a1b2c3d4-0001-* scheme', () => {
+    const programId = makePositionDeriver('a1b2c3d4-0001-4000-8000-');
+    expect(programId(1)).toBe('a1b2c3d4-0001-4000-8000-000000000001');
+    expect(programId(9)).toBe('a1b2c3d4-0001-4000-8000-000000000009');
+  });
+  it('honors a custom pad width', () => {
+    expect(makePositionDeriver('ns-', 4)(7)).toBe('ns-0007');
+  });
+});
+
+describe('checkSeedIdContract', () => {
+  const SLUGS = ['seed', 'riverside', 'metro', 'lincoln'] as const;
+  // strip the `group:` prefix off IAM_KNOWN's keys -> slug-keyed pins
+  const PINNED: Record<string, string> = Object.fromEntries(
+    Object.entries(IAM_KNOWN).map(([k, v]) => [k.replace('group:', ''), v]),
+  );
+  const deriveGroup = (slug: string) => uuidv5(`group:${slug}`, IAM_ROOT);
+  const groupId = (slug: string): string => PINNED[slug] ?? '';
+
+  it('passes when accessor, derivation, and pins all agree', () => {
+    const r = checkSeedIdContract([
+      { name: 'group', slugs: SLUGS, id: groupId, derive: deriveGroup, expect: PINNED },
+    ]);
+    expect(r.failures).toEqual([]);
+    expect(r.ok).toBe(true);
+    expect(r.checked).toBe(4);
+  });
+
+  it('detects derivation drift', () => {
+    const r = checkSeedIdContract([
+      { name: 'group', slugs: SLUGS, id: () => 'a1b2c3d4-0001-4000-8000-000000000001', derive: deriveGroup, uuid: 'any' },
+    ]);
+    expect(r.ok).toBe(false);
+    expect(r.failures.some((f) => f.includes('drift'))).toBe(true);
+  });
+
+  it('detects a value-lock break (an id changed)', () => {
+    const wrong: Record<string, string> = { ...PINNED, lincoln: '00000000-0000-5000-8000-000000000000' };
+    const r = checkSeedIdContract([
+      { name: 'group', slugs: SLUGS, id: (s) => wrong[s] ?? '', expect: PINNED },
+    ]);
+    expect(r.failures.some((f) => f.includes('value-lock'))).toBe(true);
+  });
+
+  it('detects stale pinned keys not in the catalog', () => {
+    const r = checkSeedIdContract([
+      { name: 'group', slugs: ['seed'], id: groupId, expect: PINNED },
+    ]);
+    expect(r.failures.some((f) => f.includes('stale literal'))).toBe(true);
+  });
+
+  it('detects cross-collection id collisions', () => {
+    const dup = '11111111-1111-4111-8111-111111111111';
+    const r = checkSeedIdContract([
+      { name: 'a', slugs: ['x'], id: () => dup, uuid: 'any' },
+      { name: 'b', slugs: ['y'], id: () => dup, uuid: 'any' },
+    ]);
+    expect(r.failures.some((f) => f.includes('collision'))).toBe(true);
+  });
+
+  it('flags a wrong UUID shape', () => {
+    const r = checkSeedIdContract([
+      { name: 'group', slugs: ['seed'], id: () => 'not-a-uuid', uuid: 'v5' },
+    ]);
+    expect(r.failures.some((f) => f.includes('shape'))).toBe(true);
+  });
+});

--- a/packages/core/seed-ids-kit/src/contract.ts
+++ b/packages/core/seed-ids-kit/src/contract.ts
@@ -1,0 +1,114 @@
+/**
+ * Framework-agnostic drift / value-lock checker for a `*-seed-ids` package.
+ *
+ * This is the harness that every domain's contract test reuses instead of
+ * hand-rolling the same loops. It has NO test-framework dependency — it returns
+ * a plain result so the caller asserts with whatever runner it uses:
+ *
+ *   import { checkSeedIdContract } from '@saga-ed/seed-ids-kit/contract';
+ *   it('contract holds', () => {
+ *     const r = checkSeedIdContract([
+ *       { name: 'group', slugs: GROUP_SLUGS, id: groupId,
+ *         derive: deriveGroupId, expect: PINNED_GROUP_IDS },
+ *     ]);
+ *     expect(r.failures).toEqual([]);
+ *   });
+ *
+ * It checks, per collection: every slug resolves; (optional) the accessor equals
+ * an independent re-derivation; (optional) the accessor equals pinned literals
+ * (the value-lock that proves "adopting this changed no seeded id"); the id
+ * matches the expected UUID shape; and ids are unique across all collections.
+ */
+
+/** UUID shape to enforce. `v5` = hash strategy; `any` = position-suffix etc. */
+export type UuidShape = 'v5' | 'any' | 'none';
+
+export interface SeedIdCollection {
+  /** Label used in failure messages, e.g. `'group'` or `'program'`. */
+  name: string;
+  /** Every slug/key the package claims to resolve. */
+  slugs: readonly string[];
+  /** The package's public accessor under test. */
+  id: (slug: string) => string;
+  /** Optional independent re-derivation; `id(slug)` must equal `derive(slug)`. */
+  derive?: (slug: string) => string;
+  /** Optional pinned literals (value-lock); `id(slug)` must equal `expect[slug]`. */
+  expect?: Readonly<Record<string, string>>;
+  /** UUID shape to enforce on each id. Default `'v5'`. */
+  uuid?: UuidShape;
+}
+
+export interface ContractResult {
+  ok: boolean;
+  /** One human-readable line per violation; empty when `ok`. */
+  failures: string[];
+  /** How many ids were evaluated. */
+  checked: number;
+}
+
+const SHAPES: Record<Exclude<UuidShape, 'none'>, RegExp> = {
+  v5: /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+  any: /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+};
+
+const sameKeySet = (a: readonly string[], b: readonly string[]): boolean => {
+  if (a.length !== b.length) return false;
+  const x = [...a].sort();
+  const y = [...b].sort();
+  return x.every((k, i) => k === y[i]);
+};
+
+/** Run the contract checks across all collections. */
+export function checkSeedIdContract(collections: readonly SeedIdCollection[]): ContractResult {
+  const failures: string[] = [];
+  const seen = new Map<string, string>(); // id -> "name:slug" (cross-collection uniqueness)
+  let checked = 0;
+
+  for (const c of collections) {
+    const shapeKey = c.uuid ?? 'v5';
+    const shape = shapeKey === 'none' ? null : SHAPES[shapeKey];
+
+    // No stale literals: if pinned, the slug set must equal the pinned key set.
+    if (c.expect && !sameKeySet(c.slugs, Object.keys(c.expect))) {
+      failures.push(`[${c.name}] slug set != expect keys (stale literal or missing slug — re-pin)`);
+    }
+
+    for (const slug of c.slugs) {
+      checked++;
+      let id: string;
+      try {
+        id = c.id(slug);
+      } catch (err) {
+        failures.push(`[${c.name}] id("${slug}") threw: ${(err as Error).message}`);
+        continue;
+      }
+      if (!id) {
+        failures.push(`[${c.name}] id("${slug}") returned empty`);
+        continue;
+      }
+      if (c.derive) {
+        const derived = c.derive(slug);
+        if (derived !== id) {
+          failures.push(`[${c.name}] drift: id("${slug}")=${id} != derive=${derived}`);
+        }
+      }
+      if (c.expect) {
+        const pinned = c.expect[slug];
+        if (pinned && pinned !== id) {
+          failures.push(`[${c.name}] value-lock: id("${slug}")=${id} != pinned ${pinned}`);
+        }
+      }
+      if (shape && !shape.test(id)) {
+        failures.push(`[${c.name}] id("${slug}")=${id} fails ${shapeKey} UUID shape`);
+      }
+      const dup = seen.get(id);
+      if (dup) {
+        failures.push(`[${c.name}] collision: id("${slug}")=${id} also produced by ${dup}`);
+      } else {
+        seen.set(id, `${c.name}:${slug}`);
+      }
+    }
+  }
+
+  return { ok: failures.length === 0, failures, checked };
+}

--- a/packages/core/seed-ids-kit/src/derivers.ts
+++ b/packages/core/seed-ids-kit/src/derivers.ts
@@ -1,0 +1,38 @@
+/**
+ * The two deterministic-id strategies the fleet uses, as one-liner factories.
+ *
+ * They are NOT interchangeable and must not be unified: each encodes ids that
+ * are already persisted in a domain's database. Pick by the situation:
+ *
+ *   - new domain, no legacy ids   -> makeHashDeriver  (order-independent)
+ *   - preserving an existing scheme -> makePositionDeriver (keeps the numbers)
+ */
+import { uuidv5 } from './uuid.js';
+
+/**
+ * Hash strategy (rostering `iam-seed-ids`). `derive(key)` = `uuidv5(key, root)`.
+ *
+ * Order-independent: any service computes the same id from a stable key, with
+ * no catalog order, no shared database, and no network call. `rootNamespace`
+ * IS the contract — changing it re-randomizes every id. Prefer this for new
+ * domains. `key` is conventionally `"<kind>:<slug>"` (e.g. `group:lincoln`).
+ */
+export function makeHashDeriver(rootNamespace: string): (key: string) => string {
+  return (key: string): string => uuidv5(key, rootNamespace);
+}
+
+/**
+ * Position-suffix strategy (program-hub `program-seed-ids` / `content-seed-ids`).
+ * `derive(n)` = `${namespacePrefix}${pad(n)}`.
+ *
+ * Pure formatting, no crypto. Use ONLY to reproduce an EXISTING hand-assigned
+ * scheme so persisted data is not orphaned — never for a fresh domain.
+ * `namespacePrefix` must include its trailing separator, e.g.
+ * `'a1b2c3d4-0001-4000-8000-'`; `n` is the 1-based position.
+ */
+export function makePositionDeriver(
+  namespacePrefix: string,
+  padWidth = 12,
+): (n: number) => string {
+  return (n: number): string => `${namespacePrefix}${String(n).padStart(padWidth, '0')}`;
+}

--- a/packages/core/seed-ids-kit/src/index.ts
+++ b/packages/core/seed-ids-kit/src/index.ts
@@ -7,16 +7,17 @@
  * `ids.ts` + codegen). This kit factors out the parts that are genuinely the
  * same, leaving each domain to own only its catalog and its choice of strategy:
  *
- *   - `uuidv5`                     browser-safe v5 (no node:crypto)
+ *   - `uuidv5`                     browser-safe v5, DETERMINISTIC (seed ids)
  *   - `makeHashDeriver`           order-independent hash strategy (new domains)
  *   - `makePositionDeriver`       position-suffix strategy (preserve a scheme)
  *   - `checkSeedIdContract`       (from `/contract`) the reusable drift/value-lock test
+ *   - `uuidv7`                     time-ordered, for RUNTIME primary keys (not seeds)
  *
  * It is opt-in: a package adds it as a dependency when convenient. It does NOT
  * own any catalog or any id values — those stay in each domain's repo. See the
  * recipe in the saga-iac plugin's `seed-fixtures.md`.
  */
-export { uuidv5 } from './uuid.js';
+export { uuidv5, uuidv7 } from './uuid.js';
 export { makeHashDeriver, makePositionDeriver } from './derivers.js';
 export {
   checkSeedIdContract,

--- a/packages/core/seed-ids-kit/src/index.ts
+++ b/packages/core/seed-ids-kit/src/index.ts
@@ -1,0 +1,26 @@
+/**
+ * @saga-ed/seed-ids-kit — the shared mechanism behind the `*-seed-ids` contract.
+ *
+ * Canonical, deterministic entity ids let independent service seeds agree on the
+ * same UUIDs with no shared database. Historically each domain hand-rolled the
+ * same machinery (a derivation function, a drift test, sometimes a frozen
+ * `ids.ts` + codegen). This kit factors out the parts that are genuinely the
+ * same, leaving each domain to own only its catalog and its choice of strategy:
+ *
+ *   - `uuidv5`                     browser-safe v5 (no node:crypto)
+ *   - `makeHashDeriver`           order-independent hash strategy (new domains)
+ *   - `makePositionDeriver`       position-suffix strategy (preserve a scheme)
+ *   - `checkSeedIdContract`       (from `/contract`) the reusable drift/value-lock test
+ *
+ * It is opt-in: a package adds it as a dependency when convenient. It does NOT
+ * own any catalog or any id values — those stay in each domain's repo. See the
+ * recipe in the saga-iac plugin's `seed-fixtures.md`.
+ */
+export { uuidv5 } from './uuid.js';
+export { makeHashDeriver, makePositionDeriver } from './derivers.js';
+export {
+  checkSeedIdContract,
+  type SeedIdCollection,
+  type ContractResult,
+  type UuidShape,
+} from './contract.js';

--- a/packages/core/seed-ids-kit/src/uuid.ts
+++ b/packages/core/seed-ids-kit/src/uuid.ts
@@ -1,0 +1,36 @@
+/**
+ * Browser-safe deterministic UUIDs for the `*-seed-ids` contract.
+ *
+ * Uses `@noble/hashes` (audited, zero-dependency, isomorphic) instead of
+ * `node:crypto`, so the same function runs in Node seed scripts AND in browser
+ * bundles (saga-dash, janus) with byte-identical output. That removes the only
+ * reason the original `iam-seed-ids` had to pre-freeze its ids into a committed
+ * `ids.ts`: with a browser-safe hash, every consumer can compute on demand.
+ */
+// `sha1` is flagged @deprecated by @noble/hashes as security guidance — but
+// RFC 4122 v5 UUIDs are *defined* on SHA-1, so this is a correct, non-security use.
+import { sha1 } from '@noble/hashes/sha1';
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
+
+const encoder = new TextEncoder();
+
+/**
+ * RFC 4122 v5 (SHA-1) UUID — `uuidv5(name, namespace)`.
+ *
+ * Byte-identical to a `node:crypto` v5 implementation (SHA-1 is
+ * implementation-independent), so adopting this changes no existing id. The
+ * `namespace` is a UUID string; `name` is any stable key (e.g. `group:lincoln`).
+ */
+export function uuidv5(name: string, namespace: string): string {
+  const ns = hexToBytes(namespace.replace(/-/g, ''));
+  const nameBytes = encoder.encode(name);
+  const input = new Uint8Array(ns.length + nameBytes.length);
+  input.set(ns);
+  input.set(nameBytes, ns.length);
+  const b = Array.from(sha1(input).subarray(0, 16));
+  const at = (i: number): number => b[i] ?? 0; // 16-byte digest: always defined
+  b[6] = (at(6) & 0x0f) | 0x50; // version 5
+  b[8] = (at(8) & 0x3f) | 0x80; // RFC 4122 variant
+  const h = bytesToHex(Uint8Array.from(b));
+  return `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20)}`;
+}

--- a/packages/core/seed-ids-kit/src/uuid.ts
+++ b/packages/core/seed-ids-kit/src/uuid.ts
@@ -1,16 +1,16 @@
 /**
- * Browser-safe deterministic UUIDs for the `*-seed-ids` contract.
+ * UUID constructors for the fleet, built on `@noble/hashes` (audited,
+ * zero-dependency, isomorphic) so the same code runs in Node and the browser:
  *
- * Uses `@noble/hashes` (audited, zero-dependency, isomorphic) instead of
- * `node:crypto`, so the same function runs in Node seed scripts AND in browser
- * bundles (saga-dash, janus) with byte-identical output. That removes the only
- * reason the original `iam-seed-ids` had to pre-freeze its ids into a committed
- * `ids.ts`: with a browser-safe hash, every consumer can compute on demand.
+ *   - `uuidv5` — name-based, DETERMINISTIC. Same input -> same id, with no
+ *     coordination. This is what the `*-seed-ids` contract is built on.
+ *   - `uuidv7` — time-ordered, NON-deterministic. For runtime-generated primary
+ *     keys (DB index locality), NOT for seed ids.
  */
 // `sha1` is flagged @deprecated by @noble/hashes as security guidance — but
 // RFC 4122 v5 UUIDs are *defined* on SHA-1, so this is a correct, non-security use.
 import { sha1 } from '@noble/hashes/sha1';
-import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
+import { bytesToHex, hexToBytes, randomBytes } from '@noble/hashes/utils';
 
 const encoder = new TextEncoder();
 
@@ -30,6 +30,34 @@ export function uuidv5(name: string, namespace: string): string {
   const b = Array.from(sha1(input).subarray(0, 16));
   const at = (i: number): number => b[i] ?? 0; // 16-byte digest: always defined
   b[6] = (at(6) & 0x0f) | 0x50; // version 5
+  b[8] = (at(8) & 0x3f) | 0x80; // RFC 4122 variant
+  const h = bytesToHex(Uint8Array.from(b));
+  return `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20)}`;
+}
+
+/**
+ * RFC 9562 v7 UUID — time-ordered (48-bit Unix-ms timestamp + random bits).
+ *
+ * Use for **runtime-generated primary keys**, where time-ordering improves
+ * database index/B-tree locality vs random v4. **Not** for the `*-seed-ids`
+ * contract: v7 has no name input, so it is non-deterministic — independent
+ * services cannot reproduce the same id. Use `uuidv5` / the derivers for that.
+ *
+ * Ordering is millisecond-granular; ids minted in the same millisecond carry
+ * independent random bits and are not mutually ordered. `timestamp` defaults to
+ * now and is exposed only for testing / backfill.
+ */
+export function uuidv7(timestamp: number = Date.now()): string {
+  const b = Array.from(randomBytes(16));
+  // 48-bit big-endian millisecond timestamp in bytes 0..5 (division avoids the
+  // 32-bit truncation a bitwise mask would hit on values above 2^32).
+  let t = Math.floor(timestamp);
+  for (let i = 5; i >= 0; i--) {
+    b[i] = t % 256;
+    t = Math.floor(t / 256);
+  }
+  const at = (i: number): number => b[i] ?? 0; // 16 bytes: always defined
+  b[6] = (at(6) & 0x0f) | 0x70; // version 7
   b[8] = (at(8) & 0x3f) | 0x80; // RFC 4122 variant
   const h = bytesToHex(Uint8Array.from(b));
   return `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20)}`;

--- a/packages/core/seed-ids-kit/tsconfig.json
+++ b/packages/core/seed-ids-kit/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@saga-ed/soa-typescript-config/base.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node", "vitest"],
+    "noEmit": false
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/core/seed-ids-kit/tsup.config.ts
+++ b/packages/core/seed-ids-kit/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  // All entries are browser-safe (no node:crypto): `@noble/hashes` is isomorphic.
+  entry: ['src/index.ts', 'src/uuid.ts', 'src/derivers.ts', 'src/contract.ts'],
+  format: ['esm'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  outDir: 'dist',
+  splitting: false,
+  skipNodeModulesBundle: true,
+  target: 'es2022',
+});

--- a/packages/core/seed-ids-kit/vitest.config.ts
+++ b/packages/core/seed-ids-kit/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/__tests__/**/*.unit.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -593,6 +593,28 @@ importers:
         specifier: ^1.6.1
         version: 1.6.1(@types/node@24.0.12)(jsdom@25.0.1)
 
+  packages/core/seed-ids-kit:
+    dependencies:
+      '@noble/hashes':
+        specifier: ^1.8.0
+        version: 1.8.0
+    devDependencies:
+      '@saga-ed/soa-typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      '@types/node':
+        specifier: 24.0.12
+        version: 24.0.12
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@24.0.12)(jsdom@25.0.1)
+
   packages/core/tgql-codegen:
     dependencies:
       '@graphql-codegen/cli':


### PR DESCRIPTION
## What

New **`@saga-ed/seed-ids-kit`** (`packages/core/seed-ids-kit`) — the shared, **opt-in** mechanism behind the `*-seed-ids` contract (canonical deterministic entity UUIDs that independent seeds agree on with no shared DB).

Resolves cross-repo audit **candidate G** (the *mechanism* is reusable; the catalogs and id values are not).

## API

- **`uuidv5(name, namespace)`** — browser-safe RFC 4122 v5 via [`@noble/hashes`](https://github.com/paulmillr/noble-hashes) (audited, zero-dep, isomorphic). **Byte-identical** to `node:crypto`, verified against iam-seed-ids' frozen literals. This is what lets a package drop the node-only `derive` entry + frozen `ids.ts` + codegen and compute on demand — **zero id change**.
- **`makeHashDeriver(rootNamespace)`** / **`makePositionDeriver(prefix, pad)`** — the fleet's two existing strategies as one-line factories. They are **not** unified: each encodes ids already persisted in a domain's DB.
- **`checkSeedIdContract(collections)`** — framework-agnostic drift / value-lock / uniqueness / UUID-shape test helper (returns `{ ok, failures, checked }`, no test-framework dep).

## Why opt-in

The kit owns **no** catalog and **no** id values — those stay in each domain's repo. Existing packages (`iam-seed-ids`, `program-seed-ids`, `content-seed-ids`) adopt it on their own schedule; new domains use it from day one. The narrative recipe lives in the saga-iac plugin's `seed-fixtures.md`.

## Verification

- `build`, `check-types`, `lint`, `test` all green. 12 unit tests, including byte-identical reproduction of iam-seed-ids frozen literals and every `checkSeedIdContract` failure mode (drift, value-lock break, stale key, collision, bad shape).
- Lockfile diff is scoped (new importer + `@noble/hashes@^1.8.0`, already present transitively); no unrelated churn.
- Additive leaf package — nothing depends on it yet.

## Follow-ups

- Publish a dev version to CodeArtifact to enable cross-repo opt-in.
- **Candidate A** (separate PR, rostering): migrate `iam-seed-ids` to the light shape via browser-safe SHA-1, with a full literal value-lock as the oracle.

---

## Update — `uuidv7()` for runtime IDs

Added `uuidv7()` (RFC 9562, time-ordered: 48-bit ms timestamp + random) so the kit is the fleet's **one UUID toolkit** — deterministic `uuidv5` + derivers for the seed-ids contract, `uuidv7` for **runtime-generated primary keys** (DB index locality).

**Explicitly not for seed ids:** v7 is non-deterministic (no name input), so independent services can't reproduce the same id. seed-ids stays on `uuidv5`. Browser-safe (`Date.now` + `@noble/hashes` `randomBytes`, no new dependency). 16 tests total.

Wiring `uuidv7()` into specific services' runtime PK generation is a follow-up.
