### PR TITLE
chore(infra): bump infra-compose to 1.3.4 (release sidecar capture)

### DIFF
--- a/infra/package.json
+++ b/infra/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/infra-compose",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "description": "Composable Docker service templates for Saga platform local development",
     "bin": {
         "infra-compose": "bin/infra-compose"


### PR DESCRIPTION
Releases the schema-rev sidecar capture (#148) as a publishable version. The #148 merge landed the `extract_prisma_rev` + sidecar-write code in `snapshot_db` but did not bump the version (still 1.3.3), so there's nothing to `npm install` until this ships. 1.3.4 carries the merged code.

After merge: publish to CodeArtifact, then in-place-update the 5 running db-host nodes + bump the iac ASG pin (saga-ed/iac#... companion).

Part of the snapshot↔schema versioning effort. Producer half. Detector consumer: saga-ed/program-hub#191.