### PR TITLE
fix: recover AMQP channels after connection loss (outbox relay + event consumer)

### DIFF
--- a/packages/node/event-consumer/package.json
+++ b/packages/node/event-consumer/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/soa-event-consumer",
-    "version": "0.1.0-dev.6",
+    "version": "0.1.0-dev.7",
     "private": false,
     "type": "module",
     "main": "dist/index.js",

--- a/packages/node/event-consumer/src/__tests__/consumer-channel-recovery.unit.test.ts
+++ b/packages/node/event-consumer/src/__tests__/consumer-channel-recovery.unit.test.ts
@@ -129,6 +129,78 @@ describe('EventConsumer channel recovery', () => {
         expect(newChannel).toHaveBeenCalledTimes(1);
     });
 
+    it("does not keep a channel whose 'close' fired during setup", async () => {
+        vi.useFakeTimers();
+        const ch1 = makeChannel();
+        // 'close' arrives before setupChannel's assignment resumes — the
+        // close listener's identity guard can't catch it.
+        ch1.consume.mockImplementationOnce(async () => {
+            ch1.emit('close');
+            return { consumerTag: 'tag-1' };
+        });
+        const ch2 = makeChannel();
+        const newChannel = vi.fn().mockResolvedValueOnce(ch1).mockResolvedValueOnce(ch2);
+        const { consumer } = makeConsumer(newChannel);
+
+        await expect(consumer.start()).rejects.toThrow(/closed during setup/);
+        expect(ch1.close).toHaveBeenCalled();
+
+        // start() schedules the backoff loop before rethrowing.
+        await vi.advanceTimersByTimeAsync(1_000);
+        expect(ch2.consume).toHaveBeenCalledTimes(1);
+    });
+
+    it('a stop() racing an in-flight setup closes the channel instead of resuming consumption', async () => {
+        const ch1 = makeChannel();
+        let releaseChannel!: (ch: unknown) => void;
+        const newChannel = vi.fn().mockReturnValue(
+            new Promise((res) => {
+                releaseChannel = res;
+            }),
+        );
+        const { consumer } = makeConsumer(newChannel);
+
+        const starting = consumer.start();
+        await consumer.stop(); // wins the race while setupChannel awaits newChannel
+        releaseChannel(ch1);
+        await starting;
+
+        await vi.waitFor(() => expect(ch1.close).toHaveBeenCalled());
+        expect((consumer as unknown as { channel: unknown }).channel).toBeNull();
+    });
+
+    it('schedules the backoff loop when start() itself fails (no silent boot stall)', async () => {
+        vi.useFakeTimers();
+        const ch1 = makeChannel();
+        const newChannel = vi
+            .fn()
+            .mockRejectedValueOnce(new Error('boot flake'))
+            .mockResolvedValue(ch1);
+        const { consumer } = makeConsumer(newChannel);
+
+        await expect(consumer.start()).rejects.toThrow('boot flake');
+        await vi.advanceTimersByTimeAsync(1_000);
+        expect(ch1.consume).toHaveBeenCalledTimes(1);
+    });
+
+    it('recovers from a broker-initiated consumer cancel (null message)', async () => {
+        vi.useFakeTimers();
+        const ch1 = makeChannel();
+        const ch2 = makeChannel();
+        const newChannel = vi.fn().mockResolvedValueOnce(ch1).mockResolvedValueOnce(ch2);
+        const { consumer, logger } = makeConsumer(newChannel);
+
+        await consumer.start();
+        const onMessage = ch1.consume.mock.calls[0][1] as (msg: unknown) => void;
+        onMessage(null); // queue deleted / HA failover: channel stays open
+
+        expect(logger.warn).toHaveBeenCalledWith(
+            expect.stringContaining('cancelled by broker'),
+        );
+        await vi.advanceTimersByTimeAsync(1_000);
+        expect(ch2.consume).toHaveBeenCalledTimes(1);
+    });
+
     it('ack/nack on a dead channel is absorbed (broker redelivers; idempotency dedups)', async () => {
         const ch1 = makeChannel();
         const newChannel = vi.fn().mockResolvedValue(ch1);

--- a/packages/node/event-consumer/src/__tests__/consumer-channel-recovery.unit.test.ts
+++ b/packages/node/event-consumer/src/__tests__/consumer-channel-recovery.unit.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import type { Pool } from 'pg';
+import type { ILogger } from '@saga-ed/soa-logger';
+import type { ConnectionManager } from '@saga-ed/soa-rabbitmq';
+import { EventConsumer } from '../consumer.js';
+
+/**
+ * The ConnectionManager auto-reconnects the *connection* after a socket drop,
+ * but channels die with the old connection and are not resurrected. For a
+ * consumer that failure mode is silent: no errors, no consumption, messages
+ * piling up in the durable queue. These tests pin the recovery contract:
+ * a non-stop() channel 'close' schedules a re-subscribe (with backoff) that
+ * re-runs the full topology setup, while stop() never triggers one.
+ */
+
+function makeChannel() {
+    const ch = new EventEmitter() as EventEmitter & Record<string, ReturnType<typeof vi.fn>>;
+    ch.prefetch = vi.fn().mockResolvedValue(undefined);
+    ch.assertExchange = vi.fn().mockResolvedValue({});
+    ch.assertQueue = vi.fn().mockResolvedValue({});
+    ch.bindQueue = vi.fn().mockResolvedValue({});
+    ch.consume = vi.fn().mockResolvedValue({ consumerTag: 'tag-1' });
+    ch.cancel = vi.fn().mockResolvedValue(undefined);
+    ch.close = vi.fn().mockResolvedValue(undefined);
+    ch.ack = vi.fn();
+    ch.nack = vi.fn();
+    return ch;
+}
+
+function makeConsumer(newChannel: ReturnType<typeof vi.fn>) {
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    const connectionManager = {
+        ensureConnected: vi.fn().mockResolvedValue(undefined),
+        newChannel,
+    };
+    const consumer = new EventConsumer({
+        consumerName: 'test-consumer',
+        pool: {} as Pool,
+        connectionManager: connectionManager as unknown as ConnectionManager,
+        queue: 'test.queue',
+        bindings: [{ exchange: 'test.events', routingKey: '#' }],
+        handlers: [],
+        logger: logger as unknown as ILogger,
+    });
+    return { consumer, connectionManager, logger };
+}
+
+afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+});
+
+describe('EventConsumer channel recovery', () => {
+    it("re-subscribes after a channel 'close' it did not initiate", async () => {
+        vi.useFakeTimers();
+        const ch1 = makeChannel();
+        const ch2 = makeChannel();
+        const newChannel = vi.fn().mockResolvedValueOnce(ch1).mockResolvedValueOnce(ch2);
+        const { consumer, logger } = makeConsumer(newChannel);
+
+        await consumer.start();
+        expect(ch1.consume).toHaveBeenCalledTimes(1);
+
+        ch1.emit('close');
+        expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('channel lost'));
+
+        await vi.advanceTimersByTimeAsync(1_000);
+
+        expect(newChannel).toHaveBeenCalledTimes(2);
+        expect(ch2.consume).toHaveBeenCalledTimes(1);
+        // Full topology re-declared on the new channel.
+        expect(ch2.assertExchange).toHaveBeenCalledWith('test.events', 'topic', {
+            durable: true,
+        });
+        expect(ch2.bindQueue).toHaveBeenCalledWith('test.queue', 'test.events', '#');
+    });
+
+    it('backs off and keeps retrying while the broker stays down', async () => {
+        vi.useFakeTimers();
+        const ch1 = makeChannel();
+        const ch2 = makeChannel();
+        const newChannel = vi
+            .fn()
+            .mockResolvedValueOnce(ch1)
+            .mockRejectedValueOnce(new Error('still down'))
+            .mockRejectedValueOnce(new Error('still down'))
+            .mockResolvedValueOnce(ch2);
+        const { consumer, logger } = makeConsumer(newChannel);
+
+        await consumer.start();
+        ch1.emit('close');
+
+        await vi.advanceTimersByTimeAsync(1_000); // attempt 1 fails
+        await vi.advanceTimersByTimeAsync(2_000); // attempt 2 fails (backed off)
+        await vi.advanceTimersByTimeAsync(4_000); // attempt 3 succeeds
+
+        expect(newChannel).toHaveBeenCalledTimes(4);
+        expect(ch2.consume).toHaveBeenCalledTimes(1);
+        expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('re-subscribed'));
+    });
+
+    it("stop() does not trigger a re-subscribe when the channel then closes", async () => {
+        vi.useFakeTimers();
+        const ch1 = makeChannel();
+        const newChannel = vi.fn().mockResolvedValue(ch1);
+        const { consumer } = makeConsumer(newChannel);
+
+        await consumer.start();
+        await consumer.stop();
+        // amqplib emits 'close' as the channel finishes closing.
+        ch1.emit('close');
+
+        await vi.advanceTimersByTimeAsync(60_000);
+        expect(newChannel).toHaveBeenCalledTimes(1);
+    });
+
+    it('a pending reconnect is cancelled by stop()', async () => {
+        vi.useFakeTimers();
+        const ch1 = makeChannel();
+        const newChannel = vi.fn().mockResolvedValue(ch1);
+        const { consumer } = makeConsumer(newChannel);
+
+        await consumer.start();
+        ch1.emit('close'); // schedules reconnect in 1s
+        await consumer.stop();
+
+        await vi.advanceTimersByTimeAsync(60_000);
+        expect(newChannel).toHaveBeenCalledTimes(1);
+    });
+
+    it('ack/nack on a dead channel is absorbed (broker redelivers; idempotency dedups)', async () => {
+        const ch1 = makeChannel();
+        const newChannel = vi.fn().mockResolvedValue(ch1);
+        const { consumer, logger } = makeConsumer(newChannel);
+
+        await consumer.start();
+        const onMessage = ch1.consume.mock.calls[0][1] as (msg: unknown) => void;
+
+        // Malformed payload → poison → nack path; the channel died in between.
+        ch1.nack.mockImplementation(() => {
+            throw new Error('IllegalOperationError: Channel closed');
+        });
+        onMessage({ content: Buffer.from('not json'), fields: {}, properties: {} });
+        await vi.waitFor(() => {
+            expect(logger.warn).toHaveBeenCalledWith(
+                expect.stringContaining('ack/nack failed on dead channel'),
+            );
+        });
+    });
+});

--- a/packages/node/event-consumer/src/consumer.ts
+++ b/packages/node/event-consumer/src/consumer.ts
@@ -177,10 +177,23 @@ export class EventConsumer {
 
     async start(): Promise<void> {
         this.stopped = false;
-        await this.setupChannel();
-        this.opts.logger.info(
-            `[EventConsumer:${this.opts.consumerName}] started (queue=${this.opts.queue})`,
-        );
+        try {
+            await this.setupChannel();
+        } catch (err) {
+            // A transient broker failure at boot must not leave the consumer
+            // permanently silent: callers in this fleet often log-and-continue
+            // on startup errors (the durable queue buffers meanwhile), and
+            // without this the backoff loop would only ever start from a
+            // channel 'close'. Callers treating the rejection as fatal exit
+            // anyway, making the scheduled retry moot.
+            this.scheduleReconnect();
+            throw err;
+        }
+        if (!this.stopped) {
+            this.opts.logger.info(
+                `[EventConsumer:${this.opts.consumerName}] started (queue=${this.opts.queue})`,
+            );
+        }
     }
 
     /**
@@ -209,7 +222,9 @@ export class EventConsumer {
                 `[EventConsumer:${this.opts.consumerName}] channel error: ${err.message}`,
             );
         });
+        let closed = false;
         channel.on('close', () => {
+            closed = true;
             if (this.channel === channel) {
                 this.channel = null;
                 this.consumerTag = null;
@@ -259,7 +274,24 @@ export class EventConsumer {
         const consumeRes = await channel.consume(
             this.opts.queue,
             (msg) => {
-                if (!msg) return;
+                if (!msg) {
+                    // Broker-initiated consumer cancel (queue deleted, HA
+                    // failover) — amqplib signals it with a null message.
+                    // The channel stays open, so no 'close' fires; recover
+                    // explicitly or the consumer stalls silently.
+                    if (this.channel === channel && !this.stopped) {
+                        this.channel = null;
+                        this.consumerTag = null;
+                        this.opts.logger.warn(
+                            `[EventConsumer:${this.opts.consumerName}] consumer cancelled by broker; scheduling re-subscribe`,
+                        );
+                        void Promise.resolve()
+                            .then(() => channel.close())
+                            .catch(() => {});
+                        this.scheduleReconnect();
+                    }
+                    return;
+                }
                 // Bind dispatch to THIS channel: delivery tags are
                 // channel-scoped, so a message must never be acked/nacked on
                 // a replacement channel.
@@ -270,6 +302,19 @@ export class EventConsumer {
 
         this.channel = channel;
         this.consumerTag = consumeRes.consumerTag;
+        // Setup can race a channel death ('close' fired before the
+        // assignments above, so the listener's identity guard missed it) or
+        // a concurrent stop(). Either way this channel must not stay live.
+        if (closed || this.stopped) {
+            this.channel = null;
+            this.consumerTag = null;
+            void Promise.resolve()
+                .then(() => channel.close())
+                .catch(() => {});
+            if (closed && !this.stopped) {
+                throw new Error('channel closed during setup');
+            }
+        }
     }
 
     /**
@@ -376,9 +421,14 @@ export class EventConsumer {
         try {
             op();
         } catch (err) {
-            this.opts.logger.warn(
-                `[EventConsumer:${this.opts.consumerName}] ack/nack failed on dead channel (broker will redeliver): ${err instanceof Error ? err.message : String(err)}`,
-            );
+            const detail = `[EventConsumer:${this.opts.consumerName}] ack/nack failed on dead channel (broker will redeliver): ${err instanceof Error ? err.message : String(err)}`;
+            // Routine during graceful shutdown (stop() closes the channel
+            // while a handler is in flight) — only unexpected while running.
+            if (this.stopped) {
+                this.opts.logger.debug(detail);
+            } else {
+                this.opts.logger.warn(detail);
+            }
         }
     }
 

--- a/packages/node/event-consumer/src/consumer.ts
+++ b/packages/node/event-consumer/src/consumer.ts
@@ -167,30 +167,78 @@ export class EventConsumer {
     private channel: Channel | null = null;
     private consumerTag: string | null = null;
     private readonly handlerMap: HandlerMap;
+    private stopped = true;
+    private reconnectTimer: NodeJS.Timeout | null = null;
+    private reconnectAttempts = 0;
 
     constructor(private readonly opts: EventConsumerOpts) {
         this.handlerMap = buildHandlerMap(opts.handlers);
     }
 
     async start(): Promise<void> {
-        this.channel = await this.opts.connectionManager.newChannel();
-        await this.channel.prefetch(this.opts.prefetch ?? 10);
+        this.stopped = false;
+        await this.setupChannel();
+        this.opts.logger.info(
+            `[EventConsumer:${this.opts.consumerName}] started (queue=${this.opts.queue})`,
+        );
+    }
+
+    /**
+     * Open a channel, declare the topology, and begin consuming. Runs once
+     * from start() and again from the reconnect path whenever the channel
+     * dies: the ConnectionManager auto-reconnects the *connection* after a
+     * socket drop, but channels are not resurrected with it — without the
+     * re-subscribe, a consumer that lost its channel would silently stop
+     * consuming while messages pile up in the queue.
+     */
+    private async setupChannel(): Promise<void> {
+        // Covers the case where the manager's own post-'close' reconnect
+        // exhausted its retries — nothing else would retry the connection.
+        // Older soa-rabbitmq versions predate ensureConnected(); the consumer
+        // then falls through to newChannel(), which fails descriptively on a
+        // dead connection and is retried by the backoff loop.
+        if (typeof this.opts.connectionManager.ensureConnected === 'function') {
+            await this.opts.connectionManager.ensureConnected();
+        }
+        const channel = await this.opts.connectionManager.newChannel();
+        // 'error' must have a listener (an unhandled EventEmitter 'error'
+        // crashes the process); the terminal signal is the 'close' that
+        // follows, which schedules the re-subscribe.
+        channel.on('error', (err: Error) => {
+            this.opts.logger.warn(
+                `[EventConsumer:${this.opts.consumerName}] channel error: ${err.message}`,
+            );
+        });
+        channel.on('close', () => {
+            if (this.channel === channel) {
+                this.channel = null;
+                this.consumerTag = null;
+                if (!this.stopped) {
+                    this.opts.logger.warn(
+                        `[EventConsumer:${this.opts.consumerName}] channel lost; scheduling re-subscribe`,
+                    );
+                    this.scheduleReconnect();
+                }
+            }
+        });
+
+        await channel.prefetch(this.opts.prefetch ?? 10);
 
         // Wire DLQ first if configured — must be declared before the main queue
         // so the main queue's x-dead-letter-exchange resolves.
         if (this.opts.dlq) {
-            await this.channel.assertExchange(this.opts.dlq.exchange, 'topic', {
+            await channel.assertExchange(this.opts.dlq.exchange, 'topic', {
                 durable: true,
             });
-            await this.channel.assertQueue(this.opts.dlq.queue, { durable: true });
-            await this.channel.bindQueue(
+            await channel.assertQueue(this.opts.dlq.queue, { durable: true });
+            await channel.bindQueue(
                 this.opts.dlq.queue,
                 this.opts.dlq.exchange,
                 '#',
             );
         }
 
-        await this.channel.assertQueue(this.opts.queue, {
+        await channel.assertQueue(this.opts.queue, {
             durable: true,
             ...(this.opts.dlq
                 ? { arguments: { 'x-dead-letter-exchange': this.opts.dlq.exchange } }
@@ -198,32 +246,68 @@ export class EventConsumer {
         });
 
         for (const binding of this.opts.bindings) {
-            await this.channel.assertExchange(binding.exchange, 'topic', {
+            await channel.assertExchange(binding.exchange, 'topic', {
                 durable: true,
             });
-            await this.channel.bindQueue(
+            await channel.bindQueue(
                 this.opts.queue,
                 binding.exchange,
                 binding.routingKey,
             );
         }
 
-        const consumeRes = await this.channel.consume(
+        const consumeRes = await channel.consume(
             this.opts.queue,
             (msg) => {
                 if (!msg) return;
-                void this.dispatch(msg);
+                // Bind dispatch to THIS channel: delivery tags are
+                // channel-scoped, so a message must never be acked/nacked on
+                // a replacement channel.
+                void this.dispatch(channel, msg);
             },
             { noAck: false },
         );
 
+        this.channel = channel;
         this.consumerTag = consumeRes.consumerTag;
-        this.opts.logger.info(
-            `[EventConsumer:${this.opts.consumerName}] started (queue=${this.opts.queue})`,
-        );
+    }
+
+    /**
+     * Exponential backoff (1s → 30s cap) around setupChannel(). Retries
+     * forever until it succeeds or stop() is called — the queue and its
+     * bindings are durable, so messages accumulate safely while the broker
+     * is unreachable.
+     */
+    private scheduleReconnect(): void {
+        if (this.stopped || this.reconnectTimer) return;
+        const delay = Math.min(30_000, 1_000 * 2 ** this.reconnectAttempts);
+        this.reconnectTimer = setTimeout(() => {
+            this.reconnectTimer = null;
+            if (this.stopped) return;
+            void this.setupChannel().then(
+                () => {
+                    this.reconnectAttempts = 0;
+                    this.opts.logger.info(
+                        `[EventConsumer:${this.opts.consumerName}] re-subscribed (queue=${this.opts.queue})`,
+                    );
+                },
+                (err: unknown) => {
+                    this.reconnectAttempts++;
+                    this.opts.logger.warn(
+                        `[EventConsumer:${this.opts.consumerName}] re-subscribe failed (attempt ${this.reconnectAttempts}): ${err instanceof Error ? err.message : String(err)}`,
+                    );
+                    this.scheduleReconnect();
+                },
+            );
+        }, delay);
     }
 
     async stop(): Promise<void> {
+        this.stopped = true;
+        if (this.reconnectTimer) {
+            clearTimeout(this.reconnectTimer);
+            this.reconnectTimer = null;
+        }
         if (this.channel && this.consumerTag) {
             try {
                 await this.channel.cancel(this.consumerTag);
@@ -260,10 +344,10 @@ export class EventConsumer {
         await this.processEnvelope(envelope);
     }
 
-    private async dispatch(msg: ConsumeMessage): Promise<void> {
+    private async dispatch(channel: Channel, msg: ConsumeMessage): Promise<void> {
         try {
             await this.handleMessage(msg.content);
-            this.channel?.ack(msg);
+            this.settle(() => channel.ack(msg));
         } catch (err) {
             // Poison errors never requeue — re-delivering an unparseable or
             // unrouteable message just spins the same failure forever and
@@ -277,7 +361,24 @@ export class EventConsumer {
                 `[EventConsumer:${this.opts.consumerName}] handler error → ${fate}`,
                 err instanceof Error ? err : undefined,
             );
-            this.channel?.nack(msg, false, requeue);
+            this.settle(() => channel.nack(msg, false, requeue));
+        }
+    }
+
+    /**
+     * Ack/nack can race a channel death (handler ran while the socket
+     * dropped). Settling on a dead channel throws IllegalOperationError; the
+     * broker will redeliver the unsettled message on the replacement channel
+     * and the consumed_events idempotency check absorbs the duplicate, so
+     * the right move is to log and move on rather than crash the dispatch.
+     */
+    private settle(op: () => void): void {
+        try {
+            op();
+        } catch (err) {
+            this.opts.logger.warn(
+                `[EventConsumer:${this.opts.consumerName}] ack/nack failed on dead channel (broker will redeliver): ${err instanceof Error ? err.message : String(err)}`,
+            );
         }
     }
 

--- a/packages/node/event-outbox/package.json
+++ b/packages/node/event-outbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saga-ed/soa-event-outbox",
-  "version": "0.1.0-dev.7",
+  "version": "0.1.0-dev.8",
   "private": false,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/node/event-outbox/src/__tests__/relay-channel-recovery.unit.test.ts
+++ b/packages/node/event-outbox/src/__tests__/relay-channel-recovery.unit.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { OutboxRelay } from '../relay.js';
+import type { OutboxRelayOpts } from '../relay.js';
+
+/**
+ * The ConnectionManager auto-reconnects the *connection* after a socket drop,
+ * but channels die with the old connection and are not resurrected. These
+ * tests pin the relay's recovery contract: a dead channel is dropped on its
+ * 'close' event and a fresh one (with the exchange re-asserted) is acquired
+ * on the next poll — instead of publishing into the dead channel forever
+ * (observed in dev as one IllegalOperationError per 500ms tick while outbox
+ * rows backed up, ~615K log lines/day).
+ */
+
+function makeChannel() {
+    const ch = new EventEmitter() as EventEmitter & {
+        assertExchange: ReturnType<typeof vi.fn>;
+        publish: ReturnType<typeof vi.fn>;
+        close: ReturnType<typeof vi.fn>;
+    };
+    ch.assertExchange = vi.fn().mockResolvedValue({});
+    ch.publish = vi.fn().mockReturnValue(true);
+    ch.close = vi.fn().mockResolvedValue(undefined);
+    return ch;
+}
+
+const ROW = {
+    event_id: '4d1c1adc-0000-4000-8000-000000000001',
+    aggregate_type: 'program',
+    aggregate_id: 'p-1',
+    event_type: 'program.created',
+    event_version: 1,
+    payload: { id: 'p-1' },
+    meta: null,
+    occurred_at: new Date('2026-07-01T00:00:00Z'),
+    attempts: 0,
+};
+
+function makePgPool() {
+    const client = {
+        query: vi.fn(async (sql: string) => {
+            if (String(sql).includes('FROM outbox_event')) {
+                return { rows: [ROW], rowCount: 1 };
+            }
+            return { rows: [], rowCount: 1 };
+        }),
+        release: vi.fn(),
+    };
+    return { pool: { connect: vi.fn().mockResolvedValue(client) }, client };
+}
+
+function makeRelay(newChannel: ReturnType<typeof vi.fn>) {
+    const { pool } = makePgPool();
+    const logger = { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() };
+    const connectionManager = {
+        ensureConnected: vi.fn().mockResolvedValue(undefined),
+        newChannel,
+    };
+    const relay = new OutboxRelay({
+        pool: pool as unknown as OutboxRelayOpts['pool'],
+        connectionManager: connectionManager as unknown as OutboxRelayOpts['connectionManager'],
+        exchange: 'test.events',
+        logger: logger as unknown as OutboxRelayOpts['logger'],
+    });
+    return { relay, connectionManager, logger };
+}
+
+const drain = (relay: OutboxRelay) =>
+    (relay as unknown as { drainBatch: () => Promise<void> }).drainBatch();
+
+const tick = (relay: OutboxRelay) =>
+    (relay as unknown as { tick: () => Promise<void> }).tick();
+
+describe('OutboxRelay channel recovery', () => {
+    it("re-acquires a channel after 'close' and publishes on the new one", async () => {
+        const ch1 = makeChannel();
+        const ch2 = makeChannel();
+        const newChannel = vi.fn().mockResolvedValueOnce(ch1).mockResolvedValueOnce(ch2);
+        const { relay, connectionManager } = makeRelay(newChannel);
+
+        await drain(relay);
+        expect(ch1.publish).toHaveBeenCalledTimes(1);
+
+        ch1.emit('close');
+        await drain(relay);
+
+        expect(newChannel).toHaveBeenCalledTimes(2);
+        expect(connectionManager.ensureConnected).toHaveBeenCalledTimes(2);
+        expect(ch2.assertExchange).toHaveBeenCalledWith('test.events', 'topic', {
+            durable: true,
+        });
+        expect(ch2.publish).toHaveBeenCalledTimes(1);
+    });
+
+    it('reuses the live channel across polls (no per-tick churn)', async () => {
+        const ch1 = makeChannel();
+        const newChannel = vi.fn().mockResolvedValue(ch1);
+        const { relay } = makeRelay(newChannel);
+
+        await drain(relay);
+        await drain(relay);
+
+        expect(newChannel).toHaveBeenCalledTimes(1);
+        expect(ch1.assertExchange).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not cache a channel whose exchange assertion failed', async () => {
+        const ch1 = makeChannel();
+        ch1.assertExchange.mockRejectedValueOnce(new Error('PRECONDITION_FAILED (406)'));
+        const ch2 = makeChannel();
+        const newChannel = vi.fn().mockResolvedValueOnce(ch1).mockResolvedValueOnce(ch2);
+        const { relay } = makeRelay(newChannel);
+
+        await expect(drain(relay)).rejects.toThrow(/406/);
+        await drain(relay);
+
+        expect(newChannel).toHaveBeenCalledTimes(2);
+        expect(ch2.publish).toHaveBeenCalledTimes(1);
+    });
+
+    it("swallows channel 'error' events (no unhandled EventEmitter crash)", async () => {
+        const ch1 = makeChannel();
+        const newChannel = vi.fn().mockResolvedValue(ch1);
+        const { relay, logger } = makeRelay(newChannel);
+
+        await drain(relay);
+        // Without a listener this would throw out of emit() and crash.
+        ch1.emit('error', new Error('channel-level 406'));
+        expect(logger.warn).toHaveBeenCalledWith(
+            expect.stringContaining('channel error'),
+        );
+    });
+});
+
+describe('OutboxRelay failure-log throttling', () => {
+    it('logs the first consecutive failure, then goes quiet until the heartbeat', async () => {
+        const newChannel = vi.fn().mockRejectedValue(new Error('broker down'));
+        const { relay, logger } = makeRelay(newChannel);
+
+        await tick(relay);
+        await tick(relay);
+        await tick(relay);
+
+        expect(logger.error).toHaveBeenCalledTimes(1);
+        expect(logger.error).toHaveBeenCalledWith(
+            expect.stringContaining('(1 consecutive)'),
+            expect.any(Error),
+        );
+    });
+
+    it('resets the failure counter after a successful poll', async () => {
+        const ch1 = makeChannel();
+        const newChannel = vi
+            .fn()
+            .mockRejectedValueOnce(new Error('broker down'))
+            .mockResolvedValue(ch1);
+        const { relay, logger } = makeRelay(newChannel);
+
+        await tick(relay); // fails → logs (1 consecutive)
+        await tick(relay); // recovers
+        ch1.emit('close');
+        newChannel.mockRejectedValueOnce(new Error('broker down again'));
+        await tick(relay); // fails → logs (1 consecutive) again
+
+        expect(logger.error).toHaveBeenCalledTimes(2);
+        const messages = logger.error.mock.calls.map((c) => String(c[0]));
+        expect(messages.every((m) => m.includes('(1 consecutive)'))).toBe(true);
+    });
+});

--- a/packages/node/event-outbox/src/__tests__/relay-channel-recovery.unit.test.ts
+++ b/packages/node/event-outbox/src/__tests__/relay-channel-recovery.unit.test.ts
@@ -1,7 +1,13 @@
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { EventEmitter } from 'node:events';
 import { OutboxRelay } from '../relay.js';
 import type { OutboxRelayOpts } from '../relay.js';
+
+// tick() reschedules itself; fake timers keep those schedules inert so
+// manually driven ticks don't spawn real 500ms follow-ups.
+afterEach(() => {
+    vi.useRealTimers();
+});
 
 /**
  * The ConnectionManager auto-reconnects the *connection* after a socket drop,
@@ -63,6 +69,9 @@ function makeRelay(newChannel: ReturnType<typeof vi.fn>) {
         exchange: 'test.events',
         logger: logger as unknown as OutboxRelayOpts['logger'],
     });
+    // Mark "started" — ensureChannel refuses to cache a channel acquired
+    // after stop(), and tick() suppresses post-stop failure logs.
+    (relay as unknown as { running: boolean }).running = true;
     return { relay, connectionManager, logger };
 }
 
@@ -119,6 +128,36 @@ describe('OutboxRelay channel recovery', () => {
         expect(ch2.publish).toHaveBeenCalledTimes(1);
     });
 
+    it("does not cache a channel whose 'close' fired during setup", async () => {
+        const ch1 = makeChannel();
+        // 'close' arrives before ensureChannel's assignment resumes — the
+        // close listener's identity guard can't catch it.
+        ch1.assertExchange.mockImplementationOnce(async () => {
+            ch1.emit('close');
+            return {};
+        });
+        const ch2 = makeChannel();
+        const newChannel = vi.fn().mockResolvedValueOnce(ch1).mockResolvedValueOnce(ch2);
+        const { relay } = makeRelay(newChannel);
+
+        await expect(drain(relay)).rejects.toThrow(/closed during setup/);
+        expect(ch1.close).toHaveBeenCalled();
+
+        await drain(relay);
+        expect(ch2.publish).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not cache a channel acquired while stop() raced the setup', async () => {
+        const ch1 = makeChannel();
+        const newChannel = vi.fn().mockResolvedValue(ch1);
+        const { relay } = makeRelay(newChannel);
+        (relay as unknown as { running: boolean }).running = false; // stop() won the race
+
+        await expect(drain(relay)).rejects.toThrow(/stopped during channel setup/);
+        expect(ch1.close).toHaveBeenCalled();
+        expect((relay as unknown as { channel: unknown }).channel).toBeNull();
+    });
+
     it("swallows channel 'error' events (no unhandled EventEmitter crash)", async () => {
         const ch1 = makeChannel();
         const newChannel = vi.fn().mockResolvedValue(ch1);
@@ -135,6 +174,7 @@ describe('OutboxRelay channel recovery', () => {
 
 describe('OutboxRelay failure-log throttling', () => {
     it('logs the first consecutive failure, then goes quiet until the heartbeat', async () => {
+        vi.useFakeTimers();
         const newChannel = vi.fn().mockRejectedValue(new Error('broker down'));
         const { relay, logger } = makeRelay(newChannel);
 
@@ -149,7 +189,26 @@ describe('OutboxRelay failure-log throttling', () => {
         );
     });
 
+    it('logs immediately when the failure mode changes mid-streak', async () => {
+        vi.useFakeTimers();
+        const newChannel = vi
+            .fn()
+            .mockRejectedValueOnce(new Error('broker down'))
+            .mockRejectedValueOnce(new Error('broker down'))
+            .mockRejectedValueOnce(new Error('pool exhausted'));
+        const { relay, logger } = makeRelay(newChannel);
+
+        await tick(relay); // 'broker down' → logged (new error)
+        await tick(relay); // same error → throttled
+        await tick(relay); // 'pool exhausted' → logged (changed error)
+
+        expect(logger.error).toHaveBeenCalledTimes(2);
+        const messages = logger.error.mock.calls.map((c) => (c[1] as Error).message);
+        expect(messages).toEqual(['broker down', 'pool exhausted']);
+    });
+
     it('resets the failure counter after a successful poll', async () => {
+        vi.useFakeTimers();
         const ch1 = makeChannel();
         const newChannel = vi
             .fn()

--- a/packages/node/event-outbox/src/relay.ts
+++ b/packages/node/event-outbox/src/relay.ts
@@ -89,12 +89,12 @@ export class OutboxRelay {
     private channel: Channel | null = null;
     private timer: NodeJS.Timeout | null = null;
     private running = false;
+    private consecutiveFailures = 0;
 
     constructor(private readonly opts: OutboxRelayOpts) {}
 
     async start(): Promise<void> {
-        this.channel = await this.opts.connectionManager.newChannel();
-        await this.channel.assertExchange(this.opts.exchange, 'topic', { durable: true });
+        await this.ensureChannel();
         // Publishes use `persistent: true` for durability but do NOT wait for
         // publisher confirms — `@saga-ed/soa-rabbitmq` exposes only a plain
         // Channel today, not a ConfirmChannel. A broker crash between
@@ -105,6 +105,48 @@ export class OutboxRelay {
         this.running = true;
         this.opts.logger.info(`[OutboxRelay] started (exchange=${this.opts.exchange})`);
         this.scheduleNext();
+    }
+
+    /**
+     * Return a live channel, creating one if the previous channel died.
+     * The ConnectionManager auto-reconnects the *connection* after a socket
+     * drop, but channels are not resurrected with it — without this, the
+     * relay would keep publishing into the dead channel from the old
+     * connection forever (one IllegalOperationError per tick until the task
+     * restarts, with outbox rows backing up the whole time).
+     */
+    private async ensureChannel(): Promise<Channel> {
+        if (this.channel) {
+            return this.channel;
+        }
+        // Covers the case where the manager's own post-'close' reconnect
+        // exhausted its retries — nothing else would retry the connection.
+        // Older soa-rabbitmq versions predate ensureConnected(); the relay
+        // then falls through to newChannel(), which fails descriptively on a
+        // dead connection and is retried next tick.
+        if (typeof this.opts.connectionManager.ensureConnected === 'function') {
+            await this.opts.connectionManager.ensureConnected();
+        }
+        const channel = await this.opts.connectionManager.newChannel();
+        // 'error' must have a listener (an unhandled EventEmitter 'error'
+        // crashes the process); the terminal signal is the 'close' that
+        // follows, where the channel is dropped for next-tick re-acquisition.
+        channel.on('error', (err: Error) => {
+            this.opts.logger.warn(`[OutboxRelay] channel error: ${err.message}`);
+        });
+        channel.on('close', () => {
+            if (this.channel === channel) {
+                this.channel = null;
+                if (this.running) {
+                    this.opts.logger.warn(
+                        '[OutboxRelay] channel lost; re-acquiring on next poll',
+                    );
+                }
+            }
+        });
+        await channel.assertExchange(this.opts.exchange, 'topic', { durable: true });
+        this.channel = channel;
+        return channel;
     }
 
     async stop(): Promise<void> {
@@ -135,6 +177,7 @@ export class OutboxRelay {
     private async tick(): Promise<void> {
         try {
             await this.drainBatch();
+            this.consecutiveFailures = 0;
         } catch (err) {
             const e = err instanceof Error ? err : new Error(String(err));
             if (isFatalPgError(e)) {
@@ -154,15 +197,26 @@ export class OutboxRelay {
                 }
                 return;
             }
-            this.opts.logger.error('[OutboxRelay] poll failed', e);
+            // Throttle repeat failures: at a 500ms poll interval a persistent
+            // fault (broker outage, wedged channel) would otherwise emit ~2
+            // multi-line error logs per second until someone intervenes.
+            // Log the first failure and then one heartbeat per ~60s.
+            this.consecutiveFailures++;
+            if (this.consecutiveFailures === 1 || this.consecutiveFailures % 120 === 0) {
+                this.opts.logger.error(
+                    `[OutboxRelay] poll failed (${this.consecutiveFailures} consecutive)`,
+                    e,
+                );
+            }
         }
         this.scheduleNext();
     }
 
     private async drainBatch(): Promise<void> {
-        if (!this.channel) {
-            throw new Error('OutboxRelay not started');
-        }
+        // Re-acquire the channel BEFORE opening the pg transaction: broker
+        // recovery can take seconds-to-minutes and must not run while row
+        // locks are held. No-op when the channel is live.
+        const channel = await this.ensureChannel();
         const batchSize = this.opts.batchSize ?? 100;
         const client = await this.opts.pool.connect();
         let clientPoisoned = false;
@@ -195,7 +249,7 @@ export class OutboxRelay {
 
             const publishedIds: string[] = [];
             for (const row of result.rows) {
-                await this.publishRow(row);
+                await this.publishRow(channel, row);
                 publishedIds.push(row.event_id);
             }
 
@@ -229,11 +283,7 @@ export class OutboxRelay {
         }
     }
 
-    private async publishRow(row: OutboxRow): Promise<void> {
-        if (!this.channel) {
-            throw new Error('OutboxRelay channel missing');
-        }
-
+    private async publishRow(channel: Channel, row: OutboxRow): Promise<void> {
         // Restore the trace context the publisher captured at outbox-write
         // time so this PRODUCER span chains under the original request span,
         // and the consumer's CONSUMER span chains under this one. End-to-end
@@ -284,7 +334,7 @@ export class OutboxRelay {
                     ...(Object.keys(wireMeta).length > 0 ? { meta: wireMeta } : {}),
                 };
 
-                const ok = this.channel!.publish(
+                const ok = channel.publish(
                     this.opts.exchange,
                     row.event_type,
                     Buffer.from(JSON.stringify(message)),
@@ -302,7 +352,7 @@ export class OutboxRelay {
                     // relay because none of those events arrive until
                     // amqplib's heartbeat eventually closes the connection,
                     // and the row stays locked under FOR UPDATE SKIP LOCKED.
-                    const ch = this.channel!;
+                    const ch = channel;
                     const timeoutMs = this.opts.drainTimeoutMs ?? 30_000;
                     await new Promise<void>((resolve, reject) => {
                         const cleanup = (): void => {

--- a/packages/node/event-outbox/src/relay.ts
+++ b/packages/node/event-outbox/src/relay.ts
@@ -90,11 +90,20 @@ export class OutboxRelay {
     private timer: NodeJS.Timeout | null = null;
     private running = false;
     private consecutiveFailures = 0;
+    private lastFailureMessage: string | null = null;
 
     constructor(private readonly opts: OutboxRelayOpts) {}
 
     async start(): Promise<void> {
-        await this.ensureChannel();
+        // `running` flips on BEFORE the first channel acquisition so
+        // ensureChannel's stop-race guard can see a concurrent stop().
+        this.running = true;
+        try {
+            await this.ensureChannel();
+        } catch (err) {
+            this.running = false;
+            throw err;
+        }
         // Publishes use `persistent: true` for durability but do NOT wait for
         // publisher confirms — `@saga-ed/soa-rabbitmq` exposes only a plain
         // Channel today, not a ConfirmChannel. A broker crash between
@@ -102,7 +111,6 @@ export class OutboxRelay {
         // soa-rabbitmq with `newConfirmChannel()` to restore strict
         // at-least-once.
 
-        this.running = true;
         this.opts.logger.info(`[OutboxRelay] started (exchange=${this.opts.exchange})`);
         this.scheduleNext();
     }
@@ -134,7 +142,9 @@ export class OutboxRelay {
         channel.on('error', (err: Error) => {
             this.opts.logger.warn(`[OutboxRelay] channel error: ${err.message}`);
         });
+        let closed = false;
         channel.on('close', () => {
+            closed = true;
             if (this.channel === channel) {
                 this.channel = null;
                 if (this.running) {
@@ -146,6 +156,20 @@ export class OutboxRelay {
         });
         await channel.assertExchange(this.opts.exchange, 'topic', { durable: true });
         this.channel = channel;
+        // Setup can race a channel death ('close' fired before the
+        // assignment above, so the listener's identity guard missed it) or
+        // a concurrent stop(). Either way this channel must not be cached.
+        if (closed || !this.running) {
+            this.channel = null;
+            void Promise.resolve()
+                .then(() => channel.close())
+                .catch(() => {});
+            throw new Error(
+                closed
+                    ? 'channel closed during setup'
+                    : 'relay stopped during channel setup',
+            );
+        }
         return channel;
     }
 
@@ -178,7 +202,10 @@ export class OutboxRelay {
         try {
             await this.drainBatch();
             this.consecutiveFailures = 0;
+            this.lastFailureMessage = null;
         } catch (err) {
+            // A tick interrupted by stop() isn't a failure worth reporting.
+            if (!this.running) return;
             const e = err instanceof Error ? err : new Error(String(err));
             if (isFatalPgError(e)) {
                 // Configuration / permission errors aren't going to fix
@@ -197,12 +224,19 @@ export class OutboxRelay {
                 }
                 return;
             }
-            // Throttle repeat failures: at a 500ms poll interval a persistent
-            // fault (broker outage, wedged channel) would otherwise emit ~2
-            // multi-line error logs per second until someone intervenes.
-            // Log the first failure and then one heartbeat per ~60s.
+            // Throttle repeat failures: a persistent fault (broker outage,
+            // wedged channel) would otherwise emit a multi-line error log
+            // every poll tick until someone intervenes. Log each NEW error
+            // (first of a streak, or the failure mode changing mid-outage)
+            // immediately, then one heartbeat per ~60s of poll ticks.
             this.consecutiveFailures++;
-            if (this.consecutiveFailures === 1 || this.consecutiveFailures % 120 === 0) {
+            const ticksPerHeartbeat = Math.max(
+                1,
+                Math.round(60_000 / (this.opts.pollIntervalMs ?? 500)),
+            );
+            const newError = e.message !== this.lastFailureMessage;
+            this.lastFailureMessage = e.message;
+            if (newError || this.consecutiveFailures % ticksPerHeartbeat === 0) {
                 this.opts.logger.error(
                     `[OutboxRelay] poll failed (${this.consecutiveFailures} consecutive)`,
                     e,

--- a/packages/node/rabbitmq/__tests__/ensure-connected.unit.test.ts
+++ b/packages/node/rabbitmq/__tests__/ensure-connected.unit.test.ts
@@ -1,0 +1,95 @@
+// Unit tests for ConnectionManager.ensureConnected + single-flight connect().
+//
+// Channel holders (outbox relay, event consumers) call ensureConnected()
+// from their channel-recovery paths. Two invariants matter:
+//   1. ensureConnected() is a no-op while the connection is usable
+//      (READY / DEGRADED) — recovery ticks must not churn the connection.
+//   2. Concurrent connect()/ensureConnected() callers join one in-flight
+//      attempt instead of racing parallel connection loops.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConnectionManager } from '../src/connection-manager.js';
+import type { ConnectionState } from '../src/connection-manager.js';
+
+vi.mock('amqplib', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('amqplib')>();
+    return { ...actual, connect: vi.fn() };
+});
+
+const { connect: mockConnect } = await import('amqplib');
+
+const NOOP_LOGGER = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+};
+
+function fakeChannelModel() {
+    return { on: vi.fn(), createChannel: vi.fn() };
+}
+
+function makeManager() {
+    return new ConnectionManager(NOOP_LOGGER as never, { url: 'amqp://localhost' });
+}
+
+function setState(cm: ConnectionManager, state: ConnectionState) {
+    (cm as unknown as { currentState: ConnectionState }).currentState = state;
+}
+
+beforeEach(() => {
+    vi.mocked(mockConnect).mockReset();
+});
+
+describe('ConnectionManager.ensureConnected', () => {
+    it('is a no-op when READY', async () => {
+        const cm = makeManager();
+        setState(cm, 'READY');
+        await cm.ensureConnected();
+        expect(mockConnect).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when DEGRADED (connected but flow-blocked)', async () => {
+        const cm = makeManager();
+        setState(cm, 'DEGRADED');
+        await cm.ensureConnected();
+        expect(mockConnect).not.toHaveBeenCalled();
+    });
+
+    it('connects when DISCONNECTED and lands in READY', async () => {
+        const cm = makeManager();
+        vi.mocked(mockConnect).mockResolvedValue(fakeChannelModel() as never);
+        await cm.ensureConnected();
+        expect(mockConnect).toHaveBeenCalledTimes(1);
+        expect(cm.state()).toBe('READY');
+    });
+});
+
+describe('ConnectionManager.connect single-flight', () => {
+    it('joins concurrent callers onto one underlying attempt', async () => {
+        const cm = makeManager();
+        let release!: (model: unknown) => void;
+        vi.mocked(mockConnect).mockReturnValue(
+            new Promise((res) => {
+                release = res;
+            }) as never,
+        );
+
+        const first = cm.connect();
+        const second = cm.ensureConnected();
+        release(fakeChannelModel());
+        await Promise.all([first, second]);
+
+        expect(mockConnect).toHaveBeenCalledTimes(1);
+        expect(cm.state()).toBe('READY');
+    });
+
+    it('allows a fresh attempt after the previous one settles', async () => {
+        const cm = makeManager();
+        vi.mocked(mockConnect).mockResolvedValue(fakeChannelModel() as never);
+        await cm.connect();
+        setState(cm, 'DISCONNECTED');
+        await cm.connect();
+        expect(mockConnect).toHaveBeenCalledTimes(2);
+    });
+});

--- a/packages/node/rabbitmq/__tests__/ensure-connected.unit.test.ts
+++ b/packages/node/rabbitmq/__tests__/ensure-connected.unit.test.ts
@@ -63,6 +63,21 @@ describe('ConnectionManager.ensureConnected', () => {
         expect(mockConnect).toHaveBeenCalledTimes(1);
         expect(cm.state()).toBe('READY');
     });
+
+    it("rejects when connect() resolves without a usable connection (log-and-continue breaker trip)", async () => {
+        // In 'log-and-continue' mode, a circuit-breaker trip makes connect()
+        // RESOLVE with no connection. ensureConnected must still throw so
+        // recovery callers (relay tick, consumer backoff) don't proceed onto
+        // a dead channelModel believing the connection is usable.
+        vi.mocked(mockConnect).mockRejectedValue(new Error('ECONNREFUSED'));
+        const cm = new ConnectionManager(NOOP_LOGGER as never, {
+            url: 'amqp://localhost',
+            failureMode: 'log-and-continue',
+            reconnect: { enabled: true, maxRetries: 1, initialDelay: 1, maxDelay: 2 },
+        });
+        await expect(cm.ensureConnected()).rejects.toThrow(/connection unavailable/);
+        expect(cm.state()).toBe('CIRCUIT_OPEN');
+    });
 });
 
 describe('ConnectionManager.connect single-flight', () => {

--- a/packages/node/rabbitmq/package.json
+++ b/packages/node/rabbitmq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saga-ed/soa-rabbitmq",
-  "version": "1.3.0-dev.1",
+  "version": "1.4.0-dev.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/node/rabbitmq/src/connection-manager.ts
+++ b/packages/node/rabbitmq/src/connection-manager.ts
@@ -102,6 +102,7 @@ export class ConnectionManager {
   }
 
   private setState(state: ConnectionState) {
+    if (state === this.currentState) return;
     this.currentState = state;
     this.logger.info(`[MQConnectionManager] State: ${state}`);
   }
@@ -138,14 +139,22 @@ export class ConnectionManager {
    * fresh channel — it covers the gap where an automatic reconnect after
    * 'close' exhausted its retries and nothing else would ever try again.
    * No-op when READY (or DEGRADED, i.e. connected but flow-blocked).
-   * Throws while the circuit breaker is open — callers are expected to
-   * retry on their own cadence (poll tick, backoff timer).
+   * Throws when the connection is not usable afterwards — including in
+   * `log-and-continue` mode, where connect() itself resolves after a
+   * circuit-breaker trip. Callers are expected to retry on their own
+   * cadence (poll tick, backoff timer).
    */
   async ensureConnected(): Promise<void> {
     if (this.currentState === "READY" || this.currentState === "DEGRADED") {
       return;
     }
-    return this.connect();
+    await this.connect();
+    const state = this.state();
+    if (state !== "READY" && state !== "DEGRADED") {
+      throw new Error(
+        `RabbitMQ connection unavailable after connect attempt (state=${state})`,
+      );
+    }
   }
 
   private async doConnect(): Promise<void> {

--- a/packages/node/rabbitmq/src/connection-manager.ts
+++ b/packages/node/rabbitmq/src/connection-manager.ts
@@ -68,6 +68,14 @@ export class ConnectionManager {
 
   private currentState: ConnectionState = "DISCONNECTED";
 
+  /**
+   * Single-flight guard: concurrent connect()/ensureConnected() callers all
+   * await the same underlying attempt instead of racing parallel connection
+   * loops (each channel holder — outbox relay, event consumers — recovers
+   * independently, so concurrent calls are the norm after a drop).
+   */
+  private connectPromise: Promise<void> | null = null;
+
   // Circuit breaker prameters
   private failureCount = 0;
   private circuitOpen = false;
@@ -116,6 +124,31 @@ export class ConnectionManager {
   }
 
   async connect(): Promise<void> {
+    if (!this.connectPromise) {
+      this.connectPromise = this.doConnect().finally(() => {
+        this.connectPromise = null;
+      });
+    }
+    return this.connectPromise;
+  }
+
+  /**
+   * Reconnect if (and only if) the connection is not currently usable.
+   * Channel holders call this from their recovery paths before requesting a
+   * fresh channel — it covers the gap where an automatic reconnect after
+   * 'close' exhausted its retries and nothing else would ever try again.
+   * No-op when READY (or DEGRADED, i.e. connected but flow-blocked).
+   * Throws while the circuit breaker is open — callers are expected to
+   * retry on their own cadence (poll tick, backoff timer).
+   */
+  async ensureConnected(): Promise<void> {
+    if (this.currentState === "READY" || this.currentState === "DEGRADED") {
+      return;
+    }
+    return this.connect();
+  }
+
+  private async doConnect(): Promise<void> {
     if (this.isCircuitOpen()) {
       this.setState("CIRCUIT_OPEN");
       throw new Error("RabbitMQ circuit breaker is OPEN");


### PR DESCRIPTION
Closes #231

## Problem

\`ConnectionManager\` auto-reconnects the AMQP **connection** after a socket drop, but channels die with the old connection and are never resurrected:

- **OutboxRelay** acquires its channel once in \`start()\` and then publishes into the dead channel forever — one \`IllegalOperationError\` per 500ms tick while \`outbox_event\` rows back up. Observed live in dev: programs-api (\`sandbox-e2e-626\`) lost its connection to an \`exchange.declare\` 406 on 2026-07-01T21:34Z, the manager reconnected in 300ms, and the relay then failed every tick until the next task restart (~615K unparseable log lines/day, all at \`status:info\`).
- **EventConsumer** has the same bug with a silent failure mode: it stops consuming and messages pile up in the durable queue with zero errors.
- **ConnectionManager**: when the automatic post-\`close\` reconnect exhausts its retries, nothing ever tries again; concurrent \`connect()\` callers could race parallel connection loops.

## Changes

**soa-rabbitmq 1.4.0-dev.1**
- \`connect()\` is single-flight: concurrent callers join the in-flight attempt.
- New \`ensureConnected()\`: no-op when READY/DEGRADED, otherwise (re)connects; throws when the connection is not usable afterwards — including in \`log-and-continue\` mode, where a circuit-breaker trip makes \`connect()\` itself resolve without a connection.
- \`setState()\` logs only on state change (an open circuit polled every 500ms was ~2 log lines/sec).

**soa-event-outbox 0.1.0-dev.8**
- Relay drops its channel on \`'close'\` and lazily re-acquires (+ re-asserts the exchange) on the next poll — before the pg transaction opens, so broker recovery never runs while row locks are held.
- Setup races are guarded: a \`'close'\` that fires before the channel is cached, or a \`stop()\` racing an in-flight setup, both prevent caching and close the channel (previously either could permanently wedge or leak).
- Channel \`'error'\` gets a listener (an unhandled EventEmitter \`'error'\` crashes the process); a channel whose \`assertExchange\` fails (e.g. 406) is never cached.
- Poll-failure logs are throttled: each **new** error (start of streak or mid-streak change of failure mode) logs immediately, then one heartbeat per ~60s derived from \`pollIntervalMs\` — instead of 2 multi-line errors/sec.

**soa-event-consumer 0.1.0-dev.7**
- Non-\`stop()\` channel \`'close'\` schedules a full topology re-subscribe (DLQ, queue, bindings, consume) with 1s→30s exponential backoff, retrying until success or \`stop()\`.
- Same setup-race guards as the relay (close-during-setup, stop-during-setup).
- Broker-initiated consumer cancel (null message: queue deleted, HA failover) recovers via the re-subscribe path — previously a silent stall with the channel still open.
- \`start()\` failing on a transient boot error schedules the backoff loop before rethrowing, so log-and-continue bootstraps don't get a consumer that never consumes.
- \`dispatch\` binds ack/nack to the channel the message arrived on (delivery tags are channel-scoped) and absorbs dead-channel settle failures (broker redelivers; \`consumed_events\` dedups) — logged at debug during graceful shutdown, warn otherwise.

Backward-compatible: both channel holders feature-detect \`ensureConnected\` so they still work against older soa-rabbitmq instances (apps construct and inject their own \`ConnectionManager\`, so version skew is possible).

## Testing

- 21 new unit tests across the three packages (channel re-acquisition, close-during-setup and stop-during-setup races, broker-cancel recovery, start-failure rescheduling, ensureConnected contract incl. log-and-continue breaker trip, single-flight connect, log throttling/heartbeat/changed-error).
- All pre-existing tests pass: 75 tests total; \`check-types\` and \`lint\` clean, including downstream \`event-integration-tests\`.
- Note: \`event-integration-tests\`' testcontainers suite (\`test:int\`, not run by CI) is broken on \`main\` independent of this change — its \`REPO_ROOT\` resolves to \`packages/\` and it references \`apps/identity-svc\`/\`apps/admissions-svc\`, which don't exist in the repo.

## Not fixed here (follow-ups noted in #231)

- Legacy \`MessagePublisher\`/\`MessageConsumer\` in soa-rabbitmq share the dead-channel bug class (Map-cached channels, never recovered).
- The dev 406 trigger itself (exchange property mismatch in the sandbox-e2e composition).
- pr-307 preview crash-loop: preview DB missing the \`outbox_event\` migration (42P01 → fatal-halt → restart every ~5.5s).

https://claude.ai/code/session_017THmZ4ZHCWfc2uNzJiPN1R