### PR TITLE
saga-authz-model: add staff control-plane namespace (saga_platform + staff_org)

### DIFF
--- a/packages/core/saga-authz-model/model.fga
+++ b/packages/core/saga-authz-model/model.fga
@@ -113,3 +113,48 @@ type whiteboard
     define parent: [session]
     define editor: [user, group#member] or host from parent or participant from parent
     define viewer: editor or observer from parent
+
+# ---------------------------------------------------------------------------
+# Staff control-plane (namespace: staff)
+# ---------------------------------------------------------------------------
+#
+# Saga INTERNAL staff (employees), distinct from platform users. Staff roles
+# are driven by JumpCloud group membership (the sync worker writes the role
+# tuples from the SSM group->role mapping). App code checks the `can_*`
+# computed relations, never the raw role nouns.
+#
+# SECURITY (SEC-CRIT-2): `staff_org` is a DISTINCT type — NOT a reuse of
+# `tenant` — and its admin relation is `staff_admin`, NEVER `admin`. Reusing
+# `tenant` + an `admin` relation would (a) overwrite `tenant.admin` above and
+# (b) feed the `admin from parent` cascades on group/school/cohort/program,
+# silently making a staff persona-admin an admin of the ENTIRE district
+# resource tree. `staff_org` has NO `admin from parent` edge into the resource
+# types above; the cascade is impossible by construction.
+
+# The singleton staff control-plane root (object id: saga_platform:root).
+# Staff roles attach here; capabilities are computed from the roles.
+type saga_platform
+  relations
+    # Direct role grants — written by the authz-sync worker from JumpCloud
+    # group membership via the SSM group->role mapping.
+    define super_admin: [user, group#member]
+    define support: [user, group#member] or super_admin
+    define org_admin: [user, group#member] or super_admin
+
+    # Computed capabilities — app code (fgaCheck) evaluates these, never the
+    # role nouns above.
+    define can_impersonate: support
+    define can_create_org: org_admin
+    define can_admin_personas: org_admin
+    define can_manage_staff: super_admin
+
+# An organization staff create/administer. Maps 1:1 to an iam-api group
+# (kind=district): object id is the rostering group id. DISTINCT from the
+# resource `tenant`; the admin relation is `staff_admin`, never `admin`.
+type staff_org
+  relations
+    define platform: [saga_platform]
+    define staff_admin: [user, group#member] or can_admin_personas from platform
+    define can_view: staff_admin
+    define can_edit: staff_admin
+    define can_delete: staff_admin

--- a/packages/core/saga-authz-model/package.json
+++ b/packages/core/saga-authz-model/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/saga-authz-model",
-    "version": "0.1.0-dev.2",
+    "version": "0.1.0-dev.3",
     "private": false,
     "type": "module",
     "description": "Saga's OpenFGA authorization model (.fga DSL) and tuple-key helpers. Source of truth for ReBAC types and relations.",

--- a/packages/core/saga-authz-model/src/__tests__/model-fga.unit.test.ts
+++ b/packages/core/saga-authz-model/src/__tests__/model-fga.unit.test.ts
@@ -57,3 +57,49 @@ describe('model.fga is a valid OpenFGA model', () => {
         expect(json.schema_version).toBe('1.1');
     });
 });
+
+/**
+ * SEC-CRIT-2: the staff control-plane is a DISTINCT namespace. `staff_org`
+ * must NOT reuse the `admin` relation (that would overwrite tenant.admin and
+ * feed the `admin from parent` cascades), and must NOT inherit admin from a
+ * resource parent. These assertions fail CI if a future edit collapses the
+ * staff namespace back into the resource tree.
+ */
+describe('staff control-plane namespace (SEC-CRIT-2)', () => {
+    const json = transformer.transformDSLToJSONObject(modelText);
+    const byType = Object.fromEntries(
+        json.type_definitions.map((t) => [t.type, t]),
+    );
+
+    it('declares the staff types', () => {
+        expect(byType.saga_platform).toBeDefined();
+        expect(byType.staff_org).toBeDefined();
+    });
+
+    it('saga_platform exposes the computed capabilities', () => {
+        const rels = Object.keys(byType.saga_platform.relations ?? {});
+        expect(rels).toEqual(
+            expect.arrayContaining([
+                'can_impersonate',
+                'can_create_org',
+                'can_admin_personas',
+                'can_manage_staff',
+            ]),
+        );
+    });
+
+    it('staff_org uses staff_admin and NEVER admin (SEC-CRIT-2)', () => {
+        const rels = Object.keys(byType.staff_org.relations ?? {});
+        expect(rels).toContain('staff_admin');
+        expect(rels).not.toContain('admin');
+    });
+
+    it('staff_org has no `from parent` cascade into the resource tree', () => {
+        // No relation on staff_org may resolve through a `parent` edge —
+        // the only computed-userset source allowed is `platform`.
+        const relations = byType.staff_org.relations ?? {};
+        const serialized = JSON.stringify(relations);
+        expect(serialized).not.toMatch(/"relation"\s*:\s*"parent"/);
+        expect(byType.staff_org.relations).not.toHaveProperty('parent');
+    });
+});

--- a/packages/core/saga-authz-model/src/types.ts
+++ b/packages/core/saga-authz-model/src/types.ts
@@ -18,6 +18,10 @@ export const FGA_TYPES = [
     'session',
     'room',
     'whiteboard',
+    // Staff control-plane (namespace: staff) — distinct from the resource
+    // tree; see model.fga's SEC-CRIT-2 note (staff_org is NOT tenant).
+    'saga_platform',
+    'staff_org',
 ] as const;
 export type FgaType = (typeof FGA_TYPES)[number];
 
@@ -43,6 +47,24 @@ export interface FgaRelationsByType {
         | 'can_join';
     room: 'parent' | 'session' | 'member' | 'moderator' | 'can_join';
     whiteboard: 'parent' | 'editor' | 'viewer';
+    // Staff control-plane. `saga_platform` carries the role grants
+    // (super_admin/support/org_admin) and the computed `can_*` capabilities
+    // app code checks. `staff_org` is the per-org control object; its admin
+    // relation is `staff_admin` (NEVER `admin` — SEC-CRIT-2).
+    saga_platform:
+        | 'super_admin'
+        | 'support'
+        | 'org_admin'
+        | 'can_impersonate'
+        | 'can_create_org'
+        | 'can_admin_personas'
+        | 'can_manage_staff';
+    staff_org:
+        | 'platform'
+        | 'staff_admin'
+        | 'can_view'
+        | 'can_edit'
+        | 'can_delete';
 }
 
 export type FgaRelation<T extends FgaType> = FgaRelationsByType[T];


### PR DESCRIPTION
Adds the `staff` namespace to the fleet OpenFGA model — the published source of truth all services bootstrap their store from (ADR 0005). This is **step A** of the rostering staff-identity enable chain (the hard prerequisite for turning on `FGA_ENABLED`): the namespace previously lived only in rostering's *vendored* `scripts/fga/model.fga`, so enabling FGA against a store seeded from this package would **silently deny every staff capability** (the store would have no `saga_platform`/`staff_org` types).

Pairs with **rostering #556** (the code that checks these relations) and **iac #428** (OpenFGA write-auth). Closes #165.

## What changed (purely additive — 2 new types, 0 modifications)

- **`saga_platform`** — singleton control-plane root (`saga_platform:root`). Carries the staff role grants (`super_admin`/`support`/`org_admin`, written by the authz-sync worker from JumpCloud group membership via the SSM group→role mapping) and the computed `can_*` capabilities app code checks: `can_impersonate`, `can_create_org`, `can_admin_personas`, `can_manage_staff`.
- **`staff_org`** — per-org control object, 1:1 with an iam-api district group.

## SEC-CRIT-2 (the security-critical invariant)

`staff_org` is a **DISTINCT** type from the resource `tenant`, and its admin relation is **`staff_admin`, never `admin`**. Reusing `tenant` + an `admin` relation would (a) overwrite `tenant.admin` and (b) feed the `admin from parent` cascades on `group`/`school`/`cohort`/`program` — silently making a staff persona-admin an admin of the entire district resource tree. There is **no `admin from parent` edge** into the resource types; the cascade is impossible by construction.

Four new unit tests assert this structurally (staff_admin present, `admin` absent, no `parent`-relation cascade) so a future edit can't regress it.

## Lockstep + verification

- `src/types.ts` updated in lockstep with the DSL (the existing `model-fga` test asserts the TS type set agrees with the `.fga` — CI fails on drift).
- `pnpm check-types` ✅ · `pnpm build` ✅ · `pnpm test` ✅ (28 tests; the model transforms through the OpenFGA syntax-transformer to exactly 13 type definitions).
- Version bump `0.1.0-dev.2` → `0.1.0-dev.3` (CodeArtifact currently has only `dev.1`/`dev.2` — no collision).

## ⚠️ Publish + re-pin are follow-up steps (NOT in this PR)

Merging this PR does **not** by itself un-gate FGA. After merge:
1. **Publish** `0.1.0-dev.3` to CodeArtifact (the ADR-0005 fleet release).
2. **Re-pin** rostering `scripts/fga/package.json` to `0.1.0-dev.3`.
3. **Re-bootstrap** the dev store so it picks up the new model.

Then steps B (enable FGA), C (rostering #557 console session path), and D (STS-replay, last) follow per the rostering enable runbook.

https://claude.ai/code/session_01MrCAR3triSqdRGmzmCBX18