### PR TITLE
feat(preview-headers): @saga-ed/soa-preview-headers — canonical HTTP-plane preview routing

### DIFF
--- a/packages/node/preview-headers/package.json
+++ b/packages/node/preview-headers/package.json
@@ -1,0 +1,38 @@
+{
+    "name": "@saga-ed/soa-preview-headers",
+    "version": "0.1.0-dev.0",
+    "private": false,
+    "type": "module",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
+        }
+    },
+    "files": ["dist"],
+    "scripts": {
+        "build": "tsup",
+        "check-types": "tsc --noEmit",
+        "test": "vitest run --passWithNoTests",
+        "lint": "eslint src/",
+        "clean": "rm -rf dist"
+    },
+    "devDependencies": {
+        "@saga-ed/soa-typescript-config": "workspace:*",
+        "@types/node": "^24.0.3",
+        "tsup": "^8.5.0",
+        "typescript": "5.8.2",
+        "vitest": "^1.6.1"
+    },
+    "publishConfig": {
+        "registry": "https://saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/",
+        "access": "public"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/saga-ed/soa.git",
+        "directory": "packages/node/preview-headers"
+    }
+}

--- a/packages/node/preview-headers/src/forward.ts
+++ b/packages/node/preview-headers/src/forward.ts
@@ -1,0 +1,26 @@
+import { getPreviewHeaders } from './store.js';
+
+/**
+ * Merge the current request's preview headers into an outbound header bag,
+ * making "forward the preview routing headers" the default for any S2S client
+ * instead of a step each client must remember (the propagation gap the fleet
+ * audit flagged: a client that forgets to spread `getPreviewHeaders()` silently
+ * routes that hop to `main`).
+ *
+ * Framework-agnostic — drop it into any tRPC `httpBatchLink` headers function or
+ * fetch wrapper. The caller's own headers (auth token, cookie) take precedence
+ * over the preview headers per-key, so passing the existing bag never has a
+ * preview header clobber an auth header.
+ *
+ * @example
+ *   // tRPC httpBatchLink:
+ *   headers: async () => withPreviewHeaders({ 'x-service-token': await token() })
+ *
+ *   // fetch:
+ *   fetch(url, { headers: withPreviewHeaders({ cookie }) })
+ */
+export function withPreviewHeaders(
+  headers: Record<string, string> = {},
+): Record<string, string> {
+  return { ...getPreviewHeaders(), ...headers };
+}

--- a/packages/node/preview-headers/src/header-keys.ts
+++ b/packages/node/preview-headers/src/header-keys.ts
@@ -1,0 +1,55 @@
+/**
+ * The canonical preview-routing header prefix. Every Saga service routes
+ * preview/sandbox traffic with `x-saga-preview-<service>: sandbox-<name>`; the
+ * ALB matches on that header + value and sends the hop to the preview deployment
+ * of `<service>` instead of `main`. This is the HTTP-plane counterpart of the
+ * event-plane `applyPreviewTag()` in `@saga-ed/soa-event-envelope`.
+ */
+export const HEADER_PREFIX = 'x-saga-preview-';
+
+/**
+ * Normalize a service key into a full preview-header name. Accepts either the
+ * short service key (`iam-api`) or the already-prefixed header name
+ * (`x-saga-preview-iam-api`) and returns the lowercased full header name. Lets
+ * config (e.g. an origination map) be written in the terse short form.
+ *
+ * @example
+ *   toPreviewHeaderName('iam-api')                // → 'x-saga-preview-iam-api'
+ *   toPreviewHeaderName('x-saga-preview-iam-api') // → 'x-saga-preview-iam-api'
+ */
+export function toPreviewHeaderName(serviceKeyOrHeader: string): string {
+  const trimmed = serviceKeyOrHeader.trim().toLowerCase();
+  return trimmed.startsWith(HEADER_PREFIX) ? trimmed : `${HEADER_PREFIX}${trimmed}`;
+}
+
+/**
+ * The inverse of {@link toPreviewHeaderName}: strip the prefix to recover the
+ * service key. Returns the input unchanged if it carries no prefix.
+ *
+ * @example
+ *   toServiceKey('x-saga-preview-iam-api') // → 'iam-api'
+ */
+export function toServiceKey(header: string): string {
+  const lower = header.trim().toLowerCase();
+  return lower.startsWith(HEADER_PREFIX) ? lower.slice(HEADER_PREFIX.length) : lower;
+}
+
+/**
+ * Filter an inbound header bag down to just the `x-saga-preview-*` string
+ * entries (lowercased keys). Shared by the capture middleware and any caller
+ * that wants to extract preview headers from a raw request without the
+ * AsyncLocalStorage plumbing. Array-valued headers (which a routing header
+ * should never be) are skipped.
+ */
+export function extractPreviewHeaders(
+  headers: Record<string, string | string[] | undefined>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    const lower = key.toLowerCase();
+    if (lower.startsWith(HEADER_PREFIX) && typeof value === 'string') {
+      out[lower] = value;
+    }
+  }
+  return out;
+}

--- a/packages/node/preview-headers/src/index.ts
+++ b/packages/node/preview-headers/src/index.ts
@@ -1,0 +1,19 @@
+/**
+ * @saga-ed/soa-preview-headers — the canonical HTTP-plane preview/sandbox
+ * routing-header primitives for Saga services.
+ *
+ * Every service routes preview traffic with `x-saga-preview-<service>:
+ * sandbox-<name>`: the header is captured off the inbound request, forwarded
+ * onto outbound S2S calls, and matched by the ALB to reach the right preview
+ * deployment. This package is the one home for that mechanism, consolidating the
+ * per-service copies that previously drifted (and re-implemented the same
+ * origination feature N times). It is the HTTP-plane sibling of the event-plane
+ * `applyPreviewTag()` in `@saga-ed/soa-event-envelope`.
+ *
+ * Backend-only: it depends on `node:async_hooks` and must not enter a browser
+ * bundle. Browser forwarders read `document.cookie` and stay separate.
+ */
+export { HEADER_PREFIX, toPreviewHeaderName, toServiceKey, extractPreviewHeaders } from './header-keys.js';
+export { parseOriginateMap } from './originate-map.js';
+export { runWithPreviewHeaders, getPreviewHeaders } from './store.js';
+export { withPreviewHeaders } from './forward.js';

--- a/packages/node/preview-headers/src/originate-map.ts
+++ b/packages/node/preview-headers/src/originate-map.ts
@@ -1,0 +1,31 @@
+import { toPreviewHeaderName } from './header-keys.js';
+
+/**
+ * Parse a `PREVIEW_ORIGINATE_MAP`-style string into a header→value map.
+ *
+ * The capture store (see `./store`) only FORWARDS headers that arrived on the
+ * inbound request, so a service with no browser/dash entrypoint — a headless
+ * projection consumer, or a local-source service in a synthetic-dev mesh —
+ * cannot route a downstream call to a sandbox dependency: its inbound request
+ * never carried the header. The origination map lets such a service ORIGINATE
+ * the header for a sandbox downstream.
+ *
+ * Format: comma-separated `key=value` pairs. The key may be the short service
+ * name (`iam-api`) or the full `x-saga-preview-` header; the value is the literal
+ * ALB routing slug `sandbox-<name>` the sandbox deploy registers. e.g.:
+ *   PREVIEW_ORIGINATE_MAP=iam-api=sandbox-alice,scheduling-api=sandbox-alice
+ *
+ * Empty/unset (the all-local and production cases) yields an empty map, so the
+ * forward-only behavior is unchanged when no origination is configured.
+ */
+export function parseOriginateMap(raw: string | undefined): Record<string, string> {
+  const map: Record<string, string> = {};
+  for (const pair of (raw ?? '').split(',')) {
+    const [rawKey, ...rest] = pair.split('=');
+    const key = (rawKey ?? '').trim();
+    const value = rest.join('=').trim();
+    if (!key || !value) continue;
+    map[toPreviewHeaderName(key)] = value;
+  }
+  return map;
+}

--- a/packages/node/preview-headers/src/preview-headers.test.ts
+++ b/packages/node/preview-headers/src/preview-headers.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  HEADER_PREFIX,
+  extractPreviewHeaders,
+  parseOriginateMap,
+  toPreviewHeaderName,
+  toServiceKey,
+} from './index.js';
+
+afterEach(() => {
+  vi.resetModules();
+  delete process.env.PREVIEW_ORIGINATE_MAP;
+});
+
+/** Re-import store/forward with PREVIEW_ORIGINATE_MAP set (parsed at load). */
+async function loadWithEnv(raw: string | undefined) {
+  vi.resetModules();
+  if (raw === undefined) delete process.env.PREVIEW_ORIGINATE_MAP;
+  else process.env.PREVIEW_ORIGINATE_MAP = raw;
+  return import('./index.js');
+}
+
+describe('header-key transforms', () => {
+  it('prefix is the canonical x-saga-preview-', () => {
+    expect(HEADER_PREFIX).toBe('x-saga-preview-');
+  });
+
+  it('toPreviewHeaderName accepts short and full forms, lowercases', () => {
+    expect(toPreviewHeaderName('iam-api')).toBe('x-saga-preview-iam-api');
+    expect(toPreviewHeaderName('X-Saga-Preview-Iam-Api')).toBe('x-saga-preview-iam-api');
+    expect(toServiceKey('x-saga-preview-iam-api')).toBe('iam-api');
+  });
+
+  it('extractPreviewHeaders keeps only string x-saga-preview-* entries (lowercased)', () => {
+    expect(
+      extractPreviewHeaders({
+        'X-Saga-Preview-Iam-Api': 'sandbox-a',
+        'content-type': 'application/json',
+        'x-saga-preview-multi': ['a', 'b'], // array-valued → skipped
+      }),
+    ).toEqual({ 'x-saga-preview-iam-api': 'sandbox-a' });
+  });
+});
+
+describe('parseOriginateMap', () => {
+  it('parses short + full forms, ignores malformed/empty pairs', () => {
+    expect(
+      parseOriginateMap(',iam-api=sandbox-a,=sandbox-x, , x-saga-preview-scheduling-api=sandbox-b ,'),
+    ).toEqual({
+      'x-saga-preview-iam-api': 'sandbox-a',
+      'x-saga-preview-scheduling-api': 'sandbox-b',
+    });
+  });
+
+  it('empty/undefined → empty map', () => {
+    expect(parseOriginateMap(undefined)).toEqual({});
+    expect(parseOriginateMap('')).toEqual({});
+  });
+});
+
+describe('getPreviewHeaders origination map', () => {
+  it('is empty (forward-only) when no map is configured', async () => {
+    const { getPreviewHeaders } = await loadWithEnv(undefined);
+    expect(getPreviewHeaders()).toEqual({});
+  });
+
+  it('originates a header for a sandbox downstream with no inbound request', async () => {
+    const { getPreviewHeaders } = await loadWithEnv('iam-api=sandbox-alice');
+    expect(getPreviewHeaders()).toEqual({ 'x-saga-preview-iam-api': 'sandbox-alice' });
+  });
+
+  it('lets an inbound header win its own key while the map fills the others', async () => {
+    const { getPreviewHeaders, runWithPreviewHeaders } = await loadWithEnv(
+      'iam-api=sandbox-map,scheduling-api=sandbox-map',
+    );
+    runWithPreviewHeaders({ 'x-saga-preview-iam-api': 'pr-42' }, () => {
+      expect(getPreviewHeaders()).toEqual({
+        'x-saga-preview-iam-api': 'pr-42', // inbound wins its key
+        'x-saga-preview-scheduling-api': 'sandbox-map', // map fills the gap
+      });
+    });
+  });
+});
+
+describe('withPreviewHeaders forward helper', () => {
+  it('merges preview headers under the caller bag (caller wins per-key)', async () => {
+    const { withPreviewHeaders, runWithPreviewHeaders } = await loadWithEnv(undefined);
+    runWithPreviewHeaders({ 'x-saga-preview-iam-api': 'pr-7' }, () => {
+      expect(withPreviewHeaders({ 'x-service-token': 'tok' })).toEqual({
+        'x-saga-preview-iam-api': 'pr-7',
+        'x-service-token': 'tok',
+      });
+    });
+  });
+
+  it('a caller header never gets clobbered by a same-named preview header', async () => {
+    const { withPreviewHeaders, runWithPreviewHeaders } = await loadWithEnv(undefined);
+    runWithPreviewHeaders({ 'x-saga-preview-iam-api': 'pr-7' }, () => {
+      // contrived collision: caller explicitly overrides → caller wins
+      expect(withPreviewHeaders({ 'x-saga-preview-iam-api': 'forced' })).toEqual({
+        'x-saga-preview-iam-api': 'forced',
+      });
+    });
+  });
+});

--- a/packages/node/preview-headers/src/store.ts
+++ b/packages/node/preview-headers/src/store.ts
@@ -1,0 +1,54 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { extractPreviewHeaders } from './header-keys.js';
+import { parseOriginateMap } from './originate-map.js';
+
+/**
+ * Request-scoped storage for the preview headers captured off an inbound
+ * request. Outbound HTTP clients read it (via {@link getPreviewHeaders}) to
+ * forward the routing headers downstream, so the ALB routes each hop to the
+ * matching preview deployment.
+ */
+const previewHeaderStore = new AsyncLocalStorage<Record<string, string>>();
+
+/**
+ * Static origination map, parsed once at module load from
+ * `PREVIEW_ORIGINATE_MAP`. See {@link parseOriginateMap} for the rationale and
+ * format. Empty/unset → forward-only behavior, unchanged.
+ */
+const ORIGINATE_MAP = parseOriginateMap(process.env.PREVIEW_ORIGINATE_MAP);
+
+/**
+ * Capture the `x-saga-preview-*` headers from an inbound request's header bag
+ * and run `fn` with them available via {@link getPreviewHeaders}. Framework-
+ * agnostic: pass any `Record<string, string | string[] | undefined>` (e.g.
+ * `req.headers`). When the request carried no preview headers, `fn` runs without
+ * a new scope (the origination map, if any, still applies).
+ *
+ * @example
+ *   app.use((req, _res, next) => runWithPreviewHeaders(req.headers, next));
+ */
+export function runWithPreviewHeaders<T>(
+  headers: Record<string, string | string[] | undefined>,
+  fn: () => T,
+): T {
+  const captured = extractPreviewHeaders(headers);
+  if (Object.keys(captured).length > 0) {
+    return previewHeaderStore.run(captured, fn);
+  }
+  return fn();
+}
+
+/**
+ * Get the preview headers to attach to an outbound call from the current
+ * request context.
+ *
+ * Headers captured from the inbound request take precedence over the static
+ * origination map per-key: a browser-seeded `x-saga-preview-iam-api` overrides
+ * the map's entry for that one header while the map still supplies any other
+ * downstream the inbound request did not carry. With no map configured this is
+ * exactly the inbound store (forward-only behavior unchanged) — and an empty
+ * object when called outside a {@link runWithPreviewHeaders} scope.
+ */
+export function getPreviewHeaders(): Record<string, string> {
+  return { ...ORIGINATE_MAP, ...(previewHeaderStore.getStore() ?? {}) };
+}

--- a/packages/node/preview-headers/tsconfig.json
+++ b/packages/node/preview-headers/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "@saga-ed/soa-typescript-config/base.json",
+    "compilerOptions": {
+        "outDir": "./dist",
+        "rootDir": "./src",
+        "noEmit": true
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/node/preview-headers/tsup.config.ts
+++ b/packages/node/preview-headers/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+    entry: ['src/index.ts'],
+    format: ['esm'],
+    dts: true,
+    clean: true,
+    sourcemap: true,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1422,6 +1422,24 @@ importers:
         specifier: ^1.5.0
         version: 1.6.1(@types/node@24.0.12)(jsdom@25.0.1)
 
+  packages/node/preview-headers:
+    devDependencies:
+      '@saga-ed/soa-typescript-config':
+        specifier: workspace:*
+        version: link:../../core/typescript-config
+      '@types/node':
+        specifier: ^24.0.3
+        version: 24.0.12
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.2)(yaml@2.8.2)
+      typescript:
+        specifier: 5.8.2
+        version: 5.8.2
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@24.0.12)(jsdom@25.0.1)
+
   packages/node/pubsub-client:
     dependencies:
       '@saga-ed/soa-logger':

--- a/turbo.json
+++ b/turbo.json
@@ -2,7 +2,8 @@
   "$schema": "https://turborepo.com/schema.json",
   "ui": "tui",
   "globalEnv": [
-    "EVENT_PREVIEW_TAG"
+    "EVENT_PREVIEW_TAG",
+    "PREVIEW_ORIGINATE_MAP"
   ],
   "tasks": {
     "build": {


### PR DESCRIPTION
## What

New backend package `@saga-ed/soa-preview-headers` — the **one canonical home** for HTTP-plane preview/sandbox routing-header logic, which had been reimplemented per-service across the fleet (rostering's two copies, program-hub's shared `rostering-client`, qboard's inline variant). It's the HTTP-plane sibling of `applyPreviewTag()` in `@saga-ed/soa-event-envelope` (the event plane) — `PREVIEW_ORIGINATE_MAP` even sits next to `EVENT_PREVIEW_TAG` in `turbo.json`.

## Why now

The trigger was concrete duplication tax: the same ~30-line origination-map feature got written twice in one sprint (sis-api's copy + program-hub's `rostering-client`). Consolidating makes "add a preview-header capability" a one-place change.

## API surface

- `HEADER_PREFIX`, `toPreviewHeaderName`, `toServiceKey`, `extractPreviewHeaders` — the pure transforms every copy duplicated.
- `runWithPreviewHeaders(headers, fn)` — **framework-agnostic** AsyncLocalStorage capture (program-hub's signature, deliberately *not* rostering's express-coupled `capturePreviewHeaders(): RequestHandler` — the express wrapper is a 3-line per-service adapter instead, so the package never drags express types into consumers).
- `getPreviewHeaders()` — with the `PREVIEW_ORIGINATE_MAP` merge baked in (inbound wins per-key; map fills downstreams the request lacked; empty env = forward-only, a no-op in prod/all-local).
- `parseOriginateMap`.
- **(net-new)** `withPreviewHeaders(bag)` — makes "forward the preview headers" the default for any tRPC link / fetch wrapper, closing the latent gap a service hits if it adds an outbound client and forgets to spread the headers.

## Scope

Backend-only by construction — it depends on `node:async_hooks` and must not enter a browser bundle. The browser forwarders (saga-dash, janus) and qboard's cookie-source BFF stay separate; they're a different (cookie-source) shape and out of scope.

## Tests / build

tsup ESM+DTS, 10 unit tests (incl. the inbound-wins-per-key merge), lint clean.

## Rollout

`0.1.0-dev.0` has already been published to CodeArtifact (via the `single_package` publish workflow) so the consumer PRs could be vetted against the real artifact before this merges:
- saga-ed/program-hub#245 — `rostering-client` re-exports from this package (35/35 green)
- saga-ed/rostering#596 — iam-api + sis-api collapse onto it (sis-api 73/73 green)

https://claude.ai/code/session_018ErVDAYE5vjaWZc8hehuJA
