### PR TITLE
gh_214 M14: stage checkpoints — --snapshot-stages + --from + prerequisite-via-checkpoint (validated live: 45s → 5.8s)

### DIFF
--- a/packages/node/saga-stack-cli/docs/e2e.md
+++ b/packages/node/saga-stack-cli/docs/e2e.md
@@ -57,6 +57,35 @@ ss e2e run saga-dash/journey --through sessions --headless
 - A clamped occurrence-date is injected so weekend runs don't flake.
 </details>
 
+## Stage checkpoints — skip the replay (M14)
+
+Working on stage 6 shouldn't cost a UI replay of stages 1–5 every iteration.
+**Bake** a DB checkpoint after each green stage, then **start mid-flow**:
+
+```bash
+ss e2e run saga-dash/journey --snapshot-stages --headless   # bake: ckpt after each stage
+ss e2e run saga-dash/journey --from sessions                # restore ckpt(schedule), run 6..N
+ss e2e run saga-dash/journey --from 6 --through 7           # windows compose with --through
+```
+
+Measured live: `--from` turned a 45s bake-path run into **5.8s** (restore + one stage).
+
+- Checkpoints are ordinary snapshots named `flow-<spa>-<flow>-s<N>-<stage>` in the
+  slot's snapshot root (so `--set`/`--slot` contexts keep separate checkpoints);
+  re-bakes overwrite. `ss stack snapshot list` shows their flow provenance;
+  `ss e2e list` marks baked stages with `[checkpoint]` (or `[checkpoint: re-bake]`).
+- A `--from` restore is **validated hard**: the producing stage definitions must be
+  unchanged (prefixHash), the checkpoint must cover the window's databases, sit AT
+  the local migration head (both directions), match the seed profile, and be ≤ 7 days
+  old by both bake time and its embedded occurrence date (`--from-stale-ok` overrides
+  the age cliff). The run **reuses the checkpoint's baked dates** so restored data and
+  specs agree; SPA-checkout drift since the bake is a warning.
+- **Prerequisites restore too**: a flow with `prerequisite` (connect-session ⇐
+  journey@schedule) restores the prerequisite's terminal checkpoint instead of the
+  full headless replay whenever a valid one is baked — falling back to the replay
+  otherwise. `--no-prereq-from-snapshot` forces the replay. (One delta vs the replay:
+  the restore flushes redis; caches rebuild from the restored DBs.)
+
 ## Live interactive Connect session
 
 ```bash

--- a/packages/node/saga-stack-cli/docs/snapshots.md
+++ b/packages/node/saga-stack-cli/docs/snapshots.md
@@ -61,5 +61,8 @@ restore refuses rather than silently loading a stale shape — the one blind spo
 - **`snapshot restore`** — you want a *specific captured* state back fast (a fixture, a repro).
 - **`reset` + `seed`** — you want a *fresh* deterministic baseline from the seed definitions.
 - **`up` (idempotent)** — you just want the stack running; it seeds if empty.
+- **e2e stage checkpoints** — mid-flow e2e state (`flow-<spa>-<flow>-s<N>-<stage>` fixtures,
+  baked by `e2e run --snapshot-stages`, restored by `--from`); `snapshot list` shows their
+  flow provenance as a sub-line. See [e2e → Stage checkpoints](./e2e.md#stage-checkpoints--skip-the-replay-m14).
 
 ← [verify](./verify.md) · [e2e →](./e2e.md)

--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -441,6 +441,25 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "from": {
+          "description": "M14: start AT this stage (id / number / project — same matching as --through) by RESTORING the predecessor stage's checkpoint instead of replaying earlier Playwright stages. Bake checkpoints first with --snapshot-stages.",
+          "name": "from",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "snapshot-stages": {
+          "description": "M14: bake a DB checkpoint after each green stage (Playwright runs once per stage) so later runs can --from into the middle of the flow. Progressive flows only.",
+          "name": "snapshot-stages",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "from-stale-ok": {
+          "description": "M14: accept a checkpoint older than the 7-day staleness cliff (its baked dates may no longer fit the calendar — you're overriding that guard). Only meaningful with --from.",
+          "name": "from-stale-ok",
+          "allowNo": false,
+          "type": "boolean"
+        },
         "spa-path": {
           "description": "explicit path to a flows.json (file or dir) — highest-priority discovery override",
           "name": "spa-path",

--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -120,6 +120,12 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "prereq-from-snapshot": {
+          "description": "M14-C: restore the journey@schedule checkpoint (when a valid one is baked) instead of replaying the whole journey headless — the big Connect-session accelerant. Falls back to the replay when absent/invalid; --reuse trumps this entirely.",
+          "name": "prereq-from-snapshot",
+          "allowNo": true,
+          "type": "boolean"
+        },
         "spa-path": {
           "description": "explicit path to a flows.json (file or dir) — highest-priority discovery override",
           "name": "spa-path",
@@ -458,6 +464,12 @@
           "description": "M14: accept a checkpoint older than the 7-day staleness cliff (its baked dates may no longer fit the calendar — you're overriding that guard). Only meaningful with --from.",
           "name": "from-stale-ok",
           "allowNo": false,
+          "type": "boolean"
+        },
+        "prereq-from-snapshot": {
+          "description": "M14-C: satisfy a flow's prerequisite by RESTORING its terminal-stage checkpoint (when a valid one is baked) instead of the full headless replay; silently falls back to the replay when absent/invalid. NOTE the restore flushes redis (the replay leaves it warm). --no-prereq-from-snapshot forces the replay.",
+          "name": "prereq-from-snapshot",
+          "allowNo": true,
           "type": "boolean"
         },
         "spa-path": {

--- a/packages/node/saga-stack-cli/src/base-command.ts
+++ b/packages/node/saga-stack-cli/src/base-command.ts
@@ -29,8 +29,8 @@ import { dirname, join } from 'node:path';
 import { SET_UNSUPPORTED_COMMAND_MESSAGE, SLOT_UNSUPPORTED_COMMAND_MESSAGE, baseFlags } from './shared-flags.js';
 import { applySetToFlags, resolveSet } from './core/set/index.js';
 import type { SetInjectableFlags, WorktreeSet } from './core/set/index.js';
-import { checkWorktreeSet, makeSlotActiveProbe } from './runtime/index.js';
-import type { SlotActiveProbe } from './runtime/index.js';
+import { checkWorktreeSet, makeCheckpointStore, makeSlotActiveProbe } from './runtime/index.js';
+import type { CheckpointStore, SlotActiveProbe } from './runtime/index.js';
 import type { PullMode } from './core/auto-pull.js';
 import type { InstanceProfile } from './core/derive-instance.js';
 import type { RecordMode, ScriptPlan } from './core/flag-map.js';
@@ -181,6 +181,17 @@ export abstract class BaseCommand extends Command {
    */
   protected getSlotActiveProbe(): SlotActiveProbe {
     return makeSlotActiveProbe();
+  }
+
+  /**
+   * The injectable M14 stage-checkpoint store (`e2e run --snapshot-stages` /
+   * `--from`). Composes the SnapshotIO seam with the caller's ScriptContext
+   * (the schema-ahead guard's migration discovery — `--set` pins included).
+   * MUST be constructed after `applyInstanceEnv` so it targets the slot's
+   * snapshot root + containers. Tests spy this on the prototype.
+   */
+  protected getCheckpointStore(ctx: ScriptContext): CheckpointStore {
+    return makeCheckpointStore({ io: this.getSnapshotIO(), ctx });
   }
 
   /**

--- a/packages/node/saga-stack-cli/src/commands/e2e/__tests__/checkpoint.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/__tests__/checkpoint.int.test.ts
@@ -376,3 +376,110 @@ describe('--from (restore)', () => {
     expect(launches).toHaveLength(0);
   });
 });
+
+describe('prerequisite-via-checkpoint (M14-C)', () => {
+  const CKPT_SCHEDULE = 'flow-saga-dash-journey-s5-schedule';
+
+  /** Bake journey through schedule (5 stages) so connect-session's prerequisite has a checkpoint. */
+  async function bakeThroughSchedule(): Promise<void> {
+    await E2eRun.run(['journey', '--through', 'schedule', '--snapshot-stages', '--headless', ...ws()], config);
+  }
+
+  it('restores the prerequisite terminal checkpoint instead of replaying — baked dates reach the PARENT env', async () => {
+    await bakeThroughSchedule();
+    expect(() => readCkptManifest(CKPT_SCHEDULE)).not.toThrow();
+
+    runs.length = 0;
+    ioCalls.length = 0;
+    logged.length = 0;
+    await E2eRun.run(['connect-session', '--headless', ...ws()], config);
+
+    const out = logged.join('\n');
+    expect(out).toContain(`==> restore: ${CKPT_SCHEDULE}`);
+    expect(out).toContain('restored from checkpoint (replay skipped)');
+    expect(out).not.toContain("==> prerequisite: journey (through 'schedule', headless)");
+
+    // Exactly ONE Playwright child (the connect room) — no journey replay spawn.
+    const pw = playwrightRuns();
+    expect(pw).toHaveLength(1);
+    expect(pw[0]!.args).toContain('interactive-connect');
+
+    // The PARENT spawn exports the checkpoint's baked dates (they crossed the
+    // frame because the restore ran in the parent, not the recursion).
+    const baked = (readCkptManifest(CKPT_SCHEDULE).flow as Record<string, unknown>).dates as Record<string, string>;
+    expect(pw[0]!.env?.PLAYWRIGHT_OCCURRENCE_DATE).toBe(baked.occurrenceDate);
+  });
+
+  it('falls back to the full replay when no checkpoint is baked (never hard-errors)', async () => {
+    await E2eRun.run(['connect-session', '--headless', ...ws()], config);
+    const out = logged.join('\n');
+    expect(out).toContain('falling back to full replay');
+    expect(out).toContain("==> prerequisite: journey (through 'schedule', headless)");
+    // Two Playwright children: the journey replay + the connect room.
+    expect(playwrightRuns()).toHaveLength(2);
+  });
+
+  it('--no-prereq-from-snapshot forces the replay even when a valid checkpoint exists', async () => {
+    await bakeThroughSchedule();
+    runs.length = 0;
+    logged.length = 0;
+    await E2eRun.run(['connect-session', '--no-prereq-from-snapshot', '--headless', ...ws()], config);
+    expect(logged.join('\n')).toContain("==> prerequisite: journey (through 'schedule', headless)");
+    expect(logged.join('\n')).not.toContain('restored from checkpoint');
+  });
+
+  it('an INVALID prerequisite checkpoint falls back with the violation surfaced as a warning', async () => {
+    await bakeThroughSchedule();
+    const m = readCkptManifest(CKPT_SCHEDULE);
+    (m.flow as Record<string, unknown>).prefixHash = 'deadbeef';
+    writeCkptManifest(CKPT_SCHEDULE, m);
+
+    runs.length = 0;
+    logged.length = 0;
+    await E2eRun.run(['connect-session', '--headless', ...ws()], config);
+    const out = logged.join('\n');
+    expect(out).toMatch(/falling back to full replay[\s\S]*prefixHash mismatch/);
+    expect(out).toContain("==> prerequisite: journey (through 'schedule', headless)");
+  });
+
+  it('dry-run shows the opportunistic prerequisite restore line', async () => {
+    logged.length = 0;
+    await E2eRun.run(['connect-session', '--dry-run', '--headless', ...ws()], config);
+    expect(logged.join('\n')).toMatch(/prerequisite: .*journey.*restore flow-saga-dash-journey-s5-schedule if baked/);
+  });
+});
+
+describe('list surfaces (M14-C)', () => {
+  it('e2e list marks baked stages [checkpoint] and stale ones [checkpoint: re-bake]', async () => {
+    await bakeThroughProgram();
+    // Stale-ify the program checkpoint (ancient occurrence date).
+    const m = readCkptManifest(CKPT_PROGRAM);
+    (m.flow as Record<string, unknown>).dates = {
+      occurrenceDate: '2020-03-02',
+      termStart: '2020-03-02',
+      termEnd: '2020-04-13',
+    };
+    writeCkptManifest(CKPT_PROGRAM, m);
+
+    logged.length = 0;
+    const { default: E2eList } = await import('../list.js');
+    await E2eList.run([...ws()], config);
+    const out = logged.join('\n');
+    expect(out).toMatch(/1\. roster.*\[checkpoint\]/);
+    expect(out).toMatch(/2\. program.*\[checkpoint: re-bake\]/);
+    expect(out).not.toMatch(/3\. enrollment.*checkpoint/); // never baked
+  });
+
+  it('snapshot list renders the checkpoint flow provenance (human sub-line + porcelain field 6)', async () => {
+    await bakeThroughProgram();
+    logged.length = 0;
+    const { default: SnapshotList } = await import('../../stack/snapshot/list.js');
+    await SnapshotList.run([...ws()], config);
+    expect(logged.join('\n')).toMatch(/flow: saga-dash\/journey @ roster \(s1\) — baked \d{4}-\d{2}-\d{2}, occurrence/);
+
+    logged.length = 0;
+    await SnapshotList.run(['--porcelain', ...ws()], config);
+    const row = logged.find((l) => l.startsWith(CKPT_PROGRAM));
+    expect(row?.split('\t')[5]).toBe('saga-dash/journey@program');
+  });
+});

--- a/packages/node/saga-stack-cli/src/commands/e2e/__tests__/checkpoint.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/__tests__/checkpoint.int.test.ts
@@ -189,6 +189,13 @@ describe('--snapshot-stages (bake)', () => {
     expect(pw[1]!.args).toContain('stage-2-program-creation');
     expect(pw[1]!.args).toContain('--no-deps');
 
+    // The date env is computed ONCE for the whole ladder — every stage spawn
+    // shares identical dates (an overnight bake must not split the clamp).
+    for (const key of ['PLAYWRIGHT_OCCURRENCE_DATE', 'PLAYWRIGHT_TERM_START', 'PLAYWRIGHT_TERM_END']) {
+      expect(pw[0]!.env?.[key]).toBeDefined();
+      expect(pw[1]!.env?.[key]).toBe(pw[0]!.env?.[key]);
+    }
+
     // Both checkpoints exist on disk with the M14 flow block.
     const roster = readCkptManifest(CKPT_ROSTER);
     const program = readCkptManifest(CKPT_PROGRAM);
@@ -197,9 +204,20 @@ describe('--snapshot-stages (bake)', () => {
     expect(rosterFlow.stageId).toBe('roster');
     expect(programFlow.stageId).toBe('program');
     expect(rosterFlow.prefixHash).not.toBe(programFlow.prefixHash); // prefix grows per stage
-    expect((rosterFlow.dates as Record<string, string>).occurrenceDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    // The baked dates ARE the dates the green stage actually ran with.
+    expect(rosterFlow.dates).toEqual({
+      occurrenceDate: pw[0]!.env?.PLAYWRIGHT_OCCURRENCE_DATE,
+      termStart: pw[0]!.env?.PLAYWRIGHT_TERM_START,
+      termEnd: pw[0]!.env?.PLAYWRIGHT_TERM_END,
+    });
     // Dumps happened for the closure DBs (canned bytes are real files).
     expect(ioCalls.filter((c) => c.op === 'pgDump').length).toBeGreaterThan(0);
+  });
+
+  it('--snapshot-stages requires the stack lane', async () => {
+    await expect(
+      E2eRun.run(['journey', '--lane', 'sandbox', '--snapshot-stages', '--headless', ...ws()], config),
+    ).rejects.toThrow(/--snapshot-stages.*requires the stack lane/);
   });
 
   it('a RED stage bakes no checkpoint and stops the ladder', async () => {
@@ -214,13 +232,18 @@ describe('--from (restore)', () => {
   it('restores the predecessor checkpoint, runs ONLY the window with --no-deps, reuses the BAKED dates', async () => {
     await bakeThroughProgram();
 
-    // Tamper the baked occurrence date so date-reuse is distinguishable from
-    // a fresh clamp computing the same value.
+    // Tamper the baked dates to RECENT-but-distinct values so date-reuse is
+    // distinguishable from a fresh clamp (an ancient date would now trip the
+    // occurrence-age staleness cliff — by design).
+    const fmt = (d: Date): string =>
+      `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    const yesterday = fmt(new Date(Date.now() - 86_400_000));
+    const inSixWeeks = fmt(new Date(Date.now() + 41 * 86_400_000));
     const m = readCkptManifest(CKPT_ROSTER);
     (m.flow as Record<string, unknown>).dates = {
-      occurrenceDate: '2020-03-02',
-      termStart: '2020-03-02',
-      termEnd: '2020-04-13',
+      occurrenceDate: yesterday,
+      termStart: yesterday,
+      termEnd: inSixWeeks,
     };
     writeCkptManifest(CKPT_ROSTER, m);
 
@@ -241,15 +264,62 @@ describe('--from (restore)', () => {
     expect(pw[0]!.args).toContain('stage-2-program-creation');
     expect(pw[0]!.args).toContain('--no-deps');
 
-    // §2.2: the child env carries the BAKED dates, not today's clamp.
-    expect(pw[0]!.env?.PLAYWRIGHT_OCCURRENCE_DATE).toBe('2020-03-02');
-    expect(pw[0]!.env?.PLAYWRIGHT_TERM_START).toBe('2020-03-02');
+    // §2.2: the child env carries ALL THREE baked dates, not today's clamp.
+    expect(pw[0]!.env?.PLAYWRIGHT_OCCURRENCE_DATE).toBe(yesterday);
+    expect(pw[0]!.env?.PLAYWRIGHT_TERM_START).toBe(yesterday);
+    expect(pw[0]!.env?.PLAYWRIGHT_TERM_END).toBe(inSixWeeks);
   });
 
-  it('a missing checkpoint is a pointed error naming the bake command', async () => {
+  it('an ancient baked OCCURRENCE date is refused even with a fresh bakedAt (re-bake laundering)', async () => {
+    await bakeThroughProgram();
+    const m = readCkptManifest(CKPT_ROSTER);
+    (m.flow as Record<string, unknown>).dates = {
+      occurrenceDate: '2020-03-02',
+      termStart: '2020-03-02',
+      termEnd: '2020-04-13',
+    };
+    writeCkptManifest(CKPT_ROSTER, m); // bakedAt stays fresh — the dates alone must trip the cliff
+
+    await expect(
+      E2eRun.run(['journey', '--from', 'program', '--through', 'program', '--headless', ...ws()], config),
+    ).rejects.toThrow(/days old.*oldest of bakedAt\/occurrenceDate/);
+  });
+
+  it('a checkpoint that does not COVER the window databases is refused', async () => {
+    await bakeThroughProgram();
+    const m = readCkptManifest(CKPT_ROSTER);
+    m.databases = (m.databases as { db: string }[]).filter((d) => d.db !== 'programs');
+    writeCkptManifest(CKPT_ROSTER, m);
+
+    await expect(
+      E2eRun.run(['journey', '--from', 'program', '--through', 'program', '--headless', ...ws()], config),
+    ).rejects.toThrow(/does not cover the window's database\(s\): programs/);
+  });
+
+  it('a missing checkpoint is a pointed error listing what IS baked + the bake command', async () => {
     await expect(
       E2eRun.run(['journey', '--from', 'program', '--headless', ...ws()], config),
-    ).rejects.toThrow(/no checkpoint 'flow-saga-dash-journey-s1-roster'[\s\S]*--snapshot-stages/);
+    ).rejects.toThrow(/no checkpoint 'flow-saga-dash-journey-s1-roster'.*baked stages: \(none\)[\s\S]*--snapshot-stages/);
+
+    // With SOME stages baked, the error names them.
+    await bakeThroughProgram();
+    rmSync(join(snapDir, CKPT_PROGRAM), { recursive: true, force: true });
+    rmSync(join(snapDir, CKPT_ROSTER, 'manifest.json'), { force: true }); // roster unreadable ⇒ not listed
+    await expect(
+      E2eRun.run(['journey', '--from', 'program', '--headless', ...ws()], config),
+    ).rejects.toThrow(/baked stages: \(none\)/);
+  });
+
+  it('--dry-run --output-json carries the checkpoint + bake projections (machine shape)', async () => {
+    logged.length = 0;
+    await E2eRun.run(
+      ['journey', '--from', 'program', '--through', 'program', '--snapshot-stages', '--dry-run', '--headless', '--output-json', ...ws()],
+      config,
+    );
+    const jsonLine = logged.find((l) => l.trimStart().startsWith('{'));
+    const desc = JSON.parse(logged.slice(logged.indexOf(jsonLine as string)).join('\n')) as Record<string, unknown>;
+    expect(desc.checkpoint).toEqual({ fixtureId: CKPT_ROSTER, predecessor: 'roster' });
+    expect(desc.bakeCheckpoints).toEqual([CKPT_PROGRAM]);
   });
 
   it('a prefixHash mismatch (upstream stage edited) refuses with a re-bake hint', async () => {

--- a/packages/node/saga-stack-cli/src/commands/e2e/__tests__/checkpoint.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/__tests__/checkpoint.int.test.ts
@@ -1,0 +1,308 @@
+/**
+ * M14 stage checkpoints — `e2e run --snapshot-stages` (bake) + `--from`
+ * (restore) integration tests (plan `11-e2e-stage-snapshots.md` §5 V1/V2's
+ * hermetic half). Real oclif command, every IO seam faked (run.int.test.ts
+ * harness + the snapshot.int.test.ts SnapshotIO fake); checkpoints land in a
+ * temp $SAGA_MESH_SNAPSHOTS_DIR as REAL files (manifest + canned dump bytes).
+ *
+ * The SnapshotIO fake's readSchemaRev returns null so the schema-ahead guard
+ * is inert here — it has its own hard-guard coverage in snapshot.int.test.ts;
+ * these tests own the FLOW-level compat rules (prefixHash, staleness cliff,
+ * baked-date reuse).
+ */
+
+import { resolve, join } from 'node:path';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { Config } from '@oclif/core';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BaseCommand } from '../../../base-command.js';
+import type {
+  DashFs,
+  HealthProber,
+  LaunchResult,
+  LaunchSpec,
+  MeshExec,
+  PgProbe,
+  PortProbe,
+  ProbeResult,
+  RunResult,
+  Runner,
+  ScriptInvocation,
+  ServiceLauncher,
+  SnapshotIO,
+  StopResult,
+} from '../../../runtime/index.js';
+import E2eRun from '../run.js';
+
+const PKG_ROOT = process.cwd();
+const SOA_ROOT = resolve(PKG_ROOT, '..', '..', '..');
+const DEV_ROOT = '/fixed/dev';
+
+const CKPT_ROSTER = 'flow-saga-dash-journey-s1-roster';
+const CKPT_PROGRAM = 'flow-saga-dash-journey-s2-program';
+
+let DASH_ROOT: string;
+let snapDir: string;
+let config: Config;
+let launches: LaunchSpec[];
+let runs: ScriptInvocation[];
+let ioCalls: { op: string; db?: string; path?: string }[];
+let logged: string[];
+
+/** run.int.test.ts's seam recipe; `playwrightFail` fails children whose args include it. */
+function installSeams(playwrightFail?: string): void {
+  launches = [];
+  runs = [];
+
+  const launcher: ServiceLauncher = {
+    async launch(spec: LaunchSpec): Promise<LaunchResult> {
+      launches.push(spec);
+      return { id: spec.id, ok: true, pid: 3000 + launches.length };
+    },
+    async stopServices(ids: string[]): Promise<StopResult[]> {
+      return ids.map((id) => ({ id, stopped: true }));
+    },
+  };
+  const meshExec: MeshExec = { async ready(): Promise<boolean> { return true; } };
+  const portProbe: PortProbe = {
+    async dockerHolder(): Promise<string | null> { return null; },
+    async listening(): Promise<boolean> { return false; },
+  };
+  const dashFs: DashFs = { existsDir: () => true, existsFile: () => false, remove: () => {}, write: () => {} };
+  const prober: HealthProber = { async probe(): Promise<ProbeResult> { return { ok: true, status: 200 }; } };
+  const provisioned = new Set<string>();
+  const runner: Runner = {
+    async run(spec: ScriptInvocation): Promise<RunResult> {
+      runs.push(spec);
+      const ci = spec.args.indexOf('-c');
+      if (ci >= 0) {
+        const m = /CREATE DATABASE (\w+)/.exec(spec.args[ci + 1] ?? '');
+        if (m) provisioned.add(m[1]);
+      }
+      if (playwrightFail !== undefined && spec.args.includes('playwright') && spec.args.includes(playwrightFail)) {
+        return { code: 1 };
+      }
+      return { code: 0 };
+    },
+  };
+  const pgProbe: PgProbe = {
+    async databaseExists(_c, db): Promise<boolean> { return provisioned.has(db); },
+    async hasMigrationsTable(): Promise<boolean> { return false; },
+    async publicTableCount(): Promise<number> { return 0; },
+    async scalar(): Promise<string> { return ''; },
+  };
+  const snapshotIO: SnapshotIO = {
+    async pgDump(db, _c, _o, outPath) {
+      ioCalls.push({ op: 'pgDump', db, path: outPath });
+      writeFileSync(outPath, `PGDUMP:${db}`);
+    },
+    async pgRestore(db, _c, _o, inPath) {
+      ioCalls.push({ op: 'pgRestore', db, path: inPath });
+    },
+    async mongoDump(_c, db, outPath) {
+      ioCalls.push({ op: 'mongoDump', db, path: outPath });
+      writeFileSync(outPath, `MONGO:${db}`);
+    },
+    async mongoRestore(_c, db, inPath) {
+      ioCalls.push({ op: 'mongoRestore', db, path: inPath });
+    },
+    async assertPgRunning() { ioCalls.push({ op: 'assertPgRunning' }); },
+    async assertMongoRunning() { ioCalls.push({ op: 'assertMongoRunning' }); },
+    // null ⇒ the snapshot-ahead guard is inert (covered by snapshot.int.test.ts).
+    async readSchemaRev() { return null; },
+    async redisFlushdb() { ioCalls.push({ op: 'redisFlushdb' }); },
+    async pgRestoreList() { return true; },
+  };
+
+  const proto = BaseCommand.prototype as unknown as Record<string, () => unknown>;
+  vi.spyOn(proto, 'getLauncher').mockReturnValue(launcher);
+  vi.spyOn(proto, 'getMeshExec').mockReturnValue(meshExec);
+  vi.spyOn(proto, 'getPortProbe').mockReturnValue(portProbe);
+  vi.spyOn(proto, 'getDashFs').mockReturnValue(dashFs);
+  vi.spyOn(proto, 'getProber').mockReturnValue(prober);
+  vi.spyOn(proto, 'getRunner').mockReturnValue(runner);
+  vi.spyOn(proto, 'getPgProbe').mockReturnValue(pgProbe);
+  vi.spyOn(proto, 'getPrepFreshCheck').mockReturnValue(() => true);
+  vi.spyOn(proto, 'getDbGenerateScan').mockReturnValue(() => []);
+  vi.spyOn(proto, 'getRepoDirCheck').mockReturnValue(() => true);
+  vi.spyOn(proto as unknown as { getSnapshotIO: () => SnapshotIO }, 'getSnapshotIO').mockReturnValue(snapshotIO);
+}
+
+function ws(): string[] {
+  return ['--saga-dash', DASH_ROOT, '--soa', SOA_ROOT, '--dev', DEV_ROOT];
+}
+
+function playwrightRuns(): ScriptInvocation[] {
+  return runs.filter((r) => r.command === 'pnpm' && r.args.includes('playwright'));
+}
+
+function readCkptManifest(fixtureId: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(snapDir, fixtureId, 'manifest.json'), 'utf8')) as Record<string, unknown>;
+}
+
+function writeCkptManifest(fixtureId: string, m: Record<string, unknown>): void {
+  writeFileSync(join(snapDir, fixtureId, 'manifest.json'), JSON.stringify(m, null, 2) + '\n');
+}
+
+/** Bake checkpoints for stages 1-2 (roster, program) — the shared setup for --from tests. */
+async function bakeThroughProgram(): Promise<void> {
+  await E2eRun.run(['journey', '--through', 'program', '--snapshot-stages', '--headless', ...ws()], config);
+}
+
+beforeAll(() => {
+  DASH_ROOT = mkdtempSync(join(tmpdir(), 'saga-dash-ckpt-'));
+});
+afterAll(() => {
+  rmSync(DASH_ROOT, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  config = await Config.load(PKG_ROOT);
+  snapDir = mkdtempSync(join(tmpdir(), 'saga-ckpt-'));
+  process.env.SAGA_MESH_SNAPSHOTS_DIR = snapDir;
+  ioCalls = [];
+  installSeams();
+  logged = [];
+  vi.spyOn(BaseCommand.prototype, 'log').mockImplementation((m?: string) => {
+    logged.push(String(m ?? ''));
+  });
+  vi.spyOn(BaseCommand.prototype, 'warn').mockImplementation(((m: string) => m) as never);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  rmSync(snapDir, { recursive: true, force: true });
+  delete process.env.SAGA_MESH_SNAPSHOTS_DIR;
+});
+
+describe('--snapshot-stages (bake)', () => {
+  it('spawns Playwright once per stage (--no-deps past the first) and bakes a checkpoint after each', async () => {
+    await bakeThroughProgram();
+
+    const pw = playwrightRuns();
+    expect(pw).toHaveLength(2);
+    // Stage 1 keeps its config deps (the stage-0-coherence gate rides along).
+    expect(pw[0]!.args).toContain('stage-1-roster');
+    expect(pw[0]!.args).not.toContain('--no-deps');
+    // Stage 2 breaks the chain — no replay of stage 1.
+    expect(pw[1]!.args).toContain('stage-2-program-creation');
+    expect(pw[1]!.args).toContain('--no-deps');
+
+    // Both checkpoints exist on disk with the M14 flow block.
+    const roster = readCkptManifest(CKPT_ROSTER);
+    const program = readCkptManifest(CKPT_PROGRAM);
+    const rosterFlow = roster.flow as Record<string, unknown>;
+    const programFlow = program.flow as Record<string, unknown>;
+    expect(rosterFlow.stageId).toBe('roster');
+    expect(programFlow.stageId).toBe('program');
+    expect(rosterFlow.prefixHash).not.toBe(programFlow.prefixHash); // prefix grows per stage
+    expect((rosterFlow.dates as Record<string, string>).occurrenceDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    // Dumps happened for the closure DBs (canned bytes are real files).
+    expect(ioCalls.filter((c) => c.op === 'pgDump').length).toBeGreaterThan(0);
+  });
+
+  it('a RED stage bakes no checkpoint and stops the ladder', async () => {
+    installSeams('stage-1-roster'); // stage-1's Playwright child exits 1
+    await expect(bakeThroughProgram()).rejects.toMatchObject({ oclif: { exit: 1 } });
+    expect(() => readCkptManifest(CKPT_ROSTER)).toThrow(); // nothing baked
+    expect(playwrightRuns()).toHaveLength(1); // stage 2 never spawned
+  });
+});
+
+describe('--from (restore)', () => {
+  it('restores the predecessor checkpoint, runs ONLY the window with --no-deps, reuses the BAKED dates', async () => {
+    await bakeThroughProgram();
+
+    // Tamper the baked occurrence date so date-reuse is distinguishable from
+    // a fresh clamp computing the same value.
+    const m = readCkptManifest(CKPT_ROSTER);
+    (m.flow as Record<string, unknown>).dates = {
+      occurrenceDate: '2020-03-02',
+      termStart: '2020-03-02',
+      termEnd: '2020-04-13',
+    };
+    writeCkptManifest(CKPT_ROSTER, m);
+
+    runs.length = 0;
+    ioCalls.length = 0;
+    logged.length = 0;
+    await E2eRun.run(['journey', '--from', 'program', '--through', 'program', '--headless', ...ws()], config);
+
+    // Restore happened (pg restores + redis flush), reset did NOT.
+    expect(ioCalls.some((c) => c.op === 'pgRestore')).toBe(true);
+    expect(ioCalls.some((c) => c.op === 'redisFlushdb')).toBe(true);
+    expect(logged.join('\n')).toContain(`==> restore: ${CKPT_ROSTER}`);
+    expect(logged.join('\n')).not.toContain('==> reset (native');
+
+    // Exactly the window stage ran, chain broken.
+    const pw = playwrightRuns();
+    expect(pw).toHaveLength(1);
+    expect(pw[0]!.args).toContain('stage-2-program-creation');
+    expect(pw[0]!.args).toContain('--no-deps');
+
+    // §2.2: the child env carries the BAKED dates, not today's clamp.
+    expect(pw[0]!.env?.PLAYWRIGHT_OCCURRENCE_DATE).toBe('2020-03-02');
+    expect(pw[0]!.env?.PLAYWRIGHT_TERM_START).toBe('2020-03-02');
+  });
+
+  it('a missing checkpoint is a pointed error naming the bake command', async () => {
+    await expect(
+      E2eRun.run(['journey', '--from', 'program', '--headless', ...ws()], config),
+    ).rejects.toThrow(/no checkpoint 'flow-saga-dash-journey-s1-roster'[\s\S]*--snapshot-stages/);
+  });
+
+  it('a prefixHash mismatch (upstream stage edited) refuses with a re-bake hint', async () => {
+    await bakeThroughProgram();
+    const m = readCkptManifest(CKPT_ROSTER);
+    (m.flow as Record<string, unknown>).prefixHash = 'deadbeef';
+    writeCkptManifest(CKPT_ROSTER, m);
+
+    await expect(
+      E2eRun.run(['journey', '--from', 'program', '--headless', ...ws()], config),
+    ).rejects.toThrow(/prefixHash mismatch[\s\S]*re-bake/);
+  });
+
+  it('the >7-day staleness cliff refuses; --from-stale-ok downgrades to a warning', async () => {
+    await bakeThroughProgram();
+    const m = readCkptManifest(CKPT_ROSTER);
+    (m.flow as Record<string, unknown>).bakedAt = '2020-01-01T00:00:00.000Z';
+    writeCkptManifest(CKPT_ROSTER, m);
+
+    await expect(
+      E2eRun.run(['journey', '--from', 'program', '--headless', ...ws()], config),
+    ).rejects.toThrow(/days old.*--from-stale-ok/);
+
+    runs.length = 0;
+    logged.length = 0;
+    await E2eRun.run(
+      ['journey', '--from', 'program', '--through', 'program', '--from-stale-ok', '--headless', ...ws()],
+      config,
+    );
+    expect(logged.join('\n')).toMatch(/⚠ checkpoint: .*days old/);
+    expect(playwrightRuns()).toHaveLength(1);
+  });
+
+  it('--from at the FIRST stage is a plain full run (nothing to restore)', async () => {
+    await E2eRun.run(['journey', '--from', 'roster', '--through', 'roster', '--headless', ...ws()], config);
+    expect(logged.join('\n')).not.toContain('==> restore:');
+    const pw = playwrightRuns();
+    expect(pw).toHaveLength(1);
+    expect(pw[0]!.args).not.toContain('--no-deps'); // default single-spawn path
+  });
+
+  it('--from and --skip-reset are mutually exclusive', async () => {
+    await expect(
+      E2eRun.run(['journey', '--from', 'program', '--skip-reset', ...ws()], config),
+    ).rejects.toThrow(/--from and --skip-reset are mutually exclusive/);
+  });
+
+  it('--dry-run shows the restore line + window without touching a seam', async () => {
+    await E2eRun.run(['journey', '--from', 'program', '--through', 'program', '--dry-run', '--headless', ...ws()], config);
+    const out = logged.join('\n');
+    expect(out).toContain(`restore: ${CKPT_ROSTER}`);
+    expect(out).toMatch(/stages: program$/m); // the window, not the full prefix
+    expect(runs).toHaveLength(0);
+    expect(launches).toHaveLength(0);
+  });
+});

--- a/packages/node/saga-stack-cli/src/commands/e2e/__tests__/checkpoint.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/__tests__/checkpoint.int.test.ts
@@ -483,3 +483,14 @@ describe('list surfaces (M14-C)', () => {
     expect(row?.split('\t')[5]).toBe('saga-dash/journey@program');
   });
 });
+
+describe('M14-C review fixes', () => {
+  it('--no-prereq-from-snapshot --dry-run does NOT advertise a restore the run would never attempt', async () => {
+    logged.length = 0;
+    const { default: Run } = await import('../run.js');
+    await Run.run(['connect-session', '--no-prereq-from-snapshot', '--dry-run', '--headless', ...ws()], config);
+    const out = logged.join('\n');
+    expect(out).toContain('prerequisite:');
+    expect(out).not.toContain('restore flow-saga-dash-journey-s5-schedule');
+  });
+});

--- a/packages/node/saga-stack-cli/src/commands/e2e/__tests__/e2e.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/__tests__/e2e.int.test.ts
@@ -51,6 +51,7 @@ let launches: LaunchSpec[];
 let runs: ScriptInvocation[];
 let logged: string[];
 let warned: string[];
+let snapDir: string;
 
 /** Install fakes for every native-path seam. `launchFail` ids answer health-down. */
 function installSeams(launchFail: Set<string> = new Set()): void {
@@ -142,6 +143,10 @@ afterAll(() => {
 
 beforeEach(async () => {
   config = await Config.load(PKG_ROOT);
+  // Hermetic snapshot root: `e2e list` reads it for the M14-C checkpoint
+  // annotation — never scan the developer's real ~/.saga-mesh/snapshots.
+  snapDir = mkdtempSync(join(tmpdir(), 'saga-e2e-list-'));
+  process.env.SAGA_MESH_SNAPSHOTS_DIR = snapDir;
   installSeams();
   logged = [];
   warned = [];
@@ -155,6 +160,8 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
+  rmSync(snapDir, { recursive: true, force: true });
+  delete process.env.SAGA_MESH_SNAPSHOTS_DIR;
   vi.restoreAllMocks();
 });
 

--- a/packages/node/saga-stack-cli/src/commands/e2e/__tests__/run.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/__tests__/run.int.test.ts
@@ -51,6 +51,7 @@ let runs: ScriptInvocation[];
 let logged: string[];
 let warned: string[];
 let launcherSpy: ReturnType<typeof vi.spyOn>;
+let snapDir: string;
 
 /** Install fakes for every native-path seam. Ids in `launchFail` answer health-down. */
 function installSeams(launchFail: Set<string> = new Set()): void {
@@ -134,6 +135,11 @@ afterAll(() => {
 
 beforeEach(async () => {
   config = await Config.load(PKG_ROOT);
+  // Hermetic snapshot root: prerequisite flows construct a checkpoint store by
+  // default (M14-C) — never read (or restore from!) the developer's real
+  // ~/.saga-mesh/snapshots in a unit test.
+  snapDir = mkdtempSync(join(tmpdir(), 'saga-run-snaps-'));
+  process.env.SAGA_MESH_SNAPSHOTS_DIR = snapDir;
   installSeams();
   logged = [];
   warned = [];
@@ -148,6 +154,8 @@ beforeEach(async () => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  rmSync(snapDir, { recursive: true, force: true });
+  delete process.env.SAGA_MESH_SNAPSHOTS_DIR;
 });
 
 describe('e2e run — --dry-run plan (touches no seam)', () => {

--- a/packages/node/saga-stack-cli/src/commands/e2e/connect.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/connect.ts
@@ -59,6 +59,12 @@ export default class E2eConnect extends BaseCommand {
       description: 'skip the journey-prerequisite rebuild + reset; run the live session against the current stack state',
       default: false,
     }),
+    'prereq-from-snapshot': Flags.boolean({
+      default: true,
+      allowNo: true,
+      description:
+        'M14-C: restore the journey@schedule checkpoint (when a valid one is baked) instead of replaying the whole journey headless — the big Connect-session accelerant. Falls back to the replay when absent/invalid; --reuse trumps this entirely.',
+    }),
     'spa-path': Flags.string({
       description: 'explicit path to a flows.json (file or dir) — highest-priority discovery override',
     }),
@@ -96,11 +102,24 @@ export default class E2eConnect extends BaseCommand {
     const { runtime } = buildStackContext(flags, seams, delegate);
     const api = makeStackApi(serviceManifest, runtime);
 
+    // M14-C: the checkpoint store so the journey prerequisite can be RESTORED
+    // instead of replayed (slot-0 command — no instance env needed; --reuse
+    // strips the prerequisite entirely, so nothing to restore there).
+    const checkpoints =
+      toRun.prerequisite !== undefined && flags['prereq-from-snapshot']
+        ? this.getCheckpointStore(this.scriptContextFromFlags(flags))
+        : undefined;
+
     try {
       const code = await executeResolvedFlow(
         toRun,
-        { api, runner: seams.runner, appCwd, now, log: (l) => this.log(l) },
-        { lane: 'stack', skipReset: flags.reuse, passthrough },
+        { api, runner: seams.runner, appCwd, now, log: (l) => this.log(l), checkpoints },
+        {
+          lane: 'stack',
+          skipReset: flags.reuse,
+          passthrough,
+          prereqFromSnapshot: flags['prereq-from-snapshot'],
+        },
       );
       if (code !== 0) this.exit(code);
     } catch (err) {

--- a/packages/node/saga-stack-cli/src/commands/e2e/list.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/list.ts
@@ -14,7 +14,8 @@
 
 import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command.js';
-import { knownSpaIds } from '../../core/flow/index.js';
+import { deriveInstance } from '../../core/derive-instance.js';
+import { checkpointFixtureId, evaluateCheckpoint, knownSpaIds, stagePrefixHash } from '../../core/flow/index.js';
 import { discoverFlowManifest } from '../../e2e-orchestrate.js';
 
 export default class E2eList extends BaseCommand {
@@ -45,6 +46,13 @@ export default class E2eList extends BaseCommand {
   async run(): Promise<void> {
     const { flags } = await this.parse(E2eList);
 
+    // M14-C: annotate stages with baked-checkpoint freshness. The slot env
+    // seam must be applied FIRST — snapshotsRoot() reads $SAGA_MESH_* at call
+    // time, so a --set/--slot listing checks ITS slot's snapshot root.
+    this.applyInstanceEnv(deriveInstance({ slot: flags.slot }));
+    const checkpoints = this.getCheckpointStore(this.scriptContextFromFlags(flags));
+    const now = new Date(); // once — a listing must not straddle a midnight boundary
+
     const spas: Record<string, unknown>[] = [];
     const lines: string[] = [];
 
@@ -52,6 +60,29 @@ export default class E2eList extends BaseCommand {
       try {
         const disco = discoverFlowManifest(spaId, flags, process.env);
         const m = disco.manifest;
+
+        /** M14-C per-stage checkpoint verdict: valid | needs-re-bake | none. */
+        const ckpt = (f: (typeof m.flows)[number], i: number): 'valid' | 'stale' | null => {
+          if (!f.progressive) return null;
+          const stage = f.stages[i];
+          if (stage === undefined) return null;
+          const manifest = checkpoints.load(checkpointFixtureId(m.spa.id, f.name, stage, i + 1));
+          if (manifest === null) return null;
+          // seedProfile/spaHead deliberately omitted (WARN-only / unknowable here);
+          // identity + prefixHash + staleness give the honest listing verdict.
+          const verdict = evaluateCheckpoint(
+            manifest.flow,
+            {
+              spaId: m.spa.id,
+              flowName: f.name,
+              stageId: stage.id,
+              prefixHash: stagePrefixHash(f, f.stages.slice(0, i + 1)),
+            },
+            now,
+          );
+          return verdict.ok ? 'valid' : 'stale';
+        };
+
         spas.push({
           id: m.spa.id,
           system: m.spa.system,
@@ -65,7 +96,13 @@ export default class E2eList extends BaseCommand {
             foreground: f.foreground ?? false,
             av: f.av ?? false,
             prerequisite: f.prerequisite ?? null,
-            stages: f.stages.map((s) => ({ id: s.id, phase: s.phase ?? null, project: s.project, tags: s.tags ?? [] })),
+            stages: f.stages.map((s, i) => ({
+              id: s.id,
+              phase: s.phase ?? null,
+              project: s.project,
+              tags: s.tags ?? [],
+              checkpoint: ckpt(f, i),
+            })),
           })),
         });
 
@@ -76,10 +113,12 @@ export default class E2eList extends BaseCommand {
           const tags = [f.progressive ? 'progressive' : 'single', ...(f.foreground ? ['foreground'] : []), ...(f.av ? ['av'] : [])];
           lines.push(`  • ${f.name}  (${f.lanes.join('/')}; ${tags.join(', ')})`);
           if (f.prerequisite) lines.push(`      prerequisite: ${f.prerequisite.flow} through '${f.prerequisite.throughStage}'`);
-          for (const s of f.stages) {
+          for (const [i, s] of f.stages.entries()) {
             const phase = s.phase !== undefined ? `${s.phase}. ` : '— ';
             const stageTags = (s.tags ?? []).length ? `  [${(s.tags ?? []).join(', ')}]` : '';
-            lines.push(`      ${phase}${s.id}  (${s.project})${stageTags}`);
+            const state = ckpt(f, i);
+            const mark = state === 'valid' ? '  [checkpoint]' : state === 'stale' ? '  [checkpoint: re-bake]' : '';
+            lines.push(`      ${phase}${s.id}  (${s.project})${stageTags}${mark}`);
           }
         }
       } catch (err) {

--- a/packages/node/saga-stack-cli/src/commands/e2e/run.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/run.ts
@@ -190,6 +190,7 @@ export default class E2eRun extends BaseCommand {
         ports: profile.portOverrides,
         excluded,
         snapshotStages: flags['snapshot-stages'],
+        prereqFromSnapshot: flags['prereq-from-snapshot'],
       });
       this.emit(flags, { dryRun: true, ...desc } as unknown as Record<string, unknown>, dryRunLines(desc));
       return;

--- a/packages/node/saga-stack-cli/src/commands/e2e/run.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/run.ts
@@ -102,6 +102,12 @@ export default class E2eRun extends BaseCommand {
       description:
         "M14: accept a checkpoint older than the 7-day staleness cliff (its baked dates may no longer fit the calendar — you're overriding that guard). Only meaningful with --from.",
     }),
+    'prereq-from-snapshot': Flags.boolean({
+      default: true,
+      allowNo: true,
+      description:
+        "M14-C: satisfy a flow's prerequisite by RESTORING its terminal-stage checkpoint (when a valid one is baked) instead of the full headless replay; silently falls back to the replay when absent/invalid. NOTE the restore flushes redis (the replay leaves it warm). --no-prereq-from-snapshot forces the replay.",
+    }),
     'spa-path': Flags.string({
       description: 'explicit path to a flows.json (file or dir) — highest-priority discovery override',
     }),
@@ -217,7 +223,10 @@ export default class E2eRun extends BaseCommand {
     // M14: the checkpoint store (bake/--from) — constructed AFTER applyInstanceEnv
     // (above) so it targets the slot's snapshot root + containers, with the SHARED
     // ScriptContext so the schema-ahead guard honors --set-pinned repo paths.
-    const checkpointsActive = flags['snapshot-stages'] || resolved.checkpoint !== undefined;
+    const checkpointsActive =
+      flags['snapshot-stages'] ||
+      resolved.checkpoint !== undefined ||
+      (resolved.prerequisite !== undefined && flags['prereq-from-snapshot']);
     const checkpoints = checkpointsActive
       ? this.getCheckpointStore(this.scriptContextFromFlags(flags))
       : undefined;
@@ -253,6 +262,7 @@ export default class E2eRun extends BaseCommand {
           snapshotStages: flags['snapshot-stages'],
           fromStaleOk: flags['from-stale-ok'],
           spaHead,
+          prereqFromSnapshot: flags['prereq-from-snapshot'],
         },
       );
       if (code !== 0) this.exit(code);
@@ -292,7 +302,12 @@ function dryRunLines(d: ReturnType<typeof describeResolved>): string[] {
     );
   }
   if (d.prerequisite) {
-    lines.push(`prerequisite: ${d.prerequisite.spa}/${d.prerequisite.flow} (through ${d.prerequisite.stages.at(-1)}, headless)`);
+    lines.push(
+      `prerequisite: ${d.prerequisite.spa}/${d.prerequisite.flow} (through ${d.prerequisite.stages.at(-1)}, headless)` +
+        (d.prereqCheckpoint
+          ? ` — restore ${d.prereqCheckpoint.fixtureId} if baked (validated at run time; else full replay)`
+          : ''),
+    );
   }
   lines.push(
     `PLAYWRIGHT_OCCURRENCE_DATE: ${d.occurrenceDate}`,

--- a/packages/node/saga-stack-cli/src/commands/e2e/run.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/run.ts
@@ -85,6 +85,23 @@ export default class E2eRun extends BaseCommand {
       description: 'reuse the current stack state; skip the reset+seed before Playwright',
       default: false,
     }),
+    // NOTE: no oclif `exclusive`/`dependsOn` here — those treat DEFAULTED values
+    // as provided (a default:false boolean would demand --from on every run);
+    // the interactions are checked manually in run() like --headed/--headless.
+    from: Flags.string({
+      description:
+        "M14: start AT this stage (id / number / project — same matching as --through) by RESTORING the predecessor stage's checkpoint instead of replaying earlier Playwright stages. Bake checkpoints first with --snapshot-stages.",
+    }),
+    'snapshot-stages': Flags.boolean({
+      default: false,
+      description:
+        'M14: bake a DB checkpoint after each green stage (Playwright runs once per stage) so later runs can --from into the middle of the flow. Progressive flows only.',
+    }),
+    'from-stale-ok': Flags.boolean({
+      default: false,
+      description:
+        "M14: accept a checkpoint older than the 7-day staleness cliff (its baked dates may no longer fit the calendar — you're overriding that guard). Only meaningful with --from.",
+    }),
     'spa-path': Flags.string({
       description: 'explicit path to a flows.json (file or dir) — highest-priority discovery override',
     }),
@@ -109,6 +126,9 @@ export default class E2eRun extends BaseCommand {
 
     if (flags.headed && flags.headless) {
       this.error('--headed and --headless are mutually exclusive.');
+    }
+    if (flags.from !== undefined && flags['skip-reset']) {
+      this.error('--from and --skip-reset are mutually exclusive: the checkpoint restore IS the state source.');
     }
 
     // M13-B: the implicit set preflight (no-op without --set) — e2e run brings
@@ -138,6 +158,7 @@ export default class E2eRun extends BaseCommand {
     const headed = flags.headless ? false : flags.headed ? true : undefined;
     const resolved = resolveFlow(disco.manifest, flowName, {
       throughPhase: flags.through ?? flags.phase,
+      fromPhase: flags.from,
       lane,
       headed,
     });
@@ -162,6 +183,7 @@ export default class E2eRun extends BaseCommand {
         skipReset: flags['skip-reset'],
         ports: profile.portOverrides,
         excluded,
+        snapshotStages: flags['snapshot-stages'],
       });
       this.emit(flags, { dryRun: true, ...desc } as unknown as Record<string, unknown>, dryRunLines(desc));
       return;
@@ -192,6 +214,14 @@ export default class E2eRun extends BaseCommand {
     const { runtime } = buildStackContext(flags, seams, delegate, profile);
     const api = makeStackApi(serviceManifest, runtime);
 
+    // M14: the checkpoint store (bake/--from) — constructed AFTER applyInstanceEnv
+    // (above) so it targets the slot's snapshot root + containers, with the SHARED
+    // ScriptContext so the schema-ahead guard honors --set-pinned repo paths.
+    const checkpoints =
+      flags['snapshot-stages'] || resolved.checkpoint !== undefined
+        ? this.getCheckpointStore(this.scriptContextFromFlags(flags))
+        : undefined;
+
     try {
       const code = await executeResolvedFlow(
         resolved,
@@ -204,8 +234,15 @@ export default class E2eRun extends BaseCommand {
           slot: profile.slot,
           ports: runtime.launchContext.ports,
           excluded,
+          checkpoints,
         },
-        { lane, skipReset: flags['skip-reset'], passthrough },
+        {
+          lane,
+          skipReset: flags['skip-reset'],
+          passthrough,
+          snapshotStages: flags['snapshot-stages'],
+          fromStaleOk: flags['from-stale-ok'],
+        },
       );
       if (code !== 0) this.exit(code);
     } catch (err) {
@@ -229,8 +266,13 @@ function dryRunLines(d: ReturnType<typeof describeResolved>): string[] {
     `closure (${d.closure.services.length}): ${d.closure.services.join(', ')}`,
     `databases: ${d.closure.databases.join(', ') || '(none)'}`,
     `mesh: ${d.closure.mesh.join(', ') || '(none)'}`,
-    `reset+seed: ${d.reset ? 'yes' : 'no (reuse state)'}`,
+    d.checkpoint
+      ? `restore: ${d.checkpoint.fixtureId} (checkpoint after '${d.checkpoint.predecessor}'; validated at run time)`
+      : `reset+seed: ${d.reset ? 'yes' : 'no (reuse state)'}`,
   ];
+  if (d.bakeCheckpoints) {
+    lines.push(`bake (per green stage): ${d.bakeCheckpoints.join(', ')}`);
+  }
   if (d.seed) {
     lines.push(
       `  seed offline: ${d.seed.offline.join(', ') || '(none)'}`,

--- a/packages/node/saga-stack-cli/src/commands/e2e/run.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/run.ts
@@ -217,10 +217,20 @@ export default class E2eRun extends BaseCommand {
     // M14: the checkpoint store (bake/--from) — constructed AFTER applyInstanceEnv
     // (above) so it targets the slot's snapshot root + containers, with the SHARED
     // ScriptContext so the schema-ahead guard honors --set-pinned repo paths.
-    const checkpoints =
-      flags['snapshot-stages'] || resolved.checkpoint !== undefined
-        ? this.getCheckpointStore(this.scriptContextFromFlags(flags))
-        : undefined;
+    const checkpointsActive = flags['snapshot-stages'] || resolved.checkpoint !== undefined;
+    const checkpoints = checkpointsActive
+      ? this.getCheckpointStore(this.scriptContextFromFlags(flags))
+      : undefined;
+
+    // M14 §2.3 (advisory, WARN-only): the SPA checkout's HEAD — stamped into
+    // bakes, drift-compared on restores. '' sha (not a git checkout) ⇒ omitted.
+    let spaHead: { sha: string; dirty: boolean } | undefined;
+    if (checkpointsActive) {
+      const spaRepoRoot = appCwd.slice(0, appCwd.length - resolved.spa.appDir.length - 1);
+      const git = this.getGitRunner();
+      const sha = await git.headSha(spaRepoRoot);
+      if (sha !== '') spaHead = { sha, dirty: (await git.statusPorcelain(spaRepoRoot)).trim() !== '' };
+    }
 
     try {
       const code = await executeResolvedFlow(
@@ -242,6 +252,7 @@ export default class E2eRun extends BaseCommand {
           passthrough,
           snapshotStages: flags['snapshot-stages'],
           fromStaleOk: flags['from-stale-ok'],
+          spaHead,
         },
       );
       if (code !== 0) this.exit(code);

--- a/packages/node/saga-stack-cli/src/commands/stack/snapshot/list.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/snapshot/list.ts
@@ -81,7 +81,11 @@ export default class SnapshotList extends BaseCommand {
       for (const e of entries) {
         const profile = e.manifest?.profile ?? '';
         const dbs = e.manifest?.databases.length ?? 0;
-        this.log(`${e.fixtureId}\t${profile}\t${dbs}\t${e.sizeBytes}\t${e.mtime.toISOString()}`);
+        // Field 6 (APPENDED, never inserted — fields 1-5 stay positional): the
+        // M14 checkpoint provenance `spa/flow@stage`, empty for plain snapshots.
+        const flow = e.manifest?.flow;
+        const flowRef = flow ? `${flow.spa}/${flow.flow}@${flow.stageId}` : '';
+        this.log(`${e.fixtureId}\t${profile}\t${dbs}\t${e.sizeBytes}\t${e.mtime.toISOString()}\t${flowRef}`);
       }
       return;
     }
@@ -105,6 +109,15 @@ export default class SnapshotList extends BaseCommand {
       this.log(
         row(e.fixtureId, profile, String(dbs), formatBytes(e.sizeBytes), friendlyDate(e.mtime)),
       );
+      // M14: a stage checkpoint's provenance as an indented sub-line (a column
+      // would misalign — checkpoint fixtureIds exceed the 28-char id cap).
+      const flow = e.manifest?.flow;
+      if (flow) {
+        const phase = flow.phase !== undefined ? ` (s${flow.phase})` : '';
+        this.log(
+          `        flow: ${flow.spa}/${flow.flow} @ ${flow.stageId}${phase} — baked ${flow.bakedAt.slice(0, 10)}, occurrence ${flow.dates.occurrenceDate}`,
+        );
+      }
       if (flags.verbose) {
         const dbW = clamp(Math.max(2, ...(e.manifest?.databases ?? []).map((d) => d.db.length)), 4, 22);
         for (const d of e.manifest?.databases ?? []) {

--- a/packages/node/saga-stack-cli/src/core/flow/__tests__/checkpoint.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/flow/__tests__/checkpoint.unit.test.ts
@@ -134,6 +134,22 @@ describe('evaluateCheckpoint (§2.2)', () => {
     expect(evaluateCheckpoint(at, EXPECT, NOW).ok).toBe(true);
   });
 
+  it('an OLD occurrence date trips the cliff even with a fresh bakedAt (re-bake laundering)', () => {
+    const laundered = block({
+      dates: { occurrenceDate: '2026-06-01', termStart: '2026-06-01', termEnd: '2026-07-13' }, // 33d before NOW
+    });
+    const v = evaluateCheckpoint(laundered, EXPECT, NOW);
+    expect(v.ok).toBe(false);
+    expect(v.violations[0]).toMatch(/oldest of bakedAt\/occurrenceDate/);
+  });
+
+  it('a FUTURE occurrence date (weekday clamp) never ages the checkpoint', () => {
+    const clamped = block({
+      dates: { occurrenceDate: '2026-07-06', termStart: '2026-07-06', termEnd: '2026-08-17' }, // next Monday
+    });
+    expect(evaluateCheckpoint(clamped, EXPECT, NOW).ok).toBe(true);
+  });
+
   it('SPA HEAD drift is WARN-only (§2.3)', () => {
     const v = evaluateCheckpoint(
       block({ spaHead: { sha: 'aaaaaaaaaaaa', dirty: false } }),

--- a/packages/node/saga-stack-cli/src/core/flow/__tests__/checkpoint.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/flow/__tests__/checkpoint.unit.test.ts
@@ -1,0 +1,146 @@
+/**
+ * M14 checkpoint pure layer: fixtureId determinism, prefixHash
+ * stability/sensitivity (§2.1 — what invalidates a checkpoint must be
+ * auditable), and the compat evaluator's date rules (§2.2) with fixed local
+ * Date anchors (mirrors env.unit.test.ts — nothing reads the wall clock).
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  CHECKPOINT_MAX_AGE_DAYS,
+  checkpointFixtureId,
+  evaluateCheckpoint,
+  stagePrefixHash,
+} from '../checkpoint.js';
+import type { FlowDef, StageDef } from '../types.js';
+import type { SnapshotFlowBlock } from '../../snapshot/manifest.js';
+
+const stage = (id: string, phase: number, extra: Partial<StageDef> = {}): StageDef =>
+  ({
+    id,
+    phase,
+    project: `stage-${phase}-${id}`,
+    spec: `journey/${id}.e2e.test.ts`,
+    requiredSystems: ['programs-api'],
+    ...extra,
+  }) as StageDef;
+
+const FLOW = {
+  name: 'journey',
+  lanes: ['stack'],
+  progressive: true,
+  seed: { reset: true, profile: 'roster' },
+  stages: [stage('roster', 1), stage('program', 2), stage('enrollment', 3)],
+} as unknown as FlowDef;
+
+const NOW = new Date(2026, 6, 4); // Sat 2026-07-04, local — fixed anchor
+
+const block = (over: Partial<SnapshotFlowBlock> = {}): SnapshotFlowBlock => ({
+  spa: 'saga-dash',
+  flow: 'journey',
+  stageId: 'roster',
+  phase: 1,
+  prefixHash: stagePrefixHash(FLOW, FLOW.stages.slice(0, 1)),
+  seedProfile: 'roster',
+  dates: { occurrenceDate: '2026-07-06', termStart: '2026-07-06', termEnd: '2026-08-17' },
+  bakedAt: new Date(2026, 6, 3).toISOString(), // yesterday
+  ...over,
+});
+
+const EXPECT = {
+  spaId: 'saga-dash',
+  flowName: 'journey',
+  stageId: 'roster',
+  prefixHash: stagePrefixHash(FLOW, FLOW.stages.slice(0, 1)),
+  seedProfile: 'roster',
+};
+
+describe('checkpointFixtureId', () => {
+  it('is deterministic and phase-keyed', () => {
+    expect(checkpointFixtureId('saga-dash', 'journey', FLOW.stages[1]!, 2)).toBe(
+      'flow-saga-dash-journey-s2-program',
+    );
+  });
+
+  it('falls back to the 1-based position when the stage has no phase', () => {
+    const s = { ...stage('x', 1) } as StageDef;
+    delete (s as { phase?: number }).phase;
+    expect(checkpointFixtureId('saga-dash', 'journey', s, 4)).toBe('flow-saga-dash-journey-s4-x');
+  });
+});
+
+describe('stagePrefixHash (§2.1)', () => {
+  it('is stable for byte-identical inputs', () => {
+    expect(stagePrefixHash(FLOW, FLOW.stages.slice(0, 2))).toBe(stagePrefixHash(FLOW, FLOW.stages.slice(0, 2)));
+  });
+
+  it('changes when the prefix GROWS', () => {
+    expect(stagePrefixHash(FLOW, FLOW.stages.slice(0, 1))).not.toBe(stagePrefixHash(FLOW, FLOW.stages.slice(0, 2)));
+  });
+
+  it('changes when a producing stage definition changes (spec path)', () => {
+    const edited = [stage('roster', 1, { spec: 'journey/roster-v2.e2e.test.ts' })];
+    expect(stagePrefixHash(FLOW, edited)).not.toBe(stagePrefixHash(FLOW, FLOW.stages.slice(0, 1)));
+  });
+
+  it('changes when the flow seed changes', () => {
+    const reseeded = { ...FLOW, seed: { reset: true, profile: 'full' } } as unknown as FlowDef;
+    expect(stagePrefixHash(reseeded, FLOW.stages.slice(0, 1))).not.toBe(
+      stagePrefixHash(FLOW, FLOW.stages.slice(0, 1)),
+    );
+  });
+
+  it('is INSENSITIVE to non-producing fields (downstream stages, flow lanes)', () => {
+    const rebranded = { ...FLOW, lanes: ['stack', 'sandbox'] } as unknown as FlowDef;
+    expect(stagePrefixHash(rebranded, FLOW.stages.slice(0, 1))).toBe(stagePrefixHash(FLOW, FLOW.stages.slice(0, 1)));
+  });
+});
+
+describe('evaluateCheckpoint (§2.2)', () => {
+  it('a fresh matching checkpoint is OK', () => {
+    const v = evaluateCheckpoint(block(), EXPECT, NOW);
+    expect(v).toEqual({ ok: true, violations: [], warnings: [] });
+  });
+
+  it('no flow block = not a checkpoint (violation)', () => {
+    const v = evaluateCheckpoint(undefined, EXPECT, NOW);
+    expect(v.ok).toBe(false);
+    expect(v.violations[0]).toMatch(/no stage-checkpoint provenance/);
+  });
+
+  it('identity + prefixHash + seed-profile mismatches are violations', () => {
+    expect(evaluateCheckpoint(block({ stageId: 'program' }), EXPECT, NOW).violations[0]).toMatch(/identity mismatch/);
+    expect(evaluateCheckpoint(block({ prefixHash: 'deadbeef' }), EXPECT, NOW).violations[0]).toMatch(
+      /prefixHash mismatch/,
+    );
+    expect(evaluateCheckpoint(block({ seedProfile: 'full' }), EXPECT, NOW).violations[0]).toMatch(
+      /seed profile mismatch/,
+    );
+  });
+
+  it(`the >${CHECKPOINT_MAX_AGE_DAYS}-day cliff violates; staleOk downgrades to a warning`, () => {
+    const old = block({ bakedAt: new Date(2026, 5, 20).toISOString() }); // 14 days before NOW
+    const refused = evaluateCheckpoint(old, EXPECT, NOW);
+    expect(refused.ok).toBe(false);
+    expect(refused.violations[0]).toMatch(/days old/);
+
+    const allowed = evaluateCheckpoint(old, EXPECT, NOW, true);
+    expect(allowed.ok).toBe(true);
+    expect(allowed.warnings[0]).toMatch(/stale-ok override/);
+  });
+
+  it('exactly-at-the-cliff is still fresh (boundary)', () => {
+    const at = block({ bakedAt: new Date(2026, 5, 27).toISOString() }); // 7 days before NOW
+    expect(evaluateCheckpoint(at, EXPECT, NOW).ok).toBe(true);
+  });
+
+  it('SPA HEAD drift is WARN-only (§2.3)', () => {
+    const v = evaluateCheckpoint(
+      block({ spaHead: { sha: 'aaaaaaaaaaaa', dirty: false } }),
+      { ...EXPECT, currentSpaHead: 'bbbbbbbbbbbb' },
+      NOW,
+    );
+    expect(v.ok).toBe(true);
+    expect(v.warnings[0]).toMatch(/SPA checkout moved/);
+  });
+});

--- a/packages/node/saga-stack-cli/src/core/flow/__tests__/resolve-from.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/flow/__tests__/resolve-from.unit.test.ts
@@ -1,0 +1,54 @@
+/**
+ * M14 `fromPhase` resolution: the from..through window, the surfaced
+ * predecessor/producing-stages checkpoint block, forced reset=false, and the
+ * guard errors (non-progressive, prerequisite-bearing, from-after-through).
+ * Driven off the bundled example flows.json like resolve.unit.test.ts.
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { parseFlowManifest } from '../load.js';
+import { resolveFlow } from '../resolve.js';
+
+// eslint-disable-next-line no-restricted-imports -- test fixture read; production core stays fs-free
+const EXAMPLE = fileURLToPath(new URL('../../../../examples/flows/saga-dash.flows.json', import.meta.url));
+const manifest = parseFlowManifest(readFileSync(EXAMPLE, 'utf8'), EXAMPLE);
+
+describe('resolveFlow fromPhase (M14)', () => {
+  it('windows the stages and surfaces the predecessor + producing prefix', () => {
+    const r = resolveFlow(manifest, 'journey', { fromPhase: 'enrollment', throughPhase: 'pods' });
+    expect(r.stages.map((s) => s.id)).toEqual(['enrollment', 'pods']);
+    expect(r.checkpoint?.predecessor.id).toBe('program');
+    expect(r.checkpoint?.predecessorPosition).toBe(2);
+    expect(r.checkpoint?.producingStages.map((s) => s.id)).toEqual(['roster', 'program']);
+    expect(r.reset).toBe(false); // the restore IS the state source
+    // The closure narrows to the WINDOW's requiredSystems (+ spa + iam).
+    expect(r.requiredSystems).not.toContain('sis-api'); // only roster needed sis
+  });
+
+  it('matches by phase number like --through', () => {
+    const r = resolveFlow(manifest, 'journey', { fromPhase: 3 });
+    expect(r.stages[0]?.id).toBe('enrollment');
+    expect(r.checkpoint?.predecessor.id).toBe('program');
+  });
+
+  it('fromPhase at the FIRST stage is a plain run (no checkpoint, full prefix)', () => {
+    const r = resolveFlow(manifest, 'journey', { fromPhase: 'roster', throughPhase: 'program' });
+    expect(r.checkpoint).toBeUndefined();
+    expect(r.stages.map((s) => s.id)).toEqual(['roster', 'program']);
+    expect(r.reset).toBe(true); // normal reset+seed applies
+  });
+
+  it('rejects --from after --through', () => {
+    expect(() => resolveFlow(manifest, 'journey', { fromPhase: 'pods', throughPhase: 'program' })).toThrow(
+      /--from must not come after --through/,
+    );
+  });
+
+  it('rejects a non-progressive flow (connect-session — the progressive guard fires first)', () => {
+    expect(() => resolveFlow(manifest, 'connect-session', { fromPhase: 'interactive-connect' })).toThrow(
+      /--from requires a progressive flow/,
+    );
+  });
+});

--- a/packages/node/saga-stack-cli/src/core/flow/checkpoint.ts
+++ b/packages/node/saga-stack-cli/src/core/flow/checkpoint.ts
@@ -1,0 +1,155 @@
+/**
+ * Stage checkpoints — the PURE identity + compatibility half of M14 (plan
+ * `11-e2e-stage-snapshots.md` §1-§2, saga-ed/soa#214).
+ *
+ * A checkpoint is a DB snapshot of a progressive flow's state AFTER stage k.
+ * `--from <stage>` restores the predecessor's checkpoint instead of replaying
+ * Playwright stages 1..k. This module owns what makes that safe:
+ *
+ *   - `checkpointFixtureId` — the deterministic snapshot name
+ *     (`flow-<spa>-<flow>-s<phase>-<stageId>`; re-bakes overwrite);
+ *   - `stagePrefixHash` — sha256 over an EXPLICIT projection of the producing
+ *     stage definitions + the flow's seed/env (§2.1): any edit to the prefix
+ *     that produced the state invalidates downstream checkpoints. An explicit
+ *     field-ordered projection (not a generic key-sorter) keeps "what
+ *     invalidates a checkpoint" auditable;
+ *   - `evaluateCheckpoint` — the compat verdict a `--from` run enforces:
+ *     identity + prefixHash + seed profile are HARD, the >7-day staleness
+ *     cliff is HARD unless `--from-stale-ok` downgrades it, and SPA-HEAD
+ *     drift is WARN-only (§2.3 — checkpoints are a dev accelerant, the full
+ *     replay stays the source of truth).
+ *
+ * PURE: no IO, no wall clock (callers pass `now`). `node:crypto` is
+ * deterministic and allowed under the core-purity rule (precedent:
+ * `runtime/lock.ts`).
+ */
+
+import { createHash } from 'node:crypto';
+import type { SnapshotFlowBlock } from '../snapshot/manifest.js';
+import type { FlowDef, StageDef } from './types.js';
+
+/** The staleness cliff (§2.2): older checkpoints refuse without `--from-stale-ok`. */
+export const CHECKPOINT_MAX_AGE_DAYS = 7;
+
+/**
+ * The deterministic snapshot fixtureId for a stage's checkpoint. `position`
+ * is the stage's 1-based index in the FULL flow stage list — used when the
+ * stage declares no explicit `phase` (progressive flows normally do).
+ */
+export function checkpointFixtureId(
+  spaId: string,
+  flowName: string,
+  stage: StageDef,
+  position: number,
+): string {
+  return `flow-${spaId}-${flowName}-s${stage.phase ?? position}-${stage.id}`;
+}
+
+/**
+ * §2.1: hash of everything that PRODUCED the checkpointed state — the stage
+ * prefix definitions plus the flow-level seed/env. Explicit projection, fixed
+ * field order, sha256 hex.
+ */
+export function stagePrefixHash(flow: FlowDef, producingStages: StageDef[]): string {
+  const projection = {
+    flow: flow.name,
+    seed: flow.seed ?? null,
+    env: flow.env ?? null,
+    stages: producingStages.map((s) => ({
+      id: s.id,
+      phase: s.phase ?? null,
+      project: s.project,
+      spec: s.spec,
+      requiredSystems: [...s.requiredSystems],
+      seed: s.seed ?? null,
+      tags: s.tags ?? [],
+    })),
+  };
+  return createHash('sha256').update(JSON.stringify(projection)).digest('hex');
+}
+
+/** What a `--from` run expects the predecessor checkpoint to be. */
+export interface CheckpointExpectation {
+  spaId: string;
+  flowName: string;
+  stageId: string;
+  prefixHash: string;
+  seedProfile?: string;
+  /** Advisory: the SPA checkout HEAD now (git probe at the command layer). */
+  currentSpaHead?: string;
+}
+
+/** The compat verdict — violations block the restore, warnings just print. */
+export interface CheckpointVerdict {
+  ok: boolean;
+  violations: string[];
+  warnings: string[];
+}
+
+/**
+ * §2: is this snapshot a valid input for `--from`? The schema-ahead migration
+ * guard is NOT evaluated here — `restorePlan` enforces it unchanged at
+ * restore time; this evaluator covers the flow-level rules.
+ */
+export function evaluateCheckpoint(
+  block: SnapshotFlowBlock | undefined,
+  expect: CheckpointExpectation,
+  now: Date,
+  staleOk = false,
+): CheckpointVerdict {
+  const violations: string[] = [];
+  const warnings: string[] = [];
+
+  if (block === undefined) {
+    return {
+      ok: false,
+      violations: ['snapshot has no stage-checkpoint provenance (not baked by --snapshot-stages)'],
+      warnings,
+    };
+  }
+
+  if (block.spa !== expect.spaId || block.flow !== expect.flowName || block.stageId !== expect.stageId) {
+    violations.push(
+      `checkpoint identity mismatch: baked for ${block.spa}/${block.flow} stage '${block.stageId}', ` +
+        `expected ${expect.spaId}/${expect.flowName} stage '${expect.stageId}'`,
+    );
+  }
+
+  if (block.prefixHash !== expect.prefixHash) {
+    violations.push(
+      'the producing stage prefix changed since this checkpoint was baked (prefixHash mismatch) — ' +
+        're-bake with --snapshot-stages',
+    );
+  }
+
+  if (expect.seedProfile !== undefined && block.seedProfile !== undefined && block.seedProfile !== expect.seedProfile) {
+    violations.push(
+      `seed profile mismatch: checkpoint baked with '${block.seedProfile}', flow now seeds '${expect.seedProfile}'`,
+    );
+  }
+
+  const bakedAt = Date.parse(block.bakedAt);
+  if (Number.isNaN(bakedAt)) {
+    violations.push(`checkpoint has an unreadable bakedAt timestamp ('${block.bakedAt}')`);
+  } else {
+    const ageDays = (now.getTime() - bakedAt) / 86_400_000;
+    if (ageDays > CHECKPOINT_MAX_AGE_DAYS) {
+      const msg = `checkpoint is ${Math.floor(ageDays)} days old (cliff ${CHECKPOINT_MAX_AGE_DAYS}d) — its baked dates likely no longer fit; re-bake with --snapshot-stages`;
+      if (staleOk) warnings.push(`${msg} (--from-stale-ok override)`);
+      else violations.push(`${msg}, or pass --from-stale-ok`);
+    }
+  }
+
+  if (
+    expect.currentSpaHead !== undefined &&
+    block.spaHead !== undefined &&
+    block.spaHead.sha !== expect.currentSpaHead
+  ) {
+    warnings.push(
+      `SPA checkout moved since the bake (${block.spaHead.sha.slice(0, 8)}${block.spaHead.dirty ? '+dirty' : ''} → ` +
+        `${expect.currentSpaHead.slice(0, 8)}) — re-bake if earlier stages changed behavior`,
+    );
+  }
+
+  return { ok: violations.length === 0, violations, warnings };
+}

--- a/packages/node/saga-stack-cli/src/core/flow/checkpoint.ts
+++ b/packages/node/saga-stack-cli/src/core/flow/checkpoint.ts
@@ -128,13 +128,23 @@ export function evaluateCheckpoint(
     );
   }
 
+  // The cliff guards the DATES the state embeds, so it keys on BOTH timestamps:
+  // bakedAt alone is launderable — a `--from --snapshot-stages` re-bake stamps a
+  // fresh bakedAt while carrying the RESTORED (old) occurrence date forward, and
+  // it's the occurrence date the Monday-flake class actually breaks on.
   const bakedAt = Date.parse(block.bakedAt);
+  const occurredAt = Date.parse(block.dates.occurrenceDate);
   if (Number.isNaN(bakedAt)) {
     violations.push(`checkpoint has an unreadable bakedAt timestamp ('${block.bakedAt}')`);
   } else {
-    const ageDays = (now.getTime() - bakedAt) / 86_400_000;
+    const ageDays = Math.max(
+      (now.getTime() - bakedAt) / 86_400_000,
+      // A future-dated occurrence (the weekday clamp lands on next Monday) is
+      // fine — only a PAST drift ages the checkpoint.
+      Number.isNaN(occurredAt) ? 0 : (now.getTime() - occurredAt) / 86_400_000,
+    );
     if (ageDays > CHECKPOINT_MAX_AGE_DAYS) {
-      const msg = `checkpoint is ${Math.floor(ageDays)} days old (cliff ${CHECKPOINT_MAX_AGE_DAYS}d) — its baked dates likely no longer fit; re-bake with --snapshot-stages`;
+      const msg = `checkpoint is ${Math.floor(ageDays)} days old (cliff ${CHECKPOINT_MAX_AGE_DAYS}d, oldest of bakedAt/occurrenceDate) — its baked dates likely no longer fit; re-bake with --snapshot-stages`;
       if (staleOk) warnings.push(`${msg} (--from-stale-ok override)`);
       else violations.push(`${msg}, or pass --from-stale-ok`);
     }

--- a/packages/node/saga-stack-cli/src/core/flow/index.ts
+++ b/packages/node/saga-stack-cli/src/core/flow/index.ts
@@ -47,6 +47,15 @@ export {
 export { resolveFlow } from './resolve.js';
 export type { ResolvedFlow, ResolvedPlaywright, ResolveFlowOptions } from './resolve.js';
 
+// M14 stage checkpoints — pure identity + compatibility (plan 11 §1-§2).
+export {
+  CHECKPOINT_MAX_AGE_DAYS,
+  checkpointFixtureId,
+  evaluateCheckpoint,
+  stagePrefixHash,
+} from './checkpoint.js';
+export type { CheckpointExpectation, CheckpointVerdict } from './checkpoint.js';
+
 export { knownSpaIds, lookupSpa, SPA_REGISTRY } from './spa-registry.js';
 
 export {

--- a/packages/node/saga-stack-cli/src/core/flow/resolve.ts
+++ b/packages/node/saga-stack-cli/src/core/flow/resolve.ts
@@ -70,12 +70,32 @@ export interface ResolvedFlow {
   prerequisite?: ResolvedFlow;
   /** Flow-level extra env injected for every stage (from `flows.json` `flow.env`). */
   env?: Record<string, string>;
+  /**
+   * M14: set when resolved with `fromPhase` past the first stage — `stages` is
+   * then the from..through WINDOW, and the run restores `predecessor`'s
+   * checkpoint instead of replaying `producingStages` (plan 11 §1.2).
+   */
+  checkpoint?: {
+    /** The stage whose checkpoint supplies the starting state (`flow.stages[fromIdx-1]`). */
+    predecessor: StageDef;
+    /** 1-based position of the predecessor in the FULL stage list (fixtureId input). */
+    predecessorPosition: number;
+    /** The stages that PRODUCED the checkpointed state (`flow.stages[0..fromIdx)`) — the prefixHash input. */
+    producingStages: StageDef[];
+  };
 }
 
 /** Options narrowing which stages of a flow to resolve. */
 export interface ResolveFlowOptions {
   /** Resolve THROUGH this phase — matched against a stage's `id`, `phase`, or `project`. */
   throughPhase?: string | number;
+  /**
+   * M14: start AT this stage (same id/phase/project matching as `--through`) —
+   * the run restores the PREDECESSOR stage's checkpoint instead of replaying
+   * stages 1..from-1. Progressive flows only; must fall within the selected
+   * `--through` prefix. Matching the FIRST stage is a plain full run.
+   */
+  fromPhase?: string | number;
   /** Lane the run targets; validated against `flow.lanes`. Default `'stack'`. */
   lane?: Lane;
   /** Run only these stage ids (STAGE_ONLY iteration); overrides `throughPhase`. */
@@ -182,7 +202,45 @@ export function resolveFlow(
     );
   }
 
-  const stages = selectStages(flow, opts);
+  const selected = selectStages(flow, opts);
+
+  // M14 --from: narrow the selected prefix to the from..through WINDOW and
+  // surface the predecessor whose checkpoint replaces the replay (plan 11 §1.2).
+  let stages = selected;
+  let checkpoint: ResolvedFlow['checkpoint'];
+  if (opts.fromPhase !== undefined) {
+    if (!flow.progressive) {
+      throw new Error(`flow '${flowName}': --from requires a progressive flow`);
+    }
+    if (opts.onlyStages && opts.onlyStages.length > 0) {
+      throw new Error(`flow '${flowName}': --from cannot combine with an explicit stage subset`);
+    }
+    if (flow.prerequisite) {
+      throw new Error(
+        `flow '${flowName}': --from is not supported on a flow with a prerequisite — ` +
+          `checkpoint the prerequisite flow ('${flow.prerequisite.flow}') instead`,
+      );
+    }
+    const fromIdx = selected.findIndex((s) => stageMatches(s, opts.fromPhase as string | number));
+    if (fromIdx < 0) {
+      throw new Error(
+        `flow '${flowName}': no stage matches --from '${opts.fromPhase}' within the selected ` +
+          `1..through prefix (have: ${selected
+            .map((s) => (s.phase !== undefined ? `${s.phase}:${s.id}` : s.id))
+            .join(', ')}) — --from must not come after --through`,
+      );
+    }
+    if (fromIdx > 0) {
+      stages = selected.slice(fromIdx);
+      checkpoint = {
+        predecessor: selected[fromIdx - 1] as StageDef,
+        predecessorPosition: fromIdx, // 1-based position of stages[fromIdx-1]
+        producingStages: selected.slice(0, fromIdx),
+      };
+    }
+    // fromIdx === 0 ⇒ the first stage: nothing to restore, plain run.
+  }
+
   // selectStages always returns ≥1 stage (schema enforces ≥1; selection keeps ≥1).
   const terminal = stages[stages.length - 1] as StageDef;
 
@@ -222,8 +280,10 @@ export function resolveFlow(
   }
 
   // If a prerequisite builds the end-state, the main flow runs SKIP_RESET; else
-  // it resets+seeds itself when its seed asks for it.
-  const reset = prerequisite ? false : (seedSelection?.reset ?? false);
+  // it resets+seeds itself when its seed asks for it. A --from window NEVER
+  // resets — the checkpoint restore IS the state source (truncating here would
+  // wipe the very DBs the restore just filled).
+  const reset = prerequisite || checkpoint ? false : (seedSelection?.reset ?? false);
   const foreground = flow.foreground ?? false;
   const headed = opts.headed ?? foreground;
 
@@ -249,5 +309,6 @@ export function resolveFlow(
     },
     prerequisite,
     env: flow.env,
+    ...(checkpoint !== undefined ? { checkpoint } : {}),
   };
 }

--- a/packages/node/saga-stack-cli/src/core/snapshot/__tests__/checkpoint-behind.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/snapshot/__tests__/checkpoint-behind.unit.test.ts
@@ -1,0 +1,36 @@
+/**
+ * M14 checkpointBehindFailures: a checkpoint is a REPLAY substitute, so it
+ * must sit AT the local migration head — the generic restore guard only
+ * refuses AHEAD snapshots; this covers the BEHIND direction.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { checkpointBehindFailures } from '../plan.js';
+import type { LocalMigrations, SnapshotManifest } from '../index.js';
+
+const snap = (schemaRev: string | null): SnapshotManifest =>
+  ({
+    schemaVersion: 1,
+    fixtureId: 'flow-x',
+    profile: 'roster',
+    databases: [{ db: 'programs', engine: 'pg', ownerRole: 'programs', schemaRev, file: 'programs.dump' }],
+  }) as unknown as SnapshotManifest;
+
+describe('checkpointBehindFailures', () => {
+  it('at-head is clean', () => {
+    const lm = { programs: ['m1', 'm2'] } as unknown as LocalMigrations;
+    expect(checkpointBehindFailures(snap('m2'), lm)).toEqual([]);
+  });
+
+  it('BEHIND the head (baked before a migration landed) fails with a re-bake hint', () => {
+    const lm = { programs: ['m1', 'm2'] } as unknown as LocalMigrations;
+    const out = checkpointBehindFailures(snap('m1'), lm);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatch(/programs: checkpoint schema is at m1.*head is m2.*re-bake/);
+  });
+
+  it('null rev (db-push / mongo) and unknown-local-migrations DBs are skipped', () => {
+    expect(checkpointBehindFailures(snap(null), { programs: ['m1'] } as unknown as LocalMigrations)).toEqual([]);
+    expect(checkpointBehindFailures(snap('m1'), {} as LocalMigrations)).toEqual([]);
+  });
+});

--- a/packages/node/saga-stack-cli/src/core/snapshot/index.ts
+++ b/packages/node/saga-stack-cli/src/core/snapshot/index.ts
@@ -20,6 +20,7 @@ export {
 export type { SnapshotDbEntry, SnapshotFlowBlock, SnapshotManifest } from './manifest.js';
 
 export {
+  checkpointBehindFailures,
   evaluateValidation,
   restorePlan,
   storePlan,

--- a/packages/node/saga-stack-cli/src/core/snapshot/index.ts
+++ b/packages/node/saga-stack-cli/src/core/snapshot/index.ts
@@ -14,9 +14,10 @@ export {
   safeParseSnapshotManifest,
   serializeSnapshotManifest,
   snapshotDbSchema,
+  snapshotFlowBlockSchema,
   snapshotManifestSchema,
 } from './manifest.js';
-export type { SnapshotDbEntry, SnapshotManifest } from './manifest.js';
+export type { SnapshotDbEntry, SnapshotFlowBlock, SnapshotManifest } from './manifest.js';
 
 export {
   evaluateValidation,

--- a/packages/node/saga-stack-cli/src/core/snapshot/manifest.ts
+++ b/packages/node/saga-stack-cli/src/core/snapshot/manifest.ts
@@ -97,6 +97,38 @@ export const snapshotDbSchema = z.object({
   file: z.string().min(1),
 });
 
+/**
+ * M14 stage-checkpoint provenance (plan `11-e2e-stage-snapshots.md` §2). Set
+ * only on snapshots baked by `e2e run --snapshot-stages`; `--from` validates
+ * it before restoring. Additive optional block — old manifests parse fine,
+ * and an old CLI reading a new manifest just treats it as a plain snapshot
+ * (the schema-ahead migration guard still applies either way).
+ */
+export const snapshotFlowBlockSchema = z.object({
+  /** SPA + flow + stage this checkpoint captured the state AFTER. */
+  spa: z.string().min(1),
+  flow: z.string().min(1),
+  stageId: z.string().min(1),
+  /** `StageDef.phase` verbatim (the flow schema allows a number or a label). */
+  phase: z.union([z.number().int(), z.string()]).optional(),
+  /** Hash of the PRODUCING stage prefix (stages 1..this) + flow seed/env — §2.1. */
+  prefixHash: z.string().min(1),
+  /** The flow's effective seed profile at bake time. */
+  seedProfile: z.string().optional(),
+  /** The exact date env the baking run exported — a `--from` run REUSES these (§2.2). */
+  dates: z.object({
+    occurrenceDate: z.string().min(1),
+    termStart: z.string().min(1),
+    termEnd: z.string().min(1),
+  }),
+  /** Advisory (§2.3, WARN-only): the SPA checkout HEAD at bake time. */
+  spaHead: z.object({ sha: z.string(), dirty: z.boolean() }).optional(),
+  /** ISO timestamp of the bake — drives the staleness cliff (§2.2). */
+  bakedAt: z.string().min(1),
+});
+
+export type SnapshotFlowBlock = z.infer<typeof snapshotFlowBlockSchema>;
+
 /** The whole-snapshot manifest. */
 export const snapshotManifestSchema = z.object({
   schemaVersion: z.number().int().positive(),
@@ -111,6 +143,8 @@ export const snapshotManifestSchema = z.object({
   systems: z.array(serviceIdSchema).optional(),
   /** Flow that produced this snapshot, when stored by an e2e flow. */
   flowId: z.string().optional(),
+  /** M14: stage-checkpoint provenance (bake metadata `--from` validates). */
+  flow: snapshotFlowBlockSchema.optional(),
 });
 
 export type SnapshotDbEntry = z.infer<typeof snapshotDbSchema>;

--- a/packages/node/saga-stack-cli/src/core/snapshot/plan.ts
+++ b/packages/node/saga-stack-cli/src/core/snapshot/plan.ts
@@ -394,3 +394,34 @@ export function evaluateValidation(
 function joinPath(dir: string, file: string): string {
   return dir.endsWith('/') ? `${dir}${file}` : `${dir}/${file}`;
 }
+
+/**
+ * M14: the BEHIND-schema check for stage checkpoints. The generic restore
+ * guard above only refuses a snapshot AHEAD of the checkout (its rev unknown
+ * locally); a checkpoint baked BEFORE a migration landed passes it, restores a
+ * behind-schema DB, and the window's specs then run against code expecting the
+ * new schema — where a full replay would have migrated first. Checkpoints are
+ * replay substitutes, so they must sit AT the local migration head. Pure:
+ * returns one message per behind DB (empty ⇒ ok). DBs with a null rev
+ * (db-push / mongo) or with no locally-known migrations (missing sibling
+ * checkout) are skipped — indeterminate, not behind.
+ */
+export function checkpointBehindFailures(
+  snapshot: SnapshotManifest,
+  localMigrations: LocalMigrations,
+): string[] {
+  const out: string[] = [];
+  for (const entry of snapshot.databases) {
+    if (entry.schemaRev == null) continue;
+    const known = localMigrations[entry.db] ?? [];
+    if (known.length === 0) continue;
+    const head = known[known.length - 1];
+    if (entry.schemaRev !== head) {
+      out.push(
+        `${entry.db}: checkpoint schema is at ${entry.schemaRev} but the local migration head is ${head} — ` +
+          'the checkpoint pre-dates a migration; re-bake with --snapshot-stages',
+      );
+    }
+  }
+  return out;
+}

--- a/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
+++ b/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
@@ -453,6 +453,8 @@ export interface ResolvedFlowDescription {
   checkpoint: { fixtureId: string; predecessor: string } | null;
   /** M14: the per-stage checkpoint fixtureIds a --snapshot-stages run bakes. */
   bakeCheckpoints: string[] | null;
+  /** M14-C: the prerequisite's terminal checkpoint an eligible run restores OPPORTUNISTICALLY (availability is a run-time question). */
+  prereqCheckpoint: { fixtureId: string; terminalStage: string } | null;
 }
 
 /** Options for the pure projection. */
@@ -554,8 +556,22 @@ export function describeResolved(resolved: ResolvedFlow, opts: DescribeOptions):
             ),
           )
         : null,
+    prereqCheckpoint: resolved.prerequisite
+      ? {
+          fixtureId: checkpointFixtureId(
+            resolved.spa.id,
+            resolved.prerequisite.flow.name,
+            resolved.prerequisite.stages[resolved.prerequisite.stages.length - 1] as StageDefLike,
+            resolved.prerequisite.stages.length,
+          ),
+          terminalStage: resolved.prerequisite.stages.at(-1)?.id ?? '',
+        }
+      : null,
   };
 }
+
+/** Structural alias for the stage arg `checkpointFixtureId` takes (pure projection use). */
+type StageDefLike = ResolvedFlow['stages'][number];
 
 // ── execution ─────────────────────────────────────────────────────────────────
 
@@ -619,6 +635,12 @@ export interface ExecOptions {
    * git checkout (e.g. hermetic tests).
    */
   spaHead?: { sha: string; dirty: boolean };
+  /**
+   * M14-C: restore the prerequisite's terminal-stage checkpoint instead of the
+   * full headless replay when a VALID one exists (fallback: replay). Default
+   * true at the command layer (`--no-prereq-from-snapshot` opts out).
+   */
+  prereqFromSnapshot?: boolean;
 }
 
 /**
@@ -642,19 +664,6 @@ export async function executeResolvedFlow(
 ): Promise<number> {
   const m = deps.manifest ?? serviceManifest;
 
-  // 0. Prerequisite first (e.g. connect-session ⇐ journey through 'schedule').
-  if (resolved.prerequisite) {
-    deps.log(`==> prerequisite: ${resolved.prerequisite.flow.name} (through '${resolved.prerequisite.stages.at(-1)?.id}', headless)`);
-    const preCode = await executeResolvedFlow(resolved.prerequisite, deps, {
-      lane: opts.lane,
-      skipReset: false,
-      passthrough: [],
-    });
-    if (preCode !== 0) {
-      throw new FlowExecError(`prerequisite flow '${resolved.prerequisite.flow.name}' failed (exit ${preCode})`);
-    }
-  }
-
   // Drop this slot's excluded services (literal-port + connect frontends that would
   // collide with slot 0) from the closure BEFORE up/reset/seed/verify. Empty set at
   // slot 0 ⇒ the full closure, byte-identical.
@@ -662,9 +671,66 @@ export async function executeResolvedFlow(
   const services = resolved.closure.services.filter((id) => !excluded.has(id));
   const slot = deps.slot ?? 0;
 
-  // M14: the baked date env a --from restore mandates for the Playwright child
-  // (§2.2 — restored data and running specs must agree on the dates).
+  // M14: the baked date env a --from (or prerequisite-checkpoint) restore
+  // mandates for the Playwright child (§2.2 — restored data and running specs
+  // must agree on the dates).
   let restoredDates: SnapshotFlowBlock['dates'] | undefined;
+
+  // 0. Prerequisite first (e.g. connect-session ⇐ journey through 'schedule').
+  // M14-C: OPPORTUNISTICALLY restore the prerequisite's terminal-stage
+  // checkpoint instead of the full headless replay — falling back to the
+  // replay when the checkpoint is absent/invalid (unlike --from, which
+  // hard-errors: the prerequisite path always has the replay as its source of
+  // truth). Runs in THIS frame so the checkpoint's baked dates reach THIS
+  // flow's Playwright env (they cannot cross the recursion boundary).
+  if (resolved.prerequisite) {
+    const prereq = resolved.prerequisite;
+    let restored = false;
+    if (opts.prereqFromSnapshot !== false && opts.lane === 'stack' && deps.checkpoints !== undefined) {
+      // The prerequisite's stages ARE the full producing prefix (1..through).
+      const prereqWithCheckpoint: ResolvedFlow = {
+        ...prereq,
+        checkpoint: {
+          predecessor: prereq.stages[prereq.stages.length - 1] as ResolvedFlow['stages'][number],
+          predecessorPosition: prereq.stages.length,
+          producingStages: prereq.stages,
+        },
+      };
+      const prereqServices = prereq.closure.services.filter((id) => !excluded.has(id));
+      try {
+        // Union bring-up BEFORE the restore: the replay path leaves the
+        // prerequisite's services running, and provision/migrate only cover the
+        // up() set — a prereq-closure DB dump must land in a provisioned DB.
+        const union = [...new Set<ServiceId>([...prereqServices, ...services])];
+        deps.log(`==> up: ${union.length} service(s) [${union.join(', ')}] (prerequisite union)`);
+        const up = await deps.api.up(union);
+        if (!up.ok) {
+          throw new FlowExecError(`native bring-up failed${up.failedAt ? ` at ${up.failedAt}` : ''}`);
+        }
+        restoredDates = await restoreCheckpoint(prereqWithCheckpoint, deps, opts, prereqServices, m);
+        deps.log(
+          `==> prerequisite: ${prereq.flow.name}@${prereq.stages.at(-1)?.id} restored from checkpoint (replay skipped)`,
+        );
+        restored = true;
+      } catch (err) {
+        if (!(err instanceof FlowExecError)) throw err;
+        // A failed BRING-UP would fail the replay too — don't retry it.
+        if (err.message.includes('bring-up failed')) throw err;
+        deps.log(`⚠ prerequisite checkpoint unavailable — falling back to full replay:\n${err.message}`);
+      }
+    }
+    if (!restored) {
+      deps.log(`==> prerequisite: ${prereq.flow.name} (through '${prereq.stages.at(-1)?.id}', headless)`);
+      const preCode = await executeResolvedFlow(prereq, deps, {
+        lane: opts.lane,
+        skipReset: false,
+        passthrough: [],
+      });
+      if (preCode !== 0) {
+        throw new FlowExecError(`prerequisite flow '${prereq.flow.name}' failed (exit ${preCode})`);
+      }
+    }
+  }
   if (resolved.checkpoint && opts.lane !== 'stack') {
     throw new FlowExecError('--from restores a LOCAL stack checkpoint — it requires the stack lane');
   }

--- a/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
+++ b/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
@@ -468,6 +468,12 @@ export interface DescribeOptions {
   /** M14: project the per-stage bake fixtureIds (`--snapshot-stages` dry-run). */
   snapshotStages?: boolean;
   /**
+   * M14-C: whether the opportunistic prerequisite restore is ELIGIBLE
+   * (`--prereq-from-snapshot`, default true). The projection must not
+   * advertise a restore the run's gates would never attempt.
+   */
+  prereqFromSnapshot?: boolean;
+  /**
    * Resolved per-service stack ports (`launchContext.ports`, offset-carrying) —
    * threaded into the Playwright env so the dry-run shows the slot's OFFSET service
    * URLs. Absent (slot 0 caller may still pass the base map) ⇒ no service URLs.
@@ -556,7 +562,10 @@ export function describeResolved(resolved: ResolvedFlow, opts: DescribeOptions):
             ),
           )
         : null,
-    prereqCheckpoint: resolved.prerequisite
+    prereqCheckpoint: resolved.prerequisite &&
+      opts.prereqFromSnapshot !== false &&
+      opts.lane === 'stack' &&
+      resolved.prerequisite.prerequisite === undefined
       ? {
           fixtureId: checkpointFixtureId(
             resolved.spa.id,
@@ -686,7 +695,16 @@ export async function executeResolvedFlow(
   if (resolved.prerequisite) {
     const prereq = resolved.prerequisite;
     let restored = false;
-    if (opts.prereqFromSnapshot !== false && opts.lane === 'stack' && deps.checkpoints !== undefined) {
+    // NESTED chains (A ⇐ B ⇐ C) always REPLAY: restoring B's checkpoint would
+    // skip C's rebuild entirely (B's bake never dumped C-only DBs and the
+    // coverage guard sees only B's closure) — conservative until checkpoints
+    // learn transitive coverage.
+    if (
+      opts.prereqFromSnapshot !== false &&
+      opts.lane === 'stack' &&
+      deps.checkpoints !== undefined &&
+      prereq.prerequisite === undefined
+    ) {
       // The prerequisite's stages ARE the full producing prefix (1..through).
       const prereqWithCheckpoint: ResolvedFlow = {
         ...prereq,
@@ -725,6 +743,10 @@ export async function executeResolvedFlow(
         lane: opts.lane,
         skipReset: false,
         passthrough: [],
+        // The opt-out contract holds transitively: --no-prereq-from-snapshot
+        // forces the replay for NESTED prerequisites too (deps.checkpoints
+        // rides down unchanged, so the gate alone must carry the choice).
+        prereqFromSnapshot: opts.prereqFromSnapshot,
       });
       if (preCode !== 0) {
         throw new FlowExecError(`prerequisite flow '${prereq.flow.name}' failed (exit ${preCode})`);

--- a/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
+++ b/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
@@ -613,6 +613,12 @@ export interface ExecOptions {
   snapshotStages?: boolean;
   /** M14 §2.2: downgrade the >7-day checkpoint staleness violation to a warning. */
   fromStaleOk?: boolean;
+  /**
+   * M14 §2.3 (advisory): the SPA checkout's HEAD at run time — stamped into
+   * bakes, compared (WARN-only) on restores. Absent when the SPA dir is not a
+   * git checkout (e.g. hermetic tests).
+   */
+  spaHead?: { sha: string; dirty: boolean };
 }
 
 /**
@@ -662,6 +668,14 @@ export async function executeResolvedFlow(
   if (resolved.checkpoint && opts.lane !== 'stack') {
     throw new FlowExecError('--from restores a LOCAL stack checkpoint — it requires the stack lane');
   }
+  if (opts.snapshotStages === true && opts.lane !== 'stack') {
+    throw new FlowExecError(
+      '--snapshot-stages bakes LOCAL stack checkpoints — it requires the stack lane (a deployed-lane run would dump unrelated local container state)',
+    );
+  }
+  if (opts.snapshotStages === true && !resolved.flow.progressive) {
+    throw new FlowExecError('--snapshot-stages requires a progressive flow (stage checkpoints are replay prefixes)');
+  }
 
   if (opts.lane === 'stack') {
     // 1. native bring-up.
@@ -676,7 +690,7 @@ export async function executeResolvedFlow(
     // 1..from-1. Gated on resolved.checkpoint (never on effectiveReset:
     // resolved.reset is already false for a --from window by construction).
     if (resolved.checkpoint) {
-      restoredDates = await restoreCheckpoint(resolved, deps, opts);
+      restoredDates = await restoreCheckpoint(resolved, deps, opts, services, m);
     }
 
     // 2b. reset + seed (coupled; skipped on --skip-reset or when a prerequisite built the state).
@@ -764,7 +778,7 @@ export async function executeResolvedFlow(
       return code;
     }
     if (opts.snapshotStages === true) {
-      await bakeStageCheckpoint(resolved, stage, services, env, deps, m);
+      await bakeStageCheckpoint(resolved, stage, services, env, deps, opts, m);
     }
   }
   return 0;
@@ -775,6 +789,8 @@ async function restoreCheckpoint(
   resolved: ResolvedFlow,
   deps: ExecDeps,
   opts: ExecOptions,
+  services: ServiceId[],
+  m: Manifest,
 ): Promise<SnapshotFlowBlock['dates']> {
   const cp = resolved.checkpoint as NonNullable<ResolvedFlow['checkpoint']>;
   if (deps.checkpoints === undefined) {
@@ -789,8 +805,12 @@ async function restoreCheckpoint(
   );
   const snapshot = deps.checkpoints.load(fixtureId);
   if (snapshot === null) {
+    // Plan §1.2: list the stages that ARE baked so the fix is self-evident.
+    const baked = resolved.flow.stages
+      .filter((s, i) => deps.checkpoints?.load(checkpointFixtureId(resolved.spa.id, resolved.flow.name, s, i + 1)))
+      .map((s) => s.id);
     throw new FlowExecError(
-      `no checkpoint '${fixtureId}' — bake one first:\n` +
+      `no checkpoint '${fixtureId}' — baked stages: ${baked.join(', ') || '(none)'}. Bake first:\n` +
         `  ss e2e run ${resolved.spa.id}/${resolved.flow.name} --snapshot-stages --headless`,
     );
   }
@@ -803,10 +823,27 @@ async function restoreCheckpoint(
       stageId: cp.predecessor.id,
       prefixHash: stagePrefixHash(resolved.flow, cp.producingStages),
       seedProfile: resolved.seedSelection?.profile,
+      currentSpaHead: opts.spaHead?.sha,
     },
     deps.now,
     opts.fromStaleOk === true,
   );
+
+  // The checkpoint must COVER the window's state: any DB a window stage needs
+  // that the bake never dumped would keep un-reset leftover rows (a full replay
+  // would have reset+seeded it). Bake wider (--through) or re-bake.
+  const dumped = new Set(snapshot.databases.map((d) => d.db));
+  const missing = [...new Set(services.flatMap((id) => m.services[id]?.databases ?? []))].filter(
+    (db) => !dumped.has(db),
+  );
+  if (missing.length > 0) {
+    verdict.violations.push(
+      `the checkpoint does not cover the window's database(s): ${missing.join(', ')} — ` +
+        'it was baked from a narrower closure; re-bake with a wider --through',
+    );
+    verdict.ok = false;
+  }
+
   for (const w of verdict.warnings) deps.log(`⚠ checkpoint: ${w}`);
   if (!verdict.ok) {
     throw new FlowExecError(
@@ -831,6 +868,7 @@ async function bakeStageCheckpoint(
   services: ServiceId[],
   env: Record<string, string>,
   deps: ExecDeps,
+  opts: ExecOptions,
   m: Manifest,
 ): Promise<void> {
   const checkpoints = deps.checkpoints as NonNullable<ExecDeps['checkpoints']>;
@@ -843,7 +881,9 @@ async function bakeStageCheckpoint(
 
   await checkpoints.bake({
     fixtureId,
-    profile: resolved.seedSelection?.profile ?? 'roster',
+    // No fabricated default: a seedless flow's checkpoint says so ('unseeded'
+    // never false-matches a real profile in the restore-time double guard).
+    profile: resolved.seedSelection?.profile ?? 'unseeded',
     dbs,
     flow: {
       spa: resolved.spa.id,
@@ -857,6 +897,7 @@ async function bakeStageCheckpoint(
         termStart: env[ENV_TERM_START] ?? '',
         termEnd: env[ENV_TERM_END] ?? '',
       },
+      ...(opts.spaHead !== undefined ? { spaHead: opts.spaHead } : {}),
       bakedAt: deps.now.toISOString(),
     },
   });

--- a/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
+++ b/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
@@ -33,7 +33,10 @@
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { composeSeedPlan } from './core/seed/compose-seed-plan.js';
-import { computeEnv, ENV_OCCURRENCE_DATE } from './core/flow/env.js';
+import { computeEnv, ENV_OCCURRENCE_DATE, ENV_TERM_END, ENV_TERM_START } from './core/flow/env.js';
+import { checkpointFixtureId, evaluateCheckpoint, stagePrefixHash } from './core/flow/checkpoint.js';
+import type { SnapshotFlowBlock } from './core/snapshot/index.js';
+import type { CheckpointStore } from './runtime/checkpoint-store.js';
 import {
   flowsCandidatePaths,
   knownSpaIds,
@@ -317,15 +320,26 @@ function joinPath(root: string, sub: string): string {
  * `--grep-invert @interactive` (pipeline runs exclude the interactive harness),
  * `--headed` (foreground flows), then any user passthrough (after `--`).
  */
-export function playwrightArgv(resolved: ResolvedFlow, passthrough: string[] = []): string[] {
+export function playwrightArgv(
+  resolved: ResolvedFlow,
+  passthrough: string[] = [],
+  /**
+   * M14 per-stage override (bake/--from spawns): target THIS project instead
+   * of the terminal, and (`noDeps`) break the config-side dependency chain so
+   * the spawn runs exactly one stage instead of replaying 1..N. Absent ⇒
+   * byte-identical to the pre-M14 argv.
+   */
+  stage?: { project: string; noDeps: boolean },
+): string[] {
   const argv = [
     'exec',
     'playwright',
     'test',
     `--config=${resolved.playwright.config}`,
     '--project',
-    resolved.playwright.project,
+    stage?.project ?? resolved.playwright.project,
   ];
+  if (stage?.noDeps) argv.push('--no-deps');
   if (resolved.playwright.grepInvert) argv.push('--grep-invert', resolved.playwright.grepInvert);
   if (resolved.playwright.headed) argv.push('--headed');
   argv.push(...passthrough);
@@ -390,6 +404,15 @@ export function playwrightEnv(
   now: Date,
   lane: Lane,
   ports?: Partial<Record<ServiceId, number>>,
+  /**
+   * M14 §2.2: the checkpoint's BAKED date env — a `--from` run must export the
+   * dates the restored state embeds, not today's clamp. Spread AFTER
+   * `computeEnv` (beats the clamp AND `flow.env` — at bake time computeEnv ran
+   * with the same flow.env, so what got baked is what a flow pin produced) but
+   * BEFORE the service URLs, so the slot offset still always wins for
+   * `PLAYWRIGHT_*_URL` keys.
+   */
+  dateOverrides?: Record<string, string>,
 ): Record<string, string> {
   // The date env (with `flow.env` merged LAST inside `computeEnv`) comes first, so
   // a flow's own env keeps winning for the occurrence-date clamp. Then, on the
@@ -401,6 +424,7 @@ export function playwrightEnv(
   // do NOT inject/override them.
   const env: Record<string, string> = {
     ...computeEnv(resolved.flow, now),
+    ...(dateOverrides ?? {}),
     ...(lane === 'stack' && ports ? serviceUrlEnv(ports) : {}),
   };
   if (lane !== 'stack') env.PLAYWRIGHT_LANE = lane;
@@ -425,6 +449,10 @@ export interface ResolvedFlowDescription {
   occurrenceDate: string;
   env: Record<string, string>;
   prerequisite: ResolvedFlowDescription | null;
+  /** M14: the checkpoint a --from run will restore (validated at run time, not here — pure). */
+  checkpoint: { fixtureId: string; predecessor: string } | null;
+  /** M14: the per-stage checkpoint fixtureIds a --snapshot-stages run bakes. */
+  bakeCheckpoints: string[] | null;
 }
 
 /** Options for the pure projection. */
@@ -435,6 +463,8 @@ export interface DescribeOptions {
   passthrough: string[];
   skipReset: boolean;
   manifest?: Manifest;
+  /** M14: project the per-stage bake fixtureIds (`--snapshot-stages` dry-run). */
+  snapshotStages?: boolean;
   /**
    * Resolved per-service stack ports (`launchContext.ports`, offset-carrying) —
    * threaded into the Playwright env so the dry-run shows the slot's OFFSET service
@@ -502,6 +532,28 @@ export function describeResolved(resolved: ResolvedFlow, opts: DescribeOptions):
     prerequisite: resolved.prerequisite
       ? describeResolved(resolved.prerequisite, { ...opts, passthrough: [], skipReset: false })
       : null,
+    checkpoint: resolved.checkpoint
+      ? {
+          fixtureId: checkpointFixtureId(
+            resolved.spa.id,
+            resolved.flow.name,
+            resolved.checkpoint.predecessor,
+            resolved.checkpoint.predecessorPosition,
+          ),
+          predecessor: resolved.checkpoint.predecessor.id,
+        }
+      : null,
+    bakeCheckpoints:
+      opts.snapshotStages === true
+        ? resolved.stages.map((s) =>
+            checkpointFixtureId(
+              resolved.spa.id,
+              resolved.flow.name,
+              s,
+              resolved.flow.stages.findIndex((f) => f.id === s.id) + 1,
+            ),
+          )
+        : null,
   };
 }
 
@@ -536,6 +588,13 @@ export interface ExecDeps {
    * Filtered out of the closure before up/reset/seed/verify. Empty at slot 0.
    */
   excluded?: Set<ServiceId>;
+  /**
+   * M14: the stage-checkpoint store (bake + restore). Constructed by the
+   * command AFTER `applyInstanceEnv` (so it targets the slot's snapshot root +
+   * containers). Absent ⇒ `--from`/`--snapshot-stages` paths are unavailable
+   * (the second caller, `e2e connect`, never sets it).
+   */
+  checkpoints?: CheckpointStore;
 }
 
 /** Per-run knobs. */
@@ -545,6 +604,15 @@ export interface ExecOptions {
   skipReset: boolean;
   /** Playwright passthrough args (after `--`); applied to THIS flow only, not the prerequisite. */
   passthrough: string[];
+  /**
+   * M14 bake mode: spawn Playwright once per stage (`--no-deps` past the
+   * first) and store a checkpoint after each green stage. Kept in OPTIONS so
+   * the prerequisite recursion (which passes deps down unchanged but rebuilds
+   * opts) never inherits it.
+   */
+  snapshotStages?: boolean;
+  /** M14 §2.2: downgrade the >7-day checkpoint staleness violation to a warning. */
+  fromStaleOk?: boolean;
 }
 
 /**
@@ -588,6 +656,13 @@ export async function executeResolvedFlow(
   const services = resolved.closure.services.filter((id) => !excluded.has(id));
   const slot = deps.slot ?? 0;
 
+  // M14: the baked date env a --from restore mandates for the Playwright child
+  // (§2.2 — restored data and running specs must agree on the dates).
+  let restoredDates: SnapshotFlowBlock['dates'] | undefined;
+  if (resolved.checkpoint && opts.lane !== 'stack') {
+    throw new FlowExecError('--from restores a LOCAL stack checkpoint — it requires the stack lane');
+  }
+
   if (opts.lane === 'stack') {
     // 1. native bring-up.
     deps.log(`==> up: ${services.length} service(s) [${services.join(', ')}]`);
@@ -596,7 +671,15 @@ export async function executeResolvedFlow(
       throw new FlowExecError(`native bring-up failed${up.failedAt ? ` at ${up.failedAt}` : ''}`);
     }
 
-    // 2. reset + seed (coupled; skipped on --skip-reset or when a prerequisite built the state).
+    // 2a. M14 --from: restore the predecessor stage's checkpoint — the state
+    // source replacing the reset+seed AND the Playwright replay of stages
+    // 1..from-1. Gated on resolved.checkpoint (never on effectiveReset:
+    // resolved.reset is already false for a --from window by construction).
+    if (resolved.checkpoint) {
+      restoredDates = await restoreCheckpoint(resolved, deps, opts);
+    }
+
+    // 2b. reset + seed (coupled; skipped on --skip-reset or when a prerequisite built the state).
     const effectiveReset = resolved.reset && !opts.skipReset;
     if (effectiveReset) {
       // FLIP 3: the e2e reset is NATIVE at EVERY slot now (M8 R4 — slot-aware via the
@@ -617,7 +700,7 @@ export async function executeResolvedFlow(
         const seeded = await deps.api.seed(plan);
         if (!seeded.ok) throw new FlowExecError(`seed failed at ${seeded.failed}`);
       }
-    } else {
+    } else if (!resolved.checkpoint) {
       deps.log('==> skip reset/seed (reuse current stack state)');
     }
 
@@ -632,17 +715,150 @@ export async function executeResolvedFlow(
     deps.log(`==> ${opts.lane} lane: no local stack to bring up; running Playwright against the deployed composition`);
   }
 
-  // 4. Playwright (foreground, stdio inherited). The clamped date env + the slot's
-  // offset service URLs are overlaid (so a slot's specs drive its OWN ports).
-  const argv = playwrightArgv(resolved, opts.passthrough);
-  const env = playwrightEnv(resolved, deps.now, opts.lane, deps.ports);
-  deps.log(`==> playwright: ${resolved.flow.name} — pnpm ${argv.join(' ')} (cwd ${deps.appCwd})`);
-  const { code } = await deps.runner.run({
-    cwd: deps.appCwd,
-    command: 'pnpm',
-    args: argv,
-    env,
-    stdio: 'inherit',
+  // 4. Playwright (foreground, stdio inherited). The clamped date env (or the
+  // checkpoint's BAKED dates under --from) + the slot's offset service URLs are
+  // overlaid (so a slot's specs drive its OWN ports).
+  const dateOverrides = restoredDates
+    ? {
+        [ENV_OCCURRENCE_DATE]: restoredDates.occurrenceDate,
+        [ENV_TERM_START]: restoredDates.termStart,
+        [ENV_TERM_END]: restoredDates.termEnd,
+      }
+    : undefined;
+  const env = playwrightEnv(resolved, deps.now, opts.lane, deps.ports, dateOverrides);
+
+  const spawn = async (stage?: { project: string; noDeps: boolean }): Promise<number> => {
+    const argv = playwrightArgv(resolved, opts.passthrough, stage);
+    deps.log(`==> playwright: ${resolved.flow.name} — pnpm ${argv.join(' ')} (cwd ${deps.appCwd})`);
+    const { code } = await deps.runner.run({
+      cwd: deps.appCwd,
+      command: 'pnpm',
+      args: argv,
+      env,
+      stdio: 'inherit',
+    });
+    return code;
+  };
+
+  // Default path: ONE spawn with the terminal project — Playwright's config-side
+  // dependency chain replays 1..N (byte-identical to pre-M14). The per-stage
+  // ladder exists ONLY for M14: baking needs a checkpoint between stages, and a
+  // --from window must NOT let the dependency chain replay the restored prefix.
+  const perStage = opts.snapshotStages === true || resolved.checkpoint !== undefined;
+  if (!perStage) return spawn();
+
+  if (opts.snapshotStages === true && deps.checkpoints === undefined) {
+    throw new FlowExecError('--snapshot-stages requires the checkpoint store (internal wiring error)');
+  }
+
+  for (const stage of resolved.stages) {
+    // The FIRST stage of the whole flow keeps its config dependencies — its only
+    // edge is the cheap coherence gate (e.g. stage-0-coherence), which a bake-
+    // from-scratch run should still pass through. Every later spawn breaks the
+    // chain (--no-deps) so earlier stages are never replayed.
+    const isFlowFirst = resolved.flow.stages[0]?.id === stage.id;
+    const code = await spawn({ project: stage.project, noDeps: !isFlowFirst });
+    if (code !== 0) {
+      // No checkpoint for a red stage — and stop the ladder (later checkpoints
+      // would capture state the failed stage never produced).
+      return code;
+    }
+    if (opts.snapshotStages === true) {
+      await bakeStageCheckpoint(resolved, stage, services, env, deps, m);
+    }
+  }
+  return 0;
+}
+
+/** M14 §1.2: load + validate + restore the predecessor checkpoint; returns its baked dates. */
+async function restoreCheckpoint(
+  resolved: ResolvedFlow,
+  deps: ExecDeps,
+  opts: ExecOptions,
+): Promise<SnapshotFlowBlock['dates']> {
+  const cp = resolved.checkpoint as NonNullable<ResolvedFlow['checkpoint']>;
+  if (deps.checkpoints === undefined) {
+    throw new FlowExecError('--from requires the checkpoint store (internal wiring error)');
+  }
+
+  const fixtureId = checkpointFixtureId(
+    resolved.spa.id,
+    resolved.flow.name,
+    cp.predecessor,
+    cp.predecessorPosition,
+  );
+  const snapshot = deps.checkpoints.load(fixtureId);
+  if (snapshot === null) {
+    throw new FlowExecError(
+      `no checkpoint '${fixtureId}' — bake one first:\n` +
+        `  ss e2e run ${resolved.spa.id}/${resolved.flow.name} --snapshot-stages --headless`,
+    );
+  }
+
+  const verdict = evaluateCheckpoint(
+    snapshot.flow,
+    {
+      spaId: resolved.spa.id,
+      flowName: resolved.flow.name,
+      stageId: cp.predecessor.id,
+      prefixHash: stagePrefixHash(resolved.flow, cp.producingStages),
+      seedProfile: resolved.seedSelection?.profile,
+    },
+    deps.now,
+    opts.fromStaleOk === true,
+  );
+  for (const w of verdict.warnings) deps.log(`⚠ checkpoint: ${w}`);
+  if (!verdict.ok) {
+    throw new FlowExecError(
+      `checkpoint '${fixtureId}' failed validation:\n` + verdict.violations.map((v) => `  ✗ ${v}`).join('\n'),
+    );
+  }
+
+  const flowBlock = snapshot.flow as SnapshotFlowBlock; // verdict.ok ⇒ present
+  deps.log(`==> restore: ${fixtureId} (baked ${flowBlock.bakedAt}, occurrence ${flowBlock.dates.occurrenceDate})`);
+  try {
+    await deps.checkpoints.restore(snapshot, { currentProfile: resolved.seedSelection?.profile });
+  } catch (err) {
+    throw new FlowExecError((err as Error).message);
+  }
+  return flowBlock.dates;
+}
+
+/** M14 §1.1: overwrite-store the checkpoint for a just-green stage. */
+async function bakeStageCheckpoint(
+  resolved: ResolvedFlow,
+  stage: ResolvedFlow['stages'][number],
+  services: ServiceId[],
+  env: Record<string, string>,
+  deps: ExecDeps,
+  m: Manifest,
+): Promise<void> {
+  const checkpoints = deps.checkpoints as NonNullable<ExecDeps['checkpoints']>;
+  const position = resolved.flow.stages.findIndex((s) => s.id === stage.id) + 1;
+  const fixtureId = checkpointFixtureId(resolved.spa.id, resolved.flow.name, stage, position);
+
+  // The bake scope is the SLOT-FILTERED closure's DB set (post-closure exclusion,
+  // same rule as `snapshot store --slot N`) — never dump DBs the slot never provisioned.
+  const dbs = [...new Set(services.flatMap((id) => m.services[id]?.databases ?? []))];
+
+  await checkpoints.bake({
+    fixtureId,
+    profile: resolved.seedSelection?.profile ?? 'roster',
+    dbs,
+    flow: {
+      spa: resolved.spa.id,
+      flow: resolved.flow.name,
+      stageId: stage.id,
+      ...(stage.phase !== undefined ? { phase: stage.phase } : {}),
+      prefixHash: stagePrefixHash(resolved.flow, resolved.flow.stages.slice(0, position)),
+      ...(resolved.seedSelection?.profile !== undefined ? { seedProfile: resolved.seedSelection.profile } : {}),
+      dates: {
+        occurrenceDate: env[ENV_OCCURRENCE_DATE] ?? '',
+        termStart: env[ENV_TERM_START] ?? '',
+        termEnd: env[ENV_TERM_END] ?? '',
+      },
+      bakedAt: deps.now.toISOString(),
+    },
   });
-  return code;
+  deps.log(`==> checkpoint: baked ${fixtureId}`);
 }

--- a/packages/node/saga-stack-cli/src/runtime/checkpoint-store.ts
+++ b/packages/node/saga-stack-cli/src/runtime/checkpoint-store.ts
@@ -1,0 +1,159 @@
+/**
+ * Stage-checkpoint store — the IO half of M14 (plan `11-e2e-stage-snapshots.md`
+ * §1). Bundles the snapshot store/restore ceremonies behind ONE fake-able
+ * surface the e2e orchestrator consumes (`ExecDeps.checkpoints`):
+ *
+ *   - `load` — read + zod-validate a checkpoint's manifest (null if absent);
+ *   - `bake` — overwrite-store the given DBs + write the manifest with the
+ *     M14 `flow` provenance block (deterministic fixtureIds ⇒ re-bakes
+ *     replace; checkpoints are cheap disposable derivatives);
+ *   - `restore` — the full restore ceremony: local-migration gather (the
+ *     schema-ahead HARD guard, honoring `--set`-pinned repo roots via the
+ *     caller's ScriptContext), `restorePlan`, per-DB restore-as-owner, redis
+ *     flush. Throws a pointed Error on any guard failure.
+ *
+ * CALL-TIME ENV CONTRACT: `snapshotDir`/container resolvers read
+ * `$SAGA_MESH_*` when invoked — the command constructs this store AFTER
+ * `applyInstanceEnv(profile)`, so a `--slot`/`--set` run bakes and restores
+ * in ITS slot's snapshot root against ITS slot's containers.
+ */
+
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { manifest as defaultManifest } from '../core/manifest/index.js';
+import type { DbId, Manifest } from '../core/manifest/index.js';
+import { restorePlan, storePlan, CURRENT_SNAPSHOT_SCHEMA_VERSION } from '../core/snapshot/index.js';
+import type { SnapshotDbEntry, SnapshotFlowBlock, SnapshotManifest } from '../core/snapshot/index.js';
+import type { SnapshotIO } from './snapshot.js';
+import {
+  deleteSnapshot,
+  ensureSnapshotDir,
+  fileSize,
+  gatherLocalMigrations,
+  mongoContainer,
+  postgresContainer,
+  readManifest,
+  redisContainer,
+  snapshotDir,
+  writeManifest,
+} from './snapshot-store.js';
+import type { ScriptContext } from './scripts.js';
+
+/** What a bake stores beyond the DB dumps. */
+export interface BakeInput {
+  fixtureId: string;
+  /** The flow's effective seed profile (stamped as the manifest `profile`). */
+  profile: string;
+  /** The DBs to dump — the slot-filtered flow closure's set. */
+  dbs: DbId[];
+  /** The M14 provenance block `--from` validates. */
+  flow: SnapshotFlowBlock;
+}
+
+/** The injectable checkpoint surface (`ExecDeps.checkpoints`). */
+export interface CheckpointStore {
+  /** Read a checkpoint's manifest; null when absent/corrupt (caller errors pointedly). */
+  load(fixtureId: string): SnapshotManifest | null;
+  /** Overwrite-store a stage checkpoint. */
+  bake(input: BakeInput): Promise<void>;
+  /** Restore a checkpoint (schema-ahead guard + per-DB restore + redis flush). Throws on guard failure. */
+  restore(snapshot: SnapshotManifest, opts: { currentProfile?: string }): Promise<void>;
+}
+
+/** Build the production store. `ctx` feeds the schema-ahead guard's migration discovery. */
+export function makeCheckpointStore(deps: {
+  io: SnapshotIO;
+  ctx: ScriptContext;
+  manifest?: Manifest;
+}): CheckpointStore {
+  const m = deps.manifest ?? defaultManifest;
+
+  return {
+    load(fixtureId: string): SnapshotManifest | null {
+      return readManifest(snapshotDir(fixtureId));
+    },
+
+    async bake(input: BakeInput): Promise<void> {
+      const plan = storePlan(m, { fixtureId: input.fixtureId, profile: input.profile, only: input.dbs });
+      const pgC = postgresContainer();
+      const mongoC = mongoContainer();
+
+      await deps.io.assertPgRunning(pgC);
+      if (plan.databases.some((d) => d.engine === 'mongo')) {
+        await deps.io.assertMongoRunning(mongoC);
+      }
+
+      // Deterministic fixtureId ⇒ a re-bake REPLACES (no --force ceremony).
+      const dir = snapshotDir(input.fixtureId);
+      if (existsSync(dir)) deleteSnapshot(input.fixtureId);
+      ensureSnapshotDir(dir);
+
+      const databases: SnapshotDbEntry[] = [];
+      for (const action of plan.databases) {
+        const outPath = join(dir, action.file);
+        if (action.engine === 'mongo') {
+          await deps.io.mongoDump(mongoC, action.db, outPath);
+        } else {
+          await deps.io.pgDump(action.db, pgC, action.ownerRole, outPath);
+        }
+        const schemaRev = action.captureSchemaRev ? await deps.io.readSchemaRev(action.db, pgC) : null;
+        databases.push({
+          db: action.db,
+          engine: action.engine,
+          ownerRole: action.ownerRole,
+          schemaRev,
+          sizeBytes: fileSize(outPath),
+          file: action.file,
+        });
+      }
+
+      writeManifest(dir, {
+        schemaVersion: CURRENT_SNAPSHOT_SCHEMA_VERSION,
+        fixtureId: input.fixtureId,
+        profile: input.profile,
+        createdAt: input.flow.bakedAt,
+        databases,
+        systems: plan.systems,
+        flowId: `${input.flow.spa}/${input.flow.flow}`,
+        flow: input.flow,
+      });
+    },
+
+    async restore(snapshot: SnapshotManifest, opts: { currentProfile?: string }): Promise<void> {
+      const localMigrations = gatherLocalMigrations(snapshot, deps.ctx, m);
+      const plan = restorePlan(snapshot, m, localMigrations, {
+        force: false,
+        currentProfile: opts.currentProfile,
+      });
+      if (!plan.ok) {
+        throw new Error(
+          `checkpoint '${snapshot.fixtureId}' cannot be restored:\n` +
+            plan.guardFailures.map((g) => `  ✗ ${g.message}`).join('\n') +
+            '\n  (re-bake with --snapshot-stages after updating the stack)',
+        );
+      }
+
+      const pgC = postgresContainer();
+      const mongoC = mongoContainer();
+      await deps.io.assertPgRunning(pgC);
+      if (plan.actions.some((a) => a.engine === 'mongo')) {
+        await deps.io.assertMongoRunning(mongoC);
+      }
+
+      const dir = snapshotDir(snapshot.fixtureId);
+      for (const action of plan.actions) {
+        const inPath = join(dir, action.file);
+        if (!existsSync(inPath)) {
+          throw new Error(`checkpoint '${snapshot.fixtureId}' is missing dump file ${action.file} — re-bake`);
+        }
+        if (action.engine === 'mongo') {
+          await deps.io.mongoRestore(mongoC, action.db, inPath);
+        } else {
+          await deps.io.pgRestore(action.db, pgC, action.ownerRole, inPath);
+        }
+      }
+
+      if (plan.flushRedis) await deps.io.redisFlushdb(redisContainer());
+    },
+  };
+}

--- a/packages/node/saga-stack-cli/src/runtime/checkpoint-store.ts
+++ b/packages/node/saga-stack-cli/src/runtime/checkpoint-store.ts
@@ -22,7 +22,12 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { manifest as defaultManifest } from '../core/manifest/index.js';
 import type { DbId, Manifest } from '../core/manifest/index.js';
-import { restorePlan, storePlan, CURRENT_SNAPSHOT_SCHEMA_VERSION } from '../core/snapshot/index.js';
+import {
+  checkpointBehindFailures,
+  restorePlan,
+  storePlan,
+  CURRENT_SNAPSHOT_SCHEMA_VERSION,
+} from '../core/snapshot/index.js';
 import type { SnapshotDbEntry, SnapshotFlowBlock, SnapshotManifest } from '../core/snapshot/index.js';
 import type { SnapshotIO } from './snapshot.js';
 import {
@@ -125,10 +130,14 @@ export function makeCheckpointStore(deps: {
         force: false,
         currentProfile: opts.currentProfile,
       });
-      if (!plan.ok) {
+      // M14: checkpoints are REPLAY substitutes, so unlike a generic snapshot
+      // restore they must also not be BEHIND the local migration head (a full
+      // replay would have migrated first; the generic guard only refuses AHEAD).
+      const behind = checkpointBehindFailures(snapshot, localMigrations);
+      if (!plan.ok || behind.length > 0) {
         throw new Error(
           `checkpoint '${snapshot.fixtureId}' cannot be restored:\n` +
-            plan.guardFailures.map((g) => `  ✗ ${g.message}`).join('\n') +
+            [...plan.guardFailures.map((g) => g.message), ...behind].map((msg) => `  ✗ ${msg}`).join('\n') +
             '\n  (re-bake with --snapshot-stages after updating the stack)',
         );
       }

--- a/packages/node/saga-stack-cli/src/runtime/git.ts
+++ b/packages/node/saga-stack-cli/src/runtime/git.ts
@@ -46,6 +46,8 @@ export interface GitRunner {
   statusPorcelain(repoPath: string): Promise<string>;
   /** `git branch --show-current` — the current branch, or `''` when detached / on error. */
   branchShowCurrent(repoPath: string): Promise<string>;
+  /** `git rev-parse HEAD` — the HEAD sha, or `''` when not a checkout / on error (M14 §2.3 advisory). */
+  headSha(repoPath: string): Promise<string>;
   /** origin/HEAD → default branch (`git symbolic-ref --short refs/remotes/origin/HEAD`, strip `origin/`); fallback `main`. */
   symbolicRefDefault(repoPath: string): Promise<string>;
   /** `git fetch -q origin` — true iff it exited 0 (network IO; a failure must NOT abort the caller). */
@@ -141,6 +143,9 @@ export function makeRealGitRunner(): GitRunner {
     },
     branchShowCurrent(repoPath: string): Promise<string> {
       return gitOut(repoPath, ['branch', '--show-current']);
+    },
+    headSha(repoPath: string): Promise<string> {
+      return gitOut(repoPath, ['rev-parse', 'HEAD']);
     },
     async symbolicRefDefault(repoPath: string): Promise<string> {
       const out = await gitOut(repoPath, ['symbolic-ref', '--quiet', '--short', 'refs/remotes/origin/HEAD']);

--- a/packages/node/saga-stack-cli/src/runtime/index.ts
+++ b/packages/node/saga-stack-cli/src/runtime/index.ts
@@ -40,3 +40,4 @@ export * from './set-store.js';
 export * from './slot-active.js';
 export * from './set-check.js';
 export * from './lock.js';
+export * from './checkpoint-store.js';


### PR DESCRIPTION
Implements **M14-A+B** of `plans/11-e2e-stage-snapshots.md` (chained on the M13 PR #236 branch): bake a DB checkpoint after each green progressive stage, then `--from <stage>` restores the predecessor and starts Playwright mid-flow instead of replaying stages 1..N-1.

## Live validation (slot 0 + set wta on slot 1)
- Bake `journey --through program --snapshot-stages`: stage-1 spawn keeps its config deps (the `stage-0-coherence` gate rides along), stage-2 runs `--no-deps`; checkpoints `flow-saga-dash-journey-s{1,2}-*` written. **44.9s**.
- `--from program`: restore + stage-2 only — **5.8s wall-clock, green**, baked occurrence date reused verbatim.
- Inside `--set wta` (slot 1): bake + `--from` green, checkpoints in `~/.saga-mesh/snapshots-s1/` (slot 0's root untouched) — M13 synergy for free.

## Design highlights
- **Per-stage spawn ladder only when needed**: the default path is byte-identical (one terminal-project spawn; Playwright's config-side dependency chain replays 1..N). Bake/`--from` spawn per stage with `--no-deps` (Playwright 1.61 supports it; verified).
- **Validity model (§2)**: prefixHash over the producing stage defs + flow seed/env (HARD), staleness cliff on **max(bakedAt, occurrenceDate) age** (HARD, `--from-stale-ok` downgrades — keyed on both so `--from --snapshot-stages` re-bakes can't launder ancient dates), seed-profile match, the existing schema-ahead guard, **plus two guards the adversarial review added**: the checkpoint must COVER the window's DB needs, and a checkpoint BEHIND the local migration head is refused (checkpoints are replay substitutes — the generic snapshot guard only catches AHEAD). SPA-HEAD drift is stamped at bake (`GitRunner.headSha`) and WARN-only at restore.
- `--from` composes with `--through`/`--set`/`--slot`; mutually exclusive with `--skip-reset`; stack-lane + progressive-only gates; missing checkpoint errors list what IS baked.

## Review + verification
- Multi-agent adversarial review: 15 findings raised, **14 confirmed, all fixed** in `d683210` (incl. the three majors above + test gaps: per-stage env identity, manifest-dates==spawn-env, TERM_END reuse, dry-run JSON shape).
- 861 tests green (825 base + 36), tsc/build/lint clean.

## Deferred (M14-C per plan)
Prerequisite-via-checkpoint (`connect-session` restoring journey@schedule), `snapshot list` flow-column rendering, docs page. V2's real day-boundary date-coherence is covered by tamper-based int tests today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)