### PR TITLE
feat(api-util): promote canonical Janus perimeter config + boot guard

### DIFF
--- a/packages/node/api-util/package.json
+++ b/packages/node/api-util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saga-ed/soa-api-util",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/node/api-util/package.json
+++ b/packages/node/api-util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saga-ed/soa-api-util",
-  "version": "1.4.0",
+  "version": "1.4.0-dev.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/node/api-util/src/index.ts
+++ b/packages/node/api-util/src/index.ts
@@ -2,3 +2,5 @@ export * from './custom-types/date-time.js';
 export * from './utils/error-util.js';
 export * from './utils/cors.js';
 export * from './utils/saga-auth-url.js';
+export * from './utils/janus-config.js';
+export * from './utils/assert-janus-production.js';

--- a/packages/node/api-util/src/utils/assert-janus-production.test.ts
+++ b/packages/node/api-util/src/utils/assert-janus-production.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import {
+  janusProductionViolation,
+  assertJanusProductionConfig,
+} from './assert-janus-production.js';
+
+/**
+ * @spec specs/contracts/saga-auth-signal.spec.md (janus repo)
+ *
+ * Boot guard for the Janus perimeter. Migrated from the 5 janus cases in
+ * rostering iam-api's `assert-production-config.test.ts` so the invariant is
+ * tested at its canonical source. The aggregate asserter in rostering now just
+ * asserts the janus violation is included in its collected list.
+ */
+
+describe('janusProductionViolation', () => {
+  it('returns null when the perimeter is required (the prod default)', () => {
+    expect(janusProductionViolation({ required: true }, 'production')).toBeNull();
+  });
+
+  it('returns null when janus-off but NODE_ENV=development (dev escape hatch)', () => {
+    expect(janusProductionViolation({ required: false }, 'development')).toBeNull();
+  });
+
+  it('returns null when janus-off but NODE_ENV=test', () => {
+    expect(janusProductionViolation({ required: false }, 'test')).toBeNull();
+  });
+
+  it('returns a violation when janus-off in production', () => {
+    const v = janusProductionViolation({ required: false }, 'production');
+    expect(v).toContain('JANUS_REQUIRED must be true');
+    expect(v).toContain('NODE_ENV=production');
+  });
+
+  it('returns a violation when janus-off and NODE_ENV is unset (fail-closed)', () => {
+    // An unset NODE_ENV is NOT local-dev — staging/preview/canary land here too.
+    const v = janusProductionViolation({ required: false }, undefined);
+    expect(v).toContain('JANUS_REQUIRED must be true');
+    expect(v).toContain('NODE_ENV=(unset)');
+  });
+
+  it('treats an unrecognized NODE_ENV (e.g. staging) as non-local-dev', () => {
+    expect(janusProductionViolation({ required: false }, 'staging')).not.toBeNull();
+  });
+});
+
+describe('assertJanusProductionConfig', () => {
+  it('does not throw when the config is acceptable', () => {
+    expect(() => assertJanusProductionConfig({ required: true }, 'production')).not.toThrow();
+    expect(() => assertJanusProductionConfig({ required: false }, 'development')).not.toThrow();
+  });
+
+  it('throws with the violation message when janus-off in production', () => {
+    expect(() => assertJanusProductionConfig({ required: false }, 'production')).toThrow(
+      /JANUS_REQUIRED must be true/,
+    );
+  });
+});

--- a/packages/node/api-util/src/utils/assert-janus-production.ts
+++ b/packages/node/api-util/src/utils/assert-janus-production.ts
@@ -1,0 +1,61 @@
+import type { JanusConfig } from './janus-config.js';
+
+/**
+ * Shared boot guard for the Janus employee perimeter.
+ *
+ * `JANUS_REQUIRED=false` drops the employee Janus perimeter. It exists only so
+ * the daily e2e composition can drive deployed backends unattended (no
+ * interactive JumpCloud session) — and only on the dev account, where
+ * `NODE_ENV=development`. Outside local dev (i.e. real prod, where saga-dash is
+ * the EMPLOYEE dashboard on .saga.org) the perimeter is the actual gate;
+ * opening it must never be a single CFN-param flip. Defends the perimeter in
+ * depth at boot, not by the CFN-template default alone.
+ *
+ * Exposed in two layers so it composes with whatever a service already has:
+ *
+ *   - {@link janusProductionViolation} — pure predicate, returns the message
+ *     or `null`. A service with an aggregate config asserter folds it in
+ *     (`const v = janusProductionViolation(...); if (v) violations.push(v)`)
+ *     so its collect-all-violations posture is preserved.
+ *   - {@link assertJanusProductionConfig} — convenience that throws iff the
+ *     predicate is non-null, for services with no aggregate asserter.
+ *
+ * `isLocalDev` is `NODE_ENV in {development, test}` — matching the
+ * `Fn::If [IsProd, production, development]` task-env wiring, so dev/wootdev
+ * tasks (NODE_ENV=development) may run janus-off while real prod refuses it.
+ */
+function isLocalDevEnv(nodeEnv: string | undefined): boolean {
+  return nodeEnv === 'development' || nodeEnv === 'test';
+}
+
+/**
+ * Returns the violation message if disabling the Janus perimeter is unsafe for
+ * this environment, or `null` if the config is acceptable.
+ */
+export function janusProductionViolation(
+  config: Pick<JanusConfig, 'required'>,
+  nodeEnv: string | undefined,
+): string | null {
+  if (!config.required && !isLocalDevEnv(nodeEnv)) {
+    return (
+      `JANUS_REQUIRED must be true in any non-development environment (NODE_ENV=${nodeEnv ?? '(unset)'}). ` +
+      'Disabling the employee Janus perimeter is a dev-account-only escape hatch for unattended e2e.'
+    );
+  }
+  return null;
+}
+
+/**
+ * Throws if disabling the Janus perimeter is unsafe for this environment.
+ * No-op when the config is acceptable. Use in services that boot-check config
+ * directly; services with an aggregate asserter should call
+ * {@link janusProductionViolation} and fold the result into their own
+ * violation list instead.
+ */
+export function assertJanusProductionConfig(
+  config: Pick<JanusConfig, 'required'>,
+  nodeEnv: string | undefined,
+): void {
+  const violation = janusProductionViolation(config, nodeEnv);
+  if (violation) throw new Error(violation);
+}

--- a/packages/node/api-util/src/utils/janus-config.test.ts
+++ b/packages/node/api-util/src/utils/janus-config.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { loadJanusConfig, JanusConfigSchema } from './janus-config.js';
+
+/**
+ * @spec specs/contracts/saga-auth-signal.spec.md (janus repo)
+ *
+ * The Janus perimeter config loader. Ported from the byte-/behavior-identical
+ * copies previously living in program-hub-service-kit, rostering's iam-api, and
+ * qboard's connectv3-api. The fail-safe `required` semantics below are the
+ * security invariant the whole unattended-e2e initiative rests on.
+ */
+
+describe('loadJanusConfig', () => {
+  it('defaults required to true when JANUS_REQUIRED is unset', () => {
+    expect(loadJanusConfig({}).required).toBe(true);
+  });
+
+  it('disables the perimeter only for the literal string "false"', () => {
+    expect(loadJanusConfig({ JANUS_REQUIRED: 'false' }).required).toBe(false);
+  });
+
+  it('keeps the perimeter ON for "true"', () => {
+    expect(loadJanusConfig({ JANUS_REQUIRED: 'true' }).required).toBe(true);
+  });
+
+  it('keeps the perimeter ON for a typo (fail-safe — never silently opens)', () => {
+    // The crux: anything that is not exactly "false" must leave the gate up.
+    expect(loadJanusConfig({ JANUS_REQUIRED: 'flase' }).required).toBe(true);
+    expect(loadJanusConfig({ JANUS_REQUIRED: 'False' }).required).toBe(true);
+    expect(loadJanusConfig({ JANUS_REQUIRED: '0' }).required).toBe(true);
+    expect(loadJanusConfig({ JANUS_REQUIRED: '' }).required).toBe(true);
+  });
+
+  it('defaults jwksUrl to the wootdev gate', () => {
+    expect(loadJanusConfig({}).jwksUrl).toBe('https://gate.wootdev.com/.well-known/jwks.json');
+  });
+
+  it('reads JANUS_JWKS_URL and JANUS_LOGIN_HOST verbatim', () => {
+    const config = loadJanusConfig({
+      JANUS_JWKS_URL: 'https://gate.saga.org/.well-known/jwks.json',
+      JANUS_LOGIN_HOST: 'login.saga.org',
+    });
+    expect(config.jwksUrl).toBe('https://gate.saga.org/.well-known/jwks.json');
+    expect(config.loginHost).toBe('login.saga.org');
+  });
+
+  it('rejects a non-URL JANUS_JWKS_URL', () => {
+    expect(() => loadJanusConfig({ JANUS_JWKS_URL: 'not-a-url' })).toThrow();
+  });
+
+  it('stamps the JANUS configType discriminator', () => {
+    expect(loadJanusConfig({}).configType).toBe('JANUS');
+  });
+
+  it('schema parses an empty object to the all-defaults config', () => {
+    expect(JanusConfigSchema.parse({})).toEqual({
+      configType: 'JANUS',
+      required: true,
+      jwksUrl: 'https://gate.wootdev.com/.well-known/jwks.json',
+    });
+  });
+});

--- a/packages/node/api-util/src/utils/janus-config.ts
+++ b/packages/node/api-util/src/utils/janus-config.ts
@@ -25,11 +25,28 @@ import { z } from 'zod';
 export const JanusConfigSchema = z.object({
   configType: z.literal('JANUS').default('JANUS'),
   required: z.boolean().default(true),
-  jwksUrl: z.url().default('https://gate.wootdev.com/.well-known/jwks.json'),
+  // z.string().url() (NOT z.url()): the latter is a zod-4-only top-level API.
+  // This package serves zod-3 consumers (program-hub, rostering, qboard), and
+  // tsup bundles no zod (skipNodeModulesBundle) — so the consumer's zod runs at
+  // runtime. z.string().url() is portable across zod 3 and 4; z.url() would
+  // throw at module-eval under a zod-3 consumer.
+  jwksUrl: z.string().url().default('https://gate.wootdev.com/.well-known/jwks.json'),
   /** Host used in emitted SagaAuth `login=` URLs (e.g. login.saga.org in prod). */
   loginHost: z.string().optional(),
 });
-export type JanusConfig = z.infer<typeof JanusConfigSchema>;
+
+// Plain interface, NOT `z.infer<typeof JanusConfigSchema>`. An inferred type
+// leaks zod-internal types (z.core.$strip) into the published .d.ts, which a
+// zod-3 consumer can't resolve — the type then collapses to `unknown` at the
+// call site. A hand-written interface keeps the public type surface
+// zod-agnostic. `loadJanusConfig`'s `return JanusConfigSchema.parse(...)` below
+// is the compile-time guard that this interface stays in sync with the schema.
+export interface JanusConfig {
+  configType: 'JANUS';
+  required: boolean;
+  jwksUrl: string;
+  loginHost?: string;
+}
 
 /**
  * Build a {@link JanusConfig} from environment variables.

--- a/packages/node/api-util/src/utils/janus-config.ts
+++ b/packages/node/api-util/src/utils/janus-config.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod';
+
+/**
+ * Janus perimeter config — the OUTER, all-or-nothing Saga-employee gate.
+ *
+ * `@saga-ed/janus-client`'s janusContext + requireAuth({ janus: true })
+ * verify the janus_session cookie against the gate's JWKS ahead of the
+ * user-facing routes (health/metrics excepted). This sits in front of the
+ * inner IAM-session layer: the Saga-employee perimeter is satisfied first,
+ * then IAM identity resolves in the tRPC context.
+ *
+ * `JANUS_REQUIRED=false` is the dev-account escape hatch: the middleware
+ * short-circuits end-to-end (no JWKS dependency), so the daily e2e
+ * composition can drive deployed backends unattended (no interactive
+ * JumpCloud session). Fail-safe: only the literal string `"false"`
+ * disables — a typo'd value keeps the gate ON, so a mis-set env never
+ * silently opens the perimeter. The boot guard in
+ * {@link assertJanusProductionConfig} backs this default by refusing
+ * `required=false` outside local dev.
+ *
+ * Ported from the byte-/behavior-identical copies previously living in
+ * program-hub-service-kit, rostering's iam-api, and qboard's connectv3-api.
+ * Same consolidation as the SagaAuth URL primitives in `saga-auth-url.ts`.
+ */
+export const JanusConfigSchema = z.object({
+  configType: z.literal('JANUS').default('JANUS'),
+  required: z.boolean().default(true),
+  jwksUrl: z.url().default('https://gate.wootdev.com/.well-known/jwks.json'),
+  /** Host used in emitted SagaAuth `login=` URLs (e.g. login.saga.org in prod). */
+  loginHost: z.string().optional(),
+});
+export type JanusConfig = z.infer<typeof JanusConfigSchema>;
+
+/**
+ * Build a {@link JanusConfig} from environment variables.
+ *
+ * Reads the deployment-contract names verbatim — `JANUS_REQUIRED`,
+ * `JANUS_JWKS_URL`, `JANUS_LOGIN_HOST` — the same names the CFN templates
+ * inject. Unset vars fall through to the schema defaults.
+ *
+ * The `required` parse pins the fail-safe invariant: anything other than
+ * the literal `"false"` (including a typo or empty string) leaves the
+ * perimeter ON.
+ */
+export function loadJanusConfig(env: NodeJS.ProcessEnv = process.env): JanusConfig {
+  const input: Record<string, unknown> = {};
+  if (env.JANUS_REQUIRED !== undefined) input.required = env.JANUS_REQUIRED !== 'false';
+  if (env.JANUS_JWKS_URL !== undefined) input.jwksUrl = env.JANUS_JWKS_URL;
+  if (env.JANUS_LOGIN_HOST !== undefined) input.loginHost = env.JANUS_LOGIN_HOST;
+  return JanusConfigSchema.parse(input);
+}


### PR DESCRIPTION
## What

Promote the canonical Janus perimeter config + boot guard into the shared `@saga-ed/soa-api-util` package, so the fail-safe `JANUS_REQUIRED !== 'false'` semantics and the prod-refusal guard live in **one place fleet-wide** instead of triplicated across rostering iam-api, program-hub, and qboard connectv3-api. Same consolidation already done for the SagaAuth URL primitives in `saga-auth-url.ts`.

This is the **keystone** of a 4-PR janus-off series enabling the daily unattended switchboard-sandbox e2e run (a `JanusRequired` CFN param flips the employee perimeter off on an isolated dev sandbox, refused everywhere else).

## Changes (`packages/node/api-util/`)

- **`janus-config.ts`** — `JanusConfigSchema`, `loadJanusConfig(env?)`, and a hand-written `interface JanusConfig`. Reads the `JANUS_REQUIRED` / `JANUS_JWKS_URL` / `JANUS_LOGIN_HOST` deployment-contract env names verbatim. Fail-safe carried byte-for-byte: only the literal `"false"` disables the perimeter; a typo keeps it on.
- **`assert-janus-production.ts`** — two-layer guard:
  - `janusProductionViolation(config, nodeEnv) → string | null` — pure predicate, so a service with an aggregate config asserter (rostering) folds it into its collect-all-violations list.
  - `assertJanusProductionConfig(config, nodeEnv)` — throwing convenience for services with no aggregate asserter (program-hub, qboard).
  - `isLocalDev = NODE_ENV ∈ {development, test}`, matching the `Fn::If[IsProd,production,development]` task-env wiring — so dev/wootdev tasks may run janus-off while real prod refuses it.

## Design notes

- **Type surface is zod-version-agnostic.** `JanusConfig` is a hand-written interface, not `z.infer<>` — an inferred type leaks zod-internal types into the published `.d.ts` that a zod-3 consumer can't resolve (collapses to `unknown`). `loadJanusConfig`'s `return JanusConfigSchema.parse(...)` is the compile-time guard that the interface stays in sync with the schema.
- **`z.string().url()`, not `z.url()`** — the latter is zod-4-only and would throw at module-eval under a zod-3 consumer (tsup bundles no zod). Portable across zod 3 and 4.

Both boundary fixes were caught by prerelease-vetting the consumers — the provider-first ordering working as designed.

## Verification

- `tsc --noEmit` clean, tsup build OK (all 5 janus symbols in `dist/index.d.ts`).
- 38 tests pass (17 new: loader + guard, the guard cases migrated from rostering's aggregate test).
- **Published as `1.4.0-dev.0`** to CodeArtifact and vetted in all three consumer repos (program-hub / rostering / qboard) before this merges. Stable `1.4.0` is a follow-up cut after those consumers land — mirrors the `1.2.0-dev.0 → 1.2.0` cadence of the saga-auth-url lift.

## Rollout

Consumers depend on `1.4.0-dev.0` (already published). After this merges, cut stable `1.4.0` and the consumer PRs move their pins `1.4.0-dev.0 → 1.4.0`.
