### PR TITLE
feat(synthetic-dev): wire coach into tunnel mode

### DIFF
--- a/tools/synthetic-dev/tunnel.sh
+++ b/tools/synthetic-dev/tunnel.sh
@@ -64,6 +64,8 @@ SERVICES=(
     "connect:6210"
     "connect-api:6106"
     "rtsm:6110"
+    "coach:8800"
+    "coach-api:6105"
 )
 
 say(){  printf "\033[34m→\033[0m %s\n" "$*" >&2; }
@@ -250,7 +252,7 @@ tunnel_status(){
     for entry in "${SERVICES[@]}"; do
         name=${entry%:*}; port=${entry#*:}
         code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 \
-            "https://$name.$m.$VMS_BASE$( [[ "$name" == dash || "$name" == connect ]] && echo / || { [[ "$name" == connect-api ]] && echo /connectv3/v1/health || echo /health; })" 2>/dev/null)
+            "https://$name.$m.$VMS_BASE$( [[ "$name" == dash || "$name" == connect || "$name" == coach ]] && echo / || { [[ "$name" == connect-api ]] && echo /connectv3/v1/health || echo /health; })" 2>/dev/null)
         printf "  %-12s https://%s.%s.%s → %s\n" "$name" "$name" "$m" "$VMS_BASE" "$code" >&2
     done
 }

--- a/tools/synthetic-dev/up.sh
+++ b/tools/synthetic-dev/up.sh
@@ -1362,6 +1362,21 @@ tunnel_env(){ # svc
       printf '%s\n' "FLEET_CONFIG_PATH=$STATE/rtsm-fleet-tunnel.json" ;;
     saga-dash)
       printf '%s\n' "__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS=dash.$TUNNEL_DOMAIN" ;;
+    coach-api)
+      # EXPRESS_SERVER_CORSALLOWEDDOMAINS is coach's hostname allow-list (comma-
+      # split; api-core matches origin.hostname === d || endsWith(".d")), so the
+      # bare tunnel domain admits coach.$TUNNEL_DOMAIN — and any other tunnel
+      # label — without enumerating them. Keep $COACH_WEB_HOST (localhost) so a
+      # local browser still works alongside remote ones. Splats after the launch
+      # line's CORS value, so this wins (env last-wins).
+      printf '%s\n' "EXPRESS_SERVER_CORSALLOWEDDOMAINS=$COACH_WEB_HOST,$TUNNEL_DOMAIN" ;;
+    coach-web)
+      # PUBLIC_COACH_API_URL is BROWSER-side (SvelteKit PUBLIC_ var read at
+      # vite-dev time): a remote coworker's browser must reach coach-api via its
+      # public tunnel name, not localhost:6105. iam stays behind coach-api (the
+      # cookie composition lives server-side, coach#94), so nothing else flips.
+      printf '%s\n' "PUBLIC_COACH_API_URL=https://coach-api.$TUNNEL_DOMAIN" \
+                    "__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS=coach.$TUNNEL_DOMAIN" ;;
     *) ;; # everything else: dev CORS wildcard already admits *.wootdev.com
   esac
 }

--- a/tools/synthetic-dev/verify.sh
+++ b/tools/synthetic-dev/verify.sh
@@ -28,7 +28,7 @@ DEV=${DEV:-$HOME/dev}
 # PRs merged); without an overlay entry, on main. soa + student-data-system are
 # always on main — except a soa overlay-manifest row, which pins soa itself
 # (testing a synthetic-dev/infra tooling PR end-to-end; see the posture loop).
-MANAGED_REPOS="rostering program-hub saga-dash qboard rtsm"
+MANAGED_REPOS="rostering program-hub saga-dash coach qboard rtsm"
 ALWAYS_MAIN_REPOS="soa student-data-system"
 
 pass=0; fail=0; warn=0
@@ -59,6 +59,10 @@ probe saga-dash      8900 /
 probe rtsm-api       6110 /health
 probe connect-api    6106 /connectv3/v1/health
 probe connect-web    6210 /
+# coach-api mounts /health at the app ROOT (not under /coach/v1 — see up.sh
+# probe_path); coach-web is a vite SPA answering on /.
+probe coach-api      6105 /health
+probe coach-web      8800 /
 # Recording stack is OPT-IN (./up.sh --record) — assert it only when its
 # containers are actually up; otherwise note it without failing.
 if docker ps --format '{{.Names}}' 2>/dev/null | grep -qx fleek-recorder; then


### PR DESCRIPTION
Coach landed in `up.sh` after tunnel mode, so a `--tunnel` stack exposed every service to remote browsers **except coach**. This wires it in so `https://coach.<moniker>.vms.wootdev.com` works for a shared/group smoke test.

- **tunnel.sh**: `SERVICES` += `coach:8800`, `coach-api:6105`; status probe treats coach as a `/`-answering SPA (coach-api keeps `/health` at app root).
- **up.sh `tunnel_env()`**: `coach-api` → `EXPRESS_SERVER_CORSALLOWEDDOMAINS=$COACH_WEB_HOST,$TUNNEL_DOMAIN` (hostname allow-list; api-core's subdomain match makes the bare tunnel domain admit `coach.<moniker>…`). `coach-web` → `PUBLIC_COACH_API_URL=https://coach-api.$TUNNEL_DOMAIN` (browser-side SvelteKit var) + `__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS=coach.$TUNNEL_DOMAIN` (vite 7 host check). Session cookie already flows via the iam-api case's `.<moniker>.vms.wootdev.com` scope.
- **verify.sh**: coach-api/coach-web health probes; coach added to `MANAGED_REPOS`.

Verified: `bash -n` + shellcheck clean (remaining warnings pre-date this change); CORS comma-split confirmed in coach-api `config/schemas.ts`; subdomain matching confirmed in soa `api-core/src/express-server.ts`.

Base is `synthetic-dev-coach` (the coach integration lives there, not yet on main).