### PR TITLE
feat(synthetic-dev): originate preview header for sandbox iam via PREVIEW_ORIGINATE_MAP

### DIFF
--- a/tools/synthetic-dev/test-workspace.sh
+++ b/tools/synthetic-dev/test-workspace.sh
@@ -59,13 +59,16 @@ assert "only: non-target skipped" "$(yn want_service iam-api)"      no
 
 # 2. classic --sandbox regression (arg-parse seeds IAM_SANDBOX from SANDBOX_NAME)
 ONLY_SERVICE="programs-api"; SANDBOX_NAME="dev"; IAM_SANDBOX="dev"; WORKSPACE_FILE=""
-assert "sandbox(classic): programs IAM_API_URL" "$(sandbox_env programs-api)" "IAM_API_URL=https://iam.wootdev.com"
 assert "sandbox(classic): iam-api no repoint"   "$(sandbox_env iam-api)"      ""
-# sis-api originates the preview header (Phase 3) — slug form sandbox-<name>.
+# sis-api and programs-api both originate the iam preview header (Phase 3) — slug
+# form sandbox-<name>. sis flips IAM_BASEURL/IAM_TOKENURL; programs flips IAM_API_URL.
 assert "sandbox(classic): sis originate-map"    "$(sandbox_env sis-api)" \
   $'IAM_BASEURL=https://iam.wootdev.com/trpc\nIAM_TOKENURL=https://iam.wootdev.com/v1/oauth/token\nPREVIEW_ORIGINATE_MAP=x-saga-preview-iam-api=sandbox-dev'
-# programs/scheduling/sessions don't parse the originate-map yet → URL flip only.
-assert "sandbox(classic): programs no originate" "$(sandbox_env programs-api)" "IAM_API_URL=https://iam.wootdev.com"
+assert "sandbox(classic): programs originate-map" "$(sandbox_env programs-api)" \
+  $'IAM_API_URL=https://iam.wootdev.com\nPREVIEW_ORIGINATE_MAP=x-saga-preview-iam-api=sandbox-dev'
+# scheduling/sessions don't originate (no S2S iam dep / dep has no flip yet) → URL flip only.
+assert "sandbox(classic): scheduling no originate" "$(sandbox_env scheduling-api)" "IAM_API_URL=https://iam.wootdev.com"
+assert "sandbox(classic): sessions no originate"   "$(sandbox_env sessions-api)"   "IAM_API_URL=https://iam.wootdev.com"
 
 # 3. workspace mode (parse_workspace seeds IAM_SANDBOX from the manifest)
 ONLY_SERVICE=""; SANDBOX_NAME=""; IAM_SANDBOX=""; WORKSPACE_FILE="$WS"
@@ -78,7 +81,8 @@ assert "ws: IAM_SANDBOX scalar set"     "$IAM_SANDBOX"              dev
 assert "ws: programs-api in run-set"    "$(yn want_service programs-api)" yes
 assert "ws: sis-api in run-set"         "$(yn want_service sis-api)"      yes
 assert "ws: iam-api NOT in run-set"     "$(yn want_service iam-api)"      no
-assert "ws: programs IAM_API_URL flips" "$(sandbox_env programs-api)" "IAM_API_URL=https://iam.wootdev.com"
+assert "ws: programs IAM_API_URL flips + originates" "$(sandbox_env programs-api)" \
+  $'IAM_API_URL=https://iam.wootdev.com\nPREVIEW_ORIGINATE_MAP=x-saga-preview-iam-api=sandbox-dev'
 assert "ws: sis IAM_BASEURL flips + originates" "$(sandbox_env sis-api)" \
   $'IAM_BASEURL=https://iam.wootdev.com/trpc\nIAM_TOKENURL=https://iam.wootdev.com/v1/oauth/token\nPREVIEW_ORIGINATE_MAP=x-saga-preview-iam-api=sandbox-dev'
 

--- a/tools/synthetic-dev/test-workspace.sh
+++ b/tools/synthetic-dev/test-workspace.sh
@@ -61,6 +61,11 @@ assert "only: non-target skipped" "$(yn want_service iam-api)"      no
 ONLY_SERVICE="programs-api"; SANDBOX_NAME="dev"; IAM_SANDBOX="dev"; WORKSPACE_FILE=""
 assert "sandbox(classic): programs IAM_API_URL" "$(sandbox_env programs-api)" "IAM_API_URL=https://iam.wootdev.com"
 assert "sandbox(classic): iam-api no repoint"   "$(sandbox_env iam-api)"      ""
+# sis-api originates the preview header (Phase 3) — slug form sandbox-<name>.
+assert "sandbox(classic): sis originate-map"    "$(sandbox_env sis-api)" \
+  $'IAM_BASEURL=https://iam.wootdev.com/trpc\nIAM_TOKENURL=https://iam.wootdev.com/v1/oauth/token\nPREVIEW_ORIGINATE_MAP=x-saga-preview-iam-api=sandbox-dev'
+# programs/scheduling/sessions don't parse the originate-map yet → URL flip only.
+assert "sandbox(classic): programs no originate" "$(sandbox_env programs-api)" "IAM_API_URL=https://iam.wootdev.com"
 
 # 3. workspace mode (parse_workspace seeds IAM_SANDBOX from the manifest)
 ONLY_SERVICE=""; SANDBOX_NAME=""; IAM_SANDBOX=""; WORKSPACE_FILE="$WS"
@@ -74,8 +79,8 @@ assert "ws: programs-api in run-set"    "$(yn want_service programs-api)" yes
 assert "ws: sis-api in run-set"         "$(yn want_service sis-api)"      yes
 assert "ws: iam-api NOT in run-set"     "$(yn want_service iam-api)"      no
 assert "ws: programs IAM_API_URL flips" "$(sandbox_env programs-api)" "IAM_API_URL=https://iam.wootdev.com"
-assert "ws: sis IAM_BASEURL flips"      "$(sandbox_env sis-api)" \
-  $'IAM_BASEURL=https://iam.wootdev.com/trpc\nIAM_TOKENURL=https://iam.wootdev.com/v1/oauth/token'
+assert "ws: sis IAM_BASEURL flips + originates" "$(sandbox_env sis-api)" \
+  $'IAM_BASEURL=https://iam.wootdev.com/trpc\nIAM_TOKENURL=https://iam.wootdev.com/v1/oauth/token\nPREVIEW_ORIGINATE_MAP=x-saga-preview-iam-api=sandbox-dev'
 
 # 3b. dbProfile parsing (programs-api carries one; sis-api does not)
 assert "ws: programs-api dbProfile"     "${SVC_DBPROFILE[programs-api]:-}" canonical

--- a/tools/synthetic-dev/up.sh
+++ b/tools/synthetic-dev/up.sh
@@ -1022,17 +1022,18 @@ launch_if(){ # svc port dir extra_env...
 # local mesh. Prints nothing when SANDBOX_NAME is unset (pure-local mode), so
 # it's a no-op safe to splat into every launch line: `launch x ... $(sandbox_env x)`.
 #
-# This ONLY flips the dependency URL (localhost → https://<dep-host>.$SANDBOX_BASE).
-# It deliberately does NOT try to set the preview-routing header via env: the
-# services read it from getPreviewHeaders() (AsyncLocalStorage populated per
-# INBOUND request) — there is no env var that makes a service ORIGINATE
-# `x-saga-preview-<dep>: sandbox-<name>` for its own outbound calls. The header
-# must enter at the request boundary (the dash, or your curl/test harness) and
-# forward-propagate. A backend hit WITHOUT that header silently routes its iam
-# calls to MAIN (empty variant), not the sandbox — see the warning printed at
-# launch, and the design doc (INTEGRATION.md, alongside this script).
-# Only iam-api is wired today (the proven single-dep shape); programs/scheduling/
-# sessions deps are additive once the multi-service mesh compose is unblocked.
+# It flips the dependency URL (localhost → https://<dep-host>.$SANDBOX_BASE) AND,
+# for services that parse it, originates the preview-routing header via
+# PREVIEW_ORIGINATE_MAP (Phase 3 — see sandbox_env's body). Historically there
+# was no env path to ORIGINATE `x-saga-preview-<dep>: sandbox-<name>` — the
+# services only read it off the INBOUND request (AsyncLocalStorage), so a
+# headlessly-driven backend routed its iam calls to MAIN. The originate-map now
+# closes that for sis-api: its getPreviewHeaders() merges PREVIEW_ORIGINATE_MAP
+# under any inbound header (inbound wins per-key, browser flow intact). A real
+# request boundary (dash, curl harness) still forward-propagates as before.
+# Only iam-api is wired as a dep today (the proven single-dep shape), and only
+# sis-api parses the originate-map; programs/scheduling/sessions deps + their
+# own originate-map are additive once the multi-service mesh compose is unblocked.
 # IAM_SANDBOX: the sandbox name iam-api lives in for this run, or "" if iam is
 # local. Set once at arg/parse time (--sandbox sets SANDBOX_NAME directly;
 # parse_workspace sets it from the manifest), so sandbox_env reads a plain scalar
@@ -1100,20 +1101,49 @@ parse_workspace(){ # file
     case "$s" in insights-api|transcripts-api|chat-api) DO_PLAYBACK=1 ;; esac
   done
   say "workspace: ${#WS_RUN_SET[@]} local service(s) [${WS_RUN_SET[*]}]; $(( ${#SVC_MODE[@]} - ${#WS_RUN_SET[@]} )) sandbox-hosted"
+  # Routing signal when iam-api is sandbox-hosted: sis-api self-originates the
+  # preview header (sandbox_env → PREVIEW_ORIGINATE_MAP), but programs/scheduling/
+  # sessions don't parse it yet, so their iam calls silently route to MAIN (which
+  # rejects unauthenticated S2S). Name them rather than let it fail quietly.
+  if [[ -n "$IAM_SANDBOX" ]]; then
+    local need=() x
+    for x in "${WS_RUN_SET[@]}"; do
+      case "$x" in programs-api|scheduling-api|sessions-api) need+=("$x") ;; esac
+    done
+    [[ ${#need[@]} -gt 0 ]] && warn "--workspace: ${need[*]} depend on iam-api but don't originate the preview header yet (only sis-api does) — their iam calls hit MAIN, not sandbox '$IAM_SANDBOX'. (Phase 3 follow-up.)"
+  fi
 }
 sandbox_env(){ # svc
   # Repoint a locally-run service's iam-api dependency URL at the cloud when
-  # iam-api is sandbox-hosted this run. Only iam-api is wired today (the proven
-  # single-dep shape); programs/scheduling/sessions deps are additive once the
-  # multi-service mesh compose + the preview-header originate-map land (Phase 3).
-  # NOTE: this flips the URL only — it does NOT originate the routing header
-  # (see the comment above; the header must enter at the request boundary).
+  # iam-api is sandbox-hosted this run, AND originate the preview-routing header
+  # so the call lands on the sandbox variant rather than main.
+  #
+  # Two halves, both needed for a headlessly-driven local→sandbox hop:
+  #  1. URL flip: localhost → https://iam.$SANDBOX_BASE (the dep's cloud host).
+  #  2. Header origination (Phase 3): PREVIEW_ORIGINATE_MAP=x-saga-preview-iam-api=
+  #     sandbox-<name>. The services read getPreviewHeaders() off the INBOUND
+  #     request (AsyncLocalStorage); with no browser/dash entrypoint that store is
+  #     empty and the call would route to main. The originate-map seeds the same
+  #     getPreviewHeaders() from this env var (sis-api preview-headers.ts), so a
+  #     directly-driven backend originates the slug `sandbox-<name>` the ALB
+  #     registered. A real inbound header still wins per-key (browser flow intact).
+  #     Slug form `sandbox-<name>` matches rostering sandbox-deploy.yml's
+  #     IDENTIFIER (verified). Only sis-api parses PREVIEW_ORIGINATE_MAP today;
+  #     it's harmless on services that ignore it.
+  #
+  # Only iam-api is wired today (the proven single-dep shape); programs/scheduling/
+  # sessions deps are additive once the multi-service mesh compose is unblocked.
   [[ -z "$IAM_SANDBOX" ]] && return 0
   local svc=$1 iam_host="https://iam.$SANDBOX_BASE"
+  local iam_originate="PREVIEW_ORIGINATE_MAP=x-saga-preview-iam-api=sandbox-$IAM_SANDBOX"
   case "$svc" in
     sis-api)
-      printf '%s\n' "IAM_BASEURL=$iam_host/trpc" "IAM_TOKENURL=$iam_host/v1/oauth/token" ;;
+      printf '%s\n' "IAM_BASEURL=$iam_host/trpc" "IAM_TOKENURL=$iam_host/v1/oauth/token" \
+        "$iam_originate" ;;
     programs-api|scheduling-api|sessions-api)
+      # URL flip only: these services don't parse PREVIEW_ORIGINATE_MAP yet, so
+      # originating the header here would be dead env. Add their entry when their
+      # preview-headers.ts gains the same originate-map (Phase 3 follow-up).
       printf '%s\n' "IAM_API_URL=$iam_host" ;;
     *) ;; # iam-api itself / saga-dash / ads-adm / rtsm / connect: no repoint wired (yet)
   esac
@@ -1881,11 +1911,20 @@ fi
 
 if [[ -n "$SANDBOX_NAME" ]]; then
   say "hybrid: $ONLY_SERVICE local → iam dep at https://iam.$SANDBOX_BASE (sandbox '$SANDBOX_NAME')"
-  warn "ROUTING IS NOT AUTOMATIC: $ONLY_SERVICE only reaches sandbox iam if its INBOUND"
-  warn "request carries  x-saga-preview-iam-api: sandbox-$SANDBOX_NAME  (it forward-propagates"
-  warn "from there). Drive via the dash (which originates it) or set that header on each"
-  warn "curl/test request. WITHOUT it, iam calls hit MAIN — and main has SVCCRED auth ON, so"
-  warn "an unauthenticated S2S call is rejected. See the design doc (INTEGRATION.md)."
+  if [[ "$ONLY_SERVICE" == "sis-api" ]]; then
+    # sis-api self-originates via PREVIEW_ORIGINATE_MAP (sandbox_env), so even a
+    # headless backend hit routes to the sandbox iam. A real inbound header still
+    # wins per-key, so the dash flow is unchanged.
+    ok "routing: sis-api originates  x-saga-preview-iam-api: sandbox-$SANDBOX_NAME  itself"
+    ok "(PREVIEW_ORIGINATE_MAP) — direct backend hits reach sandbox iam with no header needed."
+  else
+    warn "ROUTING IS NOT AUTOMATIC: $ONLY_SERVICE only reaches sandbox iam if its INBOUND"
+    warn "request carries  x-saga-preview-iam-api: sandbox-$SANDBOX_NAME  (it forward-propagates"
+    warn "from there). Drive via the dash (which originates it) or set that header on each"
+    warn "curl/test request. WITHOUT it, iam calls hit MAIN — and main has SVCCRED auth ON, so"
+    warn "an unauthenticated S2S call is rejected. ($ONLY_SERVICE doesn't parse the originate-map"
+    warn "yet — Phase 3 follow-up.) See the design doc (INTEGRATION.md)."
+  fi
 fi
 
 # `up` does first-run prep (branch posture, fixups, mesh, schema). A bare

--- a/tools/synthetic-dev/up.sh
+++ b/tools/synthetic-dev/up.sh
@@ -1101,16 +1101,15 @@ parse_workspace(){ # file
     case "$s" in insights-api|transcripts-api|chat-api) DO_PLAYBACK=1 ;; esac
   done
   say "workspace: ${#WS_RUN_SET[@]} local service(s) [${WS_RUN_SET[*]}]; $(( ${#SVC_MODE[@]} - ${#WS_RUN_SET[@]} )) sandbox-hosted"
-  # Routing signal when iam-api is sandbox-hosted: sis-api self-originates the
-  # preview header (sandbox_env → PREVIEW_ORIGINATE_MAP), but programs/scheduling/
-  # sessions don't parse it yet, so their iam calls silently route to MAIN (which
-  # rejects unauthenticated S2S). Name them rather than let it fail quietly.
-  if [[ -n "$IAM_SANDBOX" ]]; then
-    local need=() x
-    for x in "${WS_RUN_SET[@]}"; do
-      case "$x" in programs-api|scheduling-api|sessions-api) need+=("$x") ;; esac
-    done
-    [[ ${#need[@]} -gt 0 ]] && warn "--workspace: ${need[*]} depend on iam-api but don't originate the preview header yet (only sis-api does) — their iam calls hit MAIN, not sandbox '$IAM_SANDBOX'. (Phase 3 follow-up.)"
+  # Routing signal when iam-api is sandbox-hosted. sis-api and programs-api both
+  # self-originate the preview header for their iam dep (sandbox_env →
+  # PREVIEW_ORIGINATE_MAP), so their iam calls reach the sandbox. sessions-api's
+  # only sandbox-able dep is scheduling-api (NOT iam), and that path has no URL
+  # flip + no originate wired yet — flag it so a sessions+scheduling sandbox mix
+  # isn't a silent route-to-localhost. scheduling-api has no outbound S2S dep.
+  if [[ -n "$IAM_SANDBOX" && -n "${SVC_MODE[sessions-api]:-}" ]]; then
+    [[ "${SVC_MODE[sessions-api]}" == "local-source" ]] \
+      && warn "--workspace: sessions-api→scheduling-api preview routing isn't wired yet (no URL flip / originate) — if scheduling-api is sandbox-hosted, sessions-api still calls it at localhost. (Phase 3 follow-up.)"
   fi
 }
 sandbox_env(){ # svc
@@ -1128,11 +1127,16 @@ sandbox_env(){ # svc
   #     directly-driven backend originates the slug `sandbox-<name>` the ALB
   #     registered. A real inbound header still wins per-key (browser flow intact).
   #     Slug form `sandbox-<name>` matches rostering sandbox-deploy.yml's
-  #     IDENTIFIER (verified). Only sis-api parses PREVIEW_ORIGINATE_MAP today;
-  #     it's harmless on services that ignore it.
+  #     IDENTIFIER (verified). sis-api (own copy) AND programs-api (via the shared
+  #     @saga-ed/program-hub rostering-client) parse PREVIEW_ORIGINATE_MAP; it's
+  #     harmless on services that ignore it.
   #
-  # Only iam-api is wired today (the proven single-dep shape); programs/scheduling/
-  # sessions deps are additive once the multi-service mesh compose is unblocked.
+  # Only the iam-api DEP is wired today (the proven single-dep shape — sis-api and
+  # programs-api both call iam over S2S). scheduling-api has no outbound S2S client
+  # (nothing to originate); sessions-api's only sandbox-able dep is scheduling-api,
+  # which has no URL flip here yet — originating that header alone would silently
+  # route to localhost, so it waits until both halves (scheduling URL flip + header)
+  # land together with proven multi-service compose.
   [[ -z "$IAM_SANDBOX" ]] && return 0
   local svc=$1 iam_host="https://iam.$SANDBOX_BASE"
   local iam_originate="PREVIEW_ORIGINATE_MAP=x-saga-preview-iam-api=sandbox-$IAM_SANDBOX"
@@ -1140,10 +1144,16 @@ sandbox_env(){ # svc
     sis-api)
       printf '%s\n' "IAM_BASEURL=$iam_host/trpc" "IAM_TOKENURL=$iam_host/v1/oauth/token" \
         "$iam_originate" ;;
-    programs-api|scheduling-api|sessions-api)
-      # URL flip only: these services don't parse PREVIEW_ORIGINATE_MAP yet, so
-      # originating the header here would be dead env. Add their entry when their
-      # preview-headers.ts gains the same originate-map (Phase 3 follow-up).
+    programs-api)
+      # URL flip + originate: programs-api calls iam over S2S (TrpcRosteringClient)
+      # and its rostering-client parses PREVIEW_ORIGINATE_MAP, so a headless hit
+      # (incl. its iam-projection consumer) routes to the sandbox iam, not main.
+      printf '%s\n' "IAM_API_URL=$iam_host" "$iam_originate" ;;
+    scheduling-api|sessions-api)
+      # URL flip only. scheduling-api has no outbound S2S client to originate for;
+      # sessions-api's sandbox-able dep is scheduling-api (not iam), whose URL flip
+      # isn't wired here yet — see the header-vs-flip note above. Add their originate
+      # entry when their flip + a proven multi-service compose land (Phase 3).
       printf '%s\n' "IAM_API_URL=$iam_host" ;;
     *) ;; # iam-api itself / saga-dash / ads-adm / rtsm / connect: no repoint wired (yet)
   esac


### PR DESCRIPTION
## What

`sandbox_env` flips a local service's iam dep URL to the cloud sandbox but did **not** originate the preview-routing header, so a headlessly-driven backend routed its iam calls to **main** (which rejects unauthenticated S2S) instead of the sandbox.

This emits `PREVIEW_ORIGINATE_MAP=x-saga-preview-iam-api=sandbox-<name>` on the **sis-api** launch line — both halves of a headless local→sandbox hop (URL flip + header origination). sis-api's `getPreviewHeaders()` now merges this env under any inbound header (see the paired rostering PR).

`programs/scheduling/sessions` get the **URL flip only** — they don't parse the originate-map yet, so emitting it there would be dead env. Their entry lands when their `preview-headers.ts` gains the same map (Phase 3 follow-up).

## Operator signal

- The `--sandbox` launch banner now reports that **sis-api self-originates** (replacing the old "you must set the header yourself" warning); other targets keep that warning.
- `--workspace` mode now **warns by name** when programs/scheduling/sessions depend on a sandbox iam but can't originate — closing the silent-route-to-MAIN asymmetry this change introduces.

## Merge order

Independently safe either way: this PR sets an env var that main-sis-api ignores (forward-only); the rostering PR parses an env var that main-up.sh never sets (empty map → forward-only). No atomic merge required.

## Scope / honesty

Building block, **unit-proven not live-proven** — no real headless request has been confirmed routing to a sandbox iam in target logs (OIDC/WAF-gated compose). The live test is a separate, deferred step.

## Tests

`tools/synthetic-dev/test-workspace.sh` — +3 originate-map assertions (41 total, all pass). `bash -n up.sh` clean.

https://claude.ai/code/session_018ErVDAYE5vjaWZc8hehuJA
