### PR TITLE
synthetic-dev: wire ADS/ADM (real mode, sessions-api, iam names) + reset/verify hardening

### DIFF
--- a/tools/synthetic-dev/up.sh
+++ b/tools/synthetic-dev/up.sh
@@ -1458,7 +1458,10 @@ services_up(){
        EXPRESS_SERVER_PORT=6303 RABBITMQ_URL="$MESH_MQ" \
        AUTH_AUTHENABLED=false $(tunnel_env chat-api)
   fi
-  launch_if saga-dash 8900 "$SAGA_DASH/apps/web/dash" $(tunnel_env saga-dash)
+  # VITE_ADS_ADM_REAL=true: serve the ADS/ADM page (/adm) against the real
+  # ads-adm-api (:5005) instead of the mock generators — the default for this
+  # integration stack (see saga-dash docs/dev-toggle-ads-adm.md).
+  launch_if saga-dash 8900 "$SAGA_DASH/apps/web/dash" VITE_ADS_ADM_REAL=true $(tunnel_env saga-dash)
   # rtsm-api: a ONE-NODE FLEET, not bare single-instance mode. rtsm-client
   # always discovers via GET /fleet/discover (404 without fleet mode → the
   # browser's "Fleet discovery failed … Fleet mode may not be active"), so the

--- a/tools/synthetic-dev/up.sh
+++ b/tools/synthetic-dev/up.sh
@@ -1420,6 +1420,7 @@ services_up(){
   launch_if ads-adm-api 5005 "$SDS/apps/node/ads-adm-api" \
      ADS_ADM_SCHEDULE_PROVIDER=program-hub \
      SESSIONS_API_CLIENT_BASEURL=http://localhost:3007 \
+     IAM_API_CLIENT_BASEURL=http://localhost:3010/trpc \
      SERVICE_TOKEN_SERVICESLUG=ads-adm-api \
      ADS_ADM_DATABASE_URL=postgresql://ads_adm:ads_adm@localhost:5432/ads_adm_local \
      DATABASE_URL=postgresql://ads_adm:ads_adm@localhost:5432/ads_adm_local \

--- a/tools/synthetic-dev/up.sh
+++ b/tools/synthetic-dev/up.sh
@@ -1536,7 +1536,7 @@ services_up(){
 # Preserves _prisma_migrations so no re-migrate. Uses the mesh superuser
 # (postgres_admin) so it can truncate tables owned by iam / saga_user / etc.
 reset_data(){
-  say "resetting synthetic data → empty baseline (iam, programs, scheduling, sessions, sis, connect)…"
+  say "resetting synthetic data → empty baseline (iam, programs, scheduling, sessions, sis, ads-adm, connect)…"
   local trunc="DO \$\$ DECLARE r RECORD; BEGIN FOR r IN SELECT tablename FROM pg_tables WHERE schemaname='public' AND tablename <> '_prisma_migrations' LOOP EXECUTE 'TRUNCATE TABLE public.'||quote_ident(r.tablename)||' RESTART IDENTITY CASCADE'; END LOOP; END \$\$;"
   # `sessions` truncation also clears its consumed-event cursors, so its
   # event-built projections re-converge from the producers' outbox replay.
@@ -1544,7 +1544,12 @@ reset_data(){
   # leaves seeded fixtures intact. NOTE: `--reset --with-playback` truncates them
   # but re-seed runs only on --seed full — so follow such a reset with `--seed
   # full` (or `--with-playback --seed full`) to repopulate, else they stay empty.
-  local dbs=(iam_local iam_pii_local programs scheduling sessions content sis_db)
+  # ads_adm_local (ads-adm-api's Prisma DB): without this, lazily-created
+  # adm_attendance rows accumulate across journey runs — old program generations
+  # leave rows whose occurrences no longer resolve, which then 500 on save
+  # ("schedule has shifted out from under this record"). Generic truncate keeps
+  # _prisma_migrations, so the schema survives.
+  local dbs=(iam_local iam_pii_local programs scheduling sessions content sis_db ads_adm_local)
   [[ $DO_PLAYBACK == 1 ]] && dbs+=(transcripts_local insights_local chat_local)
   for db in "${dbs[@]}"; do
     if docker exec -i soa-postgres-1 psql -U postgres_admin -d "$db" -v ON_ERROR_STOP=1 -c "$trunc" >/dev/null 2>&1; then

--- a/tools/synthetic-dev/up.sh
+++ b/tools/synthetic-dev/up.sh
@@ -1408,8 +1408,19 @@ services_up(){
   # store. The dash picker reads it from the browser (CORS → dash origin) and
   # connect-api resolves contentRef→body from it S2S. RABBITMQ for its outbox events.
   launch_if content-api "$CONTENT_PORT" "$PROGRAM_HUB/apps/node/content-api"     NODE_ENV=development PORT="$CONTENT_PORT" DATABASE_URL="$CONTENT_DB_URL"   IAM_API_URL="$IAM_URL" RABBITMQ_URL="$MESH_MQ" CORS_ORIGIN="$DASH_URL" $(tunnel_env content-api)
+  # ADS/ADM session integration (ads-adm/session-integration branches): ADM now
+  # reads "who is expected, when" on demand from sessions-api (:3007) via its
+  # program-hub schedule provider (decisions D1/D2), instead of the retired
+  # saga_api mock. It presents the x-service-token credential (dev: raw slug;
+  # sessions-api dev-bypass trusts it — decisions D-AUTH). Policy stays default-off
+  # (ADS_ADM_POLICY_PROVIDER unset → Mock) so non-session orgs don't hit the absent
+  # saga_api. SESSIONS_API_CLIENT_BASEURL + SERVICE_TOKEN_SERVICESLUG default to
+  # :3007 / ads-adm-api, but are set explicitly here for clarity. Set
+  # ADS_ADM_SCHEDULE_PROVIDER=mock to fall back to the legacy fixture path.
   launch_if ads-adm-api 5005 "$SDS/apps/node/ads-adm-api" \
-     ADS_ADM_SCHEDULE_PROVIDER=mock \
+     ADS_ADM_SCHEDULE_PROVIDER=program-hub \
+     SESSIONS_API_CLIENT_BASEURL=http://localhost:3007 \
+     SERVICE_TOKEN_SERVICESLUG=ads-adm-api \
      ADS_ADM_DATABASE_URL=postgresql://ads_adm:ads_adm@localhost:5432/ads_adm_local \
      DATABASE_URL=postgresql://ads_adm:ads_adm@localhost:5432/ads_adm_local \
      CORS_ORIGIN=http://localhost:8900 RABBITMQ_URL="$MESH_MQ" $(tunnel_env ads-adm-api)

--- a/tools/synthetic-dev/verify.sh
+++ b/tools/synthetic-dev/verify.sh
@@ -121,6 +121,20 @@ else
   badline "connect-mongo unreachable (run ./up.sh up — mesh_up starts it)"
 fi
 
+# Health-only mode (VERIFY_HEALTH_ONLY=1): a fast gate for callers (e.g.
+# run-stack-e2e.sh's pre-INSPECT re-check) that care ONLY about whether the
+# services + data are live. Runs the ✗-hard-failing health/data checks above,
+# then exits — skipping the source-posture/freshness sections below, which do a
+# git fetch and only ever ⚠ warn. Exit code reflects API/data health alone.
+if [[ "${VERIFY_HEALTH_ONLY:-0}" == "1" ]]; then
+  if [[ $fail -eq 0 ]]; then
+    printf "\033[32m✓ health: %d/%d checks passed — stack is healthy\033[0m\n" "$pass" "$pass"
+    exit 0
+  fi
+  printf "\033[31m✗ health: %d/%d checks failed\033[0m — tail /tmp/sds-synthetic/<service>.log for reds\n" "$fail" "$((pass+fail))"
+  exit 1
+fi
+
 # ── source posture (overlay-aware) ───────────────────────────────────
 # Read your local overlay, then assert each repo's checkout matches it. A repo
 # on the wrong branch — or on local/integration but missing an overlaid PR

--- a/tools/synthetic-dev/verify.sh
+++ b/tools/synthetic-dev/verify.sh
@@ -124,8 +124,10 @@ fi
 # ── source posture (overlay-aware) ───────────────────────────────────
 # Read your local overlay, then assert each repo's checkout matches it. A repo
 # on the wrong branch — or on local/integration but missing an overlaid PR
-# (stale, forgot to re-run refresh-suite) — fails here even though health is
-# green. No overlay is the DEFAULT: every managed repo is asserted on main below.
+# (stale, forgot to re-run refresh-suite) — is a WARNING here (⚠), not a failure:
+# we work across repos on feature branches frequently, so posture drift must not
+# gate the stack (health checks above still hard-fail). No overlay is the DEFAULT:
+# every managed repo is checked against main below.
 printf "\033[1m── source posture ──\033[0m\n"
 declare -A PINS=()
 if [[ -f "$MANIFEST" ]]; then
@@ -141,7 +143,7 @@ fi
 # soa is accepted here even though it isn't "managed": a soa manifest row is
 # how a synthetic-dev/infra tooling PR gets tested end-to-end (see below).
 for repo in "${!PINS[@]}"; do
-  case " $MANAGED_REPOS soa " in *" $repo "*) ;; *) badline "overlay lists '$repo' but it's not in MANAGED_REPOS — verify can't posture-check it"; esac
+  case " $MANAGED_REPOS soa " in *" $repo "*) ;; *) warnline "overlay lists '$repo' but it's not in MANAGED_REPOS — verify can't posture-check it (warn)"; esac
 done
 
 on_branch(){ git -C "$DEV/$1" branch --show-current 2>/dev/null; }
@@ -151,7 +153,7 @@ check_posture(){ # repo expected_branch
   [[ -d "$dir/.git" ]] || { badline "$repo: not a git repo at $dir"; return; }
   have=$(on_branch "$repo")
   if [[ "$have" == "$want" ]]; then okline "$(printf '%-20s on %s' "$repo" "$want")"
-  else badline "$(printf '%-20s on '\''%s'\'' (expected '\''%s'\'')' "$repo" "$have" "$want")"; fi
+  else warnline "$(printf '%-20s on '\''%s'\'' (expected '\''%s'\'') — posture drift (warn)' "$repo" "$have" "$want")"; fi
 }
 
 # Un-overlaid managed repo: expected on main. But refresh-suite can leave the
@@ -169,7 +171,7 @@ check_posture_main(){ # repo
   elif [[ "$have" == local/integration ]] && git -C "$dir" diff --quiet origin/main HEAD 2>/dev/null; then
     okline "$(printf '%-20s on local/integration ≡ main (no overlay)' "$repo")"
   else
-    badline "$(printf '%-20s on '\''%s'\'' (expected '\''main'\'')' "$repo" "$have")"
+    warnline "$(printf '%-20s on '\''%s'\'' (expected '\''main'\'') — posture drift (warn)' "$repo" "$have")"
   fi
 }
 
@@ -177,11 +179,11 @@ check_posture_main(){ # repo
 check_pin_merged(){ # repo pr#
   local repo=$1 n=$2 dir="$DEV/$repo" oid
   oid=$( cd "$dir" && gh pr view "$n" --json headRefOid --jq '.headRefOid' 2>/dev/null || true )
-  if [[ -z "$oid" ]]; then badline "$repo #$n: couldn't resolve head via gh (auth? PR exists?)"; return; fi
+  if [[ -z "$oid" ]]; then warnline "$repo #$n: couldn't resolve head via gh (auth? PR exists?) (warn)"; return; fi
   if git -C "$dir" merge-base --is-ancestor "$oid" HEAD 2>/dev/null; then
     okline "$(printf '%-20s #%s merged in' "$repo" "$n")"
   else
-    badline "$(printf '%-20s #%s NOT in checkout — run ./refresh-suite.sh' "$repo" "$n")"
+    warnline "$(printf '%-20s #%s NOT in checkout — run ./refresh-suite.sh (warn)' "$repo" "$n")"
   fi
 }
 


### PR DESCRIPTION
Wires the synthetic-dev stack for ADS/ADM end-to-end and hardens reset/verify. Local dev tooling only; no deployed-runtime impact.

## What's here
- Serve saga-dash in `VITE_ADS_ADM_REAL` mode (dash /adm → real ads-adm-api).
- Run ads-adm-api against sessions-api (program-hub mode) + pass `IAM_API_CLIENT_BASEURL` for name resolution.
- Source-posture checks are warnings, not failures.
- **Reset truncates `ads_adm_local`** — was skipped, so attendance rows accumulated across runs and produced stale "no meeting"/"not on roster" save failures.
- **`VERIFY_HEALTH_ONLY=1`** health-only verify mode — gates the post-suite inspect browser so it never opens on a failed/degraded stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
