### PR TITLE
CI: add timeout-minutes to uncapped jobs (Actions budget remediation)

### DIFF
--- a/.github/workflows/publish-all-packages.yml
+++ b/.github/workflows/publish-all-packages.yml
@@ -71,6 +71,7 @@ jobs:
   detect-changes:
     name: Detect Changed Packages
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       changed-packages: ${{ steps.get-changed-packages.outputs.packages }}
       has-changes: ${{ steps.get-changed-packages.outputs.has-changes }}
@@ -205,6 +206,7 @@ jobs:
   calculate-dependency-layers:
     name: Calculate Package Dependency Layers
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: detect-changes
     if: needs.detect-changes.outputs.has-changes == 'true'
     outputs:
@@ -249,6 +251,7 @@ jobs:
   test-and-lint-layer-0:
     name: Test and Lint Layer 0 (Base Packages)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: calculate-dependency-layers
     if: needs.calculate-dependency-layers.outputs.layer-0 != '[]'
     strategy:
@@ -345,6 +348,7 @@ jobs:
   test-and-lint-layer-1:
     name: Test and Lint Layer 1
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [calculate-dependency-layers, test-and-lint-layer-0]
     if: needs.calculate-dependency-layers.outputs.layer-1 != '[]'
     strategy:
@@ -441,6 +445,7 @@ jobs:
   test-and-lint-layer-2:
     name: Test and Lint Layer 2
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [calculate-dependency-layers, test-and-lint-layer-1]
     if: needs.calculate-dependency-layers.outputs.layer-2 != '[]'
     strategy:
@@ -537,6 +542,7 @@ jobs:
   test-and-lint-layer-3:
     name: Test and Lint Layer 3
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [calculate-dependency-layers, test-and-lint-layer-2]
     if: needs.calculate-dependency-layers.outputs.layer-3 != '[]'
     strategy:
@@ -633,6 +639,7 @@ jobs:
   pr-test-summary:
     name: PR Test Summary
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: [test-and-lint-layer-0, test-and-lint-layer-1, test-and-lint-layer-2, test-and-lint-layer-3]
     if: github.event_name == 'pull_request' && always()
     permissions:
@@ -664,6 +671,7 @@ jobs:
   version-and-publish:
     name: Version and Publish Packages
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs:
       [
         detect-changes,
@@ -898,6 +906,7 @@ jobs:
   create-release-summary:
     name: Create Release Summary
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: [version-and-publish]
     if: always() && needs.version-and-publish.result == 'success'
     steps:

--- a/.github/workflows/publish-codeartifact.yml
+++ b/.github/workflows/publish-codeartifact.yml
@@ -73,6 +73,7 @@ jobs:
   test:
     name: Test All Packages
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: ${{ github.event.inputs.skip_tests != 'true' }}
     steps:
       - name: Checkout code
@@ -230,6 +231,7 @@ jobs:
   version-bump:
     name: Version Bump
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: test
     if: always() && (needs.test.result == 'success' || needs.test.result == 'skipped')
     outputs:
@@ -355,6 +357,7 @@ jobs:
   publish-codeartifact:
     name: Publish to CodeArtifact
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: version-bump
     if: |
       always() &&
@@ -483,6 +486,7 @@ jobs:
   publish-github:
     name: Publish to GitHub Packages
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: version-bump
     if: |
       always() &&
@@ -587,6 +591,7 @@ jobs:
   summary:
     name: Create Release Summary
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: [version-bump, publish-codeartifact, publish-github]
     if: always()
     steps:


### PR DESCRIPTION
## Context

Org-wide Actions spend has tripled and uncapped hung jobs are a proven contributor: any job without `timeout-minutes` inherits GitHub's 360-minute default. This repo was a priority target — `publish-all-packages.yml` has 9 jobs (4 of them matrix jobs that fan out to ~30 runtime jobs per run) and `publish-codeartifact.yml` has 5 more, **all previously uncapped**. Each does a pnpm install plus AWS OIDC auth, so a single hung step (registry stall, network wedge) could burn 6 hours of runner time — multiplied across the matrix fan-out. Actual successful runs are short: across 20+ recent runs sampled via the Actions API, no job's successful execution exceeded 1.4 minutes, so these caps carry 4-10x headroom over the slowest observed success while cutting worst-case burn per job from 360 minutes to 5-15.

This PR is timeouts only — pure additions (14 inserted lines, zero modified/deleted). The planned matrix restructure is intentionally out of scope. `infra-compose-ci.yml` already caps all of its jobs and is untouched.

## Caps and basis

| File | Job | Timeout (min) | Basis |
|---|---|---|---|
| publish-all-packages.yml | detect-changes | 10 | max success 0.9 min over 21 runs; headroom for cold pnpm cache + full-history checkout |
| publish-all-packages.yml | calculate-dependency-layers | 5 | max success 0.2 min over 9 runs; no dependency install |
| publish-all-packages.yml | test-and-lint-layer-0 (matrix) | 10 | slowest successful matrix leg 1.3 min over 27 legs |
| publish-all-packages.yml | test-and-lint-layer-1 (matrix) | 10 | slowest successful matrix leg 0.9 min over 107 legs |
| publish-all-packages.yml | test-and-lint-layer-2 (matrix) | 10 | slowest successful matrix leg 1.2 min over 46 legs |
| publish-all-packages.yml | test-and-lint-layer-3 (matrix) | 10 | slowest successful matrix leg 1.4 min over 55 legs |
| publish-all-packages.yml | pr-test-summary | 5 | max success 0.2 min over 9 runs |
| publish-all-packages.yml | version-and-publish | 15 | no successful runs in sampled history (skipped in all 21 sampled runs incl. main pushes/dispatches back to Feb); build+publish category default |
| publish-all-packages.yml | create-release-summary | 5 | no successful runs in sampled history (gated on version-and-publish); echo-only steps |
| publish-codeartifact.yml | test | 10 | max success 0.8 min over 8 runs |
| publish-codeartifact.yml | version-bump | 10 | max success 0.8 min over 7 runs |
| publish-codeartifact.yml | publish-codeartifact | 10 | max success 0.9 min over 7 runs |
| publish-codeartifact.yml | publish-github | 15 | no successful runs (skipped in all 8 sampled runs — default publish target is codeartifact); category default; structurally mirrors publish-codeartifact |
| publish-codeartifact.yml | summary | 5 | max success 0.1 min over 8 runs; echo-only steps |

Lint: actionlint 1.7.12 passes

## Suggested follow-ups (not implemented here)

- **Matrix restructure** of `publish-all-packages.yml` (separately planned): the per-package fan-out repeats a full pnpm install + OIDC auth ~30 times per run for ~1-minute jobs; setup dominates useful work.
- **Possibly dead jobs:** `version-and-publish` and `create-release-summary` in `publish-all-packages.yml` have been skipped in every sampled run since at least February (publishing appears to have moved to `publish-codeartifact.yml`). Worth confirming and removing or re-gating.
- **Step-level timeouts** on the `pnpm install` and publish steps would localize failures faster than the job-level cap, if these caps ever fire.
- If `publish-github` starts being used (`publish_target: github`/`both`), revisit its 15-minute default cap against real durations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
