### PR TITLE
synthetic-dev: keep siblings in sync + fail loudly (up --pull, verify freshness, restart --login, saga-dash install)

### DIFF
--- a/tools/synthetic-dev/up.sh
+++ b/tools/synthetic-dev/up.sh
@@ -29,6 +29,7 @@
 #
 # Usage:
 #   ./up.sh                      bring up mesh + 6 services (empty)
+#   ./up.sh up --pull            ff-only sync all siblings to origin, then build/migrate
 #   ./up.sh --seed [roster|full] seed synthetic data (default: roster)
 #                                  roster = iam roster only (programs empty → from-scratch)
 #                                  full   = iam roster + programs/periods/enrollment
@@ -352,6 +353,34 @@ migrate_db(){ # dir db_name [database_url — override to point prisma at the me
   fi
 }
 
+# --pull: fast-forward each sibling repo to its upstream before building. ff-ONLY,
+# skipping repos that are dirty, detached, upstream-less, or diverged (with a
+# warning) — so it never clobbers local work or moves you off a feature branch.
+# Kills the recurring trap of building/migrating a checkout silently behind origin
+# (e.g. program-hub hundreds of commits stale → 404s on new endpoints).
+pull_repos(){
+  say "pulling siblings to upstream (ff-only)…"
+  local kv dir name dirty br behind
+  for kv in "$SOA:soa" "$ROSTERING:rostering" "$PROGRAM_HUB:program-hub" \
+            "$SAGA_DASH:saga-dash" "$SDS:student-data-system"; do
+    dir=${kv%:*}; name=${kv#*:}
+    [[ -d "$dir/.git" ]] || { printf "\033[33m⚠\033[0m %-20s not cloned — skipping\n" "$name"; continue; }
+    dirty=$(git -C "$dir" status --porcelain 2>/dev/null | grep -v '^??' || true)
+    [[ -z "$dirty" ]] || { printf "\033[33m⚠\033[0m %-20s uncommitted changes — skipping\n" "$name"; continue; }
+    git -C "$dir" fetch -q origin 2>/dev/null || { printf "\033[33m⚠\033[0m %-20s fetch failed — skipping\n" "$name"; continue; }
+    br=$(git -C "$dir" branch --show-current 2>/dev/null)
+    [[ -n "$br" ]] || { printf "\033[33m⚠\033[0m %-20s detached HEAD — skipping\n" "$name"; continue; }
+    git -C "$dir" rev-parse --abbrev-ref '@{u}' >/dev/null 2>&1 || { printf "\033[33m⚠\033[0m %-20s %s has no upstream — skipping\n" "$name" "$br"; continue; }
+    behind=$(git -C "$dir" rev-list --count "HEAD..@{u}" 2>/dev/null || echo 0)
+    if [[ "$behind" -eq 0 ]]; then ok "$name up to date ($br)"; continue; fi
+    if git -C "$dir" merge --ff-only '@{u}' >/dev/null 2>&1; then
+      ok "$name fast-forwarded $behind commit(s) ($br)"
+    else
+      printf "\033[33m⚠\033[0m %-20s %s diverged from upstream — skipping (pull by hand)\n" "$name" "$br"
+    fi
+  done
+}
+
 prep(){
   say "reconciling rostering deps + workspace build (main switch is not dep-neutral)…"
   pnpm_install "$ROSTERING"
@@ -586,7 +615,7 @@ status(){
 }
 
 # ── arg parsing: verbs (up/down/status/help) + composable flags ──────
-DO_UP=0; DO_RESET=0; DO_RESTART=0; DO_SEED=0; SEED_MODE=roster; DO_LOGIN=0; LOGIN_USER=$DEFAULT_LOGIN_USER
+DO_UP=0; DO_RESET=0; DO_RESTART=0; DO_PULL=0; DO_SEED=0; SEED_MODE=roster; DO_LOGIN=0; LOGIN_USER=$DEFAULT_LOGIN_USER
 case "${1:-up}" in
   # `shift || true`: bare `./up.sh` defaults ${1:-up} to "up" but leaves $# at 0,
   # so an unguarded shift returns 1 and `set -e` kills the script before it runs.
@@ -600,7 +629,7 @@ case "${1:-up}" in
   restart|--restart)             DO_RESTART=1; shift || true ;;
   --status)                      status; exit 0 ;;
   -h|--help)                     sed -n '2,51p' "$0"; exit 0 ;;
-  --reset|--seed|--login|--user) ;;        # flag-only invocation; skip up
+  --reset|--seed|--login|--user|--pull) ;; # flag-only invocation; skip up
   *) echo "unknown: $1 (use --help)"; exit 1 ;;
 esac
 while [[ $# -gt 0 ]]; do
@@ -609,12 +638,14 @@ while [[ $# -gt 0 ]]; do
     --seed)  DO_SEED=1; shift; case "${1:-}" in roster|full) SEED_MODE=$1; shift ;; esac ;;
     # --login / --user [email]: optional positional email; bare or next-flag → default persona
     --login|--user) DO_LOGIN=1; shift; case "${1:-}" in ''|--*) ;; *) LOGIN_USER=$1; shift ;; esac ;;
+    --pull) DO_PULL=1; shift ;;
     *) echo "unknown flag: $1 (use --help)"; exit 1 ;;
   esac
 done
 
 # `up` does first-run prep (branch posture, fixups, mesh, schema). A bare
 # `--reset` (no `up` verb) skips prep and assumes a running mesh.
+[[ $DO_PULL == 1 ]] && pull_repos        # ff-only sync siblings BEFORE we build/migrate
 if [[ $DO_UP == 1 ]]; then
   check_branches; apply_fixes; mesh_up; prep
 fi

--- a/tools/synthetic-dev/up.sh
+++ b/tools/synthetic-dev/up.sh
@@ -398,6 +398,11 @@ prep(){
   pnpm_install "$SDS"
   ( cd "$SDS/packages/node/ads-adm-db" && pnpm db:generate >/dev/null 2>&1 ) || true
   ( cd "$SDS" && pnpm build >/dev/null 2>&1 ) || true
+  # saga-dash runs via `vite dev` (no prebuild), but vite must be installed or the
+  # launch dies with "vite: not found" — and prep installs it nowhere else, so a
+  # freshly-cloned or freshly-pulled dash would 404 the whole UI. Install it here.
+  say "reconciling saga-dash deps (vite)…"
+  pnpm_install "$SAGA_DASH"
   say "applying prisma schemas (migrate deploy — canonical, see d1.5)…"
   db_step "iam-db migrate deploy"     "$ROSTERING/packages/node/iam-db"     pnpm prisma migrate deploy
   db_step "iam-pii-db db push"        "$ROSTERING/packages/node/iam-pii-db" pnpm prisma db push

--- a/tools/synthetic-dev/up.sh
+++ b/tools/synthetic-dev/up.sh
@@ -586,7 +586,7 @@ status(){
 }
 
 # ── arg parsing: verbs (up/down/status/help) + composable flags ──────
-DO_UP=0; DO_RESET=0; DO_SEED=0; SEED_MODE=roster; DO_LOGIN=0; LOGIN_USER=$DEFAULT_LOGIN_USER
+DO_UP=0; DO_RESET=0; DO_RESTART=0; DO_SEED=0; SEED_MODE=roster; DO_LOGIN=0; LOGIN_USER=$DEFAULT_LOGIN_USER
 case "${1:-up}" in
   # `shift || true`: bare `./up.sh` defaults ${1:-up} to "up" but leaves $# at 0,
   # so an unguarded shift returns 1 and `set -e` kills the script before it runs.
@@ -595,8 +595,9 @@ case "${1:-up}" in
   # Clean restart WITHOUT a data wipe: bounce services + clear vite caches, then
   # start fresh on current code. The recovery for a stale dash bundle after a
   # refresh-suite branch rewrite (corrupted vite module graph / unresponsive UI)
-  # — same restart+nuke_vite as --reset, minus reset_data.
-  restart|--restart)             services_down; nuke_vite; services_up; exit 0 ;;
+  # — same restart+nuke_vite as --reset, minus reset_data. Composes with trailing
+  # flags: `restart --login [email]` re-opens the logged-in browser the bounce kills.
+  restart|--restart)             DO_RESTART=1; shift || true ;;
   --status)                      status; exit 0 ;;
   -h|--help)                     sed -n '2,51p' "$0"; exit 0 ;;
   --reset|--seed|--login|--user) ;;        # flag-only invocation; skip up
@@ -626,8 +627,8 @@ fi
 # trap: a dead Vite watcher serving old JS even though the source changed (e.g.
 # after a refresh-suite branch swap). Plain `up` (no --reset) reuses "already
 # up" processes / cached bundles.
-if [[ $DO_RESET == 1 ]]; then
-  say "reset: clean restart — stopping services + clearing vite caches..."
+if [[ $DO_RESET == 1 || $DO_RESTART == 1 ]]; then
+  say "clean restart — stopping services + clearing vite caches..."
   services_down; nuke_vite; services_up
   ok "stack up (clean) — try: $0 --status"
 elif [[ $DO_UP == 1 ]]; then

--- a/tools/synthetic-dev/verify.sh
+++ b/tools/synthetic-dev/verify.sh
@@ -204,6 +204,24 @@ done
 # soa + student-data-system must be literally main (never integration-parked).
 for repo in $ALWAYS_MAIN_REPOS; do check_posture "$repo" "main"; done
 
+# ── freshness (behind origin) ─────────────────────────────────────────
+# A repo can be on the right branch yet stale — origin moved under it. The posture
+# checks above compare against a possibly-stale local origin ref, so they miss it
+# (how program-hub sat hundreds of commits behind and 404'd new endpoints). Fetch,
+# then flag any repo behind origin/main. WARN (main moves constantly) — fix with
+# ./up.sh up --pull. Feature-branch repos are skipped (posture already flagged them).
+printf "\033[1m── freshness (behind origin) ──\033[0m\n"
+for repo in $MANAGED_REPOS $ALWAYS_MAIN_REPOS; do
+  dir="$DEV/$repo"
+  [[ -d "$dir/.git" ]] || continue
+  case "$(on_branch "$repo")" in main|local/integration) ;; *) continue ;; esac
+  git -C "$dir" fetch -q origin 2>/dev/null || { warnline "$(printf '%-20s fetch failed — freshness unknown' "$repo")"; continue; }
+  behind=$(git -C "$dir" rev-list --count "HEAD..origin/main" 2>/dev/null || echo "?")
+  if   [[ "$behind" == 0 ]];   then okline   "$(printf '%-20s current with origin/main' "$repo")"
+  elif [[ "$behind" == "?" ]]; then warnline "$(printf '%-20s could not compare to origin/main' "$repo")"
+  else                              warnline "$(printf '%-20s %s behind origin/main — run ./up.sh up --pull' "$repo" "$behind")"; fi
+done
+
 printf "\n"
 if [[ $fail -eq 0 ]]; then
   if [[ $warn -gt 0 ]]; then


### PR DESCRIPTION
## What

Four focused fixes from a full local bring-up — all closing gaps where the stack silently ran against a stale or partial checkout:

- **`up.sh --pull`** (`89a1502`) — `./up.sh up --pull` fast-forwards every sibling repo to its upstream **before** `prep` builds/migrates, so you never build or migrate a checkout that's silently behind origin. ff-ONLY; skips dirty / detached / feature-branch / diverged repos with a warning (never clobbers local work or moves you off a branch).
- **`verify.sh` freshness** (`afd7788`) — a new "behind origin" section: fetch each repo and **warn** (not fail — main moves constantly) when it's behind `origin/main`, pointing at `up --pull`. Posture told you *which* branch; this tells you whether it's *current*. (program-hub sat hundreds of commits behind and 404'd new endpoints before this existed.) Skips feature-branch repos (posture already flags those).
- **`prep` installs saga-dash** (`4b5cd40`) — prep installed rostering/program-hub/student-data-system but **not** saga-dash, so a cloned-but-not-installed (or freshly-pulled) dash died at launch with `vite: not found`. It runs via `vite dev` (no build), so just `pnpm_install` it alongside the others.
- **`restart` composes with flags** (`905c368`) — `restart` did `services_down; nuke_vite; services_up; exit 0`, bailing before the flag loop, so `restart --login` silently logged you out (the bounce kills the auto-login browser). Now `./up.sh restart --login [email]` bounces services AND re-opens the logged-in browser, with no data wipe.

## Why

Each one reproduces a real failure hit while standing the stack up from a fresh checkout: stale siblings building old code / behind on migrations, a dash that 404'd the whole UI, and a restart that left you logged out with no window. Theme: **keep siblings in sync, and fail loudly instead of silently.**

## Test

- `bash -n` clean on `up.sh` + `verify.sh`.
- `--pull` dispatch verified with stubs: `up --pull` → pull → prep → services_up; plain `up` skips the pull; bare `--pull` pulls only.
- `restart --login` verified: bounce + relogin, no `reset_data`; regression-checked `--reset --login` still wipes.
- `verify.sh` freshness ran live — correctly warned 3 stale siblings, skipped the feature-branch repo, and did not flip the exit code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)