### PR TITLE
docs(synthetic-dev-align): convergence research + d1.1 decision

### DIFF
--- a/claude/projects/synthetic-dev-align/CLAUDE.md
+++ b/claude/projects/synthetic-dev-align/CLAUDE.md
@@ -1,0 +1,134 @@
+# synthetic-dev-align — converging local synthetic-dev onto the canonical seed-ids base
+
+Workspace for understanding and (eventually) executing **Seth Paul's
+convergence plan**: align the local `synthetic-dev` stack
+(`~/dev/soa/tools/synthetic-dev`) onto the deterministic
+`@saga-ed/*-seed-ids` base, while keeping the scenario runner as the
+**journey** layer on top.
+
+The motivating artifact is **saga-dash PR
+[#152](https://github.com/saga-ed/saga-dash/pull/152)** ("docs: seed-ids
+onboarding, local mesh runbook & synthetic-dev convergence", author
+`SethPaul`) — three docs-only files that (1) document the canonical
+seed-ids packages, (2) give a manual local-mesh runbook, and (3) propose
+the synthetic-dev convergence as a **draft for discussion**.
+
+## What this initiative is
+
+A **research / synthesis** track, not (yet) an implementation track. The
+goal is to:
+
+1. Capture Seth's plan and the canonical seed-ids design faithfully.
+2. Map it against the **current** synthetic-dev flow (scenario-runner
+   seeding, the drift log, `up.sh`/`bootstrap.sh`/`verify.sh`).
+3. Surface the seam, the layered target model, the proposed changes, and
+   the open questions — so a decision to execute can be made with eyes
+   open.
+
+The convergence itself (editing `up.sh`'s seed phase, making scenarios
+seed-ids-aware, stabilizing the dev user, updating `verify.sh`) is
+**downstream** of this synthesis and gated on the open questions in
+Seth's convergence doc.
+
+## The one-line thesis
+
+> synthetic-dev today seeds via the **scenario runner** → non-deterministic
+> UUIDs → re-login after every `--reset`, and **local diverges from
+> preview/CI** (which restore deterministic `db:seed` canonical
+> snapshots). Re-point synthetic-dev's **base** at the seed-ids `db:seed`
+> and make scenarios reference the canonical IDs, and you get
+> **local == preview == CI** with no base re-login churn — scenarios stay
+> first-class as the journey layer.
+
+## Layout
+
+```
+claude/projects/synthetic-dev-align/
+├── CLAUDE.md            # this file
+├── source/              # raw source material — Seth's PR #152 docs (snapshot), threads, prompts
+└── research/            # synthesized analysis of the plan + the convergence gap
+```
+
+Same shape as `soa/claude/projects/soa_75/` (the data-side track this
+ultimately serves) and `student-data-system/claude/projects/sds_92/`.
+
+## Source artifacts
+
+In `source/`:
+
+- `pr-152-seed-ids-onboarding.md` — Seth's seed-ids reference + ID
+  inventory (the three published `0.1.0-dev.0` packages).
+- `pr-152-seed-ids-local-mesh-runbook.md` — Seth's manual mesh bring-up
+  + the offline correlation proof (the centerpiece).
+- `pr-152-seed-ids-synthetic-dev-convergence.md` — Seth's **draft**
+  convergence proposal (the target of this initiative).
+- `pr-152-meta.md` — PR title / author / What-Why-Notes, captured from
+  `gh pr view`.
+
+> These are a **snapshot** of PR #152 as of capture; the canonical live
+> copies are in `saga-dash/docs/` on branch `docs/seed-ids-onboarding`.
+> Trust the live PR if they diverge.
+
+## Research
+
+In `research/`:
+
+- `01-seth-plan-synthesis.md` — what Seth is proposing, distilled: the
+  seed-ids design, the layered base/journey model, the four proposed
+  changes, and the payoff.
+- `02-current-synthetic-dev-flow.md` — how synthetic-dev seeds **today**
+  (scenario runner), its drift log, and exactly where the seam is.
+- `03-convergence-analysis.md` — the gap analysis, a side-by-side of the
+  two seeding worlds, the open questions, risks, and a recommended
+  sequencing with a confidence read.
+
+## Key external references
+
+- **Canonical seed-ids packages** (published `0.1.0-dev.0` to
+  CodeArtifact `saga_js`):
+  - `rostering/packages/core/iam-seed-ids`
+  - `program-hub/packages/core/program-seed-ids`
+  - `program-hub/packages/core/content-seed-ids`
+- **synthetic-dev tool:** `~/dev/soa/tools/synthetic-dev/`
+  (`README.md` = service map + drift log; `getting-started.md` =
+  onboarding + verbs; `STATUS.md` = first-run handoff).
+- **Data-side track (independent but adjacent):**
+  `~/dev/soa/claude/projects/soa_75/` — outbox / event-driven projections
+  POC. seed-ids = **seed-time** agreement; events = **runtime**
+  propagation. The two are complementary.
+- **Original seed/scenario vocabulary:**
+  `rostering/claude/seed-scenario-handoff.md`.
+
+## Decision docs — rule of thumb
+
+Inherits the repo-root convention: any decision surfaced for the user's
+review goes here as a markdown doc under a `decisions/` subdir (created on
+demand — not pre-seeded). Topic-first naming, `PENDING` at top until
+resolved (flip to `RESOLVED <date>` with a one-line summary). Each doc
+carries Context / Options / Recommendation / Related artifacts.
+
+The most likely first decision: **whether and when to execute the
+convergence**, and **how to split base vs journey rows** (Seth's open
+questions). Don't bury that in chat — write the doc.
+
+## Conventions
+
+Inherits from `~/dev/soa/CLAUDE.md`:
+
+- pnpm only (never npm/yarn)
+- ESM only (`"type": "module"`)
+- TypeScript strict mode
+- The seed-ids contract is frozen: `ROOT_NAMESPACE = b2c4f1a0-…`,
+  `CANONICAL_SOURCE = 'canonical'`. **Never** change the namespace — it
+  re-randomizes every ID and breaks every consumer.
+
+## Branch state
+
+- Repo: `soa`, branch `main` at initiative bootstrap.
+- This is a docs/research-only initiative; no code changes land here
+  until the convergence is approved (then it touches
+  `tools/synthetic-dev/` + `rostering`/`program-hub` `scripts/scenarios`).
+
+---
+
+*Last updated: 2026-06-04 (initiative bootstrap)*

--- a/claude/projects/synthetic-dev-align/decisions/d1.1-base-journey-split.md
+++ b/claude/projects/synthetic-dev-align/decisions/d1.1-base-journey-split.md
@@ -1,0 +1,204 @@
+# d1.1 — Base/journey split & the gate to converge synthetic-dev onto `db:seed`
+
+**Status:** RESOLVED 2026-06-04 — **D1 = A** (backfill per-district admin
+personas in `@saga-ed/iam-seed-ids` + `iam-db/prisma/seed.ts`); **D2 =
+adopt** the staged base/journey classification (staged/partial seeding
+preserved — see below); **D3 = execute now via an isolated track** that
+does not touch the live stack while a synthetic-dev workflow is running.
+
+## Context
+
+Seth's PR #152 proposes re-pointing the local `synthetic-dev` stack's
+**base** seed at the deterministic seed-ids `db:seed` (matching
+preview/CI), keeping the scenario runner as a **journey** layer on top
+(see `../research/01-seth-plan-synthesis.md`). His convergence doc left
+three open questions; the headline one was **base parity**: does `db:seed`
+cover everything the scenario base seeds today, per district?
+
+The step-1 parity audit (`../research/04-parity-audit.md`, code-grounded
+2026-06-04) answers that. Two findings reshape the decision:
+
+1. **`db:seed` is a strict superset of the scenario on the program-hub
+   side** (programs, periods, enrollment config — plus scheduling,
+   sessions, content the scenario never creates), all deterministic.
+2. **There is exactly one real gap: per-district admin personas.** The
+   scenario creates login-able admin personas for all 5 districts;
+   `db:seed` creates one only for `seed`. The other catalog users
+   (`multi`/riverside, `many`/metro, `new`/oakdale, `frontier`/frontier)
+   land with `personaId = null`.
+3. **The "journey layer" is essentially empty today** — neither path
+   creates per-student enrollment or dynamic flows. So this is less a
+   "split base from journey" exercise and more "adopt the superset +
+   backfill one gap."
+
+## Decision 1 — How to close the per-district admin persona gap (the gate)
+
+**A. Backfill in `@saga-ed/iam-seed-ids` + `iam-db/prisma/seed.ts`** —
+add an `admin` persona per district (riverside/metro/oakdale/frontier) and
+bind each district's catalog user to it. Lives in the contract → flows to
+local **and** preview/CI. Small, additive, drift-test-guarded.
+*Impact: ~tens of LOC in the package + seed; one PR to rostering.*
+
+**B. Keep the scenario seeding the personas (hybrid)** — let `db:seed` do
+the base, but still run a trimmed scenario step that only adds the missing
+admin personas. *Impact: keeps a scenario dependency for the base; defeats
+"local == preview == CI" since preview/CI wouldn't have them.*
+
+**C. Don't converge yet** — leave synthetic-dev on the scenario base.
+*Impact: zero work; preserves the existing local≠preview divergence and
+re-login churn.*
+
+**Recommendation: A (high confidence).** It's the smallest change, it's in
+the right repo (the contract), and it's the only option that delivers the
+local==preview==CI payoff. B reintroduces the divergence it's meant to
+kill; C forgoes the benefit.
+
+**DECIDED 2026-06-04: A.** The gate is closed by adding admin personas for
+riverside/metro/oakdale/frontier to `@saga-ed/iam-seed-ids` +
+`iam-db/prisma/seed.ts` and binding each district's catalog user to its
+admin persona. This is the one code prerequisite before synthetic-dev's
+base can flip to `db:seed`.
+
+## Decision 2 — What counts as "base" (moves to `db:seed`) vs "journey"
+
+The audit shows nearly everything the scenarios produce today is base.
+Proposed classification:
+
+- **Base (→ `db:seed`):** districts, schools, sections, users + auth +
+  memberships, per-district admin personas (after D1.A), roster, programs,
+  periods, enrollment config, schedules, sessions, content. *All of this
+  `db:seed` already produces except the persona gap.*
+- **Journey (→ scenario, future):** genuinely dynamic per-run state —
+  per-student enrollment, attendance records, live session lifecycle
+  beyond the Connect Demo fixture. **Mostly unwritten today.**
+
+**Recommendation (high confidence):** adopt the above. The scenario runner
+stays as the home for *future* journey data, but on the converged stack it
+seeds little-to-nothing at base time. Defer authoring real journey
+scenarios until a concrete test/demo needs them.
+
+**DECIDED 2026-06-04: adopt.** Plus the explicit refinement below.
+
+### D2 refinement — staged/partial seeding is preserved
+
+The "base" is itself **staged**, and each stage is an independent,
+order-free per-service `db:seed` producer. Partial seeding (e.g. roster
+only, programs empty — to click through the empty-state UI as a real user
+or run Playwright from that beginning state) is **fully preserved** and is
+controlled exactly where it is today: by `up.sh`'s `--seed` verb selecting
+which stages to invoke.
+
+| Stage | Producer (`db:seed`) | Seeds |
+|---|---|---|
+| 1. infra | mesh up | empty DBs |
+| 2. **roster base** | `iam-db/prisma/seed.ts` | districts, schools, sections, users+auth, per-district admin personas (D1=A), roster |
+| 3. programs base | `programs-api` `db:seed` | programs, periods, enrollment config, Connect Demo sessions |
+| 4. schedules | `scheduling-api` `db:seed` | schedules / RRULE / calendar events |
+| 5. content | `content-api` `db:seed` | 12 content items |
+
+Mapping (verbs unchanged): `--seed roster` → stage 2 only (programs empty);
+`--seed full` → stages 2–4 (+5 when wired). Programs-api derives org IDs
+offline, so stages are independent and any-order.
+
+- **Granularity is per-stage (per-service), not sub-service.** "Seed only
+  2 of 9 programs" is *not* a base knob — `programs-api db:seed` is
+  all-or-nothing for its 9; that finer cut belongs to a future journey
+  scenario or a seed flag.
+- **Bonus over today:** because the base is deterministic, a roster-only
+  reseed keeps stable district/user IDs + login cookie across `--reset` →
+  Playwright fixtures/selectors and the empty-state session survive resets
+  (no re-login churn — the exact friction today's scenario `--seed roster`
+  imposes).
+
+## Decision 3 — Sequencing & whether to execute now
+
+Per `../research/03-convergence-analysis.md` the safe order is: parity
+audit (done) → backfill personas (D1.A) → add additive `up.sh --seed base`
+→ stabilize dev user → scenarios reference seed-ids → `verify.sh` ID
+assertions → flip default last.
+
+**DECIDED 2026-06-04: execute now, on an ISOLATED track** — a
+synthetic-dev workflow is currently running against the live stack, so the
+D1.A change must be developed and validated **without touching the running
+stack's processes, DBs, or checked-out branches.**
+
+> **Track 1 DONE 2026-06-04 → rostering PR
+> [#397](https://github.com/saga-ed/rostering/pull/397)** (`feat/per-district-admin-personas`,
+> reviewer nerisaurus). The D1.A change (admin personas for
+> riverside/metro/oakdale/frontier in `iam-db/prisma/seed.ts`, +32/−4) was
+> built in an isolated rostering worktree (`~/dev-worktrees/rostering-personas`,
+> off `main`) and **verified against a throwaway Postgres container** (own
+> port 5439, never the mesh): `db:seed` now creates 14 personas (was 10);
+> the 4 catalog users bind to their district admin persona (32 perms each ==
+> seed District Admin); zero NULL-persona catalog district memberships
+> remain. The live stack was never touched. **Track 2 (integration via
+> `refresh-suite.sh --prs 397` + `up.sh --reset`) remains deferred until the
+> running workflow finishes and the PR merges.**
+
+### Constraint: a synthetic-dev workflow is live
+
+The running workflow consumes the shared stack: the six service processes,
+the mesh DBs (`iam_local`/`iam_pii_local`/…), and the `rostering` /
+`program-hub` checkouts the services were launched from. Anything that
+restarts a service, mutates a mesh DB, switches a branch in a live
+checkout, or rebuilds a running service's dist would **clobber it.**
+
+### Two-track plan
+
+**Track 1 — develop + validate in isolation (safe to do NOW):**
+1. **Isolated checkout.** `git worktree add` a new `rostering` worktree on
+   a feature branch (e.g. `feat/per-district-admin-personas`). The running
+   iam-api keeps running from the *main* checkout's built dist; a linked
+   worktree adds a branch without changing main's checked-out branch.
+2. **Make the D1.A change there** — add admin personas for
+   riverside/metro/oakdale/frontier to the iam-seed-ids catalog, regen
+   `ids.ts` (`pnpm gen`), bind each district's catalog user to its admin
+   persona in `iam-db/prisma/seed.ts`. *Additive — `ROOT_NAMESPACE` is
+   frozen, so existing IDs don't move; only new persona IDs appear.*
+3. **Run the drift test + build in the worktree** (`pnpm test`/`pnpm gen`)
+   — isolated from the running services.
+4. **Validate `db:seed` against a SCRATCH DB**, never the mesh DBs: create
+   a throwaway DB (`iam_align_test` + `iam_pii_align_test`) in the mesh
+   postgres, or a separate ephemeral postgres on another port. Point
+   `DATABASE_URL`/`PII_DATABASE_URL` there, run the new seed, assert the 4
+   admin personas exist + each district's user is bound. Drop the scratch
+   DB after.
+5. Open the rostering PR (reviewer per the friction cadence). **No live
+   stack contact through here.**
+
+**Track 2 — integrate (DEFERRED until the workflow finishes):**
+6. Only once the workflow completes: fold the merged PR into synthetic-dev
+   via `refresh-suite.sh --prs <PR#>` (or `refresh-integration.sh`), then a
+   normal `up.sh --reset --seed roster` to pick it up. This is the only
+   step that restarts/reseeds the live stack, so it waits.
+
+### Hard "do NOT run while the workflow is live" list
+
+`up.sh up/--reset/--seed/--down`, `bootstrap.sh`, `refresh-suite.sh`,
+`pnpm build`/restart of any of the six services, `db:seed`/`migrate`
+against any **mesh** DB, and any **branch switch** in the
+`rostering`/`program-hub`/`student-data-system`/`saga-dash` checkouts the
+running services were launched from (use a worktree instead). `up.sh
+--status` (read-only health/row-count) is fine.
+
+## Minor follow-ups (not blockers)
+
+- **School-level roster membership:** scenario adds it, `db:seed` doesn't
+  (district+section only). Confirm no saga-dash consumer reads school-level
+  roster membership; patch in `db:seed` only if one does.
+- **Username divergence:** scenario uses `dev-user`/`user-*`; catalog uses
+  `dev`/`multi`/… (emails match). Audit saga-dash for hardcoded usernames
+  before the flip (likely none — it authenticates via tRPC whoami).
+- **Dev user:** standardize `AUTH_DEVUSERID` on `userId('dev')` =
+  `1e2ca0d8-…-1186` and retire the `…beef` `seed-dev-user.ts` fallback —
+  a simplification (removes today's two-dev-identity ambiguity), not a risk.
+
+## Related artifacts
+
+- Parity audit: `../research/04-parity-audit.md`
+- Convergence analysis: `../research/03-convergence-analysis.md`
+- Plan synthesis: `../research/01-seth-plan-synthesis.md`
+- Source: saga-dash PR #152 (`../source/pr-152-*`)
+- Code: rostering `scripts/scenarios/src/program-hub.ts:431-454`,
+  `packages/node/iam-db/prisma/seed.ts:285-296,558-566`;
+  program-hub `apps/node/programs-api/src/prisma/seed.ts:380-498`.

--- a/claude/projects/synthetic-dev-align/research/01-seth-plan-synthesis.md
+++ b/claude/projects/synthetic-dev-align/research/01-seth-plan-synthesis.md
@@ -1,0 +1,145 @@
+# 01 — Seth's plan, synthesized
+
+> Source: saga-dash PR #152 (three docs). Raw snapshots in
+> `../source/pr-152-*`. This is the distilled "what is he actually
+> proposing and why" — read this before `03-convergence-analysis.md`.
+
+## The big idea in one paragraph
+
+Saga has shipped a set of tiny, **dev-only** packages —
+`@saga-ed/iam-seed-ids`, `@saga-ed/program-seed-ids`,
+`@saga-ed/content-seed-ids` (all `0.1.0-dev.0` on CodeArtifact) — that
+hand **every** service the **same UUIDs** for shared seed data **by
+construction**. Each ID is `uuidv5("<kind>:<slug>", ROOT_NAMESPACE)` (or a
+fixed literal). Two services that import the package compute the **same
+id for the same slug**, so a program's `organizationId` equals the iam
+district's id with **no shared DB, no HTTP call, and no seed ordering
+dependency**. Seth's plan is to make the local `synthetic-dev` stack seed
+its **base** from these packages (via each service's `db:seed`) so that
+**local dev == AWS preview == CI** — while keeping the scenario runner
+for **journey** data on top.
+
+## The three packages (the "what exists")
+
+| Package | Repo · path | Role |
+|---|---|---|
+| `@saga-ed/iam-seed-ids` | `rostering/packages/core/iam-seed-ids` | **Foundational** — districts/schools/sections/users/roster |
+| `@saga-ed/program-seed-ids` | `program-hub/packages/core/program-seed-ids` | Programs/periods/sessions/slots (depends on iam-seed-ids) |
+| `@saga-ed/content-seed-ids` | `program-hub/packages/core/content-seed-ids` | Content items (standalone) |
+
+The frozen contract:
+
+- **`ROOT_NAMESPACE = b2c4f1a0-5e3d-4c9a-8f6b-1d2e3f4a5b6c`** — changing it
+  re-randomizes every id and breaks every consumer. **Never touch it.**
+- **`CANONICAL_SOURCE = 'canonical'`** — the `source` tag iam-api writes on
+  every canonical group; consumers filter on it.
+
+Two import worlds:
+
+- **Browser-safe** (saga-dash, janus): import the root → frozen literal
+  UUIDs, no `node:crypto`.
+- **Node-only** (`*-api` seeds, codegen): import the `/derive` subpath for
+  live `uuidv5` derivation.
+
+The seeded inventory (the same roster synthetic-dev already produces):
+**5 districts, 13 schools, 28 sections, 6 named dev users, 168 students +
+22 tutors (190 roster), 9 programs, 12 content items.** Login is any
+`{dev,multi,many,new,frontier,none}@saga.org` / `password123`.
+
+> Note the **division of labor** Seth is careful about: *"Events remain
+> the runtime propagation path; seed-ids are the seed-time agreement."*
+> This is the clean boundary with the soa_75 outbox/event work — seed-ids
+> do **not** replace events; they make the *seed-time starting state*
+> agree so events have a consistent base to propagate from.
+
+## The correlation proof (the runbook's centerpiece)
+
+The local-mesh runbook's whole point is **Step 5**: demonstrate the same
+UUID across services with **nothing running and no HTTP**:
+
+1. `deriveGroupId('seed')` (pure offline function) → `71698462-…-0c3f`
+2. iam-api's `groups` table wrote that id (`source='canonical'`,
+   `source_id='seed'`).
+3. programs-api's `Program.organizationId` **references** that same id —
+   computed **offline** from the slug, iam-api never consulted.
+
+All three are identical. That is "integrate through the packaged
+seed-ids" — and it's exactly what AWS preview/CI already do by restoring
+canonical S3 snapshots seeded from `db:seed`.
+
+## The convergence proposal (the actual ask of this initiative)
+
+### The target model — layered, **not** either/or
+
+- **Base layer = seed-ids `db:seed` (deterministic).** Orgs, schools,
+  sections, users, roster, programs, content. Stable UUIDs that correlate
+  across services by construction and match what preview/CI restore from
+  canonical snapshots. **Stable across reseeds → the base never forces a
+  re-login.**
+- **Journey layer = scenarios, on top of that base.** Enrollments,
+  schedules, sessions, attendance flows — the dynamic, per-run state a
+  test/demo exercises. Scenarios **reference** the canonical seed-ids
+  (`groupId('seed')`, `programId('lincoln-fall')`, `personId('s-137')`)
+  for foundational entities instead of minting their own, then layer
+  journey rows on top. Per-run dynamic data may stay non-deterministic;
+  only the **base** must be stable.
+
+### The four proposed changes
+
+1. **`up.sh` seed phase → run `db:seed` for the base.** Where `up.sh`'s
+   `--seed roster` currently runs the scenario to build the base roster,
+   run each service's `pnpm db:seed` instead (iam-db, programs-api,
+   scheduling-api, +content-api when present). This is also what the
+   deployed `_deploy-ecs-api.yml` migrate/seed path already does — so
+   `up.sh` converges on the production seeding path it already mirrors for
+   migrations.
+2. **Make scenarios seed-ids-aware.** In `rostering` + `program-hub`
+   `scripts/scenarios`, resolve foundational entity IDs through the
+   seed-ids packages rather than minting them. The scenario then only
+   creates *journey* rows. Add a `--seed full` = `db:seed` base + scenario
+   journey layer.
+3. **Stabilize the dev user.** With a `db:seed` base, the dev user is
+   `userId('dev')` = `1e2ca0d8-…-1186`; set `AUTH_DEVUSERID` to that and
+   retire the separate `…beef` dev-user seeder. `./up.sh --login` and the
+   saga-dash session then survive `--reset`.
+4. **`verify.sh`** — assert the base counts against the deterministic
+   catalog (5/13/28/168/22/6, 9 programs, 12 content) and that key IDs
+   match `deriveGroupId('seed')` etc.
+
+### The payoff Seth claims
+
+- **local == preview == CI** — one canonical roster, one set of UUIDs
+  everywhere; a local bug reproduces in preview by construction.
+- **No re-login / reconfigure after `--reset`** for the base —
+  `userId('dev')`, `groupId('seed')`, saga-dash `config.json`, and
+  bookmarks all stay valid.
+- **Scenarios keep their full value** for journeys, anchored to stable
+  canonical IDs.
+- synthetic-dev keeps everything it's good at — orchestration,
+  `verify.sh`, PR-pinning, sis-api, `--login`, drift-patching — only the
+  *seed source* changes.
+
+### Non-goals Seth is explicit about
+
+- Scenarios are **not** removed — they become the journey layer.
+- Per-run dynamic journey data may stay non-deterministic; only the base
+  must be stable.
+- No change to the orchestration / verify / login harness.
+
+## Seth's own open questions (carried into `03`)
+
+1. **Base parity** — does each service's `db:seed` cover everything the
+   scenario base does today (personas + the ~593 memberships, per-district
+   admin personas)? Per-district admin personas for
+   riverside/metro/oakdale/frontier were a noted seed-ids follow-up.
+2. **Journey/base split** — which rows current scenarios create are
+   "base" (move to `db:seed`) vs "journey" (stay)? Enrollment = obvious
+   journey; programs/periods = base.
+3. **Scenario refactor scope** — how much of `scripts/scenarios` changes
+   to consume seed-ids vs mint.
+
+## Status of the proposal
+
+The convergence doc is explicitly **"draft for discussion, not a
+decision."** The onboarding + runbook docs are reference/grounded; the
+convergence is the open question this initiative exists to resolve.

--- a/claude/projects/synthetic-dev-align/research/02-current-synthetic-dev-flow.md
+++ b/claude/projects/synthetic-dev-align/research/02-current-synthetic-dev-flow.md
@@ -1,0 +1,125 @@
+# 02 — How synthetic-dev seeds **today**
+
+> Source: `~/dev/soa/tools/synthetic-dev/{README,getting-started,STATUS}.md`
+> as of 2026-06-04. This is the "what we'd be changing" baseline for the
+> convergence in `03`.
+
+## What synthetic-dev is
+
+A fully-dockerized local stack — postgres + redis + rabbitmq + **six
+APIs** — for developing against a **synthetic** roster (no PII, no VPN, no
+prod-mirror fixture). Built 2026-05-26; relocated to
+`~/dev/soa/tools/synthetic-dev` on 2026-06-03. Orchestrated by:
+
+- `bootstrap.sh` — one-shot onboarding: `refresh-suite.sh` (pin in-flight
+  PRs) → `up.sh up --reset --seed roster` → `verify.sh`.
+- `up.sh` — mesh + 6 services; verbs `--reset`, `--seed roster|full`,
+  `--status`, `--down`, `--login`.
+- `verify.sh` — 15 checks (service health · data · source posture).
+- `refresh-suite.sh` / `integration-suite.tsv` — pins each repo to `main`
+  + named in-flight PRs.
+
+### The six services
+
+| service | port | repo / branch |
+|---|---|---|
+| iam-api | 3010 | rostering main (moved 3000→3010 to match saga-dash) |
+| sis-api | 3100 | rostering main — SIS reconciliation / CSV-roster |
+| programs-api | 3006 | program-hub main |
+| scheduling-api | 3008 | program-hub main |
+| ads-adm-api | 5005 | student-data-system main (canonical checkout) |
+| saga-dash | 8900 | saga-dash main |
+| postgres / redis / rabbitmq | 5432 / 6379 / 5672 | soa-mesh |
+
+Seven empty DBs created by the canonical mesh seed: `iam_local`,
+`iam_pii_local`, `programs`, `scheduling`, `ads_adm_local`,
+`ledger_local`, `sis_db`.
+
+## How it seeds today — the **scenario runner**
+
+This is the seam. The base roster is built by **running scenarios**, not
+`db:seed`:
+
+- **IAM roster:** `cd ~/dev/rostering && pnpm tsx scripts/scenarios/src/run.ts program-hub`
+  → 5 districts / 13 schools / 28 sections / district roles / 6 named dev
+  users / 168 students / 22 tutors (197 users / 46 groups / 593
+  memberships).
+- **Programs/schedules:** `cd ~/dev/program-hub/scripts/scenarios && pnpm scenario:programs`
+  → 9 programs + 17 periods + enrollment.
+
+The scenario runner **assigns IDs at create time** → they are
+**non-deterministic**. Consequence, documented verbatim in
+`getting-started.md`:
+
+> "A reset re-seeds iam users with **new UUIDs**, so any browser session
+> you had will 401. Re-login at `localhost:3010/demo#auth` (or
+> `./up.sh --login`) after every `--reset`."
+
+The scenario files **import no seed-ids** — verified by Seth in the
+convergence doc.
+
+## Why this matters: local diverges from preview/CI
+
+| | seeds via | foundational IDs | on reset |
+|---|---|---|---|
+| **synthetic-dev (local)** | scenario runner | assigned at create time → **non-deterministic** | **new UUIDs → re-login + reconfigure** |
+| **`db:seed` (each service)** | `@saga-ed/*-seed-ids` derive | `uuidv5(...)` → **deterministic** | **identical UUIDs** |
+| **AWS preview / CI mesh** | `db:seed` → canonical S3 snapshots | deterministic | restore = identical |
+
+So **local already diverges from preview/CI**: preview/CI are built on the
+deterministic seed-ids base; synthetic-dev still mints per-run UUIDs. That
+divergence is the root of the "re-login after every `--reset`" friction
+*and* means a local repro is not guaranteed to match a preview repro.
+
+## The drift log — what `up.sh` already patches
+
+synthetic-dev exists because the current mains don't "just work"
+together. `up.sh` applies these idempotently (numbering from README):
+
+1. **`SDS` path** — defaults `SDS=$DEV/student-data-system` (sds_92
+   merged, worktree retired).
+2. **rostering main switch isn't dep-neutral** — needs `pnpm install` +
+   full `pnpm build` (new AWS SDK + `jose` deps).
+3. **iam-api dev asset (`password-blocklist.txt`)** — RESOLVED upstream
+   (rostering PR #302).
+4. **main iam-api requires new env** — `AUTH_EMAIL_LOOKUP_SECRET` /
+   `AUTH_EMAIL_VERIFICATION_SECRET` + `NODE_ENV=development`.
+5. **dev user must be a UUID** — `AUTH_DEVUSERID=f0000004-…-beef` (the
+   value `iam-db/src/seed-dev-user.ts` creates) + run the dev-user seeder.
+6. **rate limiter throttles bulk seeding** — raise
+   `SECURITY_RATELIMITMAXREQUESTS` for the 168-student create.
+6b. **programs/scheduling-api require `IAM_API_URL`** at startup (JWT via
+   JWKS) — launched with `IAM_API_URL=http://localhost:3010`.
+7. **rabbitmq port + creds mismatch** — apps default to
+   `saga_user@:5673`; mesh broker is `rabbitmq_admin@:5672`;
+   programs/scheduling **circuit-break and die** without the override.
+8. **stale scenario scripts** — use the `program-hub` scenario (sets
+   personas), not rostering `demo-small`. (The `iam_session`-cookie issue
+   RESOLVED upstream in program-hub PR #102.)
+9. **iam-api moved to :3010** (2026-05-26) to match saga-dash's Janus auth
+   rewrite config.
+10. **programs/scheduling DBs need `migrate deploy`, not `db:push`** —
+    `db:push` skips migration-only DDL (e.g. `RecurrenceRule`'s partial
+    unique index) → `schedules.upsert` 500s with PG `42P10`. `up.sh`
+    runs `pnpm db:deploy`.
+
+> **Relevance to convergence:** drift #5 (the `…beef` dev user + separate
+> seeder), #8 (scenario-vs-db:seed choice), and #10 (`migrate deploy` =
+> the production seed path `up.sh` already mirrors) are exactly the points
+> Seth's proposal touches. Drift #10 in particular shows `up.sh` is
+> *already* converging on the deployed migrate/seed path — the convergence
+> extends that posture from migrations to seeding.
+
+## What's verifiable green today (STATUS 2026-06-02)
+
+`verify.sh` = 15 checks: 6 service-health (all 200), data (iam
+`users=197`, `sis_db` migrated), source posture (repos on right branches +
+pinned PRs merged in). Pinned suite at capture: program-hub #126,
+saga-dash #136.
+
+## The harness caveat (operational, not convergence-related)
+
+`up.sh` launches services with `nohup`; from inside an agent tool-call,
+foreground `nohup`/`setsid` children get reaped on teardown — launch each
+server as its own background task instead. Affects agent-run sessions
+only.

--- a/claude/projects/synthetic-dev-align/research/03-convergence-analysis.md
+++ b/claude/projects/synthetic-dev-align/research/03-convergence-analysis.md
@@ -1,0 +1,206 @@
+# 03 — Convergence analysis: the seam, the risks, the sequencing
+
+> Builds on `01-seth-plan-synthesis.md` (the plan) and
+> `02-current-synthetic-dev-flow.md` (the baseline). This is the
+> synthesis: where exactly the two worlds meet, what's hard, and a
+> recommended order of operations. **My read, marked with confidence.**
+
+## The seam, stated precisely
+
+There is exactly **one** mechanism to change: **how synthetic-dev builds
+its base roster.**
+
+- **Today:** `up.sh --seed roster` → scenario runner → IDs assigned at
+  create time → non-deterministic → re-login after every `--reset`,
+  local ≠ preview/CI.
+- **Target:** `up.sh` base phase → each service's `pnpm db:seed` →
+  `uuidv5(slug)` derived IDs → deterministic → no base re-login, local ==
+  preview == CI.
+
+Everything else Seth proposes (scenarios become seed-ids-aware,
+`AUTH_DEVUSERID` stabilizes, `verify.sh` asserts the catalog) is
+**downstream of** or **enabling for** that single swap.
+
+## Why this is low-conceptual-risk
+
+Three things make this less scary than a typical seeding rewrite:
+
+1. **Same roster, same numbers.** Both paths describe the *identical*
+   synthetic roster (5/13/28/168/22/6, 9 programs, 12 content). Seth's
+   convergence doc and synthetic-dev's own counts agree. We're not
+   changing *what* exists, only *which UUIDs* it gets and *who* writes it.
+2. **`up.sh` is already half-converged.** Drift #10 already moved DB
+   provisioning to `prisma migrate deploy` — "the same command
+   program-hub's ECS `migrate` job runs." Switching the *seed* step to
+   `db:seed` extends an existing posture (mirror the deployed path), it
+   doesn't invent one.
+3. **The packages are published and proven.** All three seed-ids packages
+   are `0.1.0-dev.0` on CodeArtifact; the runbook's Step 5 correlation
+   proof is grounded and runnable. The base layer already works in
+   preview/CI. We're importing a known-good base into local.
+
+## Where the real work / risk sits
+
+### R1 — base/journey split is not yet drawn (the crux)
+
+The scenario runner today creates **both** base and journey rows in one
+pass. The convergence requires cleanly separating them:
+
+| Likely **base** (move to `db:seed`) | Likely **journey** (stays in scenario) |
+|---|---|
+| districts, schools, sections | enrollments |
+| users + PII + password auth | schedules / recurrence rules |
+| memberships (the ~593) | sessions |
+| programs, periods | attendance flows |
+| content items | per-run dynamic state |
+
+The boundary is *mostly* obvious (enrollment = journey; programs/periods =
+base) but **memberships and personas are the ambiguous middle** — see R2.
+**Confidence: high** that the split is doable; **medium** on where exactly
+memberships/personas land without reading the scenario source.
+
+### R2 — base parity / persona gap (Seth's open Q1)
+
+Does `db:seed` cover everything the scenario base covers *today*?
+
+- The scenario base produces **197 users / 46 groups / 593 memberships**
+  and per-district admin **personas**.
+- seed-ids `db:seed` seeds users + PII + password auth + memberships, but
+  Seth flags that **per-district admin personas for
+  riverside/metro/oakdale/frontier were a noted seed-ids follow-up.**
+- If those personas aren't in `db:seed` yet, login parity breaks for the
+  non-`seed`-district personas after convergence. **This is the single
+  most important thing to confirm before flipping `up.sh`.**
+
+**Action:** diff the scenario's produced user/membership/persona set
+against what `db:seed` produces, per district. If there's a gap, it's a
+seed-ids package PR (add the missing personas to `catalog.ts`), not a
+synthetic-dev change — which keeps the fix where the contract lives.
+
+### R3 — dev-user identity flip (drift #5 ↔ proposed change 3)
+
+> **Corrected by `04-parity-audit.md`:** `f0000004-…-beef` is **not** the
+> scenario's dev user — it's from a *separate* standalone seeder
+> (`iam-db/src/seed-dev-user.ts`, email dev@**example**.org) that `up.sh`
+> runs alongside the scenario. The scenario's `dev@saga.org` gets a
+> server-random UUID. So synthetic-dev today already juggles two "dev"
+> identities.
+
+Target is `userId('dev')` = `1e2ca0d8-…-1186` (dev@saga.org, carries
+password auth). Proposed change 3 actually **removes** the existing
+two-identity ambiguity → a simplification, not just a flip. Still a
+**coordinated** change (env var + retire the `…beef` seeder + any saga-dash
+reference move together), but lower risk than first framed. Email-based
+devLogin (`dev@saga.org`/`password123`) keeps working throughout.
+
+### R4 — scenario refactor scope (Seth's open Q3)
+
+Making scenarios "reference seed-ids instead of mint" touches `rostering`
++ `program-hub` `scripts/scenarios`. Unknown until the source is read how
+deeply IDs are threaded. Two sub-risks:
+- Scenarios import the **browser-safe root** vs the **`/derive` subpath**
+  — must pick correctly (Node context → can use either; the catalog
+  literals are fine).
+- A `--seed full` verb that = `db:seed` base + scenario journey needs the
+  scenario to be **idempotent against an already-seeded base** (today it
+  assumes it owns creation). Re-running must not double-create or
+  collide on the now-fixed base UUIDs.
+
+### R5 — "iam groups don't dedup" (existing footgun)
+
+synthetic-dev's README already warns: `--seed roster` without `--reset`
+duplicates iam groups (no dedup). With deterministic `db:seed` UUIDs +
+`upsert` on fixed ids (the producer pattern uses `prisma.group.upsert`
+keyed on `deriveGroupId(slug)`), this footgun **goes away** for the base —
+a genuine secondary benefit. **Confidence: high** (the onboarding doc's
+§4b shows the upsert-on-derived-id pattern explicitly).
+
+## Side-by-side: before vs after
+
+| Dimension | Today (scenario base) | After convergence (db:seed base) |
+|---|---|---|
+| Base seed mechanism | scenario runner | each service `pnpm db:seed` |
+| Foundational UUIDs | non-deterministic | deterministic `uuidv5(slug)` |
+| After `--reset` | new UUIDs → **re-login** | identical UUIDs → **no base re-login** |
+| local vs preview/CI | **diverges** | **identical by construction** |
+| Dev user | `…beef` + separate seeder | `userId('dev')` = `1e2ca0d8-…` |
+| iam group re-seed | duplicates (no dedup) | upsert on fixed id → idempotent |
+| Scenarios | create base + journey | reference base, create journey only |
+| `verify.sh` base check | row counts | row counts **+ ID assertions** |
+
+## Recommended sequencing
+
+A safe, reversible order — each step independently verifiable, no big-bang:
+
+1. **Parity audit first (no code).** Diff scenario-produced
+   users/groups/memberships/personas vs `db:seed` per district. Output:
+   a gap list (R2). *This is the gating artifact — everything else waits
+   on it.* → if gaps exist, file seed-ids package PR(s) to close them.
+2. **Stand up a `db:seed` base by hand** following the runbook Steps 1–5
+   on the synthetic-dev mesh; confirm the Step 5 correlation proof passes
+   locally. Validates the base works against *our* infra before touching
+   `up.sh`.
+3. **Add `up.sh --seed base` (new verb, additive).** Runs `db:seed` for
+   iam-db / programs-api / scheduling-api (+content when present). Leave
+   `--seed roster` (scenario) intact alongside it. Now both paths exist;
+   nothing breaks.
+4. **Stabilize the dev user** (`AUTH_DEVUSERID=userId('dev')`, retire the
+   `…beef` seeder) — but only once `--seed base` is the default base.
+5. **Make scenarios seed-ids-aware** + add `--seed full` = base + journey
+   (R4). Scenario stops minting foundational IDs.
+6. **`verify.sh` ID assertions** — assert `deriveGroupId('seed')` etc.
+   match the DB, plus the catalog counts.
+7. **Flip the default** (`bootstrap.sh` → `--seed base`/`full`) and update
+   STATUS/README/getting-started. Retire `--seed roster` (scenario base)
+   once parity is proven.
+
+Steps 1–2 are pure validation; steps 3–6 are additive and reversible;
+step 7 is the only one-way door, and it comes last with parity already
+proven.
+
+## My read / recommendation
+
+**Recommendation: pursue it — high value, and the architecture is right.**
+The layered "deterministic base + scenario journey" model is the correct
+shape: it fixes the genuine local≠preview divergence and the re-login
+churn *without* throwing away the scenario runner's journey value. Seth's
+restraint ("not delete the scenario runner," "only the base must be
+stable," "no harness change") keeps the blast radius small.
+
+- **Confidence the model is right: high.** It mirrors the deployed
+  seed path (which `up.sh` already half-tracks via drift #10) and the
+  packages are published and proven.
+- **Confidence on effort/scope: medium.** The unknowns are all in R1/R2/R4
+  — the base/journey split and persona parity — and none are conceptual,
+  they just need the scenario source read and a parity diff run.
+- **The one gate: R2 persona parity.** Do not flip the default until
+  `db:seed` demonstrably produces login-able personas for *every*
+  district the scenario base does today. That's a measurable
+  precondition, and step 1 produces it.
+
+**Lowest-regret next action:** run the step-1 parity audit and write it up
+as a decision doc (`decisions/d1.1-base-journey-split.md`) — it both
+unblocks the work and gives the user the base-vs-journey call to make.
+
+## Open questions to put to the user / Seth
+
+1. **Execute now or park?** This is a draft proposal; is converging
+   synthetic-dev in scope for this cycle, or is it documentation-ahead-of-
+   work? (Affects whether step 1 runs now.)
+2. **Persona parity (R2)** — is the per-district admin persona follow-up
+   in seed-ids already closed, or still open? If open, who owns the
+   `catalog.ts` PR?
+3. **Where does the convergence work land** — in `tools/synthetic-dev`
+   (the harness) for steps 3/6, and in `rostering`+`program-hub`
+   `scripts/scenarios` for step 5? Confirm the cross-repo split and
+   branch posture (likely the same integration-suite pinning model).
+4. **`--seed roster` deprecation** — keep the scenario-base verb as an
+   escape hatch, or remove it once `--seed base`/`full` prove out?
+
+## Related artifacts
+
+- Plan: `./01-seth-plan-synthesis.md` · Baseline: `./02-current-synthetic-dev-flow.md`
+- Raw source: `../source/pr-152-*`
+- Live: saga-dash PR #152 (`docs/seed-ids-{onboarding,local-mesh-runbook,synthetic-dev-convergence}.md`)
+- Tool: `~/dev/soa/tools/synthetic-dev/{README,getting-started,STATUS}.md`
+- Adjacent track: `~/dev/soa/claude/projects/soa_75/` (events = runtime; seed-ids = seed-time)

--- a/claude/projects/synthetic-dev-align/research/04-parity-audit.md
+++ b/claude/projects/synthetic-dev-align/research/04-parity-audit.md
@@ -1,0 +1,213 @@
+# 04 — Step-1 parity audit: scenario base vs `db:seed` base
+
+> **The gating artifact for the convergence** (see `03-convergence-analysis.md` R2).
+> Question: does each service's `db:seed` cover everything the scenario
+> runner seeds today, *per district* — so synthetic-dev's base can be
+> re-pointed at `db:seed` without losing login/admin parity?
+>
+> Method: two read-only code audits (2026-06-04) of the actual seed source,
+> not the docs. Every claim below is traceable to a file:line in the agent
+> findings. Repo state: `rostering` @ `main` (`f173886`), `program-hub` @
+> `local/integration` (`6bd88f2`).
+>
+> **Verdict: ONE real gap (per-district admin personas), narrowly scoped to
+> `@saga-ed/iam-seed-ids`. Everything else, `db:seed` already meets or
+> exceeds the scenario.** The convergence is lower-risk than `03` feared.
+
+---
+
+## Headline result
+
+| Domain | Scenario (Path A) | `db:seed` (Path B) | Parity? |
+|---|---|---|---|
+| Districts (5) | ✅ all 5 | ✅ all 5, deterministic UUIDs | **B ≥ A** |
+| Schools (13) | ✅ | ✅ (+1 manual + 3 CSV shadow groups) | **B ≥ A** |
+| Sections (28) | ✅ | ✅ (+1 manual Algebra I) | **B ≥ A** |
+| Roster (168 students + 22 tutors) | ✅ | ✅ same names/sections | **B = A** |
+| Named login-able users | 6 | **15** (6 canonical + 9 demo) | **B ≥ A** |
+| Password auth (login-able) | ✅ all named | ✅ all 15 (argon2id, `password123`) | **B ≥ A** |
+| **Per-district admin personas** | ✅ **all 5 districts** | ❌ **`seed` only** | **A > B — THE GAP** |
+| Roster memberships | district+school+section (3/person) | district+section (2/person) | **A > B (minor)** |
+| Programs (9) | ✅ | ✅ deterministic | **B = A** |
+| Periods (17) | ✅ | ✅ deterministic | **B = A** |
+| Enrollment config (school/section/period mappings) | ✅ | ✅ same shape, deterministic | **B = A** |
+| Schedules / RRULE / CalendarEvent | ❌ none | ✅ scheduling-api db:seed | **B > A** |
+| Sessions / Pods / Slots (Connect Demo) | ❌ none | ✅ `seedConnectDemo` | **B > A** |
+| Content (12 items) | ❌ none | ✅ content-api db:seed | **B > A** |
+| **ID determinism** | ❌ server-minted per run | ✅ `uuidv5(slug)` offline | **B > A — the whole point** |
+
+**The big realization:** for the **program-hub side, `db:seed` is a strict
+superset of the scenario** — it produces everything the scenario does
+(programs, periods, enrollment config) *plus* scheduling, sessions, and
+content the scenario never touches, all deterministically and offline. The
+scenario's *only* unique contributions are on the **iam side**: (1)
+per-district admin personas, and (2) an extra school-level membership row
+per roster person. Gap (1) is the gate; gap (2) is cosmetic.
+
+---
+
+## The one real gap — per-district admin personas (R2 confirmed)
+
+**This is exactly the follow-up Seth flagged, and it is real.**
+
+### Scenario (Path A) creates admin personas for ALL 5 districts
+`rostering/scripts/scenarios/src/program-hub.ts:431-454` — for **every**
+district it creates group-scoped `admin` + `tutor` + `student` personas
+(bound to ADMIN/TUTOR/STUDENT roles from `personas.listRoles`). Dev users
+mapped into a district receive that district's admin persona
+(`:507-517`). So `many`→metro-admin, `new`→oakdale+frontier-admin,
+`frontier`→frontier-admin, `multi`→riverside-admin all work.
+
+### `db:seed` (Path B) creates an admin persona for `seed` ONLY
+`rostering/packages/node/iam-db/prisma/seed.ts:285-296`:
+- `personaAdminDistrict` (admin, **seed** district) ✅
+- `personaAdminLincoln` (admin, **school-level**, Lincoln — still inside seed) ✅
+- riverside / metro / oakdale → **student + tutor personas only, NO admin**
+- frontier → **no personas at all**
+
+And the catalog users land in their districts *without* an admin persona:
+`seed.ts:558-566` sets `personaId: slug === 'seed' ? personaAdminDistrict : null`.
+So `multi`(riverside), `many`(metro), `new`(oakdale), `frontier`(frontier)
+all get `personaId = null` — they can authenticate but have **no district
+admin role**.
+
+### Per-district admin matrix
+
+| District | Scenario admin? | `db:seed` admin? | Catalog user there | Admin under db:seed? |
+|---|:--:|:--:|---|:--:|
+| `seed` | ✅ | ✅ | `dev` (+demo users) | ✅ |
+| `riverside` | ✅ | ❌ | `multi` | ❌ |
+| `metro` | ✅ | ❌ | `many` ← *recommended walkthrough user* | ❌ |
+| `oakdale` | ✅ | ❌ | `new` | ❌ |
+| `frontier` | ✅ | ❌ | `frontier` | ❌ |
+
+**Why it's the gate:** the onboarding doc recommends `many@saga.org`
+(metro, "richest — many programs") as the happy-path walkthrough user.
+Under `db:seed` today, `many` logs in with **no admin persona** → a
+degraded/empty admin experience in saga-dash. Flipping synthetic-dev's
+default to `db:seed` before closing this would *regress* every
+non-`seed`-district persona.
+
+### The fix is small and lives in the right place
+Add per-district admin personas to the iam seed so `db:seed` mints an
+`admin` persona for riverside/metro/oakdale/frontier (and binds the
+catalog user in each district to it). This is a **`@saga-ed/iam-seed-ids`
++ `iam-db/prisma/seed.ts` change** — it belongs in the package/contract,
+not in synthetic-dev. Once landed, it flows to local **and** preview/CI
+for free (the whole seed-ids payoff). Estimated: small, additive, drift-
+test-guarded.
+
+---
+
+## Secondary gap — roster school-level memberships (cosmetic)
+
+Scenario gives each roster person 3 membership rows
+(district+school+section, `program-hub.ts:622-663`); `db:seed` gives 2
+(district+section, `seed.ts:594-602`). This is most of why the membership
+counts differ (~593 scenario vs ~413 db:seed). Functionally minor —
+section membership already implies the school via the section's parent —
+but if any saga-dash query filters roster by *school* membership directly,
+it would see fewer rows. **Confirm whether any consumer reads school-level
+roster membership; if not, ignore. If yes, add the row in `db:seed`.**
+
+---
+
+## Correction to a premise carried in `03` and memory — the dev user
+
+The audit corrects the "`AUTH_DEVUSERID = f0000004-…-beef` is the
+scenario's dev user" framing:
+
+- The scenario assigns **no fixed dev-user ID** — `dev-user`/`dev@saga.org`
+  gets a **server-random UUID** each run (`builders.ts:171`).
+- `f0000004-0000-4000-8000-00000000beef` belongs to a **separate**
+  standalone seeder, `rostering/packages/node/iam-db/src/seed-dev-user.ts`
+  (`DEV_USER_ID`, email **dev@example.org**, username `devuser`) — which
+  synthetic-dev's `up.sh` runs *in addition to* the scenario (drift #5).
+- `db:seed` itself has **two** dev identities: the canonical `dev` =
+  `userId('dev')` = `1e2ca0d8-…-1186` (dev@saga.org) **and** a hardcoded
+  demo `devuser` = `f0000004-…-009` (dev@example.org).
+
+So synthetic-dev *today* already juggles two "dev" identities (scenario's
+random `dev@saga.org` + the `…beef` `dev@example.org` fallback). Seth's
+proposed change 3 (standardize on `userId('dev')` = `1e2ca0d8-…`) actually
+*removes* this existing ambiguity — a cleaner win than `03` credited.
+**Email-based devLogin (`dev@saga.org`/`password123`) keeps working** under
+`db:seed` because the canonical `dev` user carries that email + password
+auth.
+
+---
+
+## Username divergence (low risk, worth noting)
+
+The two paths use different **usernames** for the named users (emails
+mostly match):
+
+| email | scenario username | db:seed (catalog) username |
+|---|---|---|
+| dev@saga.org | `dev-user` | `dev` |
+| multi@saga.org | `user-multi-district` | `multi` |
+| many@saga.org | `user-many-programs` | `many` |
+| new@saga.org | `user-new-district` | `new` |
+| frontier@saga.org | `user-empty-district` | `frontier` |
+| none@saga.org | `user-no-district` | `none` |
+
+Anything keyed on **username** breaks across the flip; anything keyed on
+**email** or **derived UUID** is fine. `./up.sh --login` uses email
+devLogin, so it's unaffected. Audit saga-dash for any hardcoded username
+before flipping (likely none — it authenticates via tRPC whoami).
+
+---
+
+## Revised base/journey picture (feeds d1.1)
+
+The audit overturns the convergence doc's assumption that scenarios are a
+**journey layer on top of** the base. **Today they are not** — the
+program-hub scenario creates *base* data (programs, periods, enrollment
+config) that `db:seed` also creates, just non-deterministically. There is
+**no journey-only data today**: neither path creates per-student
+enrollment rows, and only `db:seed` creates sessions/schedules/content.
+
+Implication for the layered model:
+- The "journey layer" Seth describes (enrollments, schedules, sessions,
+  attendance flows on top of a stable base) is **aspirational** — it
+  mostly **doesn't exist yet** in either path.
+- Converging the base to `db:seed` therefore **loses essentially nothing**
+  on the program side (db:seed ⊇ scenario) and **gains** scheduling +
+  sessions + content + determinism.
+- The scenario runner's residual value, post-convergence, is: (a) the
+  per-district admin personas *until* they move into `db:seed` (then even
+  that goes away), and (b) a future home for genuinely dynamic journey
+  data that nobody has written yet.
+
+This means the convergence is closer to **"adopt the db:seed superset and
+backfill the one persona gap"** than to **"carefully split base from
+journey."** The split is easy because the journey set is nearly empty.
+
+---
+
+## Bottom line / what unblocks the flip
+
+**One precondition gates flipping synthetic-dev's default to `db:seed`:**
+
+> Add per-district admin personas (riverside / metro / oakdale / frontier)
+> to `@saga-ed/iam-seed-ids` + `iam-db/prisma/seed.ts`, and bind each
+> district's catalog user to its admin persona.
+
+Everything else is parity-or-better. Two minor follow-ups (school-level
+roster membership; username references in saga-dash) are confirm-then-
+ignore-or-patch. The dev-user change is a simplification, not a risk.
+
+See `../decisions/d1.1-base-journey-split.md` for the decision this audit
+feeds.
+
+## Source
+
+- IAM audit (Path A vs B): agent over `~/dev/rostering` —
+  `scripts/scenarios/src/{program-hub,builders,run}.ts`,
+  `packages/node/iam-db/prisma/seed.ts`,
+  `packages/core/iam-seed-ids/src/{catalog,ids,roster,derive}.ts`,
+  `packages/node/iam-db/src/seed-dev-user.ts`.
+- Program audit (Path A vs B): agent over `~/dev/program-hub` —
+  `scripts/scenarios/src/programs.ts`, `scripts/seed.sh`,
+  `apps/node/{programs,scheduling,content}-api/src/prisma/seed*.ts`,
+  `packages/core/{program,content}-seed-ids/src/{catalog,index}.ts`.

--- a/claude/projects/synthetic-dev-align/source/pr-152-meta.md
+++ b/claude/projects/synthetic-dev-align/source/pr-152-meta.md
@@ -1,0 +1,38 @@
+# saga-dash PR #152 — metadata snapshot
+
+- **Repo:** saga-ed/saga-dash
+- **PR:** [#152](https://github.com/saga-ed/saga-dash/pull/152)
+- **Title:** docs: seed-ids onboarding, local mesh runbook & synthetic-dev convergence
+- **Author:** Seth Paul (`SethPaul`)
+- **Head → base:** `docs/seed-ids-onboarding` → `main`
+- **State (at capture):** OPEN
+- **Size:** +660 / −0, docs-only (3 files)
+- **Captured:** 2026-06-04 via `gh pr view 152`
+
+## Files
+
+| Path | +/− |
+|---|---|
+| `docs/seed-ids-onboarding.md` | +258 |
+| `docs/seed-ids-local-mesh-runbook.md` | +310 |
+| `docs/seed-ids-synthetic-dev-convergence.md` | +92 |
+
+## What (verbatim)
+
+Three companion docs under `docs/` for the canonical `@saga-ed/*-seed-ids` packages:
+
+- **`seed-ids-onboarding.md`** — reference: why they exist, the three packages + APIs, the source-verified ID inventory, usage patterns, and the seed-profile/db-host plumbing.
+- **`seed-ids-local-mesh-runbook.md`** — hands-on: stand up the mesh locally, seed each service from the catalogs, and prove cross-service ID correlation offline. Defers to `soa/tools/synthetic-dev` as the canonical one-command bring-up.
+- **`seed-ids-synthetic-dev-convergence.md`** — a draft proposal to seed synthetic-dev's canonical **base** from the deterministic seed-ids `db:seed` (matching preview/CI) while keeping the scenario runner as the **journey** layer on top.
+
+## Why (verbatim)
+
+The three seed-ids packages are published to CodeArtifact at `0.1.0-dev.0`, but there was no single place explaining how to consume them, how to run the integrated mesh locally, or how the new `synthetic-dev` tooling relates. saga-dash is the browser consumer, so it hosts the references.
+
+## Notes (verbatim)
+
+- The runbook's bring-up was reconciled against `soa/tools/synthetic-dev` and the live code: programs/scheduling require `IAM_API_URL` + `RABBITMQ_URL` at startup; iam runs on `:3010`; local login via `/demo#auth` or `./up.sh --login`.
+- Correlation proof (offline `deriveGroupId('seed')` == iam group == programs `organizationId`) is the runbook's centerpiece.
+- The convergence doc is a **draft for discussion**, not a decision.
+
+Docs-only.

--- a/claude/projects/synthetic-dev-align/source/pr-152-seed-ids-local-mesh-runbook.md
+++ b/claude/projects/synthetic-dev-align/source/pr-152-seed-ids-local-mesh-runbook.md
@@ -1,0 +1,314 @@
+<!-- Snapshot of saga-dash PR #152 :: docs/seed-ids-local-mesh-runbook.md
+     Source: saga-ed/saga-dash @ branch docs/seed-ids-onboarding
+     Captured 2026-06-04. Trust the live PR if this diverges. -->
+
+# Standing Up the Saga Mesh Locally with Canonical Seed-IDs
+
+> **Companion to [`seed-ids-onboarding.md`](./seed-ids-onboarding.md)** (package/API/ID reference).
+> This is the hands-on runbook: bring up several backend services on your laptop, seed each
+> from the shared `@saga-ed/*-seed-ids` catalogs, and watch them correlate **by construction**.
+>
+> **Scope note (honesty):** Steps 1–5 (infra → install → seed → **correlation proof**) are
+> grounded in the current repo state and runnable. Step 6 (saga-dash UI) is assembled from the
+> current config (ports, flags, override mechanism) — caveats are called out inline; it is the
+> *optional visual layer*, not the proof. The proof lives in Step 5 and needs no UI.
+>
+> **Just want the stack running? Use `synthetic-dev`.** `soa/tools/synthetic-dev/bootstrap.sh` is
+> the team's one-command, automated bring-up of this exact mesh — 6 services, pinned to the team's
+> in-flight state, with a `verify.sh` and `./up.sh --login`. **This doc is the layer underneath:**
+> what that tool automates, a manual path, and the part it doesn't cover — *why the IDs correlate by
+> construction* (Step 5). One seam to know: synthetic-dev currently seeds via the **scenario runner**
+> (non-deterministic UUIDs → re-login after every `--reset`), whereas the `db:seed` path here uses the
+> **deterministic** seed-ids (stable UUIDs across reseeds). See
+> [Relationship to synthetic-dev](#relationship-to-synthetic-dev).
+
+---
+
+## The idea (why this works)
+
+Each service owns its own Postgres DB and **seeds only its own DB** from the canonical catalogs.
+Because every UUID is `uuidv5("<kind>:<slug>", ROOT_NAMESPACE)` (or a fixed literal), two services
+compute the **same id for the same slug** — so a program's `organizationId` equals the iam district's
+id with **no service calling another at seed time, no `IAM_API_URL`, and no ordering dependency**.
+Stand the services up in any order; the data lines up.
+
+**The local mesh:**
+
+| Service | Repo | Local port | Seeds from |
+|---|---|---|---|
+| iam-api (+ iam-pii) | rostering | **3010**¹ | `iam-seed-ids` (districts/schools/sections/users/roster) — the producer |
+| programs-api | program-hub | **3006** | `iam-seed-ids` (org ids) + `program-seed-ids` (programs/periods) |
+| scheduling-api | program-hub | **3008** | `program-seed-ids` (sessions/slots) |
+| content-api *(optional)* | program-hub | 3010 | `content-seed-ids` — see [Appendix](#appendix--content-api-optional) |
+| saga-dash *(optional UI)* | saga-dash | **8900** | consumes the above; log in as a seeded user |
+
+¹ iam-api's binary defaults to `:3000`, but the team (and saga-dash's `config.json`) run it on
+**`:3010`** — set `PORT=3010`. This doc uses `:3010` throughout (matching `synthetic-dev`).
+
+---
+
+## Prerequisites
+
+- **Node ≥22** for rostering/program-hub (Prisma 7 rejects older), **Node 24+** for saga-dash; `corepack` pnpm.
+- **Docker** (the mesh Postgres/Redis/RabbitMQ run in containers).
+- **AWS SSO + CodeArtifact.** The cross-repo seed-ids deps are published `0.1.0-dev.0`, so each repo
+  must auth to CodeArtifact before `pnpm install`:
+  ```bash
+  aws sso login                  # account 396913734878
+  cd ~/dev/<repo> && pnpm co:login   # writes the CodeArtifact token into npm config
+  ```
+  (`co:login` is defined in each repo's root `package.json`; rostering's `.npmrc` already pins the
+  `@saga-ed:` scope to the `saga_js` CodeArtifact registry.)
+
+---
+
+## Step 1 — bring up shared infra (one command)
+
+```bash
+cd ~/dev/soa/infra
+make up PROJECT=saga-mesh PROFILE=empty      # make down to stop, make reset to wipe
+```
+Spins up (see `soa/infra/Makefile`, `compose/projects/saga-mesh/`):
+- **Postgres** `:5432` — superuser `postgres_admin` / `password123`
+- **Redis** `:6379`, **RabbitMQ** `:5672` (mgmt `:15672`, `rabbitmq_admin`/`password123`)
+- **Empty databases** (`compose/projects/saga-mesh/seed/profile-empty.sql`):
+
+  | DB | owner / password | used by |
+  |---|---|---|
+  | `iam_local` | `iam` / `iam` | iam-api |
+  | `iam_pii_local` | `iam_pii` / `iam_pii` | iam-api (PII) |
+  | `programs` | `saga_user` / `password123` | programs-api |
+  | `scheduling` | `saga_user` / `password123` | scheduling-api |
+  | `ads_adm_local`, `ledger_local`, `sis_db` | (per owner) | SDS / future |
+
+  > ⚠️ There is **no `content` database** in the mesh seed — content-api needs one created manually
+  > (see [Appendix](#appendix--content-api-optional)).
+
+**Connection strings** (used below):
+```
+iam        postgresql://iam:iam@localhost:5432/iam_local
+iam-pii    postgresql://iam_pii:iam_pii@localhost:5432/iam_pii_local
+programs   postgresql://saga_user:password123@localhost:5432/programs
+scheduling postgresql://saga_user:password123@localhost:5432/scheduling
+```
+
+---
+
+## Step 2 — install each repo
+
+```bash
+cd ~/dev/rostering   && pnpm co:login && pnpm install && pnpm build
+cd ~/dev/program-hub && pnpm co:login && pnpm install && pnpm build
+```
+`pnpm build` (turbo) compiles workspace siblings the seeds need (e.g. `rostering-client`,
+`program-seed-ids`); the cross-repo `iam-seed-ids` resolves from CodeArtifact.
+
+---
+
+## Step 3 — migrate + seed each service
+
+Order doesn't matter for correlation (derivation is offline), but seed **iam first** by convention.
+Each service reads `DATABASE_URL` from its `.env` — copy `apps/node/<svc>/.env.example` → `.env`
+and point it at the mesh URLs above. You can also pass the URL inline as shown.
+
+**iam-api (rostering)** — two DBs:
+```bash
+cd ~/dev/rostering/packages/node/iam-db
+DATABASE_URL=postgresql://iam:iam@localhost:5432/iam_local         pnpm db:deploy   # migrate
+cd ../iam-pii-db
+DATABASE_URL=postgresql://iam_pii:iam_pii@localhost:5432/iam_pii_local pnpm db:deploy
+cd ../iam-db
+DATABASE_URL=postgresql://iam:iam@localhost:5432/iam_local \
+PII_DATABASE_URL=postgresql://iam_pii:iam_pii@localhost:5432/iam_pii_local \
+  pnpm db:seed    # also needs the dev PII keys from apps/node/iam-api/.env.example
+```
+`db:seed` materializes the whole catalog (5 districts, 13 schools, 28 sections, 6 users, 190 roster)
+with **derived canonical UUIDs**, `source='canonical'`, `source_id=<slug>`.
+
+**programs-api + scheduling-api (program-hub)** — one `db:seed` covers all program-hub services:
+```bash
+cd ~/dev/program-hub/apps/node/programs-api
+DATABASE_URL=postgresql://saga_user:password123@localhost:5432/programs   pnpm db:deploy
+cd ../scheduling-api
+DATABASE_URL=postgresql://saga_user:password123@localhost:5432/scheduling pnpm db:deploy
+cd ~/dev/program-hub
+pnpm db:seed     # scripts/seed.sh seeds programs-api + scheduling-api (+ content if its DB exists)
+```
+**No `IAM_API_URL` needed** — the programs seed derives org ids offline from the slugs.
+
+---
+
+## Step 4 — run the services
+
+Separate terminals (`pnpm dev` in each app dir):
+```bash
+# iam-api → :3010   (apps/node/iam-api/.env must set:)
+#   PORT=3010  NODE_ENV=development  AUTH_AUTHENABLED=false  AUTH_SEEDMODE=true  JANUS_REQUIRED=false
+#   AUTH_DEVUSERID=1e2ca0d8-8f6a-5a97-a141-b38d472a1186   # = userId('dev'); see Step 6 caveat
+cd ~/dev/rostering/apps/node/iam-api && PORT=3010 pnpm dev
+
+# programs/scheduling THROW at startup without IAM_API_URL (they verify iam JWTs via JWKS), and
+# circuit-break/die without a reachable broker. Launch each with BOTH:
+cd ~/dev/program-hub/apps/node/programs-api && \
+  IAM_API_URL=http://localhost:3010 \
+  RABBITMQ_URL=amqp://rabbitmq_admin:password123@localhost:5672 pnpm dev   # :3006
+cd ~/dev/program-hub/apps/node/scheduling-api && \
+  IAM_API_URL=http://localhost:3010 \
+  RABBITMQ_URL=amqp://rabbitmq_admin:password123@localhost:5672 pnpm dev   # :3008
+```
+> The mesh broker is `rabbitmq_admin@:5672`; the apps default to the wrong `saga_user@:5673`, so the
+> `RABBITMQ_URL` override is mandatory or programs/scheduling die after ~5 min (synthetic-dev drift #7).
+
+Health check: `curl localhost:3010/health`, `:3006/health`, `:3008/health`.
+iam-api **refuses to boot unless `NODE_ENV=development`** when auth is disabled (production guard).
+
+---
+
+## Step 5 — prove the integration (the point)
+
+Demonstrate the **same UUID across services, with no service running and no HTTP**:
+
+```bash
+# 1. Derive the canonical 'seed' district id (pure function, offline):
+cd ~/dev/rostering
+node --input-type=module -e "import {deriveGroupId} from '@saga-ed/iam-seed-ids/derive'; console.log(deriveGroupId('seed'))"
+#   → 71698462-2be8-5eb8-9d7c-443bd59d0c3f
+
+# 2. iam-api WROTE it as a canonical district:
+psql "postgresql://iam:iam@localhost:5432/iam_local" \
+  -c "select id, source, source_id, display_name from groups where source='canonical' and source_id='seed';"
+#   → 71698462-2be8-5eb8-9d7c-443bd59d0c3f | canonical | seed | Seed District
+
+# 3. programs-api REFERENCED it (note quoted camelCase columns — Program has no @@map):
+psql "postgresql://saga_user:password123@localhost:5432/programs" \
+  -c "select id, \"organizationId\", name from \"Program\" order by name;"
+#   → the 'seed'-district programs (Lincoln Fall, Roosevelt A/B) have organizationId = 71698462-...
+```
+
+**Punchline:** all three are `71698462-2be8-5eb8-9d7c-443bd59d0c3f`. programs-api computed it
+**offline** — iam-api wasn't consulted, `IAM_API_URL` was unset, and the seed order was irrelevant.
+That is "integrate through the packaged seed-ids." The same holds down the chain: scheduling →
+programs via `programId(slug)`, content → `contentId(slug)`, and roster people via `personId('s-137')`.
+
+---
+
+## Step 6 — see it in saga-dash (optional UI)
+
+> **Caveat:** this section is assembled from saga-dash's current config (`config.json`, auth
+> middleware) — confirm the two knobs below in your checkout. The Step 5 proof stands on its own.
+
+```bash
+cd ~/dev/saga-dash && pnpm dev      # Vite on :8900
+```
+
+**Knob 1 — the iam port.** saga-dash's `apps/web/dash/static/config.json` `localDefaults` expect
+**iam on `:3010`** — which is exactly where Step 4 runs it (`PORT=3010`), matching the team /
+synthetic-dev convention. So **no override is needed**: `program-hub`→3006 and `scheduling-api`→3008
+line up too. (If you instead leave iam on its `:3000` binary default, repoint saga-dash with
+`http://localhost:8900/?iam=localhost:3000` or the gear-icon override panel — `VITE_ENABLE_OVERRIDES`
+is on in dev.)
+
+**Knob 2 — local auth.** iam-api's middleware: with `AUTH_AUTHENABLED=false`, a **valid session
+cookie still wins**; only requests *without* a cookie fall back to `AUTH_DEVUSERID`. So:
+- **Log in as a specific canonical user (recommended):** with `JANUS_REQUIRED=false` the employee
+  gate is off, so a real login cookie takes precedence over the dev fallback. Easiest: open
+  **`http://localhost:3010/demo#auth`** and devLogin as `many@saga.org` / `password123` (synthetic-dev
+  wraps this as **`./up.sh --login`**, which mints the session and opens a logged-in Chromium). Then
+  open `http://localhost:8900`.
+- **Auto dev-user (no login):** set `AUTH_DEVUSERID` to a **seeded** id — for this `db:seed` path that's
+  `userId('dev')` = `1e2ca0d8-8f6a-5a97-a141-b38d472a1186` (lands you in as `dev@saga.org`, seed
+  district). ⚠️ The shipped `.env.example` value (`f0000004-…-009`) is **not** in the `db:seed` roster
+  → `whoami` returns an unseeded id → empty dashboard. (synthetic-dev's *scenario* seed path uses a
+  different dev user — `…beef` + its own dev-user seeder — because it doesn't run `db:seed`.)
+
+**Canonical users** (all `@saga.org`, password **`password123`**):
+
+| user | district(s) | why |
+|---|---|---|
+| `many` | metro | **richest** — many programs/schedules |
+| `dev` | seed | default happy path |
+| `multi` | seed + riverside | cross-district switching |
+| `new` / `frontier` / `none` | oakdale / frontier / — | empty-state & edge cases |
+
+---
+
+## Reset / re-seed
+
+Re-running `pnpm db:seed` rebuilds a service's data (the seeds use `deleteMany` — a destructive local
+reset; fine on the mesh). `make reset` in `soa/infra` drops everything and re-creates the empty DBs.
+Because ids are **deterministic**, reseeding produces the **same UUIDs** — saga-dash overrides,
+bookmarks, and any hardcoded `userId('dev')`/`groupId('seed')` stay valid across reseeds. That
+stability is the whole point.
+
+---
+
+## Troubleshooting (verified rough edges)
+
+- **`programs-api`/`scheduling-api` throw `IAM_API_URL … is required` at boot** → launch them with
+  `IAM_API_URL=http://localhost:3010` (Step 4). They also **circuit-break and die** without a reachable
+  broker → set `RABBITMQ_URL=amqp://rabbitmq_admin:password123@localhost:5672` (mesh broker; apps
+  default to the wrong `saga_user@:5673`).
+- **iam port** → run iam on `:3010` (Step 4) to match saga-dash + synthetic-dev; only override if you
+  leave it on its `:3000` default.
+- **`AUTH_DEVUSERID` stale in `.env.example`** → set it to `userId('dev')` = `1e2ca0d8-…-1186` (db:seed path).
+- **content-api** → no `content` DB in the mesh + its `:3010` now collides with iam → see Appendix; skip for the golden path.
+- **Node version** → Prisma 7 needs Node ≥22 (rostering/program-hub); saga-dash needs Node 24+.
+
+---
+
+## Appendix — content-api (optional)
+
+content-api postdates the mesh seed, so:
+```bash
+# 1. create its DB (absent from profile-empty.sql):
+psql "postgresql://postgres_admin:password123@localhost:5432/postgres" \
+  -c 'create database content owner saga_user;'
+# 2. migrate + seed (program-hub's pnpm db:seed picks it up once the DB exists):
+cd ~/dev/program-hub/apps/node/content-api
+DATABASE_URL=postgresql://saga_user:password123@localhost:5432/content pnpm db:deploy
+cd ~/dev/program-hub && pnpm db:seed        # seeds the 12 canonical content items by contentId()
+# 3. run it → :3010
+```
+content-api isn't in saga-dash's `services.json` on main, so it's **off the UI golden path**. Its
+default `:3010` now collides with iam (which Step 4 runs on `:3010`) — if you run content-api too,
+give it a non-default port (`PORT=3011`) and override in the UI.
+
+---
+
+## Relationship to synthetic-dev
+
+`soa/tools/synthetic-dev` is the **automated, team-canonical** way to run this mesh: `./bootstrap.sh`
+pins everyone to the same in-flight state, brings up the same stack (plus **sis-api** and
+**ads-adm-api**), runs `verify.sh`, and `./up.sh --login` drops you into an authenticated dash. Prefer
+it for day-to-day work; the manual steps above exist to explain/customize what it does.
+
+**Today it seeds via the scenario runner** (`scripts/scenarios`), which assigns IDs at create time, so
+**every `--reset` mints new UUIDs** (hence its "re-login after every reset") — it does *not* use the
+seed-ids `db:seed`. That's the one seam between the two.
+
+**The target model is layered, not either/or** — scenarios stay first-class, but on top of a
+canonical base:
+- **Base layer = seed-ids `db:seed` (deterministic).** Orgs, schools, sections, users, roster,
+  programs, content — stable UUIDs that correlate across services and match what the AWS preview/CI
+  mesh restores from canonical snapshots. Stable across reseeds → no re-login churn for the base.
+- **Journey layer = scenarios (on top).** Enrollments, schedules, sessions, attendance flows — the
+  dynamic, per-run state a test/demo exercises. Scenarios **reference the canonical seed-ids**
+  (`groupId('seed')`, `programId('lincoln-fall')`, `personId('s-137')`) for the foundational entities
+  instead of minting their own, then layer journey state on top.
+
+Pointing synthetic-dev's base seed at `db:seed` and making the scenarios seed-ids-aware would make
+**local == preview == CI** and retire the base-roster re-login churn — while keeping scenarios for
+journeys. See [`seed-ids-synthetic-dev-convergence.md`](./seed-ids-synthetic-dev-convergence.md).
+
+---
+
+## Reference
+
+| Thing | Path |
+|---|---|
+| Package/API/ID reference | [`seed-ids-onboarding.md`](./seed-ids-onboarding.md) |
+| Automated stack (canonical) | `soa/tools/synthetic-dev/` (`bootstrap.sh` · `up.sh` · `verify.sh`) |
+| Local infra harness | `soa/infra/Makefile` · `soa/infra/compose/projects/saga-mesh/` |
+| Original design + correlation proof | `rostering/claude/seed-scenario-handoff.md` (§5c, §6) |
+| iam-api auth/janus config | `rostering/apps/node/iam-api/.env.example` · `src/middleware/auth.middleware.ts` |
+| saga-dash local topology | `saga-dash/apps/web/dash/static/config.json` (`localDefaults`) |

--- a/claude/projects/synthetic-dev-align/source/pr-152-seed-ids-onboarding.md
+++ b/claude/projects/synthetic-dev-align/source/pr-152-seed-ids-onboarding.md
@@ -1,0 +1,262 @@
+<!-- Snapshot of saga-dash PR #152 :: docs/seed-ids-onboarding.md
+     Source: saga-ed/saga-dash @ branch docs/seed-ids-onboarding
+     Captured 2026-06-04. Trust the live PR if this diverges. -->
+
+# Canonical Seed-IDs — Developer Onboarding & Inventory
+
+> **Status:** all three seed-ids packages are published to CodeArtifact at **`0.1.0-dev.0`**
+> and ready to consume. See [§2](#2-the-three-packages) for the package list and
+> [§4a](#4a-install-from-codeartifact) to install.
+>
+> **Want to run the whole mesh locally?** See the companion
+> [Local Mesh Runbook](./seed-ids-local-mesh-runbook.md) — bring up several services on your
+> laptop and watch them correlate through these ids.
+
+---
+
+## 1. What these are & why they exist
+
+`@saga-ed/*-seed-ids` are tiny, **dev-only** packages that hand every service the **same
+UUIDs** for shared seed data — districts, schools, users, programs, content — **by
+construction**, with no shared database, no HTTP call, and no ordering dependency.
+
+Before them, three disconnected ID worlds existed (from `iam-seed-ids/README.md`):
+
+| Where | Example | Problem |
+|---|---|---|
+| iam-api `db:seed` | `f0000002-…`, `source=manual` | consumed by nobody cross-service |
+| rostering scenario | random UUIDs, `source=scenario` | re-randomized each run; needs live iam-api |
+| program-hub seed | `seed-org-001` strings | only resolves via an HTTP call after a scenario |
+
+The fix: every canonical UUID is `uuidv5("<kind>:<slug>", ROOT_NAMESPACE)` (or a fixed
+literal scheme). Two services that import the package compute the **same id for the same
+slug**. Restore each service DB from its **named canonical snapshot**, and the mesh lines
+up at startup. **Events remain the runtime propagation path; seed-ids are the seed-time
+agreement.**
+
+---
+
+## 2. The three packages
+
+| Package | Repo · path | Role | Version |
+|---|---|---|---|
+| `@saga-ed/iam-seed-ids` | `rostering/packages/core/iam-seed-ids` | **Foundational** — districts/schools/sections/users/roster | `0.1.0-dev.0` |
+| `@saga-ed/program-seed-ids` | `program-hub/packages/core/program-seed-ids` | Programs / periods / sessions / slots (depends on iam) | `0.1.0-dev.0` |
+| `@saga-ed/content-seed-ids` | `program-hub/packages/core/content-seed-ids` | Content items (lessons/practice/assessments) | `0.1.0-dev.0` |
+
+**Dependency direction:** `program-seed-ids` → depends on `@saga-ed/iam-seed-ids@0.1.0-dev.0`
+(for `groupId`/org resolution). `content-seed-ids` is standalone. iam-seed-ids depends on
+nothing.
+
+**Two import worlds (important):**
+- **Browser-safe** (`saga-dash`, `janus`): import the package root — frozen literal UUIDs,
+  zero `node:crypto`. e.g. `import { groupId, userId } from '@saga-ed/iam-seed-ids'`.
+- **Node-only** (`*-api` seeds, codegen): import the `/derive` subpath for the live
+  `uuidv5` derivation. e.g. `import { deriveGroupId } from '@saga-ed/iam-seed-ids/derive'`.
+  (program-/content-seed-ids expose only `.` — their literals are computed at module load.)
+
+---
+
+## 3. ID inventory (what has been created)
+
+Each package's `catalog.ts` / `ids.ts` are the source of truth for the IDs below.
+
+### 3a. `@saga-ed/iam-seed-ids`
+*Source of truth:* `src/catalog.ts` (data) · `src/ids.ts` (frozen UUIDs) · `src/roster.ts` ·
+`src/derive.ts` (derivation).
+
+- **`ROOT_NAMESPACE = b2c4f1a0-5e3d-4c9a-8f6b-1d2e3f4a5b6c`** — the contract. Changing it
+  re-randomizes every id and breaks every consumer. **NEVER change it.**
+- **`CANONICAL_SOURCE = 'canonical'`** — the `source` tag iam-api writes on every canonical
+  group; consumers filter on it.
+
+**Derivation schemes**
+- Districts / schools / sections (any "group"): `deriveGroupId(slug) = uuidv5("group:"+slug)`
+- Users: `deriveUserId(slug) = uuidv5("user:"+slug)`
+- Roster persons: pure string (browser-safe, no crypto):
+  `personId("s-7") = 00000000-0000-4000-a000-000000000007` (student, variant `a`);
+  `personId("t-3") = 00000000-0000-4000-b000-000000000003` (tutor, variant `b`).
+
+**5 districts** (each tagged with the use-case it covers):
+
+| slug | UUID | use case |
+|---|---|---|
+| `seed` | `71698462-2be8-5eb8-9d7c-443bd59d0c3f` | primary happy-path, fully populated |
+| `riverside` | `0adcbddd-7406-545e-ba75-ef195181145a` | multi-district users / cross-district isolation |
+| `metro` | `4cedce5b-9173-57c2-8f10-72f8ce4a0509` | large district (many schools/programs) |
+| `oakdale` | `b39f3ea1-0ee5-5a61-afdd-65e8c2b30db6` | district with NO programs (empty-state) |
+| `frontier` | `ea1562ee-a620-5d5c-82a8-768da7f798c2` | district with NO schools (edge case) |
+
+**13 schools** — `seed`: lincoln, washington, jefferson · `riverside`: mapleGrove, cedarPark ·
+`oakdale`: oakdaleElem, oakdaleMiddle · `metro`: metroEast, metroWest, metroCentral,
+metroNorth, metroSouth, metroLakeside.
+
+**28 sections** — `sec-101 … sec-NNN` (course offerings under schools).
+
+**6 users** (all `@saga.org`, password **`password123`**, argon2id):
+
+| slug | email | districts |
+|---|---|---|
+| `dev` (`1e2ca0d8-8f6a-5a97-a141-b38d472a1186`) | dev@saga.org | seed |
+| `multi` | multi@saga.org | seed, riverside |
+| `many` | many@saga.org | metro |
+| `new` | new@saga.org | oakdale |
+| `frontier` | frontier@saga.org | frontier |
+| `none` | none@saga.org | (no district) |
+
+> Best happy-path walkthrough user: **`many@saga.org`** (metro, many programs) or
+> **`dev@saga.org`** (seed district).
+
+**190 roster** — 168 students (`s-1 … s-168`) + 22 tutors (`t-1 … t-22`), each with a
+name + section assignment. Mirrors `@saga-ed/rostering-client`'s `seed-data.ts` byte-for-byte.
+
+### 3b. `@saga-ed/program-seed-ids`
+*Source of truth:* `src/catalog.ts` · `src/session-id.ts`. **Namespaces:** programs
+`a1b2c3d4-0001-4000-8000-*`, periods `a1b2c3d4-0002-4000-8000-*`.
+
+**9 programs** (each linked to an iam district + schools):
+
+| slug | org (district) |
+|---|---|
+| `lincoln-fall` (`…000000000001`) | seed (schools: lincoln, washington) |
+| `roosevelt-ab` | seed (jefferson) |
+| `riverside-afterschool` | riverside (mapleGrove) |
+| `metro-east` / `metro-west` / `metro-central` / `metro-north` / `metro-south` / `metro-lakeside` | metro |
+
+Plus deterministic **periods** (`periodId(programSlug, periodKey)`), **sessions**
+(`sessionId(parts)` + `encodeSessionId`/`decodeSessionId` codecs), and **slots**
+(`slotId(periodId, rotationIndex)`).
+
+**API:** `getProgram`, `programId`, `periodId`, `programOrgId` (returns the iam `groupId`),
+`periodKeys`, `sessionId`, `slotId`.
+
+### 3c. `@saga-ed/content-seed-ids`
+*Source of truth:* `src/catalog.ts`. **Namespace:** `c0a1b2c3-0001-4000-8000-*` (distinct
+from programs to avoid collisions).
+
+**12 content items** (`contentId(slug) = CONTENT_NS + index`):
+`c-warm-001` (`…000000000001`), `c-poll-014`, `c-ada-201`, `c-exit-088`, `c-geo-301`,
+`c-geo-310`, `c-geo-422`, `c-geo-555`, `c-ms-101`, `c-rt-440`, `c-ms-330`, `c-ms-340` —
+mix of practice/assessment/lesson across Algebra I, Geometry, Pre-Algebra (two Spanish).
+
+**API:** `getContent`, `contentId`.
+
+---
+
+## 4. Using seed-ids (developer guide)
+
+### 4a. Install from CodeArtifact
+These are published to the `saga_js` CodeArtifact repo
+(`saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/`). To install in a
+worktree:
+
+```bash
+aws codeartifact get-authorization-token --domain saga --domain-owner 531314149529 \
+  --profile saga-deploy-prod --query authorizationToken --output text   # write into .npmrc
+pnpm install
+```
+
+Pin the **published dev version** when consuming **across repos**:
+```jsonc
+// package.json
+"@saga-ed/iam-seed-ids":     "0.1.0-dev.0",
+"@saga-ed/program-seed-ids": "0.1.0-dev.0"
+```
+Within the **same repo**, use `workspace:*` (e.g. program-hub's `programs-api` →
+`program-seed-ids`). **Never** use a `link:../../rostering/...` path across repos — it breaks
+CI (see [§6 Conventions](#6-conventions--rules)).
+
+### 4b. Producer pattern — iam-api `db:seed` (Node, derive)
+`rostering/packages/node/iam-db/prisma/seed.ts` materializes the whole catalog:
+```ts
+import { DISTRICTS, SCHOOLS, USERS, CANONICAL_SOURCE } from '@saga-ed/iam-seed-ids';
+import { deriveGroupId } from '@saga-ed/iam-seed-ids/derive';
+
+for (const d of DISTRICTS) {
+  await prisma.group.upsert({
+    where:  { id: deriveGroupId(d.slug) },
+    create: { id: deriveGroupId(d.slug), kind: 'district',
+              displayName: d.displayName, source: CANONICAL_SOURCE, sourceId: d.slug },
+    update: {},
+  });
+}
+```
+
+### 4c. Consumer pattern — another service's seed (no live iam-api)
+`program-hub/apps/node/programs-api/src/prisma/seed.ts`:
+```ts
+import { groupId } from '@saga-ed/iam-seed-ids';
+import { programId, programOrgId } from '@saga-ed/program-seed-ids';
+
+await prisma.program.create({
+  data: { id: programId('lincoln-fall'), organizationId: programOrgId('lincoln-fall') },
+  //                                       ^ === groupId('seed') === the iam-seeded district
+});
+```
+`programOrgId('lincoln-fall')` equals the UUID iam already seeded, so the row correlates at
+DB startup — no scenario run, no HTTP resolve.
+
+### 4d. Browser pattern — saga-dash / janus (frozen literals)
+```ts
+import { groupId, userId, getDistrict } from '@saga-ed/iam-seed-ids';
+const DISTRICT = groupId('seed');     // x-organization-id header
+const DEV_USER = userId('dev');       // x-user-id — stable across reseeds
+getDistrict('oakdale').useCase;       // deliberately pick the empty-state district
+```
+
+### 4e. Adding / changing a canonical entity
+1. Edit the package's `catalog.ts` (add the district/program/content row).
+2. `pnpm gen` to regenerate `ids.ts` (frozen literals).
+3. `pnpm test` — the **drift test** (`ids.test.ts`) fails until the literal matches the
+   derivation; commit the regenerated `ids.ts`.
+4. Re-seed / re-snapshot affected services (the new id flows to every consumer for free).
+
+---
+
+## 5. Seed-profiles, snapshots & the db-host-v2 plumbing
+
+seed-ids make IDs agree; **canonical snapshots** make the data exist. PR previews and the
+local mesh restore each service DB from a named snapshot at provision time.
+
+- **Orchestrator API:** `iac/cloudformation_templates/dbs/db_host_v2/orchestrator/API.md`
+  (Lambda `dev-db-host-orchestrator`). Actions: `provision` (optional `seedProfile`+`seedFrom`),
+  `switch`/`restore`, `snapshot`, `reset`, `profiles`, `list`/`describe`, `health`.
+- **CI threading:** `provision-preview-db-secret` action + `_deploy-ecs-api.yml` +
+  `sandbox-deploy.yml` forward `seed-profile` / `seed-from` into the `provision` payload;
+  when both are set the orchestrator restores the S3 snapshot into the fresh per-PR container.
+- **Canonical snapshots** (`s3://saga-db-seeds-dev/<db>/profile-canonical.sql`):
+  `rostering-iam-canonical`, `rostering-iam-pii-canonical`, `program-hub-programs-canonical`,
+  `program-hub-scheduling-canonical`, `content-api-postgres`.
+- **Container-per-PR:** each preview deploy provisions a dedicated Postgres container
+  (iam-api provisions **two**: `iam_db` + `iam_pii_db`). `provision` is **create-once**; the
+  action guards re-provision via a triage→describe→derive idempotency path.
+
+---
+
+## 6. Conventions & rules
+
+- **Dev-only forever.** seed-ids ship **only** as `0.1.0-dev.0` prereleases — never a stable
+  release. They are test/dev seed fixtures, not production data.
+- **`ROOT_NAMESPACE` is frozen** (`b2c4f1a0-…`). Changing it invalidates every id everywhere.
+- **Cross-repo deps pin the published version** (`0.1.0-dev.0`); same-repo deps use
+  `workspace:*`. No `link:` paths across repos (breaks CI).
+- **Browser code imports the root**, never `/derive` (keeps `node:crypto` out of bundles).
+- **The catalog is the contract** — add an entity in `catalog.ts`, regenerate, let the drift
+  test enforce it. Don't hand-write UUIDs.
+
+---
+
+## 7. Reference
+
+| Thing | Path |
+|---|---|
+| iam-seed-ids package + README | `rostering/packages/core/iam-seed-ids/` |
+| program-seed-ids package | `program-hub/packages/core/program-seed-ids/` |
+| content-seed-ids package | `program-hub/packages/core/content-seed-ids/` |
+| Producer seed | `rostering/packages/node/iam-db/prisma/seed.ts` |
+| Consumer seeds | `program-hub/apps/node/{programs,scheduling,content}-api/src/prisma/seed.ts` |
+| Orchestrator API | `iac/cloudformation_templates/dbs/db_host_v2/orchestrator/API.md` |
+| CI seed-profile threading | `{rostering,program-hub}/.github/actions/provision-preview-db-secret/action.yml` |
+| CodeArtifact | domain `saga`, owner `531314149529`, repo `saga_js`, region `us-west-2` |
+
+**Canonical login:** any `{dev,multi,many,new,frontier,none}@saga.org` / `password123`.

--- a/claude/projects/synthetic-dev-align/source/pr-152-seed-ids-synthetic-dev-convergence.md
+++ b/claude/projects/synthetic-dev-align/source/pr-152-seed-ids-synthetic-dev-convergence.md
@@ -1,0 +1,96 @@
+<!-- Snapshot of saga-dash PR #152 :: docs/seed-ids-synthetic-dev-convergence.md
+     Source: saga-ed/saga-dash @ branch docs/seed-ids-onboarding
+     Captured 2026-06-04. Trust the live PR if this diverges. -->
+
+# Proposal: seed synthetic-dev's canonical base from seed-ids (`db:seed`), run scenarios on top
+
+> **Companion to [`seed-ids-onboarding.md`](./seed-ids-onboarding.md) and
+> [`seed-ids-local-mesh-runbook.md`](./seed-ids-local-mesh-runbook.md).** A proposal for converging the
+> local `synthetic-dev` stack onto the deterministic seed-ids base while keeping scenarios as the
+> journey layer on top. Status: **draft for discussion.**
+
+## Context
+
+Two seeding mechanisms describe the **same** synthetic roster (5 districts / 13 schools /
+28 sections / 168 students / 22 tutors / 6 dev personas), but with different ID behavior:
+
+| | seeds via | foundational IDs | on reset |
+|---|---|---|---|
+| **synthetic-dev (local)** | scenario runner (`rostering` + `program-hub` `scripts/scenarios`) | assigned at create time → **non-deterministic** | **new UUIDs → re-login + reconfigure** |
+| **`db:seed` (each service)** | `@saga-ed/*-seed-ids` derive | `uuidv5(...)` → **deterministic** | **identical UUIDs** |
+| **AWS preview / CI mesh** | `db:seed` → canonical S3 snapshots | deterministic | restore = identical |
+
+So **local dev and preview/CI already diverge**: preview/CI is built on the deterministic
+seed-ids base; synthetic-dev still mints per-run UUIDs via the scenario runner (verified: the
+scenario files import no seed-ids; `synthetic-dev/README.md` documents "reset → new UUIDs,
+re-login"). That divergence is the source of synthetic-dev's "re-login after every `--reset`"
+friction and means a local repro isn't guaranteed to match a preview repro.
+
+**Important: this is not "delete the scenario runner."** We still need scenarios for *journeys*
+(enrollments, schedules, sessions, attendance flows). The proposal is to **layer** them.
+
+## Target model — layered, not either/or
+
+- **Base layer = seed-ids `db:seed` (deterministic).** Orgs, schools, sections, users, roster,
+  programs, content. Stable UUIDs that correlate across services by construction and match exactly
+  what preview/CI restores from the canonical snapshots. Stable across reseeds → **the base never
+  forces a re-login**.
+- **Journey layer = scenarios, on top of that base.** The dynamic, per-run state a test/demo
+  exercises. Scenarios **reference the canonical seed-ids** (`groupId('seed')`,
+  `programId('lincoln-fall')`, `personId('s-137')`) for foundational entities instead of creating
+  their own, then add journey rows. Per-run dynamic data (a session, an attendance record) can stay
+  non-deterministic — only the *base* needs to be stable.
+
+## Proposed changes
+
+1. **`up.sh` seed phase → run `db:seed` for the base.** Where `up.sh`'s `--seed roster` currently runs
+   the scenario to build the base roster, run each service's `pnpm db:seed` instead (iam-db,
+   programs-api, scheduling-api, +content-api when present). This is also what the deployed
+   `_deploy-ecs-api.yml` migrate/seed path already does — so `up.sh` converges on the production
+   seeding path it already mirrors for migrations (`migrate deploy`, d1.5).
+2. **Make scenarios seed-ids-aware.** In `rostering` + `program-hub` `scripts/scenarios`, resolve
+   foundational entity IDs through the seed-ids packages (`groupId`/`userId`/`programId`/`personId` or
+   the `derive` subpath) rather than minting them. The scenario then only creates the *journey* rows
+   (enrollment, schedules, sessions) against the already-seeded canonical base. Add a `--seed full`
+   that = `db:seed` base + scenario journey layer.
+3. **Stabilize the dev user.** With a `db:seed` base, the dev user is `userId('dev')` =
+   `1e2ca0d8-…-1186`; set `AUTH_DEVUSERID` to that and retire the separate `…beef` dev-user seeder.
+   `./up.sh --login` and the saga-dash session then survive `--reset`.
+4. **`verify.sh`** — assert the base counts against the deterministic seed-ids catalog (already the
+   right numbers: 5/13/28/168/22/6, 9 programs, 12 content items) and that key IDs match
+   `deriveGroupId('seed')` etc.
+
+## Payoff
+
+- **local == preview == CI** — one canonical roster, one set of UUIDs everywhere; a local bug
+  reproduces in preview by construction.
+- **No re-login / reconfigure after `--reset`** for the base — `userId('dev')`, `groupId('seed')`,
+  saga-dash `config.json`, and bookmarks all stay valid.
+- **Scenarios keep their full value** for journeys, now anchored to stable canonical IDs.
+- synthetic-dev keeps everything it's good at — orchestration, `verify.sh`, PR-pinning, sis-api,
+  `--login`, drift-patching — only the *seed source* changes.
+
+## Non-goals / what stays
+
+- Scenarios are **not** removed — they become the journey layer on top of the canonical base.
+- Per-run dynamic journey data may remain non-deterministic; only the base must be stable.
+- No change to the orchestration/verify/login harness.
+
+## Open questions
+
+- **Base parity:** does each service's `db:seed` cover everything the scenario's base does today
+  (personas + the 593 memberships, per-district admin personas)? The seed-ids `db:seed` seeds users +
+  PII + password auth + memberships; per-district admin personas for riverside/metro/oakdale/frontier
+  were a noted seed-ids follow-up — confirm/close that gap so login parity holds for every persona.
+- **Journey/base split:** which rows the current scenarios create are "base" (move to `db:seed`) vs
+  "journey" (stay in the scenario)? Enrollment is the obvious journey item; programs/periods are base
+  (already in `program-seed-ids` `db:seed`).
+- **Scenario refactor scope:** how much of `scripts/scenarios` changes to consume seed-ids vs mint.
+
+## References
+
+- seed-ids reference + ID inventory: [`seed-ids-onboarding.md`](./seed-ids-onboarding.md)
+- local mesh runbook + the layered model: [`seed-ids-local-mesh-runbook.md`](./seed-ids-local-mesh-runbook.md)
+- synthetic-dev: `soa/tools/synthetic-dev/{README,getting-started}.md` + the drift log
+- original design (fixture/snapshot/scenario vocabulary): `rostering/claude/seed-scenario-handoff.md`
+- canonical snapshots / preview seeding: the canonical-seed-mesh campaign (db-host-v2 + `db:seed` → S3)


### PR DESCRIPTION
Brings the **synthetic-dev-align** initiative docs under source control. These were authored directly in the working tree and never committed; soa blocks direct-to-main, so this is the branch + PR to land them.

## What's here (docs only — no code)
`claude/projects/synthetic-dev-align/`:

- **`CLAUDE.md`** — project charter (research/synthesis track for Seth Paul's seed-ids convergence plan).
- **`source/pr-152-*.md`** — verbatim snapshots of saga-dash PR #152's onboarding / local-mesh-runbook / convergence docs + meta.
- **`research/01-04`** — plan synthesis, current synthetic-dev flow, convergence analysis, and the step-1 **parity audit**.
- **`decisions/d1.1-base-journey-split.md`** — RESOLVED: adopt the deterministic `db:seed` base + scenario-as-journey model; the one gate (per-district admin personas) is closed by **rostering PR #397**.

## Headline finding
`db:seed` is a strict superset of the scenario base on the program side; the only real gap was per-district admin personas, now fixed in rostering #397. Staged/partial seeding (roster-only, etc.) is preserved.

Pure documentation — no source, config, or infra changes. Safe to merge anytime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)