### PR TITLE
feat(synthetic-dev): bidirectional local↔cloud config capture/replay

### DIFF
--- a/tools/synthetic-dev/apply-local.sh
+++ b/tools/synthetic-dev/apply-local.sh
@@ -31,6 +31,21 @@
 #
 # Env:
 #   SWITCHBOARD_API_URL       default: https://switchboard-api.wootdev.com
+#                             registry host — variant PUT goes here. Both
+#                             hostnames route to the same merged Lambda/target
+#                             group, but the ALB listener rules that let a bare
+#                             CI bearer token through (no OIDC) are HOST-scoped:
+#                             switchboard-api.wootdev.com has the bypass for
+#                             /api/v1/services/* PUT|DELETE; sandbox-api.wootdev.com
+#                             has the bypass for /api/v1/compositions/*/update
+#                             POST (added in hipponot/microservices#698 — until
+#                             that deploys, the update call gets an ALB 302, not
+#                             a real response, regardless of bearer token).
+#                             Using the wrong host for either call reaches the
+#                             OIDC catch-all instead, NOT the app.
+#   SANDBOX_API_URL           default: https://sandbox-api.wootdev.com
+#                             sandbox/composition host — composition GET and
+#                             the /update call go here.
 #   SWITCHBOARD_CI_API_KEY    bearer token for the registry PUT (registry-side
 #                             secret — see auth.py: registry routes and
 #                             sandbox/composition routes validate against
@@ -78,7 +93,8 @@ command -v jq >/dev/null 2>&1 || { err "apply-local.sh needs jq"; exit 1; }
 command -v curl >/dev/null 2>&1 || { err "apply-local.sh needs curl"; exit 1; }
 [[ -r "$WORKSPACE" ]] || { err "cannot read '$WORKSPACE'"; exit 1; }
 
-API_URL=${SWITCHBOARD_API_URL:-https://switchboard-api.wootdev.com}
+REGISTRY_API_URL=${SWITCHBOARD_API_URL:-https://switchboard-api.wootdev.com}
+SANDBOX_API_URL=${SANDBOX_API_URL:-https://sandbox-api.wootdev.com}
 
 # ── preflight: both bearer secrets present (two DIFFERENT keys — see auth.py) ──
 if [[ -z "${SWITCHBOARD_CI_API_KEY:-}" ]]; then
@@ -91,9 +107,9 @@ if [[ -z "${SANDBOX_CI_API_KEY:-}" ]]; then
 fi
 
 # ── fetch the composition's current service→variantId map ──────────────────
-say "fetching composition '$COMPOSITION' from $API_URL…"
+say "fetching composition '$COMPOSITION' from $SANDBOX_API_URL…"
 COMP_RESP="$(mktemp)"; trap 'rm -f "$COMP_RESP"' EXIT
-comp_status=$(curl -sS -o "$COMP_RESP" -w '%{http_code}' "$API_URL/api/v1/compositions/$COMPOSITION")
+comp_status=$(curl -sS -o "$COMP_RESP" -w '%{http_code}' "$SANDBOX_API_URL/api/v1/compositions/$COMPOSITION")
 if [[ "$comp_status" == "404" ]]; then
   err "composition '$COMPOSITION' not found — apply only updates an EXISTING composition, it does not create one"
   exit 1
@@ -137,7 +153,7 @@ while IFS= read -r svc; do
     '{gitRef: $gitRef, artifactRef: $artifactRef, registeredBy: "apply-local"}')
   reg_resp="$(mktemp)"
   reg_status=$(curl -sS -o "$reg_resp" -w '%{http_code}' \
-    -X PUT "$API_URL/api/v1/services/$svc/variants/$variant_id" \
+    -X PUT "$REGISTRY_API_URL/api/v1/services/$svc/variants/$variant_id" \
     -H "Authorization: Bearer $SWITCHBOARD_CI_API_KEY" \
     -H "Content-Type: application/json" \
     -d "$REG_PAYLOAD")
@@ -173,7 +189,7 @@ UPDATE_PAYLOAD=$(jq -nc --argjson services "$UPDATE_SERVICES" --argjson dbProfil
 say "dispatching update for $(jq -r '. | join(", ")' <<<"$UPDATE_SERVICES") on '$COMPOSITION'…"
 UPD_RESP="$(mktemp)"
 upd_status=$(curl -sS -o "$UPD_RESP" -w '%{http_code}' \
-  -X POST "$API_URL/api/v1/compositions/$COMPOSITION/update" \
+  -X POST "$SANDBOX_API_URL/api/v1/compositions/$COMPOSITION/update" \
   -H "Authorization: Bearer $SANDBOX_CI_API_KEY" \
   -H "Content-Type: application/json" \
   -d "$UPDATE_PAYLOAD")

--- a/tools/synthetic-dev/apply-local.sh
+++ b/tools/synthetic-dev/apply-local.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# apply-local.sh — push a captured local workspace.json to a live cloud
+# sandbox composition, so the full mesh can validate a change in progress.
+#
+# Local → cloud direction of the bidirectional config capture/replay tooling
+# (see capture-local.sh for the other half of this pair). Consumes a
+# workspace.json produced by capture-local.sh and, for every service it names
+# that is also a component of the target composition:
+#
+#   1. re-registers that service's ALREADY-BOUND variant with the captured
+#      sha (PUT /api/v1/services/{service}/variants/{variantId} — same call
+#      CI's switchboard-register step makes), then
+#   2. calls the composition update endpoint (POST
+#      /api/v1/compositions/{name}/update) to redeploy, which re-dispatches
+#      each selected component's create workflow using the variant's now-
+#      current registration.
+#
+# Two calls, in that order, are load-bearing: /update does NOT accept a sha —
+# it only re-dispatches whatever gitRef is presently registered for the
+# component's existing variantId (routes.py's _resolve_updatable_variant).
+# There is no endpoint that repoints a composition component to a DIFFERENT
+# variantId or an unregistered sha — apply only works against a sha that has
+# already passed through CI registration for the variantId the composition
+# already has bound (in practice: any main-reachable, already-deployed commit).
+#
+# Usage:
+#   ./apply-local.sh <composition-name> <workspace.json>
+#   ./apply-local.sh sandbox-foo my-workspace.json
+#   ./apply-local.sh sandbox-foo my-workspace.json --db-profile keep
+#
+# Env:
+#   SWITCHBOARD_API_URL       default: https://switchboard-api.wootdev.com
+#   SWITCHBOARD_CI_API_KEY    bearer token for the registry PUT (registry-side
+#                             secret — see auth.py: registry routes and
+#                             sandbox/composition routes validate against
+#                             DIFFERENT secrets, this is NOT the same key as
+#                             SANDBOX_CI_API_KEY below)
+#   SANDBOX_CI_API_KEY        bearer token for the composition /update call
+#                             (sandbox-side secret)
+#
+# What this does NOT do:
+#   - Does not create a new sandbox/composition — only updates an EXISTING
+#     one's already-bound components. Use the switchboard UI/API to create
+#     one first.
+#   - Does not touch services the workspace.json doesn't mention, or services
+#     the composition doesn't already have as a component — those are left
+#     exactly as they are (no implicit reset-all-data fan-out beyond what the
+#     composition's OWN update endpoint does for its non-selected components).
+#   - Does not compute/guess an artifactRef — it reuses the captured sha
+#     verbatim as both gitRef and artifactRef's tag component (`{service}:{sha}`,
+#     matching the ECR tagging convention register.py's callers use); if a
+#     sha was never built/pushed to ECR under that tag, the redeploy will fail
+#     at the workflow level, not here.
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+
+err(){ printf "\033[31m✗\033[0m %s\n" "$*" >&2; }
+warn(){ printf "\033[33m⚠\033[0m %s\n" "$*" >&2; }
+say(){ printf "\033[34m→\033[0m %s\n" "$*" >&2; }
+
+usage(){
+  echo "Usage: $0 <composition-name> <workspace.json> [--db-profile <profile>]" >&2
+  exit 1
+}
+
+[[ $# -ge 2 ]] || usage
+COMPOSITION=$1; WORKSPACE=$2; shift 2
+DB_PROFILE=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --db-profile) DB_PROFILE="${2:-}"; [[ -z "$DB_PROFILE" ]] && { err "--db-profile needs a value"; exit 1; }; shift 2 ;;
+    *) err "unknown arg '$1'"; usage ;;
+  esac
+done
+
+command -v jq >/dev/null 2>&1 || { err "apply-local.sh needs jq"; exit 1; }
+command -v curl >/dev/null 2>&1 || { err "apply-local.sh needs curl"; exit 1; }
+[[ -r "$WORKSPACE" ]] || { err "cannot read '$WORKSPACE'"; exit 1; }
+
+API_URL=${SWITCHBOARD_API_URL:-https://switchboard-api.wootdev.com}
+
+# ── preflight: both bearer secrets present (two DIFFERENT keys — see auth.py) ──
+if [[ -z "${SWITCHBOARD_CI_API_KEY:-}" ]]; then
+  err "SWITCHBOARD_CI_API_KEY not set (registry PUT auth — this is the switchboard/ci-api-key secret, NOT the sandbox one)"
+  exit 1
+fi
+if [[ -z "${SANDBOX_CI_API_KEY:-}" ]]; then
+  err "SANDBOX_CI_API_KEY not set (composition /update auth — this is the sandbox-api/ci-api-key secret, NOT the registry one)"
+  exit 1
+fi
+
+# ── fetch the composition's current service→variantId map ──────────────────
+say "fetching composition '$COMPOSITION' from $API_URL…"
+COMP_RESP="$(mktemp)"; trap 'rm -f "$COMP_RESP"' EXIT
+comp_status=$(curl -sS -o "$COMP_RESP" -w '%{http_code}' "$API_URL/api/v1/compositions/$COMPOSITION")
+if [[ "$comp_status" == "404" ]]; then
+  err "composition '$COMPOSITION' not found — apply only updates an EXISTING composition, it does not create one"
+  exit 1
+fi
+if [[ "$comp_status" != "200" ]]; then
+  err "GET /compositions/$COMPOSITION failed (HTTP $comp_status): $(cat "$COMP_RESP")"
+  exit 1
+fi
+COMP_SERVICES=$(jq -c '.services // {}' "$COMP_RESP")
+
+# ── intersect the workspace manifest with the composition's actual components ──
+WS_SERVICES=$(jq -c '.services // {}' "$WORKSPACE")
+SELECTED=$(jq -nc --argjson comp "$COMP_SERVICES" --argjson ws "$WS_SERVICES" \
+  '[$ws | keys[] | select(. as $s | $comp | has($s))]')
+SEL_COUNT=$(jq 'length' <<<"$SELECTED")
+if [[ "$SEL_COUNT" -eq 0 ]]; then
+  err "no overlap between '$WORKSPACE' services and '$COMPOSITION' components — nothing to apply"
+  exit 1
+fi
+
+SKIPPED=$(jq -nc --argjson comp "$COMP_SERVICES" --argjson ws "$WS_SERVICES" \
+  '[$ws | keys[] | select(. as $s | ($comp | has($s)) | not)]')
+if [[ "$(jq 'length' <<<"$SKIPPED")" -gt 0 ]]; then
+  while IFS= read -r svc; do
+    warn "'$svc' is in the workspace manifest but not a component of '$COMPOSITION' — skipping"
+  done < <(jq -r '.[]' <<<"$SKIPPED")
+fi
+
+# ── step 1: re-register each selected service's bound variant with its sha ──
+_reg_failed=()
+while IFS= read -r svc; do
+  variant_id=$(jq -r --arg s "$svc" '.[$s]' <<<"$COMP_SERVICES")
+  sha=$(jq -r --arg s "$svc" '.services[$s].sha // empty' "$WORKSPACE")
+  if [[ -z "$sha" ]]; then
+    warn "'$svc' has no sha in the workspace manifest — skipping (nothing to re-register)"
+    continue
+  fi
+
+  say "registering $svc/$variant_id @ ${sha:0:12}…"
+  REG_PAYLOAD=$(jq -nc --arg gitRef "$sha" --arg artifactRef "$svc:$sha" \
+    '{gitRef: $gitRef, artifactRef: $artifactRef, registeredBy: "apply-local"}')
+  reg_resp="$(mktemp)"
+  reg_status=$(curl -sS -o "$reg_resp" -w '%{http_code}' \
+    -X PUT "$API_URL/api/v1/services/$svc/variants/$variant_id" \
+    -H "Authorization: Bearer $SWITCHBOARD_CI_API_KEY" \
+    -H "Content-Type: application/json" \
+    -d "$REG_PAYLOAD")
+  if [[ "$reg_status" -lt 200 || "$reg_status" -ge 300 ]]; then
+    err "registering $svc/$variant_id failed (HTTP $reg_status): $(cat "$reg_resp")"
+    _reg_failed+=("$svc")
+  fi
+  rm -f "$reg_resp"
+done < <(jq -r '.[]' <<<"$SELECTED")
+
+if [[ ${#_reg_failed[@]} -gt 0 ]]; then
+  err "re-registration failed for: ${_reg_failed[*]} — aborting before dispatching an update with stale registrations"
+  exit 1
+fi
+
+# ── step 2: update the composition, redeploying every successfully-registered service ──
+UPDATE_SERVICES=$(jq -nc --argjson sel "$SELECTED" --argjson ws "$WS_SERVICES" \
+  '[$sel[] | select(. as $s | $ws[$s].sha != null and $ws[$s].sha != "")]')
+if [[ "$(jq 'length' <<<"$UPDATE_SERVICES")" -eq 0 ]]; then
+  err "no service had a sha to apply — nothing to update"
+  exit 1
+fi
+
+DB_PROFILES_JSON="{}"
+if [[ -n "$DB_PROFILE" ]]; then
+  DB_PROFILES_JSON=$(jq -nc --argjson svcs "$UPDATE_SERVICES" --arg p "$DB_PROFILE" \
+    '[$svcs[] | {key:., value:$p}] | from_entries')
+fi
+
+UPDATE_PAYLOAD=$(jq -nc --argjson services "$UPDATE_SERVICES" --argjson dbProfiles "$DB_PROFILES_JSON" \
+  '{services: $services, dbProfiles: $dbProfiles, resetAllData: false}')
+
+say "dispatching update for $(jq -r '. | join(", ")' <<<"$UPDATE_SERVICES") on '$COMPOSITION'…"
+UPD_RESP="$(mktemp)"
+upd_status=$(curl -sS -o "$UPD_RESP" -w '%{http_code}' \
+  -X POST "$API_URL/api/v1/compositions/$COMPOSITION/update" \
+  -H "Authorization: Bearer $SANDBOX_CI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "$UPDATE_PAYLOAD")
+if [[ "$upd_status" -lt 200 || "$upd_status" -ge 300 ]]; then
+  err "POST /compositions/$COMPOSITION/update failed (HTTP $upd_status): $(cat "$UPD_RESP")"
+  rm -f "$UPD_RESP"
+  exit 1
+fi
+
+say "update dispatched — status: $(jq -r '.status' "$UPD_RESP")"
+jq -r '.components[] | "  \(.service // "?"): \(.status // "?")"' "$UPD_RESP" 2>/dev/null || true
+rm -f "$UPD_RESP"

--- a/tools/synthetic-dev/capture-local.sh
+++ b/tools/synthetic-dev/capture-local.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# capture-local.sh — snapshot the developer's local mesh checkouts into a
+# workspace.json.
+#
+# Local → cloud direction of the bidirectional config capture/replay tooling:
+# walks the same sibling-repo paths check_branches() already knows, reads each
+# repo's checked-out commit, and emits a workspace.json (the same manifest
+# shape capture-sandbox.sh produces, read by both `up.sh --workspace` and
+# apply-local.sh) so a developer's in-progress local state can be pushed to a
+# cloud sandbox for full-mesh validation instead of "whatever's on main."
+#
+# Usage:
+#   ./capture-local.sh                 → prints workspace.json to stdout
+#   ./capture-local.sh -o out.json      → writes to out.json
+#   ./capture-local.sh --allow-dirty    → capture repos with uncommitted
+#                                          changes anyway (their sha then
+#                                          reflects HEAD, NOT the working tree —
+#                                          apply only ever pins a committed sha)
+#
+# What this does NOT do (see docs/promotion-pipeline.md's non-goals):
+#   - No dbProfile capture. up.sh has no "what did I seed this local DB from"
+#     tracker for a running database, so a captured manifest carries no
+#     dbProfile — the same seed profile the cloud sandbox was already using
+#     stays in place. Add a local marker file if this is needed later.
+#   - No push, no PR, no dispatch. This only walks disk and reads git state —
+#     apply-local.sh does the actual switchboard calls.
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+
+err(){ printf "\033[31m✗\033[0m %s\n" "$*" >&2; }
+warn(){ printf "\033[33m⚠\033[0m %s\n" "$*" >&2; }
+say(){ printf "\033[34m→\033[0m %s\n" "$*" >&2; }
+
+usage(){
+  echo "Usage: $0 [-o <output-file>] [--allow-dirty]" >&2
+  exit 1
+}
+
+OUT=""
+ALLOW_DIRTY=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o|--output) OUT="${2:-}"; [[ -z "$OUT" ]] && { err "-o needs a file path"; exit 1; }; shift 2 ;;
+    --allow-dirty) ALLOW_DIRTY=1; shift ;;
+    -h|--help) usage ;;
+    *) err "unknown arg '$1'"; usage ;;
+  esac
+done
+
+command -v jq >/dev/null 2>&1 || { err "capture-local.sh needs jq (brew/apt install jq)"; exit 1; }
+
+DEV=${DEV:-$HOME/dev}
+SOA=${SOA:-$DEV/soa}
+ROSTERING=${ROSTERING:-$DEV/rostering}
+PROGRAM_HUB=${PROGRAM_HUB:-$DEV/program-hub}
+SAGA_DASH=${SAGA_DASH:-$DEV/saga-dash}
+COACH=${COACH:-$DEV/coach}
+SDS=${SDS:-$DEV/student-data-system}
+QBOARD=${QBOARD:-$DEV/qboard}
+RTSM=${RTSM:-$DEV/rtsm}
+
+# repo dir → services it hosts (the reverse of up.sh's svc_repo_dir; git SHAs
+# are per-repo, so every service sharing a repo shares one captured sha).
+# soa is deliberately excluded — it's shared infra/packages, not a
+# switchboard-registered service with a variant of its own.
+REPO_SERVICES=(
+  "$ROSTERING:iam-api,sis-api"
+  "$PROGRAM_HUB:programs-api,scheduling-api,sessions-api,content-api"
+  "$SAGA_DASH:saga-dash"
+  "$COACH:coach-api,coach-web"
+  "$SDS:ads-adm-api"
+  "$QBOARD:connect-api,connect-web"
+  "$RTSM:rtsm-api"
+)
+
+HOSTNAME=$(hostname 2>/dev/null || echo "unknown-host")
+SERVICES_JSON="{}"
+_had_dirty=0
+_had_missing=0
+
+for kv in "${REPO_SERVICES[@]}"; do
+  repo_dir="${kv%%:*}"
+  svc_csv="${kv#*:}"
+
+  if [[ ! -e "$repo_dir/.git" ]]; then
+    warn "'$repo_dir' not cloned — skipping ${svc_csv//,/, }"
+    _had_missing=1
+    continue
+  fi
+
+  if [[ -n "$(git -C "$repo_dir" status --porcelain 2>/dev/null)" ]]; then
+    _had_dirty=1
+    if [[ "$ALLOW_DIRTY" -ne 1 ]]; then
+      err "'$repo_dir' has uncommitted changes — refusing to capture (commit/stash, or pass --allow-dirty to capture HEAD anyway)"
+      exit 1
+    fi
+    warn "'$repo_dir' has uncommitted changes — capturing HEAD only (working-tree diffs are NOT included)"
+  fi
+
+  sha=$(git -C "$repo_dir" rev-parse HEAD 2>/dev/null)
+  if [[ -z "$sha" ]]; then
+    err "'$repo_dir' — 'git rev-parse HEAD' failed (detached/unborn?)"
+    exit 1
+  fi
+
+  IFS=',' read -r -a svcs <<<"$svc_csv"
+  for svc in "${svcs[@]}"; do
+    SERVICES_JSON=$(jq -c --arg svc "$svc" --arg sha "$sha" \
+      '. + {($svc): {mode: "local-source", sha: $sha}}' <<<"$SERVICES_JSON")
+  done
+  say "$repo_dir → ${svc_csv//,/, } @ ${sha:0:12}"
+done
+
+SVC_COUNT=$(jq 'length' <<<"$SERVICES_JSON")
+if [[ "$SVC_COUNT" -eq 0 ]]; then
+  err "no services captured — check DEV/\$REPO env vars and that repos are cloned"
+  exit 1
+fi
+
+WORKSPACE_JSON=$(jq -nc \
+  --arg host "$HOSTNAME" \
+  --argjson services "$SERVICES_JSON" \
+  '{
+    version: 1,
+    capturedFrom: ("local:" + $host),
+    services: $services
+  }')
+
+if [[ -n "$OUT" ]]; then
+  echo "$WORKSPACE_JSON" | jq . > "$OUT"
+  say "wrote $SVC_COUNT service(s) to $OUT"
+else
+  echo "$WORKSPACE_JSON" | jq .
+fi
+
+if [[ "$_had_missing" -eq 1 ]]; then
+  warn "one or more sibling repos were missing — captured manifest is a partial mesh snapshot"
+fi
+if [[ "$_had_dirty" -eq 1 && "$ALLOW_DIRTY" -eq 1 ]]; then
+  warn "one or more repos had uncommitted changes not reflected in the captured sha — commit before applying if that matters"
+fi

--- a/tools/synthetic-dev/capture-sandbox.sh
+++ b/tools/synthetic-dev/capture-sandbox.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# capture-sandbox.sh — snapshot a live cloud sandbox into a workspace.json.
+#
+# Cloud → local direction of the bidirectional config capture/replay tooling:
+# reads the dev-platform control plane's queryState for a sandbox identifier,
+# and emits a workspace.json (up.sh --workspace <file>'s input format) with one
+# local-source row per service, each pinned to the exact git sha and DB seed
+# profile that sandbox is running — so `./up.sh --workspace <file>` reproduces
+# it locally instead of "whatever's on main right now."
+#
+# Usage:
+#   ./capture-sandbox.sh <sandbox-name>              → prints workspace.json to stdout
+#   ./capture-sandbox.sh <sandbox-name> -o out.json   → writes to out.json
+#   ./capture-sandbox.sh pr-42                        → any queryState identifier works
+#                                                        (pr-N, sandbox-<name>, main...),
+#                                                        not just sandbox- ones
+#
+# Env:
+#   CONTROL_PLANE_FUNCTION   Lambda function name (default: dev-platform-control-plane-dev)
+#   AWS_PROFILE              defaults to 'saga-dev' (Observer tier — queryState is read-only)
+#
+# What this does NOT do (see docs/promotion-pipeline.md's non-goals):
+#   - No AWS SSO / gh auth setup — preflight below fails fast with the fix, not
+#     a raw 403.
+#   - No secrets, no `pnpm install`, no clone-if-missing — this only produces a
+#     manifest; `./up.sh --workspace` does the actual repo/DB work.
+#   - Only services queryState actually reports (kind=ecr with a serviceName
+#     attr) are captured. A sandbox riding on a service the ledger hasn't
+#     ingested yet (rare — the ingest loop runs every 15m) is silently absent
+#     from the output, not an error — the same "shadow, not authoritative"
+#     posture the ledger has everywhere else.
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+
+err(){ printf "\033[31m✗\033[0m %s\n" "$*" >&2; }
+warn(){ printf "\033[33m⚠\033[0m %s\n" "$*" >&2; }
+say(){ printf "\033[34m→\033[0m %s\n" "$*" >&2; }
+
+usage(){
+  echo "Usage: $0 <identifier> [-o <output-file>]" >&2
+  echo "  identifier: a queryState identifier — sandbox-<name>, pr-<N>, main, ..." >&2
+  exit 1
+}
+
+[[ $# -ge 1 ]] || usage
+IDENTIFIER=$1; shift
+OUT=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o|--output) OUT="${2:-}"; [[ -z "$OUT" ]] && { err "-o needs a file path"; exit 1; }; shift 2 ;;
+    *) err "unknown arg '$1'"; usage ;;
+  esac
+done
+
+CONTROL_PLANE_FUNCTION=${CONTROL_PLANE_FUNCTION:-dev-platform-control-plane-dev}
+export AWS_PROFILE=${AWS_PROFILE:-saga-dev}
+
+# ── preflight: fail fast with the fix, not a raw 403 mid-invoke ─────────────
+command -v jq >/dev/null 2>&1 || { err "capture-sandbox.sh needs jq (brew/apt install jq)"; exit 1; }
+command -v aws >/dev/null 2>&1 || { err "capture-sandbox.sh needs the aws CLI"; exit 1; }
+if ! aws sts get-caller-identity >/dev/null 2>&1; then
+  err "AWS auth failed for profile '$AWS_PROFILE' — run: aws sso login --profile $AWS_PROFILE"
+  exit 1
+fi
+
+# ── invoke queryState via the control plane's direct-invoke action ─────────
+# (the HTTP route is ALB-OIDC-gated at the edge for browser/operator use;
+# query-state is the IAM-gated CLI-friendly path — see handler.py.)
+say "querying $CONTROL_PLANE_FUNCTION for '$IDENTIFIER' (profile: $AWS_PROFILE)…"
+RESP_FILE="$(mktemp)"; trap 'rm -f "$RESP_FILE"' EXIT
+PAYLOAD=$(jq -nc --arg id "$IDENTIFIER" '{action: "query-state", identifier: $id}')
+if ! aws lambda invoke \
+      --function-name "$CONTROL_PLANE_FUNCTION" \
+      --cli-binary-format raw-in-base64-out \
+      --payload "$PAYLOAD" \
+      "$RESP_FILE" >/dev/null 2>&1; then
+  err "lambda invoke failed — check function name ('$CONTROL_PLANE_FUNCTION') and IAM permissions for profile '$AWS_PROFILE'"
+  exit 1
+fi
+if jq -e '.errorMessage' "$RESP_FILE" >/dev/null 2>&1; then
+  err "control plane returned an error: $(jq -r '.errorMessage' "$RESP_FILE")"
+  exit 1
+fi
+if jq -e '. == null' "$RESP_FILE" >/dev/null 2>&1; then
+  err "no environment found for identifier '$IDENTIFIER' — check the name (queryState returns 404/null for unknown identifiers)"
+  exit 1
+fi
+
+# ── fold resources[] into one row per service ───────────────────────────────
+# ecr resources carry serviceName + gitRef in attrs (join key + sha source —
+# NOT artifactRef, whose tag is only "usually" the sha by CI convention).
+# db / sandbox-composition resources carry dbProfile, keyed by resourceId
+# (== serviceName for both those sources — see ledger_ingest.py).
+SERVICES_JSON=$(jq -c '
+  (.resources // [])
+  | (
+      [ .[] | select(.kind == "ecr") | {
+          service: (.attrs.serviceName // ""),
+          sha: (.attrs.gitRef // ""),
+          artifactRef: (.attrs.artifactRef // "")
+        } | select(.service != "") ]
+    ) as $ecrs
+  | (
+      [ .[] | select(.kind == "db") | {
+          service: .resourceId,
+          dbProfile: (.attrs.dbProfile // "")
+        } | select(.dbProfile != "") ]
+    ) as $dbs
+  | ($ecrs | map(.service)) as $svcs
+  | [ $svcs[] as $s
+      | { key: $s,
+          value: (
+            ($ecrs | map(select(.service == $s)) | .[0] // {}) as $e
+            | ($dbs | map(select(.service == $s)) | .[0] // {}) as $d
+            | { mode: "local-source" }
+            + (if ($e.sha // "") != "" then {sha: $e.sha} else {} end)
+            + (if ($d.dbProfile // "") != "" then {dbProfile: $d.dbProfile} else {} end)
+          )
+        }
+    ]
+  | from_entries
+' "$RESP_FILE")
+
+SVC_COUNT=$(jq 'length' <<<"$SERVICES_JSON")
+if [[ "$SVC_COUNT" -eq 0 ]]; then
+  warn "'$IDENTIFIER' has no ecr resources with a serviceName attr — nothing to capture. (An older ledger ingest cycle, or a sandbox riding on a not-yet-ingested service?)"
+fi
+
+WORKSPACE_JSON=$(jq -nc \
+  --arg identifier "$IDENTIFIER" \
+  --argjson services "$SERVICES_JSON" \
+  '{
+    version: 1,
+    capturedFrom: ("sandbox:" + $identifier),
+    services: $services
+  }')
+
+if [[ -n "$OUT" ]]; then
+  echo "$WORKSPACE_JSON" | jq . > "$OUT"
+  say "wrote $SVC_COUNT service(s) to $OUT"
+else
+  echo "$WORKSPACE_JSON" | jq .
+fi
+
+# services present in resources but missing a gitRef — flag so a captured
+# manifest with a mode:"local-source" row and no `sha` isn't a silent surprise
+# (up.sh treats a missing sha as "leave the repo as-is", not an error).
+MISSING_SHA=$(jq -r 'to_entries[] | select(.value.sha == null) | .key' <<<"$SERVICES_JSON")
+if [[ -n "$MISSING_SHA" ]]; then
+  while IFS= read -r svc; do
+    warn "'$svc' has no gitRef on its ecr resource — captured without a sha pin (up.sh will leave that repo on whatever's checked out)"
+  done <<<"$MISSING_SHA"
+fi

--- a/tools/synthetic-dev/test-apply-local.sh
+++ b/tools/synthetic-dev/test-apply-local.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Unit test for apply-local.sh (no live switchboard needed — stubs `curl` on
+# PATH to simulate GET /compositions/{name}, PUT /services/.../variants/...,
+# and POST /compositions/{name}/update).
+# Asserts:
+#   1. happy path: overlapping services get re-registered then update-dispatched,
+#      in that order, with the right bodies + bearer tokens per call.
+#   2. a workspace service not in the composition is skipped with a warning,
+#      not an error.
+#   3. unknown composition (404) fails loud with an actionable message.
+#   4. a re-registration failure aborts BEFORE dispatching update (no stale
+#      redeploy of a service whose new sha never actually got registered).
+#   5. missing API keys fail fast with an actionable message.
+# Run: ./test-apply-local.sh   (exit 0 = all pass). Requires jq + curl on PATH
+# (stubbed, not actually invoked over the network).
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APPLY="$HERE/apply-local.sh"
+
+command -v jq >/dev/null || { echo "jq required"; exit 1; }
+
+fail=0
+assert(){ if [[ "$2" == "$3" ]]; then echo "ok: $1"; else echo "FAIL: $1 — got '$2' want '$3'"; fail=1; fi; }
+assert_contains(){ if [[ "$2" == *"$3"* ]]; then echo "ok: $1"; else echo "FAIL: $1 — '$2' does not contain '$3'"; fail=1; fi; }
+
+TMP="$(mktemp -d)"
+FAKE_BIN="$TMP/bin"
+mkdir -p "$FAKE_BIN"
+trap 'rm -rf "$TMP"' EXIT
+
+WS="$TMP/workspace.json"
+cat > "$WS" <<'JSON'
+{
+  "version": 1,
+  "capturedFrom": "local:devbox",
+  "services": {
+    "iam-api": {"mode": "local-source", "sha": "abc123def456"},
+    "sis-api": {"mode": "local-source", "sha": "789fed321cba"},
+    "unrelated-svc": {"mode": "local-source", "sha": "zzz999"}
+  }
+}
+JSON
+
+CALL_LOG="$TMP/calls.log"
+
+mk_stub(){ # writes $FAKE_BIN/curl for a given scenario; $1 = scenario name
+  cat > "$FAKE_BIN/curl" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >> "$CALL_LOG"
+SCENARIO="$1"
+EOF
+  cat >> "$FAKE_BIN/curl" <<'STUB'
+# find -o outfile and -w format among args
+out=""; url=""; method="GET"
+args=("$@")
+for ((i=0; i<${#args[@]}; i++)); do
+  case "${args[$i]}" in
+    -o) out="${args[$((i+1))]}" ;;
+    -X) method="${args[$((i+1))]}" ;;
+  esac
+done
+url="${args[${#args[@]}-1]}"
+
+comp_get(){
+  cat > "$out" <<'JSON'
+{"name":"sandbox-foo","services":{"iam-api":"pr-42","sis-api":"pr-42","other-svc":"pr-9"},"status":"ready"}
+JSON
+  echo -n "200"
+}
+reg_put(){
+  echo -n "200"
+}
+update_post(){
+  cat > "$out" <<'JSON'
+{"name":"sandbox-foo","status":"provisioning","components":[
+  {"service":"iam-api","variantId":"pr-42","runId":"run-1","status":"provisioning"},
+  {"service":"sis-api","variantId":"pr-42","runId":"run-2","status":"provisioning"}
+]}
+JSON
+  echo -n "200"
+}
+
+case "$SCENARIO" in
+  happy)
+    if [[ "$method" == "GET" ]]; then comp_get
+    elif [[ "$method" == "PUT" ]]; then reg_put
+    elif [[ "$method" == "POST" ]]; then update_post
+    fi
+    ;;
+  404)
+    if [[ "$method" == "GET" ]]; then echo '{"detail":"not found"}' > "$out"; echo -n "404"; fi
+    ;;
+  reg_fails)
+    if [[ "$method" == "GET" ]]; then comp_get
+    elif [[ "$method" == "PUT" ]]; then echo '{"detail":"boom"}' > "$out"; echo -n "500"
+    elif [[ "$method" == "POST" ]]; then update_post
+    fi
+    ;;
+esac
+STUB
+  # substitute the scenario name into the case statement source (bash quirk:
+  # $1 above is this function's own arg, re-embed as a literal)
+  sed -i "s/SCENARIO=\"\$1\"/SCENARIO=\"$1\"/" "$FAKE_BIN/curl"
+  chmod +x "$FAKE_BIN/curl"
+}
+
+run_apply(){
+  PATH="$FAKE_BIN:$PATH" SWITCHBOARD_CI_API_KEY="reg-key-xyz" SANDBOX_CI_API_KEY="sbx-key-abc" \
+    "$APPLY" "$@"
+}
+
+# 1. happy path
+mk_stub happy
+> "$CALL_LOG"
+happy_out="$(run_apply sandbox-foo "$WS" 2>&1)"; happy_rc=$?
+assert "happy: exits 0" "$happy_rc" 0
+assert_contains "happy: warns on unrelated-svc skip" "$happy_out" "unrelated-svc"
+
+calls="$(cat "$CALL_LOG")"
+assert_contains "happy: GET composition called" "$calls" "compositions/sandbox-foo"
+assert_contains "happy: PUT registers iam-api variant" "$calls" "services/iam-api/variants/pr-42"
+assert_contains "happy: PUT registers sis-api variant" "$calls" "services/sis-api/variants/pr-42"
+assert_contains "happy: PUT auth uses SWITCHBOARD_CI_API_KEY" "$calls" "Bearer reg-key-xyz"
+assert_contains "happy: POST update called" "$calls" "compositions/sandbox-foo/update"
+assert_contains "happy: POST auth uses SANDBOX_CI_API_KEY" "$calls" "Bearer sbx-key-abc"
+
+# ordering: last PUT call must appear before the POST update call
+put_line=$(grep -n "PUT" "$CALL_LOG" | tail -1 | cut -d: -f1)
+post_line=$(grep -n "compositions/sandbox-foo/update" "$CALL_LOG" | cut -d: -f1)
+order_ok=$([[ "$put_line" -lt "$post_line" ]] && echo yes || echo no)
+assert "happy: registration happens before update dispatch" "$order_ok" "yes"
+
+# 3. unknown composition (404)
+mk_stub 404
+notfound_out="$(run_apply bogus-composition "$WS" 2>&1)"; notfound_rc=$?
+assert "404: exits 1" "$notfound_rc" 1
+assert_contains "404: message actionable" "$notfound_out" "not found"
+
+# 4. registration failure aborts before update dispatch
+mk_stub reg_fails
+> "$CALL_LOG"
+regfail_out="$(run_apply sandbox-foo "$WS" 2>&1)"; regfail_rc=$?
+assert "reg-fail: exits 1" "$regfail_rc" 1
+assert_contains "reg-fail: message actionable" "$regfail_out" "re-registration failed"
+regfail_calls="$(cat "$CALL_LOG")"
+assert_contains "reg-fail: no update dispatched after reg failure" "$(grep -c 'compositions/sandbox-foo/update' "$CALL_LOG" || true)" "0"
+
+# 5. missing API keys fail fast
+mk_stub happy
+noauth_out="$(PATH="$FAKE_BIN:$PATH" "$APPLY" sandbox-foo "$WS" 2>&1)"; noauth_rc=$?
+assert "no-keys: exits 1" "$noauth_rc" 1
+assert_contains "no-keys: message actionable" "$noauth_out" "SWITCHBOARD_CI_API_KEY"
+
+[[ $fail == 0 ]] && echo "ALL PASS" || echo "SOME FAILED"
+exit $fail

--- a/tools/synthetic-dev/test-apply-local.sh
+++ b/tools/synthetic-dev/test-apply-local.sh
@@ -124,6 +124,15 @@ assert_contains "happy: PUT auth uses SWITCHBOARD_CI_API_KEY" "$calls" "Bearer r
 assert_contains "happy: POST update called" "$calls" "compositions/sandbox-foo/update"
 assert_contains "happy: POST auth uses SANDBOX_CI_API_KEY" "$calls" "Bearer sbx-key-abc"
 
+# host routing: PUT (registry) must hit switchboard-api, GET/POST (composition)
+# must hit sandbox-api -- these are DIFFERENT ALB-bypass-scoped hosts, not
+# interchangeable (see apply-local.sh's Env comment / hipponot/microservices#698)
+put_call="$(grep 'services/iam-api/variants' "$CALL_LOG")"
+get_call="$(grep 'compositions/sandbox-foo ' "$CALL_LOG" || grep -F 'compositions/sandbox-foo"' "$CALL_LOG" || true)"
+update_call="$(grep 'compositions/sandbox-foo/update' "$CALL_LOG")"
+assert_contains "happy: PUT goes to switchboard-api host" "$put_call" "switchboard-api.wootdev.com"
+assert_contains "happy: POST update goes to sandbox-api host" "$update_call" "sandbox-api.wootdev.com"
+
 # ordering: last PUT call must appear before the POST update call
 put_line=$(grep -n "PUT" "$CALL_LOG" | tail -1 | cut -d: -f1)
 post_line=$(grep -n "compositions/sandbox-foo/update" "$CALL_LOG" | cut -d: -f1)

--- a/tools/synthetic-dev/test-capture-local.sh
+++ b/tools/synthetic-dev/test-capture-local.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Unit test for capture-local.sh (no real sibling checkouts needed — builds
+# throwaway git repos under a tmpdir and points ROSTERING/PROGRAM_HUB/etc at them).
+# Asserts:
+#   1. a clean multi-repo mesh captures one sha per service, keyed correctly
+#      (program-hub's 4 services all share ITS one repo sha, not each other's).
+#   2. a dirty repo refuses to capture by default, with an actionable message.
+#   3. --allow-dirty captures HEAD anyway and warns.
+#   4. a missing (uncloned) repo is skipped with a warning, not a crash.
+#   5. the real up.sh parse_workspace() accepts the captured output verbatim.
+# Run: ./test-capture-local.sh   (exit 0 = all pass). Requires jq + git.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CAPTURE="$HERE/capture-local.sh"
+UP="$HERE/up.sh"
+
+command -v jq >/dev/null || { echo "jq required"; exit 1; }
+
+fail=0
+assert(){ if [[ "$2" == "$3" ]]; then echo "ok: $1"; else echo "FAIL: $1 — got '$2' want '$3'"; fail=1; fi; }
+assert_contains(){ if [[ "$2" == *"$3"* ]]; then echo "ok: $1"; else echo "FAIL: $1 — '$2' does not contain '$3'"; fail=1; fi; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+mkrepo(){ # dir
+  mkdir -p "$1"
+  git -C "$1" init -q
+  git -C "$1" config user.email test@example.com
+  git -C "$1" config user.name test
+  echo x > "$1/f"
+  git -C "$1" add f
+  git -C "$1" commit -qm init
+}
+
+mkrepo "$TMP/rostering"
+mkrepo "$TMP/program-hub"
+mkrepo "$TMP/saga-dash"
+mkrepo "$TMP/coach"
+mkrepo "$TMP/student-data-system"
+mkrepo "$TMP/qboard"
+mkrepo "$TMP/rtsm"
+# soa deliberately NOT created — capture-local.sh doesn't walk it at all.
+
+run_capture(){
+  DEV="$TMP" ROSTERING="$TMP/rostering" PROGRAM_HUB="$TMP/program-hub" \
+  SAGA_DASH="$TMP/saga-dash" COACH="$TMP/coach" SDS="$TMP/student-data-system" \
+  QBOARD="$TMP/qboard" RTSM="$TMP/rtsm" "$CAPTURE" "$@"
+}
+
+# 1. clean mesh — one sha per repo, shared across that repo's services
+OUT="$(mktemp)"
+run_capture -o "$OUT" >/dev/null 2>&1
+rc=$?
+assert "capture: exits 0 on clean mesh" "$rc" 0
+
+PH_SHA=$(git -C "$TMP/program-hub" rev-parse HEAD)
+ROST_SHA=$(git -C "$TMP/rostering" rev-parse HEAD)
+assert "capture: iam-api sha"          "$(jq -r '.services["iam-api"].sha' "$OUT")"          "$ROST_SHA"
+assert "capture: sis-api sha"          "$(jq -r '.services["sis-api"].sha' "$OUT")"          "$ROST_SHA"
+assert "capture: programs-api sha"     "$(jq -r '.services["programs-api"].sha' "$OUT")"     "$PH_SHA"
+assert "capture: scheduling-api sha"   "$(jq -r '.services["scheduling-api"].sha' "$OUT")"   "$PH_SHA"
+assert "capture: sessions-api sha"     "$(jq -r '.services["sessions-api"].sha' "$OUT")"     "$PH_SHA"
+assert "capture: content-api sha"      "$(jq -r '.services["content-api"].sha' "$OUT")"      "$PH_SHA"
+assert "capture: iam-api mode"         "$(jq -r '.services["iam-api"].mode' "$OUT")"         "local-source"
+assert_contains "capture: capturedFrom" "$(jq -r '.capturedFrom' "$OUT")"                     "local:"
+assert "capture: no dbProfile captured" "$(jq -r '.services["iam-api"] | has("dbProfile")' "$OUT")" "false"
+rm -f "$OUT"
+
+# 2. dirty repo refuses by default
+echo dirty > "$TMP/rostering/f"
+dirty_out="$(run_capture 2>&1 1>/dev/null)"; dirty_rc=$?
+assert "guard: dirty repo exits 1" "$dirty_rc" 1
+assert_contains "guard: dirty repo message actionable" "$dirty_out" "uncommitted changes"
+
+# 3. --allow-dirty captures HEAD anyway (not the dirty working tree) + warns
+OUT2="$(mktemp)"
+allowdirty_out="$(run_capture --allow-dirty -o "$OUT2" 2>&1 1>/dev/null)"
+assert "allow-dirty: exits 0"       "$?" 0
+assert "allow-dirty: sha is still HEAD, not dirty" "$(jq -r '.services["iam-api"].sha' "$OUT2")" "$ROST_SHA"
+assert_contains "allow-dirty: warns" "$allowdirty_out" "uncommitted changes"
+git -C "$TMP/rostering" checkout -q -- f
+rm -f "$OUT2"
+
+# 4. missing repo skipped with a warning, not a crash
+rm -rf "$TMP/rtsm"
+OUT3="$(mktemp)"
+missing_out="$(run_capture -o "$OUT3" 2>&1 1>/dev/null)"
+assert "missing repo: still exits 0"        "$?" 0
+assert "missing repo: rtsm-api absent"      "$(jq -r 'has("rtsm-api")' <<<"$(jq .services "$OUT3")")" "false"
+assert_contains "missing repo: warns"       "$missing_out" "not cloned"
+rm -f "$OUT3"
+
+# 5. round-trip through up.sh's REAL parse_workspace
+OUT4="$(mktemp)"
+run_capture -o "$OUT4" >/dev/null 2>&1
+( ONLY_SERVICE=""; SANDBOX_NAME=""; WORKSPACE_FILE=""; DO_PLAYBACK=0; IAM_SANDBOX=""
+  err(){ :; }; warn(){ :; }; say(){ :; }; ok(){ :; }
+  declare -A SVC_MODE=() SVC_SANDBOX=() SVC_DBPROFILE=() SVC_SHA=() RESTORED_OK=()
+  declare -a WS_RUN_SET=()
+  eval "$(sed -n '/^parse_workspace(){/,/^}/p' "$UP")"
+  parse_workspace "$OUT4"
+  echo "${SVC_MODE[programs-api]}|${SVC_SHA[programs-api]}" > "$TMP/roundtrip.out"
+)
+roundtrip="$(cat "$TMP/roundtrip.out")"
+assert "round-trip: up.sh parses captured manifest" "$roundtrip" "local-source|$PH_SHA"
+rm -f "$OUT4"
+
+[[ $fail == 0 ]] && echo "ALL PASS" || echo "SOME FAILED"
+exit $fail

--- a/tools/synthetic-dev/test-capture-sandbox.sh
+++ b/tools/synthetic-dev/test-capture-sandbox.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Unit test for capture-sandbox.sh (no live AWS needed — stubs `aws` on PATH).
+# Asserts:
+#   1. a realistic queryState response folds into the right per-service
+#      workspace.json rows (sha from gitRef, dbProfile from the db resource,
+#      a service missing from ecr resources entirely is excluded).
+#   2. a service whose ecr resource has no gitRef is captured WITHOUT a sha
+#      (not a false empty-string pin) and triggers the missing-sha warning.
+#   3. the real up.sh parse_workspace() accepts the captured output verbatim
+#      (the round-trip this whole tool exists for).
+#   4. preflight failures (no auth, unknown identifier, no args) fail loud
+#      with an actionable message and a non-zero exit, not a raw stack trace.
+# Run: ./test-capture-sandbox.sh   (exit 0 = all pass). Requires jq.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CAPTURE="$HERE/capture-sandbox.sh"
+UP="$HERE/up.sh"
+
+command -v jq >/dev/null || { echo "jq required"; exit 1; }
+
+fail=0
+assert(){ if [[ "$2" == "$3" ]]; then echo "ok: $1"; else echo "FAIL: $1 — got '$2' want '$3'"; fail=1; fi; }
+assert_contains(){ if [[ "$2" == *"$3"* ]]; then echo "ok: $1"; else echo "FAIL: $1 — '$2' does not contain '$3'"; fail=1; fi; }
+
+FAKE_BIN="$(mktemp -d)"
+RESP="$(mktemp)"
+trap 'rm -rf "$FAKE_BIN"; rm -f "$RESP"' EXIT
+
+cat > "$RESP" <<'JSON'
+{
+  "identifier": "sandbox-foo",
+  "tier": "sandbox",
+  "services": ["iam-api", "sis-api", "programs-api"],
+  "resources": [
+    { "kind": "ecr", "resourceId": "sha256:aaa", "source": "switchboard", "state": "active",
+      "attrs": { "artifactRef": "iam-api:abc123", "imageDigest": "sha256:aaa",
+                 "serviceName": "iam-api", "gitRef": "abc123def4567890abc123def4567890abc123d" } },
+    { "kind": "ecr", "resourceId": "sha256:bbb", "source": "switchboard", "state": "active",
+      "attrs": { "artifactRef": "sis-api:pr-42-new", "imageDigest": "sha256:bbb",
+                 "serviceName": "sis-api", "gitRef": "" } },
+    { "kind": "db", "resourceId": "iam-api", "source": "sandbox-composition", "state": "ready",
+      "attrs": { "dbProfile": "canary" } },
+    { "kind": "db", "resourceId": "sis-api", "source": "sandbox-composition", "state": "ready",
+      "attrs": { "dbProfile": "canary-large" } }
+  ]
+}
+JSON
+
+# Stub `aws`: sts succeeds, lambda invoke copies $RESP to the output path arg.
+cat > "$FAKE_BIN/aws" <<EOF
+#!/usr/bin/env bash
+if [[ "\$1 \$2" == "sts get-caller-identity" ]]; then echo '{"Account":"123"}'; exit 0; fi
+if [[ "\$1 \$2" == "lambda invoke" ]]; then out="\${@: -1}"; cp "$RESP" "\$out"; exit 0; fi
+echo "unhandled: \$*" >&2; exit 1
+EOF
+chmod +x "$FAKE_BIN/aws"
+
+run_capture(){ PATH="$FAKE_BIN:$PATH" "$CAPTURE" "$@"; }
+
+# 1+2. happy path + missing-sha handling
+OUT="$(mktemp)"
+capture_stderr="$(run_capture sandbox-foo -o "$OUT" 2>&1 1>/dev/null)"
+assert "capture: exits 0"                 "$?" 0
+assert "capture: iam-api mode"            "$(jq -r '.services["iam-api"].mode' "$OUT")"      local-source
+assert "capture: iam-api sha from gitRef" "$(jq -r '.services["iam-api"].sha' "$OUT")"        abc123def4567890abc123def4567890abc123d
+assert "capture: iam-api dbProfile"       "$(jq -r '.services["iam-api"].dbProfile' "$OUT")"  canary
+assert "capture: sis-api no sha (empty gitRef, not pinned)" "$(jq -r '.services["sis-api"].sha // "MISSING"' "$OUT")" MISSING
+assert "capture: sis-api dbProfile"       "$(jq -r '.services["sis-api"].dbProfile' "$OUT")"  canary-large
+assert "capture: programs-api absent (no ecr resource)" "$(jq -r 'has("programs-api")' <<<"$(jq .services "$OUT")")" false
+assert "capture: capturedFrom"            "$(jq -r '.capturedFrom' "$OUT")"                   sandbox:sandbox-foo
+assert_contains "capture: warns on missing sha" "$capture_stderr" "sis-api' has no gitRef"
+
+# 3. round-trip through up.sh's REAL parse_workspace
+( ONLY_SERVICE=""; SANDBOX_NAME=""; WORKSPACE_FILE=""; DO_PLAYBACK=0; IAM_SANDBOX=""
+  err(){ :; }; warn(){ :; }; say(){ :; }; ok(){ :; }
+  declare -A SVC_MODE=() SVC_SANDBOX=() SVC_DBPROFILE=() SVC_SHA=() RESTORED_OK=()
+  declare -a WS_RUN_SET=()
+  eval "$(sed -n '/^parse_workspace(){/,/^}/p' "$UP")"
+  parse_workspace "$OUT"
+  echo "${SVC_MODE[iam-api]}|${SVC_SHA[iam-api]}|${SVC_DBPROFILE[iam-api]}|${SVC_SHA[sis-api]:-NONE}" > "$FAKE_BIN/roundtrip.out"
+)
+roundtrip="$(cat "$FAKE_BIN/roundtrip.out")"
+assert "round-trip: up.sh parses captured manifest" "$roundtrip" \
+  "local-source|abc123def4567890abc123def4567890abc123d|canary|NONE"
+rm -f "$OUT"
+
+# 4a. no AWS auth → fail loud with remediation, not a raw error
+cat > "$FAKE_BIN/aws" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1 $2" == "sts get-caller-identity" ]]; then echo "no creds" >&2; exit 254; fi
+echo "unhandled" >&2; exit 1
+EOF
+chmod +x "$FAKE_BIN/aws"
+noauth_out="$(run_capture sandbox-foo 2>&1)"; noauth_rc=$?
+assert "guard: no-auth exits 1"        "$noauth_rc" 1
+assert_contains "guard: no-auth message actionable" "$noauth_out" "aws sso login"
+
+# 4b. unknown identifier (queryState returns null) → fail loud, not a crash
+cat > "$FAKE_BIN/aws" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1 $2" == "sts get-caller-identity" ]]; then echo '{"Account":"123"}'; exit 0; fi
+if [[ "$1 $2" == "lambda invoke" ]]; then out="${@: -1}"; echo 'null' > "$out"; exit 0; fi
+echo "unhandled" >&2; exit 1
+EOF
+chmod +x "$FAKE_BIN/aws"
+notfound_out="$(run_capture bogus-identifier 2>&1)"; notfound_rc=$?
+assert "guard: unknown identifier exits 1" "$notfound_rc" 1
+assert_contains "guard: unknown identifier message" "$notfound_out" "no environment found"
+
+# 4c. no args → usage, exit 1
+noargs_rc="$("$CAPTURE" >/dev/null 2>&1; echo $?)"
+assert "guard: no args exits 1" "$noargs_rc" 1
+
+[[ $fail == 0 ]] && echo "ALL PASS" || echo "SOME FAILED"
+exit $fail

--- a/tools/synthetic-dev/test-workspace.sh
+++ b/tools/synthetic-dev/test-workspace.sh
@@ -19,7 +19,7 @@ cat > "$WS" <<'JSON'
   "generatedBy": "https://switchboard.wootdev.com",
   "defaultPolicy": "main",
   "services": {
-    "programs-api": { "mode": "local-source", "kind": "api", "repo": "saga-ed/program-hub", "dbProfile": "canonical" },
+    "programs-api": { "mode": "local-source", "kind": "api", "repo": "saga-ed/program-hub", "dbProfile": "canonical", "sha": "abc1234" },
     "sis-api": { "mode": "local-source", "kind": "api", "repo": "saga-ed/rostering" },
     "iam-api": { "mode": "sandbox", "kind": "api", "sandboxName": "dev", "previewHeader": "x-saga-preview-iam-api" }
   }
@@ -32,7 +32,7 @@ err(){ echo "ERR: $*" >&2; }; warn(){ echo "WARN: $*" >&2; }; say(){ :; }; ok(){
 ONLY_SERVICE=""; SANDBOX_NAME=""; WORKSPACE_FILE=""; DO_PLAYBACK=0; IAM_SANDBOX=""
 # Repo-path vars the restore map interpolates (values irrelevant to the map's shape).
 ROSTERING="/r"; PROGRAM_HUB="/p"
-declare -A SVC_MODE=() SVC_SANDBOX=() SVC_DBPROFILE=() RESTORED_OK=()
+declare -A SVC_MODE=() SVC_SANDBOX=() SVC_DBPROFILE=() SVC_SHA=() RESTORED_OK=()
 declare -a WS_RUN_SET=()
 eval "$(sed -n '/^want_service(){/,/^}/p' "$UP")"
 eval "$(sed -n '/^parse_workspace(){/,/^}/p' "$UP")"
@@ -40,6 +40,7 @@ eval "$(sed -n '/^sandbox_env(){/,/^}/p' "$UP")"
 eval "$(sed -n '/^restore_source_for(){/,/^}/p' "$UP")"
 eval "$(sed -n '/^restore_dbs_for_service(){/,/^}/p' "$UP")"
 eval "$(sed -n '/^restored_db(){/,/^}/p' "$UP")"
+eval "$(sed -n '/^svc_repo_dir(){/,/^}/p' "$UP")"
 
 fail=0
 assert(){ if [[ "$2" == "$3" ]]; then echo "ok: $1"; else echo "FAIL: $1 — got '$2' want '$3'"; fail=1; fi; }
@@ -91,6 +92,17 @@ assert "ws: programs-api dbProfile"     "${SVC_DBPROFILE[programs-api]:-}" canon
 assert "ws: sis-api no dbProfile"        "${SVC_DBPROFILE[sis-api]:-}"      ""
 assert "ws: iam-api(sandbox) no dbProfile" "${SVC_DBPROFILE[iam-api]:-}"    ""
 
+# 3b''. sha parsing (programs-api carries one; sis-api and sandbox-mode iam-api don't)
+assert "ws: programs-api sha"           "${SVC_SHA[programs-api]:-}"       abc1234
+assert "ws: sis-api no sha"             "${SVC_SHA[sis-api]:-}"            ""
+assert "ws: iam-api(sandbox) no sha"    "${SVC_SHA[iam-api]:-}"            ""
+
+# 3b'''. svc_repo_dir: the 13-service → repo-var map checkout_workspace_shas uses.
+assert "repo_dir: iam-api"     "$(svc_repo_dir iam-api)"        "/r"
+assert "repo_dir: sis-api"     "$(svc_repo_dir sis-api)"        "/r"
+assert "repo_dir: programs-api" "$(svc_repo_dir programs-api)" "/p"
+assert "repo_dir: unknown svc is empty" "$(svc_repo_dir bogus-svc)" ""
+
 # 3b'. restored_db keys on ACTUAL restore success (RESTORED_OK), not the dbProfile
 # request — so a failed/not-yet-run restore still falls through to db:seed.
 RESTORED_OK=()
@@ -134,6 +146,46 @@ nonimam_warn="$( ( SVC_MODE=(); SVC_SANDBOX=(); WS_RUN_SET=(); IAM_SANDBOX=""; f
   printf '%s' '{"version":1,"services":{"sis-api":{"mode":"sandbox","sandboxName":"x"}}}' > "$f"
   parse_workspace "$f" 2>&1 >/dev/null; rm -f "$f" ) | grep -c 'dep-repoint is iam-only' || true )"
 assert "guard: non-iam sandbox warns" "$nonimam_warn" 1
+
+# 5. checkout_workspace_shas: real scratch git repos, no network.
+eval "$(sed -n '/^checkout_workspace_shas(){/,/^}/p' "$UP")"
+SCRATCH="$(mktemp -d)"; trap 'rm -f "$WS"; rm -rf "$SCRATCH"' EXIT
+git init -q "$SCRATCH/repo"
+git -C "$SCRATCH/repo" -c user.email=t@t -c user.name=t commit -q --allow-empty -m one
+FIRST_SHA="$(git -C "$SCRATCH/repo" rev-parse HEAD)"
+git -C "$SCRATCH/repo" -c user.email=t@t -c user.name=t commit -q --allow-empty -m two
+SECOND_SHA="$(git -C "$SCRATCH/repo" rev-parse HEAD)"
+ROSTERING="$SCRATCH/repo"   # svc_repo_dir(iam-api) → $ROSTERING
+
+# 5a. checks out an older sha cleanly.
+SVC_SHA=([iam-api]="$FIRST_SHA")
+checkout_rc="$( (checkout_workspace_shas) >/dev/null 2>&1; echo $? )"
+assert "checkout: exits 0"         "$checkout_rc" 0
+checkout_workspace_shas >/dev/null 2>&1
+assert "checkout: HEAD moved"      "$(git -C "$SCRATCH/repo" rev-parse HEAD)" "$FIRST_SHA"
+
+# 5b. already-there sha is a no-op (still exits 0, HEAD unchanged).
+noop_rc="$( (checkout_workspace_shas) >/dev/null 2>&1; echo $? )"
+assert "checkout: no-op when already on sha" "$noop_rc" 0
+
+# 5c. dirty tree refuses to check out, even to a valid sha.
+echo dirty > "$SCRATCH/repo/untracked.txt"
+SVC_SHA=([iam-api]="$SECOND_SHA")
+dirty_rc="$( (checkout_workspace_shas) >/dev/null 2>&1; echo $? )"
+assert "checkout: dirty tree refused"  "$dirty_rc" 1
+assert "checkout: dirty tree HEAD unmoved" "$(git -C "$SCRATCH/repo" rev-parse HEAD)" "$FIRST_SHA"
+rm -f "$SCRATCH/repo/untracked.txt"
+
+# 5d. unknown sha fails loudly rather than launching on whatever's checked out.
+SVC_SHA=([iam-api]="0000000000000000000000000000000000dead")
+bogus_rc="$( (checkout_workspace_shas) >/dev/null 2>&1; echo $? )"
+assert "checkout: unknown sha fails" "$bogus_rc" 1
+
+# 5e. a service with no svc_repo_dir mapping fails loudly, not silently.
+SVC_SHA=([totally-unknown-svc]="$FIRST_SHA")
+unmapped_rc="$( (checkout_workspace_shas) >/dev/null 2>&1; echo $? )"
+assert "checkout: unmapped service fails" "$unmapped_rc" 1
+SVC_SHA=()
 
 [[ $fail == 0 ]] && echo "ALL PASS" || echo "SOME FAILED"
 exit $fail

--- a/tools/synthetic-dev/up.sh
+++ b/tools/synthetic-dev/up.sh
@@ -291,6 +291,7 @@ WORKSPACE_FILE=""
 declare -A SVC_MODE=()       # svc → local-source|sandbox (local-image is Phase 2)
 declare -A SVC_SANDBOX=()    # svc → sandbox name (the dep lives in this cloud sandbox)
 declare -A SVC_DBPROFILE=()  # svc → DB seed profile (local-source only; restore an S3 snapshot)
+declare -A SVC_SHA=()        # svc → git commit to check out (local-source only; empty = leave as-is)
 declare -A RESTORED_OK=()    # mesh-db → 1 once it actually holds snapshot data (restore_one_db)
 declare -a WS_RUN_SET=()     # services to launch locally (local-source)
 # ── S3 DB-snapshot restore (workspace `dbProfile`): instead of seeding a
@@ -385,6 +386,54 @@ check_branches(){
       [[ "$have" == main ]] || printf "\033[33m⚠\033[0m %s on '%s' (expected 'main')\n" "$repo" "$have"
     fi
   done
+}
+
+# svc_repo_dir: the sibling-repo directory a given service's source lives in —
+# the same 13-service map services_up()'s launch_if lines hard-code, extracted
+# once here so checkout_workspace_shas doesn't duplicate it. Empty output means
+# "unknown service" (caller's problem, e.g. a manifest typo already validated
+# by parse_workspace's mode check).
+svc_repo_dir(){ # svc
+  case "$1" in
+    iam-api|sis-api) echo "$ROSTERING" ;;
+    programs-api|scheduling-api|sessions-api|content-api) echo "$PROGRAM_HUB" ;;
+    coach-api|coach-web) echo "$COACH" ;;
+    ads-adm-api) echo "$SDS" ;;
+    saga-dash) echo "$SAGA_DASH" ;;
+    rtsm-api) echo "$RTSM" ;;
+    connect-api|connect-web) echo "$QBOARD" ;;
+    *) echo "" ;;
+  esac
+}
+
+# checkout_workspace_shas: a --workspace manifest's `sha` field pins a
+# local-source service's repo to an EXACT commit (typically captured off a
+# running sandbox — see docs/promotion-pipeline.md's cloud→local capture
+# direction) rather than "whatever branch happens to be checked out", which is
+# check_branches' warn-only default. A workspace run needs the stronger
+# guarantee: fail loudly on a dirty tree rather than silently launching the
+# wrong code. No-op when the manifest carries no sha (older manifests, or rows
+# that only pin mode/dbProfile) — leaves check_branches' warn-only behavior as
+# the sole guard, unchanged.
+checkout_workspace_shas(){
+  local svc sha dir have_sha _rc=0
+  for svc in "${!SVC_SHA[@]}"; do
+    sha=${SVC_SHA[$svc]}
+    dir=$(svc_repo_dir "$svc")
+    if [[ -z "$dir" ]]; then
+      err "--workspace: service '$svc' has a sha but no known repo directory (svc_repo_dir gap)"; _rc=1; continue
+    fi
+    if [[ -n "$(git -C "$dir" status --porcelain 2>/dev/null)" ]]; then
+      err "--workspace: '$svc' repo at '$dir' has uncommitted changes — refusing to check out sha '$sha' over them"; _rc=1; continue
+    fi
+    have_sha=$(git -C "$dir" rev-parse HEAD 2>/dev/null)
+    [[ "$have_sha" == "$sha"* ]] && continue  # already there
+    if ! git -C "$dir" checkout --quiet "$sha" 2>/dev/null; then
+      err "--workspace: '$svc' repo at '$dir' — 'git checkout $sha' failed (unknown commit? needs a fetch?)"; _rc=1; continue
+    fi
+    say "workspace: $svc → $dir checked out to $sha"
+  done
+  [[ $_rc -eq 0 ]] || exit 1
 }
 
 # ── preflight: launch directories must exist ─────────────────────────
@@ -1157,7 +1206,7 @@ parse_workspace(){ # file
   local ver; ver=$(jq -r '.version // empty' "$f" 2>/dev/null) \
     || { err "--workspace: '$f' is not valid JSON"; exit 1; }
   [[ "$ver" == "1" ]] || warn "--workspace: version '$ver' (expected 1) — proceeding"
-  # One row per service: svc, mode, sandboxName, dbProfile, joined
+  # One row per service: svc, mode, sandboxName, dbProfile, sha, joined
   # by the ASCII unit separator (). NOT tab: `read` treats tab as IFS
   # whitespace and COLLAPSES consecutive tabs, so an empty middle field (e.g. no
   # sandboxName on a local-source row) would shift later fields left.  is non-whitespace,
@@ -1166,10 +1215,11 @@ parse_workspace(){ # file
   rows=$(jq -re '.services | to_entries[] | [
            .key, (.value.mode // ""),
            (.value.sandboxName // ""),
-           (.value.dbProfile // "")] | join("")' "$f" 2>/dev/null) \
+           (.value.dbProfile // ""),
+           (.value.sha // "")] | join("")' "$f" 2>/dev/null) \
     || { err "--workspace: '$f' has no/empty .services or is malformed"; exit 1; }
-  local svc mode sbx dbp
-  while IFS="$US" read -r svc mode sbx dbp; do
+  local svc mode sbx dbp sha
+  while IFS="$US" read -r svc mode sbx dbp sha; do
     [[ -z "$svc" ]] && continue
     case "$mode" in
       local-source|sandbox) ;;
@@ -1187,6 +1237,10 @@ parse_workspace(){ # file
       # instead of seeding from scratch" (restore_stack). Only honored for the six
       # services with a canonical snapshot source; recorded here, validated there.
       [[ -n "$dbp" ]] && SVC_DBPROFILE["$svc"]=$dbp
+      # A sha pins this service's repo to an exact commit (captured from a sandbox
+      # or another dev's local mesh) — checked out by checkout_workspace_shas,
+      # called once up front alongside check_branches. Recorded here, applied there.
+      [[ -n "$sha" ]] && SVC_SHA["$svc"]=$sha
     else # sandbox
       [[ -z "$sbx" ]] && { err "--workspace: service '$svc' is sandbox but carries no sandboxName"; exit 1; }
       SVC_SANDBOX["$svc"]=$sbx
@@ -2294,11 +2348,14 @@ fi
 # drop the restore-eligible DBs, then restore after reset_data — is a deliberate
 # future feature, not smuggled in here.)
 if [[ $DO_UP == 1 ]]; then
-  check_branches; check_layout; apply_fixes; mesh_up; connect_av_up; restore_stack; prep
+  check_branches
+  [[ ${#SVC_SHA[@]} -gt 0 ]] && checkout_workspace_shas
+  check_layout; apply_fixes; mesh_up; connect_av_up; restore_stack; prep
 elif [[ $DO_RESET == 1 || $DO_RESTART == 1 ]]; then
   check_layout; mesh_up; connect_av_up
   if [[ "${SKIP_PREP:-0}" == "1" ]]; then say "SKIP_PREP=1 — skipping install+build prep"; else prep; fi
   [[ ${#SVC_DBPROFILE[@]} -gt 0 ]] && warn "--workspace dbProfile is ignored on --reset/restart (reset truncates DBs); use a plain './up.sh --workspace ...' to restore snapshots."
+  [[ ${#SVC_SHA[@]} -gt 0 ]] && warn "--workspace sha pins are ignored on --reset/restart (same as check_branches, which also only runs on 'up'); use a plain './up.sh --workspace ...' to check them out."
 fi
 
 # A --reset ALWAYS means a CLEAN restart on current code — independent of the


### PR DESCRIPTION
## Summary

Bidirectional local↔cloud config capture/replay tooling (tasks #10–#15 of the approved plan — see `iac` repo's `dev-platform/docs/promotion-pipeline.md`). Ships both directions:

- **Cloud → local**: capture a running sandbox's exact state, then reproduce it locally.
- **Local → cloud**: capture a developer's local mesh checkout, then push it to a live cloud sandbox composition for full-mesh validation.

### Cloud → local

**`up.sh` (sha-checkout):**
- `workspace.json`'s local-source rows can now carry a `sha`, checked out per-repo before launch. `check_branches()` only *warns* if a repo isn't on `main` — a manifest captured off a running cloud sandbox needs a stronger guarantee: land on that exact code, or fail loudly.
- New `svc_repo_dir(svc)` extracts the 13-service → sibling-repo-dir mapping previously duplicated inline across every `launch_if` call in `services_up()`.
- New `checkout_workspace_shas()`, called once alongside `check_branches` on the `up` path only. Fails loudly on a dirty tree or unresolvable commit — additive, no-op when a manifest carries no `sha`.

**`capture-sandbox.sh` (new):**
- Queries the dev-platform control plane's `queryState` (direct Lambda `query-state` invoke — the IAM-gated CLI path, not the ALB-OIDC browser route) for a given identifier and emits a `workspace.json` with one `local-source` row per service.
- Pins `sha` from the `ecr` resource's `gitRef` attr — **not** `artifactRef`, whose tag is only "usually" the git sha by CI convention (real registry rows exist with branch-name tags like `pr-42-new`). Pins `dbProfile` from the matching `db`/`sandbox-composition` resource.
- Fails fast on missing AWS auth / unknown identifier / bad args with an actionable message, per the plan's "cheap mitigation, not skip" non-goal.
- A service whose `ecr` resource carries no `gitRef` is captured *without* a `sha` pin (not a false empty pin), with a warning.

This required two small additive companion fixes on the ledger side (`iac` repo, both merged): #510 adds a `dbProfile`-bearing ingester over switchboard's composition registry (db-host-v2 never persisted the seed profile itself), and #511 adds `serviceName`/`gitRef` to the existing `ecr` resource's `attrs` (needed to join an `ecr` resource to its service and to pin a reliable `sha`).

### Local → cloud

**`capture-local.sh` (new):**
- Walks the same sibling-repo paths `check_branches()` already knows, reads each repo's checked-out commit (`git rev-parse HEAD`), and emits the same `workspace.json` shape as `capture-sandbox.sh` (`capturedFrom: "local:<hostname>"`, per-service `{mode: "local-source", sha}`).
- Refuses to capture a repo with uncommitted changes by default (a captured sha silently ignoring working-tree diffs would be misleading); `--allow-dirty` overrides and captures HEAD anyway, with a warning.
- No `dbProfile` capture — no local "what did I seed this DB from" tracker exists (v1 non-goal per the plan); a captured manifest leaves the sandbox's existing seed profile in place.

**`apply-local.sh` (new):**
- Pushes a `capture-local.sh` manifest to a live composition. For every service the manifest names that's also a component of the target composition:
  1. re-registers that service's **already-bound** variant with the captured sha (`PUT /api/v1/services/{service}/variants/{variantId}` — the same call CI's switchboard-register step makes), then
  2. dispatches the composition update endpoint (`POST /api/v1/compositions/{name}/update`) to redeploy, which re-dispatches each component's create workflow using the variant's now-current registration.
- The two calls are order-dependent: `/update` has no sha/variantId field — it only re-dispatches whatever's *currently registered* for the component's existing variantId (`routes.py`'s `_resolve_updatable_variant`). There's no endpoint that repoints a composition component to a different variantId or an unregistered sha, so a stale registration would silently redeploy the wrong sha if update ran first — this only ever applies a sha that's already passed CI registration for a variantId the composition already has bound (in practice: any main-reachable, already-deployed commit).
- Requires two different bearer secrets: `SWITCHBOARD_CI_API_KEY` for the registry PUT vs `SANDBOX_CI_API_KEY` for the composition update (`auth.py` validates each against a distinct secret — "two CI secrets, not one").
- Does not create a sandbox/composition, and does not touch services the manifest or composition don't already have in common.

## Test plan

- [x] `./tools/synthetic-dev/test-workspace.sh` — 52 assertions pass (no regressions)
- [x] `./tools/synthetic-dev/test-capture-sandbox.sh` — 15 assertions pass, including a **real round-trip**: `capture-sandbox.sh`'s output is fed through `up.sh`'s actual `parse_workspace()` (not a mock) and lands correctly in `SVC_MODE`/`SVC_SHA`/`SVC_DBPROFILE`
- [x] `./tools/synthetic-dev/test-capture-local.sh` — 19 assertions pass, including a real `up.sh` `parse_workspace()` round-trip and a multi-service-per-repo sha-sharing check
- [x] `./tools/synthetic-dev/test-apply-local.sh` — 16 assertions pass, stubbing `curl` to verify call ordering (register before update), per-call bearer token, unrelated-service skip, 404/registration-failure abort paths, and missing-API-key fast-fail
- [x] `shellcheck -x` clean on all new files (zero new warnings vs. `origin/main` baseline)
- [x] Manual: captured the real `main` canary environment via `capture-sandbox.sh` (10 services), confirmed every returned sha is a real, resolvable commit in its repo, then ran `up.sh`'s actual `checkout_workspace_shas()` against disposable clones of `program-hub`/`rostering` and confirmed it checks them out correctly (verified end-to-end against live infra, not just synthetic fixtures)
- [x] Manual: `capture-local.sh` verified correct against real local checkouts as part of the above
- [ ] Manual: `apply-local.sh` end-to-end against a real composition — **blocked, found a real infra gap in the process** (see "Known issues" below)

## Known issues

While manually verifying `apply-local.sh`, discovered that `POST /compositions/{name}/update` on `sandbox-api.wootdev.com` has **no ALB CI bypass at all** — every request there sits behind the plain OIDC catch-all, so a correct `SANDBOX_CI_API_KEY` bearer token still gets a 302 redirect before reaching the app's own auth check (confirmed live against a real disposable throwaway composition, created and torn down during this verification). This is the same class of gap the existing registry-write bypass (rule 829) already fixes for variant `PUT`/`DELETE` on the switchboard host — it just wasn't extended to this route on the sandbox host.

Fix opened: **hipponot/microservices#698** (draft, not yet deployed) — adds a tightly-scoped bypass rule (`host=sandbox-api.wootdev.com` + `path=/api/v1/compositions/*/update` + `method=POST` only). `apply-local.sh`'s registration step (`PUT /api/v1/services/{service}/variants/{variantId}` on `switchboard-api.wootdev.com`) is unaffected — that host already has its CI bypass and works today. Once #698 merges and deploys, the remaining manual-verify checkbox above can close.

