### PR TITLE
fix(api-core): guard ExpressServer.init() json parser against double body reads

### DIFF
--- a/packages/node/api-core/src/__tests__/express-server.int.test.ts
+++ b/packages/node/api-core/src/__tests__/express-server.int.test.ts
@@ -412,4 +412,58 @@ describe('ExpressServer (integration)', () => {
       await new Promise(resolve => setTimeout(resolve, 100));
     }
   });
+
+  it('skips its json parser when an upstream parser already consumed the body (program-hub#306)', async () => {
+    const container = new Container();
+    const mockLogger: ILogger = {
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    };
+
+    const port = getRandomPort();
+    const config = {
+      configType: 'EXPRESS_SERVER' as const,
+      port,
+      logLevel: 'info' as const,
+      name: 'Interop Test',
+    };
+
+    container.bind('ExpressServerConfig').toConstantValue(config);
+    container.bind('ILogger').toConstantValue(mockLogger);
+    container.bind(ExpressServer).toSelf();
+
+    const server = container.get(ExpressServer);
+    // Simulate an express-5 consumer: body-parser 2.x reads the stream and
+    // sets req.body, but never sets the body-parser 1.x req._body flag. An
+    // unguarded express.json() in init() then re-reads the consumed stream
+    // and 500s "stream is not readable".
+    server.getApp().use((req: Request, _res: Response, next: (err?: unknown) => void) => {
+      let raw = '';
+      req.setEncoding('utf8');
+      req.on('data', (chunk: string) => { raw += chunk; });
+      req.on('end', () => {
+        req.body = JSON.parse(raw);
+        next();
+      });
+    });
+    await server.init(container, [InheritedParamController]);
+    server.start();
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    try {
+      const resp = await fetch(`http://localhost:${port}/inherit/echo`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ msg: 'once' }),
+      });
+      expect(resp.status).toBe(200);
+      const data = await resp.json() as any;
+      expect(data.received).toBe('once');
+    } finally {
+      server.stop();
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+  });
 });

--- a/packages/node/api-core/src/express-server.ts
+++ b/packages/node/api-core/src/express-server.ts
@@ -77,7 +77,23 @@ export class ExpressServer {
     }
 
     this.app.use(cors(corsOptions));
-    this.app.use(express.json());
+    // Parse JSON bodies for routing-controllers' @Body() params — guarded so
+    // this layer never re-reads a body a consumer-mounted parser already
+    // consumed. express 5's parsers (body-parser 2.x) set req.body but not
+    // the req._body flag body-parser 1.x checks, so without the guard the
+    // express-4 json() here — and routing-controllers' route-scoped @Body()
+    // parsers — re-read the consumed stream and 500 every JSON POST with
+    // "stream is not readable" (saga-ed/program-hub#306). Marking req._body
+    // restores the 1.x contract for those route-scoped parsers too.
+    const jsonParser = express.json();
+    this.app.use((req: express.Request, res: express.Response, next: express.NextFunction) => {
+      if (req.body !== undefined) {
+        (req as { _body?: boolean })._body = true;
+        next();
+        return;
+      }
+      jsonParser(req, res, next);
+    });
 
     // Ensure routing-controllers uses Inversify for controller resolution
     useContainer(container);


### PR DESCRIPTION
Fleet-side fix for saga-ed/program-hub#306 (program-hub-side mitigation: saga-ed/program-hub#307).

## The trap

`ExpressServer.init()` mounts an unconditional `express.json()` (added in `042cf6b` / 1.1.4 for `@Body()` parsing) using api-core's own **express 4** dependency — body-parser **1.x**. Consumers mount their own parsers before `init()`; when a consumer migrates to **express 5**, its parsers are body-parser **2.x**, which set `req.body` but no longer set the `req._body` flag that 1.x checks before reading. The 1.x parser here then re-reads the already-consumed stream → `500 stream is not readable` on **every JSON POST** (all tRPC mutations + REST `@Body` routes). This took out all four program-hub services on their express-5 bump; every other api-core consumer hits the same wall on theirs.

## Fix

Guard the parser: if an upstream parser already produced `req.body`, skip parsing **and mark `req._body`** so routing-controllers' route-scoped `@Body()` parsers (also body-parser 1.x, mounted per-route by the express driver) skip too. The integration test proved the init-level guard alone is insufficient — the route-scoped parser still 500'd. With nothing upstream, behavior is unchanged (parser runs exactly as before).

## Validation

- New integration test simulates an express-5 consumer (stream consumed + `req.body` set, no `_body` flag) through a real `@Body()` controller: 500 before, 200 after.
- Full api-core suite: 34/34 green; `tsc --noEmit` clean.

## Notes

- No version bump in this PR — `publish-codeartifact.yml` handles the bump on dispatch. Consumers currently pin published **1.1.4**, which carries the trap; once a guarded version is published and consumed, program-hub's `bodyParsedInterop()` shim (#307) can be deleted.

https://claude.ai/code/session_01KphDite9N8sm5DVUyrMbbw