### PR TITLE
synthetic-dev: empty integration suite (roster stack landed) + up.sh argless guard

### DIFF
--- a/tools/synthetic-dev/integration-suite.tsv
+++ b/tools/synthetic-dev/integration-suite.tsv
@@ -20,5 +20,8 @@
 # (2026-06-02 saga-dash #131 dropped — PR CLOSED: #129 fixed by rostering#366;
 #  "remember district" re-homed server-side as saga-dash#138.)
 # (2026-06-02 program-hub #126 dropped — landed on main; program-hub back on main.)
+# (2026-06-04 program-hub #144 added — getDistrictTree district-enrollments endpoint
+#  for the saga-dash #137 roster work; per Nathan's 2026-06-03 note. PR still open.)
 
 saga-dash	136
+program-hub	144

--- a/tools/synthetic-dev/integration-suite.tsv
+++ b/tools/synthetic-dev/integration-suite.tsv
@@ -22,6 +22,8 @@
 # (2026-06-02 program-hub #126 dropped — landed on main; program-hub back on main.)
 # (2026-06-04 program-hub #144 added — getDistrictTree district-enrollments endpoint
 #  for the saga-dash #137 roster work; per Nathan's 2026-06-03 note. PR still open.)
-
-saga-dash	136
-program-hub	144
+# (2026-06-05 program-hub #144 dropped — LANDED on main (merge 336d08f), carrying
+#  #150's getDistrictRoster pagination too; program-hub back on main. The rest of
+#  the roster stack landed alongside it: saga-dash #159 + rostering #384,#387,#396,#398.)
+# (2026-06-05 saga-dash #136 dropped — LANDED on main. Suite now EMPTY: every repo
+#  back on origin/main, nothing in flight to replay.)

--- a/tools/synthetic-dev/up.sh
+++ b/tools/synthetic-dev/up.sh
@@ -416,7 +416,9 @@ status(){
 # ── arg parsing: verbs (up/down/status/help) + composable flags ──────
 DO_UP=0; DO_RESET=0; DO_SEED=0; SEED_MODE=roster; DO_LOGIN=0; LOGIN_USER=$DEFAULT_LOGIN_USER
 case "${1:-up}" in
-  up|--up)                       DO_UP=1; shift ;;
+  # `shift || true`: bare `./up.sh` defaults ${1:-up} to "up" but leaves $# at 0,
+  # so an unguarded shift returns 1 and `set -e` kills the script before it runs.
+  up|--up)                       DO_UP=1; shift || true ;;
   --down)                        services_down; exit 0 ;;
   --status)                      status; exit 0 ;;
   -h|--help)                     sed -n '2,51p' "$0"; exit 0 ;;


### PR DESCRIPTION
## What

The sd-137 roster stack has fully landed on `main`, so the synthetic-dev integration suite no longer needs to pin any in-flight PRs.

- **`integration-suite.tsv`** — dropped the last two pins (program-hub #144, saga-dash #136); the suite is now **empty**. Every repo runs on `origin/main`, nothing in flight to replay. Dated maintenance notes added per the file's convention.
- **`up.sh`** — guard an argless `./up.sh` against a `set -e` + `shift` early-exit (earlier commit on this branch, included here).

## Landed PRs this reflects

- **saga-dash** #159 (district Roster page) + #136 (program-details rehydrate on switch)
- **program-hub** #144 — `getDistrictTree` + `getDistrictRoster` (carried #150's pagination)
- **rostering** #384, #387, #396, #398 (CORS, auth gates, wizard contract, CSV password column)

## Notes

- Local sibling checkouts (saga-dash, program-hub) already reset to `origin/main`.
- Branch is behind `main` by a few unrelated commits (event-test-harness, api-core CORS); no file overlap, merges cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
