### PR TITLE
fix(synthetic-dev): launch connect-api with NODE_ENV=development

### DIFF
--- a/tools/synthetic-dev/up.sh
+++ b/tools/synthetic-dev/up.sh
@@ -1474,6 +1474,7 @@ services_up(){
   # other services. SAGA_API_TARGET is legacy poll content (unauthenticated
   # endpoint — see header). LiveKit creds match qboard's local container.
   launch_if connect-api "$CONNECT_API_PORT" "$QBOARD/apps/node/connectv3-api" \
+     NODE_ENV=development \
      PORT="$CONNECT_API_PORT" \
      MONGO_URI="$CONNECT_MONGO_URI" \
      AUTH_ENABLED=true JANUS_REQUIRED=false \


### PR DESCRIPTION
## What

qboard `main`'s connectv3-api now hard-requires `NODE_ENV=development` to allow `JANUS_REQUIRED=false` (the dev-account-only escape hatch for the employee Janus perimeter — `assertJanusProductionConfig`). `up.sh` launched connect-api **without** `NODE_ENV` — the only service missing it — so `./up.sh --reset` aborts at connect-api:

```
fatal startup error: JANUS_REQUIRED must be true in any non-development
environment (NODE_ENV=(unset))
```

…which blocks the seed + login for the whole stack (connect-api is launched before the seed step).

## Fix

Add `NODE_ENV=development` to the connect-api launch env, matching every other service (programs / scheduling / sessions / content / ads-adm / insights all set it).

## Verification

Launched connect-api with `NODE_ENV=development` → boots past the assertion, `200` on `/connectv3/v1/health`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
