### PR TITLE
fix(event-envelope): bump to 0.1.0-dev.6, dev.4/dev.5 already published

### DIFF
--- a/packages/node/event-envelope/package.json
+++ b/packages/node/event-envelope/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/soa-event-envelope",
-    "version": "0.1.0-dev.4",
+    "version": "0.1.0-dev.6",
     "private": false,
     "type": "module",
     "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- `0.1.0-dev.4` and `dev.5` were published to CodeArtifact in May 2026, before #223's zod3→zod4 dependency bump landed. Package versions are immutable on the registry, so #223's zod4 change to `event-envelope` never actually reached consumers — anything resolving `@saga-ed/soa-event-envelope` still gets the old zod3-typed build.
- This also explains why soa's auto-publish workflow reported success on #223's merge (`Detect Changed Packages` step hit a `jq` parse error and silently produced an empty changed-set, so nothing was republished) — separate follow-up needed for that pipeline bug, not addressed here.
- Bumps to `0.1.0-dev.6` (next free version) so a fresh publish actually carries the zod4 dependency.

## Test plan
- [x] `turbo run build check-types test --filter=@saga-ed/soa-event-envelope` — 3/3 tasks green, 19/19 tests pass
- [ ] After merge, dispatch the "Publish to AWS CodeArtifact & GitHub Packages" workflow with `single_package: packages/node/event-envelope` to publish `0.1.0-dev.6` with zod4
- [ ] Confirm `npm view @saga-ed/soa-event-envelope@0.1.0-dev.6 dependencies.zod` returns `^4.4.3` on the registry
- [ ] Unblock rostering#729 (bump its exact pin from stale `0.1.0-dev.3` to `0.1.0-dev.6`)