### PR TITLE
synthetic-dev: drop #423 stopgap from suite + up.sh restart/reset recovery

### DIFF
--- a/tools/synthetic-dev/integration-suite.tsv
+++ b/tools/synthetic-dev/integration-suite.tsv
@@ -27,3 +27,21 @@
 #  the roster stack landed alongside it: saga-dash #159 + rostering #384,#387,#396,#398.)
 # (2026-06-05 saga-dash #136 dropped — LANDED on main. Suite now EMPTY: every repo
 #  back on origin/main, nothing in flight to replay.)
+# (2026-06-05 saga-dash #161 added — drag-resizable columns + truncate/copy UUID
+#  User ID for the roster grid; DRAFT, overlaid for local dev on the landed stack.)
+# (2026-06-08 saga-dash #165 added — wire Roster page Upload Roster button to
+#  Adam's CSV wizard (sd-164 integration); DRAFT, overlaid for manual testing.)
+# (2026-06-08 rostering #410 added — 'Empty Org' seed scenario (admin + empty
+#  district) for upload-from-scratch testing; overlaid for manual testing.)
+# (2026-06-08 rostering #423 added — TEMP sd-164 stopgap: re-homes csv-shadow
+#  groups under Empty Org so the example CSV renders on the roster page before
+#  Adam's tier-2 dynamic group creation. DRAFT, stacked on #410. DROP this (and
+#  the PR) once tier-2 auto-create ships.)
+# (2026-06-09 rostering #423 dropped — tier-2 CSV auto-create SHIPPED on main
+#  (#424, merges c915b43/d49b8cc/529e9f8 + #430 baseline). The engine now
+#  auto-creates referenced school/section groups, so the csv-shadow re-home
+#  stopgap is obsolete. CLOSE PR #423. #410 (Empty Org) stays — it's the
+#  truly-empty upload-from-scratch fixture auto-create needs.)
+
+saga-dash	161,165
+rostering	410

--- a/tools/synthetic-dev/up.sh
+++ b/tools/synthetic-dev/up.sh
@@ -32,7 +32,13 @@
 #   ./up.sh --seed [roster|full] seed synthetic data (default: roster)
 #                                  roster = iam roster only (programs empty → from-scratch)
 #                                  full   = iam roster + programs/periods/enrollment
-#   ./up.sh --reset              truncate synthetic data → empty baseline (keeps migrations)
+#   ./up.sh --reset              truncate synthetic data → empty baseline (keeps migrations);
+#                                  also clean-restarts services + clears vite caches
+#   ./up.sh restart              clean restart ONLY: stop services + clear vite + start,
+#                                  NO data wipe. Use after refresh-suite when the dash UI
+#                                  is stale/unresponsive (a rewritten branch corrupts vite's
+#                                  module graph and HMR doesn't recover) — same recovery as
+#                                  --reset but without truncating your seeded data.
 #   ./up.sh --login [email]      auto-login via iam-api devLogin (default: dev@saga.org)
 #   ./up.sh --user  [email]      alias for --login
 #   ./up.sh --down               stop services (leaves mesh up)
@@ -444,6 +450,11 @@ case "${1:-up}" in
   # so an unguarded shift returns 1 and `set -e` kills the script before it runs.
   up|--up)                       DO_UP=1; shift || true ;;
   --down)                        services_down; exit 0 ;;
+  # Clean restart WITHOUT a data wipe: bounce services + clear vite caches, then
+  # start fresh on current code. The recovery for a stale dash bundle after a
+  # refresh-suite branch rewrite (corrupted vite module graph / unresponsive UI)
+  # — same restart+nuke_vite as --reset, minus reset_data.
+  restart|--restart)             services_down; nuke_vite; services_up; exit 0 ;;
   --status)                      status; exit 0 ;;
   -h|--help)                     sed -n '2,51p' "$0"; exit 0 ;;
   --reset|--seed|--login|--user) ;;        # flag-only invocation; skip up
@@ -459,16 +470,25 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# `up` does first-run prep (branch posture, fixups, mesh, schema). A bare
+# `--reset` (no `up` verb) skips prep and assumes a running mesh.
 if [[ $DO_UP == 1 ]]; then
   check_branches; apply_fixes; mesh_up; prep
-  # With --reset, do a CLEAN restart: stop running services (incl. stale tsup /
-  # vite watchers that accumulate across runs) and clear vite caches, so
-  # services_up starts FRESH on current code rather than reusing stale
-  # "already up" processes / cached bundles.
-  if [[ $DO_RESET == 1 ]]; then
-    say "reset: clean restart — stopping running services + clearing vite caches..."
-    services_down; nuke_vite
-  fi
+fi
+
+# A --reset ALWAYS means a CLEAN restart on current code — independent of the
+# `up` verb, so a bare `./up.sh --reset` clears caches too (it used to only
+# truncate data, leaving stale services up). Stop running services (incl. stale
+# tsup / vite watchers that accumulate across runs), clear vite caches, then
+# bring services back up FRESH. This is what escapes the stale-cached-bundle
+# trap: a dead Vite watcher serving old JS even though the source changed (e.g.
+# after a refresh-suite branch swap). Plain `up` (no --reset) reuses "already
+# up" processes / cached bundles.
+if [[ $DO_RESET == 1 ]]; then
+  say "reset: clean restart — stopping services + clearing vite caches..."
+  services_down; nuke_vite; services_up
+  ok "stack up (clean) — try: $0 --status"
+elif [[ $DO_UP == 1 ]]; then
   services_up
   ok "stack up — try: $0 --status"
 fi


### PR DESCRIPTION
## What

Two synthetic-dev updates from the sd-164 roster↔CSV integration work:

**1. `integration-suite.tsv` — drop rostering #423 (stopgap obsolete)**

rostering#424 shipped tier-2 CSV group auto-create on main, so the TEMP sd-164 csv-shadow re-home stopgap (rostering#423, now closed) is no longer needed and is dropped from the pinned suite. rostering#410 (Empty Org) stays — it's the upload-from-scratch fixture auto-create needs. Verified live: after `refresh-suite.sh` + reseed, the roster CSV e2e (saga-dash#165) auto-creates its groups under Empty Org with no pre-seeded shadow groups — both tests green.

**2. `up.sh` — stale-vite recovery (restart verb + stronger --reset)**

- New `restart` verb: stop services + clear vite caches + start, **no data wipe** — recover a stale/unresponsive dash (corrupted vite module graph after a refresh-suite branch rewrite) without losing seeded state.
- `--reset` now **always** clean-restarts (services_down + nuke_vite + services_up) independent of the `up` verb; a bare `./up.sh --reset` used to only truncate data while stale services kept serving old bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)