### PR TITLE
chore(infra): bump infra-compose 1.4.0 → 1.5.0 (publish numbered snapshot versions #168)

### DIFF
--- a/infra/package.json
+++ b/infra/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/infra-compose",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "description": "Composable Docker service templates for Saga platform local development",
     "bin": {
         "infra-compose": "bin/infra-compose"


### PR DESCRIPTION
Version bump so `@saga-ed/infra-compose@1.5.0` can be published to CodeArtifact and the db-host-v2 ASG pinned to it, making the numbered-snapshot-version feature (#168, merged in #169) live on the db-host fleet.

Minor bump — new backward-compatible feature (immutable `profile-<p>-v<N>` artifacts + `@vN` restore pin; existing `profile-<p>` reads unchanged).

Follow-up after merge: dispatch `publish-codeartifact` (single-package: `infra`), then bump `InfraComposeVersion` → 1.5.0 in the iac db-host-v2 ASG + instance-refresh.