### PR TITLE
fix(synthetic-dev): treat an empty pin manifest as success (everyone on main)

### DIFF
--- a/tools/synthetic-dev/refresh-suite.sh
+++ b/tools/synthetic-dev/refresh-suite.sh
@@ -35,14 +35,25 @@ err()  { printf "\033[31m✗\033[0m %s\n" "$*"; }
 
 # Strip comments + blank lines; keep "<repo>\t<prs>" rows.
 rows="$(grep -vE '^\s*(#|$)' "$MANIFEST" || true)"
-[[ -n "$rows" ]] || { err "manifest has no repo rows"; exit 1; }
 
 if [[ "${1:-}" == "--list" ]]; then
   printf "\033[1mPinned integration suite (%s):\033[0m\n" "$MANIFEST"
-  while IFS=$'\t' read -r repo prs; do
-    [[ -z "${repo:-}" ]] && continue
-    printf "  %-20s PRs: %s\n" "$repo" "$prs"
-  done <<<"$rows"
+  if [[ -z "$rows" ]]; then
+    echo "  (none — every repo stays on origin/main)"
+  else
+    while IFS=$'\t' read -r repo prs; do
+      [[ -z "${repo:-}" ]] && continue
+      printf "  %-20s PRs: %s\n" "$repo" "$prs"
+    done <<<"$rows"
+  fi
+  exit 0
+fi
+
+# An empty manifest is a VALID, common state: every pinned PR has landed, so the
+# whole stack just runs on origin/main. Treat it as success (not an error), so
+# bootstrap proceeds — there's simply nothing to replay onto local/integration.
+if [[ -z "$rows" ]]; then
+  ok "no pinned PRs — every repo stays on origin/main (nothing to refresh)"
   exit 0
 fi
 


### PR DESCRIPTION
## What

`refresh-suite.sh` errored with `✗ manifest has no repo rows` and exited 1 when `integration-suite.tsv` had no pinned PRs — which aborted `bootstrap.sh` at its refresh step (step 2/4).

An empty manifest is a valid, common state: once every pinned PR has landed on `main`, there's nothing to replay onto `local/integration` and the whole stack just runs on `origin/main`.

## Change

- Empty manifest → prints `✓ no pinned PRs — every repo stays on origin/main (nothing to refresh)` and exits **0**, so `bootstrap` proceeds.
- `--list` on an empty manifest prints `(none — every repo stays on origin/main)` instead of erroring.

## Test

- `./refresh-suite.sh` (empty manifest) → exit 0 with the info line
- `./refresh-suite.sh --list` → `(none — every repo stays on origin/main)`
- Verified against the current empty `integration-suite.tsv` (0 repo rows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)