### PR TITLE
fix(synthetic-dev): wire ads-adm-api to local iam (IAM_API_URL + JWT_ISSUER)

### DIFF
--- a/tools/synthetic-dev/up.sh
+++ b/tools/synthetic-dev/up.sh
@@ -1441,6 +1441,7 @@ services_up(){
      ADS_ADM_SCHEDULE_PROVIDER=program-hub \
      SESSIONS_API_CLIENT_BASEURL=http://localhost:3007 \
      IAM_API_CLIENT_BASEURL=http://localhost:3010/trpc \
+     IAM_API_URL="$IAM_URL" JWT_ISSUER="https://iam.saga.org" \
      SERVICE_TOKEN_SERVICESLUG=ads-adm-api \
      ADS_ADM_DATABASE_URL=postgresql://ads_adm:ads_adm@localhost:5432/ads_adm_local \
      DATABASE_URL=postgresql://ads_adm:ads_adm@localhost:5432/ads_adm_local \


### PR DESCRIPTION
## Problem

`up.sh` launches `ads-adm-api` (:5005) with `IAM_API_CLIENT_BASEURL` only. ads-adm-api's auth (`student-data-system/apps/node/ads-adm-api/src/inversify.config.ts:170`) reads **`IAM_API_URL`** for its JWKS source and **defaults to `https://iam.wootdev.com`** when unset. On the local synthetic-dev stack that issuer is unreachable, so tutor `iam_session` cookies fail JWT verification:

```
[iam-auth] iam_session JWT verification failed (issuer=https://iam.wootdev.com, audience=saga-platform): fetch failed
```

Tutor-scoped ADS/ADM attendance reads then 401/empty. Admin and service-token paths are unaffected (different auth), so the only visible symptom is tutor reads — which **stalled the stage-8 `attendance-personas` journey e2e** (the SESSION-mode tutor read timed out waiting on `getAttendanceByPrograms`).

## Fix

Add `IAM_API_URL="$IAM_URL" JWT_ISSUER="https://iam.saga.org"` to the `ads-adm-api` `launch_if` block, mirroring how `connect-api` is already wired (it carries the same comment: "its issuer default is the wootdev iam, so override JWT_ISSUER to local iam-api's default"). One additive line; no other services touched.

## Verification

With the stale ads-adm-api process killed and relaunched via this wiring, the `iam.wootdev.com` errors disappear (verified in `/tmp/sds-synthetic/ads-adm-api.log`) and the SESSION-mode tutor attendance view renders the roster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)