### PR TITLE
chore(synthetic-dev): pin rostering #432 (org-scoped group identity) in the suite

### DIFF
--- a/tools/synthetic-dev/integration-suite.tsv
+++ b/tools/synthetic-dev/integration-suite.tsv
@@ -46,5 +46,11 @@
 #  83fb857 / b4d0408). #161 (resizable columns + User ID truncation) and #165
 #  (roster ↔ CSV-upload wiring, sd-164) now arrive via main; saga-dash back on
 #  origin/main. Only rostering #410 (Empty Org seed) remains in flight.)
+# (2026-06-10 rostering #432 added — org-scopes group identity (adds groups.org_id
+#  NOT NULL + unique (org_id, source, source_id); fixes cross-district CSV sourceId
+#  collisions). Its migration 20260609000000_group_org_scoped_identity is ALREADY
+#  applied to the live iam DB (so iam-api/sis-api run the #432 build), but its seed
+#  — which sets orgId on every group.create — must be overlaid or db:seed P2011s on
+#  the NOT NULL org_id. PIN alongside #410 until #432 lands on main.)
 
-rostering	410
+rostering	410,432


### PR DESCRIPTION
## What

Pin **`rostering 410,432`** in `tools/synthetic-dev/integration-suite.tsv` (was `410`).

## Why

The live `iam_local` DB is already migrated to **org-scoped group identity** — rostering [#432](https://github.com/saga-ed/rostering/pull/432) added `groups.org_id NOT NULL` + unique `(org_id, source, source_id)`, and its migration `20260609000000_group_org_scoped_identity` is applied/recorded. So iam-api/sis-api already run the #432 build.

But the suite pinned only **#410**, whose seed predates org_id and inserts no `orgId`. Result: `db:seed` fails with **`P2011 NullConstraintViolation`** on `group.create` (NULL into the NOT NULL `org_id`) — the synthetic-dev roster seed is broken for anyone refreshing the stack.

## Fix

Pinning `410,432` makes `refresh-suite` rebuild `local/integration` on the union. #432 merges cleanly onto main (it doesn't touch `iam-seed-ids`, and its seed edits a different region than #410), and its seed sets `orgId` on every `group.create` (district = its own org; schools/sections inherit their district id).

Verified locally after overlay: 58 groups, **0 null `org_id`**; Empty Org present; all six services 200; `iam users=218`.

## Follow-up

Drop #432 from the suite once it lands on `rostering` main (same lifecycle as #410).

🤖 Generated with [Claude Code](https://claude.com/claude-code)