### PR TITLE
feat(infra): capture schema-rev sidecar on postgres snapshots

### DIFF
--- a/infra/src/ec2/ec2-router.js
+++ b/infra/src/ec2/ec2-router.js
@@ -682,7 +682,9 @@ export function create_ec2_router(config = {}) {
     router.post('/dbs/:name/snapshot', (req, res) => {
         try {
             const { name } = req.params;
-            const { profile } = req.body;
+            // seedIdsVersion + appGitSha are optional provenance fields the caller
+            // (orchestrator / CI) may pass through into the schema sidecar.
+            const { profile, seedIdsVersion, appGitSha } = req.body;
             if (!profile) {
                 return res.status(400).json({ ok: false, error: 'profile is required' });
             }
@@ -704,6 +706,8 @@ export function create_ec2_router(config = {}) {
                 db_password: config.password,
                 bucket: SEED_BUCKET,
                 projects_dir,
+                seed_ids_version: seedIdsVersion,
+                app_git_sha: appGitSha,
             });
 
             res.json({ ok: true, name, profile, action: 'snapshotted', snapshot: result });

--- a/infra/src/ec2/profiles.js
+++ b/infra/src/ec2/profiles.js
@@ -54,9 +54,36 @@ function get_container_name(name, projects_dir) {
     return container || name;
 }
 
+// --- Schema-rev extraction (Prisma/postgres only) ---
+
+// The snapshot's schema version is the latest applied Prisma migration NAME, read
+// from the `_prisma_migrations` table inside the just-dumped DB. It is the
+// orderable token the restore-time compatibility gate compares against the app's
+// HEAD (see services/switchboard/docs/snapshot-schema-versioning.md in the
+// microservices repo). Order by `finished_at`, NOT max(migration_name): they agree
+// for linear history but diverge when a migration is applied out of name-order.
+//
+// Returns null (never throws) when the table is absent (non-Prisma DB) or empty
+// (fresh DB, zero migrations) — both mean "no schema rev", which the gate treats
+// as `unknown`. A failure here must not fail the snapshot: the .sql is still valid.
+function extract_prisma_rev({ container, db_name, db_user }) {
+    const sql =
+        'SELECT migration_name FROM _prisma_migrations ' +
+        'WHERE finished_at IS NOT NULL AND rolled_back_at IS NULL ' +
+        'ORDER BY finished_at DESC LIMIT 1';
+    const result = spawnSync(
+        'docker',
+        ['exec', container, 'psql', '-U', db_user || 'postgres_admin', '-d', db_name, '-t', '-A', '-c', sql],
+        { encoding: 'utf8', stdio: 'pipe' },
+    );
+    if (result.status !== 0) return null; // e.g. relation "_prisma_migrations" does not exist
+    const rev = (result.stdout || '').trim();
+    return rev.length ? rev : null;
+}
+
 // --- Snapshot (dump live DB → S3) ---
 
-export function snapshot_db({ name, profile, engine, port: _port, db_name, db_user, db_password, bucket, projects_dir }) {
+export function snapshot_db({ name, profile, engine, port: _port, db_name, db_user, db_password, bucket, projects_dir, seed_ids_version, app_git_sha }) {
     const eng = engines[engine];
     if (!eng) throw new Error(`Unknown engine: ${engine}`);
 
@@ -77,11 +104,55 @@ export function snapshot_db({ name, profile, engine, port: _port, db_name, db_us
         console.log(`Dumped ${engine} (${container}) to ${tmp_file} (${output.length} bytes)`);
     }
 
-    // Upload to S3
+    // Upload the dump FIRST so a sidecar never points at a missing/stale artifact.
     run('aws', ['s3', 'cp', tmp_file, s3_path]);
     console.log(`Uploaded snapshot to ${s3_path}`);
+    const dump_bytes = readFileSync(tmp_file).length;
 
-    return { s3Path: s3_path, size: readFileSync(tmp_file).length };
+    // Schema sidecar is postgres/Prisma-only. Writing it for mongo/mysql would be
+    // useless (no Prisma rev) AND harmful for mongo: its seed_ext is `json`, so the
+    // sidecar `profile-<p>.meta.json` collides with list_s3_profiles' `profile-(.+)
+    // \.json$` pattern and surfaces a phantom `<p>.meta` profile. So gate strictly:
+    // non-postgres snapshots stay byte-for-byte unchanged.
+    if (engine !== 'postgres') {
+        return { s3Path: s3_path, metaPath: null, schemaRev: null, sidecarOk: false, size: dump_bytes };
+    }
+
+    // Write the authoritative schema sidecar SECOND, next to the dump. The two
+    // uploads are not atomic: if this one fails the dump exists with no sidecar,
+    // which downstream reads as `unknown` (safe-degrade) — report partial success.
+    const schema_rev = extract_prisma_rev({ container, db_name: effective_db_name, db_user });
+    const meta = {
+        sidecarVersion: 1,
+        schemaRev: schema_rev,
+        engine,
+        takenAt: new Date().toISOString(),
+        takenFromDb: name,
+        profile,
+        seedIdsVersion: seed_ids_version ?? null,
+        appGitSha: app_git_sha ?? null,
+        dumpBytes: dump_bytes,
+    };
+    const meta_tmp = `/tmp/profile-${profile}.meta.json`;
+    const meta_s3 = `s3://${bucket}/${name}/profile-${profile}.meta.json`;
+    let sidecar_ok = true;
+    try {
+        writeFileSync(meta_tmp, JSON.stringify(meta, null, 2));
+        run('aws', ['s3', 'cp', meta_tmp, meta_s3]);
+        console.log(`Uploaded schema sidecar to ${meta_s3} (schemaRev=${schema_rev})`);
+    } catch (err) {
+        // Dump already uploaded; degrade to a sidecar-less snapshot rather than fail.
+        sidecar_ok = false;
+        console.log(`WARNING: sidecar upload failed for ${meta_s3}: ${err.message}`);
+    }
+
+    return {
+        s3Path: s3_path,
+        metaPath: sidecar_ok ? meta_s3 : null,
+        schemaRev: schema_rev,
+        sidecarOk: sidecar_ok,
+        size: dump_bytes,
+    };
 }
 
 function snapshot_mongo({ container, tmp_file, user, password }) {

--- a/infra/test/unit/profiles-sidecar.unit.test.js
+++ b/infra/test/unit/profiles-sidecar.unit.test.js
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Capture every spawnSync invocation, and let individual tests stub the result of
+// the `_prisma_migrations` rev query (a `psql ... -c SELECT migration_name ...`).
+const spawnSync_calls = [];
+let revQueryResult = { status: 0, stdout: '20260603120000_add_session_index\n', stderr: '' };
+
+function isRevQuery(cmd, args) {
+    return (
+        cmd === 'docker' &&
+        args[0] === 'exec' &&
+        args.includes('psql') &&
+        args.some((a) => typeof a === 'string' && a.includes('_prisma_migrations'))
+    );
+}
+
+vi.mock('child_process', () => ({
+    spawnSync: vi.fn((cmd, args) => {
+        spawnSync_calls.push([cmd, args]);
+        if (isRevQuery(cmd, args)) return revQueryResult;
+        // `docker compose ps` (container-name lookup) returns a container name.
+        if (cmd === 'docker' && args[0] === 'compose' && args.includes('ps')) {
+            return { status: 0, stdout: 'sbx-db-1\n', stderr: '' };
+        }
+        // pg_dump (via run()) returns SQL text.
+        if (cmd === 'docker' && args.includes('pg_dump')) {
+            return { status: 0, stdout: '-- dump\n', stderr: '' };
+        }
+        // mongosh export (via run()) must return parseable JSON — snapshot_mongo
+        // does JSON.parse on its stdout.
+        if (cmd === 'docker' && args.includes('mongosh')) {
+            return { status: 0, stdout: '{"_meta":{"type":"snapshot"}}\n', stderr: '' };
+        }
+        return { status: 0, stdout: '', stderr: '' };
+    }),
+    spawn: vi.fn(),
+}));
+
+// Stub filesystem writes/reads so we never touch disk. readFileSync must return a
+// Buffer-ish with a `.length` (snapshot_db uses it for dumpBytes).
+const written = {};
+vi.mock('fs', async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+        ...actual,
+        writeFileSync: vi.fn((path, content) => {
+            written[path] = content;
+        }),
+        readFileSync: vi.fn(() => Buffer.from('-- dump\n')),
+    };
+});
+
+import { snapshot_db } from '../../src/ec2/profiles.js';
+
+/** Ordered list of `aws s3 cp` destination args across this snapshot. */
+function awsCpDests() {
+    return spawnSync_calls
+        .filter(([cmd, args]) => cmd === 'aws' && args[0] === 's3' && args[1] === 'cp')
+        .map(([, args]) => args[3]);
+}
+
+const BASE = {
+    name: 'programs-api-sbx',
+    profile: 'canonical',
+    engine: 'postgres',
+    db_name: 'programs',
+    db_user: 'postgres_admin',
+    bucket: 'seeds-bkt',
+    projects_dir: '/opt/projects',
+};
+
+describe('snapshot_db — schema sidecar capture', () => {
+    beforeEach(() => {
+        spawnSync_calls.length = 0;
+        for (const k of Object.keys(written)) delete written[k];
+        revQueryResult = { status: 0, stdout: '20260603120000_add_session_index\n', stderr: '' };
+    });
+
+    it('writes a sidecar next to the dump carrying the extracted schemaRev', () => {
+        const result = snapshot_db({ ...BASE });
+
+        expect(result.schemaRev).toBe('20260603120000_add_session_index');
+        expect(result.metaPath).toBe('s3://seeds-bkt/programs-api-sbx/profile-canonical.meta.json');
+        expect(result.sidecarOk).toBe(true);
+
+        const meta = JSON.parse(written['/tmp/profile-canonical.meta.json']);
+        expect(meta).toMatchObject({
+            sidecarVersion: 1,
+            schemaRev: '20260603120000_add_session_index',
+            engine: 'postgres',
+            takenFromDb: 'programs-api-sbx',
+            profile: 'canonical',
+        });
+        expect(typeof meta.takenAt).toBe('string');
+    });
+
+    it('uploads the .sql BEFORE the sidecar (so a sidecar never points at a missing dump)', () => {
+        snapshot_db({ ...BASE });
+        const dests = awsCpDests();
+        const sqlIdx = dests.indexOf('s3://seeds-bkt/programs-api-sbx/profile-canonical.sql');
+        const metaIdx = dests.indexOf('s3://seeds-bkt/programs-api-sbx/profile-canonical.meta.json');
+        expect(sqlIdx).toBeGreaterThanOrEqual(0);
+        expect(metaIdx).toBeGreaterThanOrEqual(0);
+        expect(sqlIdx).toBeLessThan(metaIdx);
+    });
+
+    it('records schemaRev=null when _prisma_migrations is absent (non-Prisma DB)', () => {
+        // psql exits non-zero: relation "_prisma_migrations" does not exist
+        revQueryResult = { status: 1, stdout: '', stderr: 'ERROR: relation does not exist' };
+        const result = snapshot_db({ ...BASE });
+        expect(result.schemaRev).toBeNull();
+        const meta = JSON.parse(written['/tmp/profile-canonical.meta.json']);
+        expect(meta.schemaRev).toBeNull();
+    });
+
+    it('records schemaRev=null for a fresh DB with zero applied migrations', () => {
+        revQueryResult = { status: 0, stdout: '\n', stderr: '' };
+        const result = snapshot_db({ ...BASE });
+        expect(result.schemaRev).toBeNull();
+    });
+
+    it('passes through seedIdsVersion and appGitSha provenance fields', () => {
+        snapshot_db({ ...BASE, seed_ids_version: '1.4.0', app_git_sha: 'def4567' });
+        const meta = JSON.parse(written['/tmp/profile-canonical.meta.json']);
+        expect(meta.seedIdsVersion).toBe('1.4.0');
+        expect(meta.appGitSha).toBe('def4567');
+    });
+
+    it('writes NO sidecar for mongo (would collide with list_s3_profiles .json pattern)', () => {
+        const result = snapshot_db({ ...BASE, engine: 'mongo', profile: 'canonical' });
+        // No Prisma rev query, and crucially no sidecar file/upload at all — a mongo
+        // `profile-canonical.meta.json` would surface as a phantom `canonical.meta`
+        // profile (impl-plan edge-case #6).
+        expect(spawnSync_calls.some(([cmd, args]) => isRevQuery(cmd, args))).toBe(false);
+        expect(written['/tmp/profile-canonical.meta.json']).toBeUndefined();
+        expect(awsCpDests()).not.toContain('s3://seeds-bkt/programs-api-sbx/profile-canonical.meta.json');
+        expect(result.metaPath).toBeNull();
+        expect(result.schemaRev).toBeNull();
+    });
+
+    it('writes NO sidecar for mysql (out of scope; stays byte-for-byte unchanged)', () => {
+        const result = snapshot_db({ ...BASE, engine: 'mysql', profile: 'canonical' });
+        expect(written['/tmp/profile-canonical.meta.json']).toBeUndefined();
+        expect(result.metaPath).toBeNull();
+        expect(result.schemaRev).toBeNull();
+    });
+});


### PR DESCRIPTION
## What

First implementation slice of the snapshot↔schema versioning effort: **capture a schema-rev sidecar on postgres snapshots**. Backward-compatible and self-contained — nothing consumes the sidecar yet.

`snapshot_db` (`infra/src/ec2/profiles.js`) now writes an authoritative `profile-<name>.meta.json` next to the `.sql` dump:

```json
{
  "sidecarVersion": 1,
  "schemaRev": "20260603120000_add_session_index",
  "engine": "postgres",
  "takenAt": "2026-06-11T15:04:05.000Z",
  "takenFromDb": "programs-api-sbx",
  "profile": "canonical",
  "seedIdsVersion": "1.4.0",
  "appGitSha": "def4567",
  "dumpBytes": 184320
}
```

- **`schemaRev`** = latest applied Prisma migration **name**, read from `_prisma_migrations` ordered by `finished_at DESC` (orderable token the restore gate compares against the app's HEAD). Absent table (non-Prisma DB) or empty (fresh DB) → `schemaRev: null`, **without failing the snapshot** (the `.sql` is still valid).
- **`.sql` uploads first, sidecar second** — a sidecar never points at a missing/stale dump. Non-atomic by nature; sidecar-upload failure degrades to a sidecar-less snapshot (reads as `unknown` downstream) rather than failing.
- **Postgres-only by design.** A mongo sidecar (`seed_ext=json`) would collide with `list_s3_profiles`' `profile-(.+)\.json` pattern and surface a phantom `<p>.meta` profile in the db-console UI. Mongo/mysql snapshots stay **byte-for-byte unchanged**.
- Router (`ec2-router.js`) threads optional `seedIdsVersion` + `appGitSha` provenance through. Additive.

## Tests

7 new unit tests (`profiles-sidecar.unit.test.js`), modeled on `profiles-seedfrom`'s spawnSync/fs-mock style: sidecar carries the rev; `.sql`-before-sidecar ordering; `null` rev for absent table + fresh DB; provenance passthrough; **no sidecar for mongo or mysql** (locks in backward-compat + the phantom-profile fix). Full suite **96/96**, lint clean.

## Known gaps (not blocking — nothing consumes the sidecar yet)

1. **psql extraction is unit-mocked, not verified against a live Prisma DB.** The logic handles both real psql behaviors (nonzero exit on missing table → `null`; zero-exit-empty → `null`), but the exact flags/SQL (`psql -t -A -c "SELECT migration_name FROM _prisma_migrations …"`) must be validated against one real Prisma DB (integration or manual) **before the restore gate relies on it**.
2. **Rev read from the live container, not the dumped `_prisma_migrations`.** The design doc said "derived from the artifact"; reading the live container is a deliberate simplification — identical for a quiescent canonical DB. Revisit if snapshots are ever taken under write load.

## Design / context

- Design docs: `snapshot-schema-versioning.md` + `snapshot-sidecar-impl-plan.md` in **microservices PR hipponot/microservices#666** (Part 2 = this change).
- Next slices (separate PRs): Layer-2 `appHead` read + pending-window computation; the pre-flight gate; the destructive-migration detector.
