### PR TITLE
fix(infra): atomic name reservation + rollback in db-host POST /dbs

### DIFF
--- a/infra/src/ec2/ec2-router.js
+++ b/infra/src/ec2/ec2-router.js
@@ -12,7 +12,7 @@ import { resolve } from 'path';
 import { engines } from './engines.js';
 import { generate_compose } from './compose-generator.js';
 import { allocate_port, register_port, release_port, get_allocated_ports } from './ports.js';
-import { create_volume, attach_and_mount, get_instance_metadata } from './volumes.js';
+import { create_volume, attach_and_mount, cleanup_volume, get_instance_metadata } from './volumes.js';
 import { register, deregister } from './cloudmap.js';
 import { snapshot_db, download_profile_seed, seed_after_start, list_s3_profiles, read_profile_registry, write_active_profile } from './profiles.js';
 
@@ -321,65 +321,99 @@ export function create_ec2_router(config = {}) {
             const effective_db_name = db_name || name;
             const project_dir = resolve(projects_dir, name);
 
-            if (existsSync(project_dir)) {
-                return res.status(409).json({ ok: false, error: `Project ${name} already exists` });
+            // Reserve the name ATOMICALLY before the slow create path
+            // (volume create + attach + mount + seed sync runs 30-60s).
+            // An existsSync check here leaves that whole window open for a
+            // concurrent duplicate provision (e.g. a caller's transport
+            // retry) to create+attach a second volume for the same name —
+            // the loser never lands in any registry and its volume leaks.
+            try {
+                mkdirSync(project_dir);
+            } catch (err) {
+                if (err.code === 'EEXIST') {
+                    return res.status(409).json({ ok: false, error: `Project ${name} already exists` });
+                }
+                throw err;
             }
 
-            // Allocate port
-            const allocated_port = port || allocate_port(engine, name, { registry_path });
-
-            // Create EBS volume and mount
+            // Past the reservation, every failure must roll back what was
+            // built so the host stays clean and a retry can succeed —
+            // otherwise the half-provisioned volume holds a device letter
+            // that no teardown path can ever find.
+            let allocated_port;
+            let volume_id;
+            const mount_path = resolve(data_dir, name);
             const meta = get_instance_metadata();
             const effective_region = region || meta.region;
-            const volume_id = create_volume({
-                name,
-                size: volume_size,
-                az: meta.az,
-                region: effective_region,
-                env_name: process.env.ENV_NAME,
-            });
+            try {
+                // Allocate port
+                allocated_port = port || allocate_port(engine, name, { registry_path });
 
-            const mount_path = resolve(data_dir, name);
-            attach_and_mount({
-                volume_id,
-                mount_path,
-                instance_id: meta.instance_id,
-                region: effective_region,
-            });
-
-            // Pull S3 seed data if available
-            const seeds_dir = sync_seeds(name);
-
-            // Generate compose file
-            const compose_content = generate_compose({
-                name,
-                engine,
-                version,
-                port: allocated_port,
-                db_name: effective_db_name,
-                data_dir,
-                seeds_dir,
-            });
-
-            mkdirSync(project_dir, { recursive: true });
-            writeFileSync(resolve(project_dir, 'docker-compose.yml'), compose_content);
-
-            // Start the service
-            const up = compose_cmd(project_dir, ['up', '-d']);
-            if (up.status !== 0) {
-                return res.status(500).json({ ok: false, error: `docker compose up failed: ${up.stderr}` });
-            }
-
-            // Register with CloudMap
-            if (namespace_id) {
-                const ip = spawnSync('hostname', ['-I'], { encoding: 'utf8' }).stdout.trim().split(/\s+/)[0];
-                register({
+                // Create EBS volume and mount
+                volume_id = create_volume({
                     name,
-                    ip,
-                    port: allocated_port,
-                    namespace_id,
+                    size: volume_size,
+                    az: meta.az,
+                    region: effective_region,
+                    env_name: process.env.ENV_NAME,
+                });
+
+                attach_and_mount({
+                    volume_id,
+                    mount_path,
+                    instance_id: meta.instance_id,
                     region: effective_region,
                 });
+
+                // Pull S3 seed data if available
+                const seeds_dir = sync_seeds(name);
+
+                // Generate compose file
+                const compose_content = generate_compose({
+                    name,
+                    engine,
+                    version,
+                    port: allocated_port,
+                    db_name: effective_db_name,
+                    data_dir,
+                    seeds_dir,
+                });
+
+                writeFileSync(resolve(project_dir, 'docker-compose.yml'), compose_content);
+
+                // Start the service
+                const up = compose_cmd(project_dir, ['up', '-d']);
+                if (up.status !== 0) {
+                    throw new Error(`docker compose up failed: ${up.stderr}`);
+                }
+
+                // Register with CloudMap
+                if (namespace_id) {
+                    const ip = spawnSync('hostname', ['-I'], { encoding: 'utf8' }).stdout.trim().split(/\s+/)[0];
+                    register({
+                        name,
+                        ip,
+                        port: allocated_port,
+                        namespace_id,
+                        region: effective_region,
+                    });
+                }
+            } catch (err) {
+                console.log(`Provision of ${name} failed (${err.message}); rolling back`);
+                try {
+                    if (existsSync(resolve(project_dir, 'docker-compose.yml'))) {
+                        compose_cmd(project_dir, ['down']);
+                    }
+                    if (volume_id) {
+                        cleanup_volume({ volume_id, mount_path, region: effective_region });
+                    }
+                    if (allocated_port) {
+                        release_port(name, { registry_path });
+                    }
+                } finally {
+                    rmSync(project_dir, { recursive: true, force: true });
+                }
+                throw err;
             }
 
             const result = {

--- a/infra/src/ec2/ec2-router.js
+++ b/infra/src/ec2/ec2-router.js
@@ -7,7 +7,7 @@
 
 import express from 'express';
 import { spawnSync } from 'child_process';
-import { readdirSync, readFileSync, existsSync, writeFileSync, mkdirSync, rmSync } from 'fs';
+import { readdirSync, readFileSync, existsSync, writeFileSync, mkdirSync, rmSync, statSync } from 'fs';
 import { resolve } from 'path';
 import { engines } from './engines.js';
 import { generate_compose } from './compose-generator.js';
@@ -121,6 +121,9 @@ export function create_ec2_router(config = {}) {
     } = config;
 
     const VALID_NAME = /^[a-zA-Z0-9_-]+$/;
+    // Reservations older than this with no compose file are crash leftovers
+    // (a live provision finishes in tens of seconds), safe to reclaim.
+    const RESERVATION_STALE_MS = 30 * 60 * 1000;
 
     const router = express.Router();
     router.use(express.json());
@@ -283,6 +286,12 @@ export function create_ec2_router(config = {}) {
             if (!existsSync(project_dir)) {
                 return res.status(404).json({ ok: false, error: `Project ${name} not found` });
             }
+            // A reservation dir without a compose file is not a usable DB
+            // (in-flight or crashed provision) — don't report a hollow
+            // ok:true that callers would wire a connection string to.
+            if (!existsSync(resolve(project_dir, 'docker-compose.yml'))) {
+                return res.status(404).json({ ok: false, error: `Project ${name} reserved but not provisioned` });
+            }
 
             const status = get_project_status(project_dir, name);
             const ports = get_allocated_ports({ registry_path });
@@ -322,16 +331,30 @@ export function create_ec2_router(config = {}) {
             const project_dir = resolve(projects_dir, name);
 
             // Reserve the name ATOMICALLY before the slow create path
-            // (volume create + attach + mount + seed sync runs 30-60s).
-            // An existsSync check here leaves that whole window open for a
-            // concurrent duplicate provision (e.g. a caller's transport
-            // retry) to create+attach a second volume for the same name —
-            // the loser never lands in any registry and its volume leaks.
+            // (volume create + attach + mount + seed sync takes tens of
+            // seconds). An existsSync check here left that whole window
+            // open for a concurrent duplicate provision (e.g. a caller's
+            // transport retry) to create+attach a second volume for the
+            // same name — the loser landed in no registry and leaked.
+            //
+            // A reservation without a compose file means a previous
+            // provision died mid-flight (crash/power-off skips the
+            // rollback); reclaim it once it's old enough that it can't be
+            // an in-flight provision, so the name doesn't 409 forever.
+            if (existsSync(project_dir)
+                && !existsSync(resolve(project_dir, 'docker-compose.yml'))
+                && Date.now() - statSync(project_dir).mtimeMs > RESERVATION_STALE_MS) {
+                console.log(`Reclaiming stale reservation for ${name} (no compose file)`);
+                rmSync(project_dir, { recursive: true, force: true });
+            }
             try {
                 mkdirSync(project_dir);
             } catch (err) {
                 if (err.code === 'EEXIST') {
-                    return res.status(409).json({ ok: false, error: `Project ${name} already exists` });
+                    // The 'already exists' phrase is load-bearing: the
+                    // orchestrator's callers (program-hub / rostering
+                    // provision triage) grep for it to pick the reuse path.
+                    return res.status(409).json({ ok: false, error: `Project ${name} already exists (or a provision is in flight)` });
                 }
                 throw err;
             }
@@ -399,19 +422,37 @@ export function create_ec2_router(config = {}) {
                     });
                 }
             } catch (err) {
+                // Rollback is best-effort: each step logs its own failure
+                // and the ORIGINAL provisioning error is always what the
+                // caller sees — a rollback failure must never mask it.
                 console.log(`Provision of ${name} failed (${err.message}); rolling back`);
+                if (existsSync(resolve(project_dir, 'docker-compose.yml'))) {
+                    const down = compose_cmd(project_dir, ['down']);
+                    if (down.status !== 0) {
+                        console.log(`Rollback of ${name}: compose down failed: ${down.stderr}`);
+                    }
+                }
+                const rollback_volume_id = volume_id || err.volume_id;
+                if (rollback_volume_id
+                    && !cleanup_volume({ volume_id: rollback_volume_id, mount_path, region: effective_region })) {
+                    console.log(`ROLLBACK INCOMPLETE: volume ${rollback_volume_id} (${name}) left on ${meta.instance_id} — needs a reap pass`);
+                }
+                if (namespace_id) {
+                    try {
+                        deregister({ name, namespace_id, region: effective_region });
+                    } catch (cleanup_err) {
+                        console.log(`Rollback of ${name}: CloudMap deregister failed: ${cleanup_err.message}`);
+                    }
+                }
                 try {
-                    if (existsSync(resolve(project_dir, 'docker-compose.yml'))) {
-                        compose_cmd(project_dir, ['down']);
-                    }
-                    if (volume_id) {
-                        cleanup_volume({ volume_id, mount_path, region: effective_region });
-                    }
-                    if (allocated_port) {
-                        release_port(name, { registry_path });
-                    }
-                } finally {
+                    if (allocated_port) release_port(name, { registry_path });
+                } catch (cleanup_err) {
+                    console.log(`Rollback of ${name}: port release failed: ${cleanup_err.message}`);
+                }
+                try {
                     rmSync(project_dir, { recursive: true, force: true });
+                } catch (cleanup_err) {
+                    console.log(`Rollback of ${name}: reservation removal failed (name stays 409-blocked): ${cleanup_err.message}`);
                 }
                 throw err;
             }

--- a/infra/src/ec2/volumes.js
+++ b/infra/src/ec2/volumes.js
@@ -80,32 +80,30 @@ export function create_volume({ name, size, az, region, env_name }) {
     const volume_id = result.VolumeId;
     console.log(`Created volume ${volume_id} (${size}GB) in ${az}`);
 
-    run('aws', [
-        'ec2', 'wait', 'volume-available',
-        '--volume-ids', volume_id,
-        '--region', region,
-    ], { timeout: 120000 });
+    try {
+        run('aws', [
+            'ec2', 'wait', 'volume-available',
+            '--volume-ids', volume_id,
+            '--region', region,
+        ], { timeout: 120000 });
+    } catch (err) {
+        // The volume exists even though we're failing — carry its id so
+        // the caller's rollback can still find and delete it.
+        err.volume_id = volume_id;
+        throw err;
+    }
     console.log(`Volume ${volume_id} is available`);
 
     return volume_id;
 }
 
 /**
- * Attach an EBS volume, format if new, mount, and add fstab entry.
- *
- * Tolerant of a recently-terminated instance still holding the volume:
- * waits up to 180s for the volume to reach `available` before attaching.
- * The format step uses `blkid` to skip mkfs if the device already has a
- * filesystem, so this is safe to call against an existing data volume
- * (the recovery case).
- *
- * @param {{ volume_id: string, mount_path: string, instance_id: string, region: string }} config
- */
-/**
  * Best-effort cleanup of a volume from a failed provision: unmount if
- * mounted, detach if attached, delete. Every step tolerates "already
- * done" — the volume may have failed anywhere between create and mount.
- * Never throws; returns true when the volume is confirmed deleted.
+ * mounted, detach if attached, delete. Tolerates partial provisioning —
+ * the failure may have hit anywhere between create and mount. Never
+ * throws; returns true when the volume is gone (or its delete request
+ * was accepted), false when it was left behind for a manual/reap pass —
+ * the caller is responsible for logging false loudly.
  *
  * @param {{ volume_id: string, mount_path?: string, region: string }} config
  * @returns {boolean}
@@ -114,15 +112,31 @@ export function cleanup_volume({ volume_id, mount_path, region }) {
     try {
         if (mount_path) {
             spawnSync('umount', [mount_path], { encoding: 'utf8', stdio: 'pipe' });
+            // Detaching a still-mounted ext4 wedges the volume in
+            // `detaching/busy`; better to leave it attached and findable.
+            const still_mounted = spawnSync('mountpoint', ['-q', mount_path]);
+            if (still_mounted.status === 0) {
+                console.log(`Volume cleanup: ${mount_path} still mounted after umount; not detaching ${volume_id}`);
+                return false;
+            }
         }
-        const state = run('aws', [
-            'ec2', 'describe-volumes',
-            '--volume-ids', volume_id,
-            '--query', 'Volumes[0].State',
-            '--output', 'text',
-            '--region', region,
-        ]);
-        if (state === 'in-use') {
+        let state;
+        try {
+            state = run('aws', [
+                'ec2', 'describe-volumes',
+                '--volume-ids', volume_id,
+                '--query', 'Volumes[0].State',
+                '--output', 'text',
+                '--region', region,
+            ]);
+        } catch (err) {
+            if (`${err.message}`.includes('InvalidVolume.NotFound')) {
+                console.log(`Volume cleanup: ${volume_id} already gone`);
+                return true;
+            }
+            throw err;
+        }
+        if (state === 'in-use' || state === 'attaching') {
             run('aws', ['ec2', 'detach-volume', '--volume-id', volume_id, '--region', region]);
         }
         if (state !== 'available') {
@@ -141,6 +155,17 @@ export function cleanup_volume({ volume_id, mount_path, region }) {
     }
 }
 
+/**
+ * Attach an EBS volume, format if new, mount, and add fstab entry.
+ *
+ * Tolerant of a recently-terminated instance still holding the volume:
+ * waits up to 180s for the volume to reach `available` before attaching.
+ * The format step uses `blkid` to skip mkfs if the device already has a
+ * filesystem, so this is safe to call against an existing data volume
+ * (the recovery case).
+ *
+ * @param {{ volume_id: string, mount_path: string, instance_id: string, region: string }} config
+ */
 export function attach_and_mount({ volume_id, mount_path, instance_id, region }) {
     // The volume may still be detaching from a recently-terminated
     // instance. Wait for it to be available before attaching.

--- a/infra/src/ec2/volumes.js
+++ b/infra/src/ec2/volumes.js
@@ -101,6 +101,46 @@ export function create_volume({ name, size, az, region, env_name }) {
  *
  * @param {{ volume_id: string, mount_path: string, instance_id: string, region: string }} config
  */
+/**
+ * Best-effort cleanup of a volume from a failed provision: unmount if
+ * mounted, detach if attached, delete. Every step tolerates "already
+ * done" — the volume may have failed anywhere between create and mount.
+ * Never throws; returns true when the volume is confirmed deleted.
+ *
+ * @param {{ volume_id: string, mount_path?: string, region: string }} config
+ * @returns {boolean}
+ */
+export function cleanup_volume({ volume_id, mount_path, region }) {
+    try {
+        if (mount_path) {
+            spawnSync('umount', [mount_path], { encoding: 'utf8', stdio: 'pipe' });
+        }
+        const state = run('aws', [
+            'ec2', 'describe-volumes',
+            '--volume-ids', volume_id,
+            '--query', 'Volumes[0].State',
+            '--output', 'text',
+            '--region', region,
+        ]);
+        if (state === 'in-use') {
+            run('aws', ['ec2', 'detach-volume', '--volume-id', volume_id, '--region', region]);
+        }
+        if (state !== 'available') {
+            run('aws', [
+                'ec2', 'wait', 'volume-available',
+                '--volume-ids', volume_id,
+                '--region', region,
+            ], { timeout: 120000 });
+        }
+        run('aws', ['ec2', 'delete-volume', '--volume-id', volume_id, '--region', region]);
+        console.log(`Cleaned up volume ${volume_id} from failed provision`);
+        return true;
+    } catch (err) {
+        console.log(`Volume cleanup for ${volume_id} incomplete: ${err.message}`);
+        return false;
+    }
+}
+
 export function attach_and_mount({ volume_id, mount_path, instance_id, region }) {
     // The volume may still be detaching from a recently-terminated
     // instance. Wait for it to be available before attaching.

--- a/infra/test/unit/ec2-router-provision.unit.test.js
+++ b/infra/test/unit/ec2-router-provision.unit.test.js
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import http from 'http';
+import express from 'express';
+import { mkdtempSync, existsSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+// Mock everything that talks to AWS / the host so POST /dbs runs hermetically.
+vi.mock('../../src/ec2/volumes.js', () => ({
+    create_volume: vi.fn(() => 'vol-test123'),
+    attach_and_mount: vi.fn(),
+    cleanup_volume: vi.fn(() => true),
+    get_instance_metadata: vi.fn(() => ({
+        instance_id: 'i-test', az: 'us-west-2a', region: 'us-west-2',
+    })),
+}));
+vi.mock('../../src/ec2/ports.js', () => ({
+    allocate_port: vi.fn(() => 5440),
+    register_port: vi.fn(),
+    release_port: vi.fn(),
+    get_allocated_ports: vi.fn(() => ({})),
+}));
+vi.mock('../../src/ec2/cloudmap.js', () => ({
+    register: vi.fn(),
+    deregister: vi.fn(),
+}));
+vi.mock('../../src/ec2/profiles.js', () => ({
+    snapshot_db: vi.fn(),
+    download_profile_seed: vi.fn(),
+    seed_after_start: vi.fn(),
+    list_s3_profiles: vi.fn(() => []),
+    read_profile_registry: vi.fn(() => ({})),
+    write_active_profile: vi.fn(),
+}));
+// compose_cmd / sync_seeds / hostname shell out via spawnSync; default all to success.
+vi.mock('child_process', () => ({
+    spawnSync: vi.fn(() => ({ status: 0, stdout: '', stderr: '' })),
+}));
+
+import { spawnSync } from 'child_process';
+import { create_volume, cleanup_volume } from '../../src/ec2/volumes.js';
+import { release_port } from '../../src/ec2/ports.js';
+import { create_ec2_router } from '../../src/ec2/ec2-router.js';
+
+function create_test_server(router_options) {
+    const app = express();
+    app.use('/infra', create_ec2_router(router_options));
+    const server = http.createServer(app);
+    return new Promise((resolve) => {
+        server.listen(0, '127.0.0.1', () => {
+            const { port } = server.address();
+            resolve({
+                server,
+                base_url: `http://127.0.0.1:${port}/infra`,
+                close: () => new Promise(r => server.close(r)),
+            });
+        });
+    });
+}
+
+async function api(base_url, method, path, body) {
+    const opts = { method, headers: { 'Content-Type': 'application/json' } };
+    if (body) opts.body = JSON.stringify(body);
+    const resp = await fetch(`${base_url}${path}`, opts);
+    return { status: resp.status, data: await resp.json() };
+}
+
+describe('POST /dbs provision race + rollback', () => {
+    let projects_dir;
+    let data_dir;
+    let test_server;
+
+    beforeEach(async () => {
+        vi.clearAllMocks();
+        spawnSync.mockReturnValue({ status: 0, stdout: '', stderr: '' });
+        projects_dir = mkdtempSync(join(tmpdir(), 'ec2-router-projects-'));
+        data_dir = mkdtempSync(join(tmpdir(), 'ec2-router-data-'));
+        test_server = await create_test_server({ projects_dir, data_dir, registry_path: join(data_dir, 'ports.json') });
+    });
+
+    afterEach(async () => {
+        await test_server.close();
+        rmSync(projects_dir, { recursive: true, force: true });
+        rmSync(data_dir, { recursive: true, force: true });
+    });
+
+    it('creates a db and reserves the project dir', async () => {
+        const { status, data } = await api(test_server.base_url, 'POST', '/dbs', {
+            name: 'svc-pr-1', engine: 'postgres',
+        });
+        expect(status).toBe(200);
+        expect(data).toMatchObject({ ok: true, name: 'svc-pr-1', volumeId: 'vol-test123' });
+        expect(existsSync(join(projects_dir, 'svc-pr-1'))).toBe(true);
+    });
+
+    it('409s a duplicate provision without touching AWS (name reserved before create)', async () => {
+        await api(test_server.base_url, 'POST', '/dbs', { name: 'svc-pr-1', engine: 'postgres' });
+        create_volume.mockClear();
+
+        const { status, data } = await api(test_server.base_url, 'POST', '/dbs', {
+            name: 'svc-pr-1', engine: 'postgres',
+        });
+        expect(status).toBe(409);
+        expect(data.error).toMatch(/already exists/);
+        expect(create_volume).not.toHaveBeenCalled();
+    });
+
+    it('rolls back the reservation when volume creation fails, so a retry succeeds', async () => {
+        create_volume.mockImplementationOnce(() => { throw new Error('create-volume boom'); });
+
+        const fail = await api(test_server.base_url, 'POST', '/dbs', { name: 'svc-pr-2', engine: 'postgres' });
+        expect(fail.status).toBe(500);
+        expect(fail.data.error).toMatch(/create-volume boom/);
+        expect(existsSync(join(projects_dir, 'svc-pr-2'))).toBe(false);
+        expect(release_port).toHaveBeenCalledWith('svc-pr-2', expect.anything());
+        // No volume was created, so nothing to clean up
+        expect(cleanup_volume).not.toHaveBeenCalled();
+
+        const retry = await api(test_server.base_url, 'POST', '/dbs', { name: 'svc-pr-2', engine: 'postgres' });
+        expect(retry.status).toBe(200);
+        expect(retry.data.ok).toBe(true);
+    });
+
+    it('deletes the created volume when compose up fails', async () => {
+        // First spawnSync call in the route is sync_seeds' `aws s3 ls`; the
+        // docker compose up is the one with 'compose' in its args.
+        spawnSync.mockImplementation((cmd, args) => {
+            if (cmd === 'docker' && args.includes('up')) {
+                return { status: 1, stdout: '', stderr: 'compose exploded' };
+            }
+            return { status: 0, stdout: '', stderr: '' };
+        });
+
+        const { status, data } = await api(test_server.base_url, 'POST', '/dbs', {
+            name: 'svc-pr-3', engine: 'postgres',
+        });
+        expect(status).toBe(500);
+        expect(data.error).toMatch(/compose exploded/);
+        expect(cleanup_volume).toHaveBeenCalledWith(expect.objectContaining({ volume_id: 'vol-test123' }));
+        expect(release_port).toHaveBeenCalledWith('svc-pr-3', expect.anything());
+        expect(existsSync(join(projects_dir, 'svc-pr-3'))).toBe(false);
+    });
+});

--- a/infra/test/unit/ec2-router-provision.unit.test.js
+++ b/infra/test/unit/ec2-router-provision.unit.test.js
@@ -96,13 +96,39 @@ describe('POST /dbs provision race + rollback', () => {
     it('409s a duplicate provision without touching AWS (name reserved before create)', async () => {
         await api(test_server.base_url, 'POST', '/dbs', { name: 'svc-pr-1', engine: 'postgres' });
         create_volume.mockClear();
+        release_port.mockClear();
 
         const { status, data } = await api(test_server.base_url, 'POST', '/dbs', {
             name: 'svc-pr-1', engine: 'postgres',
         });
         expect(status).toBe(409);
+        // 'already exists' is load-bearing: provision triage in the caller
+        // repos greps for it to pick the reuse path.
         expect(data.error).toMatch(/already exists/);
         expect(create_volume).not.toHaveBeenCalled();
+        // The 409 must never disturb the winner's live project.
+        expect(existsSync(join(projects_dir, 'svc-pr-1'))).toBe(true);
+        expect(release_port).not.toHaveBeenCalled();
+        expect(cleanup_volume).not.toHaveBeenCalled();
+    });
+
+    it('preserves the original error when a rollback step itself throws', async () => {
+        spawnSync.mockImplementation((cmd, args) => {
+            if (cmd === 'docker' && args.includes('up')) {
+                return { status: 1, stdout: '', stderr: 'compose exploded' };
+            }
+            return { status: 0, stdout: '', stderr: '' };
+        });
+        release_port.mockImplementationOnce(() => { throw new Error('registry disk full'); });
+
+        const { status, data } = await api(test_server.base_url, 'POST', '/dbs', {
+            name: 'svc-pr-4', engine: 'postgres',
+        });
+        expect(status).toBe(500);
+        expect(data.error).toMatch(/compose exploded/);
+        expect(data.error).not.toMatch(/disk full/);
+        expect(cleanup_volume).toHaveBeenCalled();
+        expect(existsSync(join(projects_dir, 'svc-pr-4'))).toBe(false);
     });
 
     it('rolls back the reservation when volume creation fails, so a retry succeeds', async () => {

--- a/infra/test/unit/volumes-cleanup.unit.test.js
+++ b/infra/test/unit/volumes-cleanup.unit.test.js
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('child_process', () => ({ spawnSync: vi.fn() }));
+
+import { spawnSync } from 'child_process';
+import { cleanup_volume } from '../../src/ec2/volumes.js';
+
+/** aws sub-commands invoked, in order, as 'ec2 <action>' strings. */
+function aws_calls() {
+    return spawnSync.mock.calls
+        .filter(([cmd]) => cmd === 'aws')
+        .map(([, args]) => args.slice(0, 2).join(' '));
+}
+
+function mock_host({ mounted = false, state = 'available', failing = {} } = {}) {
+    spawnSync.mockImplementation((cmd, args) => {
+        if (cmd === 'mountpoint') return { status: mounted ? 0 : 1 };
+        if (cmd === 'aws') {
+            const action = args[1];
+            if (failing[action]) return { status: 1, stdout: '', stderr: failing[action] };
+            if (action === 'describe-volumes') return { status: 0, stdout: `${state}\n`, stderr: '' };
+        }
+        return { status: 0, stdout: '', stderr: '' };
+    });
+}
+
+describe('cleanup_volume', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('deletes an available volume without detaching or waiting', () => {
+        mock_host({ state: 'available' });
+        expect(cleanup_volume({ volume_id: 'vol-1', mount_path: '/mnt/data/x', region: 'us-west-2' })).toBe(true);
+        expect(aws_calls()).toContain('ec2 delete-volume');
+        expect(aws_calls()).not.toContain('ec2 detach-volume');
+        expect(aws_calls()).not.toContain('ec2 wait');
+    });
+
+    it('detaches, waits, then deletes an in-use volume — in that order', () => {
+        mock_host({ state: 'in-use' });
+        expect(cleanup_volume({ volume_id: 'vol-1', region: 'us-west-2' })).toBe(true);
+        const calls = aws_calls();
+        const detach = calls.indexOf('ec2 detach-volume');
+        const wait = calls.indexOf('ec2 wait');
+        const del = calls.indexOf('ec2 delete-volume');
+        expect(detach).toBeGreaterThan(-1);
+        expect(detach).toBeLessThan(wait);
+        expect(wait).toBeLessThan(del);
+    });
+
+    it('also detaches a volume stuck in attaching', () => {
+        mock_host({ state: 'attaching' });
+        expect(cleanup_volume({ volume_id: 'vol-1', region: 'us-west-2' })).toBe(true);
+        expect(aws_calls()).toContain('ec2 detach-volume');
+    });
+
+    it('refuses to detach while the mount is still held', () => {
+        mock_host({ mounted: true });
+        expect(cleanup_volume({ volume_id: 'vol-1', mount_path: '/mnt/data/x', region: 'us-west-2' })).toBe(false);
+        expect(aws_calls()).toEqual([]);
+    });
+
+    it('treats an already-deleted volume as success', () => {
+        mock_host({ failing: { 'describe-volumes': 'An error occurred (InvalidVolume.NotFound) when calling DescribeVolumes' } });
+        expect(cleanup_volume({ volume_id: 'vol-1', region: 'us-west-2' })).toBe(true);
+        expect(aws_calls()).not.toContain('ec2 delete-volume');
+    });
+
+    it('never throws — an aws failure returns false', () => {
+        mock_host({ state: 'in-use', failing: { 'detach-volume': 'boom' } });
+        let result;
+        expect(() => { result = cleanup_volume({ volume_id: 'vol-1', region: 'us-west-2' }); }).not.toThrow();
+        expect(result).toBe(false);
+    });
+});


### PR DESCRIPTION
Companion to saga-ed/program-hub#176 (root-cause: orphan EBS volumes exhausting db-host-v2 device letters), alongside saga-ed/program-hub#177 and hipponot/iac#404.

## Problem
POST /dbs guarded duplicates with `existsSync(project_dir)` — but the project dir was only written at the **end** of the 30–60s create path (volume create → attach → mount → seed sync). When a caller's transport layer silently retried a >60s provision (the AWS CLI/botocore default — fixed in the companion PRs), both executions passed the guard and each created+attached an EBS volume. Only one landed in the registries; the losers held device letters no teardown could find. Observed in dev: same-name volumes in triplets ~1 min apart, two hosts at 21/21 attachments, 61 detached orphan volumes.

Failed provisions leaked too: a device-letter exhaustion throws at attach, *after* create-volume, stranding an `available` volume with no cleanup.

## Fix
- **Atomic reservation**: `mkdirSync(project_dir)` (non-recursive) immediately after validation; `EEXIST` → the same `409 'Project … already exists'` contract callers already triage on. The check-and-reserve race window collapses to one syscall.
- **Rollback on any failure past the reservation**: compose down if started, detach+delete the volume (new `cleanup_volume` helper in volumes.js, best-effort/never-throws), release the port, remove the project dir. Failed provisions now leave the host clean and retries succeed.

## Verification
- New `test/unit/ec2-router-provision.unit.test.js` (first coverage of ec2-router): duplicate → 409 with zero AWS calls; create_volume failure → 500, reservation rolled back, retry succeeds; compose-up failure → volume deleted + port released + dir removed.
- Full infra suite: 73 passed; the 9 `api-pure.unit.test.js` failures (bson import resolution) are identical on unmodified origin/main.
- Note for deploy: db-host-v2 instances pick this up via the infra-compose package on next host refresh/instance launch — existing instances keep the old code until then.