### PR TITLE
feat(mesh-fixture): iam-small — rostering-only IAM scenario fixture (rostering#123)

### DIFF
--- a/packages/node/mesh-fixture-cli/fixtures/iam-small/README.md
+++ b/packages/node/mesh-fixture-cli/fixtures/iam-small/README.md
@@ -1,0 +1,83 @@
+# `iam-small` fixture
+
+A small **rostering-only / iam-only** scenario fixture (rostering#123). It exercises just the
+iam-api surface — `iam_local` + `iam_pii_local` — so you can run iam-api end-to-end and use it as a
+stable integration-test substrate (rostering#342) without standing up programs-api or ads-adm-api.
+
+## Shape
+
+```
+district  iam-small-district
+  ├─ school   iam-small-north
+  │   ├─ section  iam-small-north-a
+  │   └─ section  iam-small-north-b
+  └─ school   iam-small-south
+      └─ section  iam-small-south-a
+
+users (each with PII): iam-small-admin-1, iam-small-tutor-1, iam-small-tutor-2,
+                       iam-small-student-1 … iam-small-student-4
+memberships: admin → district; tutors → district + a school;
+             students → district + a school + a section
+```
+
+All entities tagged `source=demo`, `sourceId=<slug>`.
+
+## Scope — v1 is scoped-down (deliberately)
+
+This fixture is authored with the **existing** `iam:*` verbs only: `iam:create-org`,
+`iam:create-user` (+ PII), `iam:add-membership`. It therefore covers **groups + users + memberships
++ PII** and is enough to unblock rostering#342.
+
+It does **not** author **roles, personas, permissions, or policies** — there is no `iam:*`
+authoring command for those yet (tracked in **rostering#667**). Concretely, in v1:
+- users seed at the default `UserRole` (`USER`) — no per-user role until `iam:create-user --role`;
+- memberships carry **no** `personaId` — no persona until `iam:create-persona` / `--persona`.
+
+When #667 lands, this fixture upgrades in place to add admin/tutor/student personas wired to
+`STANDARD_BUNDLES` (see `rostering:claude/projects/r_123/02-proposed-iam-fixture.md`).
+
+## Permissions — preserved, not redefined
+
+This fixture **does not define or modify** the permission/policy catalog. That catalog is
+source-controlled in `rostering:packages/node/iam-db/src/registry.ts` (`PERMISSIONS[]` / `POLICIES[]`
+/ `STANDARD_BUNDLES`) and is unaffected by this fixture. To keep the **snapshot** consistent with the
+canonical catalog, author it on a **registry-seeded base** so the dump carries the permissions/
+policies and a restore re-installs them:
+
+1. Start from a clean `iam_local` (or `snapshot:restore` an empty base).
+2. Seed the standard registry only (no district/persona dev data): run the iam-db registry seed
+   (`pnpm -C <rostering>/packages/node/iam-db db:seed:registry`, or `seedRegistry()` directly).
+3. Run `./create.sh` to add this fixture's roster entities.
+4. `mesh-fixture snapshot:store --fixture-id iam-small`.
+
+The result is a snapshot containing the canonical permission/policy catalog + the iam-small roster,
+with **no** personas/assignments (those come with #667). It cannot drift from the source catalog
+because it never copies it — it seeds from `registry.ts`.
+
+## Author / snapshot / restore
+
+```bash
+# 0. mesh up + registry-seeded base (see §Permissions)
+saga-mesh.sh doctor && saga-mesh.sh setup
+
+# 1. author (idempotent; re-runnable)
+FIXTURE_ID=iam-small ./create.sh
+
+# 2. snapshot (whole-mesh; the non-iam DBs are simply empty)
+mesh-fixture snapshot:store --fixture-id iam-small
+
+# 3. restore (seconds; resets the mesh to this state)
+mesh-fixture snapshot:restore --fixture-id iam-small
+```
+
+> **Not yet snapshot-verified.** This recipe is authored to the `demo-small` conventions but has not
+> been run against a live mesh in this change (no container available). First use should run
+> `create.sh` + `snapshot:store` on a mesh and commit/verify the snapshot, the same author step every
+> Path-A fixture takes.
+
+## Won't interfere with the personas system
+
+Adding this fixture is purely additive — a new `fixtures/iam-small/` directory. It modifies no shared
+code (`registry.ts`, `prisma/seed.ts`, `seed-mode.ts`), no persona/permission tables, and neither
+existing fixture. The only way it touches an environment is an explicit `snapshot:restore iam-small`,
+which (like any fixture restore) resets the local mesh — opt-in.

--- a/packages/node/mesh-fixture-cli/fixtures/iam-small/create.sh
+++ b/packages/node/mesh-fixture-cli/fixtures/iam-small/create.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# create.sh — author the `iam-small` fixture on a running saga-mesh.
+#
+# A rostering-only / iam-only scenario fixture (rostering#123). Composes ONLY
+# the mesh-fixture CLI's idempotent iam:* primitives into a small district
+# roster — it touches iam_local + iam_pii_local and no other mesh DB.
+#
+# SCOPE (v1, scoped-down — see ./README.md and rostering#123):
+#   groups + users + memberships + PII, via the EXISTING iam:* verbs.
+#   It does NOT author roles, personas, permissions, or policies — those have
+#   no iam:* authoring command yet (tracked in rostering#667). Users seed at the
+#   default UserRole (USER); memberships carry no persona. The standard
+#   permission/policy catalog is preserved via the registry-seeded base the
+#   snapshot is authored on (see ./README.md §Permissions).
+#
+# Entities (all tagged source=demo, sourceId=<slug>):
+#   district  iam-small-district
+#     ├─ school   iam-small-north
+#     │   ├─ section  iam-small-north-a
+#     │   └─ section  iam-small-north-b
+#     └─ school   iam-small-south
+#         └─ section  iam-small-south-a
+#   users: iam-small-admin-1, iam-small-tutor-1, iam-small-tutor-2,
+#          iam-small-student-1 .. iam-small-student-4 (each with PII)
+#
+# Prereqs (user runs these before this script):
+#   saga-mesh.sh doctor && saga-mesh.sh setup
+#   + the standard IAM registry seeded on iam_local (see ./README.md §Permissions)
+#
+# Every command below is dedup-by-natural-key — re-running on a populated mesh
+# is a no-op. See ../../README.md for the mesh-fixture CLI flag reference.
+#
+# After this script completes, snapshot via:
+#   mesh-fixture snapshot:store --fixture-id iam-small
+# ─────────────────────────────────────────────────────────────────────────────
+
+set -euo pipefail
+
+# ─── Configuration ──────────────────────────────────────────────────────────
+FIXTURE_ID="${FIXTURE_ID:-iam-small}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MESH_FIXTURE_CLI="${MESH_FIXTURE_CLI:-$SCRIPT_DIR/../../bin/run.js}"
+
+if [[ ! -f "$MESH_FIXTURE_CLI" ]]; then
+  echo "error: mesh-fixture CLI not found at $MESH_FIXTURE_CLI" >&2
+  echo "       run 'pnpm -C $SCRIPT_DIR/../.. build' first, or set MESH_FIXTURE_CLI" >&2
+  exit 1
+fi
+
+cli() { node "$MESH_FIXTURE_CLI" "$@"; }
+
+# ─── 1. Groups (district → schools → sections) ──────────────────────────────
+# iam enforces parent-first ordering, so create the tree top-down.
+echo "==> iam: groups"
+cli iam:create-org --fixture-id "$FIXTURE_ID" --slug iam-small-district --kind district --display-name "IAM Small District"
+cli iam:create-org --fixture-id "$FIXTURE_ID" --slug iam-small-north --kind school --display-name "North School" --parent iam-small-district
+cli iam:create-org --fixture-id "$FIXTURE_ID" --slug iam-small-south --kind school --display-name "South School" --parent iam-small-district
+cli iam:create-org --fixture-id "$FIXTURE_ID" --slug iam-small-north-a --kind section --display-name "North — Section A" --parent iam-small-north
+cli iam:create-org --fixture-id "$FIXTURE_ID" --slug iam-small-north-b --kind section --display-name "North — Section B" --parent iam-small-north
+cli iam:create-org --fixture-id "$FIXTURE_ID" --slug iam-small-south-a --kind section --display-name "South — Section A" --parent iam-small-south
+
+# ─── 2. Users (+ PII) ───────────────────────────────────────────────────────
+# All seed at the default UserRole (USER) — the --role flag arrives with #667.
+echo "==> iam: users"
+cli iam:create-user --fixture-id "$FIXTURE_ID" --username iam-small-admin-1 --email iam-small-admin-1@fixture.test --name-first Ada --name-last Min
+cli iam:create-user --fixture-id "$FIXTURE_ID" --username iam-small-tutor-1 --email iam-small-tutor-1@fixture.test --name-first Tess --name-last Tutor
+cli iam:create-user --fixture-id "$FIXTURE_ID" --username iam-small-tutor-2 --email iam-small-tutor-2@fixture.test --name-first Ted --name-last Tutor
+cli iam:create-user --fixture-id "$FIXTURE_ID" --username iam-small-student-1 --email iam-small-student-1@fixture.test --name-first Stu --name-last One
+cli iam:create-user --fixture-id "$FIXTURE_ID" --username iam-small-student-2 --email iam-small-student-2@fixture.test --name-first Stu --name-last Two
+cli iam:create-user --fixture-id "$FIXTURE_ID" --username iam-small-student-3 --email iam-small-student-3@fixture.test --name-first Stu --name-last Three
+cli iam:create-user --fixture-id "$FIXTURE_ID" --username iam-small-student-4 --email iam-small-student-4@fixture.test --name-first Stu --name-last Four
+
+# ─── 3. Memberships ─────────────────────────────────────────────────────────
+# Parent-first (district → school → section). Admin at the district; each tutor
+# at the district + a school; each student at the district + one school + one
+# section (member at every tier so roster tree-walks resolve them).
+echo "==> iam: memberships"
+cli iam:add-membership --fixture-id "$FIXTURE_ID" --user iam-small-admin-1 --group iam-small-district
+
+cli iam:add-membership --fixture-id "$FIXTURE_ID" --user iam-small-tutor-1 --group iam-small-district
+cli iam:add-membership --fixture-id "$FIXTURE_ID" --user iam-small-tutor-1 --group iam-small-north
+cli iam:add-membership --fixture-id "$FIXTURE_ID" --user iam-small-tutor-2 --group iam-small-district
+cli iam:add-membership --fixture-id "$FIXTURE_ID" --user iam-small-tutor-2 --group iam-small-south
+
+cli iam:add-membership --fixture-id "$FIXTURE_ID" --user iam-small-student-1 --group iam-small-district
+cli iam:add-membership --fixture-id "$FIXTURE_ID" --user iam-small-student-1 --group iam-small-north
+cli iam:add-membership --fixture-id "$FIXTURE_ID" --user iam-small-student-1 --group iam-small-north-a
+cli iam:add-membership --fixture-id "$FIXTURE_ID" --user iam-small-student-2 --group iam-small-district
+cli iam:add-membership --fixture-id "$FIXTURE_ID" --user iam-small-student-2 --group iam-small-north
+cli iam:add-membership --fixture-id "$FIXTURE_ID" --user iam-small-student-2 --group iam-small-north-b
+cli iam:add-membership --fixture-id "$FIXTURE_ID" --user iam-small-student-3 --group iam-small-district
+cli iam:add-membership --fixture-id "$FIXTURE_ID" --user iam-small-student-3 --group iam-small-south
+cli iam:add-membership --fixture-id "$FIXTURE_ID" --user iam-small-student-3 --group iam-small-south-a
+cli iam:add-membership --fixture-id "$FIXTURE_ID" --user iam-small-student-4 --group iam-small-district
+cli iam:add-membership --fixture-id "$FIXTURE_ID" --user iam-small-student-4 --group iam-small-south
+cli iam:add-membership --fixture-id "$FIXTURE_ID" --user iam-small-student-4 --group iam-small-south-a
+
+echo
+echo "✓ fixture '$FIXTURE_ID' authored. Snapshot with:"
+echo "    mesh-fixture snapshot:store --fixture-id $FIXTURE_ID"


### PR DESCRIPTION
## What

A new **rostering-only / iam-only** scenario fixture, `iam-small` — the scoped-down deliverable from rostering #123 (decision D3). A small district roster that exercises just the iam-api surface (`iam_local` + `iam_pii_local`), so iam-api can be run/tested end-to-end without programs-api or ads-adm-api. **Unblocks rostering #342** (engine integration verification).

## Shape

district `iam-small-district` → schools `iam-small-north` / `iam-small-south` → sections (`north-a`, `north-b`, `south-a`); 1 admin + 2 tutors + 4 students (each with PII); memberships at district + school (+ section for students). Authored with the **existing** `iam:*` verbs only (`create-org` / `create-user` / `add-membership`), mirroring `demo-small`'s conventions.

## Scoped-down, on purpose

Covers **groups + users + memberships + PII** — enough for #342. It **does not** author roles / personas / permissions / policies, because no `iam:*` authoring command exists for those yet (tracked in **rostering #667**). So v1: users seed at default `UserRole`, memberships carry no persona. When #667 lands, the fixture upgrades in place (admin/tutor/student personas wired to `STANDARD_BUNDLES`).

## Permissions are preserved, not redefined

This fixture **defines no permission/policy data** — that catalog is source-controlled in `rostering:iam-db/src/registry.ts`. The README documents authoring the snapshot on a **registry-seeded base** so the dump carries the canonical catalog and a restore re-installs it; it never copies the catalog, so it can't drift from source. (Context: requested guardrail for upcoming persona-audit work.)

## Safety

Purely additive — a new `fixtures/iam-small/` directory. Modifies no shared seed/registry/persona code and neither existing fixture; the only way it touches an environment is an explicit, opt-in `snapshot:restore iam-small`.

## Not yet snapshot-verified

The recipe is authored to the `demo-small` pattern but hasn't been run against a live mesh in this change (no container available here). First use should run `create.sh` + `snapshot:store` on a mesh and verify — the standard Path-A author step. Flagged in the README.

Refs: rostering #123 (`claude/projects/r_123/`), #342, #667.

🤖 Generated with [Claude Code](https://claude.com/claude-code)