### PR TITLE
fix(synthetic-dev): unblock up.sh bootstrap on a fresh machine

### DIFF
--- a/tools/synthetic-dev/integration-suite.tsv
+++ b/tools/synthetic-dev/integration-suite.tsv
@@ -52,5 +52,11 @@
 #  applied to the live iam DB (so iam-api/sis-api run the #432 build), but its seed
 #  — which sets orgId on every group.create — must be overlaid or db:seed P2011s on
 #  the NOT NULL org_id. PIN alongside #410 until #432 lands on main.)
-
-rostering	410,432
+# (2026-06-10 rostering #432 dropped — LANDED on main (merge 9870cd9); its branch
+#  worktree-csv-group-org-scoped-identity was deleted post-merge. The org-scoped
+#  group identity fix + seed now arrive via main; no longer needs replaying.)
+# (2026-06-10 rostering #410 dropped — its merge onto post-#432 main conflicts in
+#  iam-db seed.ts and we opted not to carry the Empty Org fixture locally. #410 is
+#  still OPEN; re-add it here (and resolve the seed.ts comment-header conflict) if
+#  the empty@saga.org upload-from-scratch scenario is needed again. With this drop
+#  the suite is EMPTY: every repo back on origin/main, nothing in flight to replay.)

--- a/tools/synthetic-dev/up.sh
+++ b/tools/synthetic-dev/up.sh
@@ -358,6 +358,16 @@ prep(){
   say "reconciling program-hub deps + workspace build (new deps / stale workspace dist after a main pull)..."
   pnpm_install "$PROGRAM_HUB"
   ( cd "$PROGRAM_HUB" && pnpm build >/dev/null 2>&1 ) || true
+  # ads-adm-api imports the @saga-ed/ads-adm-db workspace package from dist/ —
+  # on a fresh clone that dist/ doesn't exist until the sds workspace is built,
+  # so install + build sds too (mirrors rostering/program-hub above). ads-adm-db's
+  # build (tsup) assumes its Prisma client is already generated at src/prisma/
+  # generated/ — turbo build won't do it, so `db:generate` must run FIRST or both
+  # the build and the runtime import of dist/prisma/generated fail.
+  say "reconciling student-data-system deps + workspace build (ads-adm-db dist for ads-adm-api)..."
+  pnpm_install "$SDS"
+  ( cd "$SDS/packages/node/ads-adm-db" && pnpm db:generate >/dev/null 2>&1 ) || true
+  ( cd "$SDS" && pnpm build >/dev/null 2>&1 ) || true
   say "applying prisma schemas (migrate deploy — canonical, see d1.5)…"
   db_step "iam-db migrate deploy"     "$ROSTERING/packages/node/iam-db"     pnpm prisma migrate deploy
   db_step "iam-pii-db db push"        "$ROSTERING/packages/node/iam-pii-db" pnpm prisma db push
@@ -384,7 +394,19 @@ launch(){ # name port dir extra_env...
 }
 
 services_up(){
-  launch iam-api "$IAM_PORT" "$ROSTERING/apps/node/iam-api" PORT="$IAM_PORT"
+  # Drift: soa-logger/soa-config on main now require a PINO_LOGGER config with
+  # no defaults — `level` + `isExpressContext` (DotenvConfigManager reads them as
+  # PINO_LOGGER_LEVEL / PINO_LOGGER_ISEXPRESSCONTEXT). Every soa node service
+  # validates this at startup, so export once here; all `env "$@" pnpm dev`
+  # children inherit it. `:-` lets an external override win. Seed paths use
+  # seed-mode (logger config inline) so they're unaffected.
+  export PINO_LOGGER_LEVEL="${PINO_LOGGER_LEVEL:-info}"
+  export PINO_LOGGER_ISEXPRESSCONTEXT="${PINO_LOGGER_ISEXPRESSCONTEXT:-true}"
+  # AUTH_DEVUSERID must be the seeded dev-user UUID (iam-api refuses to boot with
+  # the 'dev-user-001' default when AUTH_ENABLED=false). apply_fixes only set this
+  # via sed on iam-api/.env, which doesn't exist on a fresh clone — pass it on the
+  # launch env so it's independent of that file.
+  launch iam-api "$IAM_PORT" "$ROSTERING/apps/node/iam-api" PORT="$IAM_PORT" AUTH_DEVUSERID="$DEV_USER_UUID"
   # sis-api → iam-api service.* over S2S; no creds locally (iam-api dev-bypass
   # synthesizes a service actor when auth is off). IAM_BASEURL/IAM_TOKENURL must
   # point at iam on :3010 (sis-api defaults to :3000). See d1.7.


### PR DESCRIPTION
Closes #138.

Brings the synthetic-dev stack up cleanly on a fresh machine. Three drift gaps in `up.sh` made `./up.sh up --reset --seed roster` fail one service at a time; verified all six services reach `200` and `verify.sh` passes 15/15 after these changes.

## Changes (`up.sh`)

1. **PINO_LOGGER config** — export `PINO_LOGGER_LEVEL` / `PINO_LOGGER_ISEXPRESSCONTEXT` in `services_up`. soa-logger/soa-config on `main` require this config with no defaults, and every soa node service validates it at startup. `:-` lets an external override win; seed paths use seed-mode (inline logger) so are unaffected.
2. **AUTH_DEVUSERID** — pass `AUTH_DEVUSERID="$DEV_USER_UUID"` on the iam-api launch line. iam-api refuses to boot with the `dev-user-001` default when `AUTH_ENABLED=false`; `apply_fixes` only set it via `sed` on `iam-api/.env`, which doesn't exist on a fresh clone.
3. **student-data-system prep** — add install + `db:generate` + build (mirroring rostering/program-hub). ads-adm-api imports ads-adm-db's built `dist/` + generated Prisma client; `prep` previously only ran its `migrate deploy`, so both the build and the runtime import of `dist/prisma/generated` failed.

## Also (`integration-suite.tsv`)

Drop the now-empty `rostering` line: #432 landed on `main` (merge 9870cd9) and #410 was dropped, so the suite is empty and every repo runs on `origin/main`. Dated maintenance notes added in-file.

## Verification

```
── service health ──
  ✓ iam-api  ✓ sis-api  ✓ programs-api  ✓ scheduling-api  ✓ ads-adm-api  ✓ saga-dash
── source posture ── all 5 repos on main
✓ all 15 checks passed — stack is ready
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)