### PR TITLE
fix(synthetic-dev): treat empty local/integration as main-equivalent in posture checks

### DIFF
--- a/tools/synthetic-dev/up.sh
+++ b/tools/synthetic-dev/up.sh
@@ -101,9 +101,14 @@ check_branches(){
   fi
   for kv in "$ROSTERING:rostering" "$PROGRAM_HUB:program-hub" "$SAGA_DASH:saga-dash"; do
     r=${kv%:*}; repo=${kv#*:}
-    want=main; [[ -n "${PINS[$repo]:-}" ]] && want=local/integration
     have=$(git -C "$r" branch --show-current)
-    [[ "$have" == "$want" ]] || printf "\033[33m⚠\033[0m %s on '%s' (expected '%s')\n" "$repo" "$have" "$want"
+    if [[ -n "${PINS[$repo]:-}" ]]; then
+      [[ "$have" == local/integration ]] || printf "\033[33m⚠\033[0m %s on '%s' (expected 'local/integration')\n" "$repo" "$have"
+    elif [[ "$have" == main ]] || { [[ "$have" == local/integration ]] && git -C "$r" diff --quiet origin/main HEAD 2>/dev/null; }; then
+      : # on main, or an empty local/integration that's identical to main — fine
+    else
+      printf "\033[33m⚠\033[0m %s on '%s' (expected 'main')\n" "$repo" "$have"
+    fi
   done
   for kv in "$SOA:soa" "$SDS:student-data-system"; do
     r=${kv%:*}; repo=${kv#*:}; have=$(git -C "$r" branch --show-current)

--- a/tools/synthetic-dev/verify.sh
+++ b/tools/synthetic-dev/verify.sh
@@ -98,6 +98,25 @@ check_posture(){ # repo expected_branch
   else badline "$(printf '%-20s on '\''%s'\'' (expected '\''%s'\'')' "$repo" "$have" "$want")"; fi
 }
 
+# Unpinned managed repo: expected on main. But refresh-suite leaves the repo on
+# local/integration even when the suite is empty — and an empty local/integration
+# is identical to main (refresh-integration builds it as origin/main + pins; with
+# zero pins that's just origin/main). Accept that as equivalent instead of crying
+# wolf; only fail if the tree actually differs from main — a stray overlaid PR not
+# in the manifest, or a stale/behind branch — both real drift worth flagging.
+check_posture_main(){ # repo
+  local repo=$1 dir="$DEV/$repo" have
+  [[ -d "$dir/.git" ]] || { badline "$repo: not a git repo at $dir"; return; }
+  have=$(on_branch "$repo")
+  if [[ "$have" == main ]]; then
+    okline "$(printf '%-20s on main' "$repo")"
+  elif [[ "$have" == local/integration ]] && git -C "$dir" diff --quiet origin/main HEAD 2>/dev/null; then
+    okline "$(printf '%-20s on local/integration ≡ main (suite empty)' "$repo")"
+  else
+    badline "$(printf '%-20s on '\''%s'\'' (expected '\''main'\'')' "$repo" "$have")"
+  fi
+}
+
 # pinned PR actually merged into the current checkout? (resolve #→head SHA via gh)
 check_pin_merged(){ # repo pr#
   local repo=$1 n=$2 dir="$DEV/$repo" oid
@@ -119,9 +138,10 @@ for repo in $MANAGED_REPOS; do
       for n in "${nums[@]}"; do [[ -n "$n" ]] && check_pin_merged "$repo" "$n"; done
     fi
   else
-    check_posture "$repo" "main"
+    check_posture_main "$repo"   # main, or an empty local/integration that ≡ main
   fi
 done
+# soa + student-data-system must be literally main (never integration-parked).
 for repo in $ALWAYS_MAIN_REPOS; do check_posture "$repo" "main"; done
 
 printf "\n"


### PR DESCRIPTION
## Problem

`verify.sh` hard-fails (and `up.sh` warns) when a managed repo is parked on `local/integration` but its manifest pins are empty:

```
✗ program-hub  on 'local/integration' (expected 'main')
✗ saga-dash    on 'local/integration' (expected 'main')
```

This is a false alarm. `refresh-integration.sh` builds `local/integration` as `origin/main` + the pinned PRs — so with **zero pins** (the current suite state, every PR landed) that branch is **byte-identical to main**. The check was failing on a branch *name* while the code state was exactly main, contradicting its own stated goal ("same state as the team").

## Fix

Compare **content, not the label**. For an *unpinned managed* repo, accept `main` **or** a `local/integration` whose tree doesn't differ from `origin/main` (`git diff --quiet origin/main HEAD`):

- empty `local/integration` ≡ main → **passes** (the false alarm)
- `local/integration` carrying a stray PR not in the manifest → still **fails** (real drift)
- `local/integration` stale/behind main → still **fails** (correctly says: refresh)

`soa` + `student-data-system` stay strictly on `main` (unchanged). `up.sh`'s warn-only twin gets the same relaxation for consistency.

## Verification

Ran the patched `verify.sh` against the live stack — posture section now:

```
✓ rostering            on main
✓ program-hub          on local/integration ≡ main (suite empty)
✓ saga-dash            on local/integration ≡ main (suite empty)
✓ soa                  on main
✓ student-data-system  on main
✓ all 13 checks passed — stack is ready
```

Negative case confirmed: a tree that differs from `origin/main` (`rostering@HEAD~5`) returns exit 1, so genuine drift is still flagged. `bash -n` clean on both scripts.

## Note

`git diff origin/main HEAD` is only as fresh as the last fetch of `origin/main`; in this workflow `refresh-integration` cuts the branch straight from it, so they match exactly until the remote moves. Deliberately did **not** add a `git fetch` to the posture section — keeps it fast/offline-friendly, and a moved remote correctly surfaces as a (real) failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)