### PR TITLE
fix(synthetic-dev): coach_api CREATE DATABASE fails inside a transaction block

### DIFF
--- a/tools/synthetic-dev/up.sh
+++ b/tools/synthetic-dev/up.sh
@@ -1063,8 +1063,12 @@ prep(){
   # (not the pre-existing saga_user), so create the role too on existing volumes.
   if [[ "$(docker exec soa-postgres-1 psql -U postgres_admin -tAc \
         "SELECT 1 FROM pg_database WHERE datname='coach_api'" 2>/dev/null)" != 1 ]]; then
+    # Two separate -c flags on purpose: a single -c with both statements runs them
+    # in one implicit transaction, and CREATE DATABASE can't run inside a txn block.
     db_step "coach_api role+db create" "$SOA" docker exec soa-postgres-1 \
-      psql -U postgres_admin -c "DO \$\$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='coach_api_app') THEN CREATE ROLE coach_api_app LOGIN PASSWORD 'dev-password-coach-api-app'; END IF; END \$\$; CREATE DATABASE coach_api OWNER coach_api_app"
+      psql -U postgres_admin \
+      -c "DO \$\$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='coach_api_app') THEN CREATE ROLE coach_api_app LOGIN PASSWORD 'dev-password-coach-api-app'; END IF; END \$\$" \
+      -c "CREATE DATABASE coach_api OWNER coach_api_app"
   fi
   # coach's prisma schema lives in the coach-db PACKAGE (not the app); it has
   # committed migrations, so migrate deploy lands cleanly.


### PR DESCRIPTION
## Problem

`./up.sh up --reset ...` fails on a fresh mesh volume while provisioning the recently-added coach_api DB:

```
→ applying prisma schemas (migrate deploy — canonical, see d1.5)…
✗ coach_api role+db create failed:
    DO
    ERROR:  CREATE DATABASE cannot run inside a transaction block

✗ up.sh exited (code 1) BEFORE seeding — the roster was NOT seeded.
```

## Root cause

`up.sh` packed **two** SQL statements into a single `psql -c`:

```
psql -c "DO $$ ... CREATE ROLE coach_api_app ... END $$;  CREATE DATABASE coach_api OWNER coach_api_app"
```

`psql` runs a multi-statement `-c` string as **one implicit transaction**. `CREATE DATABASE` is one of the commands Postgres refuses to run inside a transaction block. The `DO` block ran (its command tag echoes), then `CREATE DATABASE` aborted the whole transaction.

The neighboring `sessions`/`content` creators don't hit this because each passes a single `CREATE DATABASE` per `-c`.

## Why it slipped through

The block is guarded by a `pg_database WHERE datname='coach_api'` check, so it only runs when the DB doesn't already exist. Anyone whose machine already had `coach_api` (manual create or a partial prior run) never exercised the broken path — it surfaces on a clean/`--reset` volume, which means the coach_api provisioning has effectively never run end-to-end from scratch.

## Fix

Split into two `-c` flags so `CREATE DATABASE` runs as its own autocommit request — matching the pattern the existing `sessions`/`content` creators already use. The change is idempotent: the `DO ... IF NOT EXISTS` guards the role and the `pg_database` check guards the DB.

## Testing

- `bash -n tools/synthetic-dev/up.sh` passes.
- Recovery needs no manual cleanup: the failed statements ran in one implicit transaction, so the `CREATE ROLE` rolled back with the aborted `CREATE DATABASE` — re-running `up.sh` starts from a clean slate.

> [!NOTE]
> Since the from-scratch coach_api path was never exercised, a full `--reset` run is worth doing to confirm the subsequent `migrate_db`/seed steps for coach are also healthy — not just the DB create.

🤖 Generated with [Claude Code](https://claude.com/claude-code)