### PR TITLE
fix(synthetic-dev): auto-install Playwright Chromium when the pinned revision is missing

### DIFF
--- a/tools/synthetic-dev/up.sh
+++ b/tools/synthetic-dev/up.sh
@@ -1967,7 +1967,22 @@ open_login_browser(){
   local email=$1
   [[ -f "$BROWSER_LOGIN" ]] || { printf "\033[33m⚠\033[0m %s missing — skipping browser auto-login (cookie jar is ready)\n" "$BROWSER_LOGIN"; return 0; }
   command -v node >/dev/null 2>&1 || { printf "\033[33m⚠\033[0m node not found — skipping browser auto-login (cookie jar is ready)\n"; return 0; }
-  [[ -d "$SAGA_DASH/apps/web/dash/node_modules/playwright" ]] || { printf "\033[33m⚠\033[0m playwright not installed in saga-dash — skipping browser auto-login. Run: (cd %s/apps/web/dash && pnpm install && pnpm exec playwright install chromium)\n" "$SAGA_DASH"; return 0; }
+  local dashdir="$SAGA_DASH/apps/web/dash"
+  [[ -d "$dashdir/node_modules/playwright" ]] || { printf "\033[33m⚠\033[0m playwright not installed in saga-dash — skipping browser auto-login. Run: (cd %s && pnpm install && pnpm exec playwright install chromium)\n" "$dashdir"; return 0; }
+  # Playwright downloads its browser binaries separately from the npm package,
+  # into ~/.cache/ms-playwright/chromium-<rev> where <rev> is pinned to the
+  # installed playwright version. A version bump (or a fresh cache) leaves the
+  # package present but that revision's binary missing — the exact "Executable
+  # doesn't exist at …/chromium-<rev>/…" launch failure. Detect it via
+  # Playwright's own executablePath() (revision-agnostic) and install on demand.
+  if ! ( cd "$dashdir" && node -e 'try{const{chromium}=require("playwright");process.exit(require("fs").existsSync(chromium.executablePath())?0:1)}catch{process.exit(1)}' ) 2>/dev/null; then
+    say "Chromium browser binary missing — installing (pnpm exec playwright install chromium)…"
+    if ! ( cd "$dashdir" && pnpm exec playwright install chromium ) >"$STATE/playwright-install.log" 2>&1; then
+      printf "\033[33m⚠\033[0m Chromium install failed — skipping browser auto-login (cookie jar is ready). Full log: %s\n" "$STATE/playwright-install.log"
+      return 0
+    fi
+    ok "Chromium browser installed"
+  fi
   if [[ -f "$STATE/browser-login.pid" ]]; then
     kill "$(cat "$STATE/browser-login.pid")" 2>/dev/null || true; rm -f "$STATE/browser-login.pid"; sleep 1
   fi


### PR DESCRIPTION
## Problem

`./up.sh up --login …` fails at browser auto-login on machines whose Playwright browser cache doesn't have the revision the installed `playwright` package pins:

```
✗ browser auto-login failed: could not launch Chromium (profile in use? missing DISPLAY?):
    browserType.launchPersistentContext: Executable doesn't exist at
    /home/…/.cache/ms-playwright/chromium-1228/chrome-linux64/chrome
  (cookie jar is still valid for harnesses.)
```

The error text guesses "profile in use? missing DISPLAY?", but the real cause is the last line: the Chromium **binary** for the pinned revision isn't installed.

## Root cause

Playwright downloads its browser binaries **separately** from the npm package, into `~/.cache/ms-playwright/chromium-<rev>`, where `<rev>` is pinned to the installed `playwright` version. The `open_login_browser` guard only checked that the npm **package** was present (`node_modules/playwright`), so a version bump in saga-dash (which moved the pin to `chromium-1228`) — or a fresh cache — left the package present but that revision's binary undownloaded, and the launch failed.

## Fix

Add a revision-agnostic preflight in `open_login_browser`:

1. Ask Playwright itself for the expected binary path via `chromium.executablePath()` (no hardcoded revision, so it survives future bumps) and check whether it exists.
2. If missing, install on demand with `pnpm exec playwright install chromium` (the same command the existing "not installed" hint already recommends).
3. If the install fails, warn and skip — the cookie jar still works for headless harnesses, matching the function's existing best-effort posture.

## Testing

- `bash -n tools/synthetic-dev/up.sh` passes.
- Verified the detection one-liner against a real mismatched install: it computed `…/chromium-1228/chrome-linux64/chrome` and reported `exists: false` (pre-install) → `true` (post-install), i.e. it correctly gates the install.
- Ran `pnpm exec playwright install chromium` to confirm it fetches the pinned revision and unblocks auto-login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)