### PR TITLE
feat(synthetic-dev): bring up sessions-api (:3007) — seventh service

### DIFF
--- a/infra/compose/projects/saga-mesh/seed/profile-empty.sql
+++ b/infra/compose/projects/saga-mesh/seed/profile-empty.sql
@@ -1,6 +1,6 @@
 -- saga-mesh / profile=empty
 --
--- Creates the seven per-app databases and owners for the SDS fixture mesh.
+-- Creates the eight per-app databases and owners for the SDS fixture mesh.
 -- No application data is seeded here — each app runs its own prisma
 -- migrations into its database after this file executes.
 --
@@ -24,6 +24,7 @@ CREATE DATABASE iam_local       OWNER iam;
 CREATE DATABASE iam_pii_local   OWNER iam_pii;
 CREATE DATABASE programs        OWNER saga_user;
 CREATE DATABASE scheduling      OWNER saga_user;
+CREATE DATABASE sessions        OWNER saga_user;
 CREATE DATABASE ads_adm_local   OWNER ads_adm;
 CREATE DATABASE ledger_local    OWNER ledger;
 CREATE DATABASE sis_db          OWNER sis;
@@ -33,6 +34,7 @@ GRANT ALL PRIVILEGES ON DATABASE iam_local     TO iam;
 GRANT ALL PRIVILEGES ON DATABASE iam_pii_local TO iam_pii;
 GRANT ALL PRIVILEGES ON DATABASE programs      TO saga_user;
 GRANT ALL PRIVILEGES ON DATABASE scheduling    TO saga_user;
+GRANT ALL PRIVILEGES ON DATABASE sessions      TO saga_user;
 GRANT ALL PRIVILEGES ON DATABASE ads_adm_local TO ads_adm;
 GRANT ALL PRIVILEGES ON DATABASE ledger_local  TO ledger;
 GRANT ALL PRIVILEGES ON DATABASE sis_db        TO sis;

--- a/tools/synthetic-dev/README.md
+++ b/tools/synthetic-dev/README.md
@@ -44,7 +44,7 @@ won't stop the run.
 |---|---|---|---|
 | **soa** | `~/dev/soa` | `main` | mesh infra (`infra/` + `projects/saga-mesh/seed`) for pg/redis/rabbitmq; shared `@saga-ed/soa-*` packages (registry mode — `soa:link:off`) |
 | **rostering** | `~/dev/rostering` | `main` | iam-api (**:3010**); **sis-api (:3100)** + sis-db prisma; iam-db / iam-pii-db prisma; the `program-hub` roster scenario (`scripts/scenarios`) |
-| **program-hub** | `~/dev/program-hub` | `main`¹ | programs-api (**:3006**) + scheduling-api (**:3008**); the `programs` scenario (`scripts/scenarios`) |
+| **program-hub** | `~/dev/program-hub` | `main`¹ | programs-api (**:3006**) + scheduling-api (**:3008**) + sessions-api (**:3007**); the `programs` scenario (`scripts/scenarios`) |
 | **student-data-system** | `~/dev/student-data-system` | `main` | ads-adm-api (**:5005**); ads-adm-db prisma. Override the path with `SDS=...` |
 | **saga-dash** | `~/dev/saga-dash` | `main` | dash web UI (**:8900**) |
 
@@ -65,14 +65,17 @@ same fix idempotently. You'll just see a `⚠ … (expected 'main')` line.
 | sis-api | 3100 | rostering main — SIS reconciliation / CSV-roster (d1.7); calls iam-api `service.*` (S2S, dev-bypass locally) |
 | programs-api | 3006 | program-hub main |
 | scheduling-api | 3008 | program-hub main |
+| sessions-api | 3007 | program-hub main — sessions read/lifecycle (harvested from programs-api in program-hub #148); projections converge via producer outbox replay |
 | ads-adm-api | 5005 | student-data-system **main** (canonical checkout) |
 | saga-dash | 8900 | saga-dash main |
 | postgres / redis / rabbitmq | 5432 / 6379 / 5672 (mgmt 15672) | soa-mesh (`soa-postgres-1` etc.) |
 
 Mesh rabbitmq creds: **`rabbitmq_admin:password123`** (not `saga_user`).
-Seven empty DBs: `iam_local`, `iam_pii_local`, `programs`, `scheduling`,
-`ads_adm_local`, `ledger_local`, `sis_db` (all created by the canonical
-mesh seed — `sis_db` added in soa#112; d1.7).
+Eight empty DBs: `iam_local`, `iam_pii_local`, `programs`, `scheduling`,
+`sessions`, `ads_adm_local`, `ledger_local`, `sis_db` (all created by the
+canonical mesh seed — `sis_db` added in soa#112, d1.7; `sessions` in soa#146.
+The seed only runs on first postgres init, so `up.sh` prep also ensures
+`sessions` exists on meshes initialized before it was added).
 
 ## Status as of 2026-05-26 (after rostering + program-hub pulled to latest origin/main)
 

--- a/tools/synthetic-dev/README.md
+++ b/tools/synthetic-dev/README.md
@@ -65,7 +65,7 @@ same fix idempotently. You'll just see a `⚠ … (expected 'main')` line.
 | sis-api | 3100 | rostering main — SIS reconciliation / CSV-roster (d1.7); calls iam-api `service.*` (S2S, dev-bypass locally) |
 | programs-api | 3006 | program-hub main |
 | scheduling-api | 3008 | program-hub main |
-| sessions-api | 3007 | program-hub main — sessions read/lifecycle (harvested from programs-api in program-hub #148); projections converge via producer outbox replay |
+| sessions-api | 3007 | program-hub main — sessions read/lifecycle (harvested from programs-api in program-hub #148); event-built projections (pre-existing data needs the one-time manual replay — see getting-started.md) |
 | ads-adm-api | 5005 | student-data-system **main** (canonical checkout) |
 | saga-dash | 8900 | saga-dash main |
 | postgres / redis / rabbitmq | 5432 / 6379 / 5672 (mgmt 15672) | soa-mesh (`soa-postgres-1` etc.) |

--- a/tools/synthetic-dev/bootstrap.sh
+++ b/tools/synthetic-dev/bootstrap.sh
@@ -5,7 +5,7 @@
 # Chains the steps a new engineer (e.g. Adam) needs:
 #   1. ensure-repos       — clone any missing of the 5 siblings + co:login & install
 #   2. refresh-suite.sh   — apply your local overlay if present (else everyone on main)
-#   3. up.sh up --reset --seed roster — mesh + 6 services, fresh synthetic roster
+#   3. up.sh up --reset --seed roster — mesh + 7 services, fresh synthetic roster
 #   4. verify.sh          — assert every service is green and the roster seeded
 #
 # Stops at the first failing step (so you fix it before the next). For the
@@ -93,7 +93,7 @@ else
   step "2/4 refresh-suite — SKIPPED (--no-refresh)"
 fi
 
-step "3/4 up.sh — mesh + 6 services + reset + seed $SEED_MODE"
+step "3/4 up.sh — mesh + 7 services + reset + seed $SEED_MODE"
 "$DIR/up.sh" up --reset --seed "$SEED_MODE" || { echo "up.sh failed — tail /tmp/sds-synthetic/*.log"; exit 1; }
 
 step "4/4 verify — assert all green"

--- a/tools/synthetic-dev/getting-started.md
+++ b/tools/synthetic-dev/getting-started.md
@@ -130,10 +130,28 @@ sessions-api (`~/dev/program-hub/apps/node/sessions-api`, on program-hub
 `static/config.json` already expects) against a dedicated `sessions` DB of
 event-built projections: it consumes `programs.*` / `scheduling.*` / `iam.*`
 events over the mesh broker, and TutoringSessions materialize lazily from
-(slot × pod × date). Starting it after its producers is fine — programs-api
-and scheduling-api replay their outbox to late-joining consumers (program-hub
-#160/#161), so the projections converge on first boot. Until a schedule +
-pods exist, `dayList` legitimately returns empty days. See soa#146.
+(slot × pod × date). Until a schedule + pods exist, `dayList` legitimately
+returns empty days. See soa#146.
+
+One-time catch-up note: the outbox replay to late-joining consumers
+(program-hub #160/#161) is a **manual, per-program CLI**, not automatic — a
+freshly-bound queue has no backlog, so events published *before* sessions-api
+first joined never reach it. On the canonical `--reset --seed` lane this
+never matters (sessions-api is up before any program exists). But if your
+mesh already had program data when sessions-api first started, replay it
+once per program:
+
+```bash
+cd ~/dev/program-hub/apps/node/programs-api && \
+  DATABASE_URL=postgresql://saga_user:password123@localhost:5432/programs \
+  pnpm replay:program-outbox <programId>
+cd ../scheduling-api && \
+  DATABASE_URL=postgresql://saga_user:password123@localhost:5432/scheduling \
+  pnpm replay:schedule-outbox <programId>   # only if a schedule existed
+```
+
+The running relay re-publishes; idempotent consumption makes it a no-op for
+already-caught-up consumers.
 
 ## Walkthrough deck (start here for the UX flow)
 

--- a/tools/synthetic-dev/getting-started.md
+++ b/tools/synthetic-dev/getting-started.md
@@ -2,7 +2,7 @@
 
 This is the local "synthetic-dev" stack we use for the attendance-UI /
 People-step work on saga-dash, and now for **cross-developing sis-api against
-saga-dash**. It's a dockerized, fully-local **six-service** stack:
+saga-dash**. It's a dockerized, fully-local **seven-service** stack:
 
 | port | service | repo |
 |---|---|---|
@@ -10,6 +10,7 @@ saga-dash**. It's a dockerized, fully-local **six-service** stack:
 | 3100 | sis-api | `~/dev/rostering` |
 | 3006 | programs-api | `~/dev/program-hub` |
 | 3008 | scheduling-api | `~/dev/program-hub` |
+| 3007 | sessions-api | `~/dev/program-hub` |
 | 5005 | ads-adm-api | `~/dev/student-data-system` |
 | 8900 | saga-dash | `~/dev/saga-dash` |
 | 5432 | postgres (`soa-postgres-1`) | mesh, from `~/dev/soa/infra` |
@@ -37,7 +38,7 @@ cd ~/dev/soa/tools/synthetic-dev
 ```bash
 ./refresh-suite.sh             # apply your local overlay if present — else a no-op (everyone on main)
 ./up.sh up --reset --seed roster
-./verify.sh                    # asserts 6 services @ 200 + roster + sis_db + SOURCE POSTURE (right branches); non-zero on any red
+./verify.sh                    # asserts 7 services @ 200 + roster + sis_db + SOURCE POSTURE (right branches); non-zero on any red
 ```
 
 On a clean checkout there's no overlay, so `refresh-suite.sh` is a no-op and
@@ -119,6 +120,21 @@ hot-reload (sis-api via `tsup --watch`, dash via Vite HMR). The dash already
 knows where sis-api lives — `up.sh` seeds a `sis-api → :3100` entry into
 saga-dash's `static/config.json`.
 
+## sessions-api (the seventh service)
+
+sessions-api (`~/dev/program-hub/apps/node/sessions-api`, on program-hub
+`main`) serves the dash's `/sessions` page — `sessions.dayList` /
+`rangeList`, the lifecycle commands (`start`/`end`/`cancel`), overrides, and
+`adhoc.create`. It was harvested out of programs-api in program-hub #148
+(2026-06). `up.sh` stands it up on **:3007** (the port saga-dash main's
+`static/config.json` already expects) against a dedicated `sessions` DB of
+event-built projections: it consumes `programs.*` / `scheduling.*` / `iam.*`
+events over the mesh broker, and TutoringSessions materialize lazily from
+(slot × pod × date). Starting it after its producers is fine — programs-api
+and scheduling-api replay their outbox to late-joining consumers (program-hub
+#160/#161), so the projections converge on first boot. Until a schedule +
+pods exist, `dayList` legitimately returns empty days. See soa#146.
+
 ## Walkthrough deck (start here for the UX flow)
 
 `../training/saga-dash-walkthrough.html` — open in a browser or serve via
@@ -146,7 +162,7 @@ captured by `../training/capture/capture.mjs` (regenerable; see
    ~/dev/
      ├── soa                  # mesh infra (provides docker compose for pg/redis/rabbitmq)
      ├── rostering            # iam-api + sis-api + iam-db / sis-db
-     ├── program-hub          # programs-api + scheduling-api
+     ├── program-hub          # programs-api + scheduling-api + sessions-api
      ├── saga-dash            # the dash itself
      └── student-data-system  # ads-adm-api + this synthetic-dev tooling
    ```
@@ -169,7 +185,7 @@ shells out to:
 That's the canonical soa-mesh compose definition. So with zero containers
 running and Docker just booted, `./up.sh up` does the right thing in one
 command — brings up the mesh, applies prisma schemas (via `migrate deploy`
-— matches the deployed pipeline; see `decisions/d1.5`), launches all six
+— matches the deployed pipeline; see `decisions/d1.5`), launches all seven
 services with the right env, and reports green.
 
 ## Verbs
@@ -180,9 +196,9 @@ services with the right env, and reports green.
 ./refresh-suite.sh --list        # print your personal overlay, no changes
 ./refresh-suite.sh --prs 165 saga-dash      # ad-hoc: overlay explicit PR(s) onto main, no file
 ./refresh-suite.sh --reset       # back out: overlaid repos → main (deletes local/integration)
-./verify.sh                      # assert 6 services + roster + sis_db + source posture (right branches) — exit code
+./verify.sh                      # assert 7 services + roster + sis_db + source posture (right branches) — exit code
 
-./up.sh up                       # bring up mesh + 6 services (empty databases)
+./up.sh up                       # bring up mesh + 7 services (empty databases)
 ./up.sh up --reset --seed roster # from-scratch: empty baseline + synthetic IAM roster
 ./up.sh up --reset --seed full   # roster + 9 programs + periods + enrollment
 ./up.sh --reset                  # truncate synthetic data → empty baseline (services stay up)
@@ -224,10 +240,10 @@ Each persona's UUID is printed at the end of every `--seed roster` run.
    `SIS_DATABASE_URL` and seeds the dash's `sis-api → :3100` config key.
 3. `mesh_up` — starts soa-mesh if not running.
 4. `prep` — `pnpm install + build` in rostering / program-hub; `prisma migrate
-   deploy` for iam / programs / scheduling / sis / ads-adm DBs (via the
-   `migrate_db` helper — matches what `_deploy-ecs-api.yml`'s migrate job runs
-   on production).
-5. `services_up` — launches the six API services / dash with the right
+   deploy` for iam / programs / scheduling / sessions / sis / ads-adm DBs (via
+   the `migrate_db` helper — matches what `_deploy-ecs-api.yml`'s migrate job
+   runs on production).
+5. `services_up` — launches the seven API services / dash with the right
    env (IAM_API_URL, RABBITMQ_URL, JWT_ACCESSTOKENTTLSECONDS, etc.) via
    `nohup pnpm dev` per service. PID files in `/tmp/sds-synthetic/`.
 
@@ -297,7 +313,7 @@ After cloning the 5 sibling repos and ensuring CodeArtifact + `gh` auth work:
 ```bash
 cd ~/dev/soa/tools/synthetic-dev
 ./bootstrap.sh
-# expect: refresh-suite green → 6 services @ 200 → "all checks passed"
+# expect: refresh-suite green → 7 services @ 200 → "all checks passed"
 ```
 
 If any service is red, `verify.sh` tells you which; tail its log under

--- a/tools/synthetic-dev/up.sh
+++ b/tools/synthetic-dev/up.sh
@@ -20,9 +20,12 @@
 # programs-api in program-hub #148, 2026-06). It owns a `sessions` DB of
 # event-built projections (programs.* / scheduling.* / iam.* consumers over the
 # mesh broker) + TutoringSession, and serves the dash's /sessions page
-# (sessions.dayList / rangeList / lifecycle). Joining late is fine: programs-api
-# and scheduling-api replay their outbox to late-joining consumers (program-hub
-# #160/#161), so its projections converge after first boot. See soa#146.
+# (sessions.dayList / rangeList / lifecycle). On the canonical --reset --seed
+# lane it's up before any program exists, so projections build live. If your
+# mesh ALREADY had program data when sessions-api first joined, catch it up
+# once with the manual per-program replay CLIs (program-hub #160/#161:
+# `pnpm replay:program-outbox <id>` / `replay:schedule-outbox <id>` — see
+# getting-started.md). See soa#146.
 #
 # Branch posture (see decisions/d1.1): iam/programs/scheduling/saga-dash/soa on
 # MAIN; ads-adm from the canonical ~/dev/student-data-system checkout (sds_92 is
@@ -358,8 +361,16 @@ migrate_db(){ # dir db_name [database_url — override to point prisma at the me
   if [[ "$(docker exec soa-postgres-1 psql -U postgres_admin -d "$db" -tAc \
         "SELECT to_regclass('public._prisma_migrations') IS NOT NULL" 2>/dev/null)" == t ]]; then
     db_step "$db migrate deploy" "$dir" "${pre[@]+"${pre[@]}"}" pnpm db:deploy                    # migration-managed → apply pending (non-destructive)
+  elif [[ "$(docker exec soa-postgres-1 psql -U postgres_admin -d "$db" -tAc \
+        "SELECT count(*) FROM pg_tables WHERE schemaname='public'" 2>/dev/null)" == 0 ]]; then
+    # Truly EMPTY DB (fresh mesh volume / just-created): migrate deploy replays
+    # the full migration history non-destructively — same end state as reset
+    # with nothing to drop. Keeps the destructive path off fresh provisions
+    # (prisma 7 also gates `migrate reset` behind an AI-consent prompt when it
+    # detects an agent, which would wedge an unattended bootstrap here).
+    db_step "$db migrate deploy (empty db)" "$dir" "${pre[@]+"${pre[@]}"}" pnpm db:deploy
   else
-    db_step "$db migrate reset"  "$dir" "${pre[@]+"${pre[@]}"}" pnpm prisma migrate reset --force  # unmanaged (db:push'd / empty) → drop + replay all
+    db_step "$db migrate reset"  "$dir" "${pre[@]+"${pre[@]}"}" pnpm prisma migrate reset --force  # unmanaged (db:push'd, no history) → drop + replay all
   fi
 }
 
@@ -479,8 +490,8 @@ services_up(){
   # sessions-api: DATABASE_URL + IAM_API_URL are REQUIRED (it throws without
   # them); its RABBITMQ_URL default is program-hub's standalone :5673, so point
   # it at the mesh. SCHEDULING_API_URL defaults to :3008 (already the mesh
-  # port) and it doesn't read JANUS_REQUIRED, so neither is set. Started after
-  # its producers (programs/scheduling); projections converge via outbox replay.
+  # port) and it doesn't read JANUS_REQUIRED, so neither is set. Pre-existing
+  # program data needs a one-time manual replay (see header note).
   launch sessions-api 3007 "$PROGRAM_HUB/apps/node/sessions-api"     NODE_ENV=development DATABASE_URL="$SESSIONS_DB_URL"   IAM_API_URL="$IAM_URL" RABBITMQ_URL="$MESH_MQ" CORS_ORIGIN="$DASH_URL"
   launch ads-adm-api 5005 "$SDS/apps/node/ads-adm-api" \
      ADS_ADM_SCHEDULE_PROVIDER=mock \

--- a/tools/synthetic-dev/up.sh
+++ b/tools/synthetic-dev/up.sh
@@ -2,7 +2,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # synthetic-dev/up.sh — stand up the local synthetic-dev stack for sds_92.
 #
-# Goal: dockerized postgres + redis + rabbitmq + the six APIs, EMPTY, ready to
+# Goal: dockerized postgres + redis + rabbitmq + the seven APIs, EMPTY, ready to
 # seed SYNTHETIC iam rosters / programs via the deterministic `db:seed`
 # (@saga-ed/*-seed-ids — same data as preview/CI, stable ids across --reset; no
 # VPN, no prod-mirror fixture). See synthetic-dev-align. The old scenario-runner
@@ -16,6 +16,14 @@
 # run iam-api in here. See decisions/d1.7. Its `sis_db` is created by the
 # canonical mesh seed (soa profile-empty.sql, soa#112) like the other app DBs.
 #
+# The seventh API is sessions-api (program-hub, :3007 — harvested out of
+# programs-api in program-hub #148, 2026-06). It owns a `sessions` DB of
+# event-built projections (programs.* / scheduling.* / iam.* consumers over the
+# mesh broker) + TutoringSession, and serves the dash's /sessions page
+# (sessions.dayList / rangeList / lifecycle). Joining late is fine: programs-api
+# and scheduling-api replay their outbox to late-joining consumers (program-hub
+# #160/#161), so its projections converge after first boot. See soa#146.
+#
 # Branch posture (see decisions/d1.1): iam/programs/scheduling/saga-dash/soa on
 # MAIN; ads-adm from the canonical ~/dev/student-data-system checkout (sds_92 is
 # merged to main; the sds_92 worktree has been retired). Override with SDS=...
@@ -28,7 +36,7 @@
 # such drift + fix is documented in README.md and applied idempotently below.
 #
 # Usage:
-#   ./up.sh                      bring up mesh + 6 services (empty)
+#   ./up.sh                      bring up mesh + 7 services (empty)
 #   ./up.sh up --pull            ff-only sync all siblings to origin, then build/migrate
 #   ./up.sh --seed [roster|full] seed synthetic data (default: roster)
 #                                  roster = iam roster only (programs empty → from-scratch)
@@ -88,10 +96,12 @@ IAM_URL="http://localhost:$IAM_PORT"
 SIS_PORT=3100                                               # sis-api port (SisConfigSchema default; rostering apps/node/sis-api)
 SIS_DB_URL="postgresql://sis:sis@localhost:5432/sis_db"     # sis-api owns a dedicated DB (read direct from SIS_DATABASE_URL; see d1.7)
 # program-hub config defaults to its OWN standalone-dev postgres on :5433; in this
-# stack programs/scheduling live in the mesh on :5432, so override DATABASE_URL
-# everywhere we run program-hub (migrate + runtime), matching seed_programs.
+# stack programs/scheduling/sessions live in the mesh on :5432, so override
+# DATABASE_URL everywhere we run program-hub (migrate + runtime), matching
+# seed_programs.
 PROGRAMS_DB_URL="postgresql://saga_user:password123@localhost:5432/programs"
 SCHEDULING_DB_URL="postgresql://saga_user:password123@localhost:5432/scheduling"
+SESSIONS_DB_URL="postgresql://saga_user:password123@localhost:5432/sessions"
 MESH_MQ="amqp://rabbitmq_admin:password123@localhost:5672"  # mesh broker creds (NOT saga_user)
 DEV_USER_UUID="f0000004-0000-4000-8000-00000000beef"        # from iam-db seed-dev-user.ts
 STATE=/tmp/sds-synthetic; mkdir -p "$STATE"
@@ -408,6 +418,15 @@ prep(){
   db_step "iam-pii-db db push"        "$ROSTERING/packages/node/iam-pii-db" pnpm prisma db push
   migrate_db "$PROGRAM_HUB/apps/node/programs-api"   programs   "$PROGRAMS_DB_URL"
   migrate_db "$PROGRAM_HUB/apps/node/scheduling-api" scheduling "$SCHEDULING_DB_URL"
+  # sessions-api (program-hub #148 harvest) owns a `sessions` DB. The mesh seed
+  # (profile-empty.sql) creates it on FIRST postgres init only — a mesh volume
+  # initialized before sessions-api existed won't have it, so ensure it here.
+  if [[ "$(docker exec soa-postgres-1 psql -U postgres_admin -tAc \
+        "SELECT 1 FROM pg_database WHERE datname='sessions'" 2>/dev/null)" != 1 ]]; then
+    db_step "sessions db create" "$SOA" docker exec soa-postgres-1 \
+      psql -U postgres_admin -c "CREATE DATABASE sessions OWNER saga_user"
+  fi
+  migrate_db "$PROGRAM_HUB/apps/node/sessions-api"   sessions   "$SESSIONS_DB_URL"
   migrate_db "$ROSTERING/packages/node/sis-db"       sis_db   # sis-api schema (d1.7); uses sis-db's own config
   db_step "ads-adm-db migrate deploy" "$SDS/packages/node/ads-adm-db"       pnpm prisma migrate deploy
   say "seeding dev user ($DEV_USER_UUID)…"
@@ -457,6 +476,12 @@ services_up(){
      IAM_BASEURL="$IAM_URL/trpc" IAM_TOKENURL="$IAM_URL/v1/oauth/token"
   launch programs-api 3006 "$PROGRAM_HUB/apps/node/programs-api"     NODE_ENV=development DATABASE_URL="$PROGRAMS_DB_URL"   IAM_API_URL="$IAM_URL" RABBITMQ_URL="$MESH_MQ" JANUS_REQUIRED=false CORS_ORIGIN="$DASH_URL"
   launch scheduling-api 3008 "$PROGRAM_HUB/apps/node/scheduling-api" NODE_ENV=development DATABASE_URL="$SCHEDULING_DB_URL" IAM_API_URL="$IAM_URL" RABBITMQ_URL="$MESH_MQ" JANUS_REQUIRED=false CORS_ORIGIN="$DASH_URL"
+  # sessions-api: DATABASE_URL + IAM_API_URL are REQUIRED (it throws without
+  # them); its RABBITMQ_URL default is program-hub's standalone :5673, so point
+  # it at the mesh. SCHEDULING_API_URL defaults to :3008 (already the mesh
+  # port) and it doesn't read JANUS_REQUIRED, so neither is set. Started after
+  # its producers (programs/scheduling); projections converge via outbox replay.
+  launch sessions-api 3007 "$PROGRAM_HUB/apps/node/sessions-api"     NODE_ENV=development DATABASE_URL="$SESSIONS_DB_URL"   IAM_API_URL="$IAM_URL" RABBITMQ_URL="$MESH_MQ" CORS_ORIGIN="$DASH_URL"
   launch ads-adm-api 5005 "$SDS/apps/node/ads-adm-api" \
      ADS_ADM_SCHEDULE_PROVIDER=mock \
      ADS_ADM_DATABASE_URL=postgresql://ads_adm:ads_adm@localhost:5432/ads_adm_local \
@@ -472,9 +497,11 @@ services_up(){
 # Preserves _prisma_migrations so no re-migrate. Uses the mesh superuser
 # (postgres_admin) so it can truncate tables owned by iam / saga_user / etc.
 reset_data(){
-  say "resetting synthetic data → empty baseline (iam, programs, scheduling, sis)…"
+  say "resetting synthetic data → empty baseline (iam, programs, scheduling, sessions, sis)…"
   local trunc="DO \$\$ DECLARE r RECORD; BEGIN FOR r IN SELECT tablename FROM pg_tables WHERE schemaname='public' AND tablename <> '_prisma_migrations' LOOP EXECUTE 'TRUNCATE TABLE public.'||quote_ident(r.tablename)||' RESTART IDENTITY CASCADE'; END LOOP; END \$\$;"
-  for db in iam_local iam_pii_local programs scheduling sis_db; do
+  # `sessions` truncation also clears its consumed-event cursors, so its
+  # event-built projections re-converge from the producers' outbox replay.
+  for db in iam_local iam_pii_local programs scheduling sessions sis_db; do
     if docker exec -i soa-postgres-1 psql -U postgres_admin -d "$db" -v ON_ERROR_STOP=1 -c "$trunc" >/dev/null 2>&1; then
       ok "truncated $db"
     else
@@ -592,7 +619,7 @@ open_login_browser(){
   printf "\033[33m⚠\033[0m Chromium still starting — watch %s\n" "$STATE/browser-login.log"
 }
 
-services_down(){ for n in iam-api sis-api programs-api scheduling-api ads-adm-api saga-dash; do
+services_down(){ for n in iam-api sis-api programs-api scheduling-api sessions-api ads-adm-api saga-dash; do
   [[ -f "$STATE/$n.pid" ]] && { pkill -P "$(cat "$STATE/$n.pid")" 2>/dev/null||true; kill "$(cat "$STATE/$n.pid")" 2>/dev/null||true; rm -f "$STATE/$n.pid"; }
 done
 [[ -f "$STATE/browser-login.pid" ]] && { kill "$(cat "$STATE/browser-login.pid")" 2>/dev/null||true; rm -f "$STATE/browser-login.pid"; }
@@ -601,7 +628,7 @@ done
 pkill -f "tsup/dist/cli-default.js --watch" 2>/dev/null||true
 # tsup's --onSuccess \`node dist/main.js\` children are orphaned by the kill above
 # and keep holding their ports; reap whatever still listens on our known ports.
-for _p in "$IAM_PORT" "$SIS_PORT" 3006 3008 5005 8900; do fuser -k "$_p/tcp" 2>/dev/null||true; done
+for _p in "$IAM_PORT" "$SIS_PORT" 3006 3007 3008 5005 8900; do fuser -k "$_p/tcp" 2>/dev/null||true; done
 ok "services down (mesh left up)"; }
 
 # Remove stale Vite optimize caches so the dash serves CURRENT source after a
@@ -617,7 +644,7 @@ nuke_vite(){
 }
 
 status(){
-  for kv in iam-api:$IAM_PORT sis-api:$SIS_PORT programs-api:3006 scheduling-api:3008 ads-adm-api:5005 saga-dash:8900; do
+  for kv in iam-api:$IAM_PORT sis-api:$SIS_PORT programs-api:3006 scheduling-api:3008 sessions-api:3007 ads-adm-api:5005 saga-dash:8900; do
     n=${kv%:*}; p=${kv#*:}; probe=/health; [[ "$n" == saga-dash ]] && probe=/
     printf "  %-15s :%s → %s\n" "$n" "$p" "$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 http://localhost:$p$probe 2>/dev/null)"
   done

--- a/tools/synthetic-dev/verify.sh
+++ b/tools/synthetic-dev/verify.sh
@@ -5,7 +5,7 @@
 # Unlike `up.sh --status` (which just prints), this EXITS NON-ZERO on any red,
 # so it's a one-shot "is my setup correct?" gate for a new engineer (or CI).
 # Checks:
-#   • all six service health endpoints return 200,
+#   • all seven service health endpoints return 200,
 #   • the mesh Postgres is reachable + the iam roster is seeded (users > 0),
 #   • SOURCE POSTURE (overlay-aware): each sibling repo is on the branch your
 #     personal overlay expects (main by default, or local/integration for repos
@@ -52,6 +52,7 @@ probe iam-api        3010 /health
 probe sis-api        3100 /health
 probe programs-api   3006 /health
 probe scheduling-api 3008 /health
+probe sessions-api   3007 /health
 probe ads-adm-api    5005 /health
 probe saga-dash      8900 /
 


### PR DESCRIPTION
Closes #146.

## Why

program-hub #148 (merged 2026-06-08) harvested the sessions sector out of programs-api into a standalone **sessions-api (:3007)** — but synthetic-dev predates the split, so the local stack never brings it up. saga-dash main's `static/config.json` already maps `sessions-api → localhost:3007`, so the live `/sessions` page points at a dead port, and stage 6 (sessions) of the dash e2e journey pipeline can't run at all.

## What

- **`infra/compose/projects/saga-mesh/seed/profile-empty.sql`** — add the `sessions` DB, `OWNER saga_user` (mirrors `programs`/`scheduling`).
- **`tools/synthetic-dev/up.sh`**
  - `SESSIONS_DB_URL` → mesh `:5432/sessions` (the service's standalone default is `:5433`);
  - prep: ensure the `sessions` DB exists idempotently (the mesh seed only runs on **first** postgres init — existing mesh volumes won't have it), then `migrate_db`;
  - **`migrate_db` gains an empty-DB branch**: a truly empty DB takes `prisma migrate deploy` (non-destructive full-history replay) instead of the destructive `migrate reset --force` fallback, which is now reserved for the real legacy case (db:push'd schema, no history). Also keeps unattended bootstraps off prisma 7's interactive AI-consent gate on `migrate reset`;
  - launch on :3007 with `DATABASE_URL` + `IAM_API_URL` (both **required** — the service throws without them) and `RABBITMQ_URL` pointed at the mesh broker (service default is `:5673`). `SCHEDULING_API_URL` defaults to `:3008` which already matches the mesh, and sessions-api does not read `JANUS_REQUIRED`, so neither is set;
  - `services_down` (pid + 3007 port reap), `--status`, and `reset_data` (truncating `sessions` also clears its consumed-event cursors, so projections rebuild from live events after a reset+seed).
- **`tools/synthetic-dev/verify.sh`** — probe `sessions-api :3007 /health`.
- **`bootstrap.sh` / `README.md` / `getting-started.md`** — six → seven services; new "sessions-api (the seventh service)" section **including the one-time manual replay recipe**: the program-hub #160/#161 outbox replay to late-joining consumers is a manual per-program CLI (`pnpm replay:program-outbox` / `replay:schedule-outbox`), not automatic — needed only when a mesh already had program data before sessions-api first joined. The canonical `--reset --seed` lane never needs it.

## Test plan — run live 2026-06-11 against the existing synthetic-dev mesh

- [x] On an **existing** mesh volume: `./up.sh up` — prep created the `sessions` DB, migrated it (4 migrations, empty-DB deploy path), sessions-api up :3007; log clean (OutboxRelay + programs/scheduling/authz consumers started, warm-on-caught-up)
- [x] `./verify.sh` — **7 services @ 200**; only red is saga-dash branch posture (expected — e2e branch checked out, unrelated)
- [x] One-time replay for the pre-existing program: 11 outbox rows re-published → sessions projections converged (1 program / 1 period / 2 pods / 6 memberships / 2 tutors, consumed=11)
- [x] Authenticated `sessions.dayList` read (devLogin as `empty@saga.org`): returns the hybrid envelope `{serverNow, <programId>: {periods: [], adhoc: []}}` — correct empty day pre-schedule
- [x] Second `./up.sh up` run: all seven "already up", DB ensure no-op
- [x] `./up.sh --down` reaps the :3007 listener (port 000 after, pidfile cleaned); cold restart brings all seven back green; projections persist
- [ ] Fresh mesh (`docker compose down -v`) full `./bootstrap.sh` — **not run** (would wipe the active e2e stack's data); the empty-DB deploy path it would take is the same code exercised above

## Notes

- Expect a small textual conflict with #119 (both touch `up.sh`); whichever lands second rebases — the changes are disjoint in intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
