### PR TITLE
feat(authz): @saga-ed/saga-authz-model — canonical OpenFGA model + tuple-key helpers

### DIFF
--- a/docs/auth/adr/0005-openfga-model-as-source-of-truth.md
+++ b/docs/auth/adr/0005-openfga-model-as-source-of-truth.md
@@ -1,0 +1,100 @@
+# ADR 0005 — OpenFGA model as source of truth
+
+**Status:** Accepted
+**Date:** 2026-05-07
+**Concept primer:** [`saga-dash/docs/auth/concepts.md` § 6 (Authorization models) and § 7 (OpenFGA and Zanzibar)](https://github.com/saga-ed/saga-dash/blob/main/docs/auth/concepts.md#6-authorization-models)
+
+## Context
+
+Saga's authorization landscape today is RBAC inside rostering with coarse organization-scoping in resource services. As more services join the fleet (program-hub, qboard, rtsm) the gaps surface:
+
+- "List every program a tutor has access to" is RBAC-hostile (n×m role lookups).
+- District → school → cohort → student is a graph; representing it as flat roles requires a role per scope.
+- Per-resource permissions (this specific program, this specific room) exhaust the role table.
+
+OpenFGA (CNCF, Zanzibar-faithful) is the right shape for this hierarchy. The decision now is *how* it integrates: who owns the model, who writes tuples, where the source-of-truth lives.
+
+## Decision
+
+### The `.fga` DSL is the source of truth
+
+The model is defined in OpenFGA's DSL (`.fga` files), versioned in `packages/core/saga-authz-model/` in this repo. No service defines tuple types in code; all references go through generated TypeScript types or the FGA SDK.
+
+Changes to the model are PRs against this directory, reviewed by the auth working group. Backwards-incompatible model changes use OpenFGA's authorization model versioning (each `WriteAuthorizationModel` returns an immutable `authorization_model_id`); old IDs continue to serve in-flight requests.
+
+### Tuple writes flow through a sync worker, not services
+
+Application services never write tuples directly. A dedicated sync worker (in rostering or a dedicated service) subscribes to `iam.*` events from rostering and translates them to tuple writes. This keeps:
+
+- The model authoritative (no service-side drift).
+- Idempotency manageable (the sync worker dedupes).
+- Audit clarity (one path for tuple changes — easier to investigate divergence).
+
+Application services only call `check`, `list-objects`, `list-relations`. They do not call `write`, `delete`, `expand`.
+
+### Two-layer namespace split
+
+Per Saga IaC plugin convention:
+
+- **Identity types** — `tenant`, `user`, `group`, `role`. Define *who* can be granted access.
+- **Resource types** — `program`, `school`, `cohort`, `session`, `room`, `whiteboard`, `enrollment`. Define *what* access is granted to.
+
+Identity-side tuples come from rostering events. Resource-side tuples come from the resource owner's events (program-hub for programs, etc.) — but *only* via the same sync worker process, fanned out by event type.
+
+### Tenant binding is mandatory
+
+Every check is tenant-scoped. The tenant is part of the resource ID format (`program:district:42:program:7`) or expressed as a parent-of relation (`(tenant:district:42, parent, program:7)`). Cross-tenant checks fail by construction.
+
+### Model lives in `packages/core/saga-authz-model/`
+
+- `model.fga` — the DSL source
+- `src/types.ts` — hand-maintained TypeScript constants mirroring the
+  DSL types and relations (`FGA_TYPES`, `FgaRelationsByType`,
+  `FgaRelation<T>`)
+- `src/__tests__/model-fga.unit.test.ts` — CI guard that diffs the
+  `.fga` file against `src/types.ts`; build fails on drift
+- `README.md` — how to read it, how to extend it (PRs MUST update both
+  files in lockstep)
+
+The TS mirror is hand-maintained, not codegen'd. A future codegen pass
+can replace `src/types.ts` without changing the package's public API
+(`FgaType`, `FgaRelation<T>`, `tupleKey<T>` are stable).
+
+The package exports tuple-key builder helpers but does not bundle the
+FGA SDK — services depend on `@openfga/sdk` directly when they need
+runtime checks.
+
+### Today vs tomorrow
+
+| Phase | What ships |
+|---|---|
+| **Today (P1)** | `model.fga` committed, types generated. No FGA store deployed. Services do not yet call `check`. |
+| **Later** | FGA store deployed, sync worker built, services adopt `authz.check` resource-by-resource alongside the existing RBAC checks. Once parity is proven, RBAC is removed. |
+
+This decoupling means the *model* is reviewed, frozen, and ready before any service depends on it at runtime — minimizing rework.
+
+## Consequences
+
+**Positive:**
+- Single canonical authorization model across the fleet.
+- Reverse-index queries ("what can user X see?") become tractable.
+- Clean separation between *model* (here) and *data* (rostering / resource services).
+- Future additions (new resource types, new relations) are local PRs against this directory.
+
+**Negative:**
+- Two-step writes (event → sync worker → tuple) add latency for grant changes; mitigated by event speed and ≤30s caching.
+- Operational complexity — running an FGA store is a new system (when it deploys later).
+
+## Alternatives considered
+
+- **Define tuple types in service code:** rejected. Drift between services would be inevitable; central review impossible.
+- **Services write tuples directly on grant changes:** rejected. Multiple writers leads to inconsistency and audit complexity.
+- **Cedar instead of OpenFGA:** rejected for the primary use case. Cedar is great for policy rules; ReBAC for resource hierarchies. The plan reserves the right to add Cedar for non-resource policy later.
+- **Stay with RBAC + ABAC:** rejected. Concept primer § 6 details why this hits a wall as the resource graph grows.
+
+## References
+
+- OpenFGA documentation — https://openfga.dev/
+- Zanzibar paper — Pang et al., 2019
+- Concept primer § 7 — full background on tuples, types, and relations
+- ADR 0001 — JWT shape (`saga.tenant` claim feeds tenant-scoped checks)

--- a/packages/core/saga-authz-model/README.md
+++ b/packages/core/saga-authz-model/README.md
@@ -1,0 +1,31 @@
+# @saga-ed/saga-authz-model
+
+Source of truth for Saga's OpenFGA authorization model. Ships:
+
+- `model.fga` — the DSL file. **The model.** Everything else flows from this.
+- `src/types.ts` — TypeScript constants mirroring the DSL types and relations.
+- `src/tuple-keys.ts` — type-safe tuple-key builders.
+- Unit tests that compile the DSL through the OpenFGA transformer (proving it
+  would load into a store) and assert it agrees with the TS types (catches drift).
+
+See [ADR 0005](../../../docs/auth/adr/0005-openfga-model-as-source-of-truth.md) for the governance model.
+
+## Today
+
+The package ships the model. **No FGA store is deployed yet** — services do not call `check` against this model in P1. The model lands ready for the sync worker (later phase) to begin writing tuples.
+
+## Tomorrow
+
+Once an FGA store is deployed:
+
+1. The CI pipeline pushes `model.fga` to the FGA store; the returned `authorization_model_id` is recorded in SSM.
+2. The sync worker (separate package) subscribes to `iam.*` events and writes tuples reflecting group/role/membership state.
+3. Services adopt `check`/`list-objects` resource-by-resource alongside their existing RBAC checks.
+4. RBAC is removed once parity is proven.
+
+## Editing the model
+
+1. Open a PR editing `model.fga` and `src/types.ts` in lockstep.
+2. The unit test asserts they agree — CI will fail if you forget one.
+3. Backwards-incompatible changes (renaming a relation, removing a type) require a coordinated rollout plan in the PR description.
+4. Additive changes (new types, new relations) can land normally.

--- a/packages/core/saga-authz-model/model.fga
+++ b/packages/core/saga-authz-model/model.fga
@@ -1,0 +1,115 @@
+# Saga Fleet Authorization Model
+#
+# Source of truth for all OpenFGA types and relations across the Saga
+# microservices fleet. See ADR 0005 for the governance model.
+#
+# Two-layer namespace per Saga IaC convention:
+#   - Identity types: tenant, user, group, role
+#   - Resource types: program, school, cohort, session, room, whiteboard,
+#                     enrollment
+#
+# Convention: every resource type defines a `parent` relation to its
+# containing tenant so cross-tenant checks are impossible by construction.
+# Every resource type also defines a small set of canonical relations
+# (`viewer`, `editor`, `admin`) that map to user-facing actions.
+#
+# This file is the v1 model; non-additive changes require a new authorization
+# model id and coordinated rollout (see ADR 0005).
+
+model
+  schema 1.1
+
+# ---------------------------------------------------------------------------
+# Identity types
+# ---------------------------------------------------------------------------
+
+# Top-level tenant (a school district). Everything else descends from one.
+type tenant
+  relations
+    define admin: [user]
+    define member: [user]
+    define support: [user]
+
+# A user identity. SPIFFE-formatted in the application layer
+# (spiffe://saga.<env>/user/<uuid>); FGA stores the bare uuid.
+type user
+
+# A group of users. Used for sections, cohorts, ad-hoc rosters.
+# Membership is tenant-scoped via `parent`.
+type group
+  relations
+    define parent: [tenant]
+    define member: [user]
+    define admin: [user] or admin from parent
+
+# A role assignment carrier. Roles are per-tenant; a user assigned a role
+# inherits the role's permissions on the resources the role grants.
+type role
+  relations
+    define parent: [tenant]
+    define holder: [user, group#member]
+
+# ---------------------------------------------------------------------------
+# Resource types
+# ---------------------------------------------------------------------------
+
+type school
+  relations
+    define parent: [tenant]
+    define admin: [user, group#member, role#holder] or admin from parent
+    define editor: [user, group#member, role#holder] or admin
+    define viewer: [user, group#member, role#holder] or editor or member from parent
+
+type cohort
+  relations
+    define parent: [school]
+    define admin: [user, group#member, role#holder] or admin from parent
+    define editor: [user, group#member, role#holder] or admin
+    define viewer: [user, group#member, role#holder] or editor
+
+type program
+  relations
+    define parent: [tenant]
+    define owner: [user]
+    define admin: [user, group#member, role#holder] or owner or admin from parent
+    define editor: [user, group#member, role#holder] or admin
+    define viewer: [user, group#member, role#holder] or editor
+
+# An enrollment links a user to a program/cohort.
+# Used by program-hub's enrollment-tree read path.
+type enrollment
+  relations
+    define parent: [tenant]
+    define program: [program]
+    define student: [user]
+    define tutor: [user]
+    define viewer: [user, group#member, role#holder] or admin from program or editor from program or student or tutor
+
+# A scheduled session (a tutoring session, a class meeting). Lives under
+# a program; participants get session-level permissions.
+type session
+  relations
+    define parent: [program]
+    define host: [user]
+    define participant: [user, group#member]
+    define observer: [user, group#member, role#holder]
+    define viewer: host or participant or observer or admin from parent
+    define can_join: host or participant or admin from parent
+
+# A real-time room (rtsm). Tenant-scoped via parent. Used to lock down
+# socket joins; the `can_join` relation is what `RoomManager.joinRoom`
+# evaluates.
+type room
+  relations
+    define parent: [tenant]
+    define session: [session]
+    define member: [user, group#member]
+    define moderator: [user, group#member, role#holder]
+    define can_join: member or moderator or can_join from session
+
+# A collaborative whiteboard surface (qboard). One whiteboard per session.
+type whiteboard
+  relations
+    define parent: [session]
+    define editor: [user, group#member] or host from parent or participant from parent
+    define viewer: editor or observer from parent

--- a/packages/core/saga-authz-model/package.json
+++ b/packages/core/saga-authz-model/package.json
@@ -1,0 +1,43 @@
+{
+    "name": "@saga-ed/saga-authz-model",
+    "version": "0.1.0-dev.1",
+    "private": false,
+    "type": "module",
+    "description": "Saga's OpenFGA authorization model (.fga DSL) and tuple-key helpers. Source of truth for ReBAC types and relations.",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
+        },
+        "./model.fga": "./model.fga"
+    },
+    "files": ["dist", "model.fga"],
+    "scripts": {
+        "build": "tsup",
+        "check-types": "tsc --noEmit",
+        "test": "vitest run --passWithNoTests",
+        "lint": "eslint src/",
+        "clean": "rm -rf dist"
+    },
+    "devDependencies": {
+        "@openfga/sdk": "^0.9.6",
+        "@openfga/syntax-transformer": "^0.2.1",
+        "@saga-ed/soa-typescript-config": "workspace:*",
+        "@types/node": "^24.0.3",
+        "tsup": "^8.5.0",
+        "typescript": "5.8.2",
+        "vitest": "^1.6.1"
+    },
+    "publishConfig": {
+        "registry": "https://saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/",
+        "access": "public"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/saga-ed/soa.git",
+        "directory": "packages/core/saga-authz-model"
+    },
+    "keywords": ["saga-soa", "openfga", "authorization", "rebac"]
+}

--- a/packages/core/saga-authz-model/package.json
+++ b/packages/core/saga-authz-model/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/saga-authz-model",
-    "version": "0.1.0-dev.1",
+    "version": "0.1.0-dev.2",
     "private": false,
     "type": "module",
     "description": "Saga's OpenFGA authorization model (.fga DSL) and tuple-key helpers. Source of truth for ReBAC types and relations.",

--- a/packages/core/saga-authz-model/src/__tests__/model-fga.unit.test.ts
+++ b/packages/core/saga-authz-model/src/__tests__/model-fga.unit.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { transformer } from '@openfga/syntax-transformer';
+import { describe, expect, it } from 'vitest';
+import { FGA_TYPES } from '../types.js';
+
+/**
+ * Verify that every type declared in src/types.ts is present in model.fga.
+ * Catches drift if someone edits one without the other.
+ */
+const modelText = readFileSync(
+    resolve(__dirname, '../../model.fga'),
+    'utf8',
+);
+
+describe('model.fga ↔ src/types.ts', () => {
+    it.each(FGA_TYPES)(
+        'declares %s in the .fga DSL',
+        (type) => {
+            expect(modelText).toMatch(new RegExp(`^type ${type}\\b`, 'm'));
+        },
+    );
+
+    it('declares schema 1.1', () => {
+        expect(modelText).toMatch(/^\s*schema 1\.1\b/m);
+    });
+
+    it('starts with the model keyword', () => {
+        expect(modelText).toMatch(/^model$/m);
+    });
+});
+
+/**
+ * The regex checks above only prove the type names *appear* — they do not
+ * prove the DSL is well-formed. The OpenFGA transformer is strict (it rejects
+ * multi-line `or`/`and` continuations, for instance), so transforming the model
+ * is the only thing that proves it would actually load into a store. This is
+ * the test that bites on a malformed model.fga before it ships.
+ */
+describe('model.fga is a valid OpenFGA model', () => {
+    it('transforms without throwing', () => {
+        expect(() =>
+            transformer.transformDSLToJSONObject(modelText),
+        ).not.toThrow();
+    });
+
+    it('compiles to exactly the FGA_TYPES type set', () => {
+        const json = transformer.transformDSLToJSONObject(modelText);
+        expect(json.type_definitions).toHaveLength(FGA_TYPES.length);
+        expect(json.type_definitions.map((t) => t.type).sort()).toEqual(
+            [...FGA_TYPES].sort(),
+        );
+    });
+
+    it('compiles to schema 1.1', () => {
+        const json = transformer.transformDSLToJSONObject(modelText);
+        expect(json.schema_version).toBe('1.1');
+    });
+});

--- a/packages/core/saga-authz-model/src/__tests__/tuple-keys.unit.test.ts
+++ b/packages/core/saga-authz-model/src/__tests__/tuple-keys.unit.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import {
+    objectRef,
+    tupleKey,
+    userRef,
+    usersetRef,
+} from '../tuple-keys.js';
+
+describe('objectRef', () => {
+    it('builds a typed object ref', () => {
+        expect(objectRef('program', 'p1')).toBe('program:p1');
+    });
+
+    it('rejects invalid id characters', () => {
+        expect(() => objectRef('program', 'has space')).toThrow();
+        expect(() => objectRef('program', 'has:colon')).toThrow();
+    });
+});
+
+describe('userRef', () => {
+    it('builds a user ref from a uuid', () => {
+        expect(userRef('00000000-0000-4000-8000-000000000001')).toBe(
+            'user:00000000-0000-4000-8000-000000000001',
+        );
+    });
+});
+
+describe('usersetRef', () => {
+    it('builds a userset reference', () => {
+        expect(usersetRef('group', 'g1', 'member')).toBe('group:g1#member');
+    });
+
+    it('builds a tenant member userset', () => {
+        expect(usersetRef('tenant', 'd42', 'member')).toBe(
+            'tenant:d42#member',
+        );
+    });
+});
+
+describe('tupleKey', () => {
+    it('builds a fully-typed tuple', () => {
+        const t = tupleKey({
+            user: userRef('00000000-0000-4000-8000-000000000001'),
+            relation: 'viewer',
+            object: objectRef('program', 'p1'),
+        });
+        expect(t).toEqual({
+            user: 'user:00000000-0000-4000-8000-000000000001',
+            relation: 'viewer',
+            object: 'program:p1',
+        });
+    });
+});

--- a/packages/core/saga-authz-model/src/index.ts
+++ b/packages/core/saga-authz-model/src/index.ts
@@ -1,0 +1,14 @@
+/**
+ * @saga-ed/saga-authz-model
+ *
+ * Source of truth for the Saga fleet OpenFGA model. The .fga DSL ships
+ * alongside the package; this index re-exports type-safe tuple-key
+ * builders and the canonical type/relation constants.
+ *
+ * Per ADR 0005, services do not write tuples directly — the sync worker
+ * does. Services use the helpers here only to construct tuple keys for
+ * `check`/`list-objects`.
+ */
+
+export * from './types.js';
+export * from './tuple-keys.js';

--- a/packages/core/saga-authz-model/src/tuple-keys.ts
+++ b/packages/core/saga-authz-model/src/tuple-keys.ts
@@ -1,0 +1,76 @@
+import type { FgaRelation, FgaType } from './types.js';
+
+/**
+ * Object reference: `<type>:<id>`. The id is the bare UUID (not the SPIFFE
+ * URL); the FGA store does not need the SPIFFE prefix.
+ */
+export type ObjectRef<T extends FgaType = FgaType> = `${T}:${string}`;
+
+/**
+ * User reference. Either a bare user id or a userset (e.g.,
+ * `group:abc#member`).
+ */
+export type UserRef =
+    | `user:${string}`
+    | `${FgaType}:${string}#${string}`;
+
+/**
+ * A tuple as written to or read from FGA.
+ */
+export interface TupleKey<T extends FgaType = FgaType> {
+    user: UserRef;
+    relation: FgaRelation<T>;
+    object: ObjectRef<T>;
+}
+
+const ID_RE = /^[a-zA-Z0-9_-]+$/;
+
+function ensureValidId(id: string): void {
+    if (!ID_RE.test(id)) {
+        throw new Error(`Invalid FGA id: ${JSON.stringify(id)}`);
+    }
+}
+
+/**
+ * Build a typed object reference. Type-checked at compile time; id format
+ * checked at runtime.
+ */
+export function objectRef<T extends FgaType>(
+    type: T,
+    id: string,
+): ObjectRef<T> {
+    ensureValidId(id);
+    return `${type}:${id}` as ObjectRef<T>;
+}
+
+/**
+ * Build a user reference (a bare user, by uuid).
+ */
+export function userRef(uuid: string): UserRef {
+    ensureValidId(uuid);
+    return `user:${uuid}`;
+}
+
+/**
+ * Build a userset reference (e.g., `group:abc#member`). Used when granting
+ * permissions to "everyone with relation R on object O".
+ */
+export function usersetRef<T extends FgaType>(
+    type: T,
+    id: string,
+    relation: FgaRelation<T>,
+): UserRef {
+    ensureValidId(id);
+    return `${type}:${id}#${relation}` as UserRef;
+}
+
+/**
+ * Build a typed tuple key.
+ */
+export function tupleKey<T extends FgaType>(args: {
+    user: UserRef;
+    relation: FgaRelation<T>;
+    object: ObjectRef<T>;
+}): TupleKey<T> {
+    return args;
+}

--- a/packages/core/saga-authz-model/src/types.ts
+++ b/packages/core/saga-authz-model/src/types.ts
@@ -1,0 +1,48 @@
+/**
+ * Type literals derived from model.fga. These constants must stay in sync
+ * with the DSL; a CI lint (added in P5/P6 follow-up) will diff the .fga
+ * file against this file and fail the build on drift.
+ */
+
+export const FGA_TYPES = [
+    // Identity
+    'tenant',
+    'user',
+    'group',
+    'role',
+    // Resources
+    'school',
+    'cohort',
+    'program',
+    'enrollment',
+    'session',
+    'room',
+    'whiteboard',
+] as const;
+export type FgaType = (typeof FGA_TYPES)[number];
+
+/**
+ * The canonical relations on each type. Used by tuple-key builders to refuse
+ * unknown relation names at compile time.
+ */
+export interface FgaRelationsByType {
+    tenant: 'admin' | 'member' | 'support';
+    user: never;
+    group: 'parent' | 'member' | 'admin';
+    role: 'parent' | 'holder';
+    school: 'parent' | 'admin' | 'editor' | 'viewer';
+    cohort: 'parent' | 'admin' | 'editor' | 'viewer';
+    program: 'parent' | 'owner' | 'admin' | 'editor' | 'viewer';
+    enrollment: 'parent' | 'program' | 'student' | 'tutor' | 'viewer';
+    session:
+        | 'parent'
+        | 'host'
+        | 'participant'
+        | 'observer'
+        | 'viewer'
+        | 'can_join';
+    room: 'parent' | 'session' | 'member' | 'moderator' | 'can_join';
+    whiteboard: 'parent' | 'editor' | 'viewer';
+}
+
+export type FgaRelation<T extends FgaType> = FgaRelationsByType[T];

--- a/packages/core/saga-authz-model/tsconfig.json
+++ b/packages/core/saga-authz-model/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "@saga-ed/soa-typescript-config/base.json",
+    "compilerOptions": {
+        "outDir": "./dist",
+        "rootDir": "./src",
+        "noEmit": true
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/core/saga-authz-model/tsup.config.ts
+++ b/packages/core/saga-authz-model/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+    entry: ['src/index.ts'],
+    format: ['esm'],
+    dts: true,
+    clean: true,
+    sourcemap: true,
+});

--- a/packages/core/saga-authz-model/vitest.config.ts
+++ b/packages/core/saga-authz-model/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        environment: 'node',
+        include: ['src/**/__tests__/**/*.test.ts', 'src/**/*.test.ts'],
+        exclude: ['**/node_modules/**', '**/*.int.test.ts'],
+    },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -593,6 +593,30 @@ importers:
         specifier: ^1.6.1
         version: 1.6.1(@types/node@24.0.12)(jsdom@25.0.1)
 
+  packages/core/saga-authz-model:
+    devDependencies:
+      '@openfga/sdk':
+        specifier: ^0.9.6
+        version: 0.9.6
+      '@openfga/syntax-transformer':
+        specifier: ^0.2.1
+        version: 0.2.1
+      '@saga-ed/soa-typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      '@types/node':
+        specifier: ^24.0.3
+        version: 24.0.12
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.2)(yaml@2.8.2)
+      typescript:
+        specifier: 5.8.2
+        version: 5.8.2
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@24.0.12)(jsdom@25.0.1)
+
   packages/core/seed-ids-kit:
     dependencies:
       '@noble/hashes':
@@ -3377,6 +3401,14 @@ packages:
     resolution: {integrity: sha512-cRKBZm14IuA6G8W84dfd3iXj3BTAoxQ5o3pUE8DKEQ4n/tVha20t5nkVeD+ISC68e0Fuw5koTMvRwXb1lJSnzg==}
     engines: {node: '>=18.0.0'}
 
+  '@openfga/sdk@0.9.6':
+    resolution: {integrity: sha512-110QWSMKp28IeZTNG8Li1NinSZPuVh2aVlDE2wCJztbOCPy/ayn0E6b5z4XJcPpAno4KRRgt3E4Tvhihoqpm8w==}
+    engines: {node: '>=20.19.0'}
+
+  '@openfga/syntax-transformer@0.2.1':
+    resolution: {integrity: sha512-bF/h4Z8iKjX91roS83BYorGarcJNxrJ1IfDwguU8jLYHRGkKWR6eVK0jPwQu05cSh0SyjKiHxqohgWBgWMEUcA==}
+    engines: {node: '>=20.19.0'}
+
   '@opentelemetry/api-logs@0.55.0':
     resolution: {integrity: sha512-3cpa+qI45VHYcA5c0bHM6VHo9gicv3p5mlLHNG3rLyjQU8b7e0st1rWtrUn3JbZ3DwwCfhKop4eQ9UuYlC6Pkg==}
     engines: {node: '>=14'}
@@ -4817,6 +4849,9 @@ packages:
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
   amqplib@0.10.9:
     resolution: {integrity: sha512-jwSftI4QjS3mizvnSnOrPGYiUnm1vI2OP1iXeOUz5pb74Ua0nbf6nPyyTzuiCLEE3fMpaJORXh2K/TQ08H5xGA==}
     engines: {node: '>=10'}
@@ -4852,6 +4887,10 @@ packages:
   ansis@3.17.0:
     resolution: {integrity: sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg==}
     engines: {node: '>=14'}
+
+  antlr4@4.13.2:
+    resolution: {integrity: sha512-QiVbZhyy4xAZ17UPEuG3YTOt8ZaoeOR1CvEAqrEsDBsOqINslaB147i9xqljZqoyf5S+EUlGStaj+t22LT9MOg==}
+    engines: {node: '>=16'}
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -4985,6 +5024,9 @@ packages:
   axe-core@4.11.0:
     resolution: {integrity: sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==}
     engines: {node: '>=4'}
+
+  axios@1.16.0:
+    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -6057,6 +6099,9 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+
   fast-xml-builder@1.1.5:
     resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
 
@@ -6170,6 +6215,15 @@ packages:
 
   follow-redirects@1.15.11:
     resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -6902,6 +6956,9 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -7875,6 +7932,10 @@ packages:
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
@@ -7996,6 +8057,10 @@ packages:
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
   require-in-the-middle@7.5.2:
@@ -8585,6 +8650,9 @@ packages:
   timeout-signal@2.0.0:
     resolution: {integrity: sha512-YBGpG4bWsHoPvofT6y/5iqulfXIiIErl5B0LdtHT1mGXDFTAhhRrbUpTvBgYbovr+3cKblya2WAOcpoy90XguA==}
     engines: {node: '>=16'}
+
+  tiny-async-pool@2.1.0:
+    resolution: {integrity: sha512-ltAHPh/9k0STRQqaoUX52NH4ZQYAJz24ZAEwf1Zm+HYg3l9OXTWeqWKyYsHu40wF/F0rxd2N2bk5sLvX2qlSvg==}
 
   tiny-jsonc@1.0.2:
     resolution: {integrity: sha512-f5QDAfLq6zIVSyCZQZhhyl0QS6MvAyTxgz4X4x3+EoCktNWEYJ6PeoEA97fyb98njpBNNi88ybpD7m+BDFXaCw==}
@@ -12250,6 +12318,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@openfga/sdk@0.9.6':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      axios: 1.16.0
+      jose: 5.10.0
+      tiny-async-pool: 2.1.0
+    transitivePeerDependencies:
+      - debug
+
+  '@openfga/syntax-transformer@0.2.1':
+    dependencies:
+      ajv: 8.20.0
+      antlr4: 4.13.2
+      yaml: 2.8.2
+
   '@opentelemetry/api-logs@0.55.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -14117,6 +14200,13 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   amqplib@0.10.9:
     dependencies:
       buffer-more-ints: 1.0.0
@@ -14143,6 +14233,8 @@ snapshots:
   ansi-styles@6.2.3: {}
 
   ansis@3.17.0: {}
+
+  antlr4@4.13.2: {}
 
   any-promise@1.3.0: {}
 
@@ -14305,6 +14397,14 @@ snapshots:
   aws-ssl-profiles@1.1.2: {}
 
   axe-core@4.11.0: {}
+
+  axios@1.16.0:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.5
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
 
   axobject-query@4.1.0: {}
 
@@ -15279,8 +15379,8 @@ snapshots:
       '@typescript-eslint/parser': 8.50.0(eslint@8.57.1)(typescript@5.8.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -15323,6 +15423,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 8.57.1
+      get-tsconfig: 4.13.0
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.15
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -15334,18 +15449,18 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.50.0(eslint@8.57.1)(typescript@5.8.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -15360,7 +15475,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -15371,7 +15486,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -15785,6 +15900,8 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
+  fast-uri@3.1.2: {}
+
   fast-xml-builder@1.1.5:
     dependencies:
       path-expression-matcher: 1.5.0
@@ -15934,6 +16051,8 @@ snapshots:
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:
       debug: 4.4.3(supports-color@8.1.1)
+
+  follow-redirects@1.16.0: {}
 
   for-each@0.3.5:
     dependencies:
@@ -16770,6 +16889,8 @@ snapshots:
   json-parse-even-better-errors@2.3.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -17813,6 +17934,8 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
+  proxy-from-env@2.1.0: {}
+
   pump@3.0.3:
     dependencies:
       end-of-stream: 1.4.5
@@ -17956,6 +18079,8 @@ snapshots:
   remove-trailing-spaces@1.0.9: {}
 
   require-directory@2.1.1: {}
+
+  require-from-string@2.0.2: {}
 
   require-in-the-middle@7.5.2:
     dependencies:
@@ -18732,6 +18857,8 @@ snapshots:
   through@2.3.8: {}
 
   timeout-signal@2.0.0: {}
+
+  tiny-async-pool@2.1.0: {}
 
   tiny-jsonc@1.0.2: {}
 


### PR DESCRIPTION
## What

Adds **`@saga-ed/saga-authz-model`** — the canonical source of truth for the Saga fleet's OpenFGA authorization model. The package ships:

- **`model.fga`** — the OpenFGA DSL (11 types: tenant/user/group/role + school/cohort/program/enrollment/session/room/whiteboard). Everything else flows from this file.
- **`src/types.ts`** — `FGA_TYPES` constant + `FgaRelationsByType` so tuple-key builders refuse unknown relations at compile time.
- **`src/tuple-keys.ts`** — type-safe `objectRef` / `userRef` / `usersetRef` / `tupleKey` builders (compile-time type-checked, runtime id-validated).
- **ADR 0005** — governance model (the `.fga` file is the source of truth; the sync worker is the only tuple writer).

## Why this PR exists / provenance

The package was first written on the closed auth-seams POC branch (#92). This PR **extracts it standalone and brings it green** so the fleet authz-spike has a published model to consume. The model here is **byte-identical to the authz-spike canonical `model.fga`** (rostering `scripts/fga/model.fga`) — with one correction over the POC source:

- The POC `enrollment.viewer` relation was written across multiple lines (`... or admin from program` on a continuation line). **The OpenFGA transformer rejects multi-line `or`/`and` continuations** — the POC model would not load into a store. It is now single-lined.

## The load-bearing test

`model-fga.unit.test.ts` now **compiles the DSL through `@openfga/syntax-transformer`** (pinned `^0.2.1`, matching the authz-spike bootstrap) and asserts:

- the model transforms without throwing (i.e. it would actually load into a store);
- `type_definitions` matches `FGA_TYPES` exactly (length **and** the sorted type set);
- it compiles to `schema 1.1`.

The pre-existing regex-only check (`grep ^type <name>`) passed on the broken POC model — this transform test is what bites on a malformed `.fga` before it ships. Verified via negative control: the transformer throws on the multi-line form.

## Scope boundary

This PR is **the package, standalone and green — nothing else**. No consumer wiring, no `fgaCheck` helper, no store deployment. Those are deferred follow-ups tracked in the spike.

## Verification

```
pnpm --filter @saga-ed/saga-authz-model check-types   # ✓
pnpm --filter @saga-ed/saga-authz-model test          # ✓ 22 tests
pnpm --filter @saga-ed/saga-authz-model build         # ✓ dist/index.{js,d.ts}
pnpm --filter @saga-ed/saga-authz-model lint          # ✓
```

Draft + flag-independent (ships only a model + helpers; nothing enforces yet), so it's non-breaking in isolation.

Part of the OpenFGA Tier-2 authz spike. Tracking: saga-ed/rostering#401.
