### PR TITLE
feat(event-test-harness): testcontainers-free ./uuid subpath (unblocks audit A)

### DIFF
--- a/packages/node/event-test-harness/package.json
+++ b/packages/node/event-test-harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/soa-event-test-harness",
-    "version": "0.1.0-dev.2",
+    "version": "0.1.0-dev.3",
     "private": false,
     "type": "module",
     "main": "dist/index.js",
@@ -9,6 +9,10 @@
         ".": {
             "types": "./dist/index.d.ts",
             "default": "./dist/index.js"
+        },
+        "./uuid": {
+            "types": "./dist/uuid.d.ts",
+            "default": "./dist/uuid.js"
         }
     },
     "files": ["dist"],

--- a/packages/node/event-test-harness/tsup.config.ts
+++ b/packages/node/event-test-harness/tsup.config.ts
@@ -1,7 +1,11 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-    entry: ['src/index.ts'],
+    // `uuid` is a separate entry so consumers can `import { id } from
+    // '@saga-ed/soa-event-test-harness/uuid'` WITHOUT pulling in testcontainers
+    // (the index entry imports @testcontainers/* for startInfra, which drags
+    // native ssh2 modules into a consumer's bundle).
+    entry: ['src/index.ts', 'src/uuid.ts'],
     format: ['esm'],
     dts: true,
     clean: true,


### PR DESCRIPTION
## What

Adds a **`./uuid`** subpath export to `@saga-ed/soa-event-test-harness` so consumers can import the deterministic `id()` helper without dragging in `testcontainers`. Bumps `0.1.0-dev.2` → `0.1.0-dev.3`.

```ts
import { id } from '@saga-ed/soa-event-test-harness/uuid';  // no testcontainers
```

## Why

The package's main entry (`index.ts`) imports `@testcontainers/postgresql` + `@testcontainers/rabbitmq` (for `startInfra`) right next to `export { id }`, and the package only exposed the `.` entry. So `import { id } from '@saga-ed/soa-event-test-harness'` pulls `testcontainers → ssh2` (native `.node` modules) into a consumer's bundle — which **breaks the build** of any service that bundles its test files (e.g. program-hub programs-api). This surfaced finishing the `id()` lift (audit **candidate A**): the consumer PRs failed CI on `Cannot find module sshcrypto.node` / `cpufeatures.node`.

## Changes

- `tsup.config.ts` — add `src/uuid.ts` as a second entry → `dist/uuid.{js,d.ts}`
- `package.json` — add `./uuid` to `exports`; version → `0.1.0-dev.3`

## Verification

- Built locally; `dist/uuid.js` confirmed **testcontainers-free** (grep: no `testcontainers`/`ssh2`/`startInfra`) and exports `id`.
- `check-types` + `lint` green.

## Follow-up

Once merged + published (single-package, dev.3), the two id()-lift PRs (program-hub#152, rostering#402) switch their imports to `@saga-ed/soa-event-test-harness/uuid` and bump to dev.3.