### PR TITLE
feat(soa-postgres): idle_in_transaction_session_timeout guard, default ON (gh-186)

### DIFF
--- a/packages/node/postgres/package.json
+++ b/packages/node/postgres/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@saga-ed/soa-postgres",
   "type": "module",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "scripts": {
     "dev": "tsup --watch",
     "build": "tsup",

--- a/packages/node/postgres/src/__tests__/postgres-provider-config.unit.test.ts
+++ b/packages/node/postgres/src/__tests__/postgres-provider-config.unit.test.ts
@@ -25,6 +25,8 @@ describe('PostgresProviderSchema', () => {
       connectionTimeoutMs: 10_000,
       statementTimeoutMs: 0,
       lockTimeoutMs: 0,
+      // Safety guard (gh-186) defaults ON, unlike the opt-in perf timeouts.
+      idleInTransactionSessionTimeoutMs: 30_000,
     });
   });
 

--- a/packages/node/postgres/src/__tests__/postgres-provider.unit.test.ts
+++ b/packages/node/postgres/src/__tests__/postgres-provider.unit.test.ts
@@ -114,8 +114,27 @@ describe('PostgresProvider resilience', () => {
     await new Promise((r) => setTimeout(r, 0));
   });
 
-  it('does not register a connect handler when no session timeouts are set', async () => {
-    await new PostgresProvider(baseConfig()).connect();
+  it('registers a connect handler that sets the idle-in-transaction guard by default (gh-186)', async () => {
+    // The idle guard defaults ON, so a connect handler is registered even with
+    // no statement/lock timeouts — and it issues only the idle SET.
+    const provider = new PostgresProvider(baseConfig());
+    await provider.connect();
+
+    expect(state.handlers.connect).toBeTypeOf('function');
+    const client = { query: vi.fn().mockResolvedValue(undefined) };
+    state.handlers.connect(client);
+    expect(client.query).toHaveBeenCalledWith(
+      'SET idle_in_transaction_session_timeout = 30000',
+    );
+    expect(client.query).not.toHaveBeenCalledWith(expect.stringContaining('statement_timeout'));
+    expect(client.query).not.toHaveBeenCalledWith(expect.stringContaining('lock_timeout'));
+    await new Promise((r) => setTimeout(r, 0));
+  });
+
+  it('registers no connect handler when every session timeout (incl. the idle guard) is disabled', async () => {
+    await new PostgresProvider(
+      baseConfig({ idleInTransactionSessionTimeoutMs: 0 }),
+    ).connect();
     expect(state.handlers.connect).toBeUndefined();
   });
 

--- a/packages/node/postgres/src/aws-postgres-loader.ts
+++ b/packages/node/postgres/src/aws-postgres-loader.ts
@@ -148,6 +148,8 @@ export interface PostgresPoolConfig {
   connectionTimeoutMs?: number;
   statementTimeoutMs?: number;
   lockTimeoutMs?: number;
+  // Safety guard (gh-186); the provider defaults it ON (30s) when omitted.
+  idleInTransactionSessionTimeoutMs?: number;
 }
 
 const DEFAULT_REGION = 'us-west-2';

--- a/packages/node/postgres/src/postgres-provider-config.ts
+++ b/packages/node/postgres/src/postgres-provider-config.ts
@@ -54,6 +54,16 @@ export const PostgresProviderSchema = z.object({
   // should set these explicitly.
   statementTimeoutMs: z.number().int().nonnegative().default(0),
   lockTimeoutMs: z.number().int().nonnegative().default(0),
+
+  // Reap connections left `idle in transaction` past this many ms. Unlike the
+  // two timeouts above (opt-in performance deadlines), this is a SAFETY GUARD
+  // and defaults ON: it bounds the @prisma/adapter-pg "ack'd-but-not-durable"
+  // leak (program-hub gh-186) where a $transaction discarded on a maxWait
+  // timeout returns a connection to the pool still inside an open transaction
+  // (released without ROLLBACK), so later writes are acknowledged but never
+  // committed. 30s is safe — Prisma interactive-transaction bodies cap at 5s.
+  // Set 0 to disable (e.g. a service with legitimate long idle-in-tx work).
+  idleInTransactionSessionTimeoutMs: z.number().int().nonnegative().default(30_000),
 });
 
 export type PostgresProviderConfig = z.infer<typeof PostgresProviderSchema>;

--- a/packages/node/postgres/src/postgres-provider.ts
+++ b/packages/node/postgres/src/postgres-provider.ts
@@ -56,6 +56,9 @@ const POOL_DEFAULTS = {
   connectionTimeoutMs: 10_000,
   statementTimeoutMs: 0,
   lockTimeoutMs: 0,
+  // Safety guard, defaults ON (see PostgresProviderSchema) — bounds the
+  // adapter-pg ack'd-but-not-durable leak (gh-186).
+  idleInTransactionSessionTimeoutMs: 30_000,
 } as const;
 
 /** Internal canonical shape both accepted configs normalize into. */
@@ -72,6 +75,7 @@ interface NormalizedConfig {
   connectionTimeoutMs: number;
   statementTimeoutMs: number;
   lockTimeoutMs: number;
+  idleInTransactionSessionTimeoutMs: number;
 }
 
 @injectable()
@@ -137,7 +141,11 @@ export class PostgresProvider {
           );
         });
 
-        if (this.cfg.statementTimeoutMs > 0 || this.cfg.lockTimeoutMs > 0) {
+        if (
+          this.cfg.statementTimeoutMs > 0 ||
+          this.cfg.lockTimeoutMs > 0 ||
+          this.cfg.idleInTransactionSessionTimeoutMs > 0
+        ) {
           this.pool.on('connect', (client: PoolClient) => {
             // Fire-and-forget, but swallow rejections: an unhandled
             // rejection here (SET against a dying backend) is another
@@ -150,6 +158,15 @@ export class PostgresProvider {
             if (this.cfg.lockTimeoutMs > 0) {
               client
                 .query(`SET lock_timeout = ${this.cfg.lockTimeoutMs}`)
+                .catch(() => {});
+            }
+            // Safety guard (gh-186): reap connections left idle-in-transaction
+            // (e.g. an adapter-pg discard that released without ROLLBACK).
+            if (this.cfg.idleInTransactionSessionTimeoutMs > 0) {
+              client
+                .query(
+                  `SET idle_in_transaction_session_timeout = ${this.cfg.idleInTransactionSessionTimeoutMs}`,
+                )
                 .catch(() => {});
             }
           });
@@ -222,6 +239,9 @@ export class PostgresProvider {
         statementTimeoutMs:
           config.statementTimeoutMs ?? POOL_DEFAULTS.statementTimeoutMs,
         lockTimeoutMs: config.lockTimeoutMs ?? POOL_DEFAULTS.lockTimeoutMs,
+        idleInTransactionSessionTimeoutMs:
+          config.idleInTransactionSessionTimeoutMs ??
+          POOL_DEFAULTS.idleInTransactionSessionTimeoutMs,
       };
     }
 
@@ -238,6 +258,7 @@ export class PostgresProvider {
       connectionTimeoutMs: config.connectionTimeoutMs,
       statementTimeoutMs: config.statementTimeoutMs,
       lockTimeoutMs: config.lockTimeoutMs,
+      idleInTransactionSessionTimeoutMs: config.idleInTransactionSessionTimeoutMs,
     };
   }
 }


### PR DESCRIPTION
## What

Adds `idleInTransactionSessionTimeoutMs` to `PostgresProvider`, set per pooled connection in the existing `pool.on('connect')` handler (alongside `statement_timeout` / `lock_timeout`). Unlike those opt-in performance deadlines, it **defaults ON (30s)** as a safety guard.

## Why

Bounds the `@prisma/adapter-pg` "ack'd-but-not-durable" leak ([program-hub#186](https://github.com/saga-ed/program-hub/issues/186)): a Prisma `$transaction` discarded on a `maxWait` timeout returns a connection to the pool still inside an open transaction (released without `ROLLBACK`), so later writes are acknowledged but never committed. Postgres now reaps the poisoned connection. 30s is safe — Prisma interactive-transaction bodies cap at 5s. Set `0` to disable.

## Validation

- 31/31 unit tests pass (config default + connect-handler behavior, incl. the opt-out path).
- Validated against a real Postgres (synthetic-dev mesh DB) via the loader-shape config path program-hub uses: default → `30s`, explicit `0` → off.

## Behavior change for consumers

A connect handler is now registered **by default** (previously only when `statement_timeout`/`lock_timeout` were set). This lets program-hub `programs-api`/`scheduling-api` drop their interim per-service `pool.on('connect')` shim, and lets rostering / student-data-system inherit the guard on re-pin.

Bumps `0.1.2 → 0.1.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)