### PR TITLE
chore(infra): bump infra-compose to 1.3.3

### DIFF
--- a/infra/package.json
+++ b/infra/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/infra-compose",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "description": "Composable Docker service templates for Saga platform local development",
     "bin": {
         "infra-compose": "bin/infra-compose"


### PR DESCRIPTION
## Why

Release vehicle for the provision-race + rollback fixes merged in #132 (atomic project-dir reservation, `cleanup_volume` rollback on partial provision failure, stale-reservation reclaim). db-hosts install `@saga-ed/infra-compose` from CodeArtifact at boot, pinned by `InfraComposeVersion` in hipponot/iac, so the fix only reaches the fleet once a new version is published and pinned.

## What

- `infra/package.json`: `1.3.2` → `1.3.3` (version-only; the code is already on main)

## Rollout (after merge)

1. Dispatch `publish-codeartifact.yml` with `single_package=infra`, `publish_target=codeartifact` (publishes the committed version — this PR is the required pre-bump).
2. Bump `InfraComposeVersion="1.3.3"` in iac `cloudformation_templates/dbs/db_host_v2/asg/samconfig.yaml` and roll the db-host instances.

Part of saga-ed/program-hub#176.