### PR TITLE
docs: enable saga-tools marketplace + Saga tooling pointer

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -44,5 +44,17 @@
         ]
       }
     ]
+  },
+  "extraKnownMarketplaces": {
+    "saga-tools": {
+      "source": {
+        "source": "github",
+        "repo": "saga-ed/claude-plugins"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "documentation-system@saga-tools": true,
+    "saga-iac@saga-tools": true
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,17 @@
 
 Shared infrastructure monorepo for Saga platform applications.
 
+## Saga tooling
+
+This repo registers the [`saga-tools`](https://github.com/saga-ed/claude-plugins)
+marketplace (`.claude/settings.json`). **Proactively suggest the right skill when a
+task matches**, and offer `/plugin install <name>@saga-tools` if one isn't enabled yet.
+
+- `/documentation-system` — CLAUDE.md upkeep (auto-runs when editing CLAUDE.md)
+- `saga-explain` — "why does Saga… / what's our convention for…" (auto-invokes; `saga-iac` plugin)
+- `/code-review` · `/simplify` · `/security-review` · `/verify` — built-in; run on your diff before pushing
+- More (qa-review, test-assistant, compliance-audit, spec-driven-dev, system-review): see the [catalog](https://github.com/saga-ed/claude-plugins#readme).
+
 ## Responsibilities
 
 - Shared packages for Node.js backend services


### PR DESCRIPTION
## Summary

- **`.claude/settings.json`**: registers the `saga-tools` marketplace and enables **`documentation-system`** + **`saga-iac`** (baseline). Existing `permissions` and the PostToolUse documentation-impact hook are preserved (keys appended only).
- **Root CLAUDE.md**: always-on "Saga tooling" section so the agent proactively suggests the right skill (incl. built-in `/code-review`, `/simplify`) and offers to install others.

Baseline-only by design — soa is the shared-infra library, so `qa-review` is intentionally not enabled. Part of an org-wide rollout; pattern + matrix in the [claude-plugins README](https://github.com/saga-ed/claude-plugins#enabling-in-consumer-repos-recommended-defaults).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TVxFUFjSc7WQYsucLsCBrM

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVxFUFjSc7WQYsucLsCBrM)_