### PR TITLE
M7 — multi-instance / --slot for saga-stack-cli (infra + CLI phases)

### DIFF
--- a/claude/projects/gh_214/plans/04-m7-multi-instance.md
+++ b/claude/projects/gh_214/plans/04-m7-multi-instance.md
@@ -1,115 +1,181 @@
-# M7 — multi-instance / concurrent stacks (`--slot`) (#214)
+<!-- Definitive M7 plan — synthesized by the m7-multi-instance-design ultracode (wf_b992c55a-e3b), grounded in current code. Supersedes the prior draft. -->
 
-> Plan for running 2+ isolated synthetic-dev stacks on one machine via the CLI, so
-> agents on different initiatives stop competing for the single stack. Built on the
-> analysis in `../research/06-multi-instance-analysis.md`; retargets the
-> `multi-synthetic-dev` bash spec onto saga-stack-cli. Architecture A (separate mesh
-> per instance). Depends on the M4 native path soaking (`02-handoff-and-status.md`).
+# M7 — Multi-Instance ("slots") for saga-stack-cli — Definitive Implementation Plan
 
-## Context
+**Status:** supersedes `plans/04-m7-multi-instance.md`. Grounded in current code (coach/bundles/skip-guard landed). Architecture A (a separate mesh per slot). Slot 0 is byte-identical to today and up.sh-compatible.
 
-The synthetic-dev stack assumes one instance per host (fixed ports, `STATE=/tmp/sds-synthetic`,
-`COMPOSE_PROJECT_NAME=soa`, profile-keyed postgres volume, in-tree `pnpm dev`). Two
-agents → `--reset` wipes each other, ports collide, `--down` kills the wrong stack.
-The prior `multi-synthetic-dev` track specced the fix in bash; we build it in the CLI
-instead — the manifest + `LaunchContext` already centralize what an instance key must
-offset, so this is a small contained feature, not a 30-call-site bash refactor.
+**Verified against source** (`/home/skelly/dev/soa/packages/node/saga-stack-cli` + `/home/skelly/dev/soa/infra`): `launch-plan.ts:346-419`, `mesh.ts:107-194`, `up.ts:388-416`, `shared-flags.ts:74-92`, `dash-defaults.ts:100-108`, `probe-plan.ts:57-72`, `preflight.ts:74-91`, `snapshot-store.ts:48-96`, `infra/Makefile:29,49,112,186-188`, and the four `services/*/compose.yml` volume blocks.
 
-## Model: one instance key derives everything (Architecture A)
+---
 
-A single `--slot <n>` (and/or `--instance <key>`) drives a pure derivation. `SLOT=0`
-reproduces today byte-for-byte (the regression guard).
+## 1. Chosen slot model
 
-| Derived | Formula | SLOT 0 | SLOT 1 |
+**Decision: deterministic port-offset (`offset = slot * 1000`) + project-suffixed namespace (`soa-s<slot>`), derived by one pure factory `deriveInstance({ slot })`. Numeric slots for MVP; a name→slot registry is a deferred enhancement, not MVP.**
+
+### Why this synthesis (and not the pure-registry `namespace` proposal)
+
+- **Determinism beats registry for the parallel-dev hot path.** The `namespace` proposal's `allocateSlot` (flock'd `slots.json` + live PortProbe + prune) solves *arbitrary string names* and *foreign-squatter detection* — real problems, but not M7's problem. Two agents running `--slot 1` / `--slot 2` need reproducible, stateless port math they can reason about, not a persisted allocator with a corruption/staleness failure mode. The registry is **strictly additive later**: it can wrap `deriveInstance` (name → stable numeric slot) without changing any downstream seam.
+- **But adopt the registry's two best ideas as pure, stateless checks:** (a) **derive generically over every manifest service + mesh unit + token — never a curated port table** (this is why coach/recorder/recordings/connect-web slot for free; the prior plan's hand-maintained table is already stale). (b) **`deriveInstance` asserts full-set port disjointness** (all services + mesh + mgmt + recorder/recordings) before returning — the `validate-then-commit` idea, minus the persistence.
+- **Stride 1000, not 100.** Verified collisions at +100: `rtsm-api 6110→6210` == `connect-web` base 6210; `coach-web 8800→8900` == `saga-dash` base 8900. I checked all base ports (3006–3010, 3100, 5005, 5432, 5672, 6105, 6106, 6110, 6210, 6301-6303, 6379, 7890, 8444, 8800, 8900, 15672, 27037): **no two are a multiple of 1000 apart**, so stride 1000 is cross-slot collision-free for any slot count by construction. The disjointness assertion stays anyway as a guard for future services and recorder/recordings.
+
+### Exact slot keying (the contract `deriveInstance` returns)
+
+`deriveInstance({ slot }) → InstanceProfile`. Slot 0 returns today's constants **verbatim** (the regression guard):
+
+| Key | Slot 0 (byte-identical to today) | Slot N (N ≥ 1) | Mechanism / seam |
 |---|---|---|---|
-| `OFFSET` | `SLOT*100` | 0 | 100 |
-| service ports | `base + OFFSET` (saga-dash `8900 + SLOT`) | 3010/3006/…/8900 | 3110/3106/…/8901 |
-| mesh ports | `base + OFFSET` | 5432/6379/5672/15672/27037 | 5532/6479/5772/15772/27137 |
-| `COMPOSE_PROJECT_NAME` | `soa-s$SLOT` (or `soa-$KEY`) | `soa` | `soa-s1` |
-| mesh container names | `${project}-<unit>-1` | `soa-postgres-1` | `soa-s1-postgres-1` |
-| `SEED_PROFILE` | `$KEY` (volume isolation) | `empty` (today) | `s1` |
-| `STATE` | `/tmp/sds-synthetic[-$KEY]` | `/tmp/sds-synthetic` | `/tmp/sds-synthetic-s1` |
-| repo roots (`DEV`) | per-instance git worktrees | `$HOME/dev/<repo>` | `$HOME/dev/wt/s1/<repo>` |
+| `offset` | `0` | `N * 1000` | applied to every service + mesh port |
+| `project` (COMPOSE_PROJECT_NAME) | `soa` | `soa-s<N>` | env into `make up`/`down` — **requires Makefile `?=`** |
+| `stateDir` | `/tmp/sds-synthetic` | `/tmp/sds-synthetic-s<N>` | default for `--state-dir` → `getLauncher` |
+| `snapshotsDir` | *(unset → `~/.saga-mesh/snapshots`)* | `~/.saga-mesh/snapshots-s<N>` | `SAGA_MESH_SNAPSHOTS_DIR` env |
+| `containerEnv` | *(none)* | `SAGA_MESH_{POSTGRES,REDIS,RABBITMQ,MONGO}_CONTAINER = soa-s<N>-<unit>-1` | existing override seam |
+| `seedProfile` | `empty` | `empty` (**unchanged — load-bearing**) | `PROFILE=empty` stays |
+| volumes | `postgres-profile-empty`, `redis-data`, … (today) | `soa-s<N>_postgres-data`, `soa-s<N>_redis-data`, … | **compose `name:` dropped** → project-prefixed |
+| DB names | unchanged | unchanged (Arch A) | no manifest DB rename |
+| dash config | `config.local.json` removed (today) | `config.local.json` **written** with offset localhost ports | new stack-lane write branch |
 
-DB **names are unchanged** — each instance has its own postgres (Arch A), so no
-manifest DB-renaming. That is the big simplification vs the shared-mesh option.
+**The mesh.** `PROJECT=saga-mesh` (the compose *file* selector) stays constant across slots — it is not the docker namespace. What varies per slot is `COMPOSE_PROJECT_NAME=soa-s<N>` (the namespace) + the five offset mesh ports + the four `SAGA_MESH_*_CONTAINER` overrides.
 
-## What's already there (reuse, no change)
+**Full port table** (base → slot 1 at stride 1000). `saga-dash` is `8900+offset` like everything else — the prior plan's `8900+slot` special case **dissolves** under a uniform offset.
 
-- **service ports** — `LaunchContext.ports` + `LaunchContextInputs.portOverrides` (`core/launch-plan.ts`); URLs derive from the (overridable) port, so an offset flows through on the same host.
-- **STATE dir** — `--state-dir` flag (`shared-flags.ts`) + `SAGA_MESH_SNAPSHOTS_DIR`.
-- **repo roots** — `--<repo>` flags / env (`runtime/scripts.ts`) → point at worktrees.
-- **mesh container names** — `SAGA_MESH_<UNIT>_CONTAINER` overrides (`runtime/mesh.ts`).
+| unit | base | slot 1 | | unit | base | slot 1 |
+|---|---|---|---|---|---|---|
+| iam-api | 3010 | 4010 | | connect-api | 6106 | 7106 |
+| sis-api | 3100 | 4100 | | connect-web | 6210 | 7210 |
+| programs-api | 3006 | 4006 | | rtsm-api | 6110 | 7110 |
+| scheduling-api | 3008 | 4008 | | coach-api | 6105 | 7105 |
+| sessions-api | 3007 | 4007 | | coach-web | 8800 | 9800 |
+| content-api | 3009 | 4009 | | transcripts-api | 6302 | 7302 |
+| ads-adm-api | 5005 | 6005 *(excluded slot>0, see §6)* | | insights-api | 6301 | 7301 |
+| saga-dash | 8900 | 9900 | | chat-api | 6303 | 7303 |
+| recorder(ctrl) | 7890 | 8890 *(AV, deferred)* | | recordings-api | 8444 | 9444 *(AV, deferred)* |
+| **mesh** postgres | 5432 | 6432 | | redis | 6379 | 7379 |
+| rabbitmq | 5672 | 6672 | | rabbitmq-mgmt | 15672 | 16672 |
+| connect-mongo | 27037 | 28037 | | | | |
 
-## The deltas to build (concrete)
+**Mesh, snapshot dir, tunnel monikers:** mesh keyed by `soa-s<N>` project + offset ports; snapshot dir per-slot `~/.saga-mesh/snapshots-s<N>` (independent of `--state-dir`, so it must be set explicitly, else slot-1 `snapshot store fixtureX` overwrites slot-0's and restores into whichever container the env last pointed at); **tunnel monikers are out of scope for M7** — the tunnel lane keys isolation by domain/cookie, not port, so the offset model buys nothing there. Slot>0 is **stack-lane only**.
 
-1. **`--slot` / `--instance` global flag + derivation** (`src/shared-flags.ts` + a new
-   pure `src/core/instance.ts`): `deriveInstance({slot, key})` → `{ offset, ports,
-   meshPorts, project, seedProfile, stateDir, containerNames }`. PURE + unit-tested;
-   `SLOT=0` returns today's values exactly.
-2. **Mesh-port offset** (`src/core/launch-plan.ts` + `src/runtime/mesh.ts`): thread
-   mesh ports through the context (today pg/mq/mongo ports are read fixed from the
-   manifest mesh defs); pass the offset ports to `make up POSTGRES_PORT=… REDIS_PORT=…`
-   and into the DB/MQ/mongo URL tokens. (Service `portOverrides` already shows the pattern.)
-3. **`COMPOSE_PROJECT_NAME` passthrough** (`src/runtime/mesh.ts`): pass
-   `COMPOSE_PROJECT_NAME=$project` to `make up` (today hardcodes `PROJECT=saga-mesh`),
-   and auto-set the `SAGA_MESH_*_CONTAINER` overrides to the matching `${project}-*-1`
-   so snapshot/reset/status target the right containers.
-4. **`SEED_PROFILE` per instance** — pass `SEED_PROFILE=$key` to the mesh so volumes
-   don't collide (depends on the infra fix below).
-5. **State-dir defaulting** — when `--slot/--instance` is set, default `--state-dir`
-   to `/tmp/sds-synthetic-$key` unless overridden.
-6. **`stack new-instance <key> [--slot n]`** (new command) — provision: `git worktree
-   add` each managed repo into `$HOME/dev/wt/$key/<repo>`, `pnpm install` per worktree,
-   write an instance config the other commands read. Optional but the ergonomic entry.
-7. **`stack ls-instances` / status across instances** (small) — list running instances
-   (by STATE dir / compose project) so an agent can see what's up.
+---
 
-## Shared infra fix (land first — helps any path, tiny soa PR)
+## 2. The single CLI seam
 
-- `infra/Makefile`: `COMPOSE_PROJECT_NAME := soa` → `?=` (backward-compatible).
-- Make the postgres (and redis/rabbitmq/connect-mongo) docker **volume names
-  project-keyed**, OR rely on per-instance `SEED_PROFILE`. **Verify empirically**
-  (prior-art Q1) that two project names + same profile really share the volume today
-  — that is the silent-corruption sharp edge.
+**One flag + one pure factory + one injection site. No call site ever hardcodes a port again.**
 
-## The crosstalk trap to test explicitly
+- **Flag:** add `slot` to `baseFlags` (`shared-flags.ts:74-92`), `Flags.integer({ default: 0, min: 0 })`. (`--instance <name>` is deferred; when it lands it resolves a name→slot via the registry and feeds the same factory.)
+- **Pure factory (NEW):** `deriveInstance({ slot }): InstanceProfile` in `core/` next to `launch-plan.ts`. No IO. Returns `{ offset, project, stateDir, snapshotsDir, containerEnv, seedProfile, portOverrides, meshOffset }`. Computes `portOverrides` generically: `for (id of Object.keys(m.services)) portOverrides[id] = getService(id).port + offset`. Runs the **disjointness assertion** over the fully-resolved service+mesh+mgmt+recorder/recordings set and throws on any collision. `deriveInstance({slot:0})` must return today's constants exactly — this is the unit-tested regression guard.
+- **Injection site (the ONLY one):** `StackUp.buildRuntime` (`commands/stack/up.ts:388-416`), where `defaultLaunchContext` + `getLauncher(state-dir)` + the mesh seams already converge. Wire the profile into the five existing seams:
+  1. `defaultLaunchContext({ …, portOverrides: profile.portOverrides, meshOffset: profile.offset })` — **`LaunchContextInputs` gains a NEW `meshOffset` field** (`launch-plan.ts:304-326`), applied to `pgPort/mqPort/mongoPort` at `:353-355` so `MESH_MQ`/`CONNECT_MONGO_URI`/`*_DB_URL` (`:387-394`) offset in lockstep with the mesh's published ports.
+  2. Mesh: **`MeshContext` gains `project` + `meshOffset` + `containerNames`** (`mesh.ts:57-77`). `meshMakeArgs(m, { project, offset })` (`mesh.ts:107-123`) emits `COMPOSE_PROJECT_NAME=<project>` + offset `POSTGRES_PORT/REDIS_PORT/…`. `meshUp` (`mesh.ts:169-194`) passes `COMPOSE_PROJECT_NAME` via `env:`. `meshDownArgs({ project })` (`mesh.ts:147-149`) passes the per-slot project — **critical**, else `make down` tears down the wrong (default) project.
+  3. Container resolvers: set `profile.containerEnv` so `meshContainer` (`mesh.ts:99-102`) and `postgres/mongo/redisContainer` (`snapshot-store.ts:57-69`) + `meshOwnedContainers` (`preflight.ts:86-88`) all target `soa-s<N>-<unit>-1`. (Cleaner long-term: thread a resolved container map through `MeshContext`; for MVP the env seam is sufficient and already wired.)
+  4. `getLauncher(flags['state-dir'] ?? profile.stateDir)` — default `--state-dir` from the slot when the user didn't pass one.
+  5. `healthProbes` (`probe-plan.ts:57-72`) must take the resolved `ctx.ports`/offset instead of `svc.lane.stack` — else `stack status`/`stack verify` probe base ports and report the wrong instance.
+- **Also thread the offset into `meshPortSpecs`** (`preflight.ts:74-83`) so the check_ports preflight probes the slot's ports, not base.
+- **Dash:** extend `syncDashLocalDefaults` (`dash-defaults.ts:100-108`) with a **third mode**: stack-lane + slot>0 ⇒ WRITE `config.local.json` with the slot's offset localhost ports (today it only removes-in-stack / writes-domain-in-tunnel).
 
-The dash trusts `config.json`/`config.local.json` ports. If a derived service port
-and the dash's config disagree, the dash silently talks to the **wrong instance's
-iam** — corruption, not a crash. The `sync-dash-local-defaults` prelaunch hook
-(already in M4) must write the instance's offset ports. **Add an integration test
-asserting the dash config ports == the instance's resolved ports.**
+Files to change: `shared-flags.ts`, `core/deriveInstance.ts` (new), `core/launch-plan.ts`, `runtime/mesh.ts`, `runtime/preflight.ts`, `runtime/snapshot-store.ts` (env-driven, mostly no change), `core/probe-plan.ts`, `runtime/dash-defaults.ts`, `commands/stack/up.ts`, `commands/stack/down.ts`, `stack-api.ts` (thread profile into `meshUp`/`meshDown`/`down`).
 
-## Tests (vitest, offline — fakes)
+---
 
-- `core/__tests__/instance.unit.test.ts`: `deriveInstance({slot:0})` == today's values
-  (byte-for-byte); `{slot:1}` offsets every port +100, saga-dash +1, project `soa-s1`,
-  state `/tmp/sds-synthetic-s1`, container `soa-s1-postgres-1`.
-- `stack-api` / launch-plan: with a slot-1 context, every service launch env + health
-  URL + DB URL + `make up` args carry the offset; no value stays at a base port.
-- mesh runtime (mocked): `make up` receives `COMPOSE_PROJECT_NAME=soa-s1` + offset ports.
-- the dash-config crosstalk assertion above.
+## 3. The infra prerequisite (shared with M8) — hard gate
 
-## Sequencing & risk
+Two changes in `~/dev/soa/infra`. **Nothing multi-instance is correct until both land.**
 
-- **Depends on the M4 native path soaking** (this rides the native launcher/mesh, not
-  the up.sh wrapper). Do M7 after/with the soak in `03-soak-plan.md`.
-- **Land the infra fix now** (standalone, cheap) — unblocks two *meshes* immediately
-  and de-risks the volume question.
-- **`SLOT=0` regression guard** keeps the default path identical to today.
-- Effort: medium, contained to `core/instance.ts` + the mesh/launch-context threading;
-  far smaller than the bash plan's ~30 call-sites across 5 scripts.
-- Resource ceiling: ~4 GB RAM + a few cores per instance; document a max (e.g. SLOT 0–4).
+**(a) Project-name override.** `infra/Makefile:29`:
+```make
+export COMPOSE_PROJECT_NAME := soa      →      export COMPOSE_PROJECT_NAME ?= soa
+```
+A `:=` assignment beats an environment value (but not a `make VAR=` CLI arg). The CLI passes overrides via child `env:` (as it does `EXTRA_POSTGRES_SEED_DIR`, `mesh.ts:192`), so `?=` is **required** for env passthrough. Still defaults to `soa` at slot 0 → backward compatible. `check-ports` self-skip (`:49`) and status filter (`:112`, `name=soa-`) follow `COMPOSE_PROJECT_NAME` automatically — though note `:112` filters `name=soa-` which still *matches* `soa-s1-*` as a prefix (harmless; status may show sibling slots — acceptable, optionally tighten later).
 
-## Near-term stopgap (before M7 lands)
+**(b) Project-key the four data volumes** — the load-bearing isolation fix (bigger than the plan's one-liner). Drop the explicit global `name:` so compose prefixes each with the project:
 
-True same-machine concurrency needs M7 (up.sh can't offset service ports). Until then,
-the cheapest relief is a **lease/lock** so agents take turns on the single stack
-(e.g. a flock/PID file checked by `stack up`) rather than clobbering each other — a
-tiny addition that prevents the `--reset`-wipes-the-other-agent failure mode today.
+- `services/postgres/compose.yml:47` — remove `name: postgres-profile-${SEED_PROFILE:-small}` → becomes `<project>_postgres-data`.
+- `services/redis/compose.yml:23` — remove `name: redis-data`.
+- `services/rabbitmq/compose.yml:27` — remove `name: rabbitmq-data`.
+- `services/connect-mongo/compose.yml:41` — remove `name: connect-mongo-data`.
 
-## Cross-references
-- `../research/06-multi-instance-analysis.md` — the analysis this plan executes.
-- `~/dev/soa/claude/projects/multi-synthetic-dev/` — the original bash spec (now retargeted here).
-- `01-saga-stack-cli-plan.md` (manifest §2.2, launch-plan §6.3), `02-handoff-and-status.md`, `03-soak-plan.md`.
+`SEED_PROFILE` **stays `empty`** — it double-duties as the seed-*file* selector (`init-and-seed.sh:18` resolves `profile-${SEED_PROFILE}.sql`, and only `profile-empty.sql` exists; `s1` would provision zero DBs). Isolation comes from the project prefix, not the profile.
+
+**Follow-on the coupling map missed:** `Makefile:186-188` (`clean-all`) removes `redis-data`/`rabbitmq-data`/`postgres-profile-$(PROFILE)` by their *old fixed names*. Once the names are project-prefixed, `clean-all` must remove `$(COMPOSE_PROJECT_NAME)_redis-data` etc. (or `docker compose down -v`). Include this in the infra PR or `clean-all` silently no-ops and leaks volumes.
+
+Backward-compat note: dropping the postgres `name:` **renames** the slot-0 volume from `postgres-profile-empty` to `soa_postgres-data`, so the first post-change `up` re-seeds from empty. That's fine for the empty-profile mesh (seeded on boot), but call it out in the PR.
+
+---
+
+## 4. Phasing (smallest shippable, low→high risk)
+
+Each phase is independently testable and leaves the tree shippable.
+
+**Phase 0 — infra PR (blocking, shared with M8).** §3 (a)+(b) + `clean-all` fix. Testable in isolation: `make up COMPOSE_PROJECT_NAME=soa-s1 POSTGRES_PORT=6432 …` brings up `soa-s1-*` containers on offset ports with `soa-s1_*` volumes, concurrent with a running `soa` stack, no volume sharing (`docker volume ls`). **No CLI change ships until this merges.**
+
+**Phase 1 — pure factory + flag, slot 0 only (zero behavior change).** Add `--slot` (default 0), `deriveInstance`, the disjointness assertion, and the `meshOffset` input to `defaultLaunchContext`. Wire into `buildRuntime` but only exercise slot 0. Ship behind the guarantee that `deriveInstance(0)` === today. Fully unit-testable; live behavior unchanged. This is the regression-guard checkpoint.
+
+**Phase 2 — MVP: two stacks, native `up`, slot>0 (stack/CRDT lane).** Thread project + mesh offset + container env through `meshUp`/`meshMakeArgs`; offset service+mesh ports; per-slot state dir + snapshots dir; dash config write branch; `probe-plan`/`meshPortSpecs` use resolved ports. **Exclude** ads-adm-api + playback trio (literal ports, §6) and AV/record from the slot>0 closure. **This is the MVP:** `stack up --slot 1` + a live `soa` stack, both healthy, no clobber.
+
+**Phase 3 — native slot-safe `down`.** `stack down` currently delegates to `up.sh --down` (`down.ts` → `runScript(flagMap.down())`), which runs host-global `pkill -f tsup` + `nuke_vite`. For slot>0, route `down` through the **native** `stopServices` (kill-by-pidfile in the slot's state dir, already isolation-safe) + native `meshDown({ project })`. Without this, `stack down --slot 1` kills slot 0's watchers. Slot 0 keeps the up.sh wrapper.
+
+**Deferred (post-M7, documented as slot-0-only until done):**
+- `reset`/`restart`/`overlay`/`bootstrap`/`seed` — still up.sh wrappers with host-global teardown. **Slot-0-only** until native-ized. Gate this in the command layer (reject `--slot>0` with a clear error, not a silent global kill).
+- Literal-port tokenization (ads-adm-api, playback trio, connect-web AV) → unlocks those services for slot>0.
+- AV/record per-slot (qboard/fleek composes need their own project-keying + offset).
+- Tunnel-per-slot (per-slot moniker).
+- `stack new-instance <key>` worktree helper + name→slot registry.
+
+---
+
+## 5. Test strategy
+
+**Unit (pure, fast, the bulk of confidence):**
+- `deriveInstance(0)` deep-equals today's constants (project `soa`, offset 0, state `/tmp/sds-synthetic`, no container env, seed `empty`, no dash write) — the byte-compat guard.
+- `deriveInstance(N)` for N∈{1,2,3}: correct offset, project `soa-s<N>`, state/snapshot dirs, container env map.
+- **No-collision property test:** for N slots (say 0..8), assert the union of all resolved ports (every service + mesh + mgmt + recorder/recordings) has no duplicates — catches any future service whose base is a multiple of the stride from another.
+- `meshMakeArgs`/`meshDownArgs` emit `COMPOSE_PROJECT_NAME=soa-s<N>` + offset ports (assert argv, no real make).
+- `defaultLaunchContext` with `meshOffset`: `MESH_MQ`/`CONNECT_MONGO_URI`/`*_DB_URL` ports match the offset mesh ports (the split-brain guard).
+- `healthProbes` builds URLs off resolved ports, not `lane.stack`.
+- `syncDashLocalDefaults` stack-lane+slot>0 writes `config.local.json` with offset ports; slot 0 still removes.
+
+**Live validation (cannot be unit-tested — the whole point of M7):**
+1. `stack up` (slot 0, up.sh-style) running; then `stack up --slot 1` concurrently.
+2. `stack verify --slot 0` and `--slot 1` both green.
+3. `docker ps` shows disjoint `soa-*` and `soa-s1-*` container sets; `docker volume ls` shows disjoint `soa_*` / `soa-s1_*` volumes (no shared `redis-data`/`rabbitmq-data`/`connect-mongo-data`).
+4. **Clobber test:** write a row to slot 1's postgres + a key to slot 1's redis; confirm slot 0 does NOT see them (the silent-corruption regression).
+5. Dash: slot 1's dash (`:9900`) resolves iam at `:4010`, not `:3010` (config.local.json assertion — the crosstalk trap).
+6. `stack down --slot 1` (Phase 3): slot 0's tsup watchers and vite caches survive (`pgrep`/cache mtime before/after).
+
+---
+
+## 6. Risks + up.sh coexistence
+
+**Collision / leak matrix (slot N vs live up.sh `soa` stack):**
+
+| Surface | Safe? | Why / condition |
+|---|---|---|
+| Host ports | ✅ | offset (stride 1000, disjointness-asserted); up.sh's fixed-port `fuser -k` can't reach offset ports |
+| Container names | ✅ | distinct project `soa-s<N>`; `make down COMPOSE_PROJECT_NAME=soa-s<N>` only tears down that slot |
+| STATE (pid/log) | ✅ | distinct dir; native kill-by-pidfile can't cross-kill |
+| **Data volumes** | ⛔→✅ | **BLOCKED until §3(b) lands** — redis/rabbitmq/connect-mongo bare global names + postgres profile-keyed-on-`empty` are silently shared (corruption, not crash). Project-prefix fixes it. |
+| Mesh DB URLs | ⚠️ | split-brain if `meshOffset` reaches `meshMakeArgs` but not `defaultLaunchContext` (or vice-versa) — single offset feeds both; unit-guarded |
+| Literal-port services | ⚠️ | ads-adm-api (`@localhost:5432`, sessions `:3007`, iam `:3010`, CORS `:8900`), playback trio (`POSTGRES_PORT '5432'`, `EXPRESS_SERVER_PORT 6301-6303`), connect-web (`livekit ws://:7880`, sessions `:3007`) bypass all token offsets → hit slot 0. **Excluded from slot>0 closure** until tokenized |
+| Dash config | ⚠️→✅ | stack-lane REMOVES config today → slot dash hits base-port iam. New write branch fixes |
+| Wrapper lifecycle (reset/restart/…) | ⛔ | host-global `pkill tsup` + `nuke_vite` (up.sh:2001/2012) clobbers all slots. **Slot-0-only** until native-ized |
+| Snapshot store | ⚠️→✅ | global root independent of `--state-dir`; must set `SAGA_MESH_SNAPSHOTS_DIR-s<N>` + container env together |
+| AV/record | ⛔ | qboard/fleek fixed project + `:7880/:6380/:7890/:8444` — single-owner. Slot>0 CRDT-only |
+| Tunnel | ⛔ | keyed by moniker/cookie-domain, not port. Stack-lane only |
+
+**bash + slotted CLI coexistence:** a live up.sh `soa` stack **is** slot 0 (byte-identical). A CLI `--slot 1` stack is a peer project — safe on ports/names/state, safe on volumes *after* §3(b), and it must never run a wrapper lifecycle command (`reset`/etc.) at slot>0 until those go native. The `?=` fix keeps `soa` as the default so up.sh's `make up` is unaffected.
+
+**Skip-guard hazard:** worktrees are **mandatory** for slot>0 (in-tree `pnpm dev` + tracked `config.json`/`.env.local` can't hold two branches). The repo-absent skip-guard (`stack-api.ts:349-365`) silently masks a mis-provisioned worktree as "repo not cloned" → a quietly partial slot. Either the future `stack new-instance` guarantees every managed worktree exists, or the guard needs a slot-aware "expected-but-missing = error" distinction. Flag for the deferred worktree-helper phase.
+
+---
+
+## 7. Open decisions for skelly
+
+1. **Stride size.** Recommend **1000** (verified collision-free for all base ports; +100 has real rtsm↔connect-web and coach-web↔saga-dash collisions). Alternative: validated disjoint bands. Any objection to 1000, or do you want headroom for a service base that could push a high slot's mongo (27037 + N·1000) toward the ephemeral range? (Practically fine for N ≤ ~30.)
+2. **Max slots.** Cap `--slot` at some N (e.g. 8) so the disjointness assertion and docker footprint stay bounded? Or leave uncapped with only the assertion guarding?
+3. **Numeric vs named slots for the shipped surface.** MVP is numeric (`--slot 1`). Do you want `--instance <name>` (name→stable slot) in M7, or is the registry genuinely deferrable? (My recommendation: defer — numeric covers the two-agent case and keeps M7 stateless.)
+4. **`ads-adm-api` + playback trio at slot>0.** Confirm it's acceptable to **exclude** them from slot>0 for M7 (they'd corrupt slot 0 otherwise) and tokenize as a fast follow — vs. blocking M7 on tokenizing them now.
+5. **Wrapper lifecycle at slot>0.** Confirm `reset`/`restart`/`overlay`/`bootstrap`/`seed` should **hard-error** at slot>0 in M7 (rather than silently clobber), accepting they're slot-0-only until native-ized.
+6. **Snapshot library:** per-slot snapshot root (isolated, chosen here) vs. a shared library with slot-tagged fixture ids? Per-slot is safer; shared is more convenient for promoting a fixture across slots. Which do you want as the default?
+
+---
+
+**Net:** one flag + one pure `deriveInstance` factory + threading in ~8 files, plus a ~two-lines-per-volume + one-line-Makefile infra PR (Phase 0, shared with M8), yields two isolated CRDT stacks running concurrently (Phase 2 MVP). Native slot-safe `down` is Phase 3. Everything cut (tunnel, AV/record, literal-port services, wrapper lifecycle, name registry, worktree helper) is documented as slot-0-only or excluded-from-closure — **never silently broken**. Slot 0 is the byte-identical, up.sh-compatible regression guard throughout.

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -26,7 +26,7 @@ COMPOSE   := docker compose --env-file .env.defaults -f compose/projects/$(PROJE
 -include .env.defaults
 -include .env
 
-export COMPOSE_PROJECT_NAME := soa
+export COMPOSE_PROJECT_NAME ?= soa   # ?= so the CLI can override per-slot via env (soa-s1, …); still soa by default
 export SEED_PROFILE := $(PROFILE)
 
 .PHONY: up switch down reset status logs list-projects list-profiles \
@@ -182,10 +182,10 @@ redis-cli:
 ## Destroy ALL volumes and containers for a project. All profile data gone.
 clean-all:
 	$(COMPOSE) down -v
-	@echo "Removing all profile volumes for services in $(PROJECT) ..."
+	@echo "Removing legacy fixed-name volumes (pre-M7) for $(PROJECT) ..."
 	@docker volume ls --filter "name=-profile-" --format "{{.Name}}" | xargs -r docker volume rm 2>/dev/null || true
 	@docker volume rm redis-data 2>/dev/null || true
-	@docker volume rm rabbitmq-data 2>/dev/null || true
+	@docker volume rm rabbitmq-data connect-mongo-data 2>/dev/null || true   # legacy fixed-name sweep (per-project volumes handled by down -v above)
 	@echo ""
 	@echo "  All data destroyed for $(PROJECT)."
 

--- a/infra/compose/services/connect-mongo/compose.yml
+++ b/infra/compose/services/connect-mongo/compose.yml
@@ -38,4 +38,4 @@ services:
 
 volumes:
   connect-mongo-data:
-    name: connect-mongo-data
+    # no explicit name → <project>_connect-mongo-data (per-slot isolation, M7)

--- a/infra/compose/services/postgres/compose.yml
+++ b/infra/compose/services/postgres/compose.yml
@@ -44,4 +44,6 @@ services:
 
 volumes:
   postgres-data:
-    name: postgres-profile-${SEED_PROFILE:-small}
+    # no explicit name → compose auto-names it <project>_postgres-data, so each
+    # COMPOSE_PROJECT_NAME (soa, soa-s1, …) gets an ISOLATED volume (M7 multi-slot).
+    # SEED_PROFILE still selects the seed FILE (profile-<name>.sql), not the volume.

--- a/infra/compose/services/rabbitmq/compose.yml
+++ b/infra/compose/services/rabbitmq/compose.yml
@@ -24,4 +24,4 @@ services:
 
 volumes:
   rabbitmq-data:
-    name: rabbitmq-data
+    # no explicit name → <project>_rabbitmq-data (per-slot isolation, M7)

--- a/infra/compose/services/redis/compose.yml
+++ b/infra/compose/services/redis/compose.yml
@@ -20,4 +20,4 @@ services:
 
 volumes:
   redis-data:
-    name: redis-data
+    # no explicit name → <project>_redis-data (per-slot isolation, M7)

--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -16,7 +16,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -38,9 +38,8 @@
           "type": "option"
         },
         "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state",
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
           "name": "state-dir",
-          "default": "/tmp/sds-synthetic",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -154,7 +153,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -176,9 +175,8 @@
           "type": "option"
         },
         "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state",
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
           "name": "state-dir",
-          "default": "/tmp/sds-synthetic",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -287,7 +285,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -309,9 +307,8 @@
           "type": "option"
         },
         "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state",
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
           "name": "state-dir",
-          "default": "/tmp/sds-synthetic",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -469,7 +466,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -491,9 +488,8 @@
           "type": "option"
         },
         "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state",
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
           "name": "state-dir",
-          "default": "/tmp/sds-synthetic",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -618,7 +614,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -640,9 +636,8 @@
           "type": "option"
         },
         "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state",
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
           "name": "state-dir",
-          "default": "/tmp/sds-synthetic",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -755,7 +750,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -777,9 +772,8 @@
           "type": "option"
         },
         "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state",
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
           "name": "state-dir",
-          "default": "/tmp/sds-synthetic",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -894,7 +888,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -916,9 +910,8 @@
           "type": "option"
         },
         "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state",
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
           "name": "state-dir",
-          "default": "/tmp/sds-synthetic",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -1054,7 +1047,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -1076,9 +1069,8 @@
           "type": "option"
         },
         "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state",
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
           "name": "state-dir",
-          "default": "/tmp/sds-synthetic",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -1192,7 +1184,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -1214,9 +1206,8 @@
           "type": "option"
         },
         "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state",
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
           "name": "state-dir",
-          "default": "/tmp/sds-synthetic",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -1327,7 +1318,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -1349,9 +1340,8 @@
           "type": "option"
         },
         "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state",
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
           "name": "state-dir",
-          "default": "/tmp/sds-synthetic",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -1467,7 +1457,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -1489,9 +1479,8 @@
           "type": "option"
         },
         "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state",
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
           "name": "state-dir",
-          "default": "/tmp/sds-synthetic",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -1628,7 +1617,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -1650,9 +1639,8 @@
           "type": "option"
         },
         "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state",
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
           "name": "state-dir",
-          "default": "/tmp/sds-synthetic",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -1761,7 +1749,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -1783,9 +1771,8 @@
           "type": "option"
         },
         "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state",
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
           "name": "state-dir",
-          "default": "/tmp/sds-synthetic",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -1987,7 +1974,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -2009,9 +1996,8 @@
           "type": "option"
         },
         "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state",
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
           "name": "state-dir",
-          "default": "/tmp/sds-synthetic",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -2157,7 +2143,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -2179,9 +2165,8 @@
           "type": "option"
         },
         "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state",
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
           "name": "state-dir",
-          "default": "/tmp/sds-synthetic",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -2284,7 +2269,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -2306,9 +2291,8 @@
           "type": "option"
         },
         "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state",
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
           "name": "state-dir",
-          "default": "/tmp/sds-synthetic",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -2424,7 +2408,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -2446,9 +2430,8 @@
           "type": "option"
         },
         "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state",
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
           "name": "state-dir",
-          "default": "/tmp/sds-synthetic",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -2570,7 +2553,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -2592,9 +2575,8 @@
           "type": "option"
         },
         "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state",
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
           "name": "state-dir",
-          "default": "/tmp/sds-synthetic",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -2745,7 +2727,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -2767,9 +2749,8 @@
           "type": "option"
         },
         "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state",
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
           "name": "state-dir",
-          "default": "/tmp/sds-synthetic",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -2877,7 +2858,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -2899,9 +2880,8 @@
           "type": "option"
         },
         "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state",
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
           "name": "state-dir",
-          "default": "/tmp/sds-synthetic",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"

--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -15,6 +15,14 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "slot": {
+          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "output-json": {
           "description": "emit structured JSON on stdout instead of human-readable text",
           "name": "output-json",
@@ -145,6 +153,14 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "slot": {
+          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "output-json": {
           "description": "emit structured JSON on stdout instead of human-readable text",
           "name": "output-json",
@@ -269,6 +285,14 @@
           "name": "porcelain",
           "allowNo": false,
           "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "output-json": {
           "description": "emit structured JSON on stdout instead of human-readable text",
@@ -444,6 +468,14 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "slot": {
+          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "output-json": {
           "description": "emit structured JSON on stdout instead of human-readable text",
           "name": "output-json",
@@ -585,6 +617,14 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "slot": {
+          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "output-json": {
           "description": "emit structured JSON on stdout instead of human-readable text",
           "name": "output-json",
@@ -713,6 +753,14 @@
           "name": "porcelain",
           "allowNo": false,
           "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "output-json": {
           "description": "emit structured JSON on stdout instead of human-readable text",
@@ -844,6 +892,14 @@
           "name": "porcelain",
           "allowNo": false,
           "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "output-json": {
           "description": "emit structured JSON on stdout instead of human-readable text",
@@ -997,6 +1053,14 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "slot": {
+          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "output-json": {
           "description": "emit structured JSON on stdout instead of human-readable text",
           "name": "output-json",
@@ -1127,6 +1191,14 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "slot": {
+          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "output-json": {
           "description": "emit structured JSON on stdout instead of human-readable text",
           "name": "output-json",
@@ -1253,6 +1325,14 @@
           "name": "porcelain",
           "allowNo": false,
           "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "output-json": {
           "description": "emit structured JSON on stdout instead of human-readable text",
@@ -1385,6 +1465,14 @@
           "name": "porcelain",
           "allowNo": false,
           "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "output-json": {
           "description": "emit structured JSON on stdout instead of human-readable text",
@@ -1539,6 +1627,14 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "slot": {
+          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "output-json": {
           "description": "emit structured JSON on stdout instead of human-readable text",
           "name": "output-json",
@@ -1663,6 +1759,14 @@
           "name": "porcelain",
           "allowNo": false,
           "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "output-json": {
           "description": "emit structured JSON on stdout instead of human-readable text",
@@ -1882,6 +1986,14 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "slot": {
+          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "output-json": {
           "description": "emit structured JSON on stdout instead of human-readable text",
           "name": "output-json",
@@ -2024,124 +2136,6 @@
         "verify.js"
       ]
     },
-    "stack:bundle:list": {
-      "aliases": [],
-      "args": {},
-      "description": "List the --with convenience bundles (name, services, seed add-on, description). Read-only.",
-      "examples": [
-        "<%= config.bin %> <%= command.id %>",
-        "<%= config.bin %> <%= command.id %> --output-json"
-      ],
-      "flags": {
-        "porcelain": {
-          "description": "machine-readable output; no color, minimal noise",
-          "name": "porcelain",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "output-json": {
-          "description": "emit structured JSON on stdout instead of human-readable text",
-          "name": "output-json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "dev": {
-          "description": "sibling-repo workspace root (where the saga repos are checked out)",
-          "name": "dev",
-          "default": "/home/skelly/dev",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state",
-          "name": "state-dir",
-          "default": "/tmp/sds-synthetic",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "soa": {
-          "description": "override path to the soa repo checkout",
-          "name": "soa",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rostering": {
-          "description": "override path to the rostering repo checkout",
-          "name": "rostering",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "program-hub": {
-          "description": "override path to the program-hub repo checkout",
-          "name": "program-hub",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "saga-dash": {
-          "description": "override path to the saga-dash repo checkout",
-          "name": "saga-dash",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "coach": {
-          "description": "override path to the coach repo checkout",
-          "name": "coach",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "sds": {
-          "description": "override path to the sds (student-data-system) repo checkout",
-          "name": "sds",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "qboard": {
-          "description": "override path to the qboard repo checkout",
-          "name": "qboard",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rtsm": {
-          "description": "override path to the rtsm repo checkout",
-          "name": "rtsm",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fleek": {
-          "description": "override path to the fleek repo checkout",
-          "name": "fleek",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "stack:bundle:list",
-      "pluginAlias": "@saga-ed/saga-stack-cli",
-      "pluginName": "@saga-ed/saga-stack-cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "stack",
-        "bundle",
-        "list.js"
-      ]
-    },
     "stack:snapshot:delete": {
       "aliases": [],
       "args": {
@@ -2161,6 +2155,14 @@
           "name": "porcelain",
           "allowNo": false,
           "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "output-json": {
           "description": "emit structured JSON on stdout instead of human-readable text",
@@ -2280,6 +2282,14 @@
           "name": "porcelain",
           "allowNo": false,
           "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "output-json": {
           "description": "emit structured JSON on stdout instead of human-readable text",
@@ -2412,6 +2422,14 @@
           "name": "porcelain",
           "allowNo": false,
           "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "output-json": {
           "description": "emit structured JSON on stdout instead of human-readable text",
@@ -2550,6 +2568,14 @@
           "name": "porcelain",
           "allowNo": false,
           "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "output-json": {
           "description": "emit structured JSON on stdout instead of human-readable text",
@@ -2718,6 +2744,14 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "slot": {
+          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "output-json": {
           "description": "emit structured JSON on stdout instead of human-readable text",
           "name": "output-json",
@@ -2825,6 +2859,132 @@
         "stack",
         "snapshot",
         "validate.js"
+      ]
+    },
+    "stack:bundle:list": {
+      "aliases": [],
+      "args": {},
+      "description": "List the --with convenience bundles (name, services, seed add-on, description). Read-only.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %>",
+        "<%= config.bin %> <%= command.id %> --output-json"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "default": "/home/skelly/dev",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state",
+          "name": "state-dir",
+          "default": "/tmp/sds-synthetic",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "stack:bundle:list",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "stack",
+        "bundle",
+        "list.js"
       ]
     }
   },

--- a/packages/node/saga-stack-cli/src/base-command.ts
+++ b/packages/node/saga-stack-cli/src/base-command.ts
@@ -25,7 +25,8 @@
 import { existsSync } from 'node:fs';
 import { Command } from '@oclif/core';
 import type { Interfaces } from '@oclif/core';
-import { SLOT_PHASE2_MESSAGE, baseFlags } from './shared-flags.js';
+import { SLOT_UNSUPPORTED_COMMAND_MESSAGE, baseFlags } from './shared-flags.js';
+import type { InstanceProfile } from './core/derive-instance.js';
 import type { ScriptPlan } from './core/flag-map.js';
 import type { RepoKey as ManifestRepoKey } from './core/manifest/index.js';
 import {
@@ -68,12 +69,24 @@ export abstract class BaseCommand extends Command {
   static baseFlags = baseFlags;
 
   /**
+   * Whether THIS command supports `--slot > 0` (M7 Phase 2). Default `false` —
+   * the central guard in `parse` rejects a `--slot > 0` for any command that does
+   * not opt in, so an un-slot-safe command (the wrapper-lifecycle set, login,
+   * tunnel, snapshot, …) fails fast rather than half-running against a peer slot's
+   * data on up.sh's host-global lifecycle. `stack up`/`status`/`verify`/`down`
+   * override this to `true`. Slot 0 (the default) is accepted everywhere.
+   */
+  protected slotAware(): boolean {
+    return false;
+  }
+
+  /**
    * Parse + a CENTRAL slot guard. `--slot` lives on `baseFlags`, so every command
-   * accepts it — but M7 Phase 1 only wires slot 0 (the injection site is
-   * `stack up`'s `buildRuntime`, a no-op at offset 0). A `--slot > 0` on ANY
-   * command must fail fast here rather than half-run at the base ports and clobber
-   * a live default stack; the mesh-project/container/down threading that makes
-   * slot > 0 real is Phase 2. Slot 0 (the default) is completely unaffected.
+   * accepts it — but only the slot-aware commands (`slotAware()` ⇒ true) wire the
+   * mesh-project / container / offset threading that makes `--slot > 0` isolated.
+   * A `--slot > 0` on a NON-slot-aware command must fail fast here rather than
+   * half-run at the base ports / on up.sh's host-global teardown and clobber a live
+   * default stack. Slot 0 (the default) is completely unaffected.
    *
    * The structural generic bounds mirror oclif's own `Command.parse` signature
    * (`FlagOutput`/`ArgOutput` are `{ [k: string]: any }`) so this is a faithful
@@ -92,10 +105,28 @@ export abstract class BaseCommand extends Command {
   ): Promise<Interfaces.ParserOutput<F, B, A>> {
     const result = await super.parse<F, B, A>(options, argv);
     const slot = (result.flags as { slot?: unknown }).slot;
-    if (typeof slot === 'number' && slot > 0) {
-      this.error(SLOT_PHASE2_MESSAGE);
+    if (typeof slot === 'number' && slot > 0 && !this.slotAware()) {
+      this.error(SLOT_UNSUPPORTED_COMMAND_MESSAGE);
     }
     return result;
+  }
+
+  /**
+   * Apply a slot's `InstanceProfile` to `process.env` (M7 Phase 2 — the "env
+   * seam"). Sets the `SAGA_MESH_*_CONTAINER` overrides so the mesh-readiness
+   * resolver (`mesh.ts` `meshContainer`), the snapshot-store resolvers, and the
+   * preflight owned-container set all target `soa-s<N>-<unit>-1`, and points
+   * `SAGA_MESH_SNAPSHOTS_DIR` at the per-slot snapshot root. At slot 0 the profile
+   * carries an empty container env and an undefined snapshot dir, so this is a
+   * NO-OP and slot 0 stays byte-identical.
+   */
+  protected applyInstanceEnv(profile: InstanceProfile): void {
+    for (const [key, value] of Object.entries(profile.containerEnv)) {
+      process.env[key] = value;
+    }
+    if (profile.snapshotsDir !== undefined) {
+      process.env.SAGA_MESH_SNAPSHOTS_DIR = profile.snapshotsDir;
+    }
   }
 
   /**

--- a/packages/node/saga-stack-cli/src/base-command.ts
+++ b/packages/node/saga-stack-cli/src/base-command.ts
@@ -24,7 +24,8 @@
 
 import { existsSync } from 'node:fs';
 import { Command } from '@oclif/core';
-import { baseFlags } from './shared-flags.js';
+import type { Interfaces } from '@oclif/core';
+import { SLOT_PHASE2_MESSAGE, baseFlags } from './shared-flags.js';
 import type { ScriptPlan } from './core/flag-map.js';
 import type { RepoKey as ManifestRepoKey } from './core/manifest/index.js';
 import {
@@ -65,6 +66,37 @@ export type WorkspaceFlags = {
 
 export abstract class BaseCommand extends Command {
   static baseFlags = baseFlags;
+
+  /**
+   * Parse + a CENTRAL slot guard. `--slot` lives on `baseFlags`, so every command
+   * accepts it — but M7 Phase 1 only wires slot 0 (the injection site is
+   * `stack up`'s `buildRuntime`, a no-op at offset 0). A `--slot > 0` on ANY
+   * command must fail fast here rather than half-run at the base ports and clobber
+   * a live default stack; the mesh-project/container/down threading that makes
+   * slot > 0 real is Phase 2. Slot 0 (the default) is completely unaffected.
+   *
+   * The structural generic bounds mirror oclif's own `Command.parse` signature
+   * (`FlagOutput`/`ArgOutput` are `{ [k: string]: any }`) so this is a faithful
+   * override, not a widening.
+   */
+  protected async parse<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    F extends { [flag: string]: any },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    B extends { [flag: string]: any },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    A extends { [arg: string]: any },
+  >(
+    options?: Interfaces.Input<F, B, A>,
+    argv?: string[],
+  ): Promise<Interfaces.ParserOutput<F, B, A>> {
+    const result = await super.parse<F, B, A>(options, argv);
+    const slot = (result.flags as { slot?: unknown }).slot;
+    if (typeof slot === 'number' && slot > 0) {
+      this.error(SLOT_PHASE2_MESSAGE);
+    }
+    return result;
+  }
 
   /**
    * The injectable process seam. Production launches real children; tests spy

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/slot-guard.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/slot-guard.unit.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Central slot guard (M7 Phase 1, plan §4/§6).
+ *
+ * `--slot` lives on `baseFlags`, so every command accepts it — but Phase 1 only
+ * wires slot 0. `BaseCommand.parse` must reject `--slot > 0` on ANY command
+ * (fail fast, not half-run at the base ports); slot 0 (default) must be
+ * unaffected. Driven through the real `StackUp` command with `--dry-run` so no
+ * IO seams are needed — the guard fires in `parse`, before any path branches.
+ */
+
+import { resolve } from 'node:path';
+import { Config } from '@oclif/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BaseCommand } from '../../../base-command.js';
+import { SLOT_PHASE2_MESSAGE } from '../../../shared-flags.js';
+import StackUp from '../up.js';
+
+const PKG_ROOT = process.cwd();
+const SOA_ROOT = resolve(PKG_ROOT, '..', '..', '..');
+const WS = ['--soa', SOA_ROOT, '--dev', '/fixed/dev'];
+
+let config: Config;
+
+beforeEach(async () => {
+  config = await Config.load(PKG_ROOT);
+  vi.spyOn(BaseCommand.prototype, 'log').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('BaseCommand slot guard', () => {
+  it('rejects --slot 1 with the Phase-2 error', async () => {
+    await expect(
+      StackUp.run(['--only', 'iam-api', '--dry-run', '--slot', '1', ...WS], config),
+    ).rejects.toThrow(SLOT_PHASE2_MESSAGE);
+  });
+
+  it('rejects a large slot too', async () => {
+    await expect(
+      StackUp.run(['--only', 'iam-api', '--dry-run', '--slot', '7', ...WS], config),
+    ).rejects.toThrow(/Phase 2/);
+  });
+
+  it('rejects a negative slot at the flag layer (min: 0)', async () => {
+    // Flags.integer({ min: 0 }) rejects before the guard — still a hard error.
+    await expect(
+      StackUp.run(['--only', 'iam-api', '--dry-run', '--slot', '-1', ...WS], config),
+    ).rejects.toBeInstanceOf(Error);
+  });
+
+  it('slot 0 (default, implicit) is accepted — no guard error', async () => {
+    await expect(
+      StackUp.run(['--only', 'iam-api', '--dry-run', ...WS], config),
+    ).resolves.toBeUndefined();
+  });
+
+  it('explicit --slot 0 is accepted', async () => {
+    await expect(
+      StackUp.run(['--only', 'iam-api', '--dry-run', '--slot', '0', ...WS], config),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/slot-guard.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/slot-guard.unit.test.ts
@@ -1,18 +1,26 @@
 /**
- * Central slot guard (M7 Phase 1, plan §4/§6).
+ * Central slot guard (M7 Phase 2, plan §4/§6).
  *
- * `--slot` lives on `baseFlags`, so every command accepts it — but Phase 1 only
- * wires slot 0. `BaseCommand.parse` must reject `--slot > 0` on ANY command
- * (fail fast, not half-run at the base ports); slot 0 (default) must be
- * unaffected. Driven through the real `StackUp` command with `--dry-run` so no
- * IO seams are needed — the guard fires in `parse`, before any path branches.
+ * `--slot` lives on `baseFlags`, so every command accepts it. Phase 2 makes the
+ * SLOT-AWARE commands (`stack up`/`status`/`verify`/`down`) act on an isolated
+ * `soa-s<N>` stack, while every OTHER command (the wrapper-lifecycle set —
+ * `reset`/`restart`/`overlay`/`bootstrap`/`seed` — plus login/tunnel/snapshot,
+ * which delegate to up.sh's host-global lifecycle) must FAIL FAST at `--slot > 0`.
+ * `BaseCommand.parse` enforces this via the per-command `slotAware()` opt-in.
+ *
+ * The slot-aware paths are exercised through `--dry-run` (up) / delegated seams
+ * elsewhere; here we assert only the GUARD boundary: which commands accept a
+ * `--slot > 0` and which reject it. Slot 0 (the default) must be accepted by all.
  */
 
 import { resolve } from 'node:path';
 import { Config } from '@oclif/core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { BaseCommand } from '../../../base-command.js';
-import { SLOT_PHASE2_MESSAGE } from '../../../shared-flags.js';
+import { SLOT_UNSUPPORTED_COMMAND_MESSAGE } from '../../../shared-flags.js';
+import StackReset from '../reset.js';
+import StackRestart from '../restart.js';
+import StackSeed from '../seed.js';
 import StackUp from '../up.js';
 
 const PKG_ROOT = process.cwd();
@@ -24,41 +32,66 @@ let config: Config;
 beforeEach(async () => {
   config = await Config.load(PKG_ROOT);
   vi.spyOn(BaseCommand.prototype, 'log').mockImplementation(() => {});
+  // Neutralize the wrappers' delegated up.sh call so a would-be accepted slot 0
+  // run doesn't spawn a real process (the reject tests never reach it anyway).
+  vi.spyOn(
+    BaseCommand.prototype as unknown as { getRunner: () => unknown },
+    'getRunner',
+  ).mockReturnValue({ async run() { return { code: 0 }; } });
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe('BaseCommand slot guard', () => {
-  it('rejects --slot 1 with the Phase-2 error', async () => {
+describe('slot-aware commands ACCEPT --slot > 0 (Phase 2)', () => {
+  it('stack up --slot 1 --dry-run is accepted (no guard error)', async () => {
     await expect(
       StackUp.run(['--only', 'iam-api', '--dry-run', '--slot', '1', ...WS], config),
-    ).rejects.toThrow(SLOT_PHASE2_MESSAGE);
-  });
-
-  it('rejects a large slot too', async () => {
-    await expect(
-      StackUp.run(['--only', 'iam-api', '--dry-run', '--slot', '7', ...WS], config),
-    ).rejects.toThrow(/Phase 2/);
-  });
-
-  it('rejects a negative slot at the flag layer (min: 0)', async () => {
-    // Flags.integer({ min: 0 }) rejects before the guard — still a hard error.
-    await expect(
-      StackUp.run(['--only', 'iam-api', '--dry-run', '--slot', '-1', ...WS], config),
-    ).rejects.toBeInstanceOf(Error);
-  });
-
-  it('slot 0 (default, implicit) is accepted — no guard error', async () => {
-    await expect(
-      StackUp.run(['--only', 'iam-api', '--dry-run', ...WS], config),
     ).resolves.toBeUndefined();
   });
 
-  it('explicit --slot 0 is accepted', async () => {
+  it('a large slot is accepted on stack up too', async () => {
+    await expect(
+      StackUp.run(['--only', 'iam-api', '--dry-run', '--slot', '7', ...WS], config),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('wrapper-lifecycle commands HARD-ERROR at --slot > 0', () => {
+  it('stack reset --slot 1 is rejected with the unsupported-command error', async () => {
+    await expect(StackReset.run(['--slot', '1', ...WS], config)).rejects.toThrow(
+      SLOT_UNSUPPORTED_COMMAND_MESSAGE,
+    );
+  });
+
+  it('stack restart --slot 1 is rejected', async () => {
+    await expect(StackRestart.run(['--slot', '1', ...WS], config)).rejects.toThrow(
+      /not supported for this command/,
+    );
+  });
+
+  it('stack seed --slot 2 is rejected', async () => {
+    await expect(StackSeed.run(['--slot', '2', ...WS], config)).rejects.toThrow(
+      /slot 0 only/,
+    );
+  });
+});
+
+describe('slot 0 is accepted everywhere', () => {
+  it('explicit --slot 0 is accepted on a slot-aware command (up)', async () => {
     await expect(
       StackUp.run(['--only', 'iam-api', '--dry-run', '--slot', '0', ...WS], config),
     ).resolves.toBeUndefined();
+  });
+
+  it('implicit slot 0 (no --slot) is accepted on a wrapper command (reset)', async () => {
+    await expect(StackReset.run([...WS], config)).resolves.toBeUndefined();
+  });
+
+  it('the flag layer still rejects a negative slot (min: 0)', async () => {
+    await expect(
+      StackUp.run(['--only', 'iam-api', '--dry-run', '--slot', '-1', ...WS], config),
+    ).rejects.toBeInstanceOf(Error);
   });
 });

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/status-verify.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/status-verify.int.test.ts
@@ -18,6 +18,7 @@ import { Config } from '@oclif/core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { BaseCommand } from '../../../base-command.js';
 import { computeClosure } from '../../../core/closure.js';
+import { deriveInstance } from '../../../core/derive-instance.js';
 import { manifest } from '../../../core/manifest/index.js';
 import type { HealthProber, ProbeResult } from '../../../runtime/health.js';
 import type { RunResult, ScriptInvocation } from '../../../runtime/index.js';
@@ -290,5 +291,35 @@ describe('stack verify --full — delegates the deep checks to verify.sh', () =>
     await expect(StackVerify.run(['--full', ...WS], config)).rejects.toMatchObject({
       oclif: { exit: 4 },
     });
+  });
+});
+
+describe('stack verify --slot N — backend-only gate on offset ports (M7 Phase 2)', () => {
+  const EXCLUDED = ['saga-dash', 'connect-api', 'connect-web', 'coach-web', 'ads-adm-api'] as const;
+
+  it('slot > 0 excludes the frontends + literal-port backends and probes offset ports', async () => {
+    await StackVerify.run(['--slot', '1', ...WS], config);
+    const profile = deriveInstance({ slot: 1 });
+
+    // the excluded services (frontends + literal-port backends) are NOT gated — at
+    // slot > 0 they aren't brought up, so gating them would always read down.
+    for (const id of EXCLUDED) {
+      const url = `http://localhost:${profile.portOverrides[id]}${manifest.services[id].healthPath}`;
+      expect(probed).not.toContain(url);
+    }
+
+    // the backend services ARE probed, on the +1000 offset port.
+    const iamUrl = `http://localhost:${profile.portOverrides['iam-api']}${manifest.services['iam-api'].healthPath}`;
+    expect(probed).toContain(iamUrl);
+    expect(iamUrl).toContain(`:${manifest.services['iam-api'].port + 1000}`);
+
+    // exactly the backend sub-stack: 13 non-optional minus the 5 excluded = 8.
+    expect(probed).toHaveLength(8);
+  });
+
+  it('slot 0 verify is byte-identical: probes every non-optional service on base ports', async () => {
+    await StackVerify.run([...WS], config);
+    expect(probed).toContain(DASH_URL); // frontends gated at slot 0
+    expect(probed).toHaveLength(13);
   });
 });

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/up-native.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/up-native.int.test.ts
@@ -212,6 +212,131 @@ describe('stack up --only — native partial-stack', () => {
   });
 });
 
+describe('stack up --slot N — isolated bring-up (M7 Phase 2)', () => {
+  // applyInstanceEnv mutates process.env (SAGA_MESH_*_CONTAINER + SNAPSHOTS_DIR);
+  // snapshot + restore the affected keys so a slot run can't leak into siblings.
+  const SLOT_ENV_KEYS = [
+    'SAGA_MESH_POSTGRES_CONTAINER',
+    'SAGA_MESH_REDIS_CONTAINER',
+    'SAGA_MESH_RABBITMQ_CONTAINER',
+    'SAGA_MESH_MONGO_CONTAINER',
+    'SAGA_MESH_CONNECT_MONGO_CONTAINER',
+    'SAGA_MESH_SNAPSHOTS_DIR',
+  ];
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    savedEnv = {};
+    for (const k of SLOT_ENV_KEYS) savedEnv[k] = process.env[k];
+  });
+  afterEach(() => {
+    for (const k of SLOT_ENV_KEYS) {
+      if (savedEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = savedEnv[k];
+    }
+  });
+
+  it('excludes the literal-port backends + frontends (backend sub-stack), and namespaces the mesh at soa-s1', async () => {
+    // request a frontend (saga-dash) + the literal-port playback trio at slot 1:
+    // the closure pulls the backend deps, but every excluded service is dropped —
+    // slot > 0 is a BACKEND sub-stack.
+    await StackUp.run(['--only', 'saga-dash', '--with', 'playback', '--slot', '1', ...WS], config);
+
+    const ids = launches.map((s) => s.id);
+    // the slot-safe BACKEND deps launched …
+    expect(ids).toContain('iam-api');
+    expect(ids).toContain('sessions-api');
+    expect(ids).toContain('content-api');
+    // … but every excluded service is dropped from the slot bring-up:
+    // frontends (no listen-port seam) …
+    expect(ids).not.toContain('saga-dash');
+    expect(ids).not.toContain('connect-web');
+    expect(ids).not.toContain('coach-web');
+    // … and the literal-port backends (bypass the offset).
+    expect(ids).not.toContain('ads-adm-api');
+    expect(ids).not.toContain('connect-api');
+    expect(ids).not.toContain('transcripts-api');
+    expect(ids).not.toContain('insights-api');
+    expect(ids).not.toContain('chat-api');
+
+    // mesh came up under the slot project on offset ports.
+    const makeUp = runs.find((r) => r.command === 'make');
+    expect(makeUp?.args).toContain('COMPOSE_PROJECT_NAME=soa-s1');
+    expect(makeUp?.args).toContain('POSTGRES_PORT=6432');
+    expect(makeUp?.env).toMatchObject({ COMPOSE_PROJECT_NAME: 'soa-s1' });
+    // readiness gated the slot's containers (env seam applied).
+    expect(meshGated.every((c) => c.startsWith('soa-s1-'))).toBe(true);
+
+    // env seam set for the snapshot store + container resolvers.
+    expect(process.env.SAGA_MESH_POSTGRES_CONTAINER).toBe('soa-s1-postgres-1');
+    expect(process.env.SAGA_MESH_SNAPSHOTS_DIR?.endsWith('/.saga-mesh/snapshots-s1')).toBe(true);
+  });
+
+  it('slot > 0 excludes saga-dash entirely — the dash prelaunch hook never runs (backend sub-stack)', async () => {
+    // saga-dash is a frontend with no listen-port seam, so it is EXCLUDED at slot > 0
+    // (it would bind slot 0's :8900). Its backend deps still come up, but the dash
+    // prelaunch hook (tied to saga-dash's own launch) never fires.
+    await StackUp.run(['--only', 'saga-dash', '--slot', '1', ...WS], config);
+    expect(launches.map((s) => s.id)).not.toContain('saga-dash');
+    expect(launches.map((s) => s.id)).toContain('iam-api'); // backend dep still up
+    expect(dashCalls).toEqual([]); // no write, no remove — hook never ran
+  });
+
+  it('BARE full-stack --slot 1 routes through the NATIVE path (never the up.sh wrapper)', async () => {
+    // BLOCKER-1: a bare `up --slot 1` (no --only) must NOT fall through to up.sh
+    // (hardcoded project soa / base ports / slot-0 STATE → clobbers slot 0). It is
+    // expanded to the full non-optional set and brought up natively as a soa-s1
+    // BACKEND sub-stack.
+    await StackUp.run(['--slot', '1', ...WS], config);
+
+    // never resolved/ran the up.sh wrapper.
+    expect(runs.some((r) => r.command.endsWith('up.sh'))).toBe(false);
+
+    // launched natively — the backend set is present, the excluded services are not.
+    const ids = launches.map((s) => s.id);
+    expect(ids.length).toBeGreaterThan(0);
+    expect(ids).toContain('iam-api');
+    expect(ids).toContain('sessions-api');
+    expect(ids).not.toContain('saga-dash');
+    expect(ids).not.toContain('connect-api');
+    expect(ids).not.toContain('connect-web');
+    expect(ids).not.toContain('coach-web');
+    expect(ids).not.toContain('ads-adm-api');
+
+    // mesh came up under the slot project on offset ports (soa-s1, +1000).
+    const makeUp = runs.find((r) => r.command === 'make');
+    expect(makeUp?.args).toContain('COMPOSE_PROJECT_NAME=soa-s1');
+    expect(makeUp?.args).toContain('POSTGRES_PORT=6432');
+    expect(makeUp?.env).toMatchObject({ COMPOSE_PROJECT_NAME: 'soa-s1' });
+  });
+
+  it('BARE full-stack at slot 0 keeps the up.sh wrapper (byte-identical)', async () => {
+    // The slot-0 wrapper path is covered in wrappers.int.test.ts (it mocks getRunner
+    // only); here we just prove a bare slot-0 run does NOT take the native path — no
+    // native service launches happen (it delegates entirely to up.sh via the Runner).
+    await StackUp.run([...WS], config);
+    expect(launches).toEqual([]);
+    expect(runs.some((r) => r.command.endsWith('up.sh'))).toBe(true);
+  });
+
+  it('--slot 10 is rejected at the flag layer (rabbitmq-mgmt collision ceiling)', async () => {
+    await expect(StackUp.run(['--slot', '10', ...WS], config)).rejects.toThrow(
+      /9|less than or equal|cannot be greater/i,
+    );
+    expect(launches).toEqual([]);
+    expect(runs).toEqual([]);
+  });
+
+  it('slot 0 launches ads-adm-api and REMOVES the dash config (byte-identical)', async () => {
+    await StackUp.run(['--only', 'saga-dash', ...WS], config);
+    expect(launches.map((s) => s.id)).toContain('ads-adm-api');
+    expect(meshGated.every((c) => !c.startsWith('soa-s1-'))).toBe(true);
+    // dash existsFile()=false in the fake ⇒ non-tunnel slot-0 path is a noop-absent
+    // (no write). The key assertion: NO stack-slot write happened at slot 0.
+    expect(dashCalls.some((c) => c.startsWith('write:'))).toBe(false);
+  });
+});
+
 describe('stack up --only --dry-run — planner prints the native launch + seed plan', () => {
   it('does NOT touch any seam and emits the seed plan', async () => {
     const logged: string[] = [];

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/wrappers.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/wrappers.int.test.ts
@@ -26,6 +26,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { BaseCommand } from '../../../base-command.js';
 import type { RunResult, ScriptInvocation } from '../../../runtime/index.js';
 import StackUp from '../up.js';
+import StackDown from '../down.js';
 import StackSeed from '../seed.js';
 import StackReset from '../reset.js';
 import StackOverlay from '../overlay.js';
@@ -142,6 +143,48 @@ describe('stack up — real path (no --dry-run) wraps up.sh', () => {
     // oclif's this.exit(code) throws an ExitError carrying `oclif.exit === code`.
     await expect(StackUp.run([...WS], config)).rejects.toMatchObject({ oclif: { exit: 3 } });
     expect(calls).toHaveLength(1);
+  });
+});
+
+describe('stack down — slot-safe teardown (M7 BLOCKER-2)', () => {
+  const INFRA_DIR = resolve(SOA_ROOT, 'infra');
+
+  it('slot 0 (bare) wraps up.sh --down (unchanged M1 behaviour)', async () => {
+    await StackDown.run([...WS], config);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].command).toBe(UP_SH);
+    expect(calls[0].args).toEqual(['--down']);
+  });
+
+  it('slot 0 --mesh: up.sh --down THEN make down for the default project', async () => {
+    await StackDown.run(['--mesh', ...WS], config);
+    expect(calls).toHaveLength(2);
+    expect(calls[0].command).toBe(UP_SH);
+    expect(calls[0].args).toEqual(['--down']);
+    // mesh teardown targets the DEFAULT project (no COMPOSE_PROJECT_NAME arg/env).
+    expect(calls[1].command).toBe('make');
+    expect(calls[1].cwd).toBe(INFRA_DIR);
+    expect(calls[1].args).toEqual(['down', 'PROJECT=saga-mesh']);
+    expect(calls[1].env).toEqual({});
+  });
+
+  it('slot > 0 does NOT invoke up.sh --down (no host-global service-stop)', async () => {
+    await StackDown.run(['--slot', '1', ...WS], config);
+    // no up.sh service-stop at all — its pkill/slot-0 STATE would kill slot 0.
+    expect(calls.some((c) => c.command.endsWith('up.sh'))).toBe(false);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('slot > 0 --mesh: ONLY the native mesh teardown for the slot project (no up.sh)', async () => {
+    await StackDown.run(['--slot', '1', '--mesh', ...WS], config);
+    // never the host-global up.sh --down.
+    expect(calls.some((c) => c.command.endsWith('up.sh'))).toBe(false);
+    // exactly one call: make down for THIS slot's project.
+    expect(calls).toHaveLength(1);
+    expect(calls[0].command).toBe('make');
+    expect(calls[0].cwd).toBe(INFRA_DIR);
+    expect(calls[0].args).toEqual(['down', 'COMPOSE_PROJECT_NAME=soa-s1', 'PROJECT=saga-mesh']);
+    expect(calls[0].env).toEqual({ COMPOSE_PROJECT_NAME: 'soa-s1' });
   });
 });
 

--- a/packages/node/saga-stack-cli/src/commands/stack/down.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/down.ts
@@ -15,13 +15,21 @@
  *
  *   node bin/dev.js stack down            # services down, mesh stays up
  *   node bin/dev.js stack down --mesh     # services down + mesh down
+ *
+ * SLOT > 0 (M7 Phase 2): the host-global `up.sh --down` service-stop is NEVER run
+ * (its `pkill -f tsup` + slot-0 STATE would kill slot 0's watchers). Only the
+ * slot-correct native mesh teardown runs, and only with `--mesh`. Stop a slot's
+ * own services by killing its process group / Ctrl-C until native per-slot
+ * service-stop lands in Phase 3. Slot 0 is unchanged.
  */
 
 import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command.js';
+import { deriveInstance } from '../../core/derive-instance.js';
+import type { InstanceProfile } from '../../core/derive-instance.js';
 import * as flagMap from '../../core/flag-map.js';
 import { meshDown, resolveRepoRoot } from '../../runtime/index.js';
-import type { ScriptContext } from '../../runtime/index.js';
+import type { MeshDownResult, ScriptContext } from '../../runtime/index.js';
 
 export default class StackDown extends BaseCommand {
   static description =
@@ -41,9 +49,46 @@ export default class StackDown extends BaseCommand {
     }),
   };
 
+  /**
+   * M7 Phase 2: `stack down --mesh --slot N` tears down the RIGHT per-slot mesh
+   * project. At slot > 0 the DESTRUCTIVE host-global `up.sh --down` service-stop is
+   * NOT run at all (see BLOCKER-2 below) — only the slot-correct native mesh
+   * teardown runs, and native per-slot service-stop is Phase 3.
+   */
+  protected slotAware(): boolean {
+    return true;
+  }
+
   async run(): Promise<void> {
     const { flags } = await this.parse(StackDown);
 
+    // M7: the slot profile supplies the per-slot COMPOSE_PROJECT_NAME for the mesh
+    // teardown. At slot 0 project stays `soa` (undefined here → the default).
+    const profile = deriveInstance({ slot: flags.slot });
+
+    // ── M7 BLOCKER-2: at slot > 0 do NOT run the host-global `up.sh --down`. ──
+    // up.sh --down does `pkill -f tsup` (HOST-GLOBAL — kills every slot's watchers)
+    // and kills the pids recorded under the hardcoded slot-0 STATE
+    // (/tmp/sds-synthetic) — running it from a slot would kill slot 0's services.
+    // So at slot > 0 we run ONLY the slot-correct native mesh teardown (when --mesh)
+    // and NEVER the up.sh service-stop.
+    if (profile.slot > 0) {
+      this.warn(
+        `slot ${profile.slot}: NOT running the host-global 'up.sh --down' (its 'pkill -f tsup' + ` +
+          'slot-0 STATE=/tmp/sds-synthetic would kill slot 0\'s watchers). Native per-slot ' +
+          "service-stop (kill-by-pidfile against this slot's state dir) is Phase 3 — for now stop " +
+          "slot N's services by killing that slot's process group / Ctrl-C.",
+      );
+
+      if (!flags.mesh) return;
+
+      // --mesh: tear down ONLY this slot's mesh project (never the default `soa`).
+      const mesh = await this.tearMeshDown(flags, profile);
+      if (mesh.code !== 0) this.exit(mesh.code);
+      return;
+    }
+
+    // ── Slot 0: unchanged M1 behaviour. ──
     // 1. Stop the services (up.sh --down). Without --mesh this is the whole job,
     //    so a non-zero exit propagates as before. With --mesh we still tear the
     //    mesh down even if services_down reported non-zero, so defer propagation
@@ -55,17 +100,31 @@ export default class StackDown extends BaseCommand {
     if (!flags.mesh) return;
 
     // 2. --mesh: ALSO tear the mesh down (inverse of up.sh mesh_up's
-    //    `make up PROJECT=saga-mesh`). IO stays in runtime/ (the shared Runner).
+    //    `make up PROJECT=saga-mesh`).
+    const mesh = await this.tearMeshDown(flags, profile);
+
+    const code = servicesCode !== 0 ? servicesCode : mesh.code;
+    if (code !== 0) this.exit(code);
+  }
+
+  /**
+   * Tear the mesh down through the shared Runner (inverse of up.sh mesh_up's
+   * `make up PROJECT=saga-mesh`). IO stays in runtime/. CRITICAL (M7): pass the
+   * slot's project so `make down` tears down THIS slot's mesh, not the default
+   * `soa` project (at slot 0 `project` is undefined → the default).
+   */
+  private async tearMeshDown(
+    flags: { dev: string; soa?: string },
+    profile: InstanceProfile,
+  ): Promise<MeshDownResult> {
     const ctx: ScriptContext = {
       dev: flags.dev,
       repoRoots: flags.soa ? { SOA: flags.soa } : {},
     };
-    const mesh = await meshDown({
+    return meshDown({
       soaRoot: resolveRepoRoot('SOA', ctx),
       runner: this.getRunner(),
+      project: profile.slot === 0 ? undefined : profile.project,
     });
-
-    const code = servicesCode !== 0 ? servicesCode : mesh.code;
-    if (code !== 0) this.exit(code);
   }
 }

--- a/packages/node/saga-stack-cli/src/commands/stack/status.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/status.ts
@@ -33,6 +33,7 @@ import {
   effectiveWithPlayback,
 } from '../../core/bundles.js';
 import { computeClosure } from '../../core/closure.js';
+import { deriveInstance } from '../../core/derive-instance.js';
 import { healthProbes } from '../../core/probe-plan.js';
 import { manifest } from '../../core/manifest/index.js';
 import type { RepoKey, ServiceId } from '../../core/manifest/index.js';
@@ -63,16 +64,30 @@ export default class StackStatus extends BaseCommand {
     }),
   };
 
+  /** M7 Phase 2: `stack status` probes a slot's offset ports at slot > 0. */
+  protected slotAware(): boolean {
+    return true;
+  }
+
   async run(): Promise<void> {
     const { flags } = await this.parse(StackStatus);
 
-    const ids = resolveServiceSet(flags.only, flags.with, (msg) => this.error(msg));
+    // M7: the slot profile drives the offset probe ports + the slot>0 exclusion.
+    // At slot 0 it's the byte-identical no-offset default (base ports, no exclusion).
+    const profile = deriveInstance({ slot: flags.slot });
+    let ids = resolveServiceSet(flags.only, flags.with, (msg) => this.error(msg));
+    // At slot > 0 the literal-port services aren't brought up (see `stack up`), so
+    // don't report them as down here either.
+    if (profile.slot > 0) {
+      const excluded = new Set(profile.excludedServices);
+      ids = ids.filter((id) => !excluded.has(id));
+    }
 
     // A service whose sibling repo isn't cloned is reported not-cloned, not probed
     // (and excluded from the healthy verdict) — consistent with `stack up`'s skip.
     const ctx = repoContextFromFlags(flags as unknown as Record<string, unknown>);
     const { probe, notCloned } = partitionByRepoPresence(ids, ctx, this.getRepoDirCheck());
-    const probes = healthProbes(manifest, probe);
+    const probes = healthProbes(manifest, probe, profile.portOverrides);
 
     const prober = this.getProber();
     const rows = await Promise.all(

--- a/packages/node/saga-stack-cli/src/commands/stack/up.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/up.ts
@@ -34,6 +34,7 @@ import {
   seedAddOnsFor,
 } from '../../core/bundles.js';
 import { computeClosure } from '../../core/closure.js';
+import { deriveInstance } from '../../core/derive-instance.js';
 import * as flagMap from '../../core/flag-map.js';
 import type { RecordMode } from '../../core/flag-map.js';
 import { defaultLaunchContext } from '../../core/launch-plan.js';
@@ -384,11 +385,22 @@ export default class StackUp extends BaseCommand {
     }
 
     const syntheticDevDir = scriptCwd({ repo: 'SOA', relPath: 'tools/synthetic-dev/up.sh' }, ctx);
+
+    // M7: the ONE slot-injection site. `deriveInstance` maps the numeric slot to
+    // its port offset / project / state+snapshot dirs / container env. At slot 0
+    // (offset 0) `portOverrides` is the base-port map and `meshOffset` is 0, so the
+    // launch context is byte-identical to the pre-M7 no-offset build — the
+    // regression guard. Slot > 0 is rejected up front in `BaseCommand.parse`
+    // (Phase 2), so only slot 0 is exercised here for now.
+    const profile = deriveInstance({ slot: flags.slot });
+
     // Mirror up.sh's `${PINO_LOGGER_LEVEL:-info}` / `${…ISEXPRESSCONTEXT:-true}`:
     // honour an ambient override, else the planner's defaults.
     const launchContext = defaultLaunchContext({
       repoRoots,
       syntheticDevDir,
+      portOverrides: profile.portOverrides,
+      meshOffset: profile.meshOffset,
       pinoLevel: process.env.PINO_LOGGER_LEVEL,
       pinoIsExpressContext: process.env.PINO_LOGGER_ISEXPRESSCONTEXT,
     });
@@ -398,7 +410,9 @@ export default class StackUp extends BaseCommand {
       launchContext,
       soaRoot: repoRoots.SOA,
       sagaDashRoot: repoRoots.SAGA_DASH,
-      launcher: this.getLauncher(flags['state-dir']),
+      // Default the launcher state-dir from the slot when `--state-dir` isn't
+      // given. At slot 0 both are `/tmp/sds-synthetic`, so this is a no-op today.
+      launcher: this.getLauncher(flags['state-dir'] ?? profile.stateDir),
       meshExec: this.getMeshExec(),
       portProbe: this.getPortProbe(),
       dashFs: this.getDashFs(),
@@ -444,6 +458,7 @@ type DryRunFlags = WorkspaceFlags & {
 };
 type NativeFlags = DryRunFlags & {
   'state-dir': string;
+  slot: number;
   reset: boolean;
   login: boolean;
 };

--- a/packages/node/saga-stack-cli/src/commands/stack/up.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/up.ts
@@ -34,7 +34,8 @@ import {
   seedAddOnsFor,
 } from '../../core/bundles.js';
 import { computeClosure } from '../../core/closure.js';
-import { deriveInstance } from '../../core/derive-instance.js';
+import { deriveInstance, slotExcludedServices } from '../../core/derive-instance.js';
+import type { InstanceProfile } from '../../core/derive-instance.js';
 import * as flagMap from '../../core/flag-map.js';
 import type { RecordMode } from '../../core/flag-map.js';
 import { defaultLaunchContext } from '../../core/launch-plan.js';
@@ -122,19 +123,39 @@ export default class StackUp extends BaseCommand {
     }),
   };
 
+  /** M7 Phase 2: `stack up` brings up an isolated `soa-s<N>` stack at slot > 0. */
+  protected slotAware(): boolean {
+    return true;
+  }
+
   async run(): Promise<void> {
     const { flags } = await this.parse(StackUp);
 
     // requested = --only ids ∪ --with bundle ids (sugar over --only); `--with`
     // participates in the same closure resolution the native/dry-run paths use.
-    const requested: ServiceId[] = combineRequested(flags.only, flags.with, (m) => this.error(m));
-    const isOnly = requested.length > 0;
+    let requested: ServiceId[] = combineRequested(flags.only, flags.with, (m) => this.error(m));
+    let isOnly = requested.length > 0;
     const withPlayback = effectiveWithPlayback(flags.with);
 
     // ── --dry-run (M0/M4): planner only. ──
     if (flags['dry-run']) {
       this.runDryRun(flags, requested, isOnly, withPlayback);
       return;
+    }
+
+    // ── M7 BLOCKER-1: a BARE full-stack `up` at slot > 0 must NOT reach the up.sh
+    // wrapper. up.sh is hardcoded to slot 0 (project `soa`, base ports, STATE=
+    // /tmp/sds-synthetic) — a bare `--slot N` falling through to `runWrapped` would
+    // CLOBBER the default stack. Expand the bare request to the FULL non-optional
+    // service set and route it through the native (slot-threaded) path below; the
+    // per-slot exclusion filter in `runNative` then drops the literal-port / frontend
+    // services, so slot > 0 comes up as a BACKEND sub-stack (see derive-instance).
+    // Slot 0 (bare) is unchanged — it keeps the up.sh wrap. ──
+    if (flags.slot > 0 && !isOnly) {
+      requested = Object.values(manifest.services)
+        .filter((s) => !s.optional)
+        .map((s) => s.id);
+      isOnly = true;
     }
 
     // ── NATIVE partial-stack (M4): --only with flags the native path can honour. ──
@@ -156,16 +177,31 @@ export default class StackUp extends BaseCommand {
         return;
       }
 
+      // M7 BLOCKER-1: the up.sh fallback below is hardcoded to slot 0 (project `soa`,
+      // base ports, STATE=/tmp/sds-synthetic). At slot > 0 it would clobber slot 0,
+      // so REFUSE rather than corrupt it — never fall through to `runWrapped`. (Native
+      // overlays for --sandbox/--tunnel/… at slot > 0 are a documented fast-follow.)
+      if (flags.slot > 0) {
+        this.error(
+          `slot ${flags.slot}: --sandbox/--tunnel/--workspace/--record/--pull/--no-auto-pull/--skip-prep ` +
+            'route through the up.sh wrapper, which is hardcoded to slot 0 (project soa, base ports, ' +
+            'STATE=/tmp/sds-synthetic) and would clobber it. Drop the flag to bring the slot up natively.',
+        );
+      }
+
       if (requested.length > 1) {
         this.error(
           'a multi-service --only/--with set boots the closure NATIVELY, but that path does not yet support --sandbox/--tunnel/--workspace/--record/--pull/--no-auto-pull/--skip-prep. Drop the unsupported flag (native), pass a single service (up.sh fallback), or use --dry-run to preview.',
         );
       }
       // Single service + an unsupported-native flag ⇒ fall through to the up.sh
-      // wrapper below (preserves the M1 --sandbox/single-service behaviour).
+      // wrapper below (preserves the M1 --sandbox/single-service behaviour). Only
+      // reached at slot 0 (slot > 0 hard-errored just above).
     }
 
-    // ── WRAPPED full-stack (M1): thin wrapper over up.sh. UNCHANGED. ──
+    // ── WRAPPED full-stack (M1): thin wrapper over up.sh. UNCHANGED. Slot 0 only —
+    // slot > 0 can never reach here (bare → native above; --only + unsupported flag
+    // → hard-error above). ──
     await this.runWrapped(flags, requested);
   }
 
@@ -190,6 +226,12 @@ export default class StackUp extends BaseCommand {
 
     const closure = computeClosure(manifest, resolvedRequest, { withPlayback });
 
+    // M7: at slot > 0 the bring-up would EXCLUDE the literal-port services; surface
+    // that in the preview so the dry-run matches what a real `--slot N` up launches.
+    const slotExcluded = slotExcludedServices(flags.slot).filter((id) =>
+      closure.services.includes(id),
+    );
+
     const reasonsObj: Record<string, string[]> = {};
     for (const svc of closure.services) reasonsObj[svc] = closure.reasons.get(svc) ?? [];
 
@@ -206,6 +248,7 @@ export default class StackUp extends BaseCommand {
       databases: closure.databases,
       mesh: closure.mesh,
       reasons: reasonsObj,
+      ...(slotExcluded.length > 0 ? { slot: flags.slot, slotExcluded } : {}),
       ...(seedPlan
         ? {
             native: true,
@@ -225,6 +268,9 @@ export default class StackUp extends BaseCommand {
       `mesh: ${closure.mesh.join(', ') || '(none)'}`,
       'reasons:',
       ...closure.services.map((svc) => `  ${svc}: ${(closure.reasons.get(svc) ?? []).join('; ')}`),
+      ...(slotExcluded.length > 0
+        ? [`slot ${flags.slot}: backend sub-stack — would EXCLUDE (literal-port + frontends, collide with slot 0): ${slotExcluded.join(', ')}`]
+        : []),
     ];
     if (seedPlan) {
       textLines.push(
@@ -250,11 +296,32 @@ export default class StackUp extends BaseCommand {
       this.error(`unknown service id(s): ${unknown.join(', ')}\nknown: ${[...known].join(', ')}`);
     }
 
-    const closure = computeClosure(manifest, requested, { withPlayback });
-    const api = makeStackApi(manifest, this.buildRuntime(flags));
+    // M7: derive the slot profile once, up front — it drives the ports/project/
+    // container-env threading (buildRuntime) AND the literal-port-service exclusion
+    // below. At slot 0 the profile is the byte-identical no-offset default.
+    const profile = deriveInstance({ slot: flags.slot });
+
+    const fullClosure = computeClosure(manifest, requested, { withPlayback });
+
+    // Exclude the literal-port backends (ads-adm-api/connect-api/playback trio) AND
+    // the browser frontends (saga-dash/connect-web/coach-web — no listen-port seam)
+    // from a slot > 0 bring-up: they'd collide with / split-brain onto slot 0 (see
+    // SLOT_EXCLUDED_SERVICES). So slot > 0 is a BACKEND sub-stack. Empty at slot 0,
+    // so slot 0 is unchanged.
+    const excluded = new Set(profile.excludedServices);
+    const services = fullClosure.services.filter((id) => !excluded.has(id));
+    const droppedForSlot = fullClosure.services.filter((id) => excluded.has(id));
+    if (droppedForSlot.length > 0) {
+      this.log(
+        `⚠ slot ${profile.slot}: backend sub-stack — excluding literal-port + frontend ` +
+          `service(s) that would collide with slot 0: ${droppedForSlot.join(', ')}`,
+      );
+    }
+
+    const api = makeStackApi(manifest, this.buildRuntime(flags, profile));
 
     // 1. native bring-up (mesh + topo-wave service launch).
-    const up = await api.up(closure.services);
+    const up = await api.up(services);
 
     // Surface any services skipped because their sibling repo isn't cloned (warn,
     // not fail) — e.g. a missing coach checkout. Printed before the failure/emit
@@ -271,7 +338,7 @@ export default class StackUp extends BaseCommand {
     // up.sh --reset truncates + re-seeds the running partial stack; the native seed
     // below then applies the SELECTED profile/add-ons on top (idempotent upserts).
     if (flags.reset) {
-      const reset = await api.reset(closure.services);
+      const reset = await api.reset(services);
       if (reset.code !== 0) this.exit(reset.code);
     }
 
@@ -282,7 +349,7 @@ export default class StackUp extends BaseCommand {
     // service-inactive instead. (restored = empty for M4 — snapshot integration can
     // pass a fully-restored set later.)
     const skippedIds = new Set(up.skipped.map((s) => s.id));
-    const active = new Set(closure.services.filter((id) => !skippedIds.has(id)));
+    const active = new Set(services.filter((id) => !skippedIds.has(id)));
     const plan: SeedPlan = composeSeedPlan(
       this.seedSelection(flags),
       active,
@@ -299,7 +366,7 @@ export default class StackUp extends BaseCommand {
       flags,
       {
         native: true,
-        services: closure.services,
+        services,
         launched: up.launched.map((r) => ({ id: r.id, ok: r.ok, alreadyUp: r.alreadyUp ?? false, pid: r.pid ?? null })),
         skipped: up.skipped.map((s) => ({ id: s.id, repo: s.repo, repoDir: s.repoDir })),
         mesh: { ok: up.mesh.ok, units: up.mesh.units.map((u) => ({ id: u.id, ok: u.ok })) },
@@ -368,7 +435,7 @@ export default class StackUp extends BaseCommand {
    * workspace. The seams (`getLauncher`/`getMeshExec`/…) are injectable, so a test
    * spies them on the prototype to drive the whole native path with fakes.
    */
-  private buildRuntime(flags: NativeFlags): Runtime {
+  private buildRuntime(flags: NativeFlags, profile: InstanceProfile): Runtime {
     // Pinned repo roots from the per-repo flags (kebab key → manifest env-var key).
     const pinned: Partial<Record<RepoKey, string>> = {};
     for (const kebab of Object.keys(REPO_ENV_VAR) as (keyof typeof REPO_ENV_VAR)[]) {
@@ -386,13 +453,21 @@ export default class StackUp extends BaseCommand {
 
     const syntheticDevDir = scriptCwd({ repo: 'SOA', relPath: 'tools/synthetic-dev/up.sh' }, ctx);
 
-    // M7: the ONE slot-injection site. `deriveInstance` maps the numeric slot to
-    // its port offset / project / state+snapshot dirs / container env. At slot 0
-    // (offset 0) `portOverrides` is the base-port map and `meshOffset` is 0, so the
-    // launch context is byte-identical to the pre-M7 no-offset build — the
-    // regression guard. Slot > 0 is rejected up front in `BaseCommand.parse`
-    // (Phase 2), so only slot 0 is exercised here for now.
-    const profile = deriveInstance({ slot: flags.slot });
+    // M7: the ONE slot-injection site. The `deriveInstance` profile (computed by the
+    // caller) maps the numeric slot to its port offset / project / state+snapshot
+    // dirs / container env. At slot 0 (offset 0) `portOverrides` is the base-port
+    // map and `meshOffset` is 0, so the launch context is byte-identical to the
+    // pre-M7 no-offset build — the regression guard.
+    //
+    // Apply the slot's env seam (SAGA_MESH_*_CONTAINER + SAGA_MESH_SNAPSHOTS_DIR) so
+    // the mesh-readiness resolver, the preflight owned-container set, and the
+    // snapshot store all target `soa-s<N>-<unit>-1`. No-op at slot 0.
+    this.applyInstanceEnv(profile);
+
+    // State dir (item 4): an EXPLICIT `--state-dir` wins; otherwise the slot's
+    // `profile.stateDir` (`/tmp/sds-synthetic` at slot 0, `…-s<N>` at slot > 0).
+    // `--state-dir` carries no oclif default, so an unset flag is `undefined` here.
+    const stateDir = flags['state-dir'] ?? profile.stateDir;
 
     // Mirror up.sh's `${PINO_LOGGER_LEVEL:-info}` / `${…ISEXPRESSCONTEXT:-true}`:
     // honour an ambient override, else the planner's defaults.
@@ -410,9 +485,16 @@ export default class StackUp extends BaseCommand {
       launchContext,
       soaRoot: repoRoots.SOA,
       sagaDashRoot: repoRoots.SAGA_DASH,
-      // Default the launcher state-dir from the slot when `--state-dir` isn't
-      // given. At slot 0 both are `/tmp/sds-synthetic`, so this is a no-op today.
-      launcher: this.getLauncher(flags['state-dir'] ?? profile.stateDir),
+      // M7 slot threading: > 0 namespaces the mesh (soa-s<N>) + offsets its ports +
+      // writes the slot's stack-lane dash config. At slot 0 project is undefined and
+      // offset 0, so `up` is byte-identical to the pre-M7 build.
+      slot: profile.slot,
+      meshProject: profile.slot === 0 ? undefined : profile.project,
+      meshOffset: profile.meshOffset,
+      // Default the launcher state-dir from the slot when `--state-dir` isn't given
+      // (see the explicit-set detection below). At slot 0 both are
+      // `/tmp/sds-synthetic`, so this is a no-op today.
+      launcher: this.getLauncher(stateDir),
       meshExec: this.getMeshExec(),
       portProbe: this.getPortProbe(),
       dashFs: this.getDashFs(),
@@ -453,11 +535,12 @@ export default class StackUp extends BaseCommand {
 type DryRunFlags = WorkspaceFlags & {
   porcelain: boolean;
   'output-json': boolean;
+  slot: number;
   with?: string[];
   seed?: string;
 };
 type NativeFlags = DryRunFlags & {
-  'state-dir': string;
+  'state-dir'?: string;
   slot: number;
   reset: boolean;
   login: boolean;

--- a/packages/node/saga-stack-cli/src/commands/stack/verify.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/verify.ts
@@ -30,6 +30,7 @@
 import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command.js';
 import { BUNDLE_NAMES } from '../../core/bundles.js';
+import { deriveInstance } from '../../core/derive-instance.js';
 import * as flagMap from '../../core/flag-map.js';
 import { healthProbes } from '../../core/probe-plan.js';
 import { manifest } from '../../core/manifest/index.js';
@@ -76,6 +77,11 @@ export default class StackVerify extends BaseCommand {
     }),
   };
 
+  /** M7 Phase 2: the native health gate probes a slot's offset ports at slot > 0. */
+  protected slotAware(): boolean {
+    return true;
+  }
+
   async run(): Promise<void> {
     const { flags } = await this.parse(StackVerify);
 
@@ -91,14 +97,23 @@ export default class StackVerify extends BaseCommand {
 
     // ── Native health gate (scoped to the --only closure, else all required). ──
     const tolerate = parseTolerate(flags.tolerate);
-    const ids = resolveServiceSet(flags.only, flags.with, (m) => this.error(m));
+    // M7: the slot profile drives the offset probe ports + the slot>0 exclusion.
+    // At slot 0 it's the byte-identical no-offset default (base ports, no exclusion).
+    const profile = deriveInstance({ slot: flags.slot });
+    let ids = resolveServiceSet(flags.only, flags.with, (m) => this.error(m));
+    // At slot > 0 the literal-port services aren't brought up (see `stack up`), so
+    // don't gate on them here either — they'd always read down.
+    if (profile.slot > 0) {
+      const excluded = new Set(profile.excludedServices);
+      ids = ids.filter((id) => !excluded.has(id));
+    }
 
     // A service whose sibling repo isn't cloned is reported not-cloned (NOT a
     // failure) — a missing coach checkout must not fail the gate, matching `stack
     // up`'s skip guard.
     const ctx = repoContextFromFlags(flags as unknown as Record<string, unknown>);
     const { probe, notCloned } = partitionByRepoPresence(ids, ctx, this.getRepoDirCheck());
-    const probes = healthProbes(manifest, probe);
+    const probes = healthProbes(manifest, probe, profile.portOverrides);
 
     const prober = this.getProber();
     const rows = await Promise.all(

--- a/packages/node/saga-stack-cli/src/core/__tests__/derive-instance.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/derive-instance.unit.test.ts
@@ -1,0 +1,110 @@
+/**
+ * derive-instance unit tests (M7 Phase 1, plan §5).
+ *
+ * The bulk of Phase-1 confidence: `deriveInstance` is pure, so the slot → profile
+ * contract, the byte-identical slot-0 regression guard, and the cross-slot
+ * port-disjointness property are all fully asserted here with no docker/make/IO.
+ * Paired with `launch-plan.slot.unit.test.ts` (the `meshOffset` split-brain guard)
+ * and `base-command.slot.unit.test.ts` (the slot > 0 Phase-2 rejection).
+ */
+
+import { homedir } from 'node:os';
+import { describe, expect, it } from 'vitest';
+import {
+  SLOT_PORT_STRIDE,
+  deriveInstance,
+} from '../derive-instance.js';
+import { getMesh, manifest } from '../manifest/index.js';
+import type { ServiceId } from '../manifest/index.js';
+
+/** The base-port override map (offset 0) — what slot 0 must produce verbatim. */
+const basePortOverrides = (): Partial<Record<ServiceId, number>> => {
+  const out: Partial<Record<ServiceId, number>> = {};
+  for (const id of Object.keys(manifest.services) as ServiceId[]) {
+    out[id] = manifest.services[id].port;
+  }
+  return out;
+};
+
+describe('deriveInstance(0) — the byte-identical regression guard', () => {
+  const p = deriveInstance({ slot: 0 });
+
+  it('returns today\'s constants verbatim', () => {
+    expect(p.slot).toBe(0);
+    expect(p.offset).toBe(0);
+    expect(p.meshOffset).toBe(0);
+    expect(p.project).toBe('soa');
+    expect(p.stateDir).toBe('/tmp/sds-synthetic');
+    expect(p.snapshotsDir).toBeUndefined();
+    expect(p.containerEnv).toEqual({});
+    expect(p.seedProfile).toBe('empty');
+  });
+
+  it('portOverrides is the base-port map (offset 0)', () => {
+    expect(p.portOverrides).toEqual(basePortOverrides());
+  });
+});
+
+describe('deriveInstance(N) for N ∈ {1,2,3}', () => {
+  it.each([1, 2, 3])('offsets everything into the soa-s%i namespace', (slot) => {
+    const p = deriveInstance({ slot });
+    const offset = slot * SLOT_PORT_STRIDE;
+
+    expect(p.slot).toBe(slot);
+    expect(p.offset).toBe(offset);
+    expect(p.meshOffset).toBe(offset);
+    expect(p.project).toBe(`soa-s${slot}`);
+    expect(p.stateDir).toBe(`/tmp/sds-synthetic-s${slot}`);
+    expect(p.snapshotsDir).toBe(`${homedir()}/.saga-mesh/snapshots-s${slot}`);
+    expect(p.seedProfile).toBe('empty');
+
+    // container env — every mesh container repointed at soa-s<N>-<unit>-1; both
+    // mongo reader names (mesh.ts `meshContainer` + snapshot-store `mongoContainer`).
+    expect(p.containerEnv).toEqual({
+      SAGA_MESH_POSTGRES_CONTAINER: `soa-s${slot}-postgres-1`,
+      SAGA_MESH_REDIS_CONTAINER: `soa-s${slot}-redis-1`,
+      SAGA_MESH_RABBITMQ_CONTAINER: `soa-s${slot}-rabbitmq-1`,
+      SAGA_MESH_MONGO_CONTAINER: `soa-s${slot}-connect-mongo-1`,
+      SAGA_MESH_CONNECT_MONGO_CONTAINER: `soa-s${slot}-connect-mongo-1`,
+    });
+
+    // every service port offset by exactly N*1000.
+    for (const id of Object.keys(manifest.services) as ServiceId[]) {
+      expect(p.portOverrides[id]).toBe(manifest.services[id].port + offset);
+    }
+  });
+});
+
+describe('no-collision property — union of ALL resolved ports is duplicate-free over slots 0..8', () => {
+  it('has no port shared across any two slots', () => {
+    const all: number[] = [];
+    for (let slot = 0; slot <= 8; slot += 1) {
+      const p = deriveInstance({ slot });
+      const offset = slot * SLOT_PORT_STRIDE;
+      // service ports
+      for (const id of Object.keys(p.portOverrides) as ServiceId[]) {
+        all.push(p.portOverrides[id] as number);
+      }
+      // mesh ports (postgres/redis/rabbitmq/rabbitmq-mgmt/connect-mongo)
+      const rabbit = getMesh('rabbitmq');
+      all.push(
+        getMesh('postgres').port + offset,
+        getMesh('redis').port + offset,
+        rabbit.port + offset,
+        (rabbit.mgmtPort ?? 15672) + offset,
+        getMesh('connect-mongo').port + offset,
+      );
+    }
+    expect(new Set(all).size).toBe(all.length);
+  });
+});
+
+describe('input validation', () => {
+  it('rejects a negative slot', () => {
+    expect(() => deriveInstance({ slot: -1 })).toThrow(/non-negative integer/);
+  });
+
+  it('rejects a non-integer slot', () => {
+    expect(() => deriveInstance({ slot: 1.5 })).toThrow(/non-negative integer/);
+  });
+});

--- a/packages/node/saga-stack-cli/src/core/__tests__/derive-instance.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/derive-instance.unit.test.ts
@@ -11,8 +11,10 @@
 import { homedir } from 'node:os';
 import { describe, expect, it } from 'vitest';
 import {
+  SLOT_EXCLUDED_SERVICES,
   SLOT_PORT_STRIDE,
   deriveInstance,
+  slotExcludedServices,
 } from '../derive-instance.js';
 import { getMesh, manifest } from '../manifest/index.js';
 import type { ServiceId } from '../manifest/index.js';
@@ -96,6 +98,57 @@ describe('no-collision property — union of ALL resolved ports is duplicate-fre
       );
     }
     expect(new Set(all).size).toBe(all.length);
+  });
+});
+
+describe('literal-port service exclusion (plan §6)', () => {
+  it('slot 0 excludes nothing (byte-identical bring-up)', () => {
+    expect(deriveInstance({ slot: 0 }).excludedServices).toEqual([]);
+    expect(slotExcludedServices(0)).toEqual([]);
+  });
+
+  it('slot > 0 excludes the literal-port backends + the browser frontends (backend sub-stack)', () => {
+    const excluded = deriveInstance({ slot: 1 }).excludedServices;
+    expect(excluded).toEqual([...SLOT_EXCLUDED_SERVICES]);
+    expect(new Set(excluded)).toEqual(
+      new Set([
+        // literal-port backends (bypass the offset)
+        'ads-adm-api',
+        'connect-api',
+        'transcripts-api',
+        'insights-api',
+        'chat-api',
+        // frontends — no listen-port seam
+        'saga-dash',
+        'connect-web',
+        'coach-web',
+      ]),
+    );
+    expect(slotExcludedServices(3)).toEqual([...SLOT_EXCLUDED_SERVICES]);
+  });
+});
+
+describe('two-slot (1 vs 2) — the full resolved port set is disjoint', () => {
+  it('no service port and no mesh port is shared between slot 1 and slot 2', () => {
+    const collect = (slot: number): number[] => {
+      const p = deriveInstance({ slot });
+      const offset = slot * SLOT_PORT_STRIDE;
+      const rabbit = getMesh('rabbitmq');
+      return [
+        ...(Object.keys(p.portOverrides) as ServiceId[]).map((id) => p.portOverrides[id] as number),
+        getMesh('postgres').port + offset,
+        getMesh('redis').port + offset,
+        rabbit.port + offset,
+        (rabbit.mgmtPort ?? 15672) + offset,
+        getMesh('connect-mongo').port + offset,
+      ];
+    };
+    const s1 = collect(1);
+    const s2 = collect(2);
+    // no intersection, and the union is duplicate-free.
+    const union = [...s1, ...s2];
+    expect(new Set(union).size).toBe(union.length);
+    expect(s1.some((p) => s2.includes(p))).toBe(false);
   });
 });
 

--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.slot.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.slot.unit.test.ts
@@ -1,0 +1,91 @@
+/**
+ * launch-plan × M7 slot tests (plan §5 — the split-brain guard).
+ *
+ * `defaultLaunchContext`'s `meshOffset` input must offset the mesh connection
+ * strings (`MESH_MQ` / `CONNECT_MONGO_URI` / `CONNECT_MONGO_PORT` / every
+ * `*_DB_URL`) in lockstep with the mesh's published ports — else a slot's
+ * services would publish on offset ports but dial the base mesh (split brain).
+ * Slot 0 (offset 0, via `deriveInstance(0)`'s profile) must be byte-identical to
+ * the pre-M7 no-offset context — the regression guard. Pure: fake repo roots.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { deriveInstance } from '../derive-instance.js';
+import { defaultLaunchContext } from '../launch-plan.js';
+import { getMesh, manifest } from '../manifest/index.js';
+import type { RepoKey } from '../manifest/index.js';
+
+const REPO_ROOTS: Record<RepoKey, string> = {
+  SOA: '/w/soa',
+  ROSTERING: '/w/rostering',
+  PROGRAM_HUB: '/w/program-hub',
+  SAGA_DASH: '/w/saga-dash',
+  COACH: '/w/coach',
+  SDS: '/w/student-data-system',
+  QBOARD: '/w/qboard',
+  RTSM: '/w/rtsm',
+  FLEEK: '/w/fleek',
+};
+
+const baseInputs = { repoRoots: REPO_ROOTS, syntheticDevDir: '/w/soa/tools/synthetic-dev' };
+
+/** Extract the `host:port` from a URL-ish token for a robust port assertion. */
+const portOf = (s: string): number => Number(new URL(s).port);
+
+describe('defaultLaunchContext meshOffset — mesh connection strings offset in lockstep', () => {
+  const offset = 1000;
+  const ctx = defaultLaunchContext({ ...baseInputs, meshOffset: offset });
+
+  const pgBase = getMesh('postgres').port;
+  const mqBase = getMesh('rabbitmq').port;
+  const mongoBase = getMesh('connect-mongo').port;
+
+  it('offsets MESH_MQ (rabbitmq port)', () => {
+    expect(portOf(ctx.tokens.MESH_MQ)).toBe(mqBase + offset);
+  });
+
+  it('offsets CONNECT_MONGO_URI + CONNECT_MONGO_PORT (mongo port)', () => {
+    expect(portOf(ctx.tokens.CONNECT_MONGO_URI)).toBe(mongoBase + offset);
+    expect(ctx.tokens.CONNECT_MONGO_PORT).toBe(String(mongoBase + offset));
+  });
+
+  it('offsets every *_DB_URL (postgres port)', () => {
+    for (const url of [
+      ctx.tokens.SIS_DB_URL,
+      ctx.tokens.PROGRAMS_DB_URL,
+      ctx.tokens.SCHEDULING_DB_URL,
+      ctx.tokens.SESSIONS_DB_URL,
+      ctx.tokens.CONTENT_DB_URL,
+      ctx.tokens.COACH_DB_URL,
+    ]) {
+      expect(portOf(url)).toBe(pgBase + offset);
+    }
+  });
+});
+
+describe('slot 0 launch context is byte-identical to the pre-M7 no-offset build', () => {
+  it('deriveInstance(0) profile fed through defaultLaunchContext == no overrides', () => {
+    const profile = deriveInstance({ slot: 0 });
+    const slot0 = defaultLaunchContext({
+      ...baseInputs,
+      portOverrides: profile.portOverrides,
+      meshOffset: profile.meshOffset,
+    });
+    const legacy = defaultLaunchContext(baseInputs);
+    expect(slot0).toEqual(legacy);
+  });
+
+  it('slot 1 ports differ from slot 0 (sanity: the offset actually moves things)', () => {
+    const p1 = deriveInstance({ slot: 1 });
+    const ctx1 = defaultLaunchContext({
+      ...baseInputs,
+      portOverrides: p1.portOverrides,
+      meshOffset: p1.meshOffset,
+    });
+    const legacy = defaultLaunchContext(baseInputs);
+    expect(ctx1.ports['iam-api']).toBe((legacy.ports['iam-api'] ?? 0) + 1000);
+    expect(ctx1.tokens.MESH_MQ).not.toBe(legacy.tokens.MESH_MQ);
+    // manifest is untouched (deriveInstance is pure).
+    expect(manifest.services['iam-api'].port).toBe(legacy.ports['iam-api']);
+  });
+});

--- a/packages/node/saga-stack-cli/src/core/__tests__/probe-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/probe-plan.unit.test.ts
@@ -64,3 +64,28 @@ describe('healthProbes — manifest-derived probe list', () => {
     expect(() => healthProbes(manifest, ['nope' as ServiceId])).toThrow(/unknown service id/);
   });
 });
+
+describe('healthProbes — M7 slot offset (portOverrides)', () => {
+  /** slot-N port map: every service's base port + N*1000. */
+  const offsetPorts = (offset: number): Partial<Record<ServiceId, number>> => {
+    const out: Partial<Record<ServiceId, number>> = {};
+    for (const id of Object.keys(manifest.services) as ServiceId[]) {
+      out[id] = manifest.services[id].port + offset;
+    }
+    return out;
+  };
+
+  it('slot 0 (base-port overrides) is byte-identical to no overrides', () => {
+    expect(healthProbes(manifest, undefined, offsetPorts(0))).toEqual(healthProbes(manifest));
+  });
+
+  it('slot > 0: each URL uses the RESOLVED offset port, not base', () => {
+    const by = Object.fromEntries(
+      healthProbes(manifest, undefined, offsetPorts(1000)).map((p) => [p.id, p.url]),
+    );
+    expect(by['iam-api']).toBe('http://localhost:4010/health'); // 3010 + 1000
+    expect(by['content-api']).toBe('http://localhost:4009/health'); // 3009 + 1000
+    expect(by['connect-api']).toBe('http://localhost:7106/connectv3/v1/health'); // 6106 + 1000
+    expect(by['saga-dash']).toBe('http://localhost:9900/'); // 8900 + 1000, root path
+  });
+});

--- a/packages/node/saga-stack-cli/src/core/derive-instance.ts
+++ b/packages/node/saga-stack-cli/src/core/derive-instance.ts
@@ -1,0 +1,171 @@
+/**
+ * derive-instance — the single pure factory for M7 multi-instance ("slots").
+ *
+ * `deriveInstance({ slot })` maps a numeric slot to an `InstanceProfile`: the
+ * complete set of per-slot namespacing knobs (port offset, compose project,
+ * state/snapshot dirs, mesh container-name overrides, seed profile, and the
+ * generic per-service port-override map). It is the ONE place slot → concrete
+ * values is computed; every downstream seam consumes the profile so no call
+ * site ever hardcodes a slot-derived value.
+ *
+ * SLOT MODEL (plan §1): deterministic port-offset `offset = slot * 1000` +
+ * project-suffixed namespace `soa-s<slot>`. Slot 0 returns TODAY'S constants
+ * verbatim (offset 0, project `soa`, state `/tmp/sds-synthetic`, no snapshot
+ * override, no container env) — the byte-identical regression guard: feeding
+ * slot-0's `portOverrides`/`meshOffset` through `defaultLaunchContext` yields
+ * exactly the no-offset context.
+ *
+ * PURITY: no docker/make/network IO. The only host-derived read is
+ * `os.homedir()` for the per-slot snapshot root (matching `snapshot-store`'s
+ * own default) — deterministic per host, no filesystem touch — which the fixed
+ * `{ slot }` signature requires. `src/core/**` never imports `src/runtime/**`.
+ *
+ * The port-override map is derived GENERICALLY over `manifest.services` (never a
+ * hand-maintained table), so any future service slots for free. After computing,
+ * the factory ASSERTS full-set port disjointness (every service port + the five
+ * mesh ports, each + offset) and throws on any collision — guarding a future
+ * service whose base could land a multiple of the stride from another.
+ */
+
+import { homedir } from 'node:os';
+import { getMesh, manifest as defaultManifest } from './manifest/index.js';
+import type { Manifest, ServiceId } from './manifest/index.js';
+
+/** The stride between adjacent slots' port bands. `offset = slot * STRIDE`. */
+export const SLOT_PORT_STRIDE = 1000;
+
+/**
+ * The complete per-slot namespacing profile. Slot 0 is byte-identical to
+ * today's implicit defaults (the regression guard); slot N ≥ 1 offsets ports by
+ * `N * SLOT_PORT_STRIDE` into an isolated `soa-s<N>` stack.
+ */
+export interface InstanceProfile {
+  /** The numeric slot this profile was derived for. */
+  slot: number;
+  /** Port offset applied to every service + mesh port (`slot * SLOT_PORT_STRIDE`). */
+  offset: number;
+  /** COMPOSE_PROJECT_NAME: `soa` at slot 0, `soa-s<N>` for N ≥ 1. */
+  project: string;
+  /** Default `--state-dir`: `/tmp/sds-synthetic` at slot 0, `…-s<N>` for N ≥ 1. */
+  stateDir: string;
+  /**
+   * Per-slot snapshot root (`SAGA_MESH_SNAPSHOTS_DIR`). `undefined` at slot 0 so
+   * `snapshot-store` falls back to today's `~/.saga-mesh/snapshots`; for N ≥ 1 an
+   * isolated `~/.saga-mesh/snapshots-s<N>` root so a slot's fixtures can't clobber
+   * another's.
+   */
+  snapshotsDir: string | undefined;
+  /**
+   * Mesh container-name overrides (the existing `SAGA_MESH_*_CONTAINER` seam).
+   * Empty at slot 0 (manifest defaults win); for N ≥ 1 points every mesh
+   * container at `soa-s<N>-<unit>-1`. Both mongo reader names are set — see the
+   * note by `containerEnvFor`.
+   */
+  containerEnv: Record<string, string>;
+  /** Seed profile — ALWAYS `empty` (load-bearing, plan §3): isolation comes from
+   *  the project prefix, not the profile, and only `profile-empty.sql` exists. */
+  seedProfile: 'empty';
+  /** Per-service resolved port (manifest base + offset), keyed by service id. */
+  portOverrides: Partial<Record<ServiceId, number>>;
+  /** Offset fed to the mesh ports (postgres/rabbitmq/mongo) — equals `offset`. */
+  meshOffset: number;
+}
+
+/**
+ * The mesh container-name override env for slot N ≥ 1.
+ *
+ * IMPORTANT — two readers, two mongo names. The mesh readiness resolver
+ * (`runtime/mesh.ts` `meshContainer`) derives its key from the unit id, so the
+ * connect-mongo unit reads `SAGA_MESH_CONNECT_MONGO_CONTAINER`; the snapshot
+ * store (`runtime/snapshot-store.ts` `mongoContainer`) reads the SHORTER
+ * `SAGA_MESH_MONGO_CONTAINER`. postgres/redis/rabbitmq agree across both
+ * readers. To isolate the mongo container for BOTH code paths at slot > 0 we set
+ * both mongo keys to the same value. (At slot 0 this map is empty, so slot 0 is
+ * unaffected regardless.)
+ */
+function containerEnvFor(slot: number): Record<string, string> {
+  if (slot === 0) return {};
+  const project = `soa-s${slot}`;
+  return {
+    SAGA_MESH_POSTGRES_CONTAINER: `${project}-postgres-1`,
+    SAGA_MESH_REDIS_CONTAINER: `${project}-redis-1`,
+    SAGA_MESH_RABBITMQ_CONTAINER: `${project}-rabbitmq-1`,
+    // snapshot-store's `mongoContainer` reader:
+    SAGA_MESH_MONGO_CONTAINER: `${project}-connect-mongo-1`,
+    // mesh.ts's `meshContainer` reader (unit-id-derived key):
+    SAGA_MESH_CONNECT_MONGO_CONTAINER: `${project}-connect-mongo-1`,
+  };
+}
+
+/**
+ * Assert the fully-resolved port set for one slot is collision-free: every
+ * service port + the five mesh ports (postgres/redis/rabbitmq/rabbitmq-mgmt/
+ * connect-mongo), each + offset. Throws a clear error on the first duplicate.
+ * Stride 1000 is collision-free by construction today; this guards a FUTURE
+ * service whose base could sit a multiple of the stride from another.
+ */
+function assertPortsDisjoint(slot: number, offset: number, m: Manifest): void {
+  const ports: number[] = [];
+  for (const id of Object.keys(m.services) as ServiceId[]) {
+    ports.push(m.services[id].port + offset);
+  }
+  const rabbit = getMesh('rabbitmq', m);
+  ports.push(
+    getMesh('postgres', m).port + offset,
+    getMesh('redis', m).port + offset,
+    rabbit.port + offset,
+    (rabbit.mgmtPort ?? 15672) + offset,
+    getMesh('connect-mongo', m).port + offset,
+  );
+
+  const seen = new Set<number>();
+  for (const p of ports) {
+    if (seen.has(p)) {
+      throw new Error(
+        `deriveInstance(slot=${slot}): resolved port ${p} collides — the service + mesh ` +
+          `port set is not disjoint under offset ${offset}. A base port must sit a multiple ` +
+          `of the ${SLOT_PORT_STRIDE} stride from another; re-band the offending service.`,
+      );
+    }
+    seen.add(p);
+  }
+}
+
+/**
+ * Map a numeric slot to its complete `InstanceProfile`. Pure (bar `os.homedir()`
+ * for the snapshot root). Slot 0 returns today's constants verbatim; slot N ≥ 1
+ * offsets everything into the `soa-s<N>` namespace. Throws on a negative slot or
+ * a port-set collision.
+ */
+export function deriveInstance(
+  { slot }: { slot: number },
+  m: Manifest = defaultManifest,
+): InstanceProfile {
+  if (!Number.isInteger(slot) || slot < 0) {
+    throw new Error(`deriveInstance: slot must be a non-negative integer, got ${slot}`);
+  }
+
+  const offset = slot * SLOT_PORT_STRIDE;
+
+  // Generic port-override map: every manifest service, offset applied. At slot 0
+  // (offset 0) this is the base-port map, so `defaultLaunchContext` resolves the
+  // same ports it would with no overrides — the byte-identical guard.
+  const portOverrides: Partial<Record<ServiceId, number>> = {};
+  for (const id of Object.keys(m.services) as ServiceId[]) {
+    portOverrides[id] = m.services[id].port + offset;
+  }
+
+  assertPortsDisjoint(slot, offset, m);
+
+  return {
+    slot,
+    offset,
+    project: slot === 0 ? 'soa' : `soa-s${slot}`,
+    stateDir: slot === 0 ? '/tmp/sds-synthetic' : `/tmp/sds-synthetic-s${slot}`,
+    snapshotsDir: slot === 0 ? undefined : `${homedir()}/.saga-mesh/snapshots-s${slot}`,
+    containerEnv: containerEnvFor(slot),
+    seedProfile: 'empty',
+    portOverrides,
+    meshOffset: offset,
+  };
+}

--- a/packages/node/saga-stack-cli/src/core/derive-instance.ts
+++ b/packages/node/saga-stack-cli/src/core/derive-instance.ts
@@ -20,6 +20,17 @@
  * own default) — deterministic per host, no filesystem touch — which the fixed
  * `{ slot }` signature requires. `src/core/**` never imports `src/runtime/**`.
  *
+ * SLOT > 0 IS A BACKEND SUB-STACK (Phase-2 MVP). Slot > 0 brings up the backend
+ * mesh + services only — `iam/programs/scheduling/sessions/content/sis/rtsm/
+ * coach-api` + the mesh. The literal-port backends and ALL browser frontends are
+ * EXCLUDED (`SLOT_EXCLUDED_SERVICES`): `connect-api` carries literal cross-slot
+ * ports (`:3007` sessions, `ws://…:7880` livekit) that bypass the offset and would
+ * split-brain onto slot 0's stateful services; the three frontends (`saga-dash`/
+ * `connect-web`/`coach-web`, all `isFrontend`) have NO listen-port seam (their
+ * `portEnvVar` metadata is DEAD — unconsumed anywhere), so at slot > 0 they'd bind
+ * their built-in default port (= slot 0's) and `verify --slot N` could never be
+ * green. Frontend multi-slot lands when the frontends grow a port seam.
+ *
  * The port-override map is derived GENERICALLY over `manifest.services` (never a
  * hand-maintained table), so any future service slots for free. After computing,
  * the factory ASSERTS full-set port disjointness (every service port + the five
@@ -33,6 +44,50 @@ import type { Manifest, ServiceId } from './manifest/index.js';
 
 /** The stride between adjacent slots' port bands. `offset = slot * STRIDE`. */
 export const SLOT_PORT_STRIDE = 1000;
+
+/**
+ * Services EXCLUDED from a slot > 0 bring-up (plan §6 collision matrix). Two
+ * classes, both of which would CLOBBER or SPLIT-BRAIN onto slot 0:
+ *
+ *   LITERAL-PORT backends — carry LITERAL ports in their launch env that bypass
+ *   the generic `${…_PORT}` / mesh-offset token machinery, so at an offset slot
+ *   they would still dial slot 0's ports (postgres :5432, sessions :3007, iam
+ *   :3010, dash CORS :8900, EXPRESS_SERVER_PORT 6301-6303, livekit ws :7880) and
+ *   silently corrupt / collide with the default stack:
+ *     - `ads-adm-api`    — literal `@localhost:5432`, `:3007`, `:3010`, CORS `:8900`.
+ *     - `connect-api`    — literal `SESSIONS_API_BASE_URL :3007` + livekit `ws :7880`;
+ *                          would read/write slot 0's stateful sessions-api.
+ *     - the playback trio — literal `POSTGRES_PORT '5432'` + `EXPRESS_SERVER_PORT`.
+ *
+ *   FRONTENDS (`isFrontend`) — `saga-dash`/`connect-web`/`coach-web` have NO
+ *   listen-port seam (their `portEnvVar` metadata is DEAD — unconsumed anywhere),
+ *   so at slot > 0 they'd bind their built-in default port (= slot 0's) and
+ *   `verify --slot N` could never be green. Excluded until they grow a port seam.
+ *
+ * Consequence: slot > 0 is a BACKEND sub-stack (see the file header). They are
+ * excluded EXPLICITLY (not via transitive drop, which would orphan a dependent).
+ * At slot 0 nothing is excluded (the set is empty), so slot 0 is unaffected.
+ */
+export const SLOT_EXCLUDED_SERVICES: readonly ServiceId[] = [
+  // literal-port backends
+  'ads-adm-api',
+  'connect-api',
+  'transcripts-api',
+  'insights-api',
+  'chat-api',
+  // frontends — no listen-port seam
+  'saga-dash',
+  'connect-web',
+  'coach-web',
+];
+
+/**
+ * The services excluded from a bring-up at `slot`: `[]` at slot 0 (byte-identical
+ * regression guard), `SLOT_EXCLUDED_SERVICES` for N ≥ 1. Pure.
+ */
+export function slotExcludedServices(slot: number): ServiceId[] {
+  return slot === 0 ? [] : [...SLOT_EXCLUDED_SERVICES];
+}
 
 /**
  * The complete per-slot namespacing profile. Slot 0 is byte-identical to
@@ -69,6 +124,11 @@ export interface InstanceProfile {
   portOverrides: Partial<Record<ServiceId, number>>;
   /** Offset fed to the mesh ports (postgres/rabbitmq/mongo) — equals `offset`. */
   meshOffset: number;
+  /**
+   * Services excluded from THIS slot's bring-up closure (literal-port services
+   * that bypass the offset — see `SLOT_EXCLUDED_SERVICES`). Empty at slot 0.
+   */
+  excludedServices: ServiceId[];
 }
 
 /**
@@ -167,5 +227,6 @@ export function deriveInstance(
     seedProfile: 'empty',
     portOverrides,
     meshOffset: offset,
+    excludedServices: slotExcludedServices(slot),
   };
 }

--- a/packages/node/saga-stack-cli/src/core/launch-plan.ts
+++ b/packages/node/saga-stack-cli/src/core/launch-plan.ts
@@ -310,6 +310,13 @@ export interface LaunchContextInputs {
   sagaApiTarget?: string;
   /** Per-service port overrides (e.g. a `check_ports` remap); defaults to the manifest port. */
   portOverrides?: Partial<Record<ServiceId, number>>;
+  /**
+   * Offset added to the mesh ports (postgres/rabbitmq/connect-mongo) so
+   * `MESH_MQ` / `CONNECT_MONGO_URI` / `*_DB_URL` (and `CONNECT_MONGO_PORT`)
+   * point at a slot's offset mesh in lockstep with the mesh's published ports
+   * (M7). Default 0 ⇒ today's base mesh ports (byte-identical to no offset).
+   */
+  meshOffset?: number;
   /** Fleek recorder control port (up.sh `RECORDER_CONTROL_PORT`; default 7890). */
   recorderControlPort?: number;
   /** Fleek recordings-api port (up.sh `RECORDINGS_API_PORT`; default 8444). */
@@ -350,9 +357,12 @@ export function defaultLaunchContext(inputs: LaunchContextInputs, m: Manifest = 
   const ports = {} as Record<ServiceId, number>;
   for (const id of Object.keys(m.services) as ServiceId[]) ports[id] = port(id);
 
-  const pgPort = getMesh('postgres', m).port; // 5432 (mesh shared instance)
-  const mqPort = getMesh('rabbitmq', m).port; // 5672
-  const mongoPort = getMesh('connect-mongo', m).port; // 27037
+  // Mesh ports offset in lockstep with the mesh's published ports (M7 slots).
+  // meshOffset 0 (the default) ⇒ today's base ports, byte-identical to no offset.
+  const meshOffset = inputs.meshOffset ?? 0;
+  const pgPort = getMesh('postgres', m).port + meshOffset; // 5432 (mesh shared instance)
+  const mqPort = getMesh('rabbitmq', m).port + meshOffset; // 5672
+  const mongoPort = getMesh('connect-mongo', m).port + meshOffset; // 27037
 
   const recorderControlPort = inputs.recorderControlPort ?? 7890;
   const recordingsApiPort = inputs.recordingsApiPort ?? 8444;

--- a/packages/node/saga-stack-cli/src/core/probe-plan.ts
+++ b/packages/node/saga-stack-cli/src/core/probe-plan.ts
@@ -53,8 +53,17 @@ export interface HealthProbe {
  * The stack-lane URL has no trailing slash (`http://localhost:3010`) and every
  * `healthPath` begins with `/`, so a plain concatenation yields the correct URL
  * for both `/health` services and the `/`-rooted frontends.
+ *
+ * M7: `portOverrides` (a slot's `InstanceProfile.portOverrides`) shifts each URL to
+ * the slot's RESOLVED offset port, so `stack status`/`verify` probe the right
+ * instance instead of base. Absent (slot 0) ⇒ the manifest base port, which equals
+ * `svc.lane.stack`, so slot 0 is byte-identical.
  */
-export function healthProbes(m: Manifest, services?: ServiceId[]): HealthProbe[] {
+export function healthProbes(
+  m: Manifest,
+  services?: ServiceId[],
+  portOverrides?: Partial<Record<ServiceId, number>>,
+): HealthProbe[] {
   const ids =
     services ??
     (Object.keys(m.services) as ServiceId[]).filter((id) => !m.services[id].optional);
@@ -62,9 +71,10 @@ export function healthProbes(m: Manifest, services?: ServiceId[]): HealthProbe[]
   return ids.map((id) => {
     const svc = m.services[id];
     if (!svc) throw new Error(`unknown service id: ${id}`);
+    const port = portOverrides?.[id] ?? svc.port;
     return {
       id,
-      url: `${svc.lane.stack}${svc.healthPath}`,
+      url: `http://localhost:${port}${svc.healthPath}`,
       healthPath: svc.healthPath,
       expectStatus: 200,
     };

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/dash-defaults.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/dash-defaults.unit.test.ts
@@ -7,12 +7,15 @@
 
 import { describe, expect, it } from 'vitest';
 import {
+  DASH_LOCAL_SERVICES,
   DASH_TUNNEL_LABELS,
   dashLocalConfigPath,
+  stackSlotConfigContents,
   syncDashLocalDefaults,
   tunnelConfigContents,
 } from '../dash-defaults.js';
 import type { DashFs } from '../dash-defaults.js';
+import type { ServiceId } from '../../core/manifest/index.js';
 
 const DASH = '/repo/saga-dash';
 const CFG = dashLocalConfigPath(DASH);
@@ -93,5 +96,55 @@ describe('syncDashLocalDefaults', () => {
     // /no/such/dash has no static dir → noop-no-static via the real fs.
     const res = syncDashLocalDefaults({ sagaDashRoot: '/no/such/dash-xyz' });
     expect(res.action).toBe('noop-no-static');
+  });
+});
+
+describe('syncDashLocalDefaults — M7 stack-lane slot config', () => {
+  /** slot-N port map for the dash-backing services. */
+  const slotPorts = (offset: number): Partial<Record<ServiceId, number>> => ({
+    'iam-api': 3010 + offset,
+    'programs-api': 3006 + offset,
+    'scheduling-api': 3008 + offset,
+    'sessions-api': 3007 + offset,
+    'sis-api': 3100 + offset,
+    'content-api': 3009 + offset,
+    'connect-api': 6106 + offset,
+  });
+
+  it('slot 0 still REMOVES config.local.json (byte-identical) even with stackPorts present', () => {
+    const { fs, removed, written } = fakeFs({ hasConfig: true });
+    const res = syncDashLocalDefaults(
+      { sagaDashRoot: DASH, slot: 0, stackPorts: slotPorts(0) },
+      fs,
+    );
+    expect(res).toEqual({ action: 'removed', path: CFG });
+    expect(removed).toEqual([CFG]);
+    expect(written).toEqual([]);
+  });
+
+  it('slot > 0 (stack lane) WRITES config.local.json with offset localhost ports', () => {
+    const { fs, written, removed } = fakeFs({ hasConfig: true });
+    const res = syncDashLocalDefaults(
+      { sagaDashRoot: DASH, slot: 1, stackPorts: slotPorts(1000) },
+      fs,
+    );
+    expect(res).toEqual({ action: 'wrote-stack-slot', path: CFG });
+    expect(removed).toEqual([]); // it writes, does not remove
+    expect(written).toHaveLength(1);
+    const parsed = JSON.parse(written[0].contents);
+    // iam offset: 3010 + 1000; program-hub + enrollment-api both back programs-api (4006).
+    expect(parsed.localDefaults.iam).toEqual({ type: 'url', url: 'http://localhost:4010' });
+    expect(parsed.localDefaults['program-hub']).toEqual({ type: 'url', url: 'http://localhost:4006' });
+    expect(parsed.localDefaults['enrollment-api']).toEqual({ type: 'url', url: 'http://localhost:4006' });
+    expect(parsed.localDefaults.connect).toEqual({ type: 'url', url: 'http://localhost:7106' });
+    // same key set as the tunnel writer.
+    expect(Object.keys(parsed.localDefaults).sort()).toEqual(Object.keys(DASH_LOCAL_SERVICES).sort());
+    expect(written[0].contents.endsWith('\n')).toBe(true);
+  });
+
+  it('stackSlotConfigContents omits a dash key whose backing service has no resolved port', () => {
+    const parsed = JSON.parse(stackSlotConfigContents({ 'iam-api': 4010 }));
+    expect(parsed.localDefaults.iam).toEqual({ type: 'url', url: 'http://localhost:4010' });
+    expect(parsed.localDefaults.connect).toBeUndefined(); // connect-api port absent → dropped
   });
 });

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/mesh.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/mesh.unit.test.ts
@@ -11,7 +11,7 @@
 import { describe, expect, it } from 'vitest';
 import { manifest } from '../../core/manifest/index.js';
 import type { RunResult, Runner, ScriptInvocation } from '../exec.js';
-import { meshMakeArgs, meshUp } from '../mesh.js';
+import { meshDownArgs, meshMakeArgs, meshUp } from '../mesh.js';
 import type { MeshExec } from '../mesh.js';
 import type { PortProbe } from '../preflight.js';
 
@@ -61,6 +61,47 @@ describe('meshMakeArgs', () => {
       'RABBITMQ_PORT=5672',
       'RABBITMQ_MGMT_PORT=15672',
       'CONNECT_MONGO_PORT=27037',
+    ]);
+  });
+
+  it('M7 slot 0 (no opts / project+offset 0) is byte-identical', () => {
+    expect(meshMakeArgs(manifest, { offset: 0 })).toEqual(meshMakeArgs(manifest));
+  });
+
+  it('M7 slot > 0: prepends COMPOSE_PROJECT_NAME + offsets every mesh port', () => {
+    expect(meshMakeArgs(manifest, { project: 'soa-s1', offset: 1000 })).toEqual([
+      'up',
+      'COMPOSE_PROJECT_NAME=soa-s1',
+      'PROJECT=saga-mesh',
+      'PROFILE=empty',
+      'POSTGRES_PORT=6432',
+      'REDIS_PORT=7379',
+      'RABBITMQ_PORT=6672',
+      'RABBITMQ_MGMT_PORT=16672',
+      'CONNECT_MONGO_PORT=28037',
+    ]);
+  });
+
+  it('two slots (1 vs 2) emit non-colliding mesh port args', () => {
+    const portsOf = (a: string[]): string[] => a.filter((x) => x.endsWith('_PORT') === false && /_PORT=/.test(x));
+    const s1 = portsOf(meshMakeArgs(manifest, { project: 'soa-s1', offset: 1000 }));
+    const s2 = portsOf(meshMakeArgs(manifest, { project: 'soa-s2', offset: 2000 }));
+    const vals1 = s1.map((x) => x.split('=')[1]);
+    const vals2 = s2.map((x) => x.split('=')[1]);
+    expect(vals1.some((v) => vals2.includes(v))).toBe(false);
+  });
+});
+
+describe('meshDownArgs', () => {
+  it('slot 0 (no project) is byte-identical to the pre-M7 form', () => {
+    expect(meshDownArgs()).toEqual(['down', 'PROJECT=saga-mesh']);
+  });
+
+  it('slot > 0: passes the per-slot COMPOSE_PROJECT_NAME (tears down the right project)', () => {
+    expect(meshDownArgs({ project: 'soa-s1' })).toEqual([
+      'down',
+      'COMPOSE_PROJECT_NAME=soa-s1',
+      'PROJECT=saga-mesh',
     ]);
   });
 });
@@ -147,6 +188,53 @@ describe('meshUp', () => {
     });
     expect(res2.ok).toBe(false);
     expect(res2.units[0]).toMatchObject({ id: 'rabbitmq', ok: false });
+  });
+
+  it('M7 slot > 0: passes COMPOSE_PROJECT_NAME (arg + env) + offset ports, gates the slot containers', async () => {
+    const { runner, calls } = fakeRunner(0);
+    const { exec, calls: gated } = fakeExec();
+    // The slot's container-name env (set from InstanceProfile.containerEnv) so the
+    // readiness resolver + owned-container preflight target soa-s1-*.
+    const saved = {
+      pg: process.env.SAGA_MESH_POSTGRES_CONTAINER,
+      rabbit: process.env.SAGA_MESH_RABBITMQ_CONTAINER,
+    };
+    process.env.SAGA_MESH_POSTGRES_CONTAINER = 'soa-s1-postgres-1';
+    process.env.SAGA_MESH_RABBITMQ_CONTAINER = 'soa-s1-rabbitmq-1';
+    try {
+      const res = await meshUp({
+        soaRoot: SOA,
+        runner,
+        exec,
+        portProbe: FREE_PROBE,
+        units: ['postgres', 'rabbitmq'],
+        project: 'soa-s1',
+        meshOffset: 1000,
+      });
+      expect(res.ok).toBe(true);
+      // COMPOSE_PROJECT_NAME both as a make arg and via child env; ports offset.
+      expect(calls[0].args).toContain('COMPOSE_PROJECT_NAME=soa-s1');
+      expect(calls[0].args).toContain('POSTGRES_PORT=6432');
+      expect(calls[0].env).toEqual({
+        EXTRA_POSTGRES_SEED_DIR: '../../projects/saga-mesh/seed',
+        COMPOSE_PROJECT_NAME: 'soa-s1',
+      });
+      // readiness gated the slot's containers, not the base names.
+      expect(gated).toEqual(['soa-s1-postgres-1', 'soa-s1-rabbitmq-1']);
+    } finally {
+      process.env.SAGA_MESH_POSTGRES_CONTAINER = saved.pg;
+      process.env.SAGA_MESH_RABBITMQ_CONTAINER = saved.rabbit;
+      if (saved.pg === undefined) delete process.env.SAGA_MESH_POSTGRES_CONTAINER;
+      if (saved.rabbit === undefined) delete process.env.SAGA_MESH_RABBITMQ_CONTAINER;
+    }
+  });
+
+  it('M7 slot 0: make env stays byte-identical (no COMPOSE_PROJECT_NAME)', async () => {
+    const { runner, calls } = fakeRunner(0);
+    const { exec } = fakeExec();
+    await meshUp({ soaRoot: SOA, runner, exec, portProbe: FREE_PROBE, units: ['postgres'] });
+    expect(calls[0].env).toEqual({ EXTRA_POSTGRES_SEED_DIR: '../../projects/saga-mesh/seed' });
+    expect(calls[0].args).not.toContain('COMPOSE_PROJECT_NAME=soa');
   });
 
   it('honours skipPreflight (caller already ran check_ports)', async () => {

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/preflight.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/preflight.unit.test.ts
@@ -46,6 +46,38 @@ describe('meshPortSpecs / meshOwnedContainers', () => {
     expect(owned.has('soa-postgres-1')).toBe(true);
     expect(owned.has('soa-connect-mongo-1')).toBe(true);
   });
+
+  it('M7 slot > 0: offsets every mesh host port', () => {
+    expect(meshPortSpecs(manifest, 1000)).toEqual([
+      { port: 6432, name: 'postgres' },
+      { port: 7379, name: 'redis' },
+      { port: 6672, name: 'rabbitmq' },
+      { port: 16672, name: 'rabbitmq-mgmt' },
+      { port: 28037, name: 'connect-mongo' },
+    ]);
+    // offset 0 is byte-identical to the default.
+    expect(meshPortSpecs(manifest, 0)).toEqual(meshPortSpecs(manifest));
+  });
+
+  it('M7 slot > 0: owned containers follow the SAGA_MESH_*_CONTAINER env (soa-s<N>)', () => {
+    const saved = {
+      pg: process.env.SAGA_MESH_POSTGRES_CONTAINER,
+      mongo: process.env.SAGA_MESH_CONNECT_MONGO_CONTAINER,
+    };
+    process.env.SAGA_MESH_POSTGRES_CONTAINER = 'soa-s1-postgres-1';
+    process.env.SAGA_MESH_CONNECT_MONGO_CONTAINER = 'soa-s1-connect-mongo-1';
+    try {
+      const owned = meshOwnedContainers(manifest);
+      expect(owned.has('soa-s1-postgres-1')).toBe(true);
+      expect(owned.has('soa-s1-connect-mongo-1')).toBe(true);
+      expect(owned.has('soa-postgres-1')).toBe(false); // base name no longer owned
+    } finally {
+      if (saved.pg === undefined) delete process.env.SAGA_MESH_POSTGRES_CONTAINER;
+      else process.env.SAGA_MESH_POSTGRES_CONTAINER = saved.pg;
+      if (saved.mongo === undefined) delete process.env.SAGA_MESH_CONNECT_MONGO_CONTAINER;
+      else process.env.SAGA_MESH_CONNECT_MONGO_CONTAINER = saved.mongo;
+    }
+  });
 });
 
 describe('checkPorts', () => {

--- a/packages/node/saga-stack-cli/src/runtime/dash-defaults.ts
+++ b/packages/node/saga-stack-cli/src/runtime/dash-defaults.ts
@@ -24,6 +24,7 @@
 
 import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
+import type { ServiceId } from '../core/manifest/index.js';
 
 /**
  * The dash service-key → tunnel host-label map (verbatim from up.sh's inline
@@ -41,6 +42,24 @@ export const DASH_TUNNEL_LABELS: Readonly<Record<string, string>> = {
   connect: 'connect',
 };
 
+/**
+ * The dash service-key → manifest `ServiceId` whose localhost port backs it (M7
+ * stack-lane slot config). Same key set as `DASH_TUNNEL_LABELS`; `program-hub` and
+ * `enrollment-api` both resolve to programs-api, `connect` to connect-api. Used to
+ * WRITE a slot's `config.local.json` pointing each dash service at its offset
+ * localhost port (else the dash's built-in defaults hit slot 0's base ports).
+ */
+export const DASH_LOCAL_SERVICES: Readonly<Record<string, ServiceId>> = {
+  iam: 'iam-api',
+  'program-hub': 'programs-api',
+  'enrollment-api': 'programs-api',
+  'scheduling-api': 'scheduling-api',
+  'sessions-api': 'sessions-api',
+  'sis-api': 'sis-api',
+  'content-api': 'content-api',
+  connect: 'connect-api',
+};
+
 /** Inputs to the dash-defaults prelaunch hook. */
 export interface DashDefaultsContext {
   /** Resolved saga-dash repo root (`resolveRepoRoot('SAGA_DASH', ctx)`). */
@@ -49,11 +68,25 @@ export interface DashDefaultsContext {
   tunnel?: boolean;
   /** `<moniker>.<VMS_BASE>` — required when `tunnel` is true. */
   tunnelDomain?: string;
+  /**
+   * Stack instance slot (M7). > 0 ⇒ stack-lane WRITE mode: emit a
+   * `config.local.json` pointing each dash service at its OFFSET localhost port
+   * (`stackPorts`), instead of removing the file (which would fall back to the
+   * dash's base-port defaults = slot 0's iam). Default 0 (or absent) ⇒ the
+   * pre-M7 remove/no-op behaviour, byte-identical.
+   */
+  slot?: number;
+  /**
+   * Resolved per-service localhost ports for the slot's stack-lane dash config
+   * (a slot's `InstanceProfile.portOverrides` / the launch context's `ports`).
+   * Required for the slot > 0 stack-lane write.
+   */
+  stackPorts?: Partial<Record<ServiceId, number>>;
 }
 
 /** What the hook did, for `emit()` / logging. */
 export interface DashSyncResult {
-  action: 'removed' | 'wrote' | 'noop-no-static' | 'noop-absent';
+  action: 'removed' | 'wrote' | 'wrote-stack-slot' | 'noop-no-static' | 'noop-absent';
   /** The config.local.json path acted on (when applicable). */
   path?: string;
 }
@@ -84,6 +117,22 @@ export function tunnelConfigContents(tunnelDomain: string): string {
 }
 
 /**
+ * Build the stack-lane SLOT `config.local.json` contents: each dash service key →
+ * `http://localhost:<offset port>` (2-space JSON + trailing newline, same shape as
+ * the tunnel writer). A dash key whose backing service has no resolved port is
+ * omitted rather than emitting `localhost:undefined`.
+ */
+export function stackSlotConfigContents(stackPorts: Partial<Record<ServiceId, number>>): string {
+  const localDefaults: Record<string, { type: 'url'; url: string }> = {};
+  for (const [key, svc] of Object.entries(DASH_LOCAL_SERVICES)) {
+    const port = stackPorts[svc];
+    if (port === undefined) continue;
+    localDefaults[key] = { type: 'url', url: `http://localhost:${port}` };
+  }
+  return `${JSON.stringify({ localDefaults }, null, 2)}\n`;
+}
+
+/**
  * Run the prelaunch hook. Pure-decision over the injectable `DashFs`, so it's
  * fully testable; returns what it did. In tunnel mode without a `tunnelDomain`
  * the write is skipped (treated as `noop-absent`) rather than emitting a broken
@@ -98,8 +147,15 @@ export function syncDashLocalDefaults(
 
   const cfgPath = dashLocalConfigPath(ctx.sagaDashRoot);
 
-  // Non-tunnel: localhost defaults — remove any stale tunnel config.
+  // Non-tunnel (stack lane):
   if (!ctx.tunnel) {
+    // M7 slot > 0: WRITE the offset-localhost config so the slot's dash dials its
+    // own ports (removing the file would fall back to the base-port = slot-0 iam).
+    if ((ctx.slot ?? 0) > 0 && ctx.stackPorts) {
+      fs.write(cfgPath, stackSlotConfigContents(ctx.stackPorts));
+      return { action: 'wrote-stack-slot', path: cfgPath };
+    }
+    // Slot 0: localhost defaults — remove any stale tunnel config (byte-identical).
     if (fs.existsFile(cfgPath)) {
       fs.remove(cfgPath);
       return { action: 'removed', path: cfgPath };

--- a/packages/node/saga-stack-cli/src/runtime/mesh.ts
+++ b/packages/node/saga-stack-cli/src/runtime/mesh.ts
@@ -59,6 +59,18 @@ export interface MeshContext {
   soaRoot: string;
   /** The Runner the `make up` invocation goes through (shared M1 process seam). */
   runner: Runner;
+  /**
+   * COMPOSE_PROJECT_NAME for this slot (M7). `soa-s<N>` at slot > 0; OMITTED at
+   * slot 0 so the make argv/env stay byte-identical (the Makefile defaults to
+   * `soa` via `?=`). Passed BOTH as a make arg (visible/testable) and via child
+   * env (the Makefile's `?=` env-override path).
+   */
+  project?: string;
+  /**
+   * Offset added to every published mesh port (M7). `slot * 1000` at slot > 0; 0
+   * (the default) at slot 0 ⇒ base ports, byte-identical to no offset.
+   */
+  meshOffset?: number;
   /** The readiness-probe seam. Default `makeRealMeshExec()`. */
   exec?: MeshExec;
   /**
@@ -104,21 +116,31 @@ export function meshContainer(unit: MeshDef): string {
 /**
  * Build the `make` argv that brings the mesh up. Ports come from the manifest
  * mesh defs (postgres/redis/rabbitmq + mgmt/connect-mongo), so this can't drift.
+ *
+ * M7: `opts.offset` shifts every published mesh port by `slot * 1000`, and
+ * `opts.project` prepends `COMPOSE_PROJECT_NAME=<project>` so the mesh comes up
+ * under the slot's `soa-s<N>` namespace. At slot 0 (offset 0, no project) the
+ * argv is byte-identical to the pre-M7 form.
  */
-export function meshMakeArgs(m: Manifest = defaultManifest): string[] {
+export function meshMakeArgs(
+  m: Manifest = defaultManifest,
+  opts: { project?: string; offset?: number } = {},
+): string[] {
+  const offset = opts.offset ?? 0;
   const pg = getMesh('postgres', m);
   const redis = getMesh('redis', m);
   const rabbit = getMesh('rabbitmq', m);
   const mongo = getMesh('connect-mongo', m);
   return [
     'up',
+    ...(opts.project ? [`COMPOSE_PROJECT_NAME=${opts.project}`] : []),
     'PROJECT=saga-mesh',
     'PROFILE=empty',
-    `POSTGRES_PORT=${pg.port}`,
-    `REDIS_PORT=${redis.port}`,
-    `RABBITMQ_PORT=${rabbit.port}`,
-    `RABBITMQ_MGMT_PORT=${rabbit.mgmtPort ?? 15672}`,
-    `CONNECT_MONGO_PORT=${mongo.port}`,
+    `POSTGRES_PORT=${pg.port + offset}`,
+    `REDIS_PORT=${redis.port + offset}`,
+    `RABBITMQ_PORT=${rabbit.port + offset}`,
+    `RABBITMQ_MGMT_PORT=${(rabbit.mgmtPort ?? 15672) + offset}`,
+    `CONNECT_MONGO_PORT=${mongo.port + offset}`,
   ];
 }
 
@@ -128,6 +150,12 @@ export interface MeshDownContext {
   soaRoot: string;
   /** The Runner the `make down` invocation goes through (shared M1 process seam). */
   runner: Runner;
+  /**
+   * COMPOSE_PROJECT_NAME for this slot (M7). `soa-s<N>` at slot > 0; OMITTED at
+   * slot 0 (defaults to `soa`). CRITICAL: without it `make down` tears down the
+   * DEFAULT project — i.e. slot 0's mesh — instead of the slot's own.
+   */
+  project?: string;
 }
 
 /** The outcome of `meshDown`. */
@@ -144,8 +172,12 @@ export interface MeshDownResult {
  * the PORT vars nor PROFILE (infra's `down:` target is just `docker compose down`,
  * keyed only by PROJECT), so we pass only PROJECT.
  */
-export function meshDownArgs(): string[] {
-  return ['down', 'PROJECT=saga-mesh'];
+export function meshDownArgs(opts: { project?: string } = {}): string[] {
+  return [
+    'down',
+    ...(opts.project ? [`COMPOSE_PROJECT_NAME=${opts.project}`] : []),
+    'PROJECT=saga-mesh',
+  ];
 }
 
 /**
@@ -158,8 +190,10 @@ export async function meshDown(ctx: MeshDownContext): Promise<MeshDownResult> {
   const { code } = await ctx.runner.run({
     cwd: join(ctx.soaRoot, 'infra'),
     command: 'make',
-    args: meshDownArgs(),
-    env: {},
+    args: meshDownArgs({ project: ctx.project }),
+    // COMPOSE_PROJECT_NAME also via env (the Makefile's `?=` override path); OMITTED
+    // at slot 0 so the env stays byte-identical to the pre-M7 `{}`.
+    env: ctx.project ? { COMPOSE_PROJECT_NAME: ctx.project } : {},
     stdio: 'inherit',
   });
   return { ok: code === 0, code };
@@ -175,21 +209,29 @@ export async function meshUp(ctx: MeshContext): Promise<MeshResult> {
   const exec = ctx.exec ?? makeRealMeshExec();
   const probe = ctx.portProbe ?? makeRealPortProbe();
   const gatedIds = ctx.units ?? (Object.keys(m.mesh) as MeshId[]);
+  const offset = ctx.meshOffset ?? 0;
 
-  // 1. check_ports preflight (unless the caller already did it).
+  // 1. check_ports preflight (unless the caller already did it) — probe the SLOT's
+  // offset ports, and treat the slot's own `soa-s<N>-*` containers as owned (via
+  // the env-aware `meshOwnedContainers`) so an idempotent re-up isn't a conflict.
   if (!ctx.skipPreflight) {
-    const conflicts = await checkPorts(meshPortSpecs(m), probe, meshOwnedContainers(m));
+    const conflicts = await checkPorts(meshPortSpecs(m, offset), probe, meshOwnedContainers(m));
     if (conflicts.length > 0) {
       return { ok: false, conflicts, makeOk: false, units: [] };
     }
   }
 
-  // 2. make up — the mesh always starts as a whole; ports are manifest-derived.
+  // 2. make up — the mesh always starts as a whole; ports are manifest-derived
+  // (+ the slot offset). COMPOSE_PROJECT_NAME goes both as a make arg and via env
+  // (the Makefile's `?=` env-override path). At slot 0 both are omitted ⇒ identical.
   const { code } = await ctx.runner.run({
     cwd: join(ctx.soaRoot, 'infra'),
     command: 'make',
-    args: meshMakeArgs(m),
-    env: { EXTRA_POSTGRES_SEED_DIR: '../../projects/saga-mesh/seed' },
+    args: meshMakeArgs(m, { project: ctx.project, offset }),
+    env: {
+      EXTRA_POSTGRES_SEED_DIR: '../../projects/saga-mesh/seed',
+      ...(ctx.project ? { COMPOSE_PROJECT_NAME: ctx.project } : {}),
+    },
     stdio: 'inherit',
   });
   if (code !== 0) {

--- a/packages/node/saga-stack-cli/src/runtime/preflight.ts
+++ b/packages/node/saga-stack-cli/src/runtime/preflight.ts
@@ -70,21 +70,35 @@ export interface PortProbe {
  * Derive the mesh host-port list from the manifest: each mesh unit's `port`, plus
  * `mgmtPort` where present (rabbitmq's 15672). Declaration order is preserved, so
  * the output reads postgres, redis, rabbitmq (+ mgmt), connect-mongo.
+ *
+ * M7: `offset` shifts every host port by the slot's `slot * 1000` so the preflight
+ * probes the SLOT's ports, not base. At offset 0 (slot 0) this is byte-identical.
  */
-export function meshPortSpecs(m: Manifest = defaultManifest): MeshPortSpec[] {
+export function meshPortSpecs(m: Manifest = defaultManifest, offset = 0): MeshPortSpec[] {
   const specs: MeshPortSpec[] = [];
   for (const unit of allMesh(m)) {
-    specs.push({ port: unit.port, name: unit.id });
+    specs.push({ port: unit.port + offset, name: unit.id });
     if (unit.mgmtPort !== undefined) {
-      specs.push({ port: unit.mgmtPort, name: `${unit.id}-mgmt` });
+      specs.push({ port: unit.mgmtPort + offset, name: `${unit.id}-mgmt` });
     }
   }
   return specs;
 }
 
-/** The set of container names that legitimately OWN a mesh port (manifest mesh containers). */
+/**
+ * The set of container names that legitimately OWN a mesh port. Each unit resolves
+ * via the `SAGA_MESH_<UNIT>_CONTAINER` env override (set from the slot's
+ * `InstanceProfile.containerEnv`) so a running `soa-s<N>-postgres-1` is recognised
+ * as ours at slot > 0; unset (slot 0) ⇒ the manifest default container names, so
+ * slot 0 is byte-identical. Kept in lock-step with `mesh.ts`'s `meshContainer`.
+ */
 export function meshOwnedContainers(m: Manifest = defaultManifest): Set<string> {
-  return new Set(allMesh(m).map((u) => u.container));
+  return new Set(
+    allMesh(m).map((u) => {
+      const envKey = `SAGA_MESH_${u.id.toUpperCase().replace(/-/g, '_')}_CONTAINER`;
+      return process.env[envKey] ?? u.container;
+    }),
+  );
 }
 
 /**

--- a/packages/node/saga-stack-cli/src/shared-flags.ts
+++ b/packages/node/saga-stack-cli/src/shared-flags.ts
@@ -71,10 +71,26 @@ export const repoFlags = {
   }),
 };
 
+/**
+ * The error surfaced when `--slot > 0` is passed on any command. Multi-slot
+ * bring-up (the mesh-project / container / down threading) lands in M7 Phase 2;
+ * until then a slot > 0 must FAIL FAST rather than half-run at the base slot 0
+ * ports and silently clobber a live default stack. Enforced centrally in
+ * `BaseCommand.parse`, so every command that spreads `baseFlags` is guarded.
+ */
+export const SLOT_PHASE2_MESSAGE =
+  'multi-slot (--slot > 0) is not enabled yet — Phase 2. Only --slot 0 (the default) is supported for now.';
+
 export const baseFlags = {
   porcelain: Flags.boolean({
     description: 'machine-readable output; no color, minimal noise',
     default: false,
+  }),
+  slot: Flags.integer({
+    default: 0,
+    min: 0,
+    description:
+      'stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.',
   }),
   'output-json': Flags.boolean({
     description: 'emit structured JSON on stdout instead of human-readable text',

--- a/packages/node/saga-stack-cli/src/shared-flags.ts
+++ b/packages/node/saga-stack-cli/src/shared-flags.ts
@@ -72,14 +72,21 @@ export const repoFlags = {
 };
 
 /**
- * The error surfaced when `--slot > 0` is passed on any command. Multi-slot
- * bring-up (the mesh-project / container / down threading) lands in M7 Phase 2;
- * until then a slot > 0 must FAIL FAST rather than half-run at the base slot 0
- * ports and silently clobber a live default stack. Enforced centrally in
- * `BaseCommand.parse`, so every command that spreads `baseFlags` is guarded.
+ * The error surfaced when `--slot > 0` is passed on a command that is NOT
+ * slot-aware (M7 Phase 2). Phase 2 makes `stack up`/`status`/`verify`/`down`
+ * bring up / act on an ISOLATED `soa-s<N>` stack; every OTHER command — the
+ * wrapper-lifecycle set (`reset`/`restart`/`overlay`/`bootstrap`/`seed`) plus
+ * `login`/`tunnel`/`snapshot`/… — still delegates to up.sh's HOST-GLOBAL
+ * lifecycle (`pkill -f tsup`, `nuke_vite`, fixed `STATE=/tmp/sds-synthetic`),
+ * which would clobber other slots. Those FAIL FAST here rather than silently
+ * corrupt a peer slot. Enforced in `BaseCommand.parse`, opted out per-command via
+ * `slotAware()`. Slot 0 (the default) is unaffected everywhere.
  */
-export const SLOT_PHASE2_MESSAGE =
-  'multi-slot (--slot > 0) is not enabled yet — Phase 2. Only --slot 0 (the default) is supported for now.';
+export const SLOT_UNSUPPORTED_COMMAND_MESSAGE =
+  "multi-slot (--slot > 0) is not supported for this command yet — only 'stack up', 'stack status', " +
+  "'stack verify', and 'stack down' are slot-aware. The wrapper-lifecycle commands " +
+  '(reset/restart/overlay/bootstrap/seed) delegate to up.sh host-global teardown ' +
+  '(pkill/nuke_vite), which would clobber other slots; run them against slot 0 only.';
 
 export const baseFlags = {
   porcelain: Flags.boolean({
@@ -89,8 +96,14 @@ export const baseFlags = {
   slot: Flags.integer({
     default: 0,
     min: 0,
+    // CEILING 9 (M7 MINOR): the mesh's rabbitmq (:5672) and rabbitmq-mgmt (:15672)
+    // differ by 10000 = 10 * the 1000 stride, so slot 10's rabbitmq (:15672) would
+    // collide with slot 0's rabbitmq-mgmt (:15672). Cap at 9 so every slot's full
+    // resolved port band stays disjoint. Slot > 0 is a BACKEND sub-stack (the
+    // literal-port backends + browser frontends are excluded — see derive-instance).
+    max: 9,
     description:
-      'stack instance slot (0 = default; N>0 offsets ports by N*1000 into an isolated soa-s<N> stack). Multi-slot bring-up lands in a later phase.',
+      'stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.',
   }),
   'output-json': Flags.boolean({
     description: 'emit structured JSON on stdout instead of human-readable text',
@@ -101,8 +114,13 @@ export const baseFlags = {
     default: defaultDevDir,
   }),
   'state-dir': Flags.string({
-    description: 'scratch dir for pid files, snapshots, and other run state',
-    default: '/tmp/sds-synthetic',
+    description:
+      'scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)',
+    // NO oclif default: an unset `--state-dir` stays `undefined` so a slot-aware
+    // command can fall back to the slot's `InstanceProfile.stateDir` (an explicit
+    // `--state-dir` still wins). The launcher's `DEFAULT_STATE_DIR` (/tmp/sds-
+    // synthetic) is the ultimate fallback for callers that pass it through
+    // unchanged (e2e), so slot 0 stays /tmp/sds-synthetic.
   }),
   ...repoFlags,
 };

--- a/packages/node/saga-stack-cli/src/stack-api.ts
+++ b/packages/node/saga-stack-cli/src/stack-api.ts
@@ -100,6 +100,20 @@ export interface Runtime {
   /** `<moniker>.<VMS_BASE>` — required when `tunnel` is true. */
   tunnelDomain?: string;
   /**
+   * Stack instance slot (M7). > 0 ⇒ `up` brings the mesh up under the slot's
+   * `soa-s<N>` project on offset ports and WRITES the slot's stack-lane dash
+   * config. Default 0 (or absent) ⇒ byte-identical to the pre-M7 build.
+   */
+  slot?: number;
+  /**
+   * COMPOSE_PROJECT_NAME for the mesh at slot > 0 (`soa-s<N>`); OMITTED at slot 0.
+   * Threaded into `meshUp`/`meshDown` so the slot's mesh is namespaced and torn
+   * down independently of the default project.
+   */
+  meshProject?: string;
+  /** Offset added to every published mesh port at slot > 0 (`slot * 1000`); 0 at slot 0. */
+  meshOffset?: number;
+  /**
    * Delegate a wrapped bash `ScriptPlan` to up.sh (the M1 Runner + script path),
    * returning its exit code. M4 wires `reset`/`login` through this because their
    * native ports are M6+. The command layer points it at `BaseCommand.runScript`
@@ -343,6 +357,9 @@ export function makeStackApi(m: Manifest, runtime: Runtime): StackApi {
         portProbe,
         units: neededMesh(services, manifest),
         manifest,
+        // M7: slot > 0 namespaces + offsets the mesh; slot 0 leaves both undefined/0.
+        project: runtime.meshProject,
+        meshOffset: runtime.meshOffset,
       });
       if (!mesh.ok) return { ok: false, mesh, launched: [], skipped: [] };
 
@@ -374,7 +391,15 @@ export function makeStackApi(m: Manifest, runtime: Runtime): StackApi {
       let dash: DashSyncResult | undefined;
       if (launchable.includes('saga-dash')) {
         dash = syncDashLocalDefaults(
-          { sagaDashRoot: runtime.sagaDashRoot, tunnel: runtime.tunnel, tunnelDomain: runtime.tunnelDomain },
+          {
+            sagaDashRoot: runtime.sagaDashRoot,
+            tunnel: runtime.tunnel,
+            tunnelDomain: runtime.tunnelDomain,
+            // M7: slot > 0 stack lane WRITES config.local.json with the offset
+            // localhost ports (launchContext.ports are already offset for the slot).
+            slot: runtime.slot,
+            stackPorts: launchContext.ports,
+          },
           dashFs,
         );
       }


### PR DESCRIPTION
**All M7 phases in one PR, stacked on `gh_214`** (the saga-stack-cli effort). Base is `gh_214`, so this shows only the M7 delta; merge `gh_214` first, then this.

Run multiple concurrent synthetic-dev stacks on one machine via `--slot`, without clobbering. **Slot 0 is byte-identical to today** (up.sh-compatible); `--slot N` offsets everything into an isolated `soa-s<N>` stack.

## Phases (accumulating here)
- **Phase 0 — infra** ✅ `project-key the mesh volumes + Makefile ?=`
  - The four mesh data volumes had fixed **global** names (`postgres-profile-empty`, `redis-data`, `rabbitmq-data`, `connect-mongo-data`) → two stacks would **silently share** them (cross-stack corruption, undetected). Drop the explicit `name:` so compose prefixes each with the project (`<project>_postgres-data`). Verified: `soa-s1_*` vs `soa_*` are disjoint. `Makefile := → ?=` for the per-slot project override. `clean-all` sweep extended.
  - ⚠️ **Caveat:** at the default project this renames the postgres volume (`postgres-profile-empty → soa_postgres-data`), so the first `make up` after merge re-seeds from empty (harmless for the empty-profile mesh; old volume orphaned — `make clean-all`).
- **Phase 1 — CLI scaffolding** ✅ `deriveInstance factory + --slot flag`
  - Pure `deriveInstance({slot})` derives offset (`slot × 1000`), project (`soa-s<N>`), per-slot state + snapshot dirs, container env, and port overrides — with a full-set port **disjointness assertion**. `--slot` flag (numeric); `slot > 0` fails fast until Phase 2. `deriveInstance(0)` deep-equals today (regression guard). 439 tests green.
- **Phase 2 — MVP (two native stacks)** ⏳ threading project/container/offset through mesh up/down + probes + dash config
- **Phase 3 — native slot-safe `down`** ⏳

## Decisions (skelly)
Numeric slots; stride **1000** (collision-free vs all base ports; +100 collides); per-slot snapshot root; `ads-adm`/playback excluded from slot>0 (tokenize as fast-follow); wrapper lifecycle commands hard-error at slot>0.

Plan of record: `claude/projects/gh_214/plans/04-m7-multi-instance.md`. Part of #214. Draft — accumulating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)