### PR TITLE
chore(infra-compose): default postgres engine version 16 → 18

### DIFF
--- a/infra/src/ec2/engines.js
+++ b/infra/src/ec2/engines.js
@@ -6,7 +6,11 @@
 export const engines = {
     postgres: {
         image_template: 'postgres:{version}',
-        default_version: '16',
+        // 18 (was 16): align the fallback with the pg18.3 RDS mainline and the
+        // preview/sandbox provision defaults (program-hub/rostering now request
+        // 18 explicitly). Only fires when a caller omits engine-version (e.g. a
+        // local synthetic-dev `up` or a bare `saga-orch provision`).
+        default_version: '18',
         container_data_path: '/var/lib/postgresql/data',
         port_range: [5432, 5499],
         default_port: 5432,

--- a/infra/test/unit/compose-generator.unit.test.js
+++ b/infra/test/unit/compose-generator.unit.test.js
@@ -72,7 +72,7 @@ describe('generate_compose resource limits', () => {
     it('still produces a valid-looking compose YAML structure', () => {
         const out = generate_compose({ ...base, engine: 'postgres' });
         expect(out).toMatch(/^services:/m);
-        expect(out).toMatch(/image: postgres:16/);
+        expect(out).toMatch(/image: postgres:18/);
         expect(out).toMatch(/container_name: pr-42/);
         expect(out).toMatch(/"5433:5432"/);
     });


### PR DESCRIPTION
## What

Bumps `engines.js` `postgres.default_version` `16` → `18`, and updates the matching compose-generator unit test assertion.

## Why

The `default_version` is the fallback used only when a provision call **omits** an explicit engine-version. Aligning it with the pg18.3 RDS mainline (and the program-hub/rostering provision defaults, which now request 18 explicitly — sibling PRs) means even the version-less paths (local synthetic-dev `up`, a bare `saga-orch provision`) get pg18.

## Scope

- Only affects **newly-generated** compose files / newly-provisioned containers. Existing containers are immutable.
- Cloud sandbox/preview provisioning already passes an explicit version (now 18 via the sibling PRs), so this fallback rarely fires there — it mainly aligns the local-mesh and ad-hoc paths.

## Part of

Standardizing Saga Postgres on pg18. Sibling PRs: program-hub #236, rostering #590 (provision defaults). Canonical snapshots re-cut at pg18 separately.