### PR TITLE
feat(synthetic-dev): wire Connect's dashboard return URL + local login host

### DIFF
--- a/tools/synthetic-dev/getting-started.md
+++ b/tools/synthetic-dev/getting-started.md
@@ -173,8 +173,15 @@ connect-api (`~/dev/qboard/apps/node/connectv3-api`, **:6106**) and connect-web
   `projection_readiness` warm row straight to the DB, so reads work on the
   event-less db:seed lane (without it, every sessions read 408s "projection …
   is warming" and Connect's `/my-sessions` 500s). The demo sessions belong to
-  the `demo-*@saga.org` personas (e.g. `demo-lead-north@saga.org`,
-  `demo-student-1@saga.org`) — log in as one of those to see them.
+  the **`demo` district**, NOT the roster personas — log in as a `demo-*@saga.org`
+  user (`demo-dadmin@saga.org` is the district admin → sees all of them; all
+  loginable with `password123` / devLogin). **To reach them via the dash
+  `/sessions` page, seed with `--seed full`**: the dash's program-list gate reads
+  **programs-api** and redirects to `/programs/new/config` when your org has no
+  programs — and only `--seed full` seeds the demo programs into programs-api
+  (`--seed roster` seeds just the sessions-api projections, which Connect reads
+  directly but the dash gate does not). Opening Connect by direct URL
+  (`:6210/?slsid=…`) works on either seed.
 - **Dedicated mongo.** Connect's mongo is part of the mesh (infra-compose
   `services/connect-mongo` → container `soa-connect-mongo-1`): standalone
   mongo:8, no auth, host port **:27037** (non-default on purpose, so it never
@@ -389,8 +396,12 @@ The reset is data-only — it truncates synthetic rows but **preserves
 | `frontier@saga.org` | admin for the Frontier district |
 | `empty@saga.org` | Empty Org admin — district with NO schools/sections/roster (the CSV upload-from-scratch fixture; `./up.sh --reset --seed roster --login empty@saga.org`) |
 | `none@saga.org` | belongs to no district |
+| `demo-dadmin@saga.org` | **Connect demo** `demo`-district admin — the persona for clicking into Connect: sees all demo programs/sessions on `/sessions` (**needs `--seed full`**) |
+| `demo-lead-north@saga.org` | Connect demo North lead tutor — the tutor view of the demo sessions |
 
-Each persona's UUID is printed at the end of every `--seed roster` run.
+The roster personas above do **not** see the Connect demo sessions (those live
+in the separate `demo` district — use a `demo-*` persona). Each persona's UUID
+is printed at the end of every `--seed roster` run.
 
 ## What `up` actually does, step by step
 

--- a/tools/synthetic-dev/up.sh
+++ b/tools/synthetic-dev/up.sh
@@ -834,10 +834,15 @@ tunnel_env(){ # svc
                       "LIVEKIT_API_SECRET=$TUNNEL_LK_SECRET"
       fi ;;
     connect-web)
+      # VITE_DASHBOARD_URL is Connect's "Back to Dashboard" target (qboard
+      # getDashboardReturn): the tunnelled dash, NOT the host-derived
+      # dash.wootdev.com guess. The dash also passes ?dash_rtn_url= per-launch,
+      # which overrides this — but the env covers a direct (no-dash) open.
       printf '%s\n' "VITE_CONNECTV3_API_URL=https://connect-api.$TUNNEL_DOMAIN" \
                     "VITE_IAM_API_URL=https://iam.$TUNNEL_DOMAIN" \
                     "VITE_RTSM_BOOTSTRAP_URL=https://rtsm.$TUNNEL_DOMAIN" \
                     "VITE_JANUS_LOGIN_HOST=https://iam.$TUNNEL_DOMAIN/demo" \
+                    "VITE_DASHBOARD_URL=https://dash.$TUNNEL_DOMAIN" \
                     "__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS=connect.$TUNNEL_DOMAIN" ;;
     rtsm-api)
       # Generated in the --tunnel resolution block; advertises the tunnel host
@@ -1003,11 +1008,18 @@ services_up(){
   # pattern (plan push silently skipped, recorder logs skipped_plan_missing);
   # the topology's nodes.url block maps the local LiveKit URL → node "local",
   # which RECORDER_URL_TEMPLATE then resolves (no {node} placeholder needed).
+  # VITE_DASHBOARD_URL: Connect's "Back to Dashboard" target (qboard
+  # getDashboardReturn) — the local dash, not a host-derived guess (on
+  # localhost the host has no dot, so Connect would otherwise show no button).
+  # VITE_JANUS_LOGIN_HOST: session-expiry redirects land on the LOCAL iam demo,
+  # not prod login.wootdev.com (tunnel_env sets the tunnel equivalent).
   launch_if connect-web "$CONNECT_WEB_PORT" "$QBOARD/apps/web/connectv3" \
      VITE_CONNECTV3_API_URL="$CONNECT_API_URL" \
      VITE_IAM_API_URL="$IAM_URL" \
      VITE_SAGA_API_TARGET="$SAGA_API_TARGET" \
      VITE_RTSM_BOOTSTRAP_URL="$RTSM_URL" \
+     VITE_DASHBOARD_URL="$DASH_URL" \
+     VITE_JANUS_LOGIN_HOST="$IAM_URL/demo" \
      VITE_PLAYBACK_ASSET_BASE_OVERRIDE="http://localhost:$RECORDINGS_API_PORT" \
      $(tunnel_env connect-web)
   return "$SERVICES_RC"   # non-zero iff a LAUNCHED service failed (skips don't count)


### PR DESCRIPTION
The soa/`tools/synthetic-dev` side of a cross-repo "URL / navigation
correctness under tunnel + localhost" pass. Injects the env Connect needs so
its URL resolution lands on **this** stack instead of prod hosts.

## up.sh
- **`VITE_DASHBOARD_URL`** on connect-web — Connect's "Back to Dashboard" target
  (qboard `getDashboardReturn`). Localhost → `http://localhost:8900`; tunnel →
  `https://dash.<moniker>.vms.wootdev.com`. The dash also passes `?dash_rtn_url=`
  per-launch (which overrides this); the env covers a direct, no-dash open. On
  **localhost** it's essential — Connect's host derivation yields no dashboard
  for a single-label host, so without it the button never appears.
- **`VITE_JANUS_LOGIN_HOST`** on the *localhost* connect-web launch — session
  expiry redirects land on the local iam demo, not prod `login.wootdev.com`.
  `tunnel_env` already set the tunnel equivalent; this closes the localhost gap.

## docs (getting-started)
The Connect demo sessions live in the separate **`demo` district** (not the
roster personas), and the dash **`/sessions` page needs `--seed full`**: its
program-list gate reads programs-api and redirects to `/programs/new/config`
when the org has no programs — and only `--seed full` seeds the demo programs
into programs-api (`--seed roster` seeds only the sessions-api projections,
which Connect reads directly but the dash gate does not). Added `demo-dadmin@`
(district admin — the persona for clicking into Connect) and `demo-lead-north@`
to the persona table.

## Companion PRs
- **qboard saga-ed/qboard#194** — Connect `getDashboardReturn` (consumes
  `VITE_DASHBOARD_URL` / `?dash_rtn_url=`).
- **saga-dash saga-ed/saga-dash#201** — connect localDefault `:6210`,
  connect-links `?dash_rtn_url=`, environment-aware logout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)