### PR TITLE
feat(inspect): @saga-ed/soa-inspect — standard /inspect surface for the sandbox visibility console

### DIFF
--- a/packages/node/inspect/README.md
+++ b/packages/node/inspect/README.md
@@ -1,0 +1,73 @@
+# @saga-ed/soa-inspect
+
+Standard introspection surface for the sandbox visibility console
+([microservices#662](https://github.com/hipponot/microservices/issues/662)).
+A service mounts one router and declares its browsable entities; the console
+discovers everything else from the manifest at runtime — so whatever build is
+actually deployed in a sandbox describes itself (no version skew between the
+console and mixed-variant compositions).
+
+## Surface
+
+| Route | Gate | Returns |
+|---|---|---|
+| `GET /inspect/manifest` | bearer only | service self-description: entities + fields + PII flags, event streams, gate states |
+| `GET /inspect/entities/:name?limit&offset&search` | `ALLOW_INSPECT_ENTITIES` | `{ rows, total, limit, offset }` |
+| `GET /inspect/entities/:name/:id` | `ALLOW_INSPECT_ENTITIES` | `{ row }` |
+| `GET /inspect/status` | `ALLOW_INSPECT_STATUS` | publisher/consumer watermarks for projection-drift checks |
+
+Gate semantics (iam-api admin-gate house pattern): `INSPECT_TOKEN` unset →
+**every** route 404s; bad bearer → 401; per-surface gate off → 404.
+Day-one posture is sandbox + dev only (see #662 auth decision).
+
+## Usage
+
+```ts
+import {
+  canonicalConsumerStatus, canonicalOutboxStatus,
+  createInspectRouter, defineEntity, loadInspectEnv,
+} from '@saga-ed/soa-inspect';
+
+const inspectEnv = loadInspectEnv();
+const sql = (q: string) => pool.query(q).then((r) => r.rows);
+
+app.use('/inspect', createInspectRouter({
+  service: 'things-api',
+  token: inspectEnv.token,
+  gates: inspectEnv.gates,
+  entities: [
+    defineEntity({
+      name: 'things',
+      schema: ThingRowSchema,            // z.object — introspected for the manifest
+      pii: ['ownerEmail'],               // console masks these by default
+      searchFields: ['name'],
+      list: async ({ limit, offset, search }) => { /* prisma/pg query */ },
+      get: async (id) => { /* findUnique */ },
+    }),
+  ],
+  events: { exchange: THINGS_EXCHANGE, published: Object.keys(thingsEvents), consumerNames: ['things.iam-projection'] },
+  status: {
+    outbox: canonicalOutboxStatus(sql),      // services on outbox_event
+    consumers: canonicalConsumerStatus(sql), // services on consumed_events
+  },
+}));
+```
+
+Mount **before** any human-session perimeter (Janus etc.) — the console
+authenticates with the inspect bearer, not a user session.
+
+Services with non-canonical outbox shapes (e.g. iam-api's poll-model
+`event_outbox`) supply their own `status.outbox` callback; the wire shape
+(`OutboxStatusSchema`) is what's fixed, not the table.
+
+## Env
+
+```
+INSPECT_TOKEN=...              # static bearer; unset ⇒ surface is dark
+ALLOW_INSPECT_ENTITIES=true    # PII-bearing entity browsing
+ALLOW_INSPECT_STATUS=true      # projection watermarks (metadata only)
+```
+
+The console-side contract (response Zod schemas) is exported from this
+package — the console validates every service response against
+`InspectManifestSchema` / `EntityListResponseSchema` / `InspectStatusResponseSchema`.

--- a/packages/node/inspect/package.json
+++ b/packages/node/inspect/package.json
@@ -1,0 +1,47 @@
+{
+    "name": "@saga-ed/soa-inspect",
+    "version": "0.1.0-dev.1",
+    "private": false,
+    "type": "module",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
+        }
+    },
+    "files": ["dist"],
+    "scripts": {
+        "build": "tsup",
+        "check-types": "tsc --noEmit",
+        "test": "vitest run --passWithNoTests",
+        "lint": "eslint src/",
+        "clean": "rm -rf dist"
+    },
+    "peerDependencies": {
+        "express": ">=4 <6",
+        "zod": "^3.25.0 || ^4.0.0"
+    },
+    "devDependencies": {
+        "@saga-ed/soa-typescript-config": "workspace:*",
+        "@types/express": "^4.17.21",
+        "@types/node": "^24.0.3",
+        "@types/supertest": "^6.0.2",
+        "express": "^4.18.2",
+        "supertest": "^7.1.0",
+        "tsup": "^8.5.0",
+        "typescript": "5.8.2",
+        "vitest": "^1.6.1",
+        "zod": "^3.25.67"
+    },
+    "publishConfig": {
+        "registry": "https://saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/",
+        "access": "public"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/saga-ed/soa.git",
+        "directory": "packages/node/inspect"
+    }
+}

--- a/packages/node/inspect/src/__tests__/manifest.test.ts
+++ b/packages/node/inspect/src/__tests__/manifest.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { entityFields } from '../manifest.js';
+import { defineEntity } from '../types.js';
+
+function fieldsOf(schema: z.ZodTypeAny, pii: string[] = []) {
+    return entityFields(
+        defineEntity({ name: 't', schema, pii, list: async () => ({ rows: [], total: 0 }) }),
+    );
+}
+
+describe('entityFields', () => {
+    it('extracts primitive types with optional/nullable flags', () => {
+        const fields = fieldsOf(
+            z.object({
+                id: z.string(),
+                count: z.number().nullable(),
+                note: z.string().optional(),
+                active: z.boolean().default(true),
+                at: z.date(),
+            }),
+        );
+        const byName = Object.fromEntries(fields.map((f) => [f.name, f]));
+        expect(byName.id).toMatchObject({ type: 'string', optional: false, nullable: false });
+        expect(byName.count).toMatchObject({ type: 'number', nullable: true });
+        expect(byName.note).toMatchObject({ type: 'string', optional: true });
+        expect(byName.active).toMatchObject({ type: 'boolean', optional: true });
+        expect(byName.at).toMatchObject({ type: 'date' });
+    });
+
+    it('unwraps stacked wrappers (optional + nullable)', () => {
+        const fields = fieldsOf(z.object({ v: z.string().nullable().optional() }));
+        expect(fields[0]).toMatchObject({ type: 'string', optional: true, nullable: true });
+    });
+
+    it('flags pii fields from the descriptor list', () => {
+        const fields = fieldsOf(z.object({ id: z.string(), email: z.string() }), ['email']);
+        expect(fields.find((f) => f.name === 'email')?.pii).toBe(true);
+        expect(fields.find((f) => f.name === 'id')?.pii).toBe(false);
+    });
+
+    it('returns [] for non-object schemas instead of throwing', () => {
+        expect(fieldsOf(z.array(z.string()) as unknown as z.ZodTypeAny)).toEqual([]);
+    });
+});

--- a/packages/node/inspect/src/__tests__/router.test.ts
+++ b/packages/node/inspect/src/__tests__/router.test.ts
@@ -1,0 +1,176 @@
+import express from 'express';
+import request from 'supertest';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { createInspectRouter } from '../router.js';
+import { defineEntity, type InspectConfig } from '../types.js';
+import { EntityListResponseSchema, InspectManifestSchema, InspectStatusResponseSchema } from '../wire.js';
+
+const TOKEN = 'test-inspect-token';
+
+const userRows = [
+    { id: 'u1', username: 'alice@example.org', status: 'ACTIVE' },
+    { id: 'u2', username: 'bob@example.org', status: 'SUSPENDED' },
+];
+
+function usersEntity() {
+    return defineEntity({
+        name: 'users',
+        displayName: 'Users',
+        schema: z.object({
+            id: z.string(),
+            username: z.string(),
+            status: z.string(),
+        }),
+        pii: ['username'],
+        searchFields: ['username'],
+        list: async ({ limit, offset }) => ({ rows: userRows.slice(offset, offset + limit), total: userRows.length }),
+        get: async (id) => userRows.find((u) => u.id === id) ?? null,
+    });
+}
+
+function appWith(overrides: Partial<InspectConfig> = {}) {
+    const config: InspectConfig = {
+        service: 'test-api',
+        entities: [usersEntity()],
+        token: TOKEN,
+        gates: { entities: true, status: true },
+        ...overrides,
+    };
+    const app = express();
+    app.use('/inspect', createInspectRouter(config));
+    return app;
+}
+
+const auth = { Authorization: `Bearer ${TOKEN}` };
+
+describe('createInspectRouter — gate semantics', () => {
+    it('404s every route when no token is configured, even with a bearer', async () => {
+        const app = appWith({ token: undefined });
+        for (const path of ['/inspect/manifest', '/inspect/status', '/inspect/entities/users']) {
+            const res = await request(app).get(path).set(auth);
+            expect(res.status).toBe(404);
+        }
+    });
+
+    it('401s a wrong or missing bearer when the token is configured', async () => {
+        const app = appWith();
+        expect((await request(app).get('/inspect/manifest')).status).toBe(401);
+        expect(
+            (await request(app).get('/inspect/manifest').set({ Authorization: 'Bearer nope' })).status,
+        ).toBe(401);
+    });
+
+    it('404s entity routes when the entities gate is off (manifest still serves)', async () => {
+        const app = appWith({ gates: { entities: false, status: true } });
+        expect((await request(app).get('/inspect/entities/users').set(auth)).status).toBe(404);
+        const manifest = await request(app).get('/inspect/manifest').set(auth);
+        expect(manifest.status).toBe(200);
+        expect(manifest.body.gates).toEqual({ entities: false, status: true });
+    });
+
+    it('404s status when the status gate is off', async () => {
+        const app = appWith({ gates: { entities: true, status: false } });
+        expect((await request(app).get('/inspect/status').set(auth)).status).toBe(404);
+    });
+
+    it('404s unknown paths under the mount', async () => {
+        const app = appWith();
+        expect((await request(app).get('/inspect/nope').set(auth)).status).toBe(404);
+    });
+});
+
+describe('createInspectRouter — manifest', () => {
+    it('serves a schema-valid manifest with field, pii, and capability info', async () => {
+        const app = appWith({
+            events: { exchange: 'test.events', published: ['test.thing.created.v1'], consumerNames: [] },
+        });
+        const res = await request(app).get('/inspect/manifest').set(auth);
+        expect(res.status).toBe(200);
+        const manifest = InspectManifestSchema.parse(res.body);
+        expect(manifest.service).toBe('test-api');
+        const users = manifest.entities.find((e) => e.name === 'users');
+        expect(users?.supportsGet).toBe(true);
+        expect(users?.fields.find((f) => f.name === 'username')?.pii).toBe(true);
+        expect(users?.fields.find((f) => f.name === 'id')?.pii).toBe(false);
+        expect(manifest.events?.exchange).toBe('test.events');
+    });
+});
+
+describe('createInspectRouter — entities', () => {
+    it('lists rows with paging defaults and a schema-valid response', async () => {
+        const res = await request(appWith()).get('/inspect/entities/users').set(auth);
+        expect(res.status).toBe(200);
+        const body = EntityListResponseSchema.parse(res.body);
+        expect(body.total).toBe(2);
+        expect(body.rows).toHaveLength(2);
+        expect(body.limit).toBe(50);
+    });
+
+    it('clamps limit via 400 rather than silently truncating', async () => {
+        const res = await request(appWith()).get('/inspect/entities/users?limit=9999').set(auth);
+        expect(res.status).toBe(400);
+    });
+
+    it('passes paging through to the descriptor', async () => {
+        const res = await request(appWith()).get('/inspect/entities/users?limit=1&offset=1').set(auth);
+        expect(res.body.rows).toEqual([userRows[1]]);
+        expect(res.body.total).toBe(2);
+    });
+
+    it('gets a row by id and 404s a miss', async () => {
+        const app = appWith();
+        const hit = await request(app).get('/inspect/entities/users/u1').set(auth);
+        expect(hit.status).toBe(200);
+        expect(hit.body.row.id).toBe('u1');
+        expect((await request(app).get('/inspect/entities/users/zzz').set(auth)).status).toBe(404);
+    });
+
+    it('404s an unknown entity and an entity without get()', async () => {
+        const noGet = defineEntity({
+            name: 'plain',
+            schema: z.object({ id: z.string() }),
+            list: async () => ({ rows: [], total: 0 }),
+        });
+        const app = appWith({ entities: [noGet] });
+        expect((await request(app).get('/inspect/entities/unknown').set(auth)).status).toBe(404);
+        expect((await request(app).get('/inspect/entities/plain/x').set(auth)).status).toBe(404);
+    });
+
+    it('500s with the underlying message when a descriptor throws', async () => {
+        const broken = defineEntity({
+            name: 'broken',
+            schema: z.object({ id: z.string() }),
+            list: async () => {
+                throw new Error('db is down');
+            },
+        });
+        const res = await request(appWith({ entities: [broken] })).get('/inspect/entities/broken').set(auth);
+        expect(res.status).toBe(500);
+        expect(res.body.error).toBe('db is down');
+    });
+});
+
+describe('createInspectRouter — status', () => {
+    it('reports provider results in a schema-valid response', async () => {
+        const app = appWith({
+            status: {
+                outbox: async () => ({ headOccurredAt: '2026-06-10T00:00:00.000Z', headPosition: '42' }),
+                consumers: async () => [
+                    { consumerName: 'test.iam-projection', lastProcessedAt: null, consumedCount: 0 },
+                ],
+            },
+        });
+        const res = await request(app).get('/inspect/status').set(auth);
+        expect(res.status).toBe(200);
+        const body = InspectStatusResponseSchema.parse(res.body);
+        expect(body.outbox?.headPosition).toBe('42');
+        expect(body.consumers[0]?.consumerName).toBe('test.iam-projection');
+    });
+
+    it('defaults to no outbox / no consumers when no providers are wired', async () => {
+        const res = await request(appWith()).get('/inspect/status').set(auth);
+        expect(res.body.outbox).toBeNull();
+        expect(res.body.consumers).toEqual([]);
+    });
+});

--- a/packages/node/inspect/src/auth.ts
+++ b/packages/node/inspect/src/auth.ts
@@ -1,0 +1,21 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+
+const BEARER_PREFIX = 'Bearer ';
+
+/**
+ * Constant-time bearer compare (same construction as iam-api's admin gates).
+ * Hashes both sides with SHA-256 first so inputs are always the same length —
+ * `timingSafeEqual` throws on length mismatch, which is itself a side-channel.
+ */
+export function tokensMatch(submitted: string, expected: string): boolean {
+    const a = createHash('sha256').update(submitted).digest();
+    const b = createHash('sha256').update(expected).digest();
+    return timingSafeEqual(a, b);
+}
+
+/** Extracts the token from an `Authorization: Bearer …` header, else null. */
+export function bearerToken(authorizationHeader: string | undefined): string | null {
+    if (!authorizationHeader?.startsWith(BEARER_PREFIX)) return null;
+    const token = authorizationHeader.slice(BEARER_PREFIX.length);
+    return token.length > 0 ? token : null;
+}

--- a/packages/node/inspect/src/env.ts
+++ b/packages/node/inspect/src/env.ts
@@ -1,0 +1,27 @@
+import type { InspectGates } from './wire.js';
+
+export interface InspectEnv {
+    token: string | undefined;
+    gates: InspectGates;
+}
+
+/**
+ * Standard env surface, shared fleet-wide so sandbox deploy workflows can
+ * inject one uniform trio per service:
+ *
+ *   INSPECT_TOKEN            — static bearer (unset ⇒ surface is dark)
+ *   ALLOW_INSPECT_ENTITIES   — 'true' to enable entity browsing (PII-bearing)
+ *   ALLOW_INSPECT_STATUS     — 'true' to enable projection-status reporting
+ *
+ * Naming follows the iam-api admin-gate convention (ALLOW_* + *_TOKEN).
+ */
+export function loadInspectEnv(env: NodeJS.ProcessEnv = process.env): InspectEnv {
+    const bool = (value: string | undefined): boolean => value?.toLowerCase() === 'true';
+    return {
+        token: env.INSPECT_TOKEN,
+        gates: {
+            entities: bool(env.ALLOW_INSPECT_ENTITIES),
+            status: bool(env.ALLOW_INSPECT_STATUS),
+        },
+    };
+}

--- a/packages/node/inspect/src/index.ts
+++ b/packages/node/inspect/src/index.ts
@@ -1,0 +1,36 @@
+export { bearerToken, tokensMatch } from './auth.js';
+export { loadInspectEnv, type InspectEnv } from './env.js';
+export { buildManifest, entityFields } from './manifest.js';
+export { createInspectRouter } from './router.js';
+export { canonicalConsumerStatus, canonicalOutboxStatus, type SqlQuery } from './status.js';
+export {
+    defineEntity,
+    type AnyEntityDescriptor,
+    type EntityDescriptor,
+    type InspectConfig,
+    type InspectLogger,
+    type ListResult,
+    type StatusProviders,
+} from './types.js';
+export {
+    ConsumerStatusSchema,
+    EntityFieldInfoSchema,
+    EntityListResponseSchema,
+    InspectEventsInfoSchema,
+    InspectGatesSchema,
+    InspectManifestSchema,
+    InspectStatusResponseSchema,
+    ListQuerySchema,
+    ManifestEntitySchema,
+    OutboxStatusSchema,
+    type ConsumerStatus,
+    type EntityFieldInfo,
+    type EntityListResponse,
+    type InspectEventsInfo,
+    type InspectGates,
+    type InspectManifest,
+    type InspectStatusResponse,
+    type ListQuery,
+    type ManifestEntity,
+    type OutboxStatus,
+} from './wire.js';

--- a/packages/node/inspect/src/manifest.ts
+++ b/packages/node/inspect/src/manifest.ts
@@ -1,0 +1,73 @@
+import type { AnyEntityDescriptor, InspectConfig } from './types.js';
+import type { EntityFieldInfo, InspectManifest, ManifestEntity } from './wire.js';
+
+// Zod-version-agnostic introspection. We deliberately duck-type instead of
+// instanceof-checking: the descriptor's zod instance is the *service's* copy
+// (zod is a peer dependency), and the fleet currently spans zod 3.25 and 4.x.
+interface ZodDefLike {
+    typeName?: string; // zod 3
+    innerType?: unknown; // ZodOptional / ZodNullable / ZodDefault wrappers
+    type?: string; // zod 4 (_zod.def.type)
+}
+
+function defOf(schema: unknown): ZodDefLike {
+    const s = schema as { _def?: ZodDefLike; _zod?: { def?: ZodDefLike } };
+    return s?._zod?.def ?? s?._def ?? {};
+}
+
+function typeNameOf(schema: unknown): string {
+    const def = defOf(schema);
+    if (typeof def.type === 'string') return def.type; // zod 4: 'string', 'number', …
+    if (typeof def.typeName === 'string') {
+        return def.typeName.replace(/^Zod/, '').toLowerCase(); // zod 3: 'ZodString' → 'string'
+    }
+    const ctor = (schema as { constructor?: { name?: string } })?.constructor?.name ?? 'unknown';
+    return ctor.replace(/^Zod/, '').toLowerCase();
+}
+
+const WRAPPERS = new Set(['optional', 'nullable', 'default']);
+
+/** Derives display field info from a descriptor's z.object schema. Returns []
+ * for non-object schemas — the entity still lists, the console just renders
+ * keys dynamically. */
+export function entityFields(descriptor: AnyEntityDescriptor): EntityFieldInfo[] {
+    const shape = (descriptor.schema as unknown as { shape?: Record<string, unknown> }).shape;
+    if (!shape || typeof shape !== 'object') return [];
+    const pii = new Set(descriptor.pii ?? []);
+
+    return Object.entries(shape).map(([name, fieldSchema]) => {
+        let optional = false;
+        let nullable = false;
+        let current: unknown = fieldSchema;
+        for (let depth = 0; depth < 8; depth++) {
+            const typeName = typeNameOf(current);
+            if (!WRAPPERS.has(typeName)) break;
+            if (typeName === 'optional' || typeName === 'default') optional = true;
+            if (typeName === 'nullable') nullable = true;
+            const inner = defOf(current).innerType;
+            if (inner === undefined) break;
+            current = inner;
+        }
+        return { name, type: typeNameOf(current), optional, nullable, pii: pii.has(name) };
+    });
+}
+
+function manifestEntity(descriptor: AnyEntityDescriptor): ManifestEntity {
+    return {
+        name: descriptor.name,
+        ...(descriptor.displayName !== undefined ? { displayName: descriptor.displayName } : {}),
+        fields: entityFields(descriptor),
+        searchFields: descriptor.searchFields ?? [],
+        supportsGet: typeof descriptor.get === 'function',
+    };
+}
+
+export function buildManifest(config: InspectConfig): InspectManifest {
+    return {
+        service: config.service,
+        contractVersion: 1,
+        gates: config.gates,
+        entities: config.entities.map(manifestEntity),
+        ...(config.events !== undefined ? { events: config.events } : {}),
+    };
+}

--- a/packages/node/inspect/src/router.ts
+++ b/packages/node/inspect/src/router.ts
@@ -1,0 +1,111 @@
+import { Router, type Request, type Response } from 'express';
+import { bearerToken, tokensMatch } from './auth.js';
+import { buildManifest } from './manifest.js';
+import type { AnyEntityDescriptor, InspectConfig } from './types.js';
+import { ListQuerySchema } from './wire.js';
+
+function notFound(res: Response): void {
+    // Same body whether the surface is unconfigured, the gate is off, or the
+    // entity doesn't exist — an unauthorized prober learns nothing.
+    res.status(404).json({ error: 'Not found' });
+}
+
+function internalError(config: InspectConfig, res: Response, where: string, err: unknown): void {
+    const message = err instanceof Error ? err.message : String(err);
+    config.logger?.error(`soa-inspect ${where} failed: ${message}`);
+    // The only caller is the trusted console BFF; surfacing the message is
+    // what makes the inspector useful against a half-broken service.
+    res.status(500).json({ error: message });
+}
+
+/**
+ * The inspect surface (microservices#662). Mount BEFORE any human-session
+ * perimeter (it authenticates with the console's bearer, not a user session):
+ *
+ *   app.use('/inspect', createInspectRouter({ ... }));
+ *
+ * Gate semantics (mirrors the iam-api admin-gate house pattern):
+ *   - no token configured  → every route 404s (default-off)
+ *   - bad/missing bearer   → 401
+ *   - per-surface gate off → 404
+ */
+export function createInspectRouter(config: InspectConfig): Router {
+    const router = Router();
+    const expected = config.token;
+
+    if (!expected) {
+        router.use((_req: Request, res: Response) => notFound(res));
+        return router;
+    }
+
+    router.use((req: Request, res: Response, next: () => void) => {
+        const submitted = bearerToken(req.headers.authorization);
+        if (!submitted || !tokensMatch(submitted, expected)) {
+            res.status(401).json({ error: 'Invalid inspect credentials' });
+            return;
+        }
+        next();
+    });
+
+    // Manifest is metadata-only by design (entity/field names, event keys,
+    // gate states) — available to any valid bearer so the console can show
+    // *why* a surface is dark instead of a bare 404.
+    router.get('/manifest', (_req: Request, res: Response) => {
+        res.json(buildManifest(config));
+    });
+
+    router.get('/status', (_req: Request, res: Response) => {
+        if (!config.gates.status) return notFound(res);
+        void (async () => {
+            const [outbox, consumers] = await Promise.all([
+                config.status?.outbox?.() ?? Promise.resolve(null),
+                config.status?.consumers?.() ?? Promise.resolve([]),
+            ]);
+            res.json({
+                service: config.service,
+                generatedAt: new Date().toISOString(),
+                outbox,
+                consumers,
+            });
+        })().catch((err: unknown) => internalError(config, res, 'status', err));
+    });
+
+    const findEntity = (name: string): AnyEntityDescriptor | undefined =>
+        config.entities.find((e) => e.name === name);
+
+    router.get('/entities/:entity', (req: Request, res: Response) => {
+        if (!config.gates.entities) return notFound(res);
+        const descriptor = findEntity(req.params.entity ?? '');
+        if (!descriptor) return notFound(res);
+        const parsed = ListQuerySchema.safeParse(req.query);
+        if (!parsed.success) {
+            res.status(400).json({ error: 'Invalid list query', issues: parsed.error.issues });
+            return;
+        }
+        const query = parsed.data;
+        void descriptor
+            .list(query)
+            .then(({ rows, total }) => {
+                res.json({ entity: descriptor.name, rows, total, limit: query.limit, offset: query.offset });
+            })
+            .catch((err: unknown) => internalError(config, res, `entities/${descriptor.name}`, err));
+    });
+
+    router.get('/entities/:entity/:id', (req: Request, res: Response) => {
+        if (!config.gates.entities) return notFound(res);
+        const descriptor = findEntity(req.params.entity ?? '');
+        if (!descriptor?.get) return notFound(res);
+        void descriptor
+            .get(req.params.id ?? '')
+            .then((row) => {
+                if (row === null) return notFound(res);
+                res.json({ entity: descriptor.name, row });
+            })
+            .catch((err: unknown) => internalError(config, res, `entities/${descriptor.name}/get`, err));
+    });
+
+    // Anything else under the mount answers like the gates-off case.
+    router.use((_req: Request, res: Response) => notFound(res));
+
+    return router;
+}

--- a/packages/node/inspect/src/status.ts
+++ b/packages/node/inspect/src/status.ts
@@ -1,0 +1,95 @@
+import type { ConsumerStatus, OutboxStatus } from './wire.js';
+
+/**
+ * Minimal SQL runner so services can back status providers with whatever
+ * client they already hold — a pg Pool (`(sql) => pool.query(sql).then(r => r.rows)`)
+ * or Prisma (`(sql) => prisma.$queryRawUnsafe(sql)`). Statements are
+ * package-authored constants over validated identifiers; no caller input
+ * reaches the SQL text.
+ */
+export type SqlQuery = (sql: string) => Promise<Array<Record<string, unknown>>>;
+
+const IDENTIFIER = /^[a-z_][a-z0-9_]*$/;
+
+function assertIdentifier(table: string): void {
+    if (!IDENTIFIER.test(table)) {
+        throw new Error(`soa-inspect: invalid table identifier '${table}'`);
+    }
+}
+
+function toIso(value: unknown): string | null {
+    if (value == null) return null;
+    if (value instanceof Date) return value.toISOString();
+    const parsed = new Date(String(value));
+    return Number.isNaN(parsed.getTime()) ? String(value) : parsed.toISOString();
+}
+
+function toInt(value: unknown): number {
+    const n = typeof value === 'bigint' ? Number(value) : Number(value ?? 0);
+    return Number.isFinite(n) ? n : 0;
+}
+
+/** True for "relation does not exist" from pg (42P01) or Prisma raw-query wrappers. */
+function isUndefinedTable(err: unknown): boolean {
+    const e = err as { code?: string; meta?: { code?: string }; message?: string };
+    return (
+        e?.code === '42P01' ||
+        e?.meta?.code === '42P01' ||
+        /relation .* does not exist/i.test(e?.message ?? '')
+    );
+}
+
+/**
+ * Publisher watermark for services on the canonical `outbox_event` table
+ * (@saga-ed/soa-event-outbox). Returns null if the table doesn't exist —
+ * callers can wire this unconditionally and non-publishers report no outbox.
+ */
+export function canonicalOutboxStatus(query: SqlQuery, table = 'outbox_event'): () => Promise<OutboxStatus | null> {
+    assertIdentifier(table);
+    const sql =
+        `SELECT max(occurred_at) AS head_occurred_at, ` +
+        `max(published_at) AS last_published_at, ` +
+        `(count(*) FILTER (WHERE published_at IS NULL))::int AS unpublished_count ` +
+        `FROM ${table}`;
+    return async () => {
+        let rows: Array<Record<string, unknown>>;
+        try {
+            rows = await query(sql);
+        } catch (err) {
+            if (isUndefinedTable(err)) return null;
+            throw err;
+        }
+        const row = rows[0] ?? {};
+        return {
+            headOccurredAt: toIso(row.head_occurred_at),
+            lastPublishedAt: toIso(row.last_published_at),
+            unpublishedCount: toInt(row.unpublished_count),
+        };
+    };
+}
+
+/**
+ * Consumer watermarks for services on the canonical `consumed_events` table
+ * (@saga-ed/soa-event-consumer). One row per consumer_name; [] if the table
+ * doesn't exist (service projects nothing).
+ */
+export function canonicalConsumerStatus(query: SqlQuery, table = 'consumed_events'): () => Promise<ConsumerStatus[]> {
+    assertIdentifier(table);
+    const sql =
+        `SELECT consumer_name, max(processed_at) AS last_processed_at, count(*)::int AS consumed_count ` +
+        `FROM ${table} GROUP BY consumer_name ORDER BY consumer_name`;
+    return async () => {
+        let rows: Array<Record<string, unknown>>;
+        try {
+            rows = await query(sql);
+        } catch (err) {
+            if (isUndefinedTable(err)) return [];
+            throw err;
+        }
+        return rows.map((row) => ({
+            consumerName: String(row.consumer_name),
+            lastProcessedAt: toIso(row.last_processed_at),
+            consumedCount: toInt(row.consumed_count),
+        }));
+    };
+}

--- a/packages/node/inspect/src/types.ts
+++ b/packages/node/inspect/src/types.ts
@@ -1,0 +1,71 @@
+import type { ZodType } from 'zod';
+import type { ConsumerStatus, InspectEventsInfo, InspectGates, ListQuery, OutboxStatus } from './wire.js';
+
+export interface ListResult<T> {
+    rows: T[];
+    total: number;
+}
+
+/**
+ * One browsable entity, declared by the service that owns it. This is the
+ * whole per-service integration surface: a name, a row schema (introspected
+ * into the manifest so the console can render without service-specific
+ * code), PII field names, and the queries.
+ */
+export interface EntityDescriptor<T> {
+    /** URL-safe key, e.g. 'users'. Unique within the service. */
+    name: string;
+    displayName?: string;
+    /** Row shape. Must be a z.object(...) for manifest field extraction. */
+    schema: ZodType<T>;
+    /** Field names the console masks by default. */
+    pii?: string[];
+    /** Fields the `search` query param matches against (documentation for
+     * the console; the list() implementation owns the actual behavior). */
+    searchFields?: string[];
+    list(query: ListQuery): Promise<ListResult<T>>;
+    get?(id: string): Promise<T | null>;
+}
+
+// Descriptors are declared with concrete row types but stored heterogeneously.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AnyEntityDescriptor = EntityDescriptor<any>;
+
+/** Erases the row type so concretely-typed descriptors can share a config array. */
+export function defineEntity<T>(descriptor: EntityDescriptor<T>): AnyEntityDescriptor {
+    return descriptor;
+}
+
+/**
+ * Publisher/consumer watermark providers. Callbacks rather than table names
+ * because outbox shapes legitimately differ across the fleet (iam-api's
+ * `event_outbox` is a poll-model bigserial outbox with no published_at;
+ * canonical relay services use `outbox_event`). Services on the canonical
+ * tables can use canonicalOutboxStatus()/canonicalConsumerStatus().
+ */
+export interface StatusProviders {
+    outbox?: () => Promise<OutboxStatus | null>;
+    consumers?: () => Promise<ConsumerStatus[]>;
+}
+
+/** Minimal logger so the package doesn't depend on a logging framework. */
+export interface InspectLogger {
+    warn(message: string): void;
+    error(message: string): void;
+}
+
+export interface InspectConfig {
+    /** Service identity reported in every response, e.g. 'iam-api'. */
+    service: string;
+    entities: AnyEntityDescriptor[];
+    events?: InspectEventsInfo;
+    status?: StatusProviders;
+    /**
+     * Static bearer expected from the console BFF (microservices#662 auth
+     * decision). Undefined ⇒ the whole surface answers 404, indistinguishable
+     * from a service without soa-inspect — default-off is the contract.
+     */
+    token: string | undefined;
+    gates: InspectGates;
+    logger?: InspectLogger;
+}

--- a/packages/node/inspect/src/wire.ts
+++ b/packages/node/inspect/src/wire.ts
@@ -1,0 +1,100 @@
+// Wire contract for the inspect surface (microservices#662). These schemas
+// are the single source of truth for what travels between a service's
+// /inspect router and the sandbox visibility console — the console validates
+// every response against them, so a service on an older soa-inspect version
+// fails loudly instead of rendering garbage.
+import { z } from 'zod';
+
+// ---- Manifest ----
+
+export const EntityFieldInfoSchema = z.object({
+    name: z.string(),
+    /** Best-effort primitive hint derived from the descriptor's Zod schema
+     * (string | number | boolean | date | enum | …). Display hint only —
+     * the console must not branch on values outside this set. */
+    type: z.string(),
+    optional: z.boolean(),
+    nullable: z.boolean(),
+    /** Console masks these by default (click-to-reveal). */
+    pii: z.boolean(),
+});
+export type EntityFieldInfo = z.infer<typeof EntityFieldInfoSchema>;
+
+export const ManifestEntitySchema = z.object({
+    name: z.string(),
+    displayName: z.string().optional(),
+    fields: z.array(EntityFieldInfoSchema),
+    searchFields: z.array(z.string()),
+    supportsGet: z.boolean(),
+});
+export type ManifestEntity = z.infer<typeof ManifestEntitySchema>;
+
+export const InspectEventsInfoSchema = z.object({
+    exchange: z.string().optional(),
+    /** Published event keys, e.g. 'iam.user.created.v1'. */
+    published: z.array(z.string()).optional(),
+    /** consumed_events.consumer_name values this service projects under. */
+    consumerNames: z.array(z.string()).optional(),
+});
+export type InspectEventsInfo = z.infer<typeof InspectEventsInfoSchema>;
+
+export const InspectGatesSchema = z.object({
+    entities: z.boolean(),
+    status: z.boolean(),
+});
+export type InspectGates = z.infer<typeof InspectGatesSchema>;
+
+export const InspectManifestSchema = z.object({
+    service: z.string(),
+    contractVersion: z.literal(1),
+    gates: InspectGatesSchema,
+    entities: z.array(ManifestEntitySchema),
+    events: InspectEventsInfoSchema.optional(),
+});
+export type InspectManifest = z.infer<typeof InspectManifestSchema>;
+
+// ---- Projection status ----
+
+export const OutboxStatusSchema = z.object({
+    /** Monotonic publisher head when the outbox has one (e.g. max(id)). */
+    headPosition: z.string().nullable().optional(),
+    headOccurredAt: z.string().nullable(),
+    unpublishedCount: z.number().int().nullable().optional(),
+    lastPublishedAt: z.string().nullable().optional(),
+});
+export type OutboxStatus = z.infer<typeof OutboxStatusSchema>;
+
+export const ConsumerStatusSchema = z.object({
+    consumerName: z.string(),
+    lastProcessedAt: z.string().nullable(),
+    consumedCount: z.number().int(),
+});
+export type ConsumerStatus = z.infer<typeof ConsumerStatusSchema>;
+
+export const InspectStatusResponseSchema = z.object({
+    service: z.string(),
+    generatedAt: z.string(),
+    /** null when this service publishes no events (or its outbox table is absent). */
+    outbox: OutboxStatusSchema.nullable(),
+    /** Empty when this service projects nothing. */
+    consumers: z.array(ConsumerStatusSchema),
+});
+export type InspectStatusResponse = z.infer<typeof InspectStatusResponseSchema>;
+
+// ---- Entity listing ----
+
+export const ListQuerySchema = z.object({
+    limit: z.coerce.number().int().positive().max(200).default(50),
+    offset: z.coerce.number().int().nonnegative().default(0),
+    search: z.string().trim().min(1).optional(),
+});
+export type ListQuery = z.infer<typeof ListQuerySchema>;
+
+export const EntityListResponseSchema = z.object({
+    entity: z.string(),
+    rows: z.array(z.record(z.string(), z.unknown())),
+    total: z.number().int(),
+    limit: z.number().int(),
+    offset: z.number().int(),
+});
+export type EntityListResponse = z.infer<typeof EntityListResponseSchema>;

--- a/packages/node/inspect/tsconfig.json
+++ b/packages/node/inspect/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "@saga-ed/soa-typescript-config/base.json",
+    "compilerOptions": {
+        "outDir": "./dist",
+        "rootDir": "./src",
+        "noEmit": true,
+        "esModuleInterop": true
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/node/inspect/tsup.config.ts
+++ b/packages/node/inspect/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+    entry: ['src/index.ts'],
+    format: ['esm'],
+    dts: true,
+    clean: true,
+    sourcemap: true,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1150,6 +1150,39 @@ importers:
         specifier: ^1.5.0
         version: 1.6.1(@types/node@25.9.2)(jsdom@25.0.1)
 
+  packages/node/inspect:
+    devDependencies:
+      '@saga-ed/soa-typescript-config':
+        specifier: workspace:*
+        version: link:../../core/typescript-config
+      '@types/express':
+        specifier: ^4.17.21
+        version: 4.17.25
+      '@types/node':
+        specifier: ^24.0.3
+        version: 24.0.12
+      '@types/supertest':
+        specifier: ^6.0.2
+        version: 6.0.3
+      express:
+        specifier: ^4.18.2
+        version: 4.22.1
+      supertest:
+        specifier: ^7.1.0
+        version: 7.1.4
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.2)(yaml@2.8.2)
+      typescript:
+        specifier: 5.8.2
+        version: 5.8.2
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@24.0.12)(jsdom@25.0.1)
+      zod:
+        specifier: ^3.25.67
+        version: 3.25.67
+
   packages/node/logger:
     dependencies:
       inversify:
@@ -15337,7 +15370,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## What

New package `@saga-ed/soa-inspect` — the standard introspection surface for the **sandbox visibility console** (hipponot/microservices#662). A service mounts one express router and declares its browsable entities; the console discovers everything else from the manifest at runtime. Because the surface ships *inside* each service build, whatever variant is actually deployed in a sandbox describes itself — no version skew between the console and mixed-variant compositions.

## Surface

| Route | Gate | Returns |
|---|---|---|
| `GET /inspect/manifest` | bearer only | entities + fields + PII flags, event streams, gate states |
| `GET /inspect/entities/:name?limit&offset&search` | `ALLOW_INSPECT_ENTITIES` | `{ rows, total, limit, offset }` |
| `GET /inspect/entities/:name/:id` | `ALLOW_INSPECT_ENTITIES` | `{ row }` |
| `GET /inspect/status` | `ALLOW_INSPECT_STATUS` | publisher/consumer watermarks for drift checks |

Gate semantics follow the iam-api admin-gate house pattern: `INSPECT_TOKEN` unset → **every** route 404s (default-off); bad bearer → 401 (timing-safe compare); per-surface gate off → 404. Day-one posture is sandbox + dev only — see the auth decision on hipponot/microservices#662.

## Design notes

- **REST, not a tRPC fragment**: a package-provided tRPC router can't merge into each service's own `initTRPC` instance, and REST avoids coupling the fleet to a tRPC version. The wire contract is the exported Zod schemas (`InspectManifestSchema`, `EntityListResponseSchema`, `InspectStatusResponseSchema`) — the console validates every response against them.
- **Status providers are callbacks** with canonical helpers for `outbox_event` / `consumed_events`. Outbox shapes legitimately differ (iam-api's `event_outbox` is a poll-model bigserial outbox with no `published_at`); the wire shape is what's fixed, not the table.
- **PII flags in descriptors from day one** — the console masks flagged fields by default.
- zod 3.25/4.x compatible (duck-typed schema introspection; the descriptor's zod instance is the service's copy via peer dep).

## Verification

- `pnpm build` (tsup + dts), `pnpm check-types`, `pnpm lint` clean; **18/18 unit tests** (gate semantics, manifest, paging, status, error surfacing).
- Piloted end-to-end in iam-api against a live boot + real dev DB (companion rostering PR): 401/200 auth behavior, manifest with PII flags, real `event_outbox` watermark, entity list + get-by-id round trips.

## Sequencing

`0.1.0-dev.1` must publish to CodeArtifact after merge **before** the companion rostering PR (iam-api pilot) can resolve it.
