### PR TITLE
docs(synthetic-dev-align): canonical re-cut plans + execution outcomes

### DIFF
--- a/claude/projects/synthetic-dev-align/plans/numbered-snapshot-versioning-design.md
+++ b/claude/projects/synthetic-dev-align/plans/numbered-snapshot-versioning-design.md
@@ -1,0 +1,113 @@
+# Design — numbered, immutable canonical snapshot versions (non-destructive re-cut + rollback)
+
+> ## ✅ Outcome (IMPLEMENTED + SHIPPED 2026-06-19)
+> Built as **soa#168** → PR #169 (merged) → published as `@saga-ed/infra-compose@1.5.0` (PR #170) →
+> deployed to all 5 dev db-host-v2 nodes in place via SSM `npm install -g` (no instance refresh) →
+> iac db-host-v2 ASG template default bumped 1.3.2→1.5.0 (hipponot/iac#435, merged). `snapshot_db`
+> now writes immutable `profile-<p>-v<N>.sql` + sidecar (version/supersedes) then advances the mutable
+> `profile-<p>.sql` pointer; `download_profile_seed` accepts a `<profile>@vN` rollback pin. Exercised by
+> the canonical re-cut: existing canonicals backfilled to `-v1`, re-cut landed as `-v2`, the new sessions
+> canonical as `-v1`, and the iam-pii fix as `-v3` — all non-destructively, prior versions retained.
+> See `rebaseline-canonical-from-synthetic-dev.md` Outcome block.
+
+**Status:** DONE 2026-06-19 (was DRAFT 2026-06-18; design prerequisite for Goal 2, now implemented + live)
+**Scope:** the db-host-v2 snapshot/restore flow — `soa/infra/src/ec2/profiles.js` (`snapshot_db` /
+`download_profile_seed` / `list_s3_profiles`), the orchestrator pass-through (`iac` db_host_v2), and
+the `saga-orch snapshot|restore` CLI.
+**Complements (does NOT duplicate):** `microservices/services/switchboard/docs/snapshot-schema-versioning.md`
+— that doc handles *schema-rev compatibility* (snapshot behind/ahead app migrations → auto-heal vs
+hard-fail). THIS doc handles *artifact retention + rollback* (don't lose the prior snapshot on re-cut).
+Orthogonal; both wanted.
+
+## Problem
+
+`snapshot_db` writes `s3://<bucket>/<name>/profile-<profile>.sql` and **overwrites in place**
+(`profiles.js:7,23`). The seed bucket `saga-db-seeds-dev` has **S3 versioning OFF** (verified
+2026-06-18: objects have `VersionId: null`, single version). So every canonical re-cut **destroys the
+prior snapshot with no rollback** — a bad cut silently breaks every future sandbox that restores
+`canonical`, and there's no way back to the last-known-good. This is the blocker that stopped the
+Goal-2 fleet canonical re-cut: overwriting `profile-canonical.sql` is irreversible today.
+
+## Goal
+
+Make canonical re-cuts **non-destructive and rollback-able** with a **legible, by-number** scheme
+(not opaque S3 version IDs), baked into the standard snapshot flow so every future re-cut is safe.
+
+## Design
+
+### Artifacts (S3 layout, per `<serviceName>/`)
+```
+profile-canonical-v1.sql        profile-canonical-v1.meta.json     ← immutable, never overwritten
+profile-canonical-v2.sql        profile-canonical-v2.meta.json     ← each re-cut = a NEW number
+profile-canonical.sql           profile-canonical.meta.json        ← "latest" pointer (= copy of newest vN)
+```
+- **Numbered files are immutable** — a re-cut only ever *adds* `v<N+1>`; old ones are retained.
+- **`profile-canonical.sql` stays as the latest-pointer** — exactly what `download_profile_seed` reads
+  today (`profiles.js:12`), so **restore is unchanged and backward-compatible** by default.
+- `N` is derived by listing existing `profile-<profile>-v*.sql` and taking max+1 — no global counter,
+  no DynamoDB dependency. First snapshot of a profile = `v1`.
+
+### Sidecar (extend the existing `sidecarVersion:1` meta — `profiles.js:126-134`)
+Add to `profile-<profile>-vN.meta.json` (and the pointer copy):
+- `version: N` — the integer snapshot version (NEW)
+- `supersedes: N-1 | null` — provenance chain (NEW)
+- keep existing `schemaRev`, `takenAt`, `takenFromDb`, `profile`, `seedIdsVersion`, `appGitSha`.
+(`version` here is the *artifact* number; `schemaRev` remains the *schema* token from the sibling doc —
+distinct fields, distinct purposes.)
+
+### `snapshot_db` change (`profiles.js`)
+1. Dump as today.
+2. Compute `N` = max existing `-vNN` for this profile + 1 (via `aws s3 ls <name>/profile-<profile>-v`).
+3. Upload `profile-<profile>-v<N>.sql` (immutable) FIRST.
+4. Write `profile-<profile>-v<N>.meta.json` (sidecar + `version:N`, `supersedes:N-1`).
+5. Copy `v<N>` → `profile-<profile>.sql` + `.meta.json` (the latest-pointer) LAST (so the pointer never
+   leads a missing artifact — mirrors the existing "upload dump before sidecar" ordering at :22).
+   Return `{ s3Path, version:N, ... }`.
+
+### Restore change (`download_profile_seed`) — additive, backward-compatible
+- Default unchanged: `profile=canonical` → reads `profile-canonical.sql` (the pointer = latest). No
+  caller change; existing composes keep working.
+- NEW optional pin: `profile=canonical@v1` (or a `version` param) → reads `profile-canonical-v1.sql`.
+  This is the **rollback path** — re-point a sandbox (or re-cut) at a prior known-good version.
+
+### CLI / orchestrator
+- `saga-orch snapshot` surfaces the assigned `version` in its response.
+- `saga-orch restore --seed-profile canonical@v1` (or `--version 1`) for rollback.
+- `saga-orch list-versions --service-name <svc> --seed-profile canonical` → enumerate `v1..vN` + their
+  `takenAt`/`schemaRev` (extends `list_s3_profiles`).
+
+### `list_s3_profiles` collision guard
+The existing helper matches `profile-(.+)\.json$` and already had to dodge `*.meta.json` phantoms
+(`profiles.js:29-30`). The new `-vN.meta.json` files must be excluded from the *profile* listing too
+(they're versions of a profile, not profiles). Filter `-v\d+\.meta\.json$`.
+
+## Migration / rollout
+- **Backfill:** the current `profile-canonical.sql` (the stale pre-#419 cut) becomes `v1` for each
+  service (one `s3 cp`), so history starts from the existing known state rather than orphaning it.
+- **Backward compatibility:** old sandboxes/tooling that read `profile-canonical.sql` keep working
+  unchanged — they always get latest. Only callers wanting rollback use the `@vN` form.
+- **Retention:** keep all numbered versions for now (dumps are KB–MB); add a lifecycle/prune policy
+  later if needed (out of scope).
+
+## Why by-number over enabling S3 bucket versioning
+S3 versioning would auto-retain overwrites, but versions are **opaque S3 IDs** — not enumerable as
+`v1/v2/v3`, not self-describing, and rollback means juggling version-id strings. The by-number scheme
+is **legible** (`canonical@v2`), self-documents in the sidecar (`version`/`supersedes`), and is visible
+in a plain `s3 ls`. (Enabling bucket versioning as defense-in-depth is compatible and cheap, but it's
+not the primary mechanism.)
+
+## Then: Goal 2 runs under this flow
+Once snapshot writes numbered versions: the canonical re-cut (load the validated synthetic-dev dumps →
+`saga-orch snapshot --seed-profile canonical`) **automatically** produces `v2` while retaining the
+stale `v1` — non-destructive, with `restore …canonical@v1` as instant rollback. See
+`rebaseline-canonical-from-synthetic-dev.md` (the re-cut runbook) — it should be updated to assume this
+versioned flow once built.
+
+## Open questions
+- **Pointer-copy vs. symlink/manifest:** copy is simplest + keeps restore a dumb `s3 cp`; a manifest
+  (`profile-canonical.json` → `{latest: "v2"}`) is cleaner but changes the restore read. Recommend the
+  copy for v1 of this feature (minimal restore change).
+- **Per-version schemaRev gating:** ties into the sibling schema-versioning doc — a pinned `@vN` restore
+  should still run that doc's behind/ahead/destructive gate against the app HEAD.
+- **Mongo/MySQL profiles:** same numbering applies (engine-agnostic key scheme); sidecar stays
+  postgres-only as today.

--- a/claude/projects/synthetic-dev-align/plans/push-button-canonical-recut.md
+++ b/claude/projects/synthetic-dev-align/plans/push-button-canonical-recut.md
@@ -1,6 +1,39 @@
 # Plan — push-button canonical snapshot re-cut (`/cut-canonical <service>`)
 
-**Status:** DRAFT 2026-06-19 (design for review; not yet built)
+**Status:** DRAFT 2026-06-19 — design + **chain PROVEN end-to-end by hand** (programs-api → test prefix);
+workflow YAML not yet authored.
+
+> ## ✅ Prove-run (2026-06-19) — the chain works; corrections to the design below
+> Manually executed the full throwaway chain once for programs-api to a `program-hub-programs-canonical-test`
+> prefix, then verified + tore down. Result: every step works. Key CORRECTIONS the design couldn't know:
+> - **`cut-canonical` must run the seed ITSELF** — it cannot rely on `sandbox-deploy` to seed. The
+>   `sandbox-deploy`/`_deploy-ecs-api.yml` **Seed job gates on `inputs.is-preview == true`** (and
+>   `seed-profile == ''`); a sandbox dispatch has is-preview=false, so Seed is SKIPPED (DB comes up
+>   migrated-but-empty: 26 tables, Program=0). So: deploy the identifier (sandbox-deploy with empty
+>   seed-profile gives task-def + provisioned + migrated DB), THEN run `db:seed:run` explicitly via
+>   `run-migrate-task.sh`.
+> - **`run-migrate-task.sh` needs explicit SSM overrides for dev** (its defaults point at non-existent
+>   `/program-hub/infra/dev/*` paths). Use what the real migrate job uses:
+>   `CLUSTER_SSM_PATH=/dev/shared-arm/ecs-cluster-arn`,
+>   `SG_SSM_PATH=/program-hub/<api>/infra/dev/sg-id`,
+>   `CAPACITY_PROVIDER=dev-shared-ec2-cluster-arm-capacity-provider`. (`SUBNETS_SSM_PATH` default
+>   `/shared/infra/dev/private-subnet-ids` is correct.) Tier: `saga-infra-dev` (ecs:RunTask + PassRole).
+> - **The two "blockers" collapsed:** `canonseed` is just a normal preview identifier (the parameterized
+>   SAM deploy creates the task-def); and the `PROGRAM_HUB_DEPLOY_ROLE_ARN` the previews assume already
+>   writes `/preview/*` secrets (previews do it every run). No IAM PR needed if cut-canonical mirrors
+>   that auth.
+> - **The s3-cp-versioning glue WORKS** (the one net-new piece): list dest `profile-canonical-v{N}.sql`,
+>   N+1, `s3 cp` dump → `-v{N}.sql`, write fresh sidecar (schemaRev from the snapshot, `takenFromDb`=the
+>   real canonical name, `version`/`supersedes`, and **`seedIdsVersion` finally populated** from the
+>   package version), then `s3 cp` → the `profile-canonical.sql` + `.meta.json` pointer LAST.
+> - **Verified consumable:** the test canonical restored into a fresh pg18 container clean — Program=11,
+>   `_prisma_migrations` head `20260605120000_add_pod_group`. The cloud-side seed wrote migration history
+>   natively (the P3005 recurrence guard holds by construction).
+> - Provisioned DB came up **pg15** because the default-bump PRs (program-hub #236 / rostering #590 /
+>   soa #173) aren't merged yet; once merged, canonseed DBs provision pg18 (and pg16→pg18 restore is
+>   already proven, so no transition gap).
+
+**Status (original):** DRAFT 2026-06-19 (design for review; not yet built)
 **Goal:** turn the (currently manual, ~15-step) canonical re-cut into a **single rote action** a
 developer runs after extending a service's `@saga-ed/*-seed-ids` catalog, so the refreshed seed data
 is reusable by every future sandbox.

--- a/claude/projects/synthetic-dev-align/plans/push-button-canonical-recut.md
+++ b/claude/projects/synthetic-dev-align/plans/push-button-canonical-recut.md
@@ -1,0 +1,151 @@
+# Plan — push-button canonical snapshot re-cut (`/cut-canonical <service>`)
+
+**Status:** DRAFT 2026-06-19 (design for review; not yet built)
+**Goal:** turn the (currently manual, ~15-step) canonical re-cut into a **single rote action** a
+developer runs after extending a service's `@saga-ed/*-seed-ids` catalog, so the refreshed seed data
+is reusable by every future sandbox.
+**Origin:** distilled from the hand-executed re-cut of 2026-06-19 (see
+`rebaseline-canonical-from-synthetic-dev.md` Outcome block). That run *is* the spec — minus the
+one-time bootstrap noise that does not recur.
+
+---
+
+## What does NOT recur (shed from the manual run)
+
+The manual re-cut was hard mostly because of first-time-migration accidents, none of which apply to
+"a dev extended a seed-id":
+
+- **pg18→pg15 strip / `*-sdvload` staging** — artifact of dumping from a local pg18 synthetic-dev mesh.
+  A cloud-side seed runs at the sandbox's own pg version; no laptop dump, no strip.
+- **Local-vs-fleet PII-key mismatch** — artifact of seeding locally then loading. A cloud seed task
+  reads the dev-fleet PII keys from Secrets Manager natively; the mismatch cannot happen.
+- **Backfill-to-`v1` before snapshot** — only needed because the pre-existing canonicals predated
+  numbered versioning. They are all `v1+` now, so `snapshot_db` auto-increments the next version
+  non-destructively on its own.
+
+## The steady-state spine (≈3 rote steps)
+
+For one `<service>` (e.g. `programs-api`):
+
+1. **Seed a throwaway DB cloud-side** — clean `prisma migrate deploy` + `db:seed` (PII keys injected
+   from Secrets Manager) against a freshly-provisioned `<service>-canonseed` DB.
+2. **HARD-GATE verify** (blocking — see below) before any pointer moves.
+3. **Snapshot + publish to the canonical prefix** as the next immutable version.
+
+That is the "very simple rote process" the ask wants. Everything below is how to make those 3 steps
+real and safe.
+
+---
+
+## Decisions (locked by the user 2026-06-19)
+
+- **Trigger:** pure manual `workflow_dispatch` (and/or a `/cut-canonical <service>` Slack command).
+  No CI auto-detection, no auto-cut-on-merge — a canonical re-cut is **fleet-wide** (every future
+  sandbox restores it), so it stays an explicit human action. (Auto-cut-on-merge was explicitly
+  rejected: a bad/incomplete seed would silently become every sandbox's baseline — cf. the iam-pii
+  P3005 of 2026-06-19.)
+- **DB model:** **throwaway DB per run** — provision `<service>-canonseed`, seed it, snapshot, tear it
+  down. The long-lived `<service>-canonical` DB is never left in a half-seeded state.
+- **Snapshot destination:** `saga-orch snapshot` has no destination override (it writes to
+  `<serviceName>/profile-canonical.sql`). So the workflow snapshots the throwaway, then **`s3 cp`s the
+  artifact into `<service>-canonical/`**, computing the next version number and **re-writing the
+  sidecar in-workflow** (it must NOT carry the throwaway's provenance).
+
+---
+
+## The hard gate (non-negotiable — this is the bug we already hit)
+
+A naive "seed → snapshot" re-creates the iam-pii P3005 fleet-wide: that dump shipped `user_pii` with
+**no `_prisma_migrations`** because the local seed swallowed a migrate failure, and it silently became
+`v2`. The verify step is therefore **blocking**, run against the seeded throwaway DB *before* the
+`s3 cp` that advances the pointer. It asserts, at minimum:
+
+- `_prisma_migrations` table exists **and** its latest row == repo HEAD migration for that package
+  (this is why a clean cloud-side `migrate deploy` — not a restore-from-dump — is mandatory; it is
+  what writes the history table in the first place).
+- Expected core table row counts are non-zero and within sane bounds (per-service assertion table).
+- For iam: `user_pii` row count > 0 (PII keys were actually present), `roles` table absent + `UserRole`
+  enum present (current model), users/personas counts match.
+- The dump that will be copied actually **contains the `_prisma_migrations` COPY block** (grep the
+  artifact, not just the DB) — catches a pg_dump that omitted it.
+
+If any assertion fails → abort, do not touch the canonical prefix, leave the throwaway for inspection.
+
+---
+
+## Build (mostly glue over existing primitives)
+
+Known gaps from the 2026-06-19 Explore pass:
+
+1. **No canonical-shaped task-def / identifier.** `run-migrate-task.sh` targets
+   `${PROJECT}-${SERVICE}-${IDENTIFIER}`; there is no `canonseed` identifier. Smallest glue: a
+   throwaway `identifier=canonseed` deploy (creates the task-def family + its
+   `DatabaseUrlSecretArn` secret) so the existing migrate/seed script works unchanged. iam-api needs
+   BOTH `DatabaseUrlSecretArn` + `PiiDatabaseUrlSecretArn` written.
+2. **Orchestrator is OIDC-gated over HTTP.** All `provision`/`snapshot`/`teardown` calls must go via
+   `aws lambda invoke` (i.e. `saga-orch`, which already does this) — never the ALB.
+3. **PII crypto keys** must be injected into the iam seed task env from Secrets Manager
+   (`rostering/dev/pii-dek`, `pii-hmac-key`, `pii-dek-version`) — else iam-pii seeds 0 rows and the
+   gate (correctly) fails.
+4. **The s3-cp-versioning glue** re-implements a slice of `snapshot_db`: list `<service>-canonical/`
+   for existing `profile-canonical-v{N}.sql`, pick `N+1`, `cp` the throwaway dump →
+   `profile-canonical-v{N+1}.sql`, write a fresh sidecar (`schemaRev` from the verify step,
+   `takenFromDb=<service>-canonical`, `supersedes=N`, `seedIdsVersion` from the package version),
+   then `cp` → the `profile-canonical.sql` pointer **last**. (Note: this is the one spot that bypasses
+   `snapshot_db`'s native versioning. A future infra-compose `snapshot --dest <prefix>` override would
+   eliminate it — deferred; not chosen now.)
+
+### Workflow skeleton (`cut-canonical.yml`, `workflow_dispatch` input `service`)
+
+```
+inputs: service (programs-api | scheduling-api | sessions-api | iam-api | …)
+
+1. resolve per-service config: repo, seed package, canonical prefix(es), pii? (iam only)
+2. deploy throwaway identifier=canonseed (task-def + DB secret)         [run-migrate-task infra]
+3. provision <service>-canonseed DB(s) via saga-orch                    [lambda invoke]
+4. write canonseed DB conn into the throwaway secret(s) (incl. PII for iam)
+5. ECS migrate task:  migrate deploy   (writes _prisma_migrations)
+6. ECS seed task:     db:seed / db:seed:run  (PII keys injected)
+7. HARD-GATE verify (assertions above) — abort on any failure
+8. saga-orch snapshot <service>-canonseed --seed-profile canonical
+9. s3-cp the versioned dump + fresh sidecar into <service>-canonical/   [compute vN+1, pointer last]
+10. teardown throwaway DB + identifier stack + secret
+11. (optional) prove-once: restore the new pointer into a throwaway sandbox DB, run migrate deploy,
+    assert "No pending migrations to apply"
+12. report: new version, counts, schemaRev, S3 paths
+```
+
+### Per-service config table (the only thing that varies)
+
+| service | repo | seed cmd | canonical prefix(es) | PII? |
+|---|---|---|---|---|
+| programs-api | program-hub | `db:seed:run` | program-hub-programs-canonical | no |
+| scheduling-api | program-hub | `db:seed:run` | program-hub-scheduling-canonical | no |
+| sessions-api | program-hub | `db:seed:run` | program-hub-sessions-canonical | no |
+| iam-api | rostering | iam-db `db:seed` | rostering-iam-canonical + rostering-iam-pii-canonical | **yes** |
+
+(iam is the one multi-DB / PII case; the others are single-DB no-PII and share one shape.)
+
+---
+
+## Recurrence guard baked in
+
+The hard gate's `_prisma_migrations` assertion is exactly what makes this safe to repeat: any service
+whose local seed swallows a migrate failure would fail the gate instead of silently shipping a
+history-less canonical. The cloud-side clean `migrate deploy` ensures the history is written natively,
+so the iam-pii regression class cannot recur through this path.
+
+## Open items before build
+
+- Confirm the throwaway `canonseed` identifier deploy is cheap/clean to create + tear down per run
+  (vs. a persistent canonseed identifier reused across runs).
+- Pin the Secrets Manager `PutSecretValue` tier for writing the canonseed DB conn into the throwaway
+  secret (flagged UNVERIFIED in the rebaseline runbook).
+- Decide the trigger surface: a `cut-canonical.yml` `workflow_dispatch` is the MVP; a `/cut-canonical`
+  Slack command (mirroring program-hub `db-commands.yml`) is the nicer UX on top.
+- Sidecar `seedIdsVersion`: currently always null; this workflow is the natural place to finally
+  populate it (audit trail of which seed-ids version a canonical was cut from).
+
+---
+*Design distilled 2026-06-19 from the hand-executed re-cut; decisions (manual trigger, throwaway DB,
+s3-cp dest) locked by the user same day.*

--- a/claude/projects/synthetic-dev-align/plans/rebaseline-canonical-from-synthetic-dev.md
+++ b/claude/projects/synthetic-dev-align/plans/rebaseline-canonical-from-synthetic-dev.md
@@ -1,0 +1,197 @@
+# Plan — re-baseline the dev `canonical` seed snapshots to current-main synthetic-dev state
+
+> ## ✅ Outcome (EXECUTED 2026-06-19)
+> All 5 dev `canonical` snapshots were re-cut from current-main synthetic-dev data and verified
+> end-to-end. The execution diverged from (and simplified) the plan below — record of what actually
+> happened:
+> - **Simpler path than the "throwaway-identifier + ECS migrate/seed" Option A:** Goal 1 had already
+>   produced validated, pg-stripped, dev-fleet-PII-key dumps staged at
+>   `s3://saga-db-seeds-dev/<svc>-sdvload/profile-syntheticdev.sql`. So the re-cut was: provision/reuse
+>   the canonical-named DB → `saga-orch raw restore` (seedFrom=`<svc>-sdvload`) → SSM-verify counts →
+>   `saga-orch snapshot --seed-profile canonical`. No ECS migrate/seed tasks, no Secrets Manager
+>   retarget needed.
+> - **Numbered versioning (soa#168, infra-compose 1.5.0) was deployed FIRST** so snapshots are
+>   non-destructive: backfilled each existing `profile-canonical.sql` → `-v1` BEFORE snapshotting, so
+>   the re-cut landed as `-v2` (+ pointer). Fleet upgraded to 1.5.0 in place via SSM `npm install -g`
+>   (no instance refresh — preserved per-sandbox EBS).
+> - **Results:** rostering-iam → v2 (users 218, personas 28, roles-table dropped / UserRole enum);
+>   rostering-iam-pii → v2 (user_pii 28, dev-fleet keys); program-hub-programs → v2; program-hub-scheduling
+>   → v2; **program-hub-sessions → v1 (NEW prefix — the gap is closed)**. Consumer wiring: program-hub
+>   PR #230 added the `sessions-api` seedFrom case arm.
+> - **pg15 compat:** `\restrict` in pg16 dumps is NOT fatal via the `psql -f` restore path (proven);
+>   the Goal-1 killer was `SET transaction_timeout` (pg17+ only, absent in pg16). No strip needed.
+> - **Verified end-to-end** by composing a fresh sandbox (`canon-check-0619`) on `canonical`: dash
+>   rendered synthetic-dev data (Sessions list, Rosters 6/3/4, Demo District).
+> - **⚠ RECURRENCE — iam-pii migration history:** the first iam-pii re-cut (v2) dropped the
+>   `_prisma_migrations` table because its `*-sdvload` source dump came from a LOCAL synthetic-dev iam-pii
+>   whose own `prisma migrate deploy` had P3005'd and never wrote history. A fresh sandbox then hit P3005
+>   on iam-pii deploy. Fixed by restoring the migration-history row (canonical → v3). **Any future iam-pii
+>   canonical re-cut MUST run a clean local `migrate deploy` first (so `_prisma_migrations` is written)
+>   before the dump, or it regresses the same way.** This applies to any service whose local seed swallows
+>   a migrate failure — verify the source dump contains `_prisma_migrations` before snapshotting.
+
+**Status:** DONE 2026-06-19 (was DRAFT 2026-06-18 — see Outcome block above for how execution differed)
+**Scope:** the dev `canonical` profile snapshots in `s3://saga-db-seeds-dev/*-canonical/`.
+**Why now:** the current canonical is ~7 iam migrations behind `origin/main`; the blocker is
+rostering `20260609170418_replace_roles_table_with_user_role_enum` (#419 — drops the `roles`
+table, role becomes a `UserRole` enum). Restoring the stale canonical onto current-main iam-api
+risks the schema-versioning destructive-gate. This is the "compatible versions" fix the user named.
+**Sibling:** `trueup-latest-main-sandbox-to-synthetic-dev.md` (the consumer); `up-sh-db-seed-transition.md`
+(the local-side db:seed convergence this mirrors in-cloud).
+
+## Goal & success criterion
+
+Re-cut each service's `canonical` S3 snapshot from a DB **migrated to current `origin/main`
+schema and seeded by the same `db:seed` synthetic-dev uses** — so a sandbox composed on `canonical`
+holds the new role model + synthetic-dev's full-seed data. Parity holds **by construction**: the
+deployed `db:seed:run`/`db:seed` is the same seed binary at the same `main` commit as local
+synthetic-dev's `pnpm db:seed`, both rooted in `seed-ids`.
+
+**Acceptance per chain (diff the new snapshot before pointing latest-main at it):**
+- iam: NO `roles` table; `UserRole` enum present; personas carry `role` inline; **205 users**;
+  **6 admin personas** (#397) — not the old 2; deterministic dev id present.
+- iam-pii: **user_pii ≈ 15** (NOT empty — see the PII crypto-key requirement below).
+- programs: Program 10 / TutoringPeriod 24 / Pod 8 etc.; scheduling: Schedule 9 / RecurrenceRule 17.
+
+## How seeding/snapshotting actually works (verified `origin/main`, 2026-06-18)
+
+- **S3 prefix == serviceName.** Snapshot has no destination override: `s3://saga-db-seeds-dev/<serviceName>/profile-<profile>.sql` (`soa: infra/src/ec2/profiles.js:92`) + a `profile-<profile>.meta.json` schemaRev sidecar (`:136-142`). To land at `program-hub-programs-canonical/profile-canonical.sql` you MUST snapshot a DB whose **registered serviceName is literally `program-hub-programs-canonical`**, with `--seed-profile canonical`.
+- **Snapshot/pg_dump runs ON the db-host EC2** under its `InstanceRole` `S3SeedData` policy (`iac: cloudformation_templates/dbs/db_host_v2/iam/template.yaml:56-67`). So **no human S3-write tier is needed** — provision/snapshot/restore are host-role-mediated.
+- **`saga-orch`** (`iac: saga-platform/.../orchestrator/cli.py`) verbs: `provision`/`describe`/`snapshot`/`restore`/`reset`/`teardown`/`list`. CI uses `saga-orch raw --payload` = direct `aws lambda invoke`.
+- **No automated "cut canonical" workflow exists** in any repo — the `*-canonical` prefixes appear only as `seedFrom` read-sources. This runbook IS the manual procedure (the by-hand form of the absent "Flow B" / re-snapshot-canonical automation; automate once proven).
+
+## ⚠ THE off-paved step — DB connection targeting
+
+`run-migrate-task.sh` (`program-hub: .github/scripts/run-migrate-task.sh`) launches a one-off ECS
+task against family `FAMILY=<project>-<service>-<identifier>` and overrides **only the container
+`command`**. The DB connection is **injected via Secrets Manager `ValueFrom`** (`DatabaseUrlSecretArn`
+→ `DATABASE_URL`, `PiiDatabaseUrlSecretArn` → `PII_DATABASE_URL`; `program-hub: infra/programs-api/service-template.yaml:262-271`,
+rostering equivalently). **There is no canonical-shaped task-def**, so the migrate/seed task can't
+target a canonical scratch DB out of the box.
+
+**Resolution (use the throwaway-identifier path; do NOT repoint a live service's secret):**
+1. Deploy a **dedicated throwaway identifier** stack (e.g. `identifier=canonseed`) for the service —
+   this creates a task-def family `<project>-<service>-canonseed` and its `DatabaseUrlSecretArn`
+   secret (`/preview/<api>/canonseed/database-url`).
+2. Write the **canonical scratch DB's** connection into that secret (`secretsmanager:PutSecretValue`):
+   `postgresql://postgres_admin:password123@<PRIVATE_IP>:<PORT>/<db_name>?schema=public`.
+   **Use the instance PRIVATE IP from `saga-orch describe`, not the CloudMap `<name>.dbs-v2.local`** —
+   one-off tasks often can't resolve CloudMap → Prisma `P1001`.
+3. Run migrate + seed against `identifier=canonseed` (the task reads the retargeted secret).
+4. Snapshot the **canonical-named** DB (separate `saga-orch` call — see chains).
+5. Tear down the throwaway identifier stack + its secret.
+
+> **NEVER** repoint an existing live/serving identifier's secret at the canonical DB — it silently
+> redirects a running service and is trivially forgotten un-reverted.
+
+**Alternative — "migrate an existing sandbox, then `s3 cp` the snapshot" (least work IF a current-main
+sandbox PR is already open per service).** The migrate/seed half is *cleaner* here: an existing
+`<api>-pr-NN` sandbox already has a task-def whose secret points at its own DB, so you migrate+seed it
+with NO secret rewrite. BUT snapshot has no destination override — `saga-orch snapshot --service-name
+<api>-pr-NN` lands at `<api>-pr-NN/profile-canonical.sql`, which previews (`seedFrom=...-canonical`)
+never read (`seedFrom` overrides the *read* source only; there is no symmetric write override). The
+only rescue is an **out-of-band `aws s3 cp`** of `<api>-pr-NN/profile-canonical.{sql,meta.json}` →
+`<...>-canonical/profile-canonical.{sql,meta.json}`. Tradeoffs: ✅ no provision, no secret-write;
+❌ off the orchestrator path (no DDB registry row, no profile-registry update), and the **copied
+`.meta.json` schemaRev is NOT recomputed** — the destructive-migration detector reads that sidecar,
+so a stale/mismatched schemaRev after a manual cp can mis-fire. Acceptable for a one-time re-baseline,
+not as a habit. Needs `s3:GetObject`+`PutObject` on the seed bucket directly. **Prefer Option A**
+(provision the canonical-named DB so the snapshot lands natively + the sidecar is freshly computed);
+fall back to this only if a clean current-main sandbox already exists and provisioning is undesirable.
+
+## AWS tiers
+
+| Step | Tier | Evidence |
+|---|---|---|
+| `saga-orch` provision/describe/snapshot/restore (lambda:InvokeFunction) | **saga-runtime-dev** | `iac: app_runtime_permission_set/template.yaml:88-94` |
+| migrate/seed one-off ECS task (`ecs:RunTask` + `iam:PassRole`) | **saga-infra-dev** | `app_infra_permission_set/template.yaml:104-107` + `saga_cap_iam_pass_role_saga_services` |
+| SSM read in run-migrate-task.sh | saga-runtime-dev | `saga_cap_app_runtime_read` (all tiers) |
+| Secrets Manager `PutSecretValue` on `/preview/*` (the retarget) | **UNVERIFIED — pin before executing** | preview path uses the deploy role, not a tiered profile |
+| S3 PutObject (snapshot upload) | **none — host-role-mediated** | db-host `InstanceRole` `S3SeedData` |
+
+Announce + confirm before elevating; no step requires admin.
+
+## The four chains (sessions is a fifth, see below)
+
+### Order (load-bearing)
+**iam + iam-pii FIRST**, then programs/scheduling/sessions — the programs/sessions `db:seed` call a
+live, seeded iam-api (`program-hub: scripts/reset-and-reseed.sh` seeds IAM, starts iam-api, then
+seeds programs with `IAM_API_URL`). Cut iam canonical and have a reachable seeded iam-api up first.
+
+### Chain A — iam (TWO DBs, one combined migrate/seed task)
+```bash
+saga-orch provision --service-name rostering-iam-canonical     --engine postgres --engine-version 15 --db-name iam_canonical
+saga-orch provision --service-name rostering-iam-pii-canonical --engine postgres --engine-version 15 --db-name iam_pii_canonical
+saga-orch describe  --service-name rostering-iam-canonical       # PRIVATE IP:port → DATABASE_URL
+saga-orch describe  --service-name rostering-iam-pii-canonical   # PRIVATE IP:port → PII_DATABASE_URL
+# Off-paved: write BOTH secrets (DatabaseUrlSecretArn + PiiDatabaseUrlSecretArn) on the throwaway iam identifier.
+
+# Combined migrate + seed (one task, both DBs):
+PROJECT=rostering SERVICE=iam-api IDENTIFIER=canonseed ENV=dev CONTAINER=iam-api \
+  COMMAND='["sh","-c","pnpm --filter @saga-ed/iam-db db:deploy && pnpm --filter @saga-ed/iam-pii-db db:deploy && pnpm --filter @saga-ed/iam-db db:seed"]' \
+  ./.github/scripts/run-migrate-task.sh
+
+saga-orch snapshot --service-name rostering-iam-canonical     --seed-profile canonical
+saga-orch snapshot --service-name rostering-iam-pii-canonical --seed-profile canonical
+```
+
+> **⚠ CRITICAL — iam-pii is NOT schema-only; do not let it come out empty.** iam-db's `db:seed`
+> DOES write the ~15 `user_pii` rows, but `prisma/seed.ts:52-58` **silently skips PII unless the
+> PII crypto keys are present in the task env**: `PII_DATABASE_URL` PLUS
+> `PII_DEK_HEX`+`PII_HMAC_KEY_HEX` (local-dev names) OR `PII_CRYPTO_PIIDEKHEX`+`PII_CRYPTO_PIIHMACKEYHEX`
+> (runtime names). The deployed iam-api task already has the runtime crypto config; **verify those
+> env/secret values are present on the `canonseed` task** before running seed, or the new
+> `rostering-iam-pii-canonical` regresses today's 15 rows to 0 and breaks email-keyed login in every
+> future sandbox. Acceptance: `user_pii ≈ 15`, NOT empty.
+
+### Chain B — programs (single DB)
+```bash
+saga-orch provision --service-name program-hub-programs-canonical --engine postgres --engine-version 15 --db-name programs_api_canonical
+saga-orch describe  --service-name program-hub-programs-canonical    # PRIVATE IP:port
+# Off-paved: write the programs throwaway identifier's DatabaseUrlSecretArn at this DB.
+PROJECT=program-hub SERVICE=programs-api IDENTIFIER=canonseed ENV=dev CONTAINER=programs-api \
+  COMMAND='["npm","run","db:deploy"]'   ./.github/scripts/run-migrate-task.sh
+PROJECT=program-hub SERVICE=programs-api IDENTIFIER=canonseed ENV=dev CONTAINER=programs-api \
+  COMMAND='["npm","run","db:seed:run"]' ./.github/scripts/run-migrate-task.sh
+saga-orch snapshot --service-name program-hub-programs-canonical --seed-profile canonical
+```
+
+### Chain C — scheduling
+Same shape as B with `SERVICE=scheduling-api`, `--service-name program-hub-scheduling-canonical`,
+`--db-name scheduling_api_canonical`.
+
+### Chain D / fifth — sessions (NEW prefix — needs a code change too)
+sessions-api has the db scripts (`db:deploy`, `db:seed:run`) but **no canonical prefix and is
+absent from the seedFrom case statement**. Beyond cutting the snapshot:
+- Provision `program-hub-sessions-canonical`, migrate + `db:seed:run`, snapshot `--seed-profile canonical`.
+- **Code change:** add a `sessions-api) SF=program-hub-sessions-canonical ;;` arm to
+  `program-hub: .github/workflows/_deploy-ecs-api.yml` seedFrom case (PR) so composes can `seedFrom` it.
+
+## Per-service migrate/seed commands (verified)
+
+| Service | migrate | seed | note |
+|---|---|---|---|
+| programs/scheduling/sessions | `npm run db:deploy` | `npm run db:seed:run` (= `node dist/seed/seed.js`) | bundled in runtime image `dist/seed/seed.js` |
+| iam-db | `pnpm --filter @saga-ed/iam-db db:deploy` | `pnpm --filter @saga-ed/iam-db db:seed` | writes iam + (with crypto keys) PII |
+| iam-pii-db | `pnpm --filter @saga-ed/iam-pii-db db:deploy` | none (PII written by iam-db's seed) | schema applied here; data from iam-db seed |
+
+## Safety gates (execute as steps, not prose)
+1. **Back up** each existing `profile-canonical.sql` + `.meta.json` to a dated key
+   (`aws s3 cp ... s3://saga-db-seeds-dev/<prefix>/backup-2026-06-18/`) BEFORE any overwrite.
+   Confirm whether the bucket has versioning; if not, the backup is the only rollback.
+2. **Pin the Secrets Manager write tier** (the retarget needs `PutSecretValue`) — currently UNVERIFIED.
+3. **Prove once against a throwaway prefix** (e.g. `program-hub-programs-canonical-test`) → restore
+   into a sandbox → confirm role model + counts → THEN overwrite the real canonical.
+4. **Explicit user go-ahead before the first real canonical overwrite** (fleet-wide blast radius:
+   every future dev sandbox restores this).
+5. After each re-cut, **diff vs acceptance** (above) before pointing latest-main at it.
+
+## Then: recompose latest-main against fresh canonical
+Once canonical is re-cut + validated, recompose `latest-main` (resetAllData=canonical) per
+`trueup-latest-main-sandbox-to-synthetic-dev.md`. NOTE iam-api rides a separate rostering deploy
+track and was not in the last recompose — ensure its sandbox variant restores the new
+`rostering-iam-canonical` too.
+
+---
+*Mechanics verified against origin/main 2026-06-18 (iac/program-hub/rostering/soa); iam-pii crypto-key
+requirement confirmed in rostering iam-db/prisma/seed.ts:44-58.*

--- a/claude/projects/synthetic-dev-align/plans/trueup-latest-main-sandbox-to-synthetic-dev.md
+++ b/claude/projects/synthetic-dev-align/plans/trueup-latest-main-sandbox-to-synthetic-dev.md
@@ -1,0 +1,134 @@
+# Plan — true up the `latest-main` sandbox to synthetic-dev's full-seed state
+
+> ## ✅ Outcome (EXECUTED 2026-06-18/19 — "Goal 1")
+> The `latest-main` sandbox's 5 DBs were directly loaded with synthetic-dev `--seed full` data
+> (current-main schema) and the data confirmed by logging into the dash as
+> `demo-dadmin@saga.org` / `password123`. Hard-won lessons that fed the canonical re-cut:
+> - **pg18→pg15 strip:** local mesh dumps on pg18 emit `\restrict`/`SET transaction_timeout` that abort
+>   a pg15 sandbox load (silently — the restore swallows errors and returns `"action":"restored"`
+>   regardless). Strip those directives; verify loads by SSM-querying the DB, not the restore envelope.
+> - **PII keys:** iam_pii must be seeded with the DEV FLEET's PII crypto keys (Secrets Manager
+>   `rostering/dev/pii-dek`/`pii-hmac-key`), not local keys, or email_hash/encryption won't match and
+>   login fails at the PII lookup. The seed already creates PASSWORD auth_associations (argon2id,
+>   `password123`) for all demo users.
+> - The **janus employee-SSO perimeter** sits in front of iam-api; reaching the product login needs
+>   JumpCloud first (the dash gates jumpcloud → iam).
+>
+> Sibling: the fleet-wide counterpart (re-cut `canonical` so EVERY future sandbox gets this state) was
+> then executed — see `rebaseline-canonical-from-synthetic-dev.md` Outcome block, verified via the fresh
+> `canon-check-0619` composition.
+
+**Status:** DONE 2026-06-18/19 (was DRAFT 2026-06-18 — see Outcome block)
+**Scope:** the deployed `latest-main` switchboard sandbox + the `canonical` S3
+seed snapshots (`s3://saga-db-seeds-dev/*-canonical/`). No local `up.sh` changes.
+**Sibling track:** the cloud-side counterpart of `up-sh-db-seed-transition.md` —
+that plan converges the *local* base onto `db:seed`/seed-ids; this one makes the
+*deployed* `canonical` snapshot equal that same seeded state.
+
+## Goal & success criterion
+
+Make the deployed `latest-main` sandbox hold the same DB data as a fresh local
+`./up.sh --reset --seed full`. User framing: *revise `canonical` to be
+version-compatible copies of the synthetic-dev database state.*
+
+**Acceptance test:** `./up.sh --reset --seed full` locally → `pg_dump` each
+service DB → diff against the restored sandbox DBs (or against the canonical S3
+dumps) → row-for-row parity, especially sessions-api projections + the
+`projection_readiness` warm row.
+
+## What's actually true (verified 2026-06-18, `saga-infra-dev` S3 read + seed code on `main`)
+
+**Canonical already IS a synthetic-style seed — just slightly older.** The current
+`profile-canonical.sql` dumps carry deterministic `seed-ids` data (dev id
+`1e2ca0d8-…` present; Demo/Lincoln/Metro/Riverside districts), re-cut 2026-06-15
+(iam/programs) / 06-11 (scheduling):
+
+| DB (S3 prefix) | key rows | schemaRev (sidecar) |
+|---|---|---|
+| iam (`rostering-iam-canonical`) | users 205, user_profiles 205, groups 47, group_memberships 411, personas 10 | `20260519201834_add_login_profiles` |
+| iam-pii (`rostering-iam-pii-canonical`) | user_pii 15 | `20260415162135` |
+| programs (`program-hub-programs-canonical`) | Program 10, TutoringPeriod 24, ProgramSectionMapping 23, Pod 8 (+PodStudent 14/PodTutor 8), content_item 12 | `20260527000401_sessions_sector` |
+| scheduling (`program-hub-scheduling-canonical`) | Schedule 9, RecurrenceRule 17, CalendarEvent 1626, PeriodScheduleConfig 15 | `20260521120100…` |
+| **sessions** | **— NO SNAPSHOT EXISTS —** | — |
+
+(205 users = the same superset as `../decisions/d2.1-user-count-superset.md`.
+`districts`/`schools`/`sections` tables are 0 *by design* — the roster is modeled
+AS `groups` = 47 ≈ 5 districts + 13 schools + 28 sections + demo.)
+
+**The empty `*_projection` tables are NOT a defect.** `period_projection`,
+`program_projection`, `user_projection`, `slot_projection`, `pod_assignment` in
+the programs/scheduling dumps are EVENT-BUILT (scheduling-api `db:seed` writes 0
+projection rows). They're empty in synthetic-dev's *own* `--seed full` dump too —
+built lazily at runtime by event consumers. `outbox_event`/`consumed_events` are
+transient (empty by design). So canonical *matches* synthetic-dev's at-rest state
+for these. (Ties into the `soa_75` outbox/event track — seed-time vs runtime.)
+
+**The dash read path is sessions-api's DB, which IS fully at-rest.** sessions-api's
+`db:seed` writes every projection + the `projectionReadiness` warm row directly
+(`program-hub/apps/node/sessions-api/src/prisma/seed.ts:110/137/192/226/298/344`).
+This is the DB the dash's People/Schedule/Sessions pages actually read — and it
+has **no canonical snapshot at all.**
+
+## The three trueing-up actions, in priority order
+
+### 1. Recompose `latest-main` to restore *current* canonical  *(cheap, do first)*
+Canonical was refreshed 06-15. Any `latest-main` composed before that restored a
+*stale* snapshot. A recompose/redeploy (re-running the composition, or
+`POST /compositions/{name}/update` with `resetAllData` / `dbProfile=canonical`)
+re-restores the current dumps. This alone may close most of the gap for
+iam/programs/scheduling — no data engineering required.
+
+> Needs sandbox-api access (CI bearer + perimeter bypass, or the OIDC'd console
+> UI). `dbProfiles` defaults to `canonical` everywhere, so this is a redeploy, not
+> a reconfigure.
+
+### 2. ADD a `sessions` canonical snapshot  *(the high-value missing piece)*
+The real gap. Sequence (existing primitives only — `saga-orch snapshot` →
+db-host-v2 `POST /dbs/{name}/snapshot` → `pg_dump` → S3):
+
+1. Seed a sessions DB to synthetic-dev's full-seed state — two options:
+   - **(a) From synthetic-dev local:** `./up.sh --reset --seed full`, then
+     `pg_dump --no-owner --no-acl <sessions_db>` of the local `sessions` DB.
+     Requires an **S3-write tier** to upload as
+     `s3://saga-db-seeds-dev/<sessions-prefix>/profile-canonical.sql` (+ a
+     `profile-canonical.meta.json` sidecar with the matching `schemaRev`).
+   - **(b) On a db-host scratch DB:** provision a sessions DB, run sessions-api
+     `db:seed` against it, then `saga-orch snapshot --service-name sessions-api
+     --seed-profile canonical`. The sanctioned path; writes the sidecar
+     automatically (soa#148 capture).
+2. Register the sessions service's canonical so compositions can restore it.
+
+> Confirm the sessions service's registered switchboard name + expected S3 prefix
+> (the others are `program-hub-programs-canonical` etc.) before uploading.
+
+### 3. Re-baseline iam/programs/scheduling canonical to current synthetic-dev main  *(optional, closes minor drift)*
+Drift is small (personas: 2 `admin` rows vs rostering #397's per-district 6 — the
+d1.1 gate; Program 9→10). For exact parity:
+- Snapshot synthetic-dev at the **same `main`** `latest-main` runs (so `schemaRev`
+  matches — restore migrate-forwards if behind, hard-fails if ahead/destructive,
+  per switchboard `snapshot-schema-versioning.md`).
+- Re-cut each: iam is **TWO DBs** (iam + iam-pii — both). content-api has a 05-31
+  canonical — decide if in scope.
+- Same option (a) or (b) as step 2.
+
+## Open items / decisions
+- **S3-write tier** for option (a) uploads — not held at Observer/AppInfra-read;
+  needs the seed-bucket write grant (AppInfra/Platform or a db-host operator path).
+- **Sessions service registration** — confirm its switchboard name + canonical S3
+  prefix before cutting the snapshot.
+- **Automate?** Flow B (re-snapshot-canonical) is design-only (switchboard
+  `snapshot-schema-versioning.md`); this is the manual version. Worth wiring into
+  CI once proven once by hand. → candidate `decisions/` doc: *whether/when to
+  execute, and whether to automate canonical re-baselining.*
+
+## Related artifacts
+- `up-sh-db-seed-transition.md` — the local-side base→`db:seed` transition (sibling).
+- `../decisions/d2.1-user-count-superset.md` — the 205-user superset rationale.
+- `../decisions/d1.1-base-journey-split.md` — base vs journey layering.
+- synthetic-dev `INTEGRATION.md` — the `--sandbox`/`--compose-rest` hybrid (the
+  *consumer* of canonical; does NOT push local data into a sandbox).
+- switchboard `docs/snapshot-schema-versioning.md` — sidecar/`schemaRev` + Flow B.
+
+---
+
+*Verified against live dev S3 + program-hub/rostering `main` on 2026-06-18.*


### PR DESCRIPTION
## What

Lands the three plan/design docs for the "true up deployed sandboxes to synthetic-dev data" initiative, each annotated with an **Outcome** block recording what was actually executed (2026-06-18/19):

- `trueup-latest-main-sandbox-to-synthetic-dev.md` — Goal 1 (load latest-main sandbox DBs with synthetic-dev data; verified by dash login). **DONE.**
- `rebaseline-canonical-from-synthetic-dev.md` — Goal 2 (re-cut all 5 fleet `canonical` snapshots from current-main synthetic-dev, under the numbered-versioning flow). **DONE.** Includes the iam-pii `_prisma_migrations` **recurrence note** (future iam-pii re-cuts must run a clean local migrate first).
- `numbered-snapshot-versioning-design.md` — soa#168 design. **IMPLEMENTED + SHIPPED** as `@saga-ed/infra-compose@1.5.0`.

## Why

These were drafted before execution and lived in an un-merged worktree. They're worth keeping as the durable record of the design + the (sometimes divergent) execution, alongside the existing `synthetic-dev-align/` research/decisions docs already on main.

## Notes

- Docs-only; no code. Branched from current `origin/main` so the diff is exactly the 3 files (the original draft branch had diverged and carried unrelated stale changes, so it was not merged directly).
- `up-sh-db-seed-transition.md` (the fourth plan) is already on main.