### PR TITLE
chore(synthetic-dev): onboarding refresh — trim landed pins, doc accuracy, overlay warnings

### DIFF
--- a/tools/synthetic-dev/getting-started.md
+++ b/tools/synthetic-dev/getting-started.md
@@ -16,9 +16,9 @@ saga-dash**. It's a dockerized, fully-local **six-service** stack:
 | 6379 | redis | mesh |
 | 5672 / 15672 | rabbitmq | mesh |
 
-Seeds a realistic synthetic roster: **5 districts / 13 schools / 28 sections
-/ 168 students / 22 tutors / 6 named dev personas** — no PII, no VPN, no
-prod-mirror fixture. The 6 dev personas are admin/PM accounts you log in as
+Seeds a realistic synthetic roster: **7 districts / 15 schools / 32 sections
+/ 168 students / 22 tutors / 7 named dev personas** — no PII, no VPN, no
+prod-mirror fixture. The 7 dev personas are admin/PM accounts you log in as
 (separate from the roster).
 
 ## Fastest path — land in the team's exact state
@@ -52,8 +52,8 @@ The pinned suite (snapshot — `./refresh-suite.sh --list` for the live list):
 
 | repo | pinned PRs |
 |---|---|
-| saga-dash | #136 (program-details stale-on-switch) |
-| program-hub, rostering, soa, student-data-system | none — stay on `origin/main` |
+| rostering | #410 (Empty Org seed — the truly-empty upload-from-scratch fixture) |
+| saga-dash, program-hub, soa, student-data-system | none — stay on `origin/main` |
 
 **Maintenance:** when one of these PRs merges to `main`, delete its line from
 `integration-suite.tsv` — the fix then arrives via `main` (up.sh's `prep`
@@ -62,9 +62,9 @@ was a repo's *last* pin (as rostering's #366 was), also `git checkout main`
 in that repo so it leaves `local/integration` — `refresh-suite.sh` no longer
 manages it.
 
-> `refresh-suite.sh` leaves pinned repos (program-hub, saga-dash) **on
-> `local/integration`**; unpinned ones (rostering, soa, student-data-system)
-> stay on `main`. Both `up.sh`'s `check_branches` and `verify.sh` are
+> `refresh-suite.sh` leaves pinned repos (currently just **rostering**) **on
+> `local/integration`**; unpinned ones (saga-dash, program-hub, soa,
+> student-data-system) stay on `main`. Both `up.sh`'s `check_branches` and `verify.sh` are
 > **manifest-aware** — they expect exactly that, so the *correct* setup is
 > silent. A `⚠` (or a `verify.sh` posture failure) now means **real drift**:
 > wrong branch, or a pinned PR not actually merged into your `local/integration`
@@ -185,11 +185,12 @@ The reset is data-only — it truncates synthetic rows but **preserves
 | email | role |
 |---|---|
 | `dev@saga.org` | Seed District admin (the default — most things work) |
-| `multi@saga.org` | belongs to multiple districts |
-| `new@saga.org` | district admin for a fresh district |
-| `many@saga.org` | admin for many programs |
+| `multi@saga.org` | belongs to multiple districts (seed + riverside) |
+| `many@saga.org` | admin for many programs (metro) |
+| `new@saga.org` | district admin for a fresh district (oakdale) |
+| `frontier@saga.org` | admin for the Frontier district |
+| `empty@saga.org` | Empty Org admin — district with NO schools/sections/roster (the CSV upload-from-scratch fixture; `./up.sh --reset --seed roster --login empty@saga.org`) |
 | `none@saga.org` | belongs to no district |
-| `frontier@saga.org` | empty-district admin |
 
 Each persona's UUID is printed at the end of every `--seed roster` run.
 

--- a/tools/synthetic-dev/integration-suite.tsv
+++ b/tools/synthetic-dev/integration-suite.tsv
@@ -42,6 +42,9 @@
 #  auto-creates referenced school/section groups, so the csv-shadow re-home
 #  stopgap is obsolete. CLOSE PR #423. #410 (Empty Org) stays — it's the
 #  truly-empty upload-from-scratch fixture auto-create needs.)
+# (2026-06-09 saga-dash #161,#165 dropped — both LANDED on main (merges
+#  83fb857 / b4d0408). #161 (resizable columns + User ID truncation) and #165
+#  (roster ↔ CSV-upload wiring, sd-164) now arrive via main; saga-dash back on
+#  origin/main. Only rostering #410 (Empty Org seed) remains in flight.)
 
-saga-dash	161,165
 rostering	410

--- a/tools/synthetic-dev/up.sh
+++ b/tools/synthetic-dev/up.sh
@@ -48,6 +48,14 @@
 # recipes (no post-deletes — selectivity is in what you seed):
 #   ./up.sh --reset --seed roster --login  from-scratch roster + dev@saga.org session
 #   ./up.sh --reset --seed full --login    roster + 9 programs + a fresh dev@saga.org session
+#   ./up.sh --reset --seed roster --login empty@saga.org
+#                                          same db:seed, but log in as the EMPTY ORG
+#                                          admin. db:seed always builds an Empty Org too
+#                                          (an admin on a district with NO schools/sections/
+#                                          roster) — the persona you --login picks which
+#                                          district you see. Use empty@saga.org for CSV
+#                                          upload-from-scratch testing; dev@saga.org lands
+#                                          you in the fully-rostered Seed District.
 # (--reset / --seed / --login against an already-running stack skip the up step.)
 #
 # IMPORTANT: the default --login persona (dev@saga.org) is the rostered Seed

--- a/tools/synthetic-dev/verify.sh
+++ b/tools/synthetic-dev/verify.sh
@@ -28,9 +28,12 @@ DEV=${DEV:-$HOME/dev}
 MANAGED_REPOS="rostering program-hub saga-dash"
 ALWAYS_MAIN_REPOS="soa student-data-system"
 
-pass=0; fail=0
+pass=0; fail=0; warn=0
 okline()  { printf "  \033[32m✓\033[0m %s\n" "$*"; pass=$((pass+1)); }
 badline() { printf "  \033[31m✗\033[0m %s\n" "$*"; fail=$((fail+1)); }
+# Warn = real drift worth surfacing but not a failure (e.g. a legitimate ad-hoc
+# overlay). Does NOT touch pass/fail, so it never flips the exit code.
+warnline(){ printf "  \033[33m⚠\033[0m %s\n" "$*"; warn=$((warn+1)); }
 
 probe(){ # name port path
   local name=$1 port=$2 path=$3 code
@@ -145,6 +148,43 @@ check_pin_merged(){ # repo pr#
   fi
 }
 
+# What's ACTUALLY overlaid vs what the manifest pins. The manifest checks above
+# only ask "is every pin present?" — they're blind to branches merged in by an
+# ad-hoc `refresh-integration --prs` that AREN'T pinned. Those are legitimate
+# (warn, not fail) but invisible and silently dropped by the next refresh-suite,
+# so surface them. Overlay set = PR-branch merges in origin/main..HEAD (commits
+# local/integration carries but main hasn't landed — landed PRs are ancestors of
+# main and fall out of the range automatically). Subtract the pinned branches;
+# whatever's left is an unpinned overlay.
+check_unpinned_overlays(){ # repo  pinned_csv
+  local repo=$1 pins=$2 dir="$DEV/$repo" b n num
+  [[ "$(on_branch "$repo")" == local/integration ]] || return   # only meaningful on integration
+  local merged
+  merged=$( cd "$dir" && git log --merges --pretty=%s origin/main..HEAD 2>/dev/null \
+            | sed -nE "s/.*Merge remote-tracking branch 'origin\/([^']+)'.*/\1/p" \
+            | grep -vxE 'main|master' | sort -u )
+  [[ -z "$merged" ]] && return
+  # pinned branches: resolve each pinned # → headRefName (the branch that gets merged)
+  declare -A PINNED_BRANCH=()
+  IFS=',' read -ra nums <<<"$pins"
+  for n in "${nums[@]}"; do
+    [[ -z "$n" ]] && continue
+    b=$( cd "$dir" && gh pr view "$n" --json headRefName --jq '.headRefName' 2>/dev/null || true )
+    [[ -n "$b" ]] && PINNED_BRANCH["$b"]=$n
+  done
+  local extras=()
+  while IFS= read -r b; do
+    [[ -z "$b" ]] && continue
+    [[ -n "${PINNED_BRANCH[$b]:-}" ]] && continue            # pinned — already reported as ✓
+    num=$( cd "$dir" && gh pr list --head "$b" --state all --json number --jq '.[0].number' 2>/dev/null || true )
+    extras+=( "${num:+#$num }$b" )
+  done <<<"$merged"
+  if [[ ${#extras[@]} -gt 0 ]]; then
+    warnline "$(printf '%-20s +%d unpinned overlay(s): %s' "$repo" "${#extras[@]}" "${extras[*]}")"
+    warnline "$(printf '%-20s   ad-hoc (refresh-integration --prs) — not in manifest; dropped on next refresh-suite' '')"
+  fi
+}
+
 for repo in $MANAGED_REPOS; do
   prs="${PINS[$repo]:-}"
   if [[ -n "$prs" ]]; then
@@ -152,6 +192,7 @@ for repo in $MANAGED_REPOS; do
     if [[ "$(on_branch "$repo")" == "local/integration" ]]; then   # only meaningful if branch is right
       IFS=',' read -ra nums <<<"$prs"
       for n in "${nums[@]}"; do [[ -n "$n" ]] && check_pin_merged "$repo" "$n"; done
+      check_unpinned_overlays "$repo" "$prs"   # surface ad-hoc overlays not in the manifest
     fi
   else
     check_posture_main "$repo"   # main, or an empty local/integration that ≡ main
@@ -162,7 +203,12 @@ for repo in $ALWAYS_MAIN_REPOS; do check_posture "$repo" "main"; done
 
 printf "\n"
 if [[ $fail -eq 0 ]]; then
-  printf "\033[32m✓ all %d checks passed — stack is ready\033[0m\n" "$pass"; exit 0
+  if [[ $warn -gt 0 ]]; then
+    printf "\033[32m✓ all %d checks passed\033[0m \033[33m(%d warning(s) — see ⚠ above)\033[0m — stack is ready\n" "$pass" "$warn"
+  else
+    printf "\033[32m✓ all %d checks passed — stack is ready\033[0m\n" "$pass"
+  fi
+  exit 0
 else
   printf "\033[31m✗ %d/%d checks failed\033[0m — tail /tmp/sds-synthetic/<service>.log for reds\n" "$fail" "$((pass+fail))"; exit 1
 fi


### PR DESCRIPTION
Tidies the synthetic-dev stack ahead of onboarding a new developer — a clean clone should reproduce the team's exact state with no confusing no-op merges, and the getting-started guide should match reality.

## Changes

**`integration-suite.tsv` — trim landed pins**
- Drop saga-dash **#161** (resizable columns + User ID truncation) and **#165** (roster ↔ CSV-upload wiring, sd-164) — both landed on `main` (merges `83fb857` / `b4d0408`) and now arrive via `main`. Keeping them pinned made `refresh-suite` re-merge already-landed PRs (harmless no-op, but noisy on a first run).
- Only **rostering #410** (Empty Org seed) remains in flight.

**`up.sh` — document the Empty Org login recipe**
- `./up.sh --reset --seed roster --login empty@saga.org` — `db:seed` always builds the Empty Org (an admin on a district with no schools/sections/roster); the `--login` persona just picks which district you land in. `empty@saga.org` is the CSV upload-from-scratch fixture; `dev@saga.org` lands in the fully-rostered Seed District.

**`verify.sh` — surface unpinned ad-hoc overlays**
- `refresh-integration --prs` can merge branches that aren't in the manifest. They're legitimate but invisible, and the next `refresh-suite` silently drops them. New `check_unpinned_overlays` reports them as `⚠` warnings. Warn-only — never flips the exit code.

**`getting-started.md` — correct drift** (verified against `iam-seed-ids` catalog/roster)
- Roster headline: **7 districts / 15 schools / 32 sections / 168 students / 22 tutors / 7 personas** (was 5/13/28/…/6).
- Pinned-suite snapshot now shows **rostering #410** (was the stale saga-dash #136); branch-posture note updated (rostering is the pinned repo).
- Personas table adds **`empty@saga.org`** and fixes the `frontier@saga.org` description — frontier is its own district; `empty@saga.org` is the truly-empty org.

## Verification
- `bash -n up.sh && bash -n verify.sh` — clean.
- `./refresh-suite.sh --list` → `rostering PRs: 410`.
- Doc counts pulled from the compiled `@saga-ed/iam-seed-ids` exports (`DISTRICTS`/`SCHOOLS`/`SECTIONS`/`STUDENTS`/`TUTORS`/`USERS`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)