### PR TITLE
fix(synthetic-dev): connect-api NODE_ENV dev-bypass + loud warning on skipped seed

### DIFF
--- a/tools/synthetic-dev/up.sh
+++ b/tools/synthetic-dev/up.sh
@@ -1909,6 +1909,21 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# Make a SKIPPED seed loud: with `set -e`, any failure after this point but
+# before the seed dispatch below (commonly a service that doesn't come up —
+# services_up returns non-zero) exits the script BEFORE seed_stack, silently
+# leaving the roster unseeded; the only symptom is then cryptic verify reds
+# ("deterministic dev id absent…"). Trap the early exit and say so.
+SEED_DONE=0
+_warn_unseeded_on_exit() {
+  local rc=$?
+  if (( rc != 0 )) && [[ "${DO_SEED:-0}" == 1 && "${SEED_DONE:-0}" == 0 ]]; then
+    printf '\033[31m\n✗ up.sh exited (code %s) BEFORE seeding — the roster was NOT seeded.\033[0m\n' "$rc" >&2
+    printf '\033[33m  A step above failed (usually a service that did not come up). Fix it, then seed:\n      %s --seed %s\033[0m\n' "$0" "${SEED_MODE:-roster}" >&2
+  fi
+}
+trap _warn_unseeded_on_exit EXIT
+
 # Hybrid-mode sanity: --only takes a real service; --sandbox is only meaningful
 # with --only (running the full local stack against a cloud iam is not the point).
 if [[ -n "$ONLY_SERVICE" ]]; then
@@ -2093,6 +2108,6 @@ if [[ $TUNNEL == 1 ]]; then
   "$SCRIPT_DIR/tunnel.sh" up
 fi
 [[ $DO_RECORD == 1 ]] && record_up "$RECORD_MODE"
-[[ $DO_SEED == 1 ]]  && seed_stack "$SEED_MODE"
+[[ $DO_SEED == 1 ]]  && { seed_stack "$SEED_MODE"; SEED_DONE=1; }
 [[ $DO_LOGIN == 1 ]] && login_user "$LOGIN_USER"
 exit 0

--- a/tools/synthetic-dev/up.sh
+++ b/tools/synthetic-dev/up.sh
@@ -1491,6 +1491,7 @@ services_up(){
   launch_if connect-api "$CONNECT_API_PORT" "$QBOARD/apps/node/connectv3-api" \
      PORT="$CONNECT_API_PORT" \
      MONGO_URI="$CONNECT_MONGO_URI" \
+     NODE_ENV=development \
      AUTH_ENABLED=true JANUS_REQUIRED=false \
      IAM_API_URL="$IAM_URL" JWT_ISSUER="https://iam.saga.org" \
      ALLOWED_ORIGINS="$CONNECT_WEB_URL" \


### PR DESCRIPTION
## 1. connect-api fix (the regression)
On a fresh `./up.sh up` against `main`, **connect-api (:6106) fatals on startup**:

```
[connectv3-api] fatal startup error: JANUS_REQUIRED must be true in any
non-development environment (NODE_ENV=(unset)). Disabling the employee Janus
perimeter is a dev-account-only escape hatch for unattended e2e.
```

connectv3-api now only permits `JANUS_REQUIRED=false` when `NODE_ENV=development`, and up.sh launched connect-api without `NODE_ENV` set — so the dev-bypass perimeter killed it (verify: `connect-api :6106 → 000`). **Fix:** set `NODE_ENV=development` on the connect-api `launch_if` (parity with programs-api / scheduling-api).

## 2. Loud warning on a skipped seed (observability)
That connect-api failure had a nasty side effect: under `set -euo pipefail`, `services_up` returning non-zero **exits up.sh before `seed_stack`**, silently leaving the roster unseeded — the only symptom is then cryptic verify reds (`deterministic dev id absent`, `admin personas=0`). Added an EXIT trap (armed right after arg-parse): if `--seed` was requested but the script exits before seeding, it prints a loud warning + the recovery command `./up.sh --seed <mode>`.

## Verified
- **connect-api**: `./up.sh --only connect-api` → `✓ connect-api up :6106`; `./verify.sh` → `connect-api :6106 → 200`.
- **warning**: fires on an early post-parse exit with `--seed`; silent without `--seed` and on a clean seed; `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
