### PR TITLE
feat(soa-logger): inject OTel trace/span IDs into structured logs

### DIFF
--- a/packages/node/logger/package.json
+++ b/packages/node/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saga-ed/soa-logger",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "private": false,
   "scripts": {
     "dev": "tsup --watch",
@@ -19,6 +19,7 @@
     }
   },
   "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
     "inversify": "^6.2.2",
     "pino": "^8.15.0",
     "pino-pretty": "^10.3.1",
@@ -27,6 +28,8 @@
     "zod": "3.25.67"
   },
   "devDependencies": {
+    "@opentelemetry/context-async-hooks": "^1.28.0",
+    "@opentelemetry/sdk-trace-base": "^1.28.0",
     "@saga-ed/soa-typescript-config": "workspace:*",
     "@types/node": "latest",
     "tsup": "^8.5.0",

--- a/packages/node/logger/src/__tests__/pino-logger.unit.test.ts
+++ b/packages/node/logger/src/__tests__/pino-logger.unit.test.ts
@@ -1,6 +1,8 @@
 import { Writable } from 'node:stream';
 import pino from 'pino';
-import { PinoLogger, redact } from '../pino-logger.js';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
+import { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
+import { PinoLogger, redact, traceCorrelationMixin } from '../pino-logger.js';
 import { PinoLoggerConfig } from '../pino-logger-schema.js';
 import { describe, it, expect, afterEach, vi } from 'vitest';
 
@@ -176,6 +178,56 @@ describe('PinoLogger', () => {
       const s = sink();
       pino({ redact }, s.stream).info('looked up alice@example.org');
       expect(s.text).toContain('alice@example.org');
+    });
+  });
+
+  describe('trace/log correlation (`mixin` config)', () => {
+    // `trace.getActiveSpan()` reads from the GLOBAL context manager, not
+    // from the provider/tracer directly — `startActiveSpan` is a no-op for
+    // propagation unless both the provider AND a context manager are
+    // registered globally (sdk-trace-base ships neither by default; real
+    // services get this via `NodeSDK.start()` in soa-observability).
+    const provider = new BasicTracerProvider();
+    provider.register({ contextManager: new AsyncLocalStorageContextManager() });
+    const tracer = provider.getTracer('pino-logger.unit.test');
+
+    it('adds no trace_id/span_id when there is no active span', () => {
+      const s = sink();
+      pino({ mixin: traceCorrelationMixin }, s.stream).info('startup');
+      const line = JSON.parse(s.text);
+      expect(line.trace_id).toBeUndefined();
+      expect(line.span_id).toBeUndefined();
+    });
+
+    it("adds trace_id/span_id matching the active span, in Datadog's expected hex format", () => {
+      const s = sink();
+      const logger = pino({ mixin: traceCorrelationMixin }, s.stream);
+
+      tracer.startActiveSpan('test-span', span => {
+        const spanContext = span.spanContext();
+        logger.info('handled request');
+
+        const line = JSON.parse(s.text);
+        expect(line.trace_id).toBe(spanContext.traceId);
+        expect(line.span_id).toBe(spanContext.spanId);
+        expect(line.trace_id).toMatch(/^[0-9a-f]{32}$/);
+        expect(line.span_id).toMatch(/^[0-9a-f]{16}$/);
+
+        span.end();
+      });
+    });
+
+    it('does not collide with PII redaction when both are configured together', () => {
+      const s = sink();
+      const logger = pino({ redact, mixin: traceCorrelationMixin }, s.stream);
+
+      tracer.startActiveSpan('test-span-2', span => {
+        logger.info({ email: 'alice@example.org' }, 'lookup');
+        const line = JSON.parse(s.text);
+        expect(line.email).toBe('[REDACTED]');
+        expect(line.trace_id).toBe(span.spanContext().traceId);
+        span.end();
+      });
     });
   });
 });

--- a/packages/node/logger/src/pino-logger.ts
+++ b/packages/node/logger/src/pino-logger.ts
@@ -1,5 +1,6 @@
 import { injectable, inject } from 'inversify';
 import pino, { Logger, TransportTargetOptions } from 'pino';
+import { trace } from '@opentelemetry/api';
 import { ILogger } from './i-logger.js';
 import type { PinoLoggerConfig } from './pino-logger-schema.js';
 
@@ -62,6 +63,25 @@ const REDACT_PATHS = [
 /** Shared so both pino construction paths (prod stdout + transport) redact identically. */
 export const redact = { paths: [...REDACT_PATHS], censor: '[REDACTED]' };
 
+/**
+ * Merges the active OTel span's trace/span IDs into every log line so
+ * Datadog can link a log to its trace. pino calls this on each log call
+ * (cheaper than wrapping every public method) and merges the result under
+ * the log object. `trace.getActiveSpan()` returns undefined outside a
+ * traced context (e.g. startup messages), so those logs are unaffected.
+ *
+ * OTel's SpanContext.traceId/spanId are already lowercase hex strings
+ * (32/16 chars) per the W3C Trace Context spec — the exact format Datadog
+ * expects for its `trace_id`/`span_id` log fields, no conversion needed.
+ */
+export function traceCorrelationMixin(): Record<string, string> {
+  const spanContext = trace.getActiveSpan()?.spanContext();
+  if (!spanContext) {
+    return {};
+  }
+  return { trace_id: spanContext.traceId, span_id: spanContext.spanId };
+}
+
 @injectable()
 export class PinoLogger implements ILogger {
   private readonly logger: Logger;
@@ -86,7 +106,7 @@ export class PinoLogger implements ILogger {
     // driver → CloudWatch.
     if (env === 'production' && isExpressContext) {
       const dest = pinoFn.destination({ dest: logFile ?? 1, sync: false });
-      this.logger = pinoFn({ level: config.level, redact }, dest);
+      this.logger = pinoFn({ level: config.level, redact, mixin: traceCorrelationMixin }, dest);
       this.logger.info(`Logger initialized with level ${config.level}`);
       return;
     }
@@ -155,6 +175,7 @@ export class PinoLogger implements ILogger {
     this.logger = pinoFn({
       level: config.level,
       redact,
+      mixin: traceCorrelationMixin,
       transport: {
         targets,
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@25.9.3)(jsdom@25.0.1)
+        version: 1.6.1(@types/node@24.0.12)(jsdom@25.0.1)
 
   apps/node/gql-api:
     dependencies:
@@ -53,7 +53,7 @@ importers:
         version: link:../../../packages/node/logger
       '@types/mongodb':
         specifier: ^4.0.7
-        version: 4.0.7(@aws-sdk/credential-providers@3.1054.0)(socks@2.8.7)
+        version: 4.0.7(@aws-sdk/credential-providers@3.1054.0)(gcp-metadata@6.1.1)(socks@2.8.7)
       express:
         specifier: ^4.18.2
         version: 4.22.1
@@ -120,7 +120,7 @@ importers:
         version: link:../../../packages/node/logger
       '@types/mongodb':
         specifier: ^4.0.7
-        version: 4.0.7(@aws-sdk/credential-providers@3.1054.0)(socks@2.8.7)
+        version: 4.0.7(@aws-sdk/credential-providers@3.1054.0)(gcp-metadata@6.1.1)(socks@2.8.7)
       express:
         specifier: ^4.18.2
         version: 4.22.1
@@ -181,7 +181,7 @@ importers:
         version: link:../../../packages/node/logger
       '@types/mongodb':
         specifier: ^4.0.7
-        version: 4.0.7(@aws-sdk/credential-providers@3.1054.0)(socks@2.8.7)
+        version: 4.0.7(@aws-sdk/credential-providers@3.1054.0)(gcp-metadata@6.1.1)(socks@2.8.7)
       express:
         specifier: ^4.18.2
         version: 4.22.1
@@ -309,7 +309,7 @@ importers:
         version: 11.8.0(typescript@5.9.3)
       '@types/mongodb':
         specifier: ^4.0.7
-        version: 4.0.7(@aws-sdk/credential-providers@3.1054.0)(socks@2.8.7)
+        version: 4.0.7(@aws-sdk/credential-providers@3.1054.0)(gcp-metadata@6.1.1)(socks@2.8.7)
       express:
         specifier: ^4.18.2
         version: 4.22.1
@@ -484,7 +484,7 @@ importers:
         version: 4.22.1
       mongodb:
         specifier: ^6.0.0
-        version: 6.21.0(@aws-sdk/credential-providers@3.1054.0)(socks@2.8.7)
+        version: 6.21.0(@aws-sdk/credential-providers@3.1054.0)(gcp-metadata@6.1.1)(socks@2.8.7)
       mysql2:
         specifier: ^3.0.0
         version: 3.20.0(@types/node@25.9.3)
@@ -932,10 +932,10 @@ importers:
         version: 6.2.2(reflect-metadata@0.2.2)
       mongodb:
         specifier: ^6.12.0
-        version: 6.21.0(@aws-sdk/credential-providers@3.1054.0)(socks@2.8.7)
+        version: 6.21.0(@aws-sdk/credential-providers@3.1054.0)(gcp-metadata@6.1.1)(socks@2.8.7)
       mongodb-memory-server:
         specifier: ^10.1.4
-        version: 10.4.2(@aws-sdk/credential-providers@3.1054.0)(socks@2.8.7)
+        version: 10.4.2(@aws-sdk/credential-providers@3.1054.0)(gcp-metadata@6.1.1)(socks@2.8.7)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -1154,7 +1154,7 @@ importers:
         version: 6.2.2(reflect-metadata@0.2.2)
       mongodb:
         specifier: ^6.0.0
-        version: 6.21.0(@aws-sdk/credential-providers@3.1054.0)(socks@2.8.7)
+        version: 6.21.0(@aws-sdk/credential-providers@3.1054.0)(gcp-metadata@6.1.1)(socks@2.8.7)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -1249,6 +1249,9 @@ importers:
 
   packages/node/logger:
     dependencies:
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.1
       inversify:
         specifier: ^6.2.2
         version: 6.2.2(reflect-metadata@0.2.2)
@@ -1268,6 +1271,12 @@ importers:
         specifier: 3.25.67
         version: 3.25.67
     devDependencies:
+      '@opentelemetry/context-async-hooks':
+        specifier: ^1.28.0
+        version: 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^1.28.0
+        version: 1.30.1(@opentelemetry/api@1.9.1)
       '@saga-ed/soa-typescript-config':
         specifier: workspace:*
         version: link:../../core/typescript-config
@@ -1521,7 +1530,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@25.9.3)(jsdom@25.0.1)
+        version: 1.6.1(@types/node@24.0.12)(jsdom@25.0.1)
 
   packages/node/pubsub-server:
     dependencies:
@@ -1632,7 +1641,7 @@ importers:
         version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@25.9.3)(jsdom@25.0.1)
+        version: 1.6.1(@types/node@24.0.12)(jsdom@25.0.1)
 
   packages/node/test-util:
     dependencies:
@@ -1670,7 +1679,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@25.9.3)(jsdom@25.0.1)
+        version: 1.6.1(@types/node@24.0.12)(jsdom@25.0.1)
 
   packages/web/ui:
     dependencies:
@@ -14905,9 +14914,9 @@ snapshots:
     dependencies:
       minimatch: 10.2.5
 
-  '@types/mongodb@4.0.7(@aws-sdk/credential-providers@3.1054.0)(socks@2.8.7)':
+  '@types/mongodb@4.0.7(@aws-sdk/credential-providers@3.1054.0)(gcp-metadata@6.1.1)(socks@2.8.7)':
     dependencies:
-      mongodb: 6.21.0(@aws-sdk/credential-providers@3.1054.0)(socks@2.8.7)
+      mongodb: 6.21.0(@aws-sdk/credential-providers@3.1054.0)(gcp-metadata@6.1.1)(socks@2.8.7)
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
       - '@mongodb-js/zstd'
@@ -16656,8 +16665,8 @@ snapshots:
       '@typescript-eslint/parser': 8.50.0(eslint@8.57.1)(typescript@5.8.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -16700,21 +16709,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 8.57.1
-      get-tsconfig: 4.13.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.15
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -16726,22 +16720,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.50.0(eslint@8.57.1)(typescript@5.8.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -16752,7 +16746,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -16763,7 +16757,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -16792,7 +16786,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -18518,7 +18512,7 @@ snapshots:
       '@types/whatwg-url': 11.0.5
       whatwg-url: 14.2.0
 
-  mongodb-memory-server-core@10.4.2(@aws-sdk/credential-providers@3.1054.0)(socks@2.8.7):
+  mongodb-memory-server-core@10.4.2(@aws-sdk/credential-providers@3.1054.0)(gcp-metadata@6.1.1)(socks@2.8.7):
     dependencies:
       async-mutex: 0.5.0
       camelcase: 6.3.0
@@ -18526,7 +18520,7 @@ snapshots:
       find-cache-dir: 3.3.2
       follow-redirects: 1.15.11(debug@4.4.3)
       https-proxy-agent: 7.0.6
-      mongodb: 6.21.0(@aws-sdk/credential-providers@3.1054.0)(socks@2.8.7)
+      mongodb: 6.21.0(@aws-sdk/credential-providers@3.1054.0)(gcp-metadata@6.1.1)(socks@2.8.7)
       new-find-package-json: 2.0.0
       semver: 7.7.3
       tar-stream: 3.1.7
@@ -18544,9 +18538,9 @@ snapshots:
       - socks
       - supports-color
 
-  mongodb-memory-server@10.4.2(@aws-sdk/credential-providers@3.1054.0)(socks@2.8.7):
+  mongodb-memory-server@10.4.2(@aws-sdk/credential-providers@3.1054.0)(gcp-metadata@6.1.1)(socks@2.8.7):
     dependencies:
-      mongodb-memory-server-core: 10.4.2(@aws-sdk/credential-providers@3.1054.0)(socks@2.8.7)
+      mongodb-memory-server-core: 10.4.2(@aws-sdk/credential-providers@3.1054.0)(gcp-metadata@6.1.1)(socks@2.8.7)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
@@ -18569,13 +18563,14 @@ snapshots:
       '@aws-sdk/credential-providers': 3.1054.0
       '@mongodb-js/saslprep': 1.4.4
 
-  mongodb@6.21.0(@aws-sdk/credential-providers@3.1054.0)(socks@2.8.7):
+  mongodb@6.21.0(@aws-sdk/credential-providers@3.1054.0)(gcp-metadata@6.1.1)(socks@2.8.7):
     dependencies:
       '@mongodb-js/saslprep': 1.4.4
       bson: 6.10.4
       mongodb-connection-string-url: 3.0.2
     optionalDependencies:
       '@aws-sdk/credential-providers': 3.1054.0
+      gcp-metadata: 6.1.1
       socks: 2.8.7
 
   ms@2.0.0: {}


### PR DESCRIPTION
## Summary

Part of [hipponot/iac#486](https://github.com/hipponot/iac/issues/486) — fleet-wide check showed `dd.trace_id` (or any trace-correlation field) on 0 of 9,477 iam-api logs sampled over 1h, so structured logs and APM traces can't be linked in Datadog even though OTel tracing is working fine server-side.

- Adds a pino `mixin` to `PinoLogger` that merges `trace_id`/`span_id` from the active OTel span (`trace.getActiveSpan()?.spanContext()`) into every log line, when one exists.
- Wired into **both** pino construction paths in this class — the production/Express stdout-destination path (line 89, what ECS/Fargate actually runs) and the local/dev transport path (line ~155) — a single-site fix would silently miss the deployed fleet.
- Field names/format follow Datadog's OTel correlation docs: top-level `trace_id` (32-char lowercase hex) / `span_id` (16-char lowercase hex). The OTel JS SDK's `SpanContext` is already in this exact format — no conversion needed.
- Adds `@opentelemetry/api` as a direct dependency (previously only present transitively via the sibling `soa-observability` package — fragile to rely on).
- 3 new tests alongside the existing PII-redaction suite, using the same `sink()`-stream pattern: no active span → no fields added; active span → `trace_id`/`span_id` match the span's own context and pass the hex-format regex; mixin + `redact` both configured together don't collide (PII still redacted, trace fields still present).

## Why version bump (1.1.3 → 1.2.0)

This package is a shared fleet-wide dependency — there's no way to scope a code change to one service. So the POC is **version-scoped**: this PR lands the capability, then exactly one service (iam-api, the service used to confirm the original gap) bumps to 1.2.0 in dev and gets verified against real Datadog data (a log line click-throughs to its trace — not just that the field is present) before any fleet-wide bump.

## Test plan

- [x] `pnpm test` — 16/16 pass (incl. 3 new trace-correlation tests + a redaction-collision check)
- [x] `pnpm build` — clean, no type errors
- [ ] iam-api POC: bump to 1.2.0 in dev, deploy, confirm via Datadog MCP that a log's `trace_id` matches a real APM trace and click-throughs correctly
- [ ] Fleet-wide version bump (separate PRs, after POC passes)