### PR TITLE
feat(soa-health): mountReadinessRoutes for richer readiness probes (dev.2)

### DIFF
--- a/packages/node/health/package.json
+++ b/packages/node/health/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/soa-health",
-    "version": "0.1.0-dev.1",
+    "version": "0.1.0-dev.2",
     "private": false,
     "type": "module",
     "main": "dist/index.js",

--- a/packages/node/health/src/__tests__/health.unit.test.ts
+++ b/packages/node/health/src/__tests__/health.unit.test.ts
@@ -72,4 +72,25 @@ describe('mountHealthRoutes', () => {
     expect(body.dependencies.postgres.status).toBe('unhealthy');
     expect(body.dependencies.postgres.latencyMs).toBeUndefined();
   });
+
+  // dev.1 -> dev.2 superset guard: adding mountReadinessRoutes must NOT alter
+  // the existing two-arg mountHealthRoutes contract. program-hub is exact-pinned
+  // to dev.1 and must see byte-identical /health + /health/details output, so a
+  // future repin to dev.2 is a no-op. (timestamp is the only non-deterministic
+  // field; asserted by shape, the rest by exact value.)
+  it('dev.1 superset: the two-arg mountHealthRoutes output is unchanged', async () => {
+    const { app, call, paths } = fakeApp();
+    mountHealthRoutes(app, { serviceName: 'Programs API', pingDb: async () => undefined });
+    expect(paths().sort()).toEqual(['/health', '/health/details']);
+
+    expect(await call('/health')).toEqual({ status: 'ok', service: 'Programs API' });
+
+    const details = (await call('/health/details')) as Record<string, unknown>;
+    expect(details.status).toBe('healthy');
+    expect(details.service).toBe('Programs API');
+    expect(typeof details.timestamp).toBe('string');
+    expect((details.dependencies as { postgres: { status: string } }).postgres.status).toBe('healthy');
+    // exact key set — no new top-level fields leaked into the dev.1 body
+    expect(Object.keys(details).sort()).toEqual(['dependencies', 'service', 'status', 'timestamp']);
+  });
 });

--- a/packages/node/health/src/__tests__/readiness.unit.test.ts
+++ b/packages/node/health/src/__tests__/readiness.unit.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  mountReadinessRoutes,
+  type ReadinessRouter,
+  type ProbeResult,
+} from '../readiness.js';
+
+/**
+ * Captures the route handlers a service would register and invokes them with a
+ * fake `res` that records both the JSON body and the HTTP status code (default
+ * 200 until `status()` is called), so we can assert the 200/503 contract
+ * without a real HTTP server. `status(c)` returns the same fake so `.json()`
+ * chains, mirroring Express's `res.status(c).json(b)`.
+ */
+function fakeApp() {
+  const routes = new Map<string, (req: unknown, res: unknown) => void>();
+  const app: ReadinessRouter = {
+    get(path, handler) {
+      routes.set(path, handler as (req: unknown, res: unknown) => void);
+      return undefined;
+    },
+  };
+  async function call(path: string): Promise<{ code: number; body: unknown }> {
+    const handler = routes.get(path);
+    if (!handler) throw new Error(`no handler for ${path}`);
+    let code = 200;
+    let body: unknown;
+    const res = {
+      status(c: number) {
+        code = c;
+        return { json: (b: unknown) => ((body = b), b) };
+      },
+      json: (b: unknown) => ((body = b), b),
+    };
+    // The /health/ready handler is async at runtime though typed `=> void`;
+    // await it so all probes settle before we read code/body.
+    await (handler({}, res) as unknown as Promise<void> | void);
+    return { code, body };
+  }
+  return { app, call, paths: () => Array.from(routes.keys()) };
+}
+
+const ok = (detail = 'connected'): ProbeResult => ({ ready: true, detail });
+const down = (detail = 'error'): ProbeResult => ({ ready: false, detail });
+
+describe('mountReadinessRoutes', () => {
+  it('registers exactly /health/live and /health/ready', () => {
+    const { app, paths } = fakeApp();
+    mountReadinessRoutes(app, { probes: {} });
+    expect(paths().sort()).toEqual(['/health/live', '/health/ready']);
+  });
+
+  it('/health/live is a 200 liveness ping', async () => {
+    const { app, call } = fakeApp();
+    mountReadinessRoutes(app, { probes: {} });
+    const { code, body } = await call('/health/live');
+    expect(code).toBe(200);
+    expect(body).toEqual({ status: 'ok' });
+  });
+
+  it('/health/ready returns 200 + ready when every probe is ready', async () => {
+    const { app, call } = fakeApp();
+    mountReadinessRoutes(app, {
+      probes: { iamDb: async () => ok(), redis: async () => ok('PONG') },
+    });
+    const { code, body } = await call('/health/ready');
+    expect(code).toBe(200);
+    expect(body).toEqual({
+      status: 'ready',
+      checks: { iamDb: ok(), redis: ok('PONG') },
+    });
+  });
+
+  it('/health/ready returns 503 + not ready when one probe is not ready', async () => {
+    const { app, call } = fakeApp();
+    mountReadinessRoutes(app, {
+      probes: { iamDb: async () => ok(), piiDb: async () => down('disconnected') },
+    });
+    const { code, body } = await call('/health/ready') as {
+      code: number;
+      body: { status: string; checks: Record<string, ProbeResult> };
+    };
+    expect(code).toBe(503);
+    expect(body.status).toBe('not ready');
+    expect(body.checks.piiDb).toEqual(down('disconnected'));
+  });
+
+  it('treats a disabled-but-optional dependency as ready (200)', async () => {
+    const { app, call } = fakeApp();
+    // redis disabled (operator chose to run without it) must NOT block readiness.
+    mountReadinessRoutes(app, {
+      probes: { iamDb: async () => ok(), redis: async () => ok('disabled') },
+    });
+    const { code, body } = await call('/health/ready') as {
+      code: number;
+      body: { status: string; checks: Record<string, ProbeResult> };
+    };
+    expect(code).toBe(200);
+    expect(body.status).toBe('ready');
+    expect(body.checks.redis).toEqual({ ready: true, detail: 'disabled' });
+  });
+
+  it('a hung probe times out and is counted not-ready (503)', async () => {
+    vi.useFakeTimers();
+    const { app, call } = fakeApp();
+    mountReadinessRoutes(app, {
+      timeoutMs: 2000,
+      probes: {
+        iamDb: async () => ok(),
+        // never settles — must be killed by the timeout, not hang the response.
+        redis: () => new Promise<ProbeResult>(() => {}),
+      },
+    });
+    const promise = call('/health/ready');
+    await vi.advanceTimersByTimeAsync(2000);
+    const { code, body } = (await promise) as {
+      code: number;
+      body: { status: string; checks: Record<string, ProbeResult> };
+    };
+    expect(code).toBe(503);
+    expect(body.status).toBe('not ready');
+    expect(body.checks.redis).toEqual({ ready: false, detail: 'timeout' });
+    vi.useRealTimers();
+  });
+
+  it('a throwing probe is counted not-ready (caught, not propagated)', async () => {
+    const { app, call } = fakeApp();
+    mountReadinessRoutes(app, {
+      probes: {
+        iamDb: async () => ok(),
+        kms: async () => {
+          throw new Error('jwks fetch failed');
+        },
+      },
+    });
+    const { code, body } = await call('/health/ready') as {
+      code: number;
+      body: { status: string; checks: Record<string, ProbeResult> };
+    };
+    expect(code).toBe(503);
+    expect(body.status).toBe('not ready');
+    // a throw lands as not-ready with detail 'error' (distinct from 'timeout')
+    expect(body.checks.kms).toEqual({ ready: false, detail: 'error' });
+  });
+});

--- a/packages/node/health/src/index.ts
+++ b/packages/node/health/src/index.ts
@@ -4,3 +4,11 @@ export {
     type HealthResponse,
     type MountHealthOptions,
 } from './health.js';
+
+export {
+    mountReadinessRoutes,
+    type ReadinessRouter,
+    type ReadinessResponse,
+    type ProbeResult,
+    type MountReadinessOptions,
+} from './readiness.js';

--- a/packages/node/health/src/readiness.ts
+++ b/packages/node/health/src/readiness.ts
@@ -1,0 +1,104 @@
+/**
+ * Shared `/health/live` + `/health/ready` routes for Saga Node services that
+ * have a richer readiness posture than the single-Postgres `mountHealthRoutes`
+ * liveness/details pair.
+ *
+ * Mounted BEFORE any auth perimeter so ALB / load-balancer probes (which carry
+ * no session cookie) reach them. `/health/live` is a pure process-liveness ping
+ * (always 200). `/health/ready` runs every configured probe and returns **200
+ * when all probes are ready, 503 otherwise** — the status code is the contract
+ * an ALB target-group health check (matcher 200-299) keys on, so a not-ready
+ * service is pulled from the load balancer.
+ *
+ * Each probe is `name -> () => Promise<ProbeResult>`. A probe reports a
+ * tri-state (`{ ready, detail }`) rather than throw/resolve, because a
+ * dependency can be deliberately *disabled* (still ready) vs *erroring* (not
+ * ready) — and the "disabled is ready" decision belongs in the closure that
+ * owns the domain knowledge, not in a central predicate. Readiness is simply
+ * "every probe resolved `{ ready: true }`".
+ *
+ * Each probe is wrapped in a hard timeout (default 2s) so a hung dependency
+ * (e.g. an unreachable Redis or KMS) cannot block the probe past the load
+ * balancer's health-check window — a timed-out probe counts as not-ready.
+ *
+ * Typed structurally (no express import) so the helper has no framework
+ * dependency — any object with `get(path, handler)` works, and the readiness
+ * handler's `res` only needs `status(code).json(body)` (which Express's
+ * response satisfies: `res.status(code)` returns the response, which has
+ * `.json()`).
+ */
+
+/** A single dependency probe's outcome. Only `ready` drives the 200/503. */
+export interface ProbeResult {
+  /** Whether this dependency is ready (a disabled-but-optional dep is ready). */
+  ready: boolean;
+  /** Human/operator-facing state, surfaced in the body, e.g. 'connected' | 'disabled' | 'error' | 'timeout'. */
+  detail: string;
+}
+
+/**
+ * Express's `res` exposes `status(code)` returning the response (so `.json()`
+ * chains) and a bare `json(body)`. We model only what the handlers use.
+ */
+export interface ReadinessResponse {
+  status(code: number): { json(body: unknown): unknown };
+  json(body: unknown): unknown;
+}
+
+export interface ReadinessRouter {
+  get(path: string, handler: (req: unknown, res: ReadinessResponse) => void): unknown;
+}
+
+export interface MountReadinessOptions {
+  /**
+   * Named dependency probes. Readiness = EVERY probe resolves `{ ready: true }`.
+   * A probe that throws or exceeds `timeoutMs` counts as `{ ready: false }`.
+   */
+  probes: Record<string, () => Promise<ProbeResult>>;
+  /**
+   * Per-probe hard timeout in milliseconds (default 2000). A probe that does
+   * not settle within the window is treated as `{ ready: false, detail: 'timeout' }`
+   * so a hung dependency cannot block the probe past the load-balancer window.
+   */
+  timeoutMs?: number;
+}
+
+/** A sentinel the timeout rejects with, so we can tell timeout from a probe throw. */
+const TIMEOUT = Symbol('readiness-probe-timeout');
+
+/** Reject with TIMEOUT after `ms` so a hung probe cannot stall the response. */
+function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(TIMEOUT), ms);
+  });
+  // Clear the pending timer once the probe settles so a fast probe doesn't
+  // leave a dangling 2s timer (harmless but tidy under high request rates).
+  return Promise.race([p, timeout]).finally(() => clearTimeout(timer));
+}
+
+export function mountReadinessRoutes(app: ReadinessRouter, opts: MountReadinessOptions): void {
+  const timeoutMs = opts.timeoutMs ?? 2000;
+
+  app.get('/health/live', (_req, res) => {
+    res.json({ status: 'ok' });
+  });
+
+  app.get('/health/ready', async (_req, res) => {
+    const entries = await Promise.all(
+      Object.entries(opts.probes).map(async ([name, probe]) => {
+        // A probe that hangs is killed by the timeout (detail 'timeout'); a
+        // probe that throws is reported separately (detail 'error'). Either
+        // way it counts as not-ready.
+        const result: ProbeResult = await withTimeout(probe(), timeoutMs).catch((err) => ({
+          ready: false,
+          detail: err === TIMEOUT ? 'timeout' : 'error',
+        }));
+        return [name, result] as const;
+      }),
+    );
+    const checks: Record<string, ProbeResult> = Object.fromEntries(entries);
+    const ready = entries.every(([, r]) => r.ready);
+    res.status(ready ? 200 : 503).json({ status: ready ? 'ready' : 'not ready', checks });
+  });
+}


### PR DESCRIPTION
## What

Generalizes `@saga-ed/soa-health` (**dev.1 → dev.2**) with a new sibling export `mountReadinessRoutes`, for services whose readiness posture is richer than the single-Postgres liveness/details pair `mountHealthRoutes` provides.

```ts
mountReadinessRoutes(app, {
  probes: {
    iamDb: async () => ({ ready: !!prisma, detail: prisma ? 'connected' : 'disconnected' }),
    redis: async () => redis ? { ready: (await redis.ping()) === 'PONG', detail: 'PONG' }
                             : { ready: true, detail: 'disabled' },
    // ...
  },
  // timeoutMs?: number   // default 2000
});
```

- **`/health/live`** → `200 { status: 'ok' }` (pure process liveness).
- **`/health/ready`** → **`200` when every probe is ready, `503` otherwise**. The status code is the contract an ALB target-group health check (matcher 200-299) keys on, so a not-ready service is pulled from the load balancer. Body: `{ status: 'ready' | 'not ready', checks: { <name>: { ready, detail } } }`.

## Design decisions

- **Tri-state `ProbeResult { ready, detail }`, not throw/resolve.** A dependency can be deliberately *disabled* (still ready) vs *erroring* (not ready) — and "disabled is ready" belongs in the closure that owns the domain knowledge, not a central predicate. Readiness = every probe resolves `{ ready: true }`.
- **Per-probe hard timeout (default 2s), baked into the mounter.** A hung dependency (unreachable Redis/KMS) cannot block the probe past the load-balancer window. Timeout → not-ready (`detail: 'timeout'`); a thrown probe → not-ready (`detail: 'error'`); the two are distinguished.
- **`mountHealthRoutes` is left byte-untouched.** The new code is a separate `readiness.ts` + barrel re-export, so dev.2 is a **strict superset** of dev.1: existing consumers (program-hub, exact-pinned to `dev.1`) see identical `/health` + `/health/details` output, and a future repin to dev.2 is a no-op. A **regression test** asserts the two-arg `mountHealthRoutes` still emits the identical dev.1 body (exact key set, exact values).
- **No framework dependency.** Structurally typed (`ReadinessRouter` / `ReadinessResponse`) — `res` only needs `status(code).json(body)`, which Express's response satisfies. (Express assignability compiles at the consumer call site, not here — these tests use a fake app, as dev.1's do; verified against a real Express `app` at the rostering adoption site.)

## Motivation

rostering's iam-api serves `/health/ready` (Redis + KMS + dual-Prisma readiness, 503-on-not-ready) as its ALB `HealthCheckPath` — it cannot adopt the dev.1 single-Postgres mounter without regressing that contract. A consumer-contract sweep confirmed only the **path** (`/health/ready`, matcher 200-299) is load-bearing; the response **body fields have zero external consumers**, so rostering conforms its body to this canonical shape rather than the package growing per-field config.

## Verification

- `build` (ESM + DTS) + `check-types` + `test` green. **12 tests** — 7 readiness (registration, live, ready-200, ready-503, disabled-is-ready, timeout→not-ready, throw→error) + 5 health (incl. the dev.1 superset regression guard).
- `pnpm install --frozen-lockfile` ✓ — `readiness.ts` adds zero dependencies, lockfile unchanged.

## Publish / adoption

Publish of `@saga-ed/soa-health@0.1.0-dev.2` is **deferred to post-merge** — no consumer needs it this PR (rostering adoption is a separate later change), and a version is one-shot, so publishing only after the source is frozen on `main` avoids any registry/main divergence. rostering adoption (translating its inline `/health/*` handlers into probe closures) lands separately once dev.2 is published.

---

https://claude.ai/code/session_01624Sqb4wZy6Zgi7ZyX4y1i
