### PR TITLE
fix(synthetic-dev): tunnel URL correctness — content-api exposure + dash 401 login host

### DIFF
--- a/tools/synthetic-dev/tunnel.sh
+++ b/tools/synthetic-dev/tunnel.sh
@@ -58,6 +58,7 @@ SERVICES=(
     "programs:3006"
     "scheduling:3008"
     "sessions:3007"
+    "content:3009"
     "ads-adm:5005"
     "dash:8900"
     "connect:6210"

--- a/tools/synthetic-dev/up.sh
+++ b/tools/synthetic-dev/up.sh
@@ -942,7 +942,8 @@ sync_dash_local_defaults(){
     const fs = require("fs");
     const [out, domain] = process.argv.slice(1);
     const map = { "iam":"iam", "program-hub":"programs", "enrollment-api":"programs",
-      "scheduling-api":"scheduling", "sessions-api":"sessions", "sis-api":"sis", "connect":"connect" };
+      "scheduling-api":"scheduling", "sessions-api":"sessions", "sis-api":"sis",
+      "content-api":"content", "connect":"connect" };
     const localDefaults = {};
     for (const [key, label] of Object.entries(map)) localDefaults[key] = { type: "url", url: `https://${label}.${domain}` };
     fs.writeFileSync(out, JSON.stringify({ localDefaults }, null, 2) + "\n");


### PR DESCRIPTION
Follow-up to #159 (content-api in the mesh — now merged).

## Bug
Under `--tunnel`, the dash hit `http://localhost:3009/trpc/content.search` and failed. #159 wired content-api into the stack (service, DB, seed, CORS) but not into the **tunnel exposure**, so:
- there was no `content.<moniker>.vms.wootdev.com` subdomain, and
- `sync_dash_local_defaults` didn't write a `content-api` key into the untracked `config.local.json`,

so the dash fell back to `config.json`'s `content-api: localhost:3009` and a tunnel browser tried to reach the laptop's localhost.

## Fix
- **`tunnel.sh`** — add `content:3009` to `SERVICES` (frp tunnel + the box mints the wildcard cert for the new subdomain).
- **`up.sh` `sync_dash_local_defaults`** — map `content-api → content`, so `config.local.json` overlays the dash's content endpoint onto `https://content.<moniker>.vms.wootdev.com`. `clients.ts` strips to origin + `/trpc`, giving `…/trpc/content.search`.

No saga-dash change: its `config.local.json` overlay (saga-dash #194) resolves any service generically — soa just wasn't telling it about content. content-api CORS already admits `*.wootdev.com`. Localhost mode unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)