### PR TITLE
feat(infra): numbered immutable snapshot versions + rollback (soa#168)

### DIFF
--- a/infra/src/ec2/profiles.js
+++ b/infra/src/ec2/profiles.js
@@ -89,8 +89,14 @@ export function snapshot_db({ name, profile, engine, port: _port, db_name, db_us
 
     const ext = eng.seed_ext;
     const tmp_file = `/tmp/profile-${profile}.${ext}`;
-    const s3_path = `s3://${bucket}/${name}/profile-${profile}.${ext}`;
     const effective_db_name = db_name || name;
+
+    // soa#168: assign the next immutable version number. The dump is written to
+    // `profile-<p>-v<N>.<ext>` (never overwritten) and then copied to the mutable
+    // `profile-<p>.<ext>` latest-pointer (what restore reads by default).
+    const version = next_profile_version({ name, profile, engine, bucket });
+    const versioned_s3 = `s3://${bucket}/${name}/profile-${profile}-v${version}.${ext}`;
+    const pointer_s3 = `s3://${bucket}/${name}/profile-${profile}.${ext}`;
 
     const container = get_container_name(name, projects_dir);
 
@@ -104,26 +110,31 @@ export function snapshot_db({ name, profile, engine, port: _port, db_name, db_us
         console.log(`Dumped ${engine} (${container}) to ${tmp_file} (${output.length} bytes)`);
     }
 
-    // Upload the dump FIRST so a sidecar never points at a missing/stale artifact.
-    run('aws', ['s3', 'cp', tmp_file, s3_path]);
-    console.log(`Uploaded snapshot to ${s3_path}`);
+    // Upload the IMMUTABLE versioned dump FIRST so a sidecar/pointer never points
+    // at a missing artifact.
+    run('aws', ['s3', 'cp', tmp_file, versioned_s3]);
+    console.log(`Uploaded snapshot v${version} to ${versioned_s3}`);
     const dump_bytes = readFileSync(tmp_file).length;
 
     // Schema sidecar is postgres/Prisma-only. Writing it for mongo/mysql would be
     // useless (no Prisma rev) AND harmful for mongo: its seed_ext is `json`, so the
     // sidecar `profile-<p>.meta.json` collides with list_s3_profiles' `profile-(.+)
     // \.json$` pattern and surfaces a phantom `<p>.meta` profile. So gate strictly:
-    // non-postgres snapshots stay byte-for-byte unchanged.
+    // non-postgres snapshots write only the versioned dump + pointer (no sidecar).
     if (engine !== 'postgres') {
-        return { s3Path: s3_path, metaPath: null, schemaRev: null, sidecarOk: false, size: dump_bytes };
+        // Advance the latest-pointer to this version (server-side copy, no re-dump).
+        run('aws', ['s3', 'cp', versioned_s3, pointer_s3]);
+        return { s3Path: pointer_s3, versionedS3Path: versioned_s3, version, metaPath: null, schemaRev: null, sidecarOk: false, size: dump_bytes };
     }
 
-    // Write the authoritative schema sidecar SECOND, next to the dump. The two
-    // uploads are not atomic: if this one fails the dump exists with no sidecar,
+    // Write the authoritative schema sidecar SECOND, next to the versioned dump.
+    // The uploads are not atomic: if this fails the dump exists with no sidecar,
     // which downstream reads as `unknown` (safe-degrade) — report partial success.
     const schema_rev = extract_prisma_rev({ container, db_name: effective_db_name, db_user });
     const meta = {
         sidecarVersion: 1,
+        version,
+        supersedes: version > 1 ? version - 1 : null,
         schemaRev: schema_rev,
         engine,
         takenAt: new Date().toISOString(),
@@ -134,21 +145,37 @@ export function snapshot_db({ name, profile, engine, port: _port, db_name, db_us
         dumpBytes: dump_bytes,
     };
     const meta_tmp = `/tmp/profile-${profile}.meta.json`;
-    const meta_s3 = `s3://${bucket}/${name}/profile-${profile}.meta.json`;
+    const versioned_meta_s3 = `s3://${bucket}/${name}/profile-${profile}-v${version}.meta.json`;
+    const pointer_meta_s3 = `s3://${bucket}/${name}/profile-${profile}.meta.json`;
     let sidecar_ok = true;
     try {
         writeFileSync(meta_tmp, JSON.stringify(meta, null, 2));
-        run('aws', ['s3', 'cp', meta_tmp, meta_s3]);
-        console.log(`Uploaded schema sidecar to ${meta_s3} (schemaRev=${schema_rev})`);
+        run('aws', ['s3', 'cp', meta_tmp, versioned_meta_s3]);
+        console.log(`Uploaded schema sidecar v${version} to ${versioned_meta_s3} (schemaRev=${schema_rev})`);
     } catch (err) {
-        // Dump already uploaded; degrade to a sidecar-less snapshot rather than fail.
+        // Versioned dump already uploaded; degrade to a sidecar-less snapshot.
         sidecar_ok = false;
-        console.log(`WARNING: sidecar upload failed for ${meta_s3}: ${err.message}`);
+        console.log(`WARNING: sidecar upload failed for ${versioned_meta_s3}: ${err.message}`);
+    }
+
+    // Advance the latest-pointer LAST (after the versioned dump + sidecar exist),
+    // via server-side copy — so `profile-<p>.<ext>` and its sidecar always resolve
+    // to a complete version. Copy the sidecar pointer only if the sidecar uploaded.
+    run('aws', ['s3', 'cp', versioned_s3, pointer_s3]);
+    if (sidecar_ok) {
+        try {
+            run('aws', ['s3', 'cp', versioned_meta_s3, pointer_meta_s3]);
+        } catch (err) {
+            console.log(`WARNING: pointer sidecar copy failed for ${pointer_meta_s3}: ${err.message}`);
+        }
     }
 
     return {
-        s3Path: s3_path,
-        metaPath: sidecar_ok ? meta_s3 : null,
+        s3Path: pointer_s3,
+        versionedS3Path: versioned_s3,
+        version,
+        metaPath: sidecar_ok ? pointer_meta_s3 : null,
+        versionedMetaPath: sidecar_ok ? versioned_meta_s3 : null,
         schemaRev: schema_rev,
         sidecarOk: sidecar_ok,
         size: dump_bytes,
@@ -197,6 +224,11 @@ export function seed_after_start({ container, engine, seeds_dir, profile, db_use
     const eng = engines[engine];
     if (!eng) throw new Error(`Unknown engine: ${engine}`);
 
+    // Normalize a `<p>@v<N>` version pin to its base profile — the local seed
+    // files (written by download_profile_seed) are keyed by base profile, and
+    // the SQL entrypoint (`01-seed.sql`) is profile-independent. (soa#168)
+    const base_profile = profile.replace(/@v\d+$/, '');
+
     // Wait for container to be healthy (up to 60s)
     for (let i = 0; i < 30; i++) {
         const health = spawnSync('docker', ['inspect', '--format', '{{.State.Health.Status}}', container], {
@@ -208,11 +240,11 @@ export function seed_after_start({ container, engine, seeds_dir, profile, db_use
 
     if (engine === 'mongo') {
         const loader = resolve(seeds_dir, '01-seed.js');
-        const seed_json = resolve(seeds_dir, `profile-${profile}.json`);
+        const seed_json = resolve(seeds_dir, `profile-${base_profile}.json`);
         if (!existsSync(loader) || !existsSync(seed_json)) return;
 
         // Copy files into container and execute
-        run('docker', ['cp', seed_json, `${container}:/tmp/profile-${profile}.json`]);
+        run('docker', ['cp', seed_json, `${container}:/tmp/profile-${base_profile}.json`]);
         run('docker', ['cp', loader, `${container}:/tmp/01-seed.js`]);
 
         const args = ['exec', container, 'mongosh', '--quiet'];
@@ -258,7 +290,13 @@ export function download_profile_seed({ name, profile, engine, bucket, seeds_bas
     // template name (e.g. programs-api-canonical). Used by both branches below.
     const src = source_name || name;
     const seeds_dir = resolve(seeds_base, name);
-    const s3_path = `s3://${bucket}/${src}/profile-${profile}.${ext}`;
+    // soa#168: optional version pin `profile=<p>@v<N>` resolves the IMMUTABLE
+    // `profile-<p>-v<N>.<ext>` (the rollback path). Bare `<p>` resolves the
+    // mutable `profile-<p>.<ext>` latest-pointer (default — backward compatible).
+    const at = profile.match(/^(.+)@v(\d+)$/);
+    const base_profile = at ? at[1] : profile;
+    const object_stem = at ? `profile-${base_profile}-v${at[2]}` : `profile-${base_profile}`;
+    const s3_path = `s3://${bucket}/${src}/${object_stem}.${ext}`;
 
     // Clear seeds dir
     if (existsSync(seeds_dir)) {
@@ -269,13 +307,14 @@ export function download_profile_seed({ name, profile, engine, bucket, seeds_bas
     mkdirSync(seeds_dir, { recursive: true });
 
     if (engine === 'mongo') {
-        // Download JSON seed file
-        const seed_json = resolve(seeds_dir, `profile-${profile}.json`);
+        // Download JSON seed file. Local filename uses base_profile (no `@vN`) so
+        // the loader path is stable regardless of whether a version was pinned.
+        const seed_json = resolve(seeds_dir, `profile-${base_profile}.json`);
         run('aws', ['s3', 'cp', s3_path, seed_json]);
 
         // Write a mongosh loader script (executed via docker exec, reads from /tmp)
-        const loader = `// Auto-generated loader for profile: ${profile}
-const raw = fs.readFileSync('/tmp/profile-${profile}.json', 'utf8');
+        const loader = `// Auto-generated loader for profile: ${base_profile}
+const raw = fs.readFileSync('/tmp/profile-${base_profile}.json', 'utf8');
 const spec = EJSON.parse(raw);
 for (const [dbName, collections] of Object.entries(spec)) {
     if (dbName === '_meta') continue;
@@ -286,7 +325,7 @@ for (const [dbName, collections] of Object.entries(spec)) {
         print('  ' + dbName + '.' + collName + ': ' + docs.length + ' docs');
     }
 }
-print('Seed complete: profile ${profile}');
+print('Seed complete: profile ${base_profile}');
 `;
         writeFileSync(resolve(seeds_dir, '01-seed.js'), loader);
         console.log(`Prepared mongo seed: ${seeds_dir}`);
@@ -318,13 +357,56 @@ export function list_s3_profiles({ name, engine, bucket }) {
     for (const line of ls.stdout.trim().split('\n')) {
         const match = line.match(pattern);
         if (match) {
+            const profileName = match[2];
+            // Numbered immutable versions (`profile-<p>-v<N>.<ext>`) are VERSIONS of
+            // a profile, not profiles in their own right — exclude them so the
+            // listing stays keyed by logical profile (the `profile-<p>.<ext>`
+            // latest-pointer). See list_profile_versions / next_profile_version.
+            if (/-v\d+$/.test(profileName)) continue;
             profiles.push({
-                name: match[2],
+                name: profileName,
                 size: Number(match[1]),
-                file: `profile-${match[2]}.${ext}`,
+                file: `profile-${profileName}.${ext}`,
             });
         }
     }
 
     return profiles;
+}
+
+// --- Numbered immutable snapshot versions (soa#168) ---
+//
+// Each snapshot writes an IMMUTABLE `profile-<p>-v<N>.<ext>` (+ `.meta.json`)
+// alongside the mutable `profile-<p>.<ext>` "latest pointer". A re-cut only ever
+// ADDS the next number; prior versions are retained, so an overwrite is never
+// destructive and a known-good version can be restored via `profile=<p>@v<N>`.
+// `N` is derived from S3 (max existing + 1) — no global counter / DynamoDB.
+
+const VERSION_RE = /^profile-(.+)-v(\d+)\.[^.]+$/;
+
+/** List the numbered versions of a profile in S3, ascending by version. */
+export function list_profile_versions({ name, profile, engine, bucket }) {
+    const eng = engines[engine];
+    if (!eng) return [];
+    const ext = eng.seed_ext;
+    const ls = spawnSync('aws', ['s3', 'ls', `s3://${bucket}/${name}/`], { encoding: 'utf8', stdio: 'pipe' });
+    if (ls.status !== 0 || !ls.stdout.trim()) return [];
+
+    const versions = [];
+    for (const line of ls.stdout.trim().split('\n')) {
+        const file = line.trim().split(/\s+/).pop() || '';
+        const m = file.match(VERSION_RE);
+        // Match this profile's versioned dumps only (exclude `.meta.json` sidecars,
+        // whose ext is `json` and would otherwise collide for mongo profiles).
+        if (m && m[1] === profile && file.endsWith(`.${ext}`)) {
+            versions.push(Number(m[2]));
+        }
+    }
+    return versions.sort((a, b) => a - b);
+}
+
+/** Next version number for a profile (max existing + 1; 1 if none). */
+export function next_profile_version({ name, profile, engine, bucket }) {
+    const versions = list_profile_versions({ name, profile, engine, bucket });
+    return versions.length ? versions[versions.length - 1] + 1 : 1;
 }

--- a/infra/test/unit/profiles-seedfrom.unit.test.js
+++ b/infra/test/unit/profiles-seedfrom.unit.test.js
@@ -70,4 +70,35 @@ describe('download_profile_seed — seedFrom source-override', () => {
         // …but the local seed destination stays keyed by the TARGET db name.
         expect(args[3]).toContain('/tmp/seeds/programs-api-sbx/');
     });
+
+    // soa#168 — `<profile>@v<N>` version pin (the rollback path).
+    it('resolves the IMMUTABLE versioned object when profile carries an @vN pin', () => {
+        download_profile_seed({
+            name: 'programs-api-sbx',
+            profile: 'canonical@v1',
+            engine: 'postgres',
+            bucket: 'seeds-bkt',
+            seeds_base: '/tmp/seeds',
+        });
+        const args = awsCpArgs();
+        expect(args).not.toBeNull();
+        // reads profile-canonical-v1.sql (immutable), NOT the bare pointer
+        expect(args[2]).toBe('s3://seeds-bkt/programs-api-sbx/profile-canonical-v1.sql');
+    });
+
+    it('combines @vN pin with seedFrom (rollback a sandbox to a prior canonical version)', () => {
+        download_profile_seed({
+            name: 'programs-api-sbx',
+            profile: 'canonical@v2',
+            engine: 'postgres',
+            bucket: 'seeds-bkt',
+            seeds_base: '/tmp/seeds',
+            source_name: 'programs-api-canonical',
+        });
+        const args = awsCpArgs();
+        expect(args).not.toBeNull();
+        expect(args[2]).toBe('s3://seeds-bkt/programs-api-canonical/profile-canonical-v2.sql');
+        // local destination still keyed by the target db name
+        expect(args[3]).toContain('/tmp/seeds/programs-api-sbx/');
+    });
 });

--- a/infra/test/unit/profiles-versioning.unit.test.js
+++ b/infra/test/unit/profiles-versioning.unit.test.js
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// soa#168 — numbered immutable snapshot versions. Mirrors the mocking style of
+// profiles-sidecar.unit.test.js: capture spawnSync, stub `aws s3 ls` (the
+// version-enumeration call) and the prisma-rev query, stub fs writes.
+
+const spawnSync_calls = [];
+// `aws s3 ls <prefix>` output the version helpers parse — set per test.
+let s3LsStdout = '';
+let revQueryResult = { status: 0, stdout: '20260603120000_add_session_index\n', stderr: '' };
+
+function isRevQuery(cmd, args) {
+    return cmd === 'docker' && args[0] === 'exec' && args.includes('psql') &&
+        args.some((a) => typeof a === 'string' && a.includes('_prisma_migrations'));
+}
+
+vi.mock('child_process', () => ({
+    spawnSync: vi.fn((cmd, args) => {
+        spawnSync_calls.push([cmd, args]);
+        if (cmd === 'aws' && args[0] === 's3' && args[1] === 'ls') {
+            return { status: s3LsStdout ? 0 : 1, stdout: s3LsStdout, stderr: '' };
+        }
+        if (isRevQuery(cmd, args)) return revQueryResult;
+        if (cmd === 'docker' && args[0] === 'compose' && args.includes('ps')) {
+            return { status: 0, stdout: 'sbx-db-1\n', stderr: '' };
+        }
+        if (cmd === 'docker' && args.includes('pg_dump')) {
+            return { status: 0, stdout: '-- dump\n', stderr: '' };
+        }
+        return { status: 0, stdout: '', stderr: '' };
+    }),
+    spawn: vi.fn(),
+}));
+
+const written = {};
+vi.mock('fs', async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+        ...actual,
+        writeFileSync: vi.fn((path, content) => { written[path] = content; }),
+        readFileSync: vi.fn(() => Buffer.from('-- dump\n')),
+    };
+});
+
+const { snapshot_db, next_profile_version, list_profile_versions } = await import('../../src/ec2/profiles.js');
+
+/** Ordered `aws s3 cp` destinations. */
+function cpDests() {
+    return spawnSync_calls
+        .filter(([cmd, args]) => cmd === 'aws' && args[0] === 's3' && args[1] === 'cp')
+        .map(([, args]) => args[3]);
+}
+/** A given `aws s3 cp` source→dest pair exists. */
+function cpPair(src, dest) {
+    return spawnSync_calls.some(([cmd, args]) =>
+        cmd === 'aws' && args[0] === 's3' && args[1] === 'cp' && args[2] === src && args[3] === dest);
+}
+
+// Helper: render an `aws s3 ls` listing line for a file.
+const lsLine = (file, size = 100) => `2026-06-18 00:00:00  ${size} ${file}`;
+
+const BASE = {
+    name: 'programs-api-canonical',
+    profile: 'canonical',
+    engine: 'postgres',
+    db_name: 'programs',
+    db_user: 'postgres_admin',
+    bucket: 'seeds-bkt',
+    projects_dir: '/opt/projects',
+};
+
+beforeEach(() => {
+    spawnSync_calls.length = 0;
+    for (const k of Object.keys(written)) delete written[k];
+    s3LsStdout = '';
+    revQueryResult = { status: 0, stdout: '20260603120000_add_session_index\n', stderr: '' };
+});
+
+describe('next_profile_version / list_profile_versions', () => {
+    it('returns v1 when no versions exist yet', () => {
+        s3LsStdout = '';
+        expect(next_profile_version({ ...BASE })).toBe(1);
+        expect(list_profile_versions({ ...BASE })).toEqual([]);
+    });
+
+    it('increments past the max existing version (ignores the pointer + sidecars)', () => {
+        s3LsStdout = [
+            lsLine('profile-canonical.sql'),            // the mutable pointer — ignored
+            lsLine('profile-canonical.meta.json'),      // pointer sidecar — ignored
+            lsLine('profile-canonical-v1.sql'),
+            lsLine('profile-canonical-v1.meta.json'),   // versioned sidecar — ignored (not .sql)
+            lsLine('profile-canonical-v2.sql'),
+        ].join('\n');
+        expect(list_profile_versions({ ...BASE })).toEqual([1, 2]);
+        expect(next_profile_version({ ...BASE })).toBe(3);
+    });
+
+    it('does not confuse a different profile\'s versions', () => {
+        s3LsStdout = [
+            lsLine('profile-canonical-v5.sql'),
+            lsLine('profile-other-v9.sql'),             // different profile — must not count
+        ].join('\n');
+        expect(list_profile_versions({ ...BASE, profile: 'canonical' })).toEqual([5]);
+        expect(next_profile_version({ ...BASE, profile: 'canonical' })).toBe(6);
+    });
+});
+
+describe('snapshot_db — numbered immutable versions', () => {
+    it('first snapshot writes v1 + advances the latest-pointer', () => {
+        s3LsStdout = ''; // no existing versions
+        const result = snapshot_db({ ...BASE });
+
+        expect(result.version).toBe(1);
+        expect(result.versionedS3Path).toBe('s3://seeds-bkt/programs-api-canonical/profile-canonical-v1.sql');
+        expect(result.s3Path).toBe('s3://seeds-bkt/programs-api-canonical/profile-canonical.sql');
+
+        // immutable dump uploaded, then pointer copied FROM it (server-side copy)
+        expect(cpDests()).toContain('s3://seeds-bkt/programs-api-canonical/profile-canonical-v1.sql');
+        expect(cpPair(
+            's3://seeds-bkt/programs-api-canonical/profile-canonical-v1.sql',
+            's3://seeds-bkt/programs-api-canonical/profile-canonical.sql',
+        )).toBe(true);
+
+        // sidecar carries the version + supersedes provenance
+        const meta = JSON.parse(written['/tmp/profile-canonical.meta.json']);
+        expect(meta.version).toBe(1);
+        expect(meta.supersedes).toBeNull();
+    });
+
+    it('re-cut writes the NEXT version and never overwrites a prior one', () => {
+        s3LsStdout = [lsLine('profile-canonical-v1.sql'), lsLine('profile-canonical.sql')].join('\n');
+        const result = snapshot_db({ ...BASE });
+
+        expect(result.version).toBe(2);
+        const dests = cpDests();
+        // the new immutable artifact is v2 …
+        expect(dests).toContain('s3://seeds-bkt/programs-api-canonical/profile-canonical-v2.sql');
+        // … and NOTHING is uploaded to v1 (prior version untouched)
+        expect(dests).not.toContain('s3://seeds-bkt/programs-api-canonical/profile-canonical-v1.sql');
+
+        const meta = JSON.parse(written['/tmp/profile-canonical.meta.json']);
+        expect(meta.version).toBe(2);
+        expect(meta.supersedes).toBe(1);
+    });
+
+    it('uploads the versioned dump + versioned sidecar BEFORE advancing either pointer', () => {
+        s3LsStdout = '';
+        snapshot_db({ ...BASE });
+        const dests = cpDests();
+        const vSql = dests.indexOf('s3://seeds-bkt/programs-api-canonical/profile-canonical-v1.sql');
+        const vMeta = dests.indexOf('s3://seeds-bkt/programs-api-canonical/profile-canonical-v1.meta.json');
+        const pSql = dests.indexOf('s3://seeds-bkt/programs-api-canonical/profile-canonical.sql');
+        const pMeta = dests.indexOf('s3://seeds-bkt/programs-api-canonical/profile-canonical.meta.json');
+        // versioned artifacts come first; pointers (copies) come after their source
+        expect(vSql).toBeGreaterThanOrEqual(0);
+        expect(vSql).toBeLessThan(pSql);
+        expect(vMeta).toBeGreaterThanOrEqual(0);
+        expect(vMeta).toBeLessThan(pMeta);
+    });
+});


### PR DESCRIPTION
Closes #168.

## What

Makes db-host-v2 DB snapshots **numbered, immutable, and rollback-able** instead of overwriting `profile-<p>.sql` in place. (`infra/src/ec2/profiles.js`.)

**Why:** `snapshot_db` overwrote `s3://<bucket>/<name>/profile-<profile>.sql` in place, and the seed bucket `saga-db-seeds-dev` has **S3 versioning OFF** (verified — objects report `VersionId: null`). So every canonical re-cut destroyed the prior snapshot with no rollback — a bad cut silently breaks every future sandbox restoring `canonical`. This blocked the canonical re-baseline ("Goal 2").

## How

- **`next_profile_version` / `list_profile_versions`** (new exports): derive the next version `N` from S3 (`max existing + 1`, `1` if none) — no global counter / DynamoDB. Versioned files are excluded from `list_s3_profiles` (they're versions of a profile, not profiles).
- **`snapshot_db`**: writes the **immutable** `profile-<p>-v<N>.sql` (+ `profile-<p>-v<N>.meta.json`) FIRST, then advances the mutable `profile-<p>.sql` + `.meta.json` **latest-pointer** via server-side `s3 cp` — so a pointer never leads a missing/partial artifact (mirrors the existing "dump before sidecar" ordering). Sidecar gains `version` + `supersedes`. mongo/mysql get the versioned dump + pointer (sidecar stays postgres-only). Returns `version` + `versionedS3Path`.
- **`download_profile_seed`**: optional `<profile>@v<N>` pin reads the immutable `profile-<p>-v<N>.<ext>` (the **rollback path**); bare `<profile>` reads the `profile-<p>.<ext>` pointer — **unchanged / backward-compatible** for every existing caller. `seed_after_start` normalizes the pin for local filenames.

## Backward compatibility

- Existing composes/restores that read `profile-<p>.sql` keep working unchanged — they always get latest.
- The `@vN` form is the only new surface; it flows through the ec2 `/switch|/restore` path (which validates `name`/`seedFrom` but not `profile` format).

## Tests

- New `test/unit/profiles-versioning.unit.test.js`: version increment (ignores pointer + sidecars + other profiles), v1-on-empty, immutability (re-cut writes v2, never re-touches v1), upload ordering (versioned before pointers), `supersedes` provenance.
- `@vN` restore cases added to `profiles-seedfrom.unit.test.js` (bare pin + pin-with-seedFrom rollback).
- Full infra unit suite: **104/104 green**; `eslint .` clean.

## Follow-up (not in this PR)

- **Backfill**: copy each current `profile-canonical.sql` → `profile-canonical-v1.sql` per service so history starts from the existing known-good state (one `s3 cp` each).
- `saga-orch` CLI surface for `--version` / `list-versions` (orchestrator pass-through of the returned `version`).
- The canonical re-baseline ("Goal 2") then runs under this flow — auto-produces `v2`, retains stale `v1` as rollback.

Design doc: `claude/projects/synthetic-dev-align/plans/numbered-snapshot-versioning-design.md`.
