### PR TITLE
feat(synthetic-dev): tunnel mode — share your local stack at https://<svc>.<moniker>.vms.wootdev.com

### DIFF
--- a/tools/synthetic-dev/.gitignore
+++ b/tools/synthetic-dev/.gitignore
@@ -1,3 +1,8 @@
 # Per-developer overlay of in-flight PRs (see integration-suite.example.tsv).
 # Never committed — yours alone, so it can't collide with a teammate's.
 integration-suite.local.tsv
+
+# Per-developer tunnel moniker (see tunnel.sh — prompted on first use).
+# Never committed: it's your namespace label, same isolation rationale as
+# the integration overlay above.
+.vms-moniker

--- a/tools/synthetic-dev/README.md
+++ b/tools/synthetic-dev/README.md
@@ -32,6 +32,9 @@ fixtures, no proxy, recording deferred). Ten is **rtsm-api** (rtsm,
 ./up.sh --seed [roster|full]    # seed without resetting (roster = default; iam groups don't dedup — prefer --reset)
 ./up.sh --status  # health + row counts
 ./up.sh --down    # stop services (mesh stays up)
+./up.sh --reset --tunnel --seed roster --login   # ALSO expose the browser plane at
+                  # https://<svc>.<moniker>.vms.wootdev.com for other users
+                  # (multi-user Connect) — see getting-started.md "tunnel mode"
 ```
 
 Branch posture (decision `../decisions/d1.1`): everything on **main**.

--- a/tools/synthetic-dev/getting-started.md
+++ b/tools/synthetic-dev/getting-started.md
@@ -223,6 +223,74 @@ connect-api (`~/dev/qboard/apps/node/connectv3-api`, **:6106**) and connect-web
   `VITE_PLAYBACK_ASSET_BASE_OVERRIDE=http://localhost:8444`.
 - **Deferred:** dash→connect session linking.
 
+## Multi-user access — tunnel mode (`--tunnel`)
+
+Connect is multi-user; your stack is localhost. Tunnel mode bridges that: it
+exposes the **browser-facing** services at stable public HTTPS names so other
+people (a coworker joining your Connect session, QA, a second device) can use
+*your running stack* — services keep running locally under `pnpm dev` with
+HMR. Infra is one shared rendezvous box (`vms/README.md`); day-to-day:
+
+```bash
+./up.sh --reset --tunnel --seed roster --login
+```
+
+First run prompts for your **moniker** (standard: your initials — saved to the
+gitignored `.vms-moniker`, registered automatically; the cert mint takes ~2
+min once). After that your stack is at:
+
+```
+https://connect.<moniker>.vms.wootdev.com        # Connect web — share THIS
+https://connect-api.<moniker>.vms.wootdev.com    # its API
+https://rtsm.<moniker>.vms.wootdev.com           # CRDT/socket sync
+https://iam.<moniker>.vms.wootdev.com            # login (/demo#auth for guests)
+```
+
+`./tunnel.sh status|urls|down` manages the tunnels alone (e.g. re-attach after
+a laptop sleep).
+
+**How a guest joins:** log in at `https://iam.<m>.vms.wootdev.com/demo#auth`
+(any seeded persona), then open the Connect URL. An unauthenticated guest who
+opens the Connect link directly gets bounced to that same demo page
+(tunnel mode overrides `JANUS_LOGIN_HOST` — by default Connect would send
+them to the REAL dev fleet's `login.wootdev.com`, which mints a session our
+local iam can't verify and loops). After logging in on the demo page, re-open
+the Connect link — the demo page doesn't auto-follow the `next=` param.
+
+**Saga-employee guests, one cookie gotcha:** a browser that has used the real
+dev fleet (or that hit the old redirect loop) carries an `iam_session` cookie
+on `.wootdev.com`, which is ALSO sent to `*.<m>.vms.wootdev.com` alongside our
+`.<m>.vms.wootdev.com` one — and connect-api reads the cookie name
+`iam_session` (hardcoded), so the stale real-dev one can win and 401 you even
+after a demo login. Fix: delete the `.wootdev.com` `iam_session` cookie in
+devtools (or just use an incognito window for guesting).
+
+Know these three caveats:
+
+- **Tunnel env applies at launch** — `--tunnel` on an already-running stack
+  warns and only affects newly-launched services; use `restart --tunnel` or
+  `--reset --tunnel`. In tunnel mode the session cookie is domain-scoped to
+  `.<m>.vms.wootdev.com`, so **log in via the tunnel URLs** (the `--login`
+  flow does this automatically), not localhost.
+- **AV rides the real fleek dev cluster** (`wss://*.fleek.wootdev.com`) —
+  local LiveKit is unreachable from a guest's browser (WebRTC media is UDP),
+  so tunnel mode auto-fetches the cluster creds (`qboard/fleek/livekit-creds`,
+  Secrets Manager) and repoints connect-api. If the fetch fails (expired SSO)
+  it warns and guests get CRDT-only — whiteboard/chat/sync still work.
+  Caveat: with cluster AV, `--record av`'s local egress can't capture media
+  (CRDT recording is unaffected).
+- **Remote dash needs saga-dash PR #194** (`url` service-override type) —
+  pin it in `integration-suite.local.tsv` (`saga-dash<TAB>194`) until it
+  lands. Tunnel mode then rewrites the dash's `config.json` `localDefaults`
+  to the tunnel hosts automatically (restored on the next non-tunnel run).
+  Note the config.json edit dirties the saga-dash working tree —
+  `git -C ~/dev/saga-dash checkout -- apps/web/dash/static/config.json`
+  before a `refresh-suite.sh` run (it refuses dirty repos).
+
+Prereqs: AWS SSO creds in the dev account (`aws sso login`) — tunnel
+registration reads the shared frp token from SSM. The rendezvous box itself is
+provisioned once for the whole team: `vms/README.md`.
+
 ## Walkthrough deck (start here for the UX flow)
 
 `../training/saga-dash-walkthrough.html` — open in a browser or serve via

--- a/tools/synthetic-dev/tunnel.sh
+++ b/tools/synthetic-dev/tunnel.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# tunnel.sh — expose the local synthetic-dev stack via the vms rendezvous box.
+#
+# Reverse-tunnels the browser-facing services to https://<svc>.<moniker>.vms.wootdev.com
+# (frp → the EC2 box provisioned by vms/template.yaml — see vms/README.md), so
+# other people (coworkers, QA, a second browser profile) can reach YOUR running
+# stack. The services keep running locally under `pnpm dev` with HMR — this is
+# a front door, not a deploy.
+#
+# Your moniker (the per-dev namespace label, standard = your initials) lives in
+# .vms-moniker alongside this script — gitignored, prompted for on first use,
+# and deliberately NEVER taken on the command line (placeholder monikers in
+# shared commands cross-contaminate stacks). First use also registers it in the
+# SSM moniker registry, which makes the box mint your wildcard cert
+# (*.<moniker>.vms.wootdev.com) within ~1 minute.
+#
+# Usage:
+#   ./tunnel.sh [up]        start tunnels (bootstraps moniker on first run)
+#   ./tunnel.sh down        stop tunnels
+#   ./tunnel.sh status      tunnel process + per-URL health probes
+#   ./tunnel.sh moniker     print the moniker (bootstrapping if absent) — used
+#                           by up.sh --tunnel; prompts go to stderr so the
+#                           value is safely $()-capturable
+#   ./tunnel.sh urls        print the public URL table
+#
+# Normally you don't run this directly: `./up.sh --reset --tunnel` launches the
+# services with tunnel-aware env (cookie domain, CORS, VITE_* URLs) AND brings
+# these tunnels up. Bare tunnel.sh is for re-attaching tunnels to an already
+# tunnel-launched stack (e.g. after a laptop sleep or an frp drop).
+#
+# Needs: AWS creds for the dev account (SSO; reads /vms/frp-token + registers
+# in /vms/monikers). Respects AWS_PROFILE. The frpc binary is auto-downloaded
+# (pinned FRP_VERSION, kept under ~/.local/share/synthetic-dev).
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+STATE=/tmp/sds-synthetic; mkdir -p "$STATE"
+MONIKER_FILE="$SCRIPT_DIR/.vms-moniker"
+
+VMS_BASE="${VMS_BASE:-vms.wootdev.com}"        # rendezvous domain (vms/template.yaml DomainName)
+FRP_PORT=7000                                  # frps control port on the box
+FRP_VERSION=0.61.1                             # pinned in lockstep with vms/template.yaml FrpVersion
+FRP_DIR="$HOME/.local/share/synthetic-dev/frp-$FRP_VERSION"
+AWS_REGION=us-west-2
+TOKEN_PARAM=/vms/frp-token
+MONIKERS_PARAM=/vms/monikers
+VMS_AWS_ACCOUNT="${VMS_AWS_ACCOUNT:-396913734878}"  # dev — guard asserts before any SSM write
+
+# Browser-facing services → local ports. Mirrors up.sh's launch table (the
+# internal plane — postgres/redis/rabbitmq/mongo — is deliberately absent: it
+# gets no tunnel, so it stays unreachable by construction). The hostname label
+# is the table key: <label>.<moniker>.$VMS_BASE.
+SERVICES=(
+    "iam:3010"
+    "sis:3100"
+    "programs:3006"
+    "scheduling:3008"
+    "sessions:3007"
+    "ads-adm:5005"
+    "dash:8900"
+    "connect:6210"
+    "connect-api:6106"
+    "rtsm:6110"
+)
+
+say(){  printf "\033[34m→\033[0m %s\n" "$*" >&2; }
+ok(){   printf "\033[32m✓\033[0m %s\n" "$*" >&2; }
+warn(){ printf "\033[33m⚠\033[0m %s\n" "$*" >&2; }
+err(){  printf "\033[31m✗\033[0m %s\n" "$*" >&2; }
+
+aws_cli(){ aws --region "$AWS_REGION" ${AWS_PROFILE:+--profile "$AWS_PROFILE"} "$@"; }
+
+# All /vms/* state lives in the DEV account, but profile NAMES vary per dev —
+# so resolve the profile by ACCOUNT NUMBER: scan ~/.aws/config for a profile
+# declaring sso_account_id == $VMS_AWS_ACCOUNT (pure local config reads, no
+# network, no token needed). An explicit AWS_PROFILE env always wins. With no
+# declared match we fall back to the bare default chain — which is exactly how
+# this script once registered a moniker into PROD, hence assert_dev_account
+# below verifies whatever was picked before any read or (worse) write.
+resolve_aws_profile(){
+    [[ -n "${AWS_PROFILE:-}" ]] && return 0
+    local p
+    while IFS= read -r p; do
+        [[ -z "$p" ]] && continue
+        if [[ "$(aws configure get sso_account_id --profile "$p" 2>/dev/null)" == "$VMS_AWS_ACCOUNT" ]]; then
+            AWS_PROFILE="$p"   # first declared match wins (config order)
+            say "AWS profile: '$p' (declares sso_account_id $VMS_AWS_ACCOUNT)"
+            return 0
+        fi
+    done < <(aws configure list-profiles 2>/dev/null)
+    AWS_PROFILE=""
+}
+resolve_aws_profile
+
+# Fail loudly if the credential chain lands in the wrong account (prod SSO,
+# stale default profile…) BEFORE any read or — worse — write happens.
+assert_dev_account(){
+    local acct label="${AWS_PROFILE:-<default chain>}"
+    acct=$(aws_cli sts get-caller-identity --query Account --output text 2>/dev/null) \
+        || { err "no AWS creds via '$label' — aws sso login${AWS_PROFILE:+ --profile $AWS_PROFILE}"; return 1; }
+    [[ "$acct" == "$VMS_AWS_ACCOUNT" ]] \
+        || { err "'$label' resolves to account $acct, expected dev ($VMS_AWS_ACCOUNT) — set AWS_PROFILE, or add an SSO profile for that account (aws configure sso)"; return 1; }
+}
+
+# ── moniker: read .vms-moniker, or first-run setup (prompt + SSM register) ──
+moniker(){
+    if [[ -f "$MONIKER_FILE" ]]; then
+        printf '%s\n' "$(tr -d '[:space:]' <"$MONIKER_FILE")"
+        return 0
+    fi
+    [[ -t 0 ]] || { err "no $MONIKER_FILE and no TTY to prompt — create it: echo <moniker> > $MONIKER_FILE"; return 1; }
+    assert_dev_account || return 1
+    say "first tunnel run — picking your dev moniker (the namespace in"
+    say "https://<service>.<moniker>.$VMS_BASE; standard is your initials)"
+    local m
+    while :; do
+        printf "moniker [a-z0-9, 1-8 chars]: " >&2; read -r m
+        [[ "$m" =~ ^[a-z0-9]{1,8}$ ]] && break
+        warn "'$m' — lowercase letters/digits only, 1-8 chars (it's a DNS label)"
+    done
+    register_moniker "$m" || return 1
+    printf '%s\n' "$m" >"$MONIKER_FILE"
+    ok "moniker '$m' saved to $MONIKER_FILE (gitignored) + registered"
+    say "the vms box polls the registry every minute and then mints your"
+    say "wildcard cert — first ./tunnel.sh up may wait ~2 min for TLS"
+    printf '%s\n' "$m"
+}
+
+# Append to the SSM StringList registry (create if absent). The box's renderer
+# polls this and adds a Caddy site block + wildcard cert for the new moniker.
+register_moniker(){ # m
+    local m=$1 cur
+    cur=$(aws_cli ssm get-parameter --name "$MONIKERS_PARAM" \
+              --query Parameter.Value --output text 2>/dev/null) || cur=""
+    if [[ -z "$cur" ]]; then
+        aws_cli ssm put-parameter --name "$MONIKERS_PARAM" --type StringList \
+            --value "$m" >/dev/null || { err "could not create $MONIKERS_PARAM (AWS creds? aws sso login)"; return 1; }
+    elif [[ ",$cur," == *",$m,"* ]]; then
+        : # already registered
+    else
+        aws_cli ssm put-parameter --name "$MONIKERS_PARAM" --type StringList \
+            --overwrite --value "$cur,$m" >/dev/null || { err "could not update $MONIKERS_PARAM"; return 1; }
+    fi
+}
+
+# ── frpc binary (pinned, auto-downloaded — same pattern as proxy-dev's mprocs) ──
+ensure_frpc(){
+    [[ -x "$FRP_DIR/frpc" ]] && return 0
+    local arch
+    case "$(uname -m)" in
+        x86_64)        arch=amd64 ;;
+        aarch64|arm64) arch=arm64 ;;
+        *) err "unsupported arch $(uname -m)"; return 1 ;;
+    esac
+    say "downloading frpc v$FRP_VERSION ($arch) → $FRP_DIR…"
+    mkdir -p "$FRP_DIR"
+    local tmp; tmp=$(mktemp -d)
+    curl -fsSL "https://github.com/fatedier/frp/releases/download/v${FRP_VERSION}/frp_${FRP_VERSION}_linux_${arch}.tar.gz" \
+        | tar xz -C "$tmp"
+    install -m 0755 "$tmp/frp_${FRP_VERSION}_linux_${arch}/frpc" "$FRP_DIR/frpc"
+    rm -rf "$tmp"
+    ok "frpc installed"
+}
+
+render_frpc_toml(){ # m token → writes $STATE/frpc.toml
+    local m=$1 token=$2 entry name port
+    {
+        printf '# rendered by tunnel.sh — do not edit\n'
+        printf 'serverAddr = "%s"\nserverPort = %s\n' "$VMS_BASE" "$FRP_PORT"
+        printf 'auth.method = "token"\nauth.token = "%s"\n' "$token"
+        printf 'transport.tls.enable = true\n'
+        for entry in "${SERVICES[@]}"; do
+            name=${entry%:*}; port=${entry#*:}
+            printf '\n[[proxies]]\nname = "%s-%s"\ntype = "http"\nlocalPort = %s\ncustomDomains = ["%s.%s.%s"]\n' \
+                "$name" "$m" "$port" "$name" "$m" "$VMS_BASE"
+        done
+    } >"$STATE/frpc.toml"
+    chmod 0600 "$STATE/frpc.toml"
+}
+
+print_urls(){ # m
+    local m=$1 entry name port
+    printf "  public URLs (→ local ports):\n" >&2
+    for entry in "${SERVICES[@]}"; do
+        name=${entry%:*}; port=${entry#*:}
+        printf "    %-12s https://%s.%s.%s  → :%s\n" "$name" "$name" "$m" "$VMS_BASE" "$port" >&2
+    done
+}
+
+tunnel_up(){
+    local m token
+    m=$(moniker) || exit 1
+    assert_dev_account || exit 1
+    register_moniker "$m"      # idempotent — heals a hand-written .vms-moniker
+    ensure_frpc || exit 1
+    say "fetching frp token ($TOKEN_PARAM)…"
+    token=$(aws_cli ssm get-parameter --name "$TOKEN_PARAM" --with-decryption \
+                --query Parameter.Value --output text 2>/dev/null) \
+        || { err "cannot read $TOKEN_PARAM — AWS creds expired (aws sso login), or the vms box isn't provisioned (see vms/README.md)"; exit 1; }
+    render_frpc_toml "$m" "$token"
+    if [[ -f "$STATE/frpc.pid" ]] && kill -0 "$(cat "$STATE/frpc.pid")" 2>/dev/null; then
+        say "frpc already running — restarting with current config…"
+        kill "$(cat "$STATE/frpc.pid")" 2>/dev/null || true; sleep 1
+    fi
+    say "starting frpc (log: $STATE/frpc.log)…"
+    ( nohup "$FRP_DIR/frpc" -c "$STATE/frpc.toml" >"$STATE/frpc.log" 2>&1 & echo $! >"$STATE/frpc.pid" )
+    local i
+    for i in $(seq 1 15); do
+        grep -q 'login to server success' "$STATE/frpc.log" 2>/dev/null && break
+        kill -0 "$(cat "$STATE/frpc.pid")" 2>/dev/null || { err "frpc died — tail $STATE/frpc.log"; exit 1; }
+        sleep 1
+    done
+    grep -q 'login to server success' "$STATE/frpc.log" 2>/dev/null \
+        || { err "frpc didn't reach $VMS_BASE:$FRP_PORT in 15s — tail $STATE/frpc.log (token? box up? — see vms/README.md)"; exit 1; }
+    ok "tunnels up as '$m'"
+    # End-to-end probe through DNS + Caddy + frp. A fresh moniker needs the
+    # box's 1-min registry poll + the ACME DNS-01 mint, hence the long patience.
+    say "probing https://iam.$m.$VMS_BASE/health (first run waits on cert mint, ~2 min)…"
+    for i in $(seq 1 24); do
+        [[ "$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "https://iam.$m.$VMS_BASE/health" 2>/dev/null)" == 200 ]] \
+            && { ok "end-to-end OK"; print_urls "$m"; return 0; }
+        sleep 5
+    done
+    warn "no 200 from iam through the tunnel yet. If the local stack is up"
+    warn "(./up.sh --status), give the cert mint another minute and check"
+    warn "./tunnel.sh status. Otherwise launch with: ./up.sh --reset --tunnel"
+    print_urls "$m"
+}
+
+tunnel_down(){
+    if [[ -f "$STATE/frpc.pid" ]]; then
+        kill "$(cat "$STATE/frpc.pid")" 2>/dev/null || true
+        rm -f "$STATE/frpc.pid"
+    fi
+    pkill -f "frpc -c $STATE/frpc.toml" 2>/dev/null || true
+    ok "tunnels down"
+}
+
+tunnel_status(){
+    local m entry name port code
+    m=$(moniker) || exit 1
+    if [[ -f "$STATE/frpc.pid" ]] && kill -0 "$(cat "$STATE/frpc.pid")" 2>/dev/null; then
+        ok "frpc running (pid $(cat "$STATE/frpc.pid"))"
+    else
+        err "frpc not running — ./tunnel.sh up"
+    fi
+    for entry in "${SERVICES[@]}"; do
+        name=${entry%:*}; port=${entry#*:}
+        code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 \
+            "https://$name.$m.$VMS_BASE$( [[ "$name" == dash || "$name" == connect ]] && echo / || { [[ "$name" == connect-api ]] && echo /connectv3/v1/health || echo /health; })" 2>/dev/null)
+        printf "  %-12s https://%s.%s.%s → %s\n" "$name" "$name" "$m" "$VMS_BASE" "$code" >&2
+    done
+}
+
+case "${1:-up}" in
+    up)       tunnel_up ;;
+    down)     tunnel_down ;;
+    status)   tunnel_status ;;
+    moniker)  moniker ;;
+    # The dev-account profile resolved by account number — for sibling tooling
+    # (up.sh fetches the fleek LiveKit creds with it). Empty = default chain.
+    aws-profile) printf '%s\n' "$AWS_PROFILE" ;;
+    urls)     m=$(moniker) || exit 1; print_urls "$m" ;;
+    -h|--help) sed -n '/^# Usage:/,/^# ─────/p' "$0"; exit 0 ;;
+    *) echo "unknown: $1 (up|down|status|moniker|urls)"; exit 1 ;;
+esac

--- a/tools/synthetic-dev/up.sh
+++ b/tools/synthetic-dev/up.sh
@@ -82,6 +82,15 @@
 #                                  + MinIO; `av` adds the LiveKit egress sidecar). Needs
 #                                  the fleek repo cloned + AWS CLI (CodeArtifact token
 #                                  for the image builds). Composes with up/reset/seed.
+#   ./up.sh --tunnel             ALSO expose the browser-facing services to other
+#                                  users at https://<svc>.<moniker>.vms.wootdev.com
+#                                  (multi-user Connect). Moniker comes from
+#                                  .vms-moniker (first run prompts + registers;
+#                                  never a CLI arg). Composes: `--reset --tunnel
+#                                  --seed roster --login`. Needs AWS SSO creds +
+#                                  the vms box (vms/README.md). Services must
+#                                  (re)launch to pick up tunnel env — prefer
+#                                  `restart --tunnel` / `--reset --tunnel`.
 #   ./up.sh --login [email]      auto-login via iam-api devLogin (default: dev@saga.org)
 #   ./up.sh --user  [email]      alias for --login
 #   ./up.sh --down               stop services (leaves mesh up)
@@ -188,6 +197,18 @@ DEV_USER_UUID="f0000004-0000-4000-8000-00000000beef"        # from iam-db seed-d
 ONLY_SERVICE=""                                             # --only <svc>: launch just this one
 SANDBOX_NAME=""                                             # --sandbox <name>: compose name the deps live under
 SANDBOX_BASE="${SANDBOX_BASE:-wootdev.com}"                # dev fleet base domain (preview-header routed)
+# ── tunnel mode (--tunnel): expose the browser-facing services to OTHER users
+# via the vms rendezvous box — https://<svc>.<moniker>.$VMS_BASE → this laptop
+# (tunnel.sh + vms/; built for multi-user Connect sessions). The moniker comes
+# from .vms-moniker (tunnel.sh bootstraps it on first use), deliberately NEVER
+# from the command line. tunnel_env() flips ONLY the browser-plane env (cookie
+# domain, connect CORS/VITE_* URLs); service-to-service URLs stay localhost.
+TUNNEL=0
+TUNNEL_DOMAIN=""                                            # <moniker>.$VMS_BASE once resolved
+TUNNEL_LK_KEY=""; TUNNEL_LK_SECRET=""; TUNNEL_FLEEK_TOPOLOGY=""  # AV-via-fleek (set in the tunnel block)
+VMS_BASE="${VMS_BASE:-vms.wootdev.com}"                     # rendezvous domain (vms/template.yaml)
+LOGIN_IAM_URL=""                                            # tunnel mode: login flows use the PUBLIC iam…
+LOGIN_DASH_URL=""                                           # …and dash URLs (domain cookie can't be set via localhost)
 STATE=/tmp/sds-synthetic; mkdir -p "$STATE"
 COOKIE_JAR="$STATE/cookies.txt"                             # devLogin session jar (for headless harnesses)
 DEFAULT_LOGIN_USER="dev@saga.org"                          # --login default persona (Seed District admin)
@@ -743,6 +764,135 @@ sandbox_env(){ # svc
     *) ;; # iam-api itself / saga-dash / ads-adm / rtsm / connect: no repoint wired (yet)
   esac
 }
+# tunnel_env: browser-plane env overrides for --tunnel (sandbox_env's sibling;
+# same splat-no-op contract — prints nothing unless TUNNEL=1). Splatted LAST on
+# each launch line, so its keys win over the local defaults (`env A=1 A=2` →
+# last wins). What flips, and why only this:
+#   - iam-api: AUTH_SESSIONCOOKIEDOMAIN=.<moniker>.$VMS_BASE — the iam_session
+#     cookie must flow across iam./connect-api./dash. tunnel hosts (locally the
+#     same trick is free: localhost cookies ignore ports). Env name follows the
+#     verified AUTH flattening (devUserId ↔ AUTH_DEVUSERID; AuthConfigSchema
+#     sessionCookieDomain, rostering schemas.ts:173). Scoped per-moniker, NOT
+#     .$VMS_BASE, so two devs' instances can't read each other's sessions.
+#     CORS needs nothing: soa-api-util's dev allowlist already wildcard-matches
+#     *.wootdev.com at any depth (cors.test.ts: pr-12.dash.wootdev.com passes),
+#     and rtsm subdomain-matches its parent-domain list (wootdev.com included).
+#   - connect-api: ALLOWED_ORIGINS gains the tunnel connect-web origin (qboard
+#     uses an exact-origin list, not the soa wildcard); PUBLIC_API_URL becomes
+#     the public name (recorder callbacks / absolute-URL surfaces).
+#   - connect-web: VITE_* dependency URLs flip to the tunnel hosts — these are
+#     BROWSER-side (a remote coworker's browser must reach connect-api/iam/rtsm
+#     via public names). Server-to-server URLs (IAM_API_URL etc.) stay local.
+#   - vite host check: __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS lets the vite dev
+#     servers accept the tunnel Host header (DNS-rebind protection would 403 an
+#     unknown host). Best-effort: vite ≥6.1 reads it; older vite either has no
+#     host check or needs server.allowedHosts in the app's vite config.
+# REMOTE dash: works when saga-dash carries PR #194 (the `url` override type —
+# pin it in integration-suite.local.tsv until it lands); services_up's
+# sync_dash_local_defaults rewrites config.json localDefaults to url-type
+# entries pointing at the tunnel hosts. AV (LiveKit) is UDP and doesn't
+# traverse tunnels: remote users get CRDT/chat (rtsm is websockets); for AV
+# point FLEEK_TOPOLOGY_JSON at the real fleek dev cluster.
+tunnel_env(){ # svc
+  [[ "$TUNNEL" == 0 ]] && return 0
+  local svc=$1
+  # CORS: do NOT rely on each service's built-in wootdev wildcard — iam-api
+  # (api-util allowlist) has one, but sis-api is a plain `cors` exact-string
+  # list (rostering sis-api/src/main.ts:71 — found the hard way: tunnel dash
+  # got 'no Access-Control-Allow-Origin' from sis), and the others are
+  # unaudited. Tunnel mode passes the tunnel origins EXPLICITLY everywhere a
+  # browser calls; these splat after the launch line's CORS_ORIGIN, so they
+  # win (env last-wins).
+  case "$svc" in
+    iam-api)
+      printf '%s\n' "AUTH_SESSIONCOOKIEDOMAIN=.$TUNNEL_DOMAIN" \
+                    "CORS_ORIGIN=$DASH_URL,$CONNECT_WEB_URL,https://dash.$TUNNEL_DOMAIN,https://connect.$TUNNEL_DOMAIN" ;;
+    sis-api)
+      # include the iam demo-page origins (local + tunnel): the demo page
+      # drives sis directly, and setting CORS_ORIGIN overrides sis's built-in
+      # localhost:3010 default (rostering #391)
+      printf '%s\n' "CORS_ORIGIN=$DASH_URL,http://localhost:$IAM_PORT,https://dash.$TUNNEL_DOMAIN,https://iam.$TUNNEL_DOMAIN" ;;
+    programs-api|scheduling-api|sessions-api|ads-adm-api)
+      printf '%s\n' "CORS_ORIGIN=$DASH_URL,https://dash.$TUNNEL_DOMAIN" ;;
+    connect-api)
+      # JANUS_LOGIN_HOST: where 401s send the browser. Default is the REAL dev
+      # fleet's login (login.wootdev.com), which "succeeds" via the employee
+      # janus gate and mints a real-dev iam_session our local iam can't verify
+      # → redirect LOOP. Point it at the tunneled iam's demo page (devLogin)
+      # instead — buildIamLoginUrl/new URL preserves the /demo path.
+      printf '%s\n' "ALLOWED_ORIGINS=$CONNECT_WEB_URL,https://connect.$TUNNEL_DOMAIN" \
+                    "PUBLIC_API_URL=https://connect-api.$TUNNEL_DOMAIN" \
+                    "JANUS_LOGIN_HOST=iam.$TUNNEL_DOMAIN/demo"
+      # AV → fleek dev cluster when the creds fetch succeeded (tunnel block).
+      # Splatted after the launch line's local FLEEK_TOPOLOGY_JSON/LIVEKIT_*,
+      # so these win (env last-wins). Values are space-free by construction
+      # (compact JSON) — safe through the $() splat.
+      if [[ -n "$TUNNEL_LK_KEY" && -n "$TUNNEL_LK_SECRET" ]]; then
+        printf '%s\n' "FLEEK_TOPOLOGY_JSON=$TUNNEL_FLEEK_TOPOLOGY" \
+                      "LIVEKIT_API_KEY=$TUNNEL_LK_KEY" \
+                      "LIVEKIT_API_SECRET=$TUNNEL_LK_SECRET"
+      fi ;;
+    connect-web)
+      printf '%s\n' "VITE_CONNECTV3_API_URL=https://connect-api.$TUNNEL_DOMAIN" \
+                    "VITE_IAM_API_URL=https://iam.$TUNNEL_DOMAIN" \
+                    "VITE_RTSM_BOOTSTRAP_URL=https://rtsm.$TUNNEL_DOMAIN" \
+                    "VITE_JANUS_LOGIN_HOST=https://iam.$TUNNEL_DOMAIN/demo" \
+                    "__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS=connect.$TUNNEL_DOMAIN" ;;
+    rtsm-api)
+      # Generated in the --tunnel resolution block; advertises the tunnel host
+      # as the node endpoint so discovery returns a reachable URL.
+      printf '%s\n' "FLEET_CONFIG_PATH=$STATE/rtsm-fleet-tunnel.json" ;;
+    saga-dash)
+      printf '%s\n' "__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS=dash.$TUNNEL_DOMAIN" ;;
+    *) ;; # everything else: dev CORS wildcard already admits *.wootdev.com
+  esac
+}
+
+# sync_dash_local_defaults: keep saga-dash's static/config.json localDefaults
+# in step with the launch mode. The dash resolves its API URLs from this file
+# (browser-side), so tunnel mode must rewrite the entries to url-type overrides
+# pointing at the public tunnel hosts — and a later non-tunnel run must restore
+# the committed localhost shape. Idempotent both directions; only touches keys
+# that already exist in localDefaults. Same tracked-file-patch precedent as the
+# apply_fixes sis-api edit (working-tree change on saga-dash — expected; note:
+# `git -C $SAGA_DASH checkout -- apps/web/dash/static/config.json` before a
+# refresh-suite run, which refuses dirty repos).
+# REQUIRES saga-dash PR #194 (the `url` override type) when TUNNEL=1: without
+# it the dash treats url entries as tag-less tags and silently resolves to
+# https://<svc>.wootdev.com — the REAL dev fleet. Pin #194 in your
+# integration-suite.local.tsv until it lands.
+sync_dash_local_defaults(){
+  local DASH_CFG="$SAGA_DASH/apps/web/dash/static/config.json"
+  [[ -f "$DASH_CFG" ]] || return 0
+  if node -e '
+    const fs = require("fs");
+    const [p, tunnel, domain] = process.argv.slice(1);
+    // dash service key → [tunnel host label, committed localhost port]
+    const map = {
+      "iam":            ["iam",        3010],
+      "program-hub":    ["programs",   3006],
+      "enrollment-api": ["programs",   3006],
+      "scheduling-api": ["scheduling", 3008],
+      "sessions-api":   ["sessions",   3007],
+      "sis-api":        ["sis",        3100],
+      "connect":        ["connect",    5173],
+    };
+    const c = JSON.parse(fs.readFileSync(p, "utf8"));
+    if (!c.localDefaults) process.exit(0);
+    for (const [key, [label, port]] of Object.entries(map)) {
+      if (!(key in c.localDefaults)) continue;
+      c.localDefaults[key] = tunnel === "1"
+        ? { type: "url", url: `https://${label}.${domain}` }
+        : { type: "localhost", port };
+    }
+    fs.writeFileSync(p, JSON.stringify(c, null, 2) + "\n");
+  ' "$DASH_CFG" "$TUNNEL" "$TUNNEL_DOMAIN" 2>/dev/null; then
+    if [[ "$TUNNEL" == 1 ]]; then ok "saga-dash config.json: localDefaults → https://<svc>.$TUNNEL_DOMAIN (url overrides; needs dash #194)"
+    else ok "saga-dash config.json: localDefaults → localhost ports"; fi
+  else
+    printf "\033[33m⚠\033[0m could not sync %s for tunnel mode (patch localDefaults by hand)\n" "$DASH_CFG"
+  fi
+}
 
 launch(){ # name port dir extra_env...
   local name=$1 port=$2 dir=$3 probe; shift 3
@@ -759,6 +909,9 @@ launch(){ # name port dir extra_env...
 
 services_up(){
   SERVICES_RC=0   # reset so a second call (restart) doesn't carry a stale failure
+  # Config-file deps first: the dash reads localDefaults at page load, so the
+  # file must match the mode BEFORE saga-dash (re)launches/HMRs.
+  sync_dash_local_defaults
   # Drift: soa-logger/soa-config on main now require a PINO_LOGGER config with
   # no defaults — `level` + `isExpressContext` (DotenvConfigManager reads them as
   # PINO_LOGGER_LEVEL / PINO_LOGGER_ISEXPRESSCONTEXT). Every soa node service
@@ -786,7 +939,7 @@ services_up(){
   # CORS_ORIGIN is COMMA-SEPARATED (api-util ≥1.2.0) — iam-api also gets the
   # connect-web origin, because connect-web's iam-client calls iam DIRECTLY
   # from the browser (personas.getMyPermissions, memberships, whoami…).
-  launch_if iam-api "$IAM_PORT" "$ROSTERING/apps/node/iam-api" PORT="$IAM_PORT" AUTH_DEVUSERID="$DEV_USER_UUID" CORS_ORIGIN="$DASH_URL,$CONNECT_WEB_URL"
+  launch_if iam-api "$IAM_PORT" "$ROSTERING/apps/node/iam-api" PORT="$IAM_PORT" AUTH_DEVUSERID="$DEV_USER_UUID" CORS_ORIGIN="$DASH_URL,$CONNECT_WEB_URL" $(tunnel_env iam-api)
   # sis-api → iam-api service.* over S2S; no creds locally (iam-api dev-bypass
   # synthesizes a service actor when auth is off). IAM_BASEURL/IAM_TOKENURL must
   # point at iam on :3010 (sis-api defaults to :3000). See d1.7. Under --sandbox
@@ -796,21 +949,21 @@ services_up(){
      NODE_ENV=development PORT="$SIS_PORT" \
      SIS_DATABASE_URL="$SIS_DB_URL" CORS_ORIGIN="$DASH_URL" \
      IAM_BASEURL="$IAM_URL/trpc" IAM_TOKENURL="$IAM_URL/v1/oauth/token" \
-     $(sandbox_env sis-api)
-  launch_if programs-api 3006 "$PROGRAM_HUB/apps/node/programs-api"     NODE_ENV=development DATABASE_URL="$PROGRAMS_DB_URL"   IAM_API_URL="$IAM_URL" RABBITMQ_URL="$MESH_MQ" JANUS_REQUIRED=false CORS_ORIGIN="$DASH_URL" $(sandbox_env programs-api)
-  launch_if scheduling-api 3008 "$PROGRAM_HUB/apps/node/scheduling-api" NODE_ENV=development DATABASE_URL="$SCHEDULING_DB_URL" IAM_API_URL="$IAM_URL" RABBITMQ_URL="$MESH_MQ" JANUS_REQUIRED=false CORS_ORIGIN="$DASH_URL" $(sandbox_env scheduling-api)
+     $(sandbox_env sis-api) $(tunnel_env sis-api)
+  launch_if programs-api 3006 "$PROGRAM_HUB/apps/node/programs-api"     NODE_ENV=development DATABASE_URL="$PROGRAMS_DB_URL"   IAM_API_URL="$IAM_URL" RABBITMQ_URL="$MESH_MQ" JANUS_REQUIRED=false CORS_ORIGIN="$DASH_URL" $(sandbox_env programs-api) $(tunnel_env programs-api)
+  launch_if scheduling-api 3008 "$PROGRAM_HUB/apps/node/scheduling-api" NODE_ENV=development DATABASE_URL="$SCHEDULING_DB_URL" IAM_API_URL="$IAM_URL" RABBITMQ_URL="$MESH_MQ" JANUS_REQUIRED=false CORS_ORIGIN="$DASH_URL" $(sandbox_env scheduling-api) $(tunnel_env scheduling-api)
   # sessions-api: DATABASE_URL + IAM_API_URL are REQUIRED (it throws without
   # them); its RABBITMQ_URL default is program-hub's standalone :5673, so point
   # it at the mesh. SCHEDULING_API_URL defaults to :3008 (already the mesh
   # port) and it doesn't read JANUS_REQUIRED, so neither is set. Pre-existing
   # program data needs a one-time manual replay (see header note).
-  launch_if sessions-api 3007 "$PROGRAM_HUB/apps/node/sessions-api"     NODE_ENV=development DATABASE_URL="$SESSIONS_DB_URL"   IAM_API_URL="$IAM_URL" RABBITMQ_URL="$MESH_MQ" CORS_ORIGIN="$DASH_URL" $(sandbox_env sessions-api)
+  launch_if sessions-api 3007 "$PROGRAM_HUB/apps/node/sessions-api"     NODE_ENV=development DATABASE_URL="$SESSIONS_DB_URL"   IAM_API_URL="$IAM_URL" RABBITMQ_URL="$MESH_MQ" CORS_ORIGIN="$DASH_URL" $(sandbox_env sessions-api) $(tunnel_env sessions-api)
   launch_if ads-adm-api 5005 "$SDS/apps/node/ads-adm-api" \
      ADS_ADM_SCHEDULE_PROVIDER=mock \
      ADS_ADM_DATABASE_URL=postgresql://ads_adm:ads_adm@localhost:5432/ads_adm_local \
      DATABASE_URL=postgresql://ads_adm:ads_adm@localhost:5432/ads_adm_local \
-     CORS_ORIGIN=http://localhost:8900 RABBITMQ_URL="$MESH_MQ"
-  launch_if saga-dash 8900 "$SAGA_DASH/apps/web/dash"
+     CORS_ORIGIN=http://localhost:8900 RABBITMQ_URL="$MESH_MQ" $(tunnel_env ads-adm-api)
+  launch_if saga-dash 8900 "$SAGA_DASH/apps/web/dash" $(tunnel_env saga-dash)
   # rtsm-api: a ONE-NODE FLEET, not bare single-instance mode. rtsm-client
   # always discovers via GET /fleet/discover (404 without fleet mode → the
   # browser's "Fleet discovery failed … Fleet mode may not be active"), so the
@@ -822,7 +975,8 @@ services_up(){
   # CORS allows localhost/127.0.0.1 origins unconditionally in its config.
   launch_if rtsm-api "$RTSM_PORT" "$RTSM/apps/node/rtsm-api" \
      EXPRESS_SERVER_PORT="$RTSM_PORT" \
-     FLEET_CONFIG_PATH="$SCRIPT_DIR/rtsm-fleet-local.json" FLEET_NODE_NAME=local
+     FLEET_CONFIG_PATH="$SCRIPT_DIR/rtsm-fleet-local.json" FLEET_NODE_NAME=local \
+     $(tunnel_env rtsm-api)
   # connect-api: verifies the SAME iam_session JWT the dash flow mints (JWKS
   # from local iam). Its issuer default is the wootdev iam, so override
   # JWT_ISSUER to local iam-api's JwtConfigSchema default (rostering
@@ -842,7 +996,8 @@ services_up(){
      LIVEKIT_URL="ws://localhost:7880" LIVEKIT_API_KEY=devkey LIVEKIT_API_SECRET=devsecret \
      RECORDING_SERVICE_TOKEN="$RECORDING_TOKEN" \
      RECORDER_URL_TEMPLATE="http://127.0.0.1:$RECORDER_CONTROL_PORT" \
-     FLEEK_TOPOLOGY_JSON='{"cityMap":{"_default":"ws://localhost:7880"},"nodes":{"local":{"url":"ws://localhost:7880"}}}'
+     FLEEK_TOPOLOGY_JSON='{"cityMap":{"_default":"ws://localhost:7880"},"nodes":{"local":{"url":"ws://localhost:7880"}}}' \
+     $(tunnel_env connect-api)
   # connect-web: vite on :6210 (its own config default). VITE_RTSM_BOOTSTRAP_URL
   # points the rtsm-client at the LOCAL single-node rtsm-api (it overrides
   # domain-based fleet discovery). On a qboard checkout without the plumb the
@@ -863,7 +1018,8 @@ services_up(){
      VITE_IAM_API_URL="$IAM_URL" \
      VITE_SAGA_API_TARGET="$SAGA_API_TARGET" \
      VITE_RTSM_BOOTSTRAP_URL="$RTSM_URL" \
-     VITE_PLAYBACK_ASSET_BASE_OVERRIDE="http://localhost:$RECORDINGS_API_PORT"
+     VITE_PLAYBACK_ASSET_BASE_OVERRIDE="http://localhost:$RECORDINGS_API_PORT" \
+     $(tunnel_env connect-web)
   return "$SERVICES_RC"   # non-zero iff a LAUNCHED service failed (skips don't count)
 }
 
@@ -969,11 +1125,15 @@ seed_stack(){
 #      don't land on the Janus redirect. Falls back gracefully if Playwright /
 #      saga-dash isn't available — the cookie jar half still succeeds.
 login_user(){
-  local email=${1:-$DEFAULT_LOGIN_USER} code
+  # Tunnel mode logs in through the PUBLIC iam URL: with AUTH_SESSIONCOOKIEDOMAIN
+  # set to .<moniker>.$VMS_BASE, a browser/jar rejects that Set-Cookie on a
+  # localhost response (host mismatch) — the cookie only lands via the tunnel
+  # host. The tunnel origin passes iam's allowlist (*.wootdev.com wildcard).
+  local email=${1:-$DEFAULT_LOGIN_USER} code iam_url="${LOGIN_IAM_URL:-$IAM_URL}"
   say "auto-login via iam-api devLogin as $email…"
   code=$(curl -s -o "$STATE/devlogin.json" -w '%{http_code}' --max-time 10 \
-    -X POST "$IAM_URL/trpc/auth.devLogin" \
-    -H 'Content-Type: application/json' -H "Origin: $IAM_URL" \
+    -X POST "$iam_url/trpc/auth.devLogin" \
+    -H 'Content-Type: application/json' -H "Origin: $iam_url" \
     -c "$COOKIE_JAR" -d "{\"email\":\"$email\"}" 2>/dev/null) || code=000
   if [[ "$code" != 200 ]]; then
     printf "\033[31m✗\033[0m devLogin failed (HTTP %s) for '%s'.\n" "$code" "$email"
@@ -1004,7 +1164,7 @@ open_login_browser(){
     kill "$(cat "$STATE/browser-login.pid")" 2>/dev/null || true; rm -f "$STATE/browser-login.pid"; sleep 1
   fi
   say "opening auto-logged-in dash in Chromium (profile $BROWSER_PROFILE)…"
-  ( IAM_URL="$IAM_URL" DASH_URL="$DASH_URL" LOGIN_EMAIL="$email" \
+  ( IAM_URL="${LOGIN_IAM_URL:-$IAM_URL}" DASH_URL="${LOGIN_DASH_URL:-$DASH_URL}" LOGIN_EMAIL="$email" \
       PROFILE_DIR="$BROWSER_PROFILE" SAGA_DASH_DASH="$SAGA_DASH/apps/web/dash" \
       nohup node "$BROWSER_LOGIN" >"$STATE/browser-login.log" 2>&1 & echo $! >"$STATE/browser-login.pid" )
   for _ in $(seq 1 40); do
@@ -1026,6 +1186,8 @@ services_down(){ for n in iam-api sis-api programs-api scheduling-api sessions-a
   [[ -f "$STATE/$n.pid" ]] && { pkill -P "$(cat "$STATE/$n.pid")" 2>/dev/null||true; kill "$(cat "$STATE/$n.pid")" 2>/dev/null||true; rm -f "$STATE/$n.pid"; }
 done
 [[ -f "$STATE/browser-login.pid" ]] && { kill "$(cat "$STATE/browser-login.pid")" 2>/dev/null||true; rm -f "$STATE/browser-login.pid"; }
+# tunnels: a tunnel with no services behind it is just public 502s — drop it too.
+[[ -f "$STATE/frpc.pid" ]] && { kill "$(cat "$STATE/frpc.pid")" 2>/dev/null||true; rm -f "$STATE/frpc.pid"; pkill -f "frpc -c $STATE/frpc.toml" 2>/dev/null||true; }
 # tsup watchers: match the real cmdline (node .../tsup/dist/cli-default.js --watch);
 # the literal "tsup --watch" never matches, so watchers used to survive --down.
 pkill -f "tsup/dist/cli-default.js --watch" 2>/dev/null||true
@@ -1062,6 +1224,9 @@ status(){
   fi
   docker exec soa-postgres-1 psql -U iam -d iam_local -tAc \
     "SELECT 'iam users='||count(*) FROM users" 2>/dev/null | sed 's/^/  /'
+  if [[ -f "$STATE/frpc.pid" ]] && kill -0 "$(cat "$STATE/frpc.pid")" 2>/dev/null; then
+    printf "  %-15s up — ./tunnel.sh status for public URLs\n" "tunnel"
+  fi
 }
 
 # ── arg parsing: verbs (up/down/status/help) + composable flags ──────
@@ -1081,7 +1246,7 @@ case "${1:-up}" in
   # Self-maintaining: print the header's "Usage:" block through its closing
   # ruler, instead of a hardcoded line range that drifts as the header grows.
   -h|--help)                     sed -n '/^# Usage:/,/^# ─────/p' "$0"; exit 0 ;;
-  --reset|--seed|--login|--user|--pull|--record|--only|--sandbox) ;; # flag-only invocation; skip up
+  --reset|--seed|--login|--user|--pull|--record|--only|--sandbox|--tunnel) ;; # flag-only invocation; skip up
   *) echo "unknown: $1 (use --help)"; exit 1 ;;
 esac
 while [[ $# -gt 0 ]]; do
@@ -1100,6 +1265,10 @@ while [[ $# -gt 0 ]]; do
     # header to the dev fleet (see sandbox_env). Either implies the hybrid path.
     --only)    ONLY_SERVICE="${2:-}"; [[ -z "$ONLY_SERVICE" || "$ONLY_SERVICE" == -* ]] && { echo "--only needs a service name"; exit 1; }; shift 2 ;;
     --sandbox) SANDBOX_NAME="${2:-}"; [[ -z "$SANDBOX_NAME" || "$SANDBOX_NAME" == -* ]] && { echo "--sandbox needs a name"; exit 1; }; shift 2 ;;
+    # --tunnel: NO argument — the moniker comes from .vms-moniker (tunnel.sh
+    # bootstraps it interactively on first use), keeping monikers out of shared
+    # command lines (no placeholders, no cross-contamination).
+    --tunnel)  TUNNEL=1; shift ;;
     *) echo "unknown flag: $1 (use --help)"; exit 1 ;;
   esac
 done
@@ -1124,6 +1293,71 @@ fi
 if [[ -n "$SANDBOX_NAME" && ! "$SANDBOX_NAME" =~ ^[a-zA-Z0-9][a-zA-Z0-9-]{0,39}$ ]]; then
   echo "--sandbox: '$SANDBOX_NAME' must match [a-zA-Z0-9][a-zA-Z0-9-]{0,39}"; exit 1
 fi
+# Tunnel-mode resolution. The moniker prompt (first run) talks on stderr, so
+# the $() capture stays clean. tunnel_env() needs TUNNEL_DOMAIN before any
+# launch line runs; LOGIN_*_URLs flip the login flow to the public hosts (the
+# domain cookie can't be minted via localhost). --tunnel is a LAUNCH-ENV
+# directive: services must (re)start to pick the env up, so a bare
+# `./up.sh --tunnel` implies up — but already-running services keep their
+# localhost env (warned below); `--reset --tunnel` / `restart --tunnel` flips
+# everything cleanly.
+if [[ $TUNNEL == 1 ]]; then
+  TUNNEL_MONIKER="$("$SCRIPT_DIR/tunnel.sh" moniker)" || { err "could not resolve a moniker (see tunnel.sh)"; exit 1; }
+  TUNNEL_DOMAIN="$TUNNEL_MONIKER.$VMS_BASE"
+  LOGIN_IAM_URL="https://iam.$TUNNEL_DOMAIN"
+  LOGIN_DASH_URL="https://dash.$TUNNEL_DOMAIN"
+  # rtsm fleet config, tunnel flavor. The node's `endpoint` is the
+  # BROWSER-visible host (bare, no scheme — rtsm-client composes
+  # `${scheme}://${endpoint}`, deriving the scheme from its bootstrap URL).
+  # With the https tunnel bootstrap, a localhost:6110 endpoint makes every
+  # client probe https://localhost:6110 → "no reachable fleet nodes" — so in
+  # tunnel mode the fleet must advertise the tunnel host instead.
+  # tunnel_env(rtsm-api) points FLEET_CONFIG_PATH at this generated file.
+  node -e '
+    const fs = require("fs");
+    const [src, dst, host] = process.argv.slice(1);
+    const c = JSON.parse(fs.readFileSync(src, "utf8"));
+    c._comment = "GENERATED by up.sh --tunnel from rtsm-fleet-local.json — endpoint swapped to the tunnel host (browser-visible; scheme comes from the bootstrap URL).";
+    c.nodes.local.endpoint = host;
+    fs.writeFileSync(dst, JSON.stringify(c, null, 4) + "\n");
+  ' "$SCRIPT_DIR/rtsm-fleet-local.json" "$STATE/rtsm-fleet-tunnel.json" "rtsm.$TUNNEL_DOMAIN" \
+    || { err "could not render $STATE/rtsm-fleet-tunnel.json"; exit 1; }
+  # AV via the REAL fleek dev cluster. Local LiveKit (ws://localhost:7880) is
+  # unreachable from a guest's browser (WebRTC media is UDP — it can't ride
+  # the HTTP tunnels), so tunnel mode points connect-api at the fleek dev
+  # nodes instead: the deployed topology (qboard infra/connectv3-api/
+  # samconfig.yaml — keep in sync) + the cluster's real LiveKit creds from
+  # Secrets Manager (same JSON secret the ECS task injects). Best-effort: no
+  # creds → warn and stay on local AV (guests get CRDT-only, same as before).
+  TUNNEL_LK_KEY=""; TUNNEL_LK_SECRET=""
+  TUNNEL_FLEEK_TOPOLOGY='{"domain":"fleek.wootdev.com","cityMap":{"phx":"wss://phx-1.fleek.wootdev.com","chi":"wss://chi-1.fleek.wootdev.com","nyc":"wss://nyc-1.fleek.wootdev.com","_default":"wss://chi-1.fleek.wootdev.com"}}'
+  TUNNEL_AWS_PROFILE="$("$SCRIPT_DIR/tunnel.sh" aws-profile 2>/dev/null)" || TUNNEL_AWS_PROFILE=""
+  _lk_json=$(aws secretsmanager get-secret-value --secret-id qboard/fleek/livekit-creds \
+      --region us-west-2 ${TUNNEL_AWS_PROFILE:+--profile "$TUNNEL_AWS_PROFILE"} \
+      --query SecretString --output text 2>/dev/null) || _lk_json=""
+  if [[ -n "$_lk_json" ]]; then
+    TUNNEL_LK_KEY=$(node -e 'console.log(JSON.parse(process.argv[1]).api_key||"")' "$_lk_json" 2>/dev/null) || TUNNEL_LK_KEY=""
+    TUNNEL_LK_SECRET=$(node -e 'console.log(JSON.parse(process.argv[1]).api_secret||"")' "$_lk_json" 2>/dev/null) || TUNNEL_LK_SECRET=""
+  fi
+  unset _lk_json
+  if [[ -n "$TUNNEL_LK_KEY" && -n "$TUNNEL_LK_SECRET" ]]; then
+    ok "tunnel AV: fleek dev cluster (wss://*.fleek.wootdev.com; creds from qboard/fleek/livekit-creds)"
+    [[ $DO_RECORD == 1 && "$RECORD_MODE" == av ]] \
+      && warn "--record av + --tunnel: AV rides the fleek CLUSTER, so the LOCAL egress can't capture media; CRDT recording still works."
+  else
+    warn "could not fetch qboard/fleek/livekit-creds — AV stays LOCAL (guests get CRDT-only; aws sso login and re-run for cluster AV)"
+  fi
+  say "tunnel mode: browser plane at https://<svc>.$TUNNEL_DOMAIN (Connect: https://connect.$TUNNEL_DOMAIN)"
+  warn "remote users: Connect + dash are wired (dash needs PR #194 pinned — see"
+  warn "integration-suite.local.tsv); AV is CRDT-only over tunnels (LiveKit/UDP —"
+  warn "see vms/README.md known limitations)."
+  if [[ $DO_RESET == 0 && $DO_RESTART == 0 ]]; then
+    DO_UP=1
+    warn "services already running keep their LOCALHOST env — use './up.sh restart --tunnel'"
+    warn "(or --reset --tunnel) to relaunch everything tunnel-aware."
+  fi
+fi
+
 if [[ -n "$SANDBOX_NAME" ]]; then
   say "hybrid: $ONLY_SERVICE local → iam dep at https://iam.$SANDBOX_BASE (sandbox '$SANDBOX_NAME')"
   warn "ROUTING IS NOT AUTOMATIC: $ONLY_SERVICE only reaches sandbox iam if its INBOUND"
@@ -1169,6 +1403,11 @@ if [[ $DO_RESET == 1 || $DO_RESTART == 1 ]]; then
 elif [[ $DO_UP == 1 ]]; then
   services_up
   ok "stack up — try: $0 --status"
+fi
+# Tunnels come up AFTER services (so the end-to-end probe has something to
+# hit) and BEFORE --login (which routes through the public iam in tunnel mode).
+if [[ $TUNNEL == 1 ]]; then
+  "$SCRIPT_DIR/tunnel.sh" up
 fi
 [[ $DO_RECORD == 1 ]] && record_up "$RECORD_MODE"
 [[ $DO_SEED == 1 ]]  && seed_stack "$SEED_MODE"

--- a/tools/synthetic-dev/vms/README.md
+++ b/tools/synthetic-dev/vms/README.md
@@ -1,0 +1,137 @@
+# vms — synthetic-dev tunnel rendezvous server
+
+One small EC2 box (t4g.small + EIP, dev account) that makes a developer's
+**local** synthetic-dev stack reachable by other people at stable HTTPS names:
+
+```
+coworker (anywhere) ──HTTPS──▶  vms.wootdev.com box (EIP)
+                                  │ Caddy :443 — per-dev wildcard certs (DNS-01)
+                                  │ frps  :8080 vhost — Host-header routing
+                                  ▼ reverse tunnel (frp, token-gated :7000)
+            connect.jw.vms.wootdev.com      → your laptop :6210
+            connect-api.jw.vms.wootdev.com  → your laptop :6106
+            rtsm.jw.vms.wootdev.com         → your laptop :6110
+            iam.jw.vms.wootdev.com          → your laptop :3010   …etc
+```
+
+The hostname scheme is `<service>.<moniker>.vms.wootdev.com` — a short
+per-dev moniker (your initials) namespaces every instance, so any number of
+devs share this one box with zero per-dev server config. Day-to-day use is
+entirely laptop-side: `../tunnel.sh` (or `../up.sh --tunnel`). This directory
+is only the **infra**: the CloudFormation template + these ops docs.
+
+**This is a dev/multi-user tool, not a deploy artifact.** The services keep
+running on your laptop under `pnpm dev` with HMR; the box only fronts them.
+
+## How it works (the three tricks)
+
+1. **DNS**: one wildcard record `*.vms.wootdev.com → EIP`. DNS wildcards match
+   multiple labels, so `connect-api.jw.vms.wootdev.com` already resolves —
+   no per-dev or per-service DNS ever.
+2. **TLS**: X.509 wildcards match only ONE label, so the box keeps a tiny
+   moniker registry (SSM `/vms/monikers`) and renders one Caddy site block —
+   and therefore one Let's Encrypt **wildcard cert `*.<moniker>.vms.wootdev.com`**
+   — per registered dev, minted via Route53 DNS-01 (instance role is
+   zone-scoped). Registering a moniker is something `tunnel.sh` does from the
+   laptop (SSM append); the box polls the registry every minute.
+3. **Routing**: Caddy terminates TLS and proxies everything (Host preserved)
+   to frps's local vhost port; each laptop's `frpc` declares its hostnames via
+   `customDomains`, so adding a service/dev never touches the box.
+
+## One-time provisioning
+
+Prereqs: AWS SSO creds in the dev account (396913734878), SAM CLI.
+
+```bash
+# 1. Shared frp auth token (CloudFormation can't create SecureStrings).
+aws ssm put-parameter --region us-west-2 --profile SagaDevelopmentProfile \
+    --name /vms/frp-token --type SecureString \
+    --value "$(openssl rand -hex 32)"
+
+# 2. Deploy the stack (EC2 + EIP + SG + role + DNS records + cloud-init).
+cd tools/synthetic-dev/vms
+sam deploy --config-env vms --profile SagaDevelopmentProfile
+
+# 3. Verify (cert mint for the apex takes ~1 min after boot).
+curl -s https://vms.wootdev.com    # → "vms tunnel rendezvous - see ..."
+```
+
+That's it. Devs self-register from their laptops on first `tunnel.sh` run.
+
+## What the stack creates
+
+| Resource | Notes |
+|---|---|
+| EC2 `synthetic-dev-vms` (t4g.small, AL2023 arm64) | fully regenerable from cloud-init; the EIP is the identity |
+| EIP + `vms.wootdev.com` / `*.vms.wootdev.com` A records | zone `Z06686211OOAM6WWKX6KW` (wootdev.com) |
+| SG: 443/80/7000 open, **no SSH** | shell via SSM: `aws ssm start-session --target $(aws ssm get-parameter --name /vms/infra/dev/instance-id --query Parameter.Value --output text)` |
+| Instance role | `AmazonSSMManagedInstanceCore` + Route53 change scoped to the zone (DNS-01) + read `/vms/*` SSM params |
+| SSM `/vms/infra/dev/public-ip`, `/vms/infra/dev/instance-id` | written by the stack |
+
+SSM parameters it **reads** (not stack-managed):
+
+| Param | Type | Who writes it |
+|---|---|---|
+| `/vms/frp-token` | SecureString | you, step 1 above |
+| `/vms/monikers` | StringList | `tunnel.sh` (create-or-append on first run per dev) |
+
+## Security posture
+
+- **Public by design.** Anyone can resolve and TCP-connect; what they reach is
+  a dev's synthetic-data stack (no PII — the seed is synthetic by
+  construction). The known sharp edge: local stacks run iam-api with
+  `devLogin` enabled, so anyone with the URL can mint a session as any
+  synthetic persona. Acceptable for synthetic data; if it ever isn't, the
+  graduated responses are a per-dev secret moniker, or running the local
+  iam-api with `JANUS_REQUIRED=true` (the existing JumpCloud gate).
+- Tunnel **registration** requires the frp token (SSM SecureString, dev-account
+  SSO needed) — outsiders can't attach tunnels.
+- The box itself: no SSH port, SSM-only access, nothing listens but Caddy
+  (80/443) and frps (7000, token + TLS).
+- IAM: route53 writes are zone-scoped; SSM reads are `/vms/*`-scoped.
+
+## Operations
+
+```bash
+# Health
+curl -s https://vms.wootdev.com
+# Logs / shell (no SSH)
+aws ssm start-session --target <instance-id> --profile SagaDevelopmentProfile
+#   then: journalctl -u caddy -u frps -u vms-render --since -1h
+#   cloud-init log: /var/log/vms-init.log
+# Force a config re-render (normally the 1-min timer does this)
+#   sudo /usr/local/bin/vms-render
+# Rotate the frp token (devs' tunnel.sh picks it up on next `up`)
+aws ssm put-parameter --name /vms/frp-token --type SecureString --overwrite --value "$(openssl rand -hex 32)"
+# Remove a dev: edit /vms/monikers (StringList) — the renderer drops their
+# site block within a minute
+# Replace the box (AMI refresh / config change): just redeploy the stack —
+# the instance is disposable, EIP + DNS + certs(re-minted) survive
+sam deploy --config-env vms --profile SagaDevelopmentProfile
+# Tear down everything (also releases the EIP — DNS records die with it)
+sam delete --stack-name synthetic-dev-vms --region us-west-2 --profile SagaDevelopmentProfile
+```
+
+## Costs
+
+~$12/mo (t4g.small) + ~$3.6/mo EIP + single-digit GB egress. Pennies/day; if
+it falls out of use, `sam delete` and re-provision later in ~5 minutes.
+
+## Known limitations
+
+- **AV (LiveKit) does not traverse the tunnels** (WebRTC media is UDP), so
+  `up.sh --tunnel` repoints connect-api at the **real fleek dev cluster**
+  (`wss://*.fleek.wootdev.com` + creds auto-fetched from Secrets Manager
+  `qboard/fleek/livekit-creds`). Falls back to CRDT-only for guests if the
+  creds fetch fails. CRDT/whiteboard/chat always work (rtsm is websockets —
+  tunnels fine).
+- **saga-dash for REMOTE users** needs saga-dash PR #194 (the `url` service
+  override type) — pin it in `integration-suite.local.tsv` until it lands.
+  With it, `up.sh --tunnel` rewrites the dash's `config.json` `localDefaults`
+  to url-type entries pointing at the tunnel hosts (and restores the
+  localhost shape on the next non-tunnel run).
+- frps/frpc versions are pinned in lockstep (`FrpVersion` here,
+  `FRP_VERSION` in `tunnel.sh`) — bump both together.
+- The Caddy binary comes from the official caddyserver.com build service
+  (with the route53 plugin compiled in). If that service is ever down during
+  a re-provision, build with xcaddy and scp via SSM instead.

--- a/tools/synthetic-dev/vms/samconfig.yaml
+++ b/tools/synthetic-dev/vms/samconfig.yaml
@@ -1,0 +1,23 @@
+version: 0.1
+# Manual-only stack (no CI lane) — deploy from a dev laptop:
+#   cd tools/synthetic-dev/vms && sam deploy --config-env vms --profile SagaDevelopmentProfile
+# The profile below is a local convenience; pass --profile to override.
+vms:
+  deploy:
+    parameters:
+      stack_name: synthetic-dev-vms
+      template_file: template.yaml
+      capabilities: CAPABILITY_NAMED_IAM
+      region: us-west-2
+      confirm_changeset: true
+      resolve_s3: true
+      profile: SagaDevelopmentProfile
+      parameter_overrides:
+      - DomainName=vms.wootdev.com
+      - HostedZoneId=Z06686211OOAM6WWKX6KW
+      - InstanceType=t4g.small
+      - FrpVersion=0.61.1
+      - FrpTokenParameterName=/vms/frp-token
+      - MonikersParameterName=/vms/monikers
+      - AcmeEmail=jward@saga.org
+      tags: Project=synthetic-dev Environment=dev ManagedBy=SAM Service=vms

--- a/tools/synthetic-dev/vms/template.yaml
+++ b/tools/synthetic-dev/vms/template.yaml
@@ -1,0 +1,388 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >-
+  vms - synthetic-dev tunnel rendezvous server (saga-ed/soa
+  tools/synthetic-dev/vms). One small EC2 box with a permanent EIP behind
+  vms.wootdev.com / *.vms.wootdev.com. Runs Caddy (TLS termination; per-dev
+  wildcard certs via Route53 DNS-01) and frps (reverse tunnels from dev
+  laptops), so a developer's local synthetic-dev stack is reachable at
+  https://<service>.<moniker>.vms.wootdev.com. Shared dev-infra utility, not
+  an app service - no ECS, no ALB, dev account only. See README.md alongside.
+
+Parameters:
+  DomainName:
+    Type: String
+    Default: vms.wootdev.com
+    Description: >-
+      Apex DNS name for the rendezvous box. The template creates A records for
+      this name and its wildcard (*.DomainName), both pointing at the EIP.
+  HostedZoneId:
+    Type: String
+    Default: Z06686211OOAM6WWKX6KW
+    Description: >-
+      Route53 public hosted zone the DNS records live in (wootdev.com in the
+      dev account). Also the zone the instance role may write ACME DNS-01
+      challenge records into (Caddy cert issuance).
+  InstanceType:
+    Type: String
+    Default: t4g.small
+    Description: >-
+      EC2 instance type. arm64 (t4g) - the AMI parameter below is arm64; pick
+      a Graviton type or change both. t4g.small is plenty for proxying dev
+      HTTP traffic.
+  AmiId:
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64
+    Description: >-
+      AL2023 arm64 AMI, resolved from the public SSM alias at deploy time so
+      stack updates pick up patched images.
+  VpcId:
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>
+    Default: /shared/infra/dev/vpc-id
+    Description: Shared dev VPC (resolved from the canonical shared SSM param).
+  PublicSubnetIds:
+    Type: AWS::SSM::Parameter::Value<List<String>>
+    Default: /shared/infra/dev/public-subnet-ids
+    Description: >-
+      Shared dev public subnets; the instance lands in the first one (it needs
+      a public IP - it IS the public front door).
+  FrpVersion:
+    Type: String
+    Default: 0.61.1
+    Description: >-
+      Pinned frp release installed on the box (github.com/fatedier/frp).
+      tunnel.sh pins the same version client-side; bump both together.
+  FrpTokenParameterName:
+    Type: String
+    Default: /vms/frp-token
+    Description: >-
+      SSM SecureString holding the shared frps auth token. Created out-of-band
+      (CloudFormation cannot create SecureStrings) - see README.md step 1.
+      Read by the instance at render time and by tunnel.sh on each dev laptop.
+  MonikersParameterName:
+    Type: String
+    Default: /vms/monikers
+    Description: >-
+      SSM StringList of registered dev monikers (e.g. "jw,sean"). tunnel.sh
+      appends on first run; the box polls it every minute and renders one
+      Caddy site block (and one wildcard cert) per moniker.
+  AcmeEmail:
+    Type: String
+    Default: jward@saga.org
+    Description: Contact email for Let's Encrypt cert issuance notifications.
+
+Resources:
+  SecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: vms tunnel rendezvous - public HTTPS + frp control plane
+      VpcId: !Ref VpcId
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 0.0.0.0/0
+          Description: HTTPS - Caddy TLS termination for *.DomainName
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: 0.0.0.0/0
+          Description: HTTP - ACME HTTP-01 fallback and redirect-to-HTTPS
+        # frp's control connection is a raw long-lived TCP listener; it is
+        # gated by the shared token (SSM SecureString) + TLS, not by source
+        # IP, because devs connect from arbitrary home networks.
+        - IpProtocol: tcp
+          FromPort: 7000
+          ToPort: 7000
+          CidrIp: 0.0.0.0/0
+          Description: frps control port - token-gated reverse-tunnel registration
+      SecurityGroupEgress:
+        - IpProtocol: '-1'
+          CidrIp: 0.0.0.0/0
+          Description: all outbound
+      Tags:
+        - { Key: Project, Value: synthetic-dev }
+        - { Key: Environment, Value: dev }
+        - { Key: ManagedBy, Value: SAM }
+        - { Key: Service, Value: vms }
+
+  # No SSH ingress by design - shell access is via SSM Session Manager
+  # (AmazonSSMManagedInstanceCore): aws ssm start-session --target <instance-id>
+  InstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: synthetic-dev-vms-instance-role
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal: { Service: ec2.amazonaws.com }
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+      Policies:
+        # Caddy mints per-moniker wildcard certs via ACME DNS-01: it writes a
+        # TXT challenge record into the zone and deletes it after issuance.
+        - PolicyName: Route53Dns01
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - route53:ChangeResourceRecordSets
+                  - route53:ListResourceRecordSets
+                Resource: !Sub arn:aws:route53:::hostedzone/${HostedZoneId}
+              - Effect: Allow
+                Action: route53:GetChange
+                Resource: arn:aws:route53:::change/*
+              # The caddy-dns/route53 plugin locates the zone by name at
+              # startup; list calls have no resource-level scoping.
+              - Effect: Allow
+                Action: route53:ListHostedZonesByName
+                Resource: '*'
+        - PolicyName: VmsSsmRead
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ssm:GetParameter
+                  - ssm:GetParameters
+                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/vms/*
+      Tags:
+        - { Key: Project, Value: synthetic-dev }
+        - { Key: Environment, Value: dev }
+        - { Key: ManagedBy, Value: SAM }
+        - { Key: Service, Value: vms }
+
+  InstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Roles: [!Ref InstanceRole]
+
+  # The permanent public address. DNS (below) points here, so replacing the
+  # instance (stack update / AMI refresh) keeps the same IP and certs stay
+  # valid - the box is disposable, the EIP is the identity.
+  Eip:
+    Type: AWS::EC2::EIP
+    Properties:
+      Tags:
+        - { Key: Project, Value: synthetic-dev }
+        - { Key: Environment, Value: dev }
+        - { Key: ManagedBy, Value: SAM }
+        - { Key: Service, Value: vms }
+
+  EipAssociation:
+    Type: AWS::EC2::EIPAssociation
+    Properties:
+      AllocationId: !GetAtt Eip.AllocationId
+      InstanceId: !Ref Instance
+
+  Instance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: !Ref AmiId
+      InstanceType: !Ref InstanceType
+      IamInstanceProfile: !Ref InstanceProfile
+      SubnetId: !Select [0, !Ref PublicSubnetIds]
+      SecurityGroupIds: [!Ref SecurityGroup]
+      Tags:
+        - { Key: Name, Value: synthetic-dev-vms }
+        - { Key: Project, Value: synthetic-dev }
+        - { Key: Environment, Value: dev }
+        - { Key: ManagedBy, Value: SAM }
+        - { Key: Service, Value: vms }
+      UserData:
+        Fn::Base64: !Sub |
+          #!/usr/bin/env bash
+          # vms bootstrap - everything on this box is laid down here, so the
+          # instance is fully regenerable (the EIP + DNS are the identity).
+          set -euxo pipefail
+          exec >/var/log/vms-init.log 2>&1
+
+          # First boot can precede the EIP association; if the subnet doesn't
+          # auto-assign public IPs there is no egress until it lands. Wait.
+          i=0
+          until curl -fsS -m 5 https://checkip.amazonaws.com >/dev/null 2>&1; do
+              i=$((i+1)); [ "$i" -gt 60 ] && { echo "no egress after 5m"; exit 1; }
+              sleep 5
+          done
+
+          dnf -y install tar gzip
+
+          # ── Caddy with the route53 DNS plugin (official build service) ──
+          curl -fsSL -o /usr/local/bin/caddy \
+              "https://caddyserver.com/api/download?os=linux&arch=arm64&p=github.com%2Fcaddy-dns%2Froute53"
+          chmod +x /usr/local/bin/caddy
+          useradd --system --home-dir /var/lib/caddy --create-home --shell /sbin/nologin caddy || true
+          mkdir -p /etc/caddy
+          # Bind to 80/443 as the unprivileged caddy user.
+          setcap cap_net_bind_service=+ep /usr/local/bin/caddy
+
+          # ── frps (pinned; tunnel.sh pins the same client version) ──
+          curl -fsSL "https://github.com/fatedier/frp/releases/download/v${FrpVersion}/frp_${FrpVersion}_linux_arm64.tar.gz" \
+              | tar xz -C /tmp
+          install -m 0755 "/tmp/frp_${FrpVersion}_linux_arm64/frps" /usr/local/bin/frps
+
+          # ── config renderer: SSM (token + monikers) -> frps.toml + Caddyfile ──
+          # Runs at boot and every minute (timer below), so registering a new
+          # moniker is laptop-side only: tunnel.sh appends to the SSM list and
+          # this picks it up, renders a new wildcard site block, and Caddy
+          # mints the cert. No SSH, no manual steps on the box.
+          cat >/usr/local/bin/vms-render <<'RENDER'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          export AWS_DEFAULT_REGION="__REGION__"
+          DOMAIN="__DOMAIN__"
+          TOKEN=$(aws ssm get-parameter --name "__TOKEN_PARAM__" --with-decryption \
+                      --query Parameter.Value --output text)
+          MONIKERS=$(aws ssm get-parameter --name "__MONIKERS_PARAM__" \
+                      --query Parameter.Value --output text 2>/dev/null || echo "")
+
+          new_frps=$(mktemp)
+          cat >"$new_frps" <<EOF
+          # rendered by vms-render - do not edit
+          bindPort = 7000
+          # vhost port is loopback-reachable only in practice: the SG opens
+          # 443/80/7000 exclusively; Caddy is the sole consumer of :8080.
+          vhostHTTPPort = 8080
+          auth.method = "token"
+          auth.token = "$TOKEN"
+          EOF
+
+          new_caddy=$(mktemp)
+          {
+              printf '{\n    email __ACME_EMAIL__\n}\n\n'
+              # Apex: a human-readable index, useful as a liveness probe.
+              printf '%s {\n    respond "vms tunnel rendezvous - see saga-ed/soa tools/synthetic-dev/vms" 200\n}\n\n' "$DOMAIN"
+              # One wildcard site (and so one DNS-01 wildcard cert) per
+              # registered moniker: *.<moniker>.<domain>. X.509 wildcards match
+              # a single label, which is why this is per-moniker rather than
+              # one *.<domain> cert. Host header passes through to frps, which
+              # routes to the matching laptop tunnel (customDomains).
+              # (no shell brace-expansions in this script - it lives inside
+              # Fn::Sub, which interprets every dollar-brace sequence)
+              for m in $(printf '%s' "$MONIKERS" | tr ',' ' '); do
+                  m=$(printf '%s' "$m" | tr -d '[:space:]'); [[ -z "$m" ]] && continue
+                  printf '*.%s.%s {\n    tls {\n        dns route53\n    }\n    reverse_proxy 127.0.0.1:8080\n}\n\n' "$m" "$DOMAIN"
+              done
+          } >"$new_caddy"
+
+          if ! cmp -s "$new_frps" /etc/frps.toml 2>/dev/null; then
+              mv "$new_frps" /etc/frps.toml; chmod 0600 /etc/frps.toml
+              systemctl restart frps || true
+          else rm -f "$new_frps"; fi
+          if ! cmp -s "$new_caddy" /etc/caddy/Caddyfile 2>/dev/null; then
+              mv "$new_caddy" /etc/caddy/Caddyfile
+              chown caddy:caddy /etc/caddy/Caddyfile
+              systemctl reload caddy || systemctl restart caddy || true
+          else rm -f "$new_caddy"; fi
+          RENDER
+          chmod +x /usr/local/bin/vms-render
+          sed -i \
+              -e "s|__REGION__|${AWS::Region}|" \
+              -e "s|__DOMAIN__|${DomainName}|" \
+              -e "s|__TOKEN_PARAM__|${FrpTokenParameterName}|" \
+              -e "s|__MONIKERS_PARAM__|${MonikersParameterName}|" \
+              -e "s|__ACME_EMAIL__|${AcmeEmail}|" \
+              /usr/local/bin/vms-render
+
+          # ── systemd units ──
+          cat >/etc/systemd/system/frps.service <<'EOF'
+          [Unit]
+          Description=frp server (synthetic-dev vms tunnels)
+          After=network-online.target
+          [Service]
+          ExecStart=/usr/local/bin/frps -c /etc/frps.toml
+          Restart=always
+          RestartSec=5
+          [Install]
+          WantedBy=multi-user.target
+          EOF
+
+          cat >/etc/systemd/system/caddy.service <<'EOF'
+          [Unit]
+          Description=Caddy (synthetic-dev vms TLS front door)
+          After=network-online.target
+          [Service]
+          User=caddy
+          Group=caddy
+          Environment=AWS_REGION=us-west-2
+          Environment=XDG_DATA_HOME=/var/lib/caddy
+          Environment=XDG_CONFIG_HOME=/var/lib/caddy
+          ExecStart=/usr/local/bin/caddy run --config /etc/caddy/Caddyfile
+          ExecReload=/usr/local/bin/caddy reload --config /etc/caddy/Caddyfile
+          Restart=always
+          RestartSec=5
+          [Install]
+          WantedBy=multi-user.target
+          EOF
+
+          cat >/etc/systemd/system/vms-render.service <<'EOF'
+          [Unit]
+          Description=Render frps + Caddy config from SSM (token + monikers)
+          [Service]
+          Type=oneshot
+          ExecStart=/usr/local/bin/vms-render
+          EOF
+
+          cat >/etc/systemd/system/vms-render.timer <<'EOF'
+          [Unit]
+          Description=Re-render vms config every minute (moniker registry poll)
+          [Timer]
+          OnBootSec=30
+          OnUnitActiveSec=60
+          [Install]
+          WantedBy=timers.target
+          EOF
+
+          systemctl daemon-reload
+          /usr/local/bin/vms-render
+          systemctl enable --now frps caddy vms-render.timer
+
+  ApexRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: !Ref HostedZoneId
+      Name: !Sub '${DomainName}.'
+      Type: A
+      TTL: '300'
+      ResourceRecords: [!Ref Eip]
+
+  # DNS wildcards (unlike TLS wildcards) match multiple labels, so this single
+  # record also resolves connect-api.jw.vms.wootdev.com etc. - one record
+  # covers every dev and service forever.
+  WildcardRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: !Ref HostedZoneId
+      Name: !Sub '*.${DomainName}.'
+      Type: A
+      TTL: '300'
+      ResourceRecords: [!Ref Eip]
+
+  PublicIpParam:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /vms/infra/dev/public-ip
+      Type: String
+      Value: !Ref Eip
+      Description: vms rendezvous EIP (synthetic-dev tunnel server)
+
+  InstanceIdParam:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /vms/infra/dev/instance-id
+      Type: String
+      Value: !Ref Instance
+      Description: vms rendezvous instance id (SSM Session Manager target)
+
+Outputs:
+  PublicIp:
+    Value: !Ref Eip
+    Description: The permanent public address behind DomainName.
+  InstanceId:
+    Value: !Ref Instance
+    Description: Shell access via - aws ssm start-session --target <this>
+  ApexUrl:
+    Value: !Sub https://${DomainName}
+    Description: Liveness probe URL (Caddy answers 200 with an index line).


### PR DESCRIPTION
## What

Multi-user access to a developer's **local** synthetic-dev stack — built for Connect (inherently multi-user), but exposing the whole browser plane. The services keep running locally under `pnpm dev` with HMR; a shared rendezvous box fronts them:

```
coworker (anywhere) ──HTTPS──▶ vms.wootdev.com (EC2 + EIP)
                                │ Caddy :443 — per-dev wildcard certs (Route53 DNS-01)
                                │ frps — Host-header routing, token-gated tunnels
                                ▼ reverse tunnel (frp)
        connect.jw.vms.wootdev.com  → laptop :6210     iam.jw.… → :3010
        dash.jw.…                   → :8900            rtsm.jw.… → :6110   …etc
```

- **`vms/`** — CloudFormation (single EC2 t4g.small + EIP; SG 443/80/7000 only, **no SSH — SSM Session Manager**; Route53 apex + wildcard; zone-scoped instance role for cert minting; cloud-init lays down everything, the box is disposable) + samconfig + ops README. Validated via `aws cloudformation validate-template`; running in dev now.
- **`tunnel.sh`** — laptop side: `up|down|status|moniker|urls`. First run prompts for a **moniker** (standard: your initials), saves it to the gitignored `.vms-moniker` (never a CLI arg — no placeholder cross-contamination), and self-registers via SSM (the box polls the registry and mints `*.<moniker>.vms.wootdev.com`). Resolves the AWS profile **by account number** (profile names vary per dev) and asserts the dev account before any SSM write — guard added after the default chain registered a moniker into prod.
- **`up.sh --tunnel`** — `tunnel_env()` (sibling of `sandbox_env()`, same splat-no-op contract) flips the **browser plane only**; service-to-service URLs stay localhost:
  - iam session cookie domain-scoped to `.<moniker>.vms.wootdev.com` (per-moniker isolation); `--login` flows route via the public iam (a domain cookie can't be minted via localhost)
  - explicit tunnel CORS origins for every dash-facing API (several use exact-string lists today — see cross-linked PRs)
  - connect-web `VITE_*` URLs + `JANUS_LOGIN_HOST` repointed at the tunneled iam demo page (the default `login.wootdev.com` mints a real-dev session the local iam can't verify → redirect loop)
  - rtsm one-node fleet advertising the tunnel endpoint (the client composes `scheme://endpoint` from its bootstrap URL — a localhost endpoint breaks every remote client)
  - dash `config.json` `localDefaults` synced to `url`-type overrides in tunnel mode and **losslessly restored** on non-tunnel runs (byte-identical round-trip, tested)
  - **AV rides the real fleek dev cluster** (`wss://*.fleek.wootdev.com`; creds auto-fetched from Secrets Manager `qboard/fleek/livekit-creds`) — WebRTC media is UDP and can't traverse HTTP tunnels. Graceful fallback to CRDT-only if the fetch fails.

## Cross-repo PRs this composes with

| PR | why |
|---|---|
| saga-ed/saga-dash#194 | `url` service-override type — **required** for the dash to be usable through the tunnel (its override vocabulary was `localhost\|tag` only) |
| saga-ed/rostering#533 | sis-api → shared CORS allowlist (its exact-string list rejected tunnel/preview origins) |
| saga-ed/program-hub#198 | sessions-api → shared CORS allowlist (also fixes prod trusting `*.wootdev.com`) |
| saga-ed/student-data-system#162 | ads-adm-api → shared CORS allowlist |
| saga-ed/qboard#183 | connectv3-api → env-wildcard origins via the shared allowlist |

Tunnel mode works **without** the four CORS PRs (it injects explicit origins per service); once they land, that injection can shrink. The dash-over-tunnel piece specifically needs #194.

## Running this before those PRs merge

Pin them in your personal, gitignored overlay — `tools/synthetic-dev/integration-suite.local.tsv`:

```tsv
soa    156
saga-dash	194
rostering	533
program-hub	198
qboard	183
```

then `./refresh-suite.sh && ./up.sh restart --tunnel --login`. Drop each line as its PR lands. Two footnotes: student-data-system#162 can't be pinned (sds is in `ALWAYS_MAIN_REPOS` — its fix arrives via main), and strictly only saga-dash#194 is *required* for tunnel mode — the CORS pins are "run the real upstream code" hygiene, since `tunnel_env` injects explicit origins per service either way.

## Notes

- Rebased onto current main (the mesh-mongo / ensure-repos / overlay-aware-verify changes); all tunnel seams re-verified post-rebase (syntax, function presence, env-emission harness).
- Security posture documented in `vms/README.md`: public by design (synthetic data, no PII), tunnel registration gated by an SSM SecureString token (dev-account SSO required), box has no SSH and a zone-scoped role.
- Known limits documented: `--record av`'s local egress can't capture cluster AV; frp version pinned in lockstep between template and tunnel.sh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
