### PR TITLE
synthetic-dev: pass JANUS_REQUIRED=false on iam-api launch env

### DIFF
--- a/tools/synthetic-dev/up.sh
+++ b/tools/synthetic-dev/up.sh
@@ -1391,7 +1391,16 @@ services_up(){
   # MAIL_FRONTEND_BASE_URL: the iam-realm SagaAuth login= base on 401s — the
   # local iam demo (devLogin), so a lapsed session re-logs-in here, not at prod
   # login.wootdev.com. tunnel_env overrides it with the tunnelled iam.
-  launch_if iam-api "$IAM_PORT" "$ROSTERING/apps/node/iam-api" PORT="$IAM_PORT" AUTH_DEVUSERID="$DEV_USER_UUID" CORS_ORIGIN="$DASH_URL,$CONNECT_WEB_URL" MAIL_FRONTEND_BASE_URL="http://localhost:$IAM_PORT/demo" $(tunnel_env iam-api)
+  # JANUS_REQUIRED=false on the LAUNCH ENV (not iam-api/.env): the apply_fixes
+  # sed at :419-421 patches iam-api/.env, which doesn't exist on a fresh clone
+  # (dotenv-flow logs "no .env* files"), so JANUS_REQUIRED stays unset and
+  # fail-safes to required (config schema) — iam then 401s every local S2S call
+  # with {"realms":["janus"]} (sis-api surfaces it as "Unable to transform
+  # response from server") and devLogin 401s too. Passing it here is the same
+  # literal-false bypass programs-api/scheduling-api already use on their launch
+  # env, and is .env-independent. authEnabled defaults false; this is the
+  # perimeter lever that actually gates the dev-bypass S2S actor.
+  launch_if iam-api "$IAM_PORT" "$ROSTERING/apps/node/iam-api" PORT="$IAM_PORT" AUTH_DEVUSERID="$DEV_USER_UUID" JANUS_REQUIRED=false CORS_ORIGIN="$DASH_URL,$CONNECT_WEB_URL" MAIL_FRONTEND_BASE_URL="http://localhost:$IAM_PORT/demo" $(tunnel_env iam-api)
   # sis-api → iam-api service.* over S2S; no creds locally (iam-api dev-bypass
   # synthesizes a service actor when auth is off). IAM_BASEURL/IAM_TOKENURL must
   # point at iam on :3010 (sis-api defaults to :3000). See d1.7. Under --sandbox


### PR DESCRIPTION
## Problem

On a **fresh clone**, `synthetic-dev/up.sh` brings iam-api up with the **janus perimeter ON**, so every local service-to-service call into iam-api 401s with `{"realms":["janus"]}`. Downstream this surfaces in sis-api as a confusing `"Unable to transform response from server"` tRPC error (it can't deserialize iam's plain-JSON 401 envelope), and `./up.sh --login dev@saga.org` also 401s.

### Root cause

`apply_fixes` sets `JANUS_REQUIRED=false` by `sed`-ing iam-api's `.env` (up.sh:419-421). A fresh checkout has **no `.env`** (the boot log shows `dotenv-flow ... no .env* files`), so the write never lands. `JANUS_REQUIRED` then stays unset and **fail-safes to required** per the config schema. (`authEnabled` defaults to false, but `JANUS_REQUIRED` is the lever that actually gates the local dev-bypass S2S actor.)

## Fix

Pass `JANUS_REQUIRED=false` on iam-api's **launch env** (the `launch_if` line) instead of relying on the `.env` patch. This is `.env`-independent and mirrors the literal-false bypass `programs-api` / `scheduling-api` already pass on their own launch envs.

## Verification

Killed iam-api and let `./up.sh restart` relaunch it (no manual env):
- iam-api process env now carries `JANUS_REQUIRED=false`
- `groups.getMembersBulk` S2S call → **HTTP 200 with data** (was 401)
- Full **sis-api → iam-api** `demo.reset` hop → `status: "COMPLETED"`

Surfaced while validating the rostering dependency de-skew locally in the synthetic-dev mesh.