### PR TITLE
feat(logger): add fleet-wide PII redaction to soa-logger

### DIFF
--- a/apps/node/trpc-api/src/sectors/pubsub/trpc/pubsub-router.ts
+++ b/apps/node/trpc-api/src/sectors/pubsub/trpc/pubsub-router.ts
@@ -44,7 +44,9 @@ export const pubsubRouter = router({
                     pubsubResult: result
                 };
             } catch (error) {
-                ctx.logger.error('Failed to send ping event', error instanceof Error ? error : new Error('Unknown error'), { input });
+                // Log a bounded event identifier, not the whole input — pubsub
+                // payloads are user content (unbounded) and must not land in logs.
+                ctx.logger.error('Failed to send ping event', error instanceof Error ? error : new Error('Unknown error'), { eventName: 'ping:message' });
                 throw new Error(`Failed to send ping: ${error instanceof Error ? error.message : 'Unknown error'}`);
             }
         }),
@@ -96,8 +98,10 @@ export const pubsubRouter = router({
                     message: `Event "${eventName}" sent successfully`
                 };
             } catch (error) {
+                // Log the event name only — never `input`, whose `payload` is
+                // `z.any()` (unbounded user content that could carry PII).
                 ctx.logger.error('Failed to send custom event', error instanceof Error ? error : undefined, {
-                    input
+                    eventName: input.name
                 });
                 throw new Error(`Failed to send event: ${error instanceof Error ? error.message : 'Unknown error'}`);
             }
@@ -160,7 +164,8 @@ export const pubsubRouter = router({
                 };
             } catch (error) {
                 ctx.logger.error('Failed to create subscription', error instanceof Error ? error : undefined, {
-                    input
+                    channel: input.channel,
+                    eventTypes: input.eventTypes
                 });
                 throw new Error(`Failed to subscribe: ${error instanceof Error ? error.message : 'Unknown error'}`);
             }
@@ -185,7 +190,7 @@ export const pubsubRouter = router({
                 };
             } catch (error) {
                 ctx.logger.error('Failed to unsubscribe', error instanceof Error ? error : undefined, {
-                    input
+                    subscriptionId: input.subscriptionId
                 });
                 throw new Error(`Failed to unsubscribe: ${error instanceof Error ? error.message : 'Unknown error'}`);
             }

--- a/packages/node/logger/src/__tests__/pino-logger.unit.test.ts
+++ b/packages/node/logger/src/__tests__/pino-logger.unit.test.ts
@@ -1,6 +1,31 @@
-import { PinoLogger } from '../pino-logger.js';
+import { Writable } from 'node:stream';
+import pino from 'pino';
+import { PinoLogger, redact } from '../pino-logger.js';
 import { PinoLoggerConfig } from '../pino-logger-schema.js';
 import { describe, it, expect, afterEach, vi } from 'vitest';
+
+/**
+ * Capture pino output synchronously by handing it a plain Writable sink.
+ * pino writes to its second-arg stream in-process (no worker thread, no
+ * SonicBoom flush timing), so the redaction assertions are deterministic.
+ * This exercises the exact `redact` config the PinoLogger class wires into
+ * both of its construction paths.
+ */
+function sink() {
+  let text = '';
+  const stream = new Writable({
+    write(chunk, _enc, cb) {
+      text += chunk.toString();
+      cb();
+    },
+  });
+  return {
+    stream,
+    get text() {
+      return text;
+    },
+  };
+}
 
 // Helper to mock process.stdout.isTTY
 function withTTY(value: boolean, fn: () => void) {
@@ -82,6 +107,75 @@ describe('PinoLogger', () => {
     process.env.NODE_ENV = 'local';
     withTTY(true, () => {
       expect(() => new PinoLogger(config)).not.toThrow();
+    });
+  });
+
+  describe('PII redaction (shared `redact` config)', () => {
+    // A bad path list (e.g. ancestor/descendant overlap) makes pino's
+    // fast-redact throw at construction — which would crash this shared
+    // logger fleet-wide. Constructing a logger with `redact` is the guard.
+    it('does not throw when constructing pino with the redact config', () => {
+      expect(() => pino({ redact }, sink().stream)).not.toThrow();
+    });
+
+    it('redacts email in a structured field', () => {
+      const s = sink();
+      pino({ redact }, s.stream).info({ email: 'alice@example.org' }, 'lookup');
+      expect(s.text).toContain('[REDACTED]');
+      expect(s.text).not.toContain('alice@example.org');
+    });
+
+    it('redacts a nested email one level deep (*.email)', () => {
+      const s = sink();
+      pino({ redact }, s.stream).info({ user: { email: 'bob@example.org' } }, 'sync');
+      expect(s.text).not.toContain('bob@example.org');
+    });
+
+    it('redacts student name + dob (FERPA search criteria)', () => {
+      const s = sink();
+      pino({ redact }, s.stream).info(
+        { firstNameNorm: 'jane', lastNameNorm: 'doe', dob: '2010-05-01' },
+        'student.search'
+      );
+      expect(s.text).not.toContain('jane');
+      expect(s.text).not.toContain('doe');
+      expect(s.text).not.toContain('2010-05-01');
+    });
+
+    it('redacts a whole request input/payload/body object wholesale', () => {
+      const s = sink();
+      pino({ redact }, s.stream).error(
+        { input: { email: 'c@example.org', extra: 'secret-value' } },
+        'validation failed'
+      );
+      expect(s.text).not.toContain('c@example.org');
+      expect(s.text).not.toContain('secret-value');
+    });
+
+    it('redacts secrets (password, token, clientSecret)', () => {
+      const s = sink();
+      pino({ redact }, s.stream).info(
+        { password: 'hunter2', token: 'eyJ...', clientSecret: 'shh' },
+        'auth'
+      );
+      expect(s.text).not.toContain('hunter2');
+      expect(s.text).not.toContain('eyJ...');
+      expect(s.text).not.toContain('shh');
+    });
+
+    it('does NOT redact `code` (tRPC error codes / district codes are not PII)', () => {
+      const s = sink();
+      pino({ redact }, s.stream).error({ code: 'NOT_FOUND' }, 'lookup miss');
+      expect(s.text).toContain('NOT_FOUND');
+    });
+
+    it('does NOT redact PII interpolated into the message string (documents the limit)', () => {
+      // pino's redact masks structured KEYS only — never message text. This
+      // is why request-logger strips the query string and PII-bearing reads
+      // move to POST; redaction is defense-in-depth, not the whole fix.
+      const s = sink();
+      pino({ redact }, s.stream).info('looked up alice@example.org');
+      expect(s.text).toContain('alice@example.org');
     });
   });
 });

--- a/packages/node/logger/src/pino-logger.ts
+++ b/packages/node/logger/src/pino-logger.ts
@@ -3,6 +3,65 @@ import pino, { Logger, TransportTargetOptions } from 'pino';
 import { ILogger } from './i-logger.js';
 import type { PinoLoggerConfig } from './pino-logger-schema.js';
 
+/**
+ * Fleet-wide PII redaction for structured log fields. Defense-in-depth so a
+ * caller that logs `{ email }`, a name, a token, or a whole request `input`/
+ * `body`/`payload` doesn't leak it into CloudWatch/Datadog.
+ *
+ * Limits worth knowing (pino's `redact` is not a catch-all):
+ *  - Keys ONLY. It masks structured object fields, never interpolated message
+ *    strings — `logger.info(`user ${email}`)` is NOT redacted. Keep PII out of
+ *    the message text at the call site.
+ *  - Shallow wildcards. `*.email` matches one level; pino has no recursive
+ *    `**`, so we enumerate the shapes PII actually arrives in: top-level, one
+ *    level deep (`*.`), and under the `err` wrapper that `error()` adds.
+ *  - No ancestor/descendant overlap. pino's fast-redact THROWS at construction
+ *    on a path that is both covered by a wildcard parent and listed as a child
+ *    (e.g. `input` + `input.email`) — and that throw would crash this shared
+ *    logger fleet-wide. So request objects are redacted WHOLESALE (`input`,
+ *    `payload`, `body`) with no child paths under them — blunt but safe for
+ *    unbounded user content.
+ *  - `code` is deliberately NOT redacted (tRPC error codes, HTTP status, and
+ *    district codes all use it); one-time/auth codes use specific keys
+ *    (`otp`, `authCode`).
+ */
+const REDACT_PATHS = [
+  // Email
+  'email',
+  '*.email',
+  'err.email',
+  // Names (raw + the normalized variants the student search uses)
+  'name',
+  '*.name',
+  'firstName',
+  'lastName',
+  'firstNameNorm',
+  'lastNameNorm',
+  '*.firstNameNorm',
+  '*.lastNameNorm',
+  // Date of birth (FERPA)
+  'dob',
+  '*.dob',
+  // Secrets / tokens / one-time codes
+  'password',
+  '*.password',
+  'token',
+  '*.token',
+  'accessToken',
+  'refreshToken',
+  'clientSecret',
+  'otp',
+  'authCode',
+  // Unbounded user-content objects — redacted WHOLESALE (no child paths under
+  // these, see the overlap note above)
+  'input',
+  'payload',
+  'body',
+] as const;
+
+/** Shared so both pino construction paths (prod stdout + transport) redact identically. */
+export const redact = { paths: [...REDACT_PATHS], censor: '[REDACTED]' };
+
 @injectable()
 export class PinoLogger implements ILogger {
   private readonly logger: Logger;
@@ -27,7 +86,7 @@ export class PinoLogger implements ILogger {
     // driver → CloudWatch.
     if (env === 'production' && isExpressContext) {
       const dest = pinoFn.destination({ dest: logFile ?? 1, sync: false });
-      this.logger = pinoFn({ level: config.level }, dest);
+      this.logger = pinoFn({ level: config.level, redact }, dest);
       this.logger.info(`Logger initialized with level ${config.level}`);
       return;
     }
@@ -95,6 +154,7 @@ export class PinoLogger implements ILogger {
 
     this.logger = pinoFn({
       level: config.level,
+      redact,
       transport: {
         targets,
       },


### PR DESCRIPTION
Part of a fleet-wide PII-in-logs sweep (saga-ed/student-data-system#201).

`PinoLogger` was bare pino — no `redact` paths — so every structured field a caller logged (email, student name, dob, token, a whole request `input`) reached CloudWatch/Datadog verbatim. Add a shared `redact` config wired into **both** construction paths (prod stdout early-return + transport) so they cannot drift.

**Scope / gotchas (documented + tested):**
- Masks structured **keys only**, never interpolated message strings — `logger.info(`user ${email}`)` is NOT redacted. Defense-in-depth, not a substitute for keeping PII out of message text / URLs.
- `input` / `payload` / `body` are redacted **wholesale**. Listing child paths under a wildcard parent makes pino fast-redact **throw at construction**, which would crash this shared logger fleet-wide — a construction-guard test covers that.
- `code` is deliberately **not** redacted (tRPC error codes, HTTP status, district codes use it); one-time codes use `otp` / `authCode`.
- Does not touch infra access logs.

Verified: 13 logger tests pass (8 new — email, nested email, name+dob, wholesale input, secrets, `code`-preserved, message-not-redacted, construction-guard).

---

**Update — also includes a Moderate from the same sweep:** the pubsub tRPC error/info logs no longer dump the full `input` (whose `payload` is `z.any()`); they log bounded identifiers (`eventName`/`channel`/`subscriptionId`) instead. Complements the redaction above. `trpc-api` typechecks clean.
