### PR TITLE
fix(infra-compose): seed_after_start loads into the configured DB (-d) [#177]

### DIFF
--- a/infra/package.json
+++ b/infra/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/infra-compose",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "description": "Composable Docker service templates for Saga platform local development",
     "bin": {
         "infra-compose": "bin/infra-compose"

--- a/infra/src/ec2/ec2-router.js
+++ b/infra/src/ec2/ec2-router.js
@@ -798,6 +798,7 @@ export function create_ec2_router(config = {}) {
                 profile,
                 db_user: config.user,
                 db_password: config.password,
+                db_name,
             });
 
             // Update profile registry

--- a/infra/src/ec2/profiles.js
+++ b/infra/src/ec2/profiles.js
@@ -220,7 +220,7 @@ function snapshot_mongo({ container, tmp_file, user, password }) {
 
 // --- Seed a running DB directly via docker exec ---
 
-export function seed_after_start({ container, engine, seeds_dir, profile, db_user, db_password }) {
+export function seed_after_start({ container, engine, seeds_dir, profile, db_user, db_password, db_name }) {
     const eng = engines[engine];
     if (!eng) throw new Error(`Unknown engine: ${engine}`);
 
@@ -259,9 +259,15 @@ export function seed_after_start({ container, engine, seeds_dir, profile, db_use
         const seed_file = resolve(seeds_dir, '01-seed.sql');
         if (!existsSync(seed_file)) return;
         run('docker', ['cp', seed_file, `${container}:/tmp/01-seed.sql`]);
-        const result = spawnSync('docker', [
-            'exec', container, 'psql', '-U', db_user || 'postgres', '-f', '/tmp/01-seed.sql',
-        ], { encoding: 'utf8', stdio: 'pipe' });
+        // MUST target the configured DB with `-d`: a single-DB pg_dump carries no
+        // CREATE DATABASE/\connect, so a bare `psql -f` loads into the role's
+        // default DB (or fails) and the configured DB ends up empty — the restore
+        // then reports success while loading 0 tables (soa#177). ON_ERROR_STOP
+        // surfaces a genuine load failure instead of swallowing it.
+        const psql_args = ['exec', container, 'psql', '-U', db_user || 'postgres'];
+        if (db_name) psql_args.push('-d', db_name);
+        psql_args.push('-v', 'ON_ERROR_STOP=1', '-f', '/tmp/01-seed.sql');
+        const result = spawnSync('docker', psql_args, { encoding: 'utf8', stdio: 'pipe' });
         console.log(`Postgres seed output: ${(result.stdout || '').slice(0, 500)}`);
         if (result.status !== 0) console.log(`Postgres seed error: ${result.stderr}`);
     } else if (engine === 'mysql') {

--- a/infra/test/unit/profiles-seed-after-start.unit.test.js
+++ b/infra/test/unit/profiles-seed-after-start.unit.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// soa#177 — seed_after_start's postgres branch MUST load the dump into the
+// configured DB (`psql -d <db_name>`), with ON_ERROR_STOP so a failed load is
+// not silently swallowed. A single-DB pg_dump carries no CREATE DATABASE/
+// \connect, so a bare `psql -f` (no -d) loads into the role's default DB and the
+// configured DB ends up empty while the restore reports success.
+
+const spawnSync_calls = [];
+
+vi.mock('child_process', () => ({
+    spawnSync: vi.fn((cmd, args) => {
+        spawnSync_calls.push([cmd, args]);
+        // Make the health-wait loop exit immediately.
+        if (cmd === 'docker' && args[0] === 'inspect') {
+            return { status: 0, stdout: 'healthy\n', stderr: '' };
+        }
+        return { status: 0, stdout: '', stderr: '' };
+    }),
+    spawn: vi.fn(),
+}));
+
+// The seed file must "exist" so the postgres branch proceeds to load it.
+vi.mock('fs', async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+        ...actual,
+        existsSync: vi.fn(() => true),
+    };
+});
+
+import { seed_after_start } from '../../src/ec2/profiles.js';
+
+/** The args of the `psql ... -f /tmp/01-seed.sql` load invocation (not the rev query). */
+function psqlLoadArgs() {
+    const call = spawnSync_calls.find(
+        ([cmd, args]) =>
+            cmd === 'docker' &&
+            args[0] === 'exec' &&
+            args.includes('psql') &&
+            args.includes('/tmp/01-seed.sql'),
+    );
+    return call ? call[1] : null;
+}
+
+describe('seed_after_start — postgres load targets the configured DB (soa#177)', () => {
+    beforeEach(() => {
+        spawnSync_calls.length = 0;
+    });
+
+    it('passes -d <db_name> and ON_ERROR_STOP to the psql load', () => {
+        seed_after_start({
+            container: 'programs-api-canonical',
+            engine: 'postgres',
+            seeds_dir: '/tmp/seeds',
+            profile: 'canonical',
+            db_user: 'postgres_admin',
+            db_password: 'pw',
+            db_name: 'programs_api_canonical',
+        });
+        const args = psqlLoadArgs();
+        expect(args).not.toBeNull();
+        // loads into the configured DB, not the role's default
+        const dIdx = args.indexOf('-d');
+        expect(dIdx).toBeGreaterThan(-1);
+        expect(args[dIdx + 1]).toBe('programs_api_canonical');
+        // fails loudly instead of swallowing a bad load
+        expect(args).toContain('ON_ERROR_STOP=1');
+        // still the right user + file
+        expect(args).toContain('postgres_admin');
+        expect(args).toContain('/tmp/01-seed.sql');
+    });
+
+    it('honors a <profile>@vN pin (db_name still threaded)', () => {
+        seed_after_start({
+            container: 'programs-api-sbx',
+            engine: 'postgres',
+            seeds_dir: '/tmp/seeds',
+            profile: 'canonical@v2',
+            db_user: 'postgres_admin',
+            db_password: 'pw',
+            db_name: 'programs_api_sbx',
+        });
+        const args = psqlLoadArgs();
+        expect(args).not.toBeNull();
+        const dIdx = args.indexOf('-d');
+        expect(args[dIdx + 1]).toBe('programs_api_sbx');
+    });
+});


### PR DESCRIPTION
## What
`seed_after_start`'s postgres branch ran `psql -U <user> -f 01-seed.sql` **without `-d <db>`**. A single-DB `pg_dump` carries no `CREATE DATABASE`/`\connect`, so a bare `psql -f` loads into the role's default DB (or errors), leaving the configured DB **empty** — while the restore path returns `action:restored` regardless. So a `restore` into an **already-initialized** DB silently loaded **0 tables**.

(Fresh provisions worked because they load via `docker-entrypoint-initdb.d`, which targets the correct DB — this only bites the restore-into-existing-DB path.)

## Fix
- Pass `-d <db_name>` to the `psql` load (threaded from the ec2-router caller, where `db_name` is already computed via `get_db_name`).
- Add `-v ON_ERROR_STOP=1` so a genuine load failure surfaces instead of being swallowed.
- New `profiles-seed-after-start.unit.test.js` asserting the psql load carries `-d <db_name>` + `ON_ERROR_STOP`.
- Bump `@saga-ed/infra-compose` 1.5.0 → 1.5.1.

## Verification
- Full infra unit suite: **106/106 green**.
- SSM diagnostic on a db-host (verified the root cause + fix): same dump → bare `psql -f` = **0 tables**; `psql -d <db> -f` = **26 tables**.

## Impact
Makes `saga-orch restore <db> seedFrom=<prefix>` reliable for restore-into-existing-DB fleet-wide, and unblocks the host-mediated `cut-canonical` re-cut (program-hub). Needs the standard publish + db-host fleet roll to take effect (like the 1.5.0 deploy).

Closes #177.