### PR TITLE
CI: publish-all-packages concurrency + narrowed PR paths

### DIFF
--- a/.github/workflows/publish-all-packages.yml
+++ b/.github/workflows/publish-all-packages.yml
@@ -23,7 +23,10 @@ on:
   pull_request:
     paths:
       - "packages/**"
-      - ".github/**"
+      - "build-tools/**"
+      - "turbo.json"
+      - "pnpm-workspace.yaml"
+      - ".github/workflows/publish-all-packages.yml"
   release:
     types: [published]
   workflow_dispatch:
@@ -42,6 +45,14 @@ on:
         required: false
         default: false
         type: boolean
+
+# Rapid PR pushes were stacking full ~6-min pipeline runs. Cancel superseded
+# runs on PRs; real publishes (push/release/dispatch) are never cancelled
+# mid-flight — they share one serial group so they queue instead of racing
+# on version commits.
+concurrency:
+  group: publish-all-packages-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'publish-serial' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   NODE_VERSION: "22"


### PR DESCRIPTION
Closes #129

1. Adds a `concurrency` block: PR runs cancel superseded runs (keyed on PR number); push/release/dispatch publishes share a `publish-serial` group — queued, never cancelled mid-publish, and no longer able to race each other on version commits.
2. Narrows the PR `paths:` trigger: `.github/**` → `.github/workflows/publish-all-packages.yml`, and adds `build-tools/**`, `turbo.json`, `pnpm-workspace.yaml` so the PR trigger matches the push trigger.

**Expected impact:** no more stacked 6-min pipelines on rapid pushes; workflow-only edits elsewhere in `.github/` stop triggering the full publish pipeline.