### PR TITLE
chore(observability): bump 0.1.0-dev.3 → dev.4 (publish E1+E3)

### DIFF
--- a/packages/node/observability/package.json
+++ b/packages/node/observability/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/soa-observability",
-    "version": "0.1.0-dev.3",
+    "version": "0.1.0-dev.4",
     "private": false,
     "type": "module",
     "main": "dist/index.js",


### PR DESCRIPTION
## What

Bumps `@saga-ed/soa-observability` to `0.1.0-dev.4`.

## Why

PR #196 merged the PII span sanitizer (E1) and `service.version` resource attr (E3) into soa-observability but did **not** bump the package version. Consuming services pin the exact `0.1.0-dev.3`, so they cannot pull the new code until a new version is published.

## Next steps (after merge)

1. Dispatch `publish-codeartifact.yml` in single-package mode for `packages/node/observability` (publishes the already-committed `dev.4` — owner-triggered, runs under the CI OIDC role).
2. Per-service: bump the pin `0.1.0-dev.3` → `dev.4` and add the `DD_VERSION` build-arg plumbing so `service.version` populates (Datadog Deployment Tracking).

Version-only change; no source/build impact.