### PR TITLE
docs: align CLAUDE.md hierarchy with Anthropic 2026 memory guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,8 +70,8 @@ pnpm typecheck      # Type check
 
 ## Documentation Directive
 
-**Documentation Directive:** Documentation system is provided via the `documentation-system@saga-tools` plugin. Use `/documentation-system` for maintenance instructions.
+**Documentation Directive:** Keep every CLAUDE.md < 200 lines; route each instruction to the right surface — repo/area-wide facts here or in nested CLAUDE.md (load on demand), genuinely path-scoped conventions into `.claude/rules/*.md` (none today, by design), how-to detail into `docs/`, and multi-step procedures into skills. Documentation system is provided via the `documentation-system@saga-tools` plugin; use `/documentation-system` for maintenance instructions.
 
 ---
 
-*Last updated: 2026-02*
+*Last updated: 2026-06*

--- a/apps/CLAUDE.md
+++ b/apps/CLAUDE.md
@@ -2,9 +2,7 @@
 
 Example applications demonstrating SOA package usage patterns.
 
-## Parent Context
-
-See [/CLAUDE.md](../CLAUDE.md) for repository-wide context.
+**Parent Context:** Part of [soa](../CLAUDE.md), the shared-infrastructure monorepo for Saga platform applications.
 
 ## Structure
 

--- a/apps/core/CLAUDE.md
+++ b/apps/core/CLAUDE.md
@@ -2,9 +2,7 @@
 
 Runtime-agnostic applications (CLI tools, scripts).
 
-## Parent Context
-
-See [/apps/CLAUDE.md](../CLAUDE.md) for apps overview.
+**Parent Context:** Part of [apps](../CLAUDE.md), the example applications tier.
 
 ## Runtime Environment
 

--- a/apps/node/CLAUDE.md
+++ b/apps/node/CLAUDE.md
@@ -2,9 +2,7 @@
 
 Backend applications running in Node.js environment.
 
-## Parent Context
-
-See [/apps/CLAUDE.md](../CLAUDE.md) for apps overview.
+**Parent Context:** Part of [apps](../CLAUDE.md), the example applications tier.
 
 ## Runtime Environment
 

--- a/apps/node/gql-api/CLAUDE.md
+++ b/apps/node/gql-api/CLAUDE.md
@@ -9,9 +9,7 @@ GraphQL API example using Apollo Server with SDL-first schema.
 - Sector-based architecture with resolver auto-loading
 - User and session management via GraphQL queries/mutations
 
-## Parent Context
-
-See [/apps/node/CLAUDE.md](../CLAUDE.md) for Node.js app patterns.
+**Parent Context:** Part of [apps/node](../CLAUDE.md), the Node.js backend applications tier.
 
 ## Tech Stack
 

--- a/apps/node/rest-api/CLAUDE.md
+++ b/apps/node/rest-api/CLAUDE.md
@@ -9,9 +9,7 @@ REST API example using Express with routing-controllers.
 - Sector-based architecture with controller auto-loading
 - Express middleware and request/response handling
 
-## Parent Context
-
-See [/apps/node/CLAUDE.md](../CLAUDE.md) for Node.js app patterns.
+**Parent Context:** Part of [apps/node](../CLAUDE.md), the Node.js backend applications tier.
 
 ## Tech Stack
 

--- a/apps/node/tgql-api/CLAUDE.md
+++ b/apps/node/tgql-api/CLAUDE.md
@@ -10,9 +10,7 @@ TypeGraphQL API example using Apollo Server with code-first schema.
 - Schema generation and emission via TypeGraphQL
 - User and session management via GraphQL queries/mutations
 
-## Parent Context
-
-See [/apps/node/CLAUDE.md](../CLAUDE.md) for Node.js app patterns.
+**Parent Context:** Part of [apps/node](../CLAUDE.md), the Node.js backend applications tier.
 
 ## Tech Stack
 

--- a/apps/node/trpc-api/CLAUDE.md
+++ b/apps/node/trpc-api/CLAUDE.md
@@ -9,9 +9,7 @@ tRPC API example with end-to-end type-safe RPC using Zod schemas.
 - Sector-based architecture with static router composition
 - Project, Run, and PubSub domain management
 
-## Parent Context
-
-See [/apps/node/CLAUDE.md](../CLAUDE.md) for Node.js app patterns.
+**Parent Context:** Part of [apps/node](../CLAUDE.md), the Node.js backend applications tier.
 
 ## Tech Stack
 

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -2,9 +2,7 @@
 
 Frontend applications running in browser environment.
 
-## Parent Context
-
-See [/apps/CLAUDE.md](../CLAUDE.md) for apps overview.
+**Parent Context:** Part of [apps](../CLAUDE.md), the example applications tier.
 
 ## Runtime Environment
 

--- a/apps/web/docs/CLAUDE.md
+++ b/apps/web/docs/CLAUDE.md
@@ -9,9 +9,7 @@ SOA documentation site built with Next.js 15.
 - Developer onboarding and API reference
 - Living examples of shared UI components
 
-## Parent Context
-
-See [/apps/web/CLAUDE.md](../CLAUDE.md) for web app patterns.
+**Parent Context:** Part of [apps/web](../CLAUDE.md), the frontend applications tier.
 
 ## Tech Stack
 

--- a/apps/web/web-client/CLAUDE.md
+++ b/apps/web/web-client/CLAUDE.md
@@ -9,9 +9,7 @@ SOA example client app for testing and interacting with all API examples.
 - Interactive endpoint testing with tRPC client integration
 - Demonstrates @saga-ed/soa-ui component library usage
 
-## Parent Context
-
-See [/apps/web/CLAUDE.md](../CLAUDE.md) for web app patterns.
+**Parent Context:** Part of [apps/web](../CLAUDE.md), the frontend applications tier.
 
 ## Tech Stack
 

--- a/claude/projects/soa_75/CLAUDE.md
+++ b/claude/projects/soa_75/CLAUDE.md
@@ -10,6 +10,8 @@ ads-adm-api read fan-out) and stand it up end-to-end to expose
 the real costs and design questions before any broader
 commitment.
 
+**Parent Context:** Part of [soa](../../../CLAUDE.md), the shared-infrastructure monorepo — this is a project-scoped working doc under `claude/projects/`.
+
 ## Scope
 
 Spans 4 repos, all on `soa_75` branch (the soa branch base is

--- a/claude/projects/synthetic-dev-align/CLAUDE.md
+++ b/claude/projects/synthetic-dev-align/CLAUDE.md
@@ -13,6 +13,8 @@ onboarding, local mesh runbook & synthetic-dev convergence", author
 seed-ids packages, (2) give a manual local-mesh runbook, and (3) propose
 the synthetic-dev convergence as a **draft for discussion**.
 
+**Parent Context:** Part of [soa](../../../CLAUDE.md), the shared-infrastructure monorepo — this is a project-scoped working doc under `claude/projects/`.
+
 ## What this initiative is
 
 A **research / synthesis** track, not (yet) an implementation track. The

--- a/infra/CLAUDE.md
+++ b/infra/CLAUDE.md
@@ -11,9 +11,7 @@ Docker Compose template package with instant profile switching. Published as `@s
 - CLI (`infra-compose`) + programmatic JS API + Express HTTP router
 - EC2 db-host server subsystem for remote fixture-serving VMs
 
-## Parent Context
-
-See [/CLAUDE.md](../CLAUDE.md) for repository-wide context. `infra-compose` is a sibling of `packages/` — not inside it, because it ships as a standalone npm package with its own `package.json`, its own test runner config, and its own CI.
+**Parent Context:** Part of [soa](../CLAUDE.md), the shared-infrastructure monorepo for Saga platform applications. `infra-compose` is a sibling of `packages/` — not inside it, because it ships as a standalone npm package with its own `package.json`, its own test runner config, and its own CI.
 
 ## Tech Stack
 

--- a/packages/CLAUDE.md
+++ b/packages/CLAUDE.md
@@ -2,9 +2,7 @@
 
 Shared libraries organized by runtime compatibility.
 
-## Parent Context
-
-See [/CLAUDE.md](../CLAUDE.md) for repository-wide context.
+**Parent Context:** Part of [soa](../CLAUDE.md), the shared-infrastructure monorepo for Saga platform applications.
 
 ## Runtime Categories
 

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -2,9 +2,7 @@
 
 Runtime-agnostic packages that work in any JavaScript environment.
 
-## Parent Context
-
-See [/packages/CLAUDE.md](../CLAUDE.md) for packages overview.
+**Parent Context:** Part of [packages](../CLAUDE.md), the shared-libraries tier.
 
 ## Runtime Environment
 

--- a/packages/node/CLAUDE.md
+++ b/packages/node/CLAUDE.md
@@ -2,9 +2,7 @@
 
 Server-side packages for Node.js applications.
 
-## Parent Context
-
-See [/packages/CLAUDE.md](../CLAUDE.md) for packages overview.
+**Parent Context:** Part of [packages](../CLAUDE.md), the shared-libraries tier.
 
 ## Runtime Environment
 

--- a/packages/node/api-core/CLAUDE.md
+++ b/packages/node/api-core/CLAUDE.md
@@ -11,9 +11,7 @@ Shared API server utilities for building Node.js backend services.
 - Server configuration schemas (Zod-validated)
 - Sector pattern support (automatic route/resolver discovery)
 
-## Parent Context
-
-See [/packages/node/CLAUDE.md](../CLAUDE.md) for Node.js package patterns.
+**Parent Context:** Part of [packages/node](../CLAUDE.md), the Node.js shared-packages tier.
 
 ## Tech Stack
 

--- a/packages/node/db/CLAUDE.md
+++ b/packages/node/db/CLAUDE.md
@@ -12,9 +12,7 @@ MongoDB connection management and database utilities.
 - Zod-validated database configuration
 - Future: MySQL and Redis connection managers (stubs present)
 
-## Parent Context
-
-See [/packages/node/CLAUDE.md](../CLAUDE.md) for Node.js package patterns.
+**Parent Context:** Part of [packages/node](../CLAUDE.md), the Node.js shared-packages tier.
 
 ## Tech Stack
 
@@ -140,56 +138,11 @@ This connects as `saga_admin` against `admin` (authSource), with `database: 'led
 
 ### Validation via SSM tunnels
 
-The end-to-end paths the unit tests can't reach — TLS handshake, SCRAM auth, CA-from-Secrets resolution — are exercised by `scripts/smoke-validate.mjs` against three representative targets:
-
-| Target | Tests | Auth |
-|---|---|---|
-| `dev-shared-mongo` on db-host:27017 | no-TLS / no-auth path (legacy dev pattern) | none |
-| `dev-auth-mongo` on db-host:27020 | TLS + SCRAM + per-service-user path | `ledger_api_app` (creds in `/dev/db-host/dev-auth-mongo/ledger-api-password`) |
-| Staging shared mongo | TLS + SCRAM against the real shared cluster | master admin (`/shared/infra/staging/mongodb-master-secret-arn`) |
-
-#### Setup
-
-The targets are private-VPC EC2 with no stable instance IDs (db-host can be replaced; staging mongo runs under an ASG). Always resolve the current instance at runtime:
-
-```bash
-# Resolve current targets
-DB_HOST=$(aws --profile saga-admin-dev ssm get-parameter \
-  --name /dev/db-host/instance-id --query Parameter.Value --output text)
-STG_MONGO=$(aws --profile saga-admin-dev ec2 describe-instances \
-  --filters Name=tag:aws:autoscaling:groupName,Values=saga-mongodb-staging \
-            Name=instance-state-name,Values=running \
-  --query 'Reservations[0].Instances[0].InstanceId' --output text)
-
-# Open three SSM port-forwards (one per shell, or backgrounded)
-aws --profile saga-admin-dev ssm start-session --target "$DB_HOST" \
-  --document-name AWS-StartPortForwardingSession \
-  --parameters '{"portNumber":["27017"],"localPortNumber":["27117"]}' &  # dev-shared-mongo
-aws --profile saga-admin-dev ssm start-session --target "$DB_HOST" \
-  --document-name AWS-StartPortForwardingSession \
-  --parameters '{"portNumber":["27020"],"localPortNumber":["27120"]}' &  # dev-auth-mongo (testbed)
-aws --profile saga-admin-dev ssm start-session --target "$STG_MONGO" \
-  --document-name AWS-StartPortForwardingSession \
-  --parameters '{"portNumber":["27017"],"localPortNumber":["27317"]}' &  # staging shared mongo
-```
-
-The `dev-auth-mongo` testbed lives on db-host alongside `dev-shared-mongo`; both share the same `/dev/db-host/instance-id` lookup. The dev-auth-mongo setup itself is in iac at `cloudformation_templates/dbs/db_host/dev-auth-mongo/`.
-
-Then run the smoke:
+The end-to-end paths the unit tests can't reach — TLS handshake, SCRAM auth, CA-from-Secrets resolution — are exercised by `scripts/smoke-validate.mjs` against three real targets (dev no-auth, dev TLS+SCRAM testbed, staging shared cluster) reached over SSM port-forwards. Full setup, target table, and the `directConnection` / cert-SAN rationale: [docs/smoke-validate.md](./docs/smoke-validate.md).
 
 ```bash
 AWS_PROFILE=saga-admin-dev node packages/node/db/scripts/smoke-validate.mjs
 ```
-
-The script inserts → finds → deletes one doc per target, leaves no residue.
-
-#### Why `directConnection: true`
-
-The smoke passes `options: { directConnection: true }` and drops `replicaSet` for tunnel purposes. RS members advertise their internal VPC addresses (`10.3.137.46:27017`, `127.0.0.1:27017`, etc.) to the driver during topology discovery — those aren't reachable through an SSM tunnel from a workstation. `directConnection` skips topology discovery and pins the client to the seed (the tunneled `localhost:port`). Production callers in-VPC keep `replicaSet` and full RS topology — this is purely a tunneling accommodation.
-
-#### Cert SAN
-
-Both `dev-auth-mongo` and the staging shared cert include `localhost` in `subjectAltName`, so TLS hostname validation succeeds when connecting through `localhost:<port>` tunnels. Mirror and prod inherit the same SAN convention.
 
 ## Convention Deviations
 

--- a/packages/node/db/docs/smoke-validate.md
+++ b/packages/node/db/docs/smoke-validate.md
@@ -1,0 +1,58 @@
+# db — end-to-end smoke validation via SSM tunnels
+
+> Reference runbook for `scripts/smoke-validate.mjs`. Extracted from the package
+> CLAUDE.md to keep that file under the 200-line budget; this detail only
+> matters when running the real-systems smoke against `MongoProvider`.
+
+**Parent Context:** how-to detail for [`@saga-ed/soa-db`](../CLAUDE.md).
+
+The end-to-end paths the unit tests can't reach — TLS handshake, SCRAM auth, CA-from-Secrets resolution — are exercised by `scripts/smoke-validate.mjs` against three representative targets:
+
+| Target | Tests | Auth |
+|---|---|---|
+| `dev-shared-mongo` on db-host:27017 | no-TLS / no-auth path (legacy dev pattern) | none |
+| `dev-auth-mongo` on db-host:27020 | TLS + SCRAM + per-service-user path | `ledger_api_app` (creds in `/dev/db-host/dev-auth-mongo/ledger-api-password`) |
+| Staging shared mongo | TLS + SCRAM against the real shared cluster | master admin (`/shared/infra/staging/mongodb-master-secret-arn`) |
+
+## Setup
+
+The targets are private-VPC EC2 with no stable instance IDs (db-host can be replaced; staging mongo runs under an ASG). Always resolve the current instance at runtime:
+
+```bash
+# Resolve current targets
+DB_HOST=$(aws --profile saga-admin-dev ssm get-parameter \
+  --name /dev/db-host/instance-id --query Parameter.Value --output text)
+STG_MONGO=$(aws --profile saga-admin-dev ec2 describe-instances \
+  --filters Name=tag:aws:autoscaling:groupName,Values=saga-mongodb-staging \
+            Name=instance-state-name,Values=running \
+  --query 'Reservations[0].Instances[0].InstanceId' --output text)
+
+# Open three SSM port-forwards (one per shell, or backgrounded)
+aws --profile saga-admin-dev ssm start-session --target "$DB_HOST" \
+  --document-name AWS-StartPortForwardingSession \
+  --parameters '{"portNumber":["27017"],"localPortNumber":["27117"]}' &  # dev-shared-mongo
+aws --profile saga-admin-dev ssm start-session --target "$DB_HOST" \
+  --document-name AWS-StartPortForwardingSession \
+  --parameters '{"portNumber":["27020"],"localPortNumber":["27120"]}' &  # dev-auth-mongo (testbed)
+aws --profile saga-admin-dev ssm start-session --target "$STG_MONGO" \
+  --document-name AWS-StartPortForwardingSession \
+  --parameters '{"portNumber":["27017"],"localPortNumber":["27317"]}' &  # staging shared mongo
+```
+
+The `dev-auth-mongo` testbed lives on db-host alongside `dev-shared-mongo`; both share the same `/dev/db-host/instance-id` lookup. The dev-auth-mongo setup itself is in iac at `cloudformation_templates/dbs/db_host/dev-auth-mongo/`.
+
+Then run the smoke:
+
+```bash
+AWS_PROFILE=saga-admin-dev node packages/node/db/scripts/smoke-validate.mjs
+```
+
+The script inserts → finds → deletes one doc per target, leaves no residue.
+
+## Why `directConnection: true`
+
+The smoke passes `options: { directConnection: true }` and drops `replicaSet` for tunnel purposes. RS members advertise their internal VPC addresses (`10.3.137.46:27017`, `127.0.0.1:27017`, etc.) to the driver during topology discovery — those aren't reachable through an SSM tunnel from a workstation. `directConnection` skips topology discovery and pins the client to the seed (the tunneled `localhost:port`). Production callers in-VPC keep `replicaSet` and full RS topology — this is purely a tunneling accommodation.
+
+## Cert SAN
+
+Both `dev-auth-mongo` and the staging shared cert include `localhost` in `subjectAltName`, so TLS hostname validation succeeds when connecting through `localhost:<port>` tunnels. Mirror and prod inherit the same SAN convention.

--- a/packages/node/fixture-serve/CLAUDE.md
+++ b/packages/node/fixture-serve/CLAUDE.md
@@ -11,9 +11,7 @@ Ready-to-run Express server for managing test fixtures across database environme
 - infra-compose integration (mounts `/infra` router with lifecycle hooks)
 - Systemd service restart helper + fixture-admin self-registration
 
-## Parent Context
-
-See [/packages/node/CLAUDE.md](../CLAUDE.md) for Node.js package patterns.
+**Parent Context:** Part of [packages/node](../CLAUDE.md), the Node.js shared-packages tier.
 
 ## Tech Stack
 

--- a/packages/web/CLAUDE.md
+++ b/packages/web/CLAUDE.md
@@ -2,9 +2,7 @@
 
 Browser-runtime packages for frontend applications.
 
-## Parent Context
-
-See [/packages/CLAUDE.md](../CLAUDE.md) for packages overview.
+**Parent Context:** Part of [packages](../CLAUDE.md), the shared-libraries tier.
 
 ## Runtime Environment
 

--- a/packages/web/ui/CLAUDE.md
+++ b/packages/web/ui/CLAUDE.md
@@ -10,9 +10,7 @@ React component library for SOA frontend applications.
 - Component showcasing in docs app
 - Internal package (not published externally)
 
-## Parent Context
-
-See [/packages/web/CLAUDE.md](../CLAUDE.md) for web package patterns.
+**Parent Context:** Part of [packages/web](../CLAUDE.md), the browser shared-packages tier.
 
 ## Tech Stack
 

--- a/python/CLAUDE.md
+++ b/python/CLAUDE.md
@@ -2,6 +2,8 @@
 
 Shared Python development standards and conventions for all @saga-ed/soa projects.
 
+**Parent Context:** Part of [soa](../CLAUDE.md), the shared-infrastructure monorepo for Saga platform applications.
+
 ## Package Management
 
 **CRITICAL**: All Python projects MUST use `uv` for package management.


### PR DESCRIPTION
## Summary

Aligns the CLAUDE.md hierarchy with Anthropic's current (2026) memory guidance and the `documentation-system` skill (v4.2.0). soa was already exemplary — this is format reconciliation, not a teardown.

## Changes
- Root CLAUDE.md: 77 → 77 lines (Documentation Directive + footer only; repo-wide conventions left in root by design).
- **No `.claude/rules/` created — deliberately.** soa's conventions are either repo-wide (belong in root) or already served by its on-demand nested hierarchy; nothing was genuinely path-scoped-but-misplaced.
- **23 nested CLAUDE.md** reconciled to the canonical `**Parent Context:**` format (3 were missing a parent link entirely).
- The one >200-line file (`packages/node/db/CLAUDE.md`, 208) trimmed to 161 by extracting an SSM-tunnel smoke-validation runbook to `packages/node/db/docs/smoke-validate.md` (every command/path preserved).

## Validation
`validate_structure.sh` "All structure requirements met" (0 missing Parent Context, was 23); all CLAUDE.md < 200 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TVxFUFjSc7WQYsucLsCBrM

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVxFUFjSc7WQYsucLsCBrM)_