### PR TITLE
fix(event-outbox): exempt relay tx from idle_in_transaction_session_timeout (gh-186)

### DIFF
--- a/packages/node/event-outbox/package.json
+++ b/packages/node/event-outbox/package.json
@@ -1,48 +1,50 @@
 {
-    "name": "@saga-ed/soa-event-outbox",
-    "version": "0.1.0-dev.5",
-    "private": false,
-    "type": "module",
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "default": "./dist/index.js"
-        }
-    },
-    "files": ["dist"],
-    "scripts": {
-        "build": "tsup",
-        "check-types": "tsc --noEmit",
-        "test": "vitest run --passWithNoTests",
-        "lint": "eslint src/",
-        "clean": "rm -rf dist"
-    },
-    "dependencies": {
-        "@saga-ed/soa-event-envelope": "workspace:*",
-        "@saga-ed/soa-logger": "workspace:*",
-        "@saga-ed/soa-rabbitmq": "workspace:*",
-        "@opentelemetry/api": "^1.9.0",
-        "amqplib": "^0.10.4",
-        "pg": "^8.13.0"
-    },
-    "devDependencies": {
-        "@saga-ed/soa-typescript-config": "workspace:*",
-        "@types/amqplib": "^0.10.4",
-        "@types/node": "^24.0.3",
-        "@types/pg": "^8.11.10",
-        "tsup": "^8.5.0",
-        "typescript": "5.8.2",
-        "vitest": "^1.6.1"
-    },
-    "publishConfig": {
-        "registry": "https://saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/",
-        "access": "public"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/saga-ed/soa.git",
-        "directory": "packages/node/event-outbox"
+  "name": "@saga-ed/soa-event-outbox",
+  "version": "0.1.0-dev.6",
+  "private": false,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "check-types": "tsc --noEmit",
+    "test": "vitest run --passWithNoTests",
+    "lint": "eslint src/",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@saga-ed/soa-event-envelope": "workspace:*",
+    "@saga-ed/soa-logger": "workspace:*",
+    "@saga-ed/soa-rabbitmq": "workspace:*",
+    "@opentelemetry/api": "^1.9.0",
+    "amqplib": "^0.10.4",
+    "pg": "^8.13.0"
+  },
+  "devDependencies": {
+    "@saga-ed/soa-typescript-config": "workspace:*",
+    "@types/amqplib": "^0.10.4",
+    "@types/node": "^24.0.3",
+    "@types/pg": "^8.11.10",
+    "tsup": "^8.5.0",
+    "typescript": "5.8.2",
+    "vitest": "^1.6.1"
+  },
+  "publishConfig": {
+    "registry": "https://saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/saga-ed/soa.git",
+    "directory": "packages/node/event-outbox"
+  }
 }

--- a/packages/node/event-outbox/src/__tests__/relay-idle-exempt.unit.test.ts
+++ b/packages/node/event-outbox/src/__tests__/relay-idle-exempt.unit.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest';
+import { OutboxRelay } from '../relay.js';
+import type { OutboxRelayOpts } from '../relay.js';
+
+/**
+ * gh-186: the relay holds one transaction open across the publish loop, so its
+ * connection sits idle-in-transaction during broker I/O. A pool-level
+ * idle_in_transaction_session_timeout (soa-postgres >=0.1.3 defaults it ON at
+ * 30s) would terminate the relay mid-batch. drainBatch issues
+ * `SET LOCAL idle_in_transaction_session_timeout` right after BEGIN to exempt
+ * its own transaction. These tests pin that behavior (0-row path — no broker).
+ */
+function makeRelay(opts: Partial<OutboxRelayOpts> = {}) {
+	const client = { query: vi.fn().mockResolvedValue({ rows: [] }), release: vi.fn() };
+	const pool = { connect: vi.fn().mockResolvedValue(client) };
+	const logger = { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() };
+	const relay = new OutboxRelay({
+		pool: pool as unknown as OutboxRelayOpts['pool'],
+		connectionManager: {} as unknown as OutboxRelayOpts['connectionManager'],
+		exchange: 'test.events',
+		logger: logger as unknown as OutboxRelayOpts['logger'],
+		...opts,
+	});
+	// Mark "started" — the 0-row path commits before touching the channel.
+	(relay as unknown as { channel: object }).channel = {};
+	return { relay, client };
+}
+
+const drain = (relay: OutboxRelay) =>
+	(relay as unknown as { drainBatch: () => Promise<void> }).drainBatch();
+
+describe('OutboxRelay idle-in-transaction exemption (gh-186)', () => {
+	it('SET LOCALs idle_in_transaction_session_timeout (default 300000) right after BEGIN', async () => {
+		const { relay, client } = makeRelay();
+		await drain(relay);
+		const calls = client.query.mock.calls.map((c) => String(c[0]));
+		expect(calls[0]).toBe('BEGIN');
+		expect(calls[1]).toBe('SET LOCAL idle_in_transaction_session_timeout = 300000');
+	});
+
+	it('honors a configured txIdleTimeoutMs (0 disables the timeout for the relay tx)', async () => {
+		const { relay, client } = makeRelay({ txIdleTimeoutMs: 0 });
+		await drain(relay);
+		expect(client.query).toHaveBeenCalledWith(
+			'SET LOCAL idle_in_transaction_session_timeout = 0',
+		);
+	});
+});

--- a/packages/node/event-outbox/src/relay.ts
+++ b/packages/node/event-outbox/src/relay.ts
@@ -37,6 +37,22 @@ export interface OutboxRelayOpts {
      */
     drainTimeoutMs?: number;
     /**
+     * Per-transaction `idle_in_transaction_session_timeout` (ms) for the relay's
+     * drain transaction. The relay holds ONE transaction open across the whole
+     * publish loop (BEGIN → SELECT … FOR UPDATE SKIP LOCKED → publish each row →
+     * UPDATE → COMMIT), so the connection sits *idle in transaction* during
+     * broker I/O — by design (the row locks are the multi-relay claim). If the
+     * pool carries a server-side `idle_in_transaction_session_timeout` (e.g.
+     * `@saga-ed/soa-postgres` >=0.1.3 defaults it ON at 30s as the gh-186
+     * ack'd-but-not-durable guard), that timer would terminate the relay
+     * mid-batch under broker backpressure. The relay therefore overrides it for
+     * its own transaction via `SET LOCAL`. Defaults to 300_000 (5 min): a
+     * generous backstop that clears any healthy or moderately-backpressured
+     * batch while still bounding a truly-wedged relay. Set 0 to disable the
+     * timeout entirely for the relay tx (rely solely on `drainTimeoutMs`).
+     */
+    txIdleTimeoutMs?: number;
+    /**
      * Called when the relay encounters an unrecoverable pg error
      * (auth failure, missing role, missing database, missing table). Default
      * behavior: rethrow out of `tick()` so the parent process surfaces it via
@@ -152,6 +168,15 @@ export class OutboxRelay {
         let clientPoisoned = false;
         try {
             await client.query('BEGIN');
+            // The relay holds this transaction open across the publish loop
+            // (idle-in-transaction during broker I/O). Override any pool-level
+            // idle_in_transaction_session_timeout for THIS tx so a server-side
+            // guard (e.g. soa-postgres' default-ON 30s gh-186 guard) can't
+            // terminate the relay mid-batch under backpressure. SET LOCAL is
+            // scoped to this transaction and reverts on COMMIT/ROLLBACK.
+            await client.query(
+                `SET LOCAL idle_in_transaction_session_timeout = ${this.opts.txIdleTimeoutMs ?? 300_000}`,
+            );
             const result = await client.query<OutboxRow>(
                 `SELECT event_id, aggregate_type, aggregate_id, event_type,
                         event_version, payload, meta, occurred_at, attempts


### PR DESCRIPTION
## What

The outbox relay holds **one transaction open across its whole publish loop** (`BEGIN → SELECT … FOR UPDATE SKIP LOCKED → publish each row → UPDATE → COMMIT`), so the connection sits **idle-in-transaction during broker I/O** — by design (the row locks are the multi-relay claim).

`@saga-ed/soa-postgres` 0.1.3 now defaults `idle_in_transaction_session_timeout` **ON at 30s** (the [program-hub#186](https://github.com/saga-ed/program-hub/issues/186) ack'd-but-not-durable guard). On the relay's pool that timer would **terminate the relay mid-batch under broker backpressure** → `ROLLBACK` fails → client destroyed → retry.

## Fix

`drainBatch` issues `SET LOCAL idle_in_transaction_session_timeout = <txIdleTimeoutMs>` right after `BEGIN`, scoping the override to the relay's own transaction (`SET LOCAL` reverts on COMMIT/ROLLBACK). New opt `txIdleTimeoutMs` defaults to **300_000 (5 min)** — a backstop that clears any healthy/moderately-backpressured batch while still bounding a truly-wedged relay; `0` disables it for the relay tx.

This is the principled split: the guard stays **default-ON everywhere** (corruption-safe), and the one library that *legitimately* holds a long idle-in-transaction (the relay) owns its **per-tx exemption** — so consumers don't scatter pool-level opt-outs.

Bumps `0.1.0-dev.5 → 0.1.0-dev.6`. New unit tests pin the SET LOCAL (default + configured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)