### PR TITLE
chore(api-util): cut stable 1.4.0

### DIFF
--- a/packages/node/api-util/package.json
+++ b/packages/node/api-util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saga-ed/soa-api-util",
-  "version": "1.4.0-dev.0",
+  "version": "1.4.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Cuts `@saga-ed/soa-api-util` stable **1.4.0** (from the `1.4.0-dev.0` prerelease), now that the janus-config + boot guard landed via #186.

The prerelease was vetted in all three consumer repos before this cut:
- saga-ed/program-hub#262
- saga-ed/rostering#640
- saga-ed/qboard#242

No code change vs the merged janus-config work — version field only. Mirrors the saga-auth-url lift's `1.2.0-dev.0 → 1.2.0` cadence.

After merge: publish stable 1.4.0 via `publish-codeartifact.yml` (single_package mode), then the consumer PRs move their pins `1.4.0-dev.0 → 1.4.0`.

Part of saga-ed/saga-dash#247.