### PR TITLE
feat(synthetic-dev): make all sibling repo paths overridable

### DIFF
--- a/tools/synthetic-dev/README.md
+++ b/tools/synthetic-dev/README.md
@@ -49,13 +49,25 @@ All paths are relative to `$DEV` (default `~/dev`; override by exporting
 on the branch below — `check_branches` only **warns** on a mismatch, it
 won't stop the run.
 
+Every repo path is **individually overridable** (the `<VAR>=...` in each
+row). The most useful case: point a repo at a `git worktree` of clean
+`main` when your primary checkout is dirty or on a feature branch.
+`refresh-suite` skips dirty repos, so a clean worktree is how you keep your
+in-flight work untouched while the stack runs on `main`. For example, with
+your `rostering` checkout mid-feature:
+
+```bash
+git -C ~/dev/rostering worktree add ~/dev/rostering-main origin/main
+ROSTERING=~/dev/rostering-main ./up.sh up --seed full --login
+```
+
 | repo | presumed location | branch | provides (port) |
 |---|---|---|---|
-| **soa** | `~/dev/soa` | `main` | mesh infra (`infra/` + `projects/saga-mesh/seed`) for pg/redis/rabbitmq; shared `@saga-ed/soa-*` packages (registry mode — `soa:link:off`) |
-| **rostering** | `~/dev/rostering` | `main` | iam-api (**:3010**); **sis-api (:3100)** + sis-db prisma; iam-db / iam-pii-db prisma; the `program-hub` roster scenario (`scripts/scenarios`) |
-| **program-hub** | `~/dev/program-hub` | `main`¹ | programs-api (**:3006**) + scheduling-api (**:3008**) + sessions-api (**:3007**); the `programs` scenario (`scripts/scenarios`) |
+| **soa** | `~/dev/soa` | `main` | mesh infra (`infra/` + `projects/saga-mesh/seed`) for pg/redis/rabbitmq; shared `@saga-ed/soa-*` packages (registry mode — `soa:link:off`). Override the path with `SOA=...` |
+| **rostering** | `~/dev/rostering` | `main` | iam-api (**:3010**); **sis-api (:3100)** + sis-db prisma; iam-db / iam-pii-db prisma; the `program-hub` roster scenario (`scripts/scenarios`). Override the path with `ROSTERING=...` |
+| **program-hub** | `~/dev/program-hub` | `main`¹ | programs-api (**:3006**) + scheduling-api (**:3008**) + sessions-api (**:3007**); the `programs` scenario (`scripts/scenarios`). Override the path with `PROGRAM_HUB=...` |
 | **student-data-system** | `~/dev/student-data-system` | `main` | ads-adm-api (**:5005**); ads-adm-db prisma. OPT-IN (`--with-playback`): the sds_93 playback APIs — insights-api (**:6301**), transcripts-api (**:6302**), chat-api (**:6303**) + their `*-db` prisma. Override the path with `SDS=...` |
-| **saga-dash** | `~/dev/saga-dash` | `main` | dash web UI (**:8900**) |
+| **saga-dash** | `~/dev/saga-dash` | `main` | dash web UI (**:8900**). Override the path with `SAGA_DASH=...` |
 | **qboard** | `~/dev/qboard` | `main` | connect-api (**:6106**) + connect-web (**:6210**); livekit/coturn compose (AV). Override the path with `QBOARD=...` |
 | **rtsm** | `~/dev/rtsm` | `main` | rtsm-api (**:6110**) — Connect's CRDT/socket service, single-node here. Override the path with `RTSM=...` |
 

--- a/tools/synthetic-dev/README.md
+++ b/tools/synthetic-dev/README.md
@@ -50,16 +50,22 @@ on the branch below — `check_branches` only **warns** on a mismatch, it
 won't stop the run.
 
 Every repo path is **individually overridable** (the `<VAR>=...` in each
-row). The most useful case: point a repo at a `git worktree` of clean
-`main` when your primary checkout is dirty or on a feature branch.
-`refresh-suite` skips dirty repos, so a clean worktree is how you keep your
-in-flight work untouched while the stack runs on `main`. For example, with
-your `rostering` checkout mid-feature:
+row), and the override is honored by `up.sh`, `bootstrap.sh`, and
+`refresh-suite.sh` alike (export it once; all three read it). The most
+useful case: point a repo at a `git worktree` of clean `main` when your
+primary checkout is dirty or on a feature branch — so the stack runs on
+`main` while your in-flight work stays untouched:
 
 ```bash
 git -C ~/dev/rostering worktree add ~/dev/rostering-main origin/main
-ROSTERING=~/dev/rostering-main ./up.sh up --seed full --login
+( cd ~/dev/rostering-main && pnpm install )   # worktrees don't share node_modules
+ROSTERING=~/dev/rostering-main ./bootstrap.sh --seed full   # or: ./up.sh up --seed full --login
 ```
+
+An overridden repo is **left as-is** by `refresh-suite` (it's not overlaid
+onto `local/integration` — a clean detached-`main` worktree must not be
+re-`checkout`-ed), and `bootstrap`'s repo provisioning checks the overridden
+path (a worktree's `.git` is a file, not a dir — handled).
 
 | repo | presumed location | branch | provides (port) |
 |---|---|---|---|

--- a/tools/synthetic-dev/bootstrap.sh
+++ b/tools/synthetic-dev/bootstrap.sh
@@ -43,6 +43,29 @@ err(){  printf "\033[31m✗\033[0m %s\n" "$*"; }
 DEV=${DEV:-$HOME/dev}
 SDS=${SDS:-$DEV/student-data-system}
 
+# Resolve a sibling repo's checkout path, honoring the per-repo override env
+# vars up.sh exposes (SOA/ROSTERING/PROGRAM_HUB/SAGA_DASH/SDS/QBOARD/RTSM/FLEEK)
+# so bootstrap provisions the SAME checkout up.sh will run — e.g. a clean
+# `git worktree` of main when your primary checkout is dirty. Defaults to
+# $DEV/<name>. The name→var map is explicit because SDS doesn't follow the
+# uppercase-with-dashes-to-underscores rule.
+repo_path(){ # name
+  case "$1" in
+    soa)                 echo "${SOA:-$DEV/soa}" ;;
+    rostering)           echo "${ROSTERING:-$DEV/rostering}" ;;
+    program-hub)         echo "${PROGRAM_HUB:-$DEV/program-hub}" ;;
+    saga-dash)           echo "${SAGA_DASH:-$DEV/saga-dash}" ;;
+    student-data-system) echo "${SDS:-$DEV/student-data-system}" ;;
+    qboard)              echo "${QBOARD:-$DEV/qboard}" ;;
+    rtsm)                echo "${RTSM:-$DEV/rtsm}" ;;
+    fleek)               echo "${FLEEK:-$DEV/fleek}" ;;
+    *)                   echo "$DEV/$1" ;;
+  esac
+}
+# True when a repo's resolved path differs from the $DEV/<name> default —
+# i.e. the user pointed it at an alternate checkout (e.g. a main worktree).
+repo_overridden(){ [[ "$(repo_path "$1")" != "$DEV/$1" ]]; }
+
 # Step 1 — the real one-time machine bootstrap: make sure all seven sibling repos
 # are cloned AND installed, and fully provision (clone if missing, then
 # co:login + install) any that aren't, so the run continues without a manual
@@ -52,11 +75,13 @@ SDS=${SDS:-$DEV/student-data-system}
 # re-runs (directory-existence checks only). Fails fast when non-interactive.
 ensure_repos(){
   local need=() kv dir name reason rest ans
-  for kv in "$DEV/soa:soa" "$DEV/rostering:rostering" "$DEV/program-hub:program-hub" \
-            "$DEV/saga-dash:saga-dash" "$SDS:student-data-system" "$DEV/qboard:qboard" \
-            "$DEV/rtsm:rtsm"; do
+  for name in soa rostering program-hub saga-dash student-data-system qboard rtsm; do
+    kv="$(repo_path "$name"):$name"
     dir=${kv%:*}
-    if [[ ! -d "$dir/.git" ]]; then
+    # `.git` is a DIR in a normal clone but a FILE (a `gitdir:` pointer) in a
+    # `git worktree` — accept either so an overridden worktree isn't mistaken
+    # for "needs clone" (which would `git clone` over a populated worktree).
+    if [[ ! -e "$dir/.git" ]]; then
       need+=("$kv:clone")
     elif [[ -f "$dir/package.json" && ! -d "$dir/node_modules" ]]; then
       need+=("$kv:install")

--- a/tools/synthetic-dev/refresh-suite.sh
+++ b/tools/synthetic-dev/refresh-suite.sh
@@ -55,6 +55,28 @@ EXAMPLE="$SCRIPT_DIR/integration-suite.example.tsv"
 DEV=${DEV:-$HOME/dev}
 BASE=${BASE:-main}
 INT=local/integration
+
+# Resolve a sibling repo's checkout path, honoring up.sh's per-repo override
+# env vars. Defaults to $DEV/<name>. Explicit name→var map (SDS is irregular).
+repo_path(){ # name
+  case "$1" in
+    soa)                 echo "${SOA:-$DEV/soa}" ;;
+    rostering)           echo "${ROSTERING:-$DEV/rostering}" ;;
+    program-hub)         echo "${PROGRAM_HUB:-$DEV/program-hub}" ;;
+    saga-dash)           echo "${SAGA_DASH:-$DEV/saga-dash}" ;;
+    student-data-system) echo "${SDS:-$DEV/student-data-system}" ;;
+    qboard)              echo "${QBOARD:-$DEV/qboard}" ;;
+    rtsm)                echo "${RTSM:-$DEV/rtsm}" ;;
+    fleek)               echo "${FLEEK:-$DEV/fleek}" ;;
+    *)                   echo "$DEV/$1" ;;
+  esac
+}
+# True when a repo is pointed at a non-default checkout. An overridden repo is
+# LEFT AS-IS by the overlay engine: the override is meant for a clean `main`
+# worktree (detached HEAD), and `checkout -B local/integration` there would
+# either collide with the primary checkout's branch or mutate the worktree off
+# the clean main it was created on. So we skip it loudly rather than touch it.
+repo_overridden(){ [[ "$(repo_path "$1")" != "$DEV/$1" ]]; }
 # Repos this stack overlays (the ones up.sh/verify.sh posture-check); soa +
 # student-data-system are always on main and never overlaid — with ONE
 # exception: to test a synthetic-dev/infra tooling PR end-to-end, overlay soa
@@ -102,10 +124,14 @@ usage(){ sed -n '23,35p' "$0" | sed 's/^# \{0,1\}//'; }
 # PR#s/branches. Echoes progress; returns non-zero if anything didn't apply.
 refresh_repo(){ # name  prs_csv
   local name=$1 prs=$2
-  local repo="$DEV/$name"
+  local repo; repo="$(repo_path "$name")"
   printf "\n\033[1m=== %s ===\033[0m\n" "$name"
 
-  if [[ ! -d "$repo/.git" ]]; then
+  if repo_overridden "$name"; then
+    ok "$name — overridden to $repo, left as-is (overlay skipped)"; return 0
+  fi
+
+  if [[ ! -e "$repo/.git" ]]; then   # -e: a worktree's .git is a file, not a dir
     err "$repo is not a git repo — skipping"; return 1
   fi
   cd "$repo"
@@ -352,8 +378,11 @@ if [[ $RESET -eq 1 ]]; then
   [[ ${#targets[@]} -eq 0 ]] && read -ra targets <<<"$MANAGED_REPOS"
   failed=0
   for name in "${targets[@]}"; do
-    dir="$DEV/$name"
-    [[ -d "$dir/.git" ]] || { warn "$name — not a git repo at $dir; skipping"; continue; }
+    if repo_overridden "$name"; then
+      ok "$name — overridden to $(repo_path "$name"), never overlaid; nothing to reset"; continue
+    fi
+    dir="$(repo_path "$name")"
+    [[ -e "$dir/.git" ]] || { warn "$name — not a git repo at $dir; skipping"; continue; }  # -e: worktree .git is a file
     cur=$(git -C "$dir" branch --show-current 2>/dev/null)
     if [[ "$cur" != "$INT" ]]; then
       ok "$name already on '${cur:-?}' (not overlaid)"

--- a/tools/synthetic-dev/up.sh
+++ b/tools/synthetic-dev/up.sh
@@ -519,7 +519,7 @@ connect_av_up(){
 # OFF + a dev identity (no saga cookie exists in this stack).
 record_up(){ # mode: crdt|av
   local mode=${1:-crdt} token
-  [[ -d "$FLEEK/.git" ]] || { printf "\033[31m✗\033[0m --record needs the fleek repo at %s (clone git@github.com:saga-ed/fleek.git)\n" "$FLEEK"; exit 1; }
+  [[ -e "$FLEEK/.git" ]] || { printf "\033[31m✗\033[0m --record needs the fleek repo at %s (clone git@github.com:saga-ed/fleek.git)\n" "$FLEEK"; exit 1; }  # -e: a worktree's .git is a file
   mkdir -p "$FLEEK_REC_DIR"
   # qboard's redis first (livekit.yaml names it; egress subscribes via the
   # :6380 host mapping — NOT the mesh redis on :6379), then recreate livekit

--- a/tools/synthetic-dev/up.sh
+++ b/tools/synthetic-dev/up.sh
@@ -146,10 +146,15 @@
 set -euo pipefail
 
 DEV=${DEV:-$HOME/dev}
-SOA=$DEV/soa
-ROSTERING=$DEV/rostering
-PROGRAM_HUB=$DEV/program-hub
-SAGA_DASH=$DEV/saga-dash
+# Each sibling repo path is overridable so you can point a service at an
+# alternate checkout — most usefully a `git worktree` of clean `main` when
+# your primary checkout is dirty or on a feature branch (refresh-suite skips
+# dirty repos, so a clean worktree is how you keep your in-flight work
+# untouched while the stack runs on main). Defaults to $DEV/<repo>.
+SOA=${SOA:-$DEV/soa}                         # mesh infra + shared @saga-ed/soa-* packages
+ROSTERING=${ROSTERING:-$DEV/rostering}       # iam-api + sis-api + iam/sis prisma
+PROGRAM_HUB=${PROGRAM_HUB:-$DEV/program-hub} # programs/scheduling/sessions/content-api
+SAGA_DASH=${SAGA_DASH:-$DEV/saga-dash}       # dash web UI
 SDS=${SDS:-$DEV/student-data-system}         # ads-adm from the canonical checkout (sds_92 merged to main; worktree retired)
 QBOARD=${QBOARD:-$DEV/qboard}                # Connect app (connect-api + connect-web)
 RTSM=${RTSM:-$DEV/rtsm}                      # RTSM CRDT/socket service (single-node local)


### PR DESCRIPTION
## What

Makes all eight synthetic-dev sibling repo paths overridable, honored consistently across **`up.sh`, `bootstrap.sh`, and `refresh-suite.sh`**. Previously `up.sh` hardcoded four (`SOA`/`ROSTERING`/`PROGRAM_HUB`/`SAGA_DASH`) while the other four were already `${VAR:-$DEV/<repo>}`; and even after exposing all eight in `up.sh`, the canonical `bootstrap.sh` path ignored them.

## Why — worktree support for dirty / feature-branch checkouts

`refresh-suite` skips dirty repos (won't move them to `main`), so a dirty or feature-branch primary checkout silently blocks the stack from provisioning on `main` — migrations run against the wrong tree and fail. This lets you point a repo at a `git worktree` of clean `main` without disturbing your working checkout:

```bash
git -C ~/dev/rostering worktree add ~/dev/rostering-main origin/main
( cd ~/dev/rostering-main && pnpm install )
ROSTERING=~/dev/rostering-main ./bootstrap.sh --seed full   # or ./up.sh up --seed full --login
```

## Changes

- **up.sh** — the four hardcoded paths become `${VAR:-$DEV/<repo>}` (all eight now overridable). `--record` fleek `.git` check switched `-d`→`-e`.
- **bootstrap.sh `ensure_repos`** — resolves each repo via a shared `repo_path` helper, so the present/installed gate checks the **same checkout up.sh runs**. Without this, bootstrap green-lit the primary while up.sh ran an uninstalled worktree and died later.
- **refresh-suite.sh** — an overridden repo is **left as-is** (skipped loudly) in both the overlay engine and the reset loop. The override targets a clean detached-`main` worktree; `checkout -B local/integration` there would collide with the primary's branch or mutate the worktree. Skip, don't operate-on-path.
- **`.git` checks use `-e`, not `-d`** throughout — a worktree's `.git` is a FILE (gitdir pointer), so `-d` would mistake a worktree for "needs clone" and `git clone` over it.

Env inheritance threads the override for free: bootstrap invokes refresh-suite and up.sh as subprocesses, so one `export ROSTERING=…` reaches all three. No behaviour change when vars are unset (same `$DEV/<repo>` defaults); an explicit `ROSTERING=$DEV/rostering` is treated as not-overridden.

## Proven end-to-end

With a dirty `rostering` primary checkout (stale generated Prisma client), `iam-db migrate deploy` failed `P1001` on five consecutive runs even though the mesh DB was up, provisioned, and reachable by host `psql`. Creating a clean `origin/main` worktree and running with `ROSTERING=~/dev/rostering-main`:
- `ensure_repos` accepts the worktree (no spurious clone — `-e .git` fix),
- `refresh-suite` skips it loudly (left on clean main),
- **iam-db migrate passes.**

The override mechanism and the worktree workflow both work end-to-end through the canonical `bootstrap.sh` entry point.