### PR TITLE
gh_214 M15: simplify pass — dead surface, one repo-context builder, shared test harnesses, comment diet (zero behavior change)

### DIFF
--- a/packages/node/saga-stack-cli/src/__tests__/helpers/env.ts
+++ b/packages/node/saga-stack-cli/src/__tests__/helpers/env.ts
@@ -1,0 +1,71 @@
+/**
+ * Shared process.env test scaffolding (M15-C test-harness consolidation).
+ *
+ * `useTempSnapshotsDir` is the ONE place that guarantees the snapshot root a
+ * test writes to is a throwaway temp dir. The hazard is real (the M13 lesson):
+ * the snapshot/checkpoint stores resolve their root from
+ * `$SAGA_MESH_SNAPSHOTS_DIR` and fall back to the REAL `~/.saga-mesh` under
+ * $HOME — a test that forgets to point the env var at a temp dir will read
+ * (or restore from!) the developer's actual snapshots, and one once WROTE
+ * there. Every suite that touches the snapshot root goes through this helper
+ * so the mkdtemp + env-set + rm/delete teardown can never drift out of sync.
+ *
+ * Per-test fresh dir: the helper registers its own vitest beforeEach/afterEach
+ * (matching how the suites used the inline pattern), so each test gets a brand
+ * new empty root and teardown always removes it and unsets the env var.
+ *
+ * `saveEnv`/`restoreEnv` capture the exact save-and-restore shape the suites
+ * used inline (up-native's SLOT_ENV_KEYS block, slot-guard's single key): a
+ * key that was UNSET at save time is deleted at restore time, not set to
+ * the string 'undefined'.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach } from 'vitest';
+
+/**
+ * Point `$SAGA_MESH_SNAPSHOTS_DIR` at a fresh mkdtemp root for EVERY test in
+ * the calling file (call at the top level, outside describe). Returns a getter
+ * for the current test's dir — only valid while a test is running.
+ */
+export function useTempSnapshotsDir(prefix: string): () => string {
+  let dir: string | undefined;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), prefix));
+    process.env.SAGA_MESH_SNAPSHOTS_DIR = dir;
+  });
+
+  afterEach(() => {
+    if (dir !== undefined) rmSync(dir, { recursive: true, force: true });
+    dir = undefined;
+    delete process.env.SAGA_MESH_SNAPSHOTS_DIR;
+  });
+
+  return () => {
+    if (dir === undefined) {
+      throw new Error('useTempSnapshotsDir: no active test — the temp dir only exists inside a test');
+    }
+    return dir;
+  };
+}
+
+/** Opaque snapshot of a set of env keys' values (undefined = key was unset). */
+export type EnvSnapshot = ReadonlyMap<string, string | undefined>;
+
+/** Capture the current values of `keys` so `restoreEnv` can put them back. */
+export function saveEnv(keys: readonly string[]): EnvSnapshot {
+  const values = new Map<string, string | undefined>();
+  for (const k of keys) values.set(k, process.env[k]);
+  return values;
+}
+
+/** Restore a `saveEnv` snapshot: unset keys are deleted, set keys re-assigned. */
+export function restoreEnv(snapshot: EnvSnapshot): void {
+  for (const [k, v] of snapshot) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+}

--- a/packages/node/saga-stack-cli/src/__tests__/helpers/pw.ts
+++ b/packages/node/saga-stack-cli/src/__tests__/helpers/pw.ts
@@ -1,0 +1,34 @@
+/**
+ * Playwright child-argv builder (M15-C test-harness consolidation, T5).
+ *
+ * Mirrors the argv assembly in e2e-orchestrate.ts (`exec playwright test
+ * --config=… --project <p> [--no-deps] [--grep-invert <tag>] [--headed]`) for
+ * VARIANT exact-array assertions — the ones that differ from the golden pin
+ * only in project/flags. The config is pinned to the bundled example's
+ * `playwright.stack.config.ts`, which is what every hermetic suite resolves.
+ *
+ * INTENTIONALLY NOT USED for the golden anchors: run.int.test.ts's happy-path
+ * exact-array pin and the two --dry-run prose strings (run.int + e2e.int) stay
+ * fully literal so a regression in the argv/prose SHAPE itself can never be
+ * masked by this builder drifting in the same direction.
+ */
+
+export interface PwArgvOptions {
+  /** Playwright `--project` (the terminal stage). */
+  project: string;
+  /** Append `--headed` (foreground flows). */
+  headed?: boolean;
+  /** Append `--no-deps` (checkpoint window runs break the stage chain). */
+  noDeps?: boolean;
+  /** Append `--grep-invert <tag>` (pipeline runs exclude e.g. `@interactive`). */
+  grepInvert?: string;
+}
+
+/** Build the expected `pnpm` args array for a spawned Playwright child. */
+export function pwArgv(opts: PwArgvOptions): string[] {
+  const argv = ['exec', 'playwright', 'test', '--config=playwright.stack.config.ts', '--project', opts.project];
+  if (opts.noDeps) argv.push('--no-deps');
+  if (opts.grepInvert !== undefined) argv.push('--grep-invert', opts.grepInvert);
+  if (opts.headed) argv.push('--headed');
+  return argv;
+}

--- a/packages/node/saga-stack-cli/src/__tests__/helpers/seams.ts
+++ b/packages/node/saga-stack-cli/src/__tests__/helpers/seams.ts
@@ -1,0 +1,167 @@
+/**
+ * Shared BaseCommand seam battery (M15-C test-harness consolidation).
+ *
+ * `installCoreSeams` is the ONE copy of the fake-seam recipe that the four
+ * native-orchestration suites (run.int / e2e.int / checkpoint.int in
+ * commands/e2e, up-native.int in commands/stack) each hand-rolled: a recording
+ * `ServiceLauncher`, silent `MeshExec`/`PortProbe`/`DashFs`/`HealthProber`
+ * fakes, the Runner-with-CREATE-DATABASE-tracker, the STATEFUL `PgProbe` it
+ * backs, and the `getPrepFreshCheck`/`getDbGenerateScan`/`getRepoDirCheck`
+ * predicate spies — all installed on `BaseCommand.prototype` via `vi.spyOn`,
+ * so `vi.restoreAllMocks()` in the caller's afterEach tears them down.
+ *
+ * The load-bearing divergences between the old copies are EXPLICIT REQUIRED
+ * options — every call site states them; there is no silent shared default:
+ *
+ * - `pidBase` — the fake launch pid floor (run.int/checkpoint used 3000,
+ *   e2e.int/up-native 2000). Cosmetic, but pinned per-suite to keep the
+ *   converted suites byte-equivalent to their hand-rolled fakes.
+ * - `prepFresh` — what `getPrepFreshCheck` answers. `true` (run.int/
+ *   checkpoint) reports every repo fresh so the R1 prep build is SKIPPED;
+ *   `false` (e2e.int/up-native) makes R1 run (the fixed `/fixed/dev` paths
+ *   don't exist, so the real check would never report fresh). This changes
+ *   which `runs` the suites observe — it must never default silently.
+ *
+ * Stateful pgProbe (mirrors the up-native original): a DB is ABSENT until the
+ * Runner sees R2 provision's `CREATE DATABASE <name>` psql, after which it
+ * EXISTS — so provision CREATEs each closure DB and the later R4/reset
+ * existence probe truncates rather than skips (the live-run BUG 2). The
+ * returned `provisioned` set is the tracker itself: up-native PRE-SEEDS the
+ * playback trio (their services create those DBs, not R2 provision).
+ *
+ * Composition: suites layer their extras ON TOP after calling this —
+ * checkpoint re-spies `getSnapshotIO` (helpers/snapshot-io.ts), up-native
+ * re-spies `getMeshExec`/`getDashFs` with RECORDING fakes and adds its
+ * login/git/vite/tunnel/record seams. Re-`vi.spyOn` on an already-spied
+ * method returns the same spy, so `.mockReturnValue` cleanly replaces the
+ * core fake without stacking.
+ */
+
+import { vi } from 'vitest';
+import { BaseCommand } from '../../base-command.js';
+import type {
+  DashFs,
+  HealthProber,
+  LaunchResult,
+  LaunchSpec,
+  MeshExec,
+  PgProbe,
+  PortProbe,
+  ProbeResult,
+  RunResult,
+  Runner,
+  ScriptInvocation,
+  ServiceLauncher,
+  StopResult,
+} from '../../runtime/index.js';
+
+export interface CoreSeamsOptions {
+  /** Fake launch pid floor (pid = pidBase + launch ordinal). EXPLICIT at every call site. */
+  pidBase: number;
+  /**
+   * `getPrepFreshCheck` answer. EXPLICIT at every call site: `true` skips the
+   * R1 prep build (run.int/checkpoint), `false` runs it (e2e.int/up-native).
+   */
+  prepFresh: boolean;
+  /** Service ids whose launch reports health-down (`ok: false`). */
+  launchFail?: Set<string>;
+  /**
+   * Fail (exit 1) any Playwright child whose args include this token —
+   * checkpoint.int's RED-stage lever. Non-Playwright runs still exit 0.
+   */
+  playwrightFail?: string;
+  /** Also return the `getLauncher` spy (run.int asserts its state-dir argument). */
+  captureLauncherSpy?: boolean;
+}
+
+export interface CoreSeams {
+  /** Every LaunchSpec the fake launcher received, in launch order. */
+  launches: LaunchSpec[];
+  /** Every ScriptInvocation the fake Runner received, in run order. */
+  runs: ScriptInvocation[];
+  /**
+   * The CREATE-DATABASE tracker backing the stateful pgProbe. Mutable on
+   * purpose: up-native pre-seeds the playback trio before any test runs.
+   */
+  provisioned: Set<string>;
+  /** Present only when `captureLauncherSpy` was set. */
+  launcherSpy?: ReturnType<typeof vi.spyOn>;
+}
+
+/** Install the shared fake-seam battery on BaseCommand.prototype. */
+export function installCoreSeams(opts: CoreSeamsOptions): CoreSeams {
+  const launchFail = opts.launchFail ?? new Set<string>();
+  const launches: LaunchSpec[] = [];
+  const runs: ScriptInvocation[] = [];
+
+  const launcher: ServiceLauncher = {
+    async launch(spec: LaunchSpec): Promise<LaunchResult> {
+      launches.push(spec);
+      return { id: spec.id, ok: !launchFail.has(spec.id), pid: opts.pidBase + launches.length };
+    },
+    async stopServices(ids: string[]): Promise<StopResult[]> {
+      return ids.map((id) => ({ id, stopped: true }));
+    },
+  };
+  const meshExec: MeshExec = { async ready(): Promise<boolean> { return true; } };
+  const portProbe: PortProbe = {
+    async dockerHolder(): Promise<string | null> { return null; },
+    async listening(): Promise<boolean> { return false; },
+  };
+  const dashFs: DashFs = { existsDir: () => true, existsFile: () => false, remove: () => {}, write: () => {} };
+  const prober: HealthProber = { async probe(): Promise<ProbeResult> { return { ok: true, status: 200 }; } };
+
+  // Runner + CREATE DATABASE tracker: R2 provision's `psql -c "CREATE DATABASE
+  // <name>"` marks the DB present for the stateful pgProbe below.
+  const provisioned = new Set<string>();
+  const runner: Runner = {
+    async run(spec: ScriptInvocation): Promise<RunResult> {
+      runs.push(spec);
+      const ci = spec.args.indexOf('-c');
+      if (ci >= 0) {
+        const m = /CREATE DATABASE (\w+)/.exec(spec.args[ci + 1] ?? '');
+        if (m) provisioned.add(m[1]);
+      }
+      if (
+        opts.playwrightFail !== undefined &&
+        spec.args.includes('playwright') &&
+        spec.args.includes(opts.playwrightFail)
+      ) {
+        return { code: 1 };
+      }
+      return { code: 0 };
+    },
+  };
+  // Stateful existence (absent until provision CREATEs it) so provision CREATEs
+  // each closure DB and reset then sees it present + truncates; table-empty so
+  // migrate takes the `empty → db:deploy` branch (migrate consults
+  // hasMigrationsTable/publicTableCount, NOT databaseExists).
+  const pgProbe: PgProbe = {
+    async databaseExists(_c, db): Promise<boolean> { return provisioned.has(db); },
+    async hasMigrationsTable(): Promise<boolean> { return false; },
+    async publicTableCount(): Promise<number> { return 0; },
+    async scalar(): Promise<string> { return ''; },
+  };
+
+  const proto = BaseCommand.prototype as unknown as Record<string, () => unknown>;
+  const launcherSpy = vi.spyOn(proto, 'getLauncher').mockReturnValue(launcher);
+  vi.spyOn(proto, 'getMeshExec').mockReturnValue(meshExec);
+  vi.spyOn(proto, 'getPortProbe').mockReturnValue(portProbe);
+  vi.spyOn(proto, 'getDashFs').mockReturnValue(dashFs);
+  vi.spyOn(proto, 'getProber').mockReturnValue(prober);
+  vi.spyOn(proto, 'getRunner').mockReturnValue(runner);
+  vi.spyOn(proto, 'getPgProbe').mockReturnValue(pgProbe);
+  vi.spyOn(proto, 'getPrepFreshCheck').mockReturnValue(() => opts.prepFresh);
+  vi.spyOn(proto, 'getDbGenerateScan').mockReturnValue(() => []);
+  // Fake workspace paths (--dev /fixed/dev) don't exist on disk; report every
+  // repo present so no service is skipped. Suites that test the skip-when-absent
+  // path re-spy this per test.
+  vi.spyOn(proto, 'getRepoDirCheck').mockReturnValue(() => true);
+
+  return {
+    launches,
+    runs,
+    provisioned,
+    ...(opts.captureLauncherSpy ? { launcherSpy } : {}),
+  };
+}

--- a/packages/node/saga-stack-cli/src/__tests__/helpers/set-fakes.ts
+++ b/packages/node/saga-stack-cli/src/__tests__/helpers/set-fakes.ts
@@ -1,0 +1,164 @@
+/**
+ * Shared set-command fakes (M15-C test-harness consolidation).
+ *
+ * One home for the seam spies the `set …` integration suites (set-commands /
+ * set-flag / set-preflight) previously each declared inline: the canned set
+ * store, the canned git runner, the pinned fresh-check, the canned slot
+ * activity probe, and the zero-IO probe command. Everything is spied on
+ * `BaseCommand.prototype` — mirroring how `getRunner`/`getGitRunner`/… are
+ * mocked everywhere else — so the spies apply to every command class and are
+ * torn down by the suites' own `vi.restoreAllMocks()`.
+ *
+ * Deliberately parameterized, never defaulted, where the suites diverge:
+ * `spyPrepFresh` REQUIRES the prebuilt verdict, `spySlotActive` REQUIRES the
+ * active-project list, and `makeProbeCommand` REQUIRES each call site to name
+ * whether the probe runs the M13-B preflight. Store FIXTURES stay in the
+ * tests — the scenario deltas (slot bindings, createdFrom drift, which repo a
+ * set pins) are the point of each test — except the two shapes repeated
+ * verbatim across suites (`oneSetWithSagaDash`, `twoSetsSharingCheckout`).
+ */
+
+import { Flags } from '@oclif/core';
+import type { Config } from '@oclif/core';
+import { vi } from 'vitest';
+import { BaseCommand } from '../../base-command.js';
+import { parseWorktreeSetsFile } from '../../core/set/index.js';
+import type { GitRunner, SetStore, SlotActiveProbe } from '../../runtime/index.js';
+
+/** Canned path every faked store reports; asserted verbatim by `set list`. */
+export const CANNED_STORE_PATH = '/canned/worktree-sets.json';
+
+/**
+ * Spy `getSetStore` to a canned store: `load()` runs the REAL
+ * `parseWorktreeSetsFile` over `data`, so schema violations still throw
+ * exactly as they would off disk.
+ */
+export function spySetStore(data: unknown): void {
+  const store: SetStore = {
+    path: () => CANNED_STORE_PATH,
+    load: () => parseWorktreeSetsFile(data),
+  };
+  vi.spyOn(
+    BaseCommand.prototype as unknown as { getSetStore: () => SetStore },
+    'getSetStore',
+  ).mockReturnValue(store);
+}
+
+/**
+ * Spy `getGitRunner` to a canned runner: `branches` maps repoPath → current
+ * branch (unknown paths report 'main'), `porcelain` is the status output
+ * (default clean), and any path in `nonCheckouts` fails `revParseVerify`.
+ */
+export function spyGitRunner(
+  opts: { branches?: Record<string, string>; porcelain?: string; nonCheckouts?: string[] } = {},
+): void {
+  const fake: Partial<GitRunner> = {
+    branchShowCurrent: async (repoPath: string) => opts.branches?.[repoPath] ?? 'main',
+    statusPorcelain: async () => opts.porcelain ?? '',
+    revParseVerify: async (repoPath: string) => !(opts.nonCheckouts ?? []).includes(repoPath),
+  };
+  vi.spyOn(
+    BaseCommand.prototype as unknown as { getGitRunner: () => GitRunner },
+    'getGitRunner',
+  ).mockReturnValue(fake as GitRunner);
+}
+
+/** Pin `getPrepFreshCheck` so EVERY root reports the given prebuilt verdict. */
+export function spyPrepFresh(prebuilt: boolean): void {
+  vi.spyOn(
+    BaseCommand.prototype as unknown as { getPrepFreshCheck: () => (root: string) => boolean },
+    'getPrepFreshCheck',
+  ).mockReturnValue(() => prebuilt);
+}
+
+/**
+ * Spy `getSlotActiveProbe` so exactly the named projects (e.g. 'soa-s2')
+ * report active. Pass `[]` to pin the probe INACTIVE so no test ever consults
+ * docker/state dirs. Re-callable inside a test to override the value a
+ * beforeEach installed (vitest returns the existing spy on a re-spy).
+ */
+export function spySlotActive(activeProjects: string[]): void {
+  const probe: SlotActiveProbe = {
+    isActive: async (_state, project) => activeProjects.includes(project),
+  };
+  vi.spyOn(
+    BaseCommand.prototype as unknown as { getSlotActiveProbe: () => SlotActiveProbe },
+    'getSlotActiveProbe',
+  ).mockReturnValue(probe);
+}
+
+/** What a `makeProbeCommand` class exposes to the tests. */
+export interface ProbeCommandClass {
+  /** The post-injection parsed flag bag from the most recent run. */
+  captured: Record<string, unknown>;
+  run(argv: string[], config: Config): Promise<unknown>;
+}
+
+/**
+ * Zero-IO probe command factory unifying the set-flag suite's SetProbe and
+ * the set-preflight suite's PreflightProbe: always slot-aware, records the
+ * post-injection parsed flags on the static `captured` — every real command
+ * reads the same parsed bag, so what the probe sees is what up/status/e2e/…
+ * see. Each divergence between the two originals is an EXPLICIT option:
+ *
+ * - `setAware`     — whether the central --set guard admits the command.
+ * - `allowPrimary` — define the `--allow-primary` boolean flag (default
+ *                    false), as `stack up`/`e2e run` do.
+ * - `preflight`    — run the M13-B `runSetPreflight` after parsing (parse +
+ *                    preflight, nothing else). Keep false to probe the
+ *                    parse-choke-point injection alone.
+ */
+export function makeProbeCommand(opts: {
+  setAware?: boolean;
+  allowPrimary?: boolean;
+  preflight?: boolean;
+}): ProbeCommandClass {
+  const { setAware = true, allowPrimary = false, preflight = false } = opts;
+
+  class ProbeCommand extends BaseCommand {
+    static flags = {
+      ...BaseCommand.baseFlags,
+      ...(allowPrimary ? { 'allow-primary': Flags.boolean({ default: false }) } : {}),
+    };
+
+    static captured: Record<string, unknown> = {};
+
+    protected slotAware(): boolean {
+      return true;
+    }
+
+    protected setAware(): boolean {
+      return setAware;
+    }
+
+    async run(): Promise<void> {
+      const { flags } = await this.parse(ProbeCommand);
+      ProbeCommand.captured = flags as Record<string, unknown>;
+      if (preflight) await this.runSetPreflight(flags);
+    }
+  }
+
+  return ProbeCommand as unknown as ProbeCommandClass;
+}
+
+/**
+ * The single-repo store shape repeated verbatim across the check/preflight
+ * tests: one set `x` on slot 1 pinning only saga-dash at `path`.
+ */
+export function oneSetWithSagaDash(path: string): unknown {
+  return { version: 1, sets: { x: { slot: 1, repos: { 'saga-dash': path } } } };
+}
+
+/**
+ * The cross-set collision fixture: sets `a`@1 and `b`@2 both pinning
+ * rostering at the SAME checkout `path`.
+ */
+export function twoSetsSharingCheckout(path: string): unknown {
+  return {
+    version: 1,
+    sets: {
+      a: { slot: 1, repos: { rostering: path } },
+      b: { slot: 2, repos: { rostering: path } },
+    },
+  };
+}

--- a/packages/node/saga-stack-cli/src/__tests__/helpers/snapshot-io.ts
+++ b/packages/node/saga-stack-cli/src/__tests__/helpers/snapshot-io.ts
@@ -1,0 +1,80 @@
+/**
+ * Shared fake `SnapshotIO` (M15-C test-harness consolidation).
+ *
+ * Unifies the two hand-rolled copies that lived in snapshot.int.test.ts and
+ * checkpoint.int.test.ts: every call is recorded into the caller-owned
+ * `ioCalls` array, and each "dump" writes a few canned bytes so the manifest /
+ * sizes / validate gate stay REAL fs operations against the temp snapshots
+ * root. No container, DB, or pg_dump/mongodump binary is ever touched.
+ *
+ * The load-bearing divergences between the old copies are EXPLICIT options —
+ * pass them at every call site rather than leaning on the defaults:
+ *
+ * - `schemaRev` — what `readSchemaRev` reports for every migration DB.
+ *   snapshot.int.test.ts passes its canned rev so the restore snapshot-ahead
+ *   guard has a real rev to check; checkpoint.int.test.ts passes `null`,
+ *   which keeps the schema-ahead guard INERT there (the guard has its own
+ *   hard-guard coverage in snapshot.int.test.ts — the checkpoint suite owns
+ *   the FLOW-level compat rules instead).
+ * - `pgRestoreOk` — what `pgRestoreList` (validate --deep's per-dump check)
+ *   answers; `false` simulates a corrupt dump.
+ *
+ * NOTE the fake captures the `ioCalls` ARRAY REFERENCE — reset it between
+ * phases with `ioCalls.length = 0`, never by reassigning the variable.
+ */
+
+import { writeFileSync } from 'node:fs';
+import type { SnapshotIO } from '../../runtime/index.js';
+
+/** One recorded SnapshotIO call (superset of both suites' shapes). */
+export interface SnapshotIOCall {
+  op: string;
+  db?: string;
+  container?: string;
+  ownerRole?: string;
+  path?: string;
+}
+
+export function fakeSnapshotIO(opts: {
+  /** Caller-owned recording array — the fake pushes every call into it. */
+  ioCalls: SnapshotIOCall[];
+  /** `readSchemaRev` answer; `null` (the default) keeps the schema-ahead guard inert. */
+  schemaRev?: string | null;
+  /** `pgRestoreList` answer (validate --deep); defaults to true (dump readable). */
+  pgRestoreOk?: boolean;
+}): SnapshotIO {
+  const { ioCalls } = opts;
+  return {
+    async pgDump(db, container, ownerRole, outPath) {
+      ioCalls.push({ op: 'pgDump', db, container, ownerRole, path: outPath });
+      writeFileSync(outPath, `PGDUMP:${db}`);
+    },
+    async pgRestore(db, container, ownerRole, inPath) {
+      ioCalls.push({ op: 'pgRestore', db, container, ownerRole, path: inPath });
+    },
+    async mongoDump(container, dbName, outPath) {
+      ioCalls.push({ op: 'mongoDump', db: dbName, container, path: outPath });
+      writeFileSync(outPath, `MONGO:${dbName}`);
+    },
+    async mongoRestore(container, dbName, inPath) {
+      ioCalls.push({ op: 'mongoRestore', db: dbName, container, path: inPath });
+    },
+    async assertPgRunning(container) {
+      ioCalls.push({ op: 'assertPgRunning', container });
+    },
+    async assertMongoRunning(container) {
+      ioCalls.push({ op: 'assertMongoRunning', container });
+    },
+    async readSchemaRev(db, container) {
+      ioCalls.push({ op: 'readSchemaRev', db, container });
+      return opts.schemaRev ?? null;
+    },
+    async redisFlushdb(container) {
+      ioCalls.push({ op: 'redisFlushdb', container });
+    },
+    async pgRestoreList(container, inPath) {
+      ioCalls.push({ op: 'pgRestoreList', container, path: inPath });
+      return opts.pgRestoreOk ?? true;
+    },
+  };
+}

--- a/packages/node/saga-stack-cli/src/base-command.ts
+++ b/packages/node/saga-stack-cli/src/base-command.ts
@@ -100,7 +100,6 @@ import type {
  */
 export type WorkspaceFlags = {
   dev?: string;
-  soa?: string;
 } & Partial<Record<RepoKey, string>>;
 
 /**

--- a/packages/node/saga-stack-cli/src/base-command.ts
+++ b/packages/node/saga-stack-cli/src/base-command.ts
@@ -58,6 +58,8 @@ import {
   makeRealRunner,
   makeRealPrepLock,
   makeRealSetStore,
+  repoContextFromFlags,
+  repoOverridesFromFlags,
   makeRealSnapshotIO,
   makeRealViteClear,
   generateTunnelFleetConfig,
@@ -68,7 +70,6 @@ import {
   scriptCwd,
   stopServices,
   REPO_DEFAULT_DIR,
-  REPO_ENV_VAR,
 } from './runtime/index.js';
 import type {
   ConfirmSeam,
@@ -83,7 +84,6 @@ import type {
   PgProbe,
   PortProbe,
   RepoKey,
-  RepoOverrides,
   Runner,
   ScriptContext,
   SetStore,
@@ -596,12 +596,7 @@ export abstract class BaseCommand extends Command {
    * fleet-config generation).
    */
   protected scriptContextFromFlags(flags: WorkspaceFlags): ScriptContext {
-    const pinned: Partial<Record<ManifestRepoKey, string>> = {};
-    for (const kebab of Object.keys(REPO_ENV_VAR) as (keyof typeof REPO_ENV_VAR)[]) {
-      const value = (flags as unknown as Record<string, string | undefined>)[kebab];
-      if (value) pinned[REPO_ENV_VAR[kebab] as ManifestRepoKey] = value;
-    }
-    return { dev: flags.dev, repoRoots: pinned };
+    return repoContextFromFlags(flags as Record<string, unknown>);
   }
 
   protected buildNativeRuntime(
@@ -721,17 +716,8 @@ export abstract class BaseCommand extends Command {
     // Build BOTH the per-repo override env (for the child process) and the
     // per-repo path-pin map (for locating the script), keyed by the manifest
     // env-var name. `--soa` lands in both because `REPO_ENV_VAR.soa === 'SOA'`.
-    const overrides: RepoOverrides = { dev: flags.dev };
-    const repoRoots: Partial<Record<ManifestRepoKey, string>> = {};
-    for (const repo of Object.keys(REPO_ENV_VAR) as RepoKey[]) {
-      const value = flags[repo];
-      if (value) {
-        overrides[repo] = value;
-        repoRoots[REPO_ENV_VAR[repo] as ManifestRepoKey] = value;
-      }
-    }
-
-    const ctx: ScriptContext = { dev: flags.dev, repoRoots };
+    const overrides = repoOverridesFromFlags(flags as Record<string, unknown>);
+    const ctx = repoContextFromFlags(flags as Record<string, unknown>);
     const command = resolveScript(plan.script, ctx);
     const cwd = scriptCwd(plan.script, ctx);
 
@@ -753,12 +739,7 @@ export abstract class BaseCommand extends Command {
    * up.sh/tunnel.sh/refresh-suite.sh read (`SOA`, `SAGA_DASH`, …).
    */
   protected buildRepoOverrideEnv(flags: WorkspaceFlags): Record<string, string> {
-    const overrides: RepoOverrides = { dev: flags.dev };
-    for (const repo of Object.keys(REPO_ENV_VAR) as RepoKey[]) {
-      const value = flags[repo];
-      if (value) overrides[repo] = value;
-    }
-    return buildRepoEnv(overrides);
+    return buildRepoEnv(repoOverridesFromFlags(flags as Record<string, unknown>));
   }
 
   /**

--- a/packages/node/saga-stack-cli/src/base-command.ts
+++ b/packages/node/saga-stack-cli/src/base-command.ts
@@ -17,6 +17,18 @@
  *     env from the workspace flags) and hands it to the Runner, propagating the
  *     child exit code (read-only commands opt out via `propagateExit:false`).
  *
+ * ── THE SEAM-GETTER PATTERN ──
+ * Roughly two dozen protected `getX()` methods below are injectable SEAMS.
+ * Uniformly: production returns a real implementation (`makeRealX()`) that is
+ * THE single place its real side-effect happens (a spawned child, a network
+ * probe, a `docker exec`, an fs write), and every one is designed to be spied
+ * on the prototype (`BaseCommand.prototype.getX`) so a test can swap in a fake
+ * and assert the PLAN without the real effect. That prototype-spy-ability IS the
+ * test architecture: these getters MUST stay instance methods on the prototype
+ * (never inlined or hoisted to free functions) or the suite loses its seams. So
+ * each getter's own doc below states only WHAT it returns + its load-bearing
+ * side-effect; the spy mechanism is uniform and documented here, once.
+ *
  * Subclass flag sets MUST spread `...BaseCommand.baseFlags` so the shared
  * flags stay attached. Top-level error handling is delegated to oclif's
  * default handler — don't override it.
@@ -163,31 +175,28 @@ export abstract class BaseCommand extends Command {
   }
 
   /**
-   * The injectable worktree-set store seam (M13-A). Production reads
-   * `$SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json`; tests spy this on
-   * the prototype to feed a canned store without fs — mirroring
-   * `getRunner`/`getGitRunner`/`getSnapshotIO`.
+   * The worktree-set store seam (M13-A). Production reads
+   * `$SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json`.
    */
   protected getSetStore(): SetStore {
     return makeRealSetStore();
   }
 
   /**
-   * The injectable slot-activity probe (M13-A `set list` ACTIVE column,
-   * M13-B up-time collision check). Derived LIVE from state-dir pid liveness +
-   * compose containers — no recorded active state. Tests spy this on the
-   * prototype to pin activity without fs/docker.
+   * The slot-activity probe (M13-A `set list` ACTIVE column, M13-B up-time
+   * collision check). Derived LIVE from state-dir pid liveness + compose
+   * containers — no recorded active state.
    */
   protected getSlotActiveProbe(): SlotActiveProbe {
     return makeSlotActiveProbe();
   }
 
   /**
-   * The injectable M14 stage-checkpoint store (`e2e run --snapshot-stages` /
-   * `--from`). Composes the SnapshotIO seam with the caller's ScriptContext
-   * (the schema-ahead guard's migration discovery — `--set` pins included).
-   * MUST be constructed after `applyInstanceEnv` so it targets the slot's
-   * snapshot root + containers. Tests spy this on the prototype.
+   * The M14 stage-checkpoint store (`e2e run --snapshot-stages` / `--from`).
+   * Composes the SnapshotIO seam with the caller's ScriptContext (the
+   * schema-ahead guard's migration discovery — `--set` pins included). MUST be
+   * constructed after `applyInstanceEnv` so it targets the slot's snapshot root
+   * + containers.
    */
   protected getCheckpointStore(ctx: ScriptContext): CheckpointStore {
     return makeCheckpointStore({ io: this.getSnapshotIO(), ctx });
@@ -315,252 +324,207 @@ export abstract class BaseCommand extends Command {
   }
 
   /**
-   * The injectable process seam. Production launches real children; tests spy
-   * this on the prototype to record the `ScriptInvocation` without spawning.
+   * The process seam — production is the only place a real OS child is spawned
+   * for a `ScriptInvocation`.
    */
   protected getRunner(): Runner {
     return makeRealRunner();
   }
 
   /**
-   * The injectable HTTP health-probe seam (M2). Production returns a real
-   * short-timeout `fetch` prober (the only place a real network request is
-   * made); the native `stack status` / `stack verify` tests spy this on the
-   * prototype to return canned `ProbeResult`s without hitting the network or a
-   * running stack — mirroring how `getRunner` is mocked for the process seam.
-   * Provided here as a SEAM; the M2 build phase wires it into status/verify.
+   * The HTTP health-probe seam (M2) — production is a real short-timeout `fetch`
+   * prober (the only place a real network request is made for `stack status` /
+   * `stack verify`).
    */
   protected getProber(): HealthProber {
     return makeRealProber();
   }
 
   /**
-   * The injectable snapshot-IO seam (M3). Production returns
-   * `makeRealSnapshotIO()` — the only place `docker exec
-   * pg_dump/pg_restore/mongodump/mongorestore/psql/redis-cli` is launched; the
-   * `stack snapshot store|restore|list|validate` TESTS spy this on the prototype
-   * to return a fake that records the calls and yields canned bytes, so the
-   * snapshot logic is asserted WITHOUT a real container, DB, or dump file —
-   * mirroring how `getRunner`/`getProber` are mocked for the process/HTTP seams.
+   * The snapshot-IO seam (M3) — production is the only place `docker exec
+   * pg_dump/pg_restore/mongodump/mongorestore/psql/redis-cli` is launched (the
+   * `stack snapshot store|restore|list|validate` DB work).
    */
   protected getSnapshotIO(): SnapshotIO {
     return makeRealSnapshotIO();
   }
 
   /**
-   * The injectable native-launch seam (M4 — native partial-stack). Production
-   * returns `makeRealLauncher()` — the ONLY place a real `pnpm dev` child is
-   * spawned for the native `stack up --only` path (pid file written under
-   * `stateDir`, health-polled). The native partial-stack TESTS spy this on the
-   * prototype to return a fake `ServiceLauncher` that records each `LaunchSpec`
-   * and yields a canned result, so the topo-wave launch order + per-service env +
-   * health gating are asserted WITHOUT spawning a process — mirroring how
-   * `getRunner`/`getProber`/`getSnapshotIO` are mocked. `stateDir` comes from the
-   * `--state-dir` flag so pid/log files land where the rest of the stack expects.
+   * The native-launch seam (M4 — native partial-stack) — production is the ONLY
+   * place a real `pnpm dev` child is spawned for `stack up --only` (pid file
+   * under `stateDir`, health-polled). `stateDir` comes from the `--state-dir`
+   * flag so pid/log files land where the rest of the stack expects.
    */
   protected getLauncher(stateDir?: string): ServiceLauncher {
     return makeRealLauncher({ stateDir });
   }
 
   /**
-   * The injectable native slot-safe service-stopper seam (M7 Phase 3). Production
-   * returns the real `stopServices` (real fs enumeration of `<stateDir>/<id>.pid` +
-   * `process.kill`) — the ONLY place `down --slot N` reaches a slot's dev-server
-   * processes, and it reaches ONLY the pids recorded under the state dir it is given
-   * (never a host-global `pkill`). `stack down` at slot > 0 calls this against the
-   * slot's `profile.stateDir`; the TESTS spy it on the prototype (or drive the raw
-   * `stopServices` with a fake fs + fake killer) to assert the SIGTERM/SIGKILL
-   * targets are EXACTLY that slot's pids WITHOUT touching a real process — mirroring
-   * how `getRunner`/`getLauncher`/… are mocked.
+   * The slot-safe service-stopper seam (M7 Phase 3) — production is real
+   * `stopServices` (fs enumeration of `<stateDir>/<id>.pid` + `process.kill`). It
+   * reaches ONLY the pids recorded under the state dir it is given (never a
+   * host-global `pkill`), so `down --slot N` can't touch a peer slot's processes.
    */
   protected getServiceStopper(): ServiceStopper {
     return (stateDir: string) => stopServices(stateDir);
   }
 
   /**
-   * The injectable mesh-readiness seam (M4). Production returns
-   * `makeRealMeshExec()` — the only place `docker exec <container> …` runs for
-   * mesh readiness gating (pg_isready / redis-cli ping / rabbitmq-diagnostics /
-   * mongosh). Tests substitute a fake so the native `meshUp` readiness poll is
-   * asserted WITHOUT a real container.
+   * The mesh-readiness seam (M4) — production is the only place `docker exec
+   * <container> …` runs for mesh readiness gating (pg_isready / redis-cli ping /
+   * rabbitmq-diagnostics / mongosh).
    */
   protected getMeshExec(): MeshExec {
     return makeRealMeshExec();
   }
 
   /**
-   * The injectable host-port-probe seam (M4). Production returns
-   * `makeRealPortProbe()` — the only place `docker ps` / `ss` / `lsof` run for the
-   * mesh `check_ports` preflight. Tests substitute a fake so the conflict logic is
-   * asserted WITHOUT touching docker or the host socket table.
+   * The host-port-probe seam (M4) — production is the only place `docker ps` /
+   * `ss` / `lsof` run for the mesh `check_ports` preflight.
    */
   protected getPortProbe(): PortProbe {
     return makeRealPortProbe();
   }
 
   /**
-   * The injectable native-prep postgres-probe seam (M8 — R2 provision + R3
-   * migrate). Production returns `makeRealPgProbe()` — the only place the read-only
-   * `docker exec … psql -tAc` probes (pg_database existence / `_prisma_migrations`
-   * presence / public-table count) run for the native prep pass. The native `up`
-   * TESTS spy this on the prototype to return a fake that answers from a script, so
-   * the provision/migrate PLAN is asserted WITHOUT a real container or DB —
-   * mirroring how `getRunner`/`getMeshExec`/… are mocked.
+   * The native-prep postgres-probe seam (M8 — R2 provision + R3 migrate) —
+   * production is the only place the read-only `docker exec … psql -tAc` probes
+   * run (pg_database existence / `_prisma_migrations` presence / public-table
+   * count) for the native prep pass.
    */
   protected getPgProbe(): PgProbe {
     return makeRealPgProbe();
   }
 
   /**
-   * The injectable R1 fresh-repo predicate (M8 — native build/prep). A repo is
-   * "fresh" (prep skipped) only when it is BOTH installed AND built — MAJOR-D: a
+   * The R1 fresh-repo predicate (M8 — native build/prep). A repo is "fresh"
+   * (prep skipped) only when it is BOTH installed AND built — MAJOR-D: a
    * `node_modules`-only check treated an installed-but-unbuilt (or stale-`dist`-
-   * after-`git pull`) repo as fresh, skipped its build, and launched a service from
-   * a missing/stale `dist/` — the exact crash R1 exists to prevent. So this also
-   * requires built output: at least one `packages/node/*` or `apps/node/*` package
-   * has a `dist/` (a repo with no such node workspaces — e.g. saga-dash, a pure
-   * frontend that is install-only anyway — is fresh on `node_modules` alone).
-   * Injected so tests drive R1's fresh-skip WITHOUT touching the filesystem.
+   * after-`git pull`) repo as fresh, skipped its build, and launched a service
+   * from a missing/stale `dist/` (the exact crash R1 exists to prevent). So it
+   * also requires built output (at least one `packages/node/*` or `apps/node/*`
+   * package has a `dist/`); a repo with no node workspaces (saga-dash, a pure
+   * frontend that is install-only anyway) is fresh on `node_modules` alone.
    */
   protected getPrepFreshCheck(): (repoRoot: string) => boolean {
     return (repoRoot: string) => isRepoBuilt(repoRoot);
   }
 
   /**
-   * The injectable R1 `db:generate` scan seam (M8 — BLOCKER-B). Given a repo root,
-   * returns the repo-relative dirs of every `packages/node/*` package that DECLARES
-   * a `db:generate` script — a faithful port of up.sh's
-   * `for dbpkg in $SDS/packages/node/*; grep -q '"db:generate"'` loop (up.sh:1010-1013).
-   * R1 generates ALL of these before the whole-workspace `pnpm build`, so an
-   * ungenerated sibling `*-db` package (chat/insights/transcripts/ledger-db) can't
-   * fail the turbo build. Injected so tests drive R1's db:generate plan WITHOUT fs.
+   * The R1 `db:generate` scan seam (M8 — BLOCKER-B). Given a repo root, returns
+   * the repo-relative dirs of every `packages/node/*` package that DECLARES a
+   * `db:generate` script (a faithful port of up.sh's `packages/node/*` scan). R1
+   * generates ALL of these before the whole-workspace `pnpm build`, so an
+   * ungenerated sibling `*-db` package (chat/insights/transcripts/ledger-db)
+   * can't fail the turbo build.
    */
   protected getDbGenerateScan(): (repoRoot: string) => string[] {
     return (repoRoot: string) => scanDbGenerateDirs(repoRoot);
   }
 
   /**
-   * The injectable dash-config fs seam (M4 — the `sync-dash-local-defaults`
-   * prelaunch hook). Production returns `makeRealDashFs()` (the only place the
-   * dash `config.local.json` is written/removed for the hook); tests substitute a
-   * fake so the hook's mode-for-mode behaviour is asserted WITHOUT real fs IO.
+   * The dash-config fs seam (M4 — the `sync-dash-local-defaults` prelaunch hook)
+   * — production is the only place the dash `config.local.json` is
+   * written/removed for the hook.
    */
   protected getDashFs(): DashFs {
     return makeRealDashFs();
   }
 
   /**
-   * The injectable repo-dir existence check (M4 native partial-stack). Production
-   * returns a real `fs.existsSync` predicate — the native `stack up` path calls it
-   * per service to SKIP (warn, not fail) any service whose sibling-repo checkout is
-   * absent (e.g. the coach repo not cloned). Tests spy this on the prototype to
-   * drive the skip logic WITHOUT touching the filesystem — mirroring how
-   * `getLauncher`/`getMeshExec`/… are mocked. Default (real existsSync) would skip
-   * every service under a fake `--dev` path, so seam-mocking tests must stub it.
+   * The repo-dir existence check (M4 native partial-stack) — production is a real
+   * `fs.existsSync` predicate. The native `stack up` path calls it per service to
+   * SKIP (warn, not fail) any service whose sibling-repo checkout is absent (e.g.
+   * coach not cloned). NOTE: the real default skips every service under a fake
+   * `--dev` path, so seam-mocking tests MUST stub it.
    */
   protected getRepoDirCheck(): (dir: string) => boolean {
     return (dir: string) => existsSync(dir);
   }
 
   /**
-   * The injectable `--record` bring-up seam (Phase 2). Production returns
-   * `makeRealRecordUp()` — the only place the fleek recording docker-compose stack +
-   * CodeArtifact token fetch is shelled. The native `stack up --record` TESTS spy this
-   * on the prototype to assert the record PLAN (services/env) WITHOUT docker/aws —
-   * mirroring how `getLauncher`/`getRunner`/… are mocked.
+   * The `--record` bring-up seam (Phase 2) — production is the only place the
+   * fleek recording docker-compose stack + CodeArtifact token fetch is shelled.
    */
   protected getRecordUp(): RecordUp {
     return makeRealRecordUp();
   }
 
   /**
-   * The injectable `--tunnel` moniker resolver (Phase 2). Production runs the VENDORED
-   * `tunnel.sh moniker` (stdin/stderr on the TTY for the first-run prompt) and returns
-   * the captured moniker; the command composes `<moniker>.<VMS_BASE>` into the tunnel
-   * domain BEFORE building the launch env. Tests spy this on the prototype to return a
-   * fixed moniker WITHOUT spawning tunnel.sh.
+   * The `--tunnel` moniker resolver (Phase 2) — production runs the VENDORED
+   * `tunnel.sh moniker` (stdin/stderr on the TTY for the first-run prompt) and
+   * returns the captured moniker; the command composes `<moniker>.<VMS_BASE>` into
+   * the tunnel domain BEFORE building the launch env.
    */
   protected getTunnelMoniker(): (vendorTunnelSh: string) => Promise<string> {
     return resolveTunnelMoniker;
   }
 
   /**
-   * The injectable `--tunnel` rtsm fleet-config generator (Phase 2). Production returns
-   * `generateTunnelFleetConfig` — renders `<stateDir>/rtsm-fleet-tunnel.json` from the
-   * base `rtsm-fleet-local.json` with the node endpoint swapped to `rtsm.<domain>`, so
-   * rtsm-api's `tunnel_env` FLEET_CONFIG_PATH advertises a browser-reachable node (up.sh
-   * ~2170-2188). Best-effort: returns `null` when the base file can't be read/written.
-   * Tests spy this on the prototype to return a fixed path WITHOUT touching the fs.
+   * The `--tunnel` rtsm fleet-config generator (Phase 2) — production renders
+   * `<stateDir>/rtsm-fleet-tunnel.json` from the base `rtsm-fleet-local.json` with
+   * the node endpoint swapped to `rtsm.<domain>`, so rtsm-api's `tunnel_env`
+   * FLEET_CONFIG_PATH advertises a browser-reachable node. Best-effort: returns
+   * `null` when the base file can't be read/written.
    */
   protected getTunnelFleetGen(): typeof generateTunnelFleetConfig {
     return generateTunnelFleetConfig;
   }
 
   /**
-   * The injectable ff-only git seam (M9 — auto-pull). Production returns
-   * `makeRealGitRunner()` — the only place the read-only git probes + the single
-   * `merge --ff-only` run for the native sibling sync. The native `stack up` TESTS spy
-   * this on the prototype to drive the skip/ff decision WITHOUT a real repo/network —
-   * mirroring how `getRunner`/`getMeshExec`/… are mocked.
+   * The ff-only git seam (M9 — auto-pull) — production is the only place the
+   * read-only git probes + the single `merge --ff-only` run for the native
+   * sibling sync.
    */
   protected getGitRunner(): GitRunner {
     return makeRealGitRunner();
   }
 
   /**
-   * The injectable `gh` seam (M10 — overlay engine). Production returns
-   * `makeRealGhRunner()` — the only place `gh pr view` is spawned (per-repo cwd, to
-   * resolve a numeric PR token to its head branch). The native `stack overlay` TESTS
-   * spy this on the prototype to drive PR resolution WITHOUT a live `gh`/network —
-   * mirroring how `getGitRunner`/`getRunner`/… are mocked.
+   * The `gh` seam (M10 — overlay engine) — production is the only place `gh pr
+   * view` is spawned (per-repo cwd, to resolve a numeric PR token to its head
+   * branch).
    */
   protected getGhRunner(): GhRunner {
     return makeRealGhRunner();
   }
 
   /**
-   * The injectable overlay-file fs seam (M10). Production returns `makeRealOverlayFs()`
-   * — the only place `integration-suite.local.tsv` is read. The native `stack overlay
-   * list`/`apply` (file-driven) TESTS spy this on the prototype to feed canned tsv text
-   * WITHOUT touching the filesystem.
+   * The overlay-file fs seam (M10) — production is the only place
+   * `integration-suite.local.tsv` is read (the file-driven `stack overlay
+   * list`/`apply`).
    */
   protected getOverlayFs(): OverlayFs {
     return makeRealOverlayFs();
   }
 
   /**
-   * The injectable confirm seam (M11 — bootstrap ensure-repos). Production returns
-   * `makeRealConfirm()` (the only place the provisioning prompt reads `process.stdin`);
-   * the `stack bootstrap` TESTS spy this on the prototype to drive the TTY / y-n / no-tty
-   * branches WITHOUT a real terminal — mirroring how `getRunner`/`getGitRunner`/… are mocked.
+   * The confirm seam (M11 — bootstrap ensure-repos) — production is the only
+   * place the provisioning prompt reads `process.stdin`.
    */
   protected getConfirm(): ConfirmSeam {
     return makeRealConfirm();
   }
 
   /**
-   * The injectable cookie-capturing POST seam (M11 — native login). Production returns
-   * `makeRealCookiePoster()` — the only place the devLogin POST is made; the `stack login`
-   * TESTS spy this on the prototype to return canned `Set-Cookie`s WITHOUT a network.
+   * The cookie-capturing POST seam (M11 — native login) — production is the only
+   * place the devLogin POST is made.
    */
   protected getCookiePoster(): CookiePoster {
     return makeRealCookiePoster();
   }
 
   /**
-   * The injectable cookie-jar fs seam (M11 — native login). Production returns
-   * `makeRealJarWriter()` — the only place `<stateDir>/cookies.txt` is written; the
-   * `stack login` TESTS spy this on the prototype to capture the jar bytes WITHOUT fs IO.
+   * The cookie-jar fs seam (M11 — native login) — production is the only place
+   * `<stateDir>/cookies.txt` is written.
    */
   protected getJarWriter(): JarWriter {
     return makeRealJarWriter();
   }
 
   /**
-   * The injectable vite-cache-clear fs seam (M9 — native `restart`). Production returns
-   * `makeRealViteClear()` — the only place the `nuke_vite` `rm -rf` runs. The `stack
-   * restart` TESTS spy this on the prototype to assert the exact cache paths WITHOUT
-   * touching the filesystem.
+   * The vite-cache-clear fs seam (M9 — native `restart`) — production is the only
+   * place the `nuke_vite` `rm -rf` runs.
    */
   protected getViteClear(): ViteClear {
     return makeRealViteClear();
@@ -919,7 +883,7 @@ function isRepoBuilt(repoRoot: string): boolean {
 
 /**
  * BLOCKER-B: scan a repo's `packages/node/*` for every package DECLARING a
- * `db:generate` script, returning their repo-relative dirs (up.sh:1010-1013). A
+ * `db:generate` script, returning their repo-relative dirs (mirrors up.sh's scan loop). A
  * malformed/absent `package.json` is skipped; a missing workspace dir yields `[]`.
  */
 function scanDbGenerateDirs(repoRoot: string): string[] {

--- a/packages/node/saga-stack-cli/src/commands/e2e/__tests__/checkpoint.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/__tests__/checkpoint.int.test.ts
@@ -14,25 +14,13 @@
 import { resolve, join } from 'node:path';
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
+import { useTempSnapshotsDir } from '../../../__tests__/helpers/env.js';
+import { fakeSnapshotIO, type SnapshotIOCall } from '../../../__tests__/helpers/snapshot-io.js';
+import { installCoreSeams } from '../../../__tests__/helpers/seams.js';
 import { Config } from '@oclif/core';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { BaseCommand } from '../../../base-command.js';
-import type {
-  DashFs,
-  HealthProber,
-  LaunchResult,
-  LaunchSpec,
-  MeshExec,
-  PgProbe,
-  PortProbe,
-  ProbeResult,
-  RunResult,
-  Runner,
-  ScriptInvocation,
-  ServiceLauncher,
-  SnapshotIO,
-  StopResult,
-} from '../../../runtime/index.js';
+import type { LaunchSpec, ScriptInvocation, SnapshotIO } from '../../../runtime/index.js';
 import E2eRun from '../run.js';
 
 const PKG_ROOT = process.cwd();
@@ -43,90 +31,35 @@ const CKPT_ROSTER = 'flow-saga-dash-journey-s1-roster';
 const CKPT_PROGRAM = 'flow-saga-dash-journey-s2-program';
 
 let DASH_ROOT: string;
-let snapDir: string;
 let config: Config;
 let launches: LaunchSpec[];
 let runs: ScriptInvocation[];
-let ioCalls: { op: string; db?: string; path?: string }[];
+const ioCalls: SnapshotIOCall[] = [];
 let logged: string[];
 
-/** run.int.test.ts's seam recipe; `playwrightFail` fails children whose args include it. */
+// Hermetic per-test checkpoint root (real files land here — manifest + canned
+// dump bytes), never the developer's real ~/.saga-mesh/snapshots.
+const snapDir = useTempSnapshotsDir('saga-ckpt-');
+
+/**
+ * Compose the shared core-seam battery (helpers/seams.ts) + this suite's
+ * SnapshotIO fake (helpers/snapshot-io.ts) on top. pidBase/prepFresh are
+ * EXPLICIT at this call site by design: pids at 3000+, repos reported FRESH
+ * (R1 prep build skipped) — run.int.test.ts's recipe. `playwrightFail` fails
+ * Playwright children whose args include it (the RED-stage lever).
+ */
 function installSeams(playwrightFail?: string): void {
-  launches = [];
-  runs = [];
+  const seams = installCoreSeams({ pidBase: 3000, prepFresh: true, playwrightFail });
+  launches = seams.launches;
+  runs = seams.runs;
 
-  const launcher: ServiceLauncher = {
-    async launch(spec: LaunchSpec): Promise<LaunchResult> {
-      launches.push(spec);
-      return { id: spec.id, ok: true, pid: 3000 + launches.length };
-    },
-    async stopServices(ids: string[]): Promise<StopResult[]> {
-      return ids.map((id) => ({ id, stopped: true }));
-    },
-  };
-  const meshExec: MeshExec = { async ready(): Promise<boolean> { return true; } };
-  const portProbe: PortProbe = {
-    async dockerHolder(): Promise<string | null> { return null; },
-    async listening(): Promise<boolean> { return false; },
-  };
-  const dashFs: DashFs = { existsDir: () => true, existsFile: () => false, remove: () => {}, write: () => {} };
-  const prober: HealthProber = { async probe(): Promise<ProbeResult> { return { ok: true, status: 200 }; } };
-  const provisioned = new Set<string>();
-  const runner: Runner = {
-    async run(spec: ScriptInvocation): Promise<RunResult> {
-      runs.push(spec);
-      const ci = spec.args.indexOf('-c');
-      if (ci >= 0) {
-        const m = /CREATE DATABASE (\w+)/.exec(spec.args[ci + 1] ?? '');
-        if (m) provisioned.add(m[1]);
-      }
-      if (playwrightFail !== undefined && spec.args.includes('playwright') && spec.args.includes(playwrightFail)) {
-        return { code: 1 };
-      }
-      return { code: 0 };
-    },
-  };
-  const pgProbe: PgProbe = {
-    async databaseExists(_c, db): Promise<boolean> { return provisioned.has(db); },
-    async hasMigrationsTable(): Promise<boolean> { return false; },
-    async publicTableCount(): Promise<number> { return 0; },
-    async scalar(): Promise<string> { return ''; },
-  };
-  const snapshotIO: SnapshotIO = {
-    async pgDump(db, _c, _o, outPath) {
-      ioCalls.push({ op: 'pgDump', db, path: outPath });
-      writeFileSync(outPath, `PGDUMP:${db}`);
-    },
-    async pgRestore(db, _c, _o, inPath) {
-      ioCalls.push({ op: 'pgRestore', db, path: inPath });
-    },
-    async mongoDump(_c, db, outPath) {
-      ioCalls.push({ op: 'mongoDump', db, path: outPath });
-      writeFileSync(outPath, `MONGO:${db}`);
-    },
-    async mongoRestore(_c, db, inPath) {
-      ioCalls.push({ op: 'mongoRestore', db, path: inPath });
-    },
-    async assertPgRunning() { ioCalls.push({ op: 'assertPgRunning' }); },
-    async assertMongoRunning() { ioCalls.push({ op: 'assertMongoRunning' }); },
-    // null ⇒ the snapshot-ahead guard is inert (covered by snapshot.int.test.ts).
-    async readSchemaRev() { return null; },
-    async redisFlushdb() { ioCalls.push({ op: 'redisFlushdb' }); },
-    async pgRestoreList() { return true; },
-  };
-
-  const proto = BaseCommand.prototype as unknown as Record<string, () => unknown>;
-  vi.spyOn(proto, 'getLauncher').mockReturnValue(launcher);
-  vi.spyOn(proto, 'getMeshExec').mockReturnValue(meshExec);
-  vi.spyOn(proto, 'getPortProbe').mockReturnValue(portProbe);
-  vi.spyOn(proto, 'getDashFs').mockReturnValue(dashFs);
-  vi.spyOn(proto, 'getProber').mockReturnValue(prober);
-  vi.spyOn(proto, 'getRunner').mockReturnValue(runner);
-  vi.spyOn(proto, 'getPgProbe').mockReturnValue(pgProbe);
-  vi.spyOn(proto, 'getPrepFreshCheck').mockReturnValue(() => true);
-  vi.spyOn(proto, 'getDbGenerateScan').mockReturnValue(() => []);
-  vi.spyOn(proto, 'getRepoDirCheck').mockReturnValue(() => true);
-  vi.spyOn(proto as unknown as { getSnapshotIO: () => SnapshotIO }, 'getSnapshotIO').mockReturnValue(snapshotIO);
+  // schemaRev: null ⇒ the snapshot-ahead guard is inert (covered by
+  // snapshot.int.test.ts) — this suite owns the FLOW-level compat rules.
+  const snapshotIO: SnapshotIO = fakeSnapshotIO({ ioCalls, schemaRev: null });
+  vi.spyOn(
+    BaseCommand.prototype as unknown as { getSnapshotIO: () => SnapshotIO },
+    'getSnapshotIO',
+  ).mockReturnValue(snapshotIO);
 }
 
 function ws(): string[] {
@@ -138,11 +71,11 @@ function playwrightRuns(): ScriptInvocation[] {
 }
 
 function readCkptManifest(fixtureId: string): Record<string, unknown> {
-  return JSON.parse(readFileSync(join(snapDir, fixtureId, 'manifest.json'), 'utf8')) as Record<string, unknown>;
+  return JSON.parse(readFileSync(join(snapDir(), fixtureId, 'manifest.json'), 'utf8')) as Record<string, unknown>;
 }
 
 function writeCkptManifest(fixtureId: string, m: Record<string, unknown>): void {
-  writeFileSync(join(snapDir, fixtureId, 'manifest.json'), JSON.stringify(m, null, 2) + '\n');
+  writeFileSync(join(snapDir(), fixtureId, 'manifest.json'), JSON.stringify(m, null, 2) + '\n');
 }
 
 /** Bake checkpoints for stages 1-2 (roster, program) — the shared setup for --from tests. */
@@ -159,9 +92,7 @@ afterAll(() => {
 
 beforeEach(async () => {
   config = await Config.load(PKG_ROOT);
-  snapDir = mkdtempSync(join(tmpdir(), 'saga-ckpt-'));
-  process.env.SAGA_MESH_SNAPSHOTS_DIR = snapDir;
-  ioCalls = [];
+  ioCalls.length = 0;
   installSeams();
   logged = [];
   vi.spyOn(BaseCommand.prototype, 'log').mockImplementation((m?: string) => {
@@ -172,8 +103,6 @@ beforeEach(async () => {
 
 afterEach(() => {
   vi.restoreAllMocks();
-  rmSync(snapDir, { recursive: true, force: true });
-  delete process.env.SAGA_MESH_SNAPSHOTS_DIR;
 });
 
 describe('--snapshot-stages (bake)', () => {
@@ -303,8 +232,8 @@ describe('--from (restore)', () => {
 
     // With SOME stages baked, the error names them.
     await bakeThroughProgram();
-    rmSync(join(snapDir, CKPT_PROGRAM), { recursive: true, force: true });
-    rmSync(join(snapDir, CKPT_ROSTER, 'manifest.json'), { force: true }); // roster unreadable ⇒ not listed
+    rmSync(join(snapDir(), CKPT_PROGRAM), { recursive: true, force: true });
+    rmSync(join(snapDir(), CKPT_ROSTER, 'manifest.json'), { force: true }); // roster unreadable ⇒ not listed
     await expect(
       E2eRun.run(['journey', '--from', 'program', '--headless', ...ws()], config),
     ).rejects.toThrow(/baked stages: \(none\)/);

--- a/packages/node/saga-stack-cli/src/commands/e2e/__tests__/e2e.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/__tests__/e2e.int.test.ts
@@ -22,21 +22,10 @@ import { join } from 'node:path';
 import { Config } from '@oclif/core';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { BaseCommand } from '../../../base-command.js';
-import type {
-  DashFs,
-  HealthProber,
-  LaunchResult,
-  LaunchSpec,
-  MeshExec,
-  PgProbe,
-  PortProbe,
-  ProbeResult,
-  RunResult,
-  Runner,
-  ScriptInvocation,
-  ServiceLauncher,
-  StopResult,
-} from '../../../runtime/index.js';
+import type { LaunchSpec, RunResult, Runner, ScriptInvocation } from '../../../runtime/index.js';
+import { useTempSnapshotsDir } from '../../../__tests__/helpers/env.js';
+import { pwArgv } from '../../../__tests__/helpers/pw.js';
+import { installCoreSeams } from '../../../__tests__/helpers/seams.js';
 import E2eRun from '../run.js';
 import E2eList from '../list.js';
 import E2eConnect from '../connect.js';
@@ -51,77 +40,22 @@ let launches: LaunchSpec[];
 let runs: ScriptInvocation[];
 let logged: string[];
 let warned: string[];
-let snapDir: string;
 
-/** Install fakes for every native-path seam. `launchFail` ids answer health-down. */
+// Hermetic snapshot root: `e2e list` reads it for the M14-C checkpoint
+// annotation — never scan the developer's real ~/.saga-mesh/snapshots.
+useTempSnapshotsDir('saga-e2e-list-');
+
+/**
+ * Compose the shared core-seam battery (helpers/seams.ts). pidBase/prepFresh
+ * are EXPLICIT at this call site by design: pids at 2000+, and NEVER fresh
+ * (the fixed /fixed/dev paths don't exist) ⇒ the R1 prep build runs; repos
+ * reported present so no service is skipped. `launchFail` ids answer
+ * health-down.
+ */
 function installSeams(launchFail: Set<string> = new Set()): void {
-  launches = [];
-  runs = [];
-
-  const launcher: ServiceLauncher = {
-    async launch(spec: LaunchSpec): Promise<LaunchResult> {
-      launches.push(spec);
-      return { id: spec.id, ok: !launchFail.has(spec.id), pid: 2000 + launches.length };
-    },
-    async stopServices(ids: string[]): Promise<StopResult[]> {
-      return ids.map((id) => ({ id, stopped: true }));
-    },
-  };
-  const meshExec: MeshExec = { async ready(): Promise<boolean> { return true; } };
-  const portProbe: PortProbe = {
-    async dockerHolder(): Promise<string | null> { return null; },
-    async listening(): Promise<boolean> { return false; },
-  };
-  const dashFs: DashFs = {
-    existsDir: () => true,
-    existsFile: () => false,
-    remove: () => {},
-    write: () => {},
-  };
-  const prober: HealthProber = {
-    async probe(): Promise<ProbeResult> { return { ok: true, status: 200 }; },
-  };
-  // FLIP 3: the e2e's native prep pass now runs at EVERY slot (including slot 0), so
-  // `StackApi.up` runs R2 provision (CREATE DATABASE) + R3 migrate (pnpm db:deploy)
-  // through this Runner before launch+seed. Track the DBs provision CREATEs so the
-  // pgProbe below reports them present by RESET time (stateful — mirrors up-native).
-  const provisioned = new Set<string>();
-  const runner: Runner = {
-    async run(spec: ScriptInvocation): Promise<RunResult> {
-      runs.push(spec);
-      const ci = spec.args.indexOf('-c');
-      if (ci >= 0) {
-        const m = /CREATE DATABASE (\w+)/.exec(spec.args[ci + 1] ?? '');
-        if (m) provisioned.add(m[1]);
-      }
-      return { code: 0 };
-    },
-  };
-  // FLIP 3: a fake pg probe so slot 0's native prep (R2 provision + R3 migrate) is a
-  // hermetic no-op with NO real docker/postgres. Stateful existence (absent until
-  // provision CREATEs it) so provision CREATEs each closure DB and the reset then
-  // sees them present + truncates; table-empty so migrate takes the `empty → db:deploy`
-  // branch. Mirrors the up-native slot tests' stateful fake.
-  const pgProbe: PgProbe = {
-    async databaseExists(_c, db): Promise<boolean> { return provisioned.has(db); },
-    async hasMigrationsTable(): Promise<boolean> { return false; },
-    async publicTableCount(): Promise<number> { return 0; },
-    async scalar(): Promise<string> { return ''; },
-  };
-
-  const proto = BaseCommand.prototype as unknown as Record<string, () => unknown>;
-  vi.spyOn(proto, 'getLauncher').mockReturnValue(launcher);
-  vi.spyOn(proto, 'getMeshExec').mockReturnValue(meshExec);
-  vi.spyOn(proto, 'getPortProbe').mockReturnValue(portProbe);
-  vi.spyOn(proto, 'getDashFs').mockReturnValue(dashFs);
-  vi.spyOn(proto, 'getProber').mockReturnValue(prober);
-  vi.spyOn(proto, 'getRunner').mockReturnValue(runner);
-  vi.spyOn(proto, 'getPgProbe').mockReturnValue(pgProbe);
-  // Never fresh (fixed /fixed/dev paths don't exist) ⇒ R1 prep build runs; repos
-  // reported present so no service is skipped.
-  vi.spyOn(proto, 'getPrepFreshCheck').mockReturnValue(() => false);
-  vi.spyOn(proto, 'getDbGenerateScan').mockReturnValue(() => []);
-  vi.spyOn(proto, 'getRepoDirCheck').mockReturnValue(() => true);
+  const seams = installCoreSeams({ pidBase: 2000, prepFresh: false, launchFail });
+  launches = seams.launches;
+  runs = seams.runs;
 }
 
 /** Workspace flags: stub saga-dash (no flows.json → bundled fallback) + real soa. */
@@ -143,10 +77,6 @@ afterAll(() => {
 
 beforeEach(async () => {
   config = await Config.load(PKG_ROOT);
-  // Hermetic snapshot root: `e2e list` reads it for the M14-C checkpoint
-  // annotation — never scan the developer's real ~/.saga-mesh/snapshots.
-  snapDir = mkdtempSync(join(tmpdir(), 'saga-e2e-list-'));
-  process.env.SAGA_MESH_SNAPSHOTS_DIR = snapDir;
   installSeams();
   logged = [];
   warned = [];
@@ -160,8 +90,6 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
-  rmSync(snapDir, { recursive: true, force: true });
-  delete process.env.SAGA_MESH_SNAPSHOTS_DIR;
   vi.restoreAllMocks();
 });
 
@@ -178,6 +106,9 @@ describe('e2e run — --dry-run (pure planner, touches no seam)', () => {
     expect(text).toContain('closure (4):');
     expect(text).toMatch(/PLAYWRIGHT_OCCURRENCE_DATE: \d{4}-\d{2}-\d{2}/);
     // journey is foreground ⇒ headed by default; pipeline excludes @interactive.
+    // GOLDEN ANCHOR (T5): this dry-run prose string stays fully literal on
+    // purpose — do NOT rebuild it with helpers/pw.ts's pwArgv, so a drift in
+    // the printed argv shape can never be masked by the builder drifting too.
     expect(text).toContain(
       'pnpm exec playwright test --config=playwright.stack.config.ts --project stage-4-pods --grep-invert @interactive --headed',
     );
@@ -235,16 +166,10 @@ describe('e2e run — native orchestration (stack lane)', () => {
     const pw = playwrightRuns();
     expect(pw).toHaveLength(1);
     expect(pw[0].cwd).toBe(join(DASH_ROOT, 'apps', 'web', 'dash'));
-    expect(pw[0].args).toEqual([
-      'exec',
-      'playwright',
-      'test',
-      '--config=playwright.stack.config.ts',
-      '--project',
-      'stage-1-roster',
-      '--grep-invert',
-      '@interactive',
-    ]);
+    // VARIANT argv (T5): differs from run.int's golden literal pin only in the
+    // project — built with the shared pwArgv (the literal shape protection
+    // lives in run.int.test.ts's happy-path anchor).
+    expect(pw[0].args).toEqual(pwArgv({ project: 'stage-1-roster', grepInvert: '@interactive' }));
     expect(pw[0].env?.PLAYWRIGHT_OCCURRENCE_DATE).toMatch(/^\d{4}-\d{2}-\d{2}$/);
     expect(pw[0].stdio).toBe('inherit');
   });

--- a/packages/node/saga-stack-cli/src/commands/e2e/__tests__/run.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/__tests__/run.int.test.ts
@@ -23,21 +23,9 @@ import { tmpdir } from 'node:os';
 import { Config } from '@oclif/core';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { BaseCommand } from '../../../base-command.js';
-import type {
-  DashFs,
-  HealthProber,
-  LaunchResult,
-  LaunchSpec,
-  MeshExec,
-  PgProbe,
-  PortProbe,
-  ProbeResult,
-  RunResult,
-  Runner,
-  ScriptInvocation,
-  ServiceLauncher,
-  StopResult,
-} from '../../../runtime/index.js';
+import type { LaunchSpec, RunResult, Runner, ScriptInvocation } from '../../../runtime/index.js';
+import { useTempSnapshotsDir } from '../../../__tests__/helpers/env.js';
+import { installCoreSeams } from '../../../__tests__/helpers/seams.js';
 import E2eRun from '../run.js';
 
 const PKG_ROOT = process.cwd();
@@ -51,69 +39,25 @@ let runs: ScriptInvocation[];
 let logged: string[];
 let warned: string[];
 let launcherSpy: ReturnType<typeof vi.spyOn>;
-let snapDir: string;
 
-/** Install fakes for every native-path seam. Ids in `launchFail` answer health-down. */
+// Hermetic snapshot root: prerequisite flows construct a checkpoint store by
+// default (M14-C) — never read (or restore from!) the developer's real
+// ~/.saga-mesh/snapshots in a unit test.
+useTempSnapshotsDir('saga-run-snaps-');
+
+/**
+ * Compose the shared core-seam battery (helpers/seams.ts). pidBase/prepFresh
+ * are EXPLICIT at this call site by design: pids at 3000+, and repos reported
+ * FRESH so the R1 prep build is skipped (FLIP 3's provision/migrate/reset pass
+ * still runs at every slot through the shared Runner + stateful pgProbe).
+ * Ids in `launchFail` answer health-down. The launcher spy is captured — the
+ * M7 slot test asserts the state dir `getLauncher` was called with.
+ */
 function installSeams(launchFail: Set<string> = new Set()): void {
-  launches = [];
-  runs = [];
-
-  const launcher: ServiceLauncher = {
-    async launch(spec: LaunchSpec): Promise<LaunchResult> {
-      launches.push(spec);
-      return { id: spec.id, ok: !launchFail.has(spec.id), pid: 3000 + launches.length };
-    },
-    async stopServices(ids: string[]): Promise<StopResult[]> {
-      return ids.map((id) => ({ id, stopped: true }));
-    },
-  };
-  const meshExec: MeshExec = { async ready(): Promise<boolean> { return true; } };
-  const portProbe: PortProbe = {
-    async dockerHolder(): Promise<string | null> { return null; },
-    async listening(): Promise<boolean> { return false; },
-  };
-  const dashFs: DashFs = { existsDir: () => true, existsFile: () => false, remove: () => {}, write: () => {} };
-  const prober: HealthProber = { async probe(): Promise<ProbeResult> { return { ok: true, status: 200 }; } };
-  // FLIP 3: the native prep pass runs at EVERY slot (including slot 0) now, so
-  // `StackApi.up` runs R2 provision (CREATE DATABASE) + R3 migrate (pnpm db:deploy)
-  // through this Runner before launch+seed. Track the DBs provision CREATEs so the
-  // pgProbe reports them present by RESET time (stateful — mirrors up-native).
-  const provisioned = new Set<string>();
-  const runner: Runner = {
-    async run(spec: ScriptInvocation): Promise<RunResult> {
-      runs.push(spec);
-      const ci = spec.args.indexOf('-c');
-      if (ci >= 0) {
-        const m = /CREATE DATABASE (\w+)/.exec(spec.args[ci + 1] ?? '');
-        if (m) provisioned.add(m[1]);
-      }
-      return { code: 0 };
-    },
-  };
-
-  // FLIP 3 native-prep seams — mocked so the provision/migrate pass is a hermetic
-  // no-op with NO real docker/postgres at ANY slot (including slot 0, where prep is
-  // now wired). Stateful existence (absent until provision CREATEs it) so provision
-  // CREATEs each closure DB and reset then sees it present + truncates; table-empty
-  // so migrate takes the `empty → db:deploy` branch. Mirrors up-native's stateful fake.
-  const pgProbe: PgProbe = {
-    async databaseExists(_c, db): Promise<boolean> { return provisioned.has(db); },
-    async hasMigrationsTable(): Promise<boolean> { return false; },
-    async publicTableCount(): Promise<number> { return 0; },
-    async scalar(): Promise<string> { return ''; },
-  };
-
-  const proto = BaseCommand.prototype as unknown as Record<string, () => unknown>;
-  launcherSpy = vi.spyOn(proto, 'getLauncher').mockReturnValue(launcher);
-  vi.spyOn(proto, 'getMeshExec').mockReturnValue(meshExec);
-  vi.spyOn(proto, 'getPortProbe').mockReturnValue(portProbe);
-  vi.spyOn(proto, 'getDashFs').mockReturnValue(dashFs);
-  vi.spyOn(proto, 'getProber').mockReturnValue(prober);
-  vi.spyOn(proto, 'getRunner').mockReturnValue(runner);
-  vi.spyOn(proto, 'getPgProbe').mockReturnValue(pgProbe);
-  vi.spyOn(proto, 'getPrepFreshCheck').mockReturnValue(() => true);
-  vi.spyOn(proto, 'getDbGenerateScan').mockReturnValue(() => []);
-  vi.spyOn(proto, 'getRepoDirCheck').mockReturnValue(() => true);
+  const seams = installCoreSeams({ pidBase: 3000, prepFresh: true, launchFail, captureLauncherSpy: true });
+  launches = seams.launches;
+  runs = seams.runs;
+  launcherSpy = seams.launcherSpy!;
 }
 
 /** Workspace flags: stub saga-dash (no flows.json → bundled fallback) + real soa. */
@@ -135,11 +79,6 @@ afterAll(() => {
 
 beforeEach(async () => {
   config = await Config.load(PKG_ROOT);
-  // Hermetic snapshot root: prerequisite flows construct a checkpoint store by
-  // default (M14-C) — never read (or restore from!) the developer's real
-  // ~/.saga-mesh/snapshots in a unit test.
-  snapDir = mkdtempSync(join(tmpdir(), 'saga-run-snaps-'));
-  process.env.SAGA_MESH_SNAPSHOTS_DIR = snapDir;
   installSeams();
   logged = [];
   warned = [];
@@ -154,8 +93,6 @@ beforeEach(async () => {
 
 afterEach(() => {
   vi.restoreAllMocks();
-  rmSync(snapDir, { recursive: true, force: true });
-  delete process.env.SAGA_MESH_SNAPSHOTS_DIR;
 });
 
 describe('e2e run — --dry-run plan (touches no seam)', () => {
@@ -174,6 +111,9 @@ describe('e2e run — --dry-run plan (touches no seam)', () => {
     expect(text).toContain('closure (4):');
     expect(text).toMatch(/PLAYWRIGHT_OCCURRENCE_DATE: \d{4}-\d{2}-\d{2}/);
     // --headless flips the foreground default off; terminal project is stage-4-pods.
+    // GOLDEN ANCHOR (T5): this dry-run prose string stays fully literal on
+    // purpose — do NOT rebuild it with helpers/pw.ts's pwArgv, so a drift in
+    // the printed argv shape can never be masked by the builder drifting too.
     expect(text).toContain(
       'pnpm exec playwright test --config=playwright.stack.config.ts --project stage-4-pods --grep-invert @interactive',
     );
@@ -225,6 +165,11 @@ describe('e2e run — native orchestration (stack lane)', () => {
     const pw = playwrightRuns();
     expect(pw).toHaveLength(1);
     expect(pw[0].cwd).toBe(join(DASH_ROOT, 'apps', 'web', 'dash'));
+    // GOLDEN ANCHOR (T5): the happy-path exact-array pin stays fully literal on
+    // purpose — do NOT rebuild it with helpers/pw.ts's pwArgv. It is the one
+    // assertion that protects the spawned argv SHAPE itself (order + every
+    // token); building it with the same helper the variants use would let a
+    // builder bug and an orchestrator bug cancel out.
     expect(pw[0].args).toEqual([
       'exec',
       'playwright',

--- a/packages/node/saga-stack-cli/src/commands/e2e/list.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/list.ts
@@ -61,26 +61,39 @@ export default class E2eList extends BaseCommand {
         const disco = discoverFlowManifest(spaId, flags, process.env);
         const m = disco.manifest;
 
-        /** M14-C per-stage checkpoint verdict: valid | needs-re-bake | none. */
+        /**
+         * M14-C per-stage checkpoint verdict: valid | needs-re-bake | none.
+         * MEMOIZED — each verdict costs a disk read (manifest load), and both
+         * the JSON projection and the text lines consult it per stage.
+         */
+        const ckptCache = new Map<string, 'valid' | 'stale' | null>();
         const ckpt = (f: (typeof m.flows)[number], i: number): 'valid' | 'stale' | null => {
-          if (!f.progressive) return null;
-          const stage = f.stages[i];
-          if (stage === undefined) return null;
-          const manifest = checkpoints.load(checkpointFixtureId(m.spa.id, f.name, stage, i + 1));
-          if (manifest === null) return null;
-          // seedProfile/spaHead deliberately omitted (WARN-only / unknowable here);
-          // identity + prefixHash + staleness give the honest listing verdict.
-          const verdict = evaluateCheckpoint(
-            manifest.flow,
-            {
-              spaId: m.spa.id,
-              flowName: f.name,
-              stageId: stage.id,
-              prefixHash: stagePrefixHash(f, f.stages.slice(0, i + 1)),
-            },
-            now,
-          );
-          return verdict.ok ? 'valid' : 'stale';
+          const key = `${f.name}#${i}`;
+          const hit = ckptCache.get(key);
+          if (hit !== undefined) return hit;
+          const compute = (): 'valid' | 'stale' | null => {
+            if (!f.progressive) return null;
+            const stage = f.stages[i];
+            if (stage === undefined) return null;
+            const manifest = checkpoints.load(checkpointFixtureId(m.spa.id, f.name, stage, i + 1));
+            if (manifest === null) return null;
+            // seedProfile/spaHead deliberately omitted (WARN-only / unknowable here);
+            // identity + prefixHash + staleness give the honest listing verdict.
+            const verdict = evaluateCheckpoint(
+              manifest.flow,
+              {
+                spaId: m.spa.id,
+                flowName: f.name,
+                stageId: stage.id,
+                prefixHash: stagePrefixHash(f, f.stages.slice(0, i + 1)),
+              },
+              now,
+            );
+            return verdict.ok ? 'valid' : 'stale';
+          };
+          const state = compute();
+          ckptCache.set(key, state);
+          return state;
         };
 
         spas.push({

--- a/packages/node/saga-stack-cli/src/commands/set/__tests__/set-commands.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/set/__tests__/set-commands.int.test.ts
@@ -1,8 +1,8 @@
 /**
  * `set list` / `set show` / `set check` (M13-A, plan §2.4) — in-process, every
- * seam faked: set store (canned), slot-activity probe (canned), git runner
- * (canned branches), fresh-check (pinned buildable/prebuilt). Real fs only for
- * mkdtemp worktree stand-ins.
+ * seam faked via the shared set-fakes helpers: set store (canned), slot-activity
+ * probe (canned), git runner (canned branches), fresh-check (pinned
+ * buildable/prebuilt). Real fs only for mkdtemp worktree stand-ins.
  */
 
 import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
@@ -10,57 +10,24 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Config } from '@oclif/core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  oneSetWithSagaDash,
+  spyGitRunner,
+  spyPrepFresh,
+  spySetStore,
+  spySlotActive,
+  twoSetsSharingCheckout,
+} from '../../../__tests__/helpers/set-fakes.js';
 import { BaseCommand } from '../../../base-command.js';
-import { parseWorktreeSetsFile } from '../../../core/set/index.js';
-import type { GitRunner, SetStore, SlotActiveProbe } from '../../../runtime/index.js';
 import SetCheck from '../check.js';
 import SetList from '../list.js';
 import SetShow from '../show.js';
-
-/** Pin the activity probe INACTIVE so no test ever consults docker/state dirs. */
-function spyInactiveProbe(): void {
-  const probe: SlotActiveProbe = { isActive: async () => false };
-  vi.spyOn(
-    BaseCommand.prototype as unknown as { getSlotActiveProbe: () => SlotActiveProbe },
-    'getSlotActiveProbe',
-  ).mockReturnValue(probe);
-}
 
 const PKG_ROOT = process.cwd();
 
 let config: Config;
 let dir: string;
 let logged: string[];
-
-function storeOf(data: unknown): SetStore {
-  return { path: () => '/canned/worktree-sets.json', load: () => parseWorktreeSetsFile(data) };
-}
-
-function spyStore(data: unknown): void {
-  vi.spyOn(
-    BaseCommand.prototype as unknown as { getSetStore: () => SetStore },
-    'getSetStore',
-  ).mockReturnValue(storeOf(data));
-}
-
-function spyGit(branches: Record<string, string>, opts: { porcelain?: string; nonCheckouts?: string[] } = {}): void {
-  const fake: Partial<GitRunner> = {
-    branchShowCurrent: async (repoPath: string) => branches[repoPath] ?? 'main',
-    statusPorcelain: async () => opts.porcelain ?? '',
-    revParseVerify: async (repoPath: string) => !(opts.nonCheckouts ?? []).includes(repoPath),
-  };
-  vi.spyOn(
-    BaseCommand.prototype as unknown as { getGitRunner: () => GitRunner },
-    'getGitRunner',
-  ).mockReturnValue(fake as GitRunner);
-}
-
-function spyFresh(prebuilt: boolean): void {
-  vi.spyOn(
-    BaseCommand.prototype as unknown as { getPrepFreshCheck: () => (root: string) => boolean },
-    'getPrepFreshCheck',
-  ).mockReturnValue(() => prebuilt);
-}
 
 beforeEach(async () => {
   config = await Config.load(PKG_ROOT);
@@ -69,7 +36,8 @@ beforeEach(async () => {
   vi.spyOn(BaseCommand.prototype, 'log').mockImplementation((m) => {
     logged.push(String(m ?? ''));
   });
-  spyInactiveProbe();
+  // Pin the activity probe INACTIVE so no test ever consults docker/state dirs.
+  spySlotActive([]);
 });
 
 afterEach(() => {
@@ -79,18 +47,14 @@ afterEach(() => {
 
 describe('set list', () => {
   it('renders name/slot/ACTIVE/repos, ACTIVE derived live per slot', async () => {
-    spyStore({
+    spySetStore({
       version: 1,
       sets: {
         'journey-fix': { slot: 1, repos: { 'saga-dash': '/wt/dash-j' }, note: 'PR #345' },
         topology: { slot: 2, repos: { 'saga-dash': '/wt/dash-t', rostering: '/wt/rost-c' } },
       },
     });
-    const probe: SlotActiveProbe = { isActive: async (_state, project) => project === 'soa-s1' };
-    vi.spyOn(
-      SetList.prototype as unknown as { getSlotActiveProbe: () => SlotActiveProbe },
-      'getSlotActiveProbe',
-    ).mockReturnValue(probe);
+    spySlotActive(['soa-s1']);
 
     await SetList.run([], config);
     const out = logged.join('\n');
@@ -99,7 +63,7 @@ describe('set list', () => {
   });
 
   it('an empty store points at the sets file', async () => {
-    spyStore({ version: 1, sets: {} });
+    spySetStore({ version: 1, sets: {} });
     await SetList.run([], config);
     expect(logged.join('\n')).toMatch(/No worktree sets defined in \/canned\/worktree-sets\.json/);
   });
@@ -109,7 +73,7 @@ describe('set show', () => {
   it('shows live branch + dirty state + provenance per repo', async () => {
     const dash = join(dir, 'dash');
     mkdirSync(dash);
-    spyStore({
+    spySetStore({
       version: 1,
       sets: {
         x: {
@@ -121,7 +85,7 @@ describe('set show', () => {
         },
       },
     });
-    spyGit({ [dash]: 'feat/x' });
+    spyGitRunner({ branches: { [dash]: 'feat/x' } });
 
     await SetShow.run(['x'], config);
     const out = logged.join('\n');
@@ -131,15 +95,15 @@ describe('set show', () => {
   });
 
   it('unknown set name errors with the known names', async () => {
-    spyStore({ version: 1, sets: { x: { slot: 1, repos: {} } } });
+    spySetStore({ version: 1, sets: { x: { slot: 1, repos: {} } } });
     await expect(SetShow.run(['nope'], config)).rejects.toThrow(/unknown set 'nope'/);
   });
 
   it('an existing NON-git dir renders (not a git checkout), never a clean detached HEAD', async () => {
     const plainDir = join(dir, 'plain');
     mkdirSync(plainDir);
-    spyStore({ version: 1, sets: { x: { slot: 1, repos: { 'saga-dash': plainDir } } } });
-    spyGit({}, { nonCheckouts: [plainDir] });
+    spySetStore(oneSetWithSagaDash(plainDir));
+    spyGitRunner({ nonCheckouts: [plainDir] });
 
     await SetShow.run(['x'], config);
     const out = logged.join('\n');
@@ -152,18 +116,18 @@ describe('set check', () => {
   it('a clean pre-built set is OK (exit 0)', async () => {
     const dash = join(dir, 'dash');
     mkdirSync(dash);
-    spyStore({ version: 1, sets: { x: { slot: 1, repos: { 'saga-dash': dash } } } });
-    spyGit({ [dash]: 'feat/x' });
-    spyFresh(true);
+    spySetStore(oneSetWithSagaDash(dash));
+    spyGitRunner({ branches: { [dash]: 'feat/x' } });
+    spyPrepFresh(true);
 
     await expect(SetCheck.run(['x', '--dev', join(dir, 'dev')], config)).resolves.toBeUndefined();
     expect(logged.join('\n')).toMatch(/✓ x: OK/);
   });
 
   it('a missing path is a violation (exit 1)', async () => {
-    spyStore({ version: 1, sets: { x: { slot: 1, repos: { 'saga-dash': join(dir, 'nope') } } } });
-    spyGit({});
-    spyFresh(true);
+    spySetStore(oneSetWithSagaDash(join(dir, 'nope')));
+    spyGitRunner();
+    spyPrepFresh(true);
 
     await expect(SetCheck.run(['x', '--dev', join(dir, 'dev')], config)).rejects.toMatchObject({
       oclif: { exit: 1 },
@@ -174,12 +138,12 @@ describe('set check', () => {
   it('branch drift against createdFrom WARNS but never blocks', async () => {
     const dash = join(dir, 'dash');
     mkdirSync(dash);
-    spyStore({
+    spySetStore({
       version: 1,
       sets: { x: { slot: 1, repos: { 'saga-dash': { path: dash, createdBy: 'ss', createdFrom: 'feat/x' } } } },
     });
-    spyGit({ [dash]: 'feat/OTHER' });
-    spyFresh(true);
+    spyGitRunner({ branches: { [dash]: 'feat/OTHER' } });
+    spyPrepFresh(true);
 
     await expect(SetCheck.run(['x', '--dev', join(dir, 'dev')], config)).resolves.toBeUndefined();
     expect(logged.join('\n')).toMatch(/⚠ branch drift: @ feat\/OTHER, created from feat\/x/);
@@ -189,10 +153,10 @@ describe('set check', () => {
     const devRoot = join(dir, 'dev');
     const primaryDash = join(devRoot, 'saga-dash');
     mkdirSync(primaryDash, { recursive: true });
-    spyStore({ version: 1, sets: { x: { slot: 1, repos: { 'saga-dash': primaryDash } } } });
-    spyGit({ [primaryDash]: 'main' });
+    spySetStore(oneSetWithSagaDash(primaryDash));
+    spyGitRunner({ branches: { [primaryDash]: 'main' } });
 
-    spyFresh(false);
+    spyPrepFresh(false);
     await expect(SetCheck.run(['x', '--dev', devRoot], config)).rejects.toMatchObject({ oclif: { exit: 1 } });
     expect(logged.join('\n')).toMatch(/BUILDABLE entry points at the primary checkout/);
 
@@ -201,9 +165,9 @@ describe('set check', () => {
     vi.spyOn(BaseCommand.prototype, 'log').mockImplementation((m) => {
       logged.push(String(m ?? ''));
     });
-    spyStore({ version: 1, sets: { x: { slot: 1, repos: { 'saga-dash': primaryDash } } } });
-    spyGit({ [primaryDash]: 'main' });
-    spyFresh(true);
+    spySetStore(oneSetWithSagaDash(primaryDash));
+    spyGitRunner({ branches: { [primaryDash]: 'main' } });
+    spyPrepFresh(true);
     await expect(SetCheck.run(['x', '--dev', devRoot], config)).resolves.toBeUndefined();
     expect(logged.join('\n')).toMatch(/⚠ points at the primary checkout/);
   });
@@ -211,15 +175,9 @@ describe('set check', () => {
   it('two sets sharing one BUILDABLE checkout is a cross-set collision (exit 1)', async () => {
     const shared = join(dir, 'shared-rostering');
     mkdirSync(shared);
-    spyStore({
-      version: 1,
-      sets: {
-        a: { slot: 1, repos: { rostering: shared } },
-        b: { slot: 2, repos: { rostering: shared } },
-      },
-    });
-    spyGit({ [shared]: 'main' });
-    spyFresh(false);
+    spySetStore(twoSetsSharingCheckout(shared));
+    spyGitRunner({ branches: { [shared]: 'main' } });
+    spyPrepFresh(false);
 
     await expect(SetCheck.run(['a', '--dev', join(dir, 'dev')], config)).rejects.toMatchObject({
       oclif: { exit: 1 },
@@ -230,15 +188,9 @@ describe('set check', () => {
   it('--porcelain stays tab-separated and attributes a collision to its repo row', async () => {
     const shared = join(dir, 'shared-rostering');
     mkdirSync(shared);
-    spyStore({
-      version: 1,
-      sets: {
-        a: { slot: 1, repos: { rostering: shared } },
-        b: { slot: 2, repos: { rostering: shared } },
-      },
-    });
-    spyGit({ [shared]: 'main' });
-    spyFresh(false);
+    spySetStore(twoSetsSharingCheckout(shared));
+    spyGitRunner({ branches: { [shared]: 'main' } });
+    spyPrepFresh(false);
 
     await expect(SetCheck.run(['a', '--porcelain', '--dev', join(dir, 'dev')], config)).rejects.toMatchObject({
       oclif: { exit: 1 },
@@ -253,9 +205,9 @@ describe('set check', () => {
   it('an existing NON-git dir is a check violation (exit 1), not a green detached row', async () => {
     const plainDir = join(dir, 'plain');
     mkdirSync(plainDir);
-    spyStore({ version: 1, sets: { x: { slot: 1, repos: { 'saga-dash': plainDir } } } });
-    spyGit({}, { nonCheckouts: [plainDir] });
-    spyFresh(true);
+    spySetStore(oneSetWithSagaDash(plainDir));
+    spyGitRunner({ nonCheckouts: [plainDir] });
+    spyPrepFresh(true);
 
     await expect(SetCheck.run(['x', '--dev', join(dir, 'dev')], config)).rejects.toMatchObject({
       oclif: { exit: 1 },

--- a/packages/node/saga-stack-cli/src/commands/set/__tests__/set-flag.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/set/__tests__/set-flag.int.test.ts
@@ -2,17 +2,18 @@
  * Central --set guard + parse-choke-point injection (M13-A, plan §2-§3).
  *
  * Mirrors slot-guard.unit.test.ts: real command classes, in-process, the
- * set-store seam spied on the prototype. The injection itself is asserted
- * through a minimal probe command (slot/set-aware, records its parsed flags,
- * zero IO) — every real command reads the same parsed bag, so what the probe
- * sees is what up/status/e2e/… see.
+ * set-store seam spied on the prototype (shared set-fakes helpers). The
+ * injection itself is asserted through a minimal probe command (slot/set-aware,
+ * records its parsed flags, zero IO, NO preflight — makeProbeCommand) — every
+ * real command reads the same parsed bag, so what the probe sees is what
+ * up/status/e2e/… see.
  */
 
 import { resolve } from 'node:path';
 import { Config } from '@oclif/core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeProbeCommand, spySetStore } from '../../../__tests__/helpers/set-fakes.js';
 import { BaseCommand } from '../../../base-command.js';
-import { parseWorktreeSetsFile } from '../../../core/set/index.js';
 import type { SetStore } from '../../../runtime/index.js';
 import StackRestart from '../../stack/restart.js';
 
@@ -21,38 +22,16 @@ const SOA_ROOT = resolve(PKG_ROOT, '..', '..', '..');
 const WS = ['--soa', SOA_ROOT, '--dev', '/fixed/dev'];
 
 /** Canned store: journey-fix@1, topology@2 (saga-dash + rostering pinned). */
-function cannedStore(): SetStore {
-  return {
-    path: () => '/canned/worktree-sets.json',
-    load: () =>
-      parseWorktreeSetsFile({
-        version: 1,
-        sets: {
-          'journey-fix': { slot: 1, repos: { 'saga-dash': '/set/dash-journey' } },
-          topology: { slot: 2, repos: { 'saga-dash': '/set/dash-topology', rostering: '/set/rostering-c' } },
-        },
-      }),
-  };
-}
+const CANNED_SETS = {
+  version: 1,
+  sets: {
+    'journey-fix': { slot: 1, repos: { 'saga-dash': '/set/dash-journey' } },
+    topology: { slot: 2, repos: { 'saga-dash': '/set/dash-topology', rostering: '/set/rostering-c' } },
+  },
+};
 
 /** Zero-IO probe: slot/set-aware, records the post-injection flags. */
-class SetProbe extends BaseCommand {
-  static flags = { ...BaseCommand.baseFlags };
-  static captured: Record<string, unknown> = {};
-
-  protected slotAware(): boolean {
-    return true;
-  }
-
-  protected setAware(): boolean {
-    return true;
-  }
-
-  async run(): Promise<void> {
-    const { flags } = await this.parse(SetProbe);
-    SetProbe.captured = flags as Record<string, unknown>;
-  }
-}
+const SetProbe = makeProbeCommand({ setAware: true, preflight: false });
 
 let config: Config;
 
@@ -60,10 +39,7 @@ beforeEach(async () => {
   config = await Config.load(PKG_ROOT);
   SetProbe.captured = {};
   vi.spyOn(BaseCommand.prototype, 'log').mockImplementation(() => {});
-  vi.spyOn(
-    BaseCommand.prototype as unknown as { getSetStore: () => SetStore },
-    'getSetStore',
-  ).mockReturnValue(cannedStore());
+  spySetStore(CANNED_SETS);
 });
 
 afterEach(() => {

--- a/packages/node/saga-stack-cli/src/commands/set/__tests__/set-preflight.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/set/__tests__/set-preflight.int.test.ts
@@ -4,79 +4,36 @@
  * stack mutation; `--allow-primary` downgrades the primary-checkout refusal
  * to a warning; the cross-set collision is sharpened with live ACTIVE-slot
  * detection. Exercised through a zero-IO probe command (parse + preflight
- * only) plus the real `e2e run` (whose preflight fires before any discovery).
+ * only — makeProbeCommand with preflight: true) plus the real `e2e run`
+ * (whose preflight fires before any discovery). Seams faked via the shared
+ * set-fakes helpers.
  */
 
 import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { Config, Flags } from '@oclif/core';
+import { Config } from '@oclif/core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makeProbeCommand,
+  oneSetWithSagaDash,
+  spyGitRunner,
+  spyPrepFresh,
+  spySetStore,
+  spySlotActive,
+  twoSetsSharingCheckout,
+} from '../../../__tests__/helpers/set-fakes.js';
 import { BaseCommand } from '../../../base-command.js';
-import { parseWorktreeSetsFile } from '../../../core/set/index.js';
-import type { GitRunner, SetStore, SlotActiveProbe } from '../../../runtime/index.js';
 import E2eRun from '../../e2e/run.js';
 
 const PKG_ROOT = process.cwd();
 
 /** Zero-IO probe: parse + the M13-B preflight, nothing else. */
-class PreflightProbe extends BaseCommand {
-  static flags = {
-    ...BaseCommand.baseFlags,
-    'allow-primary': Flags.boolean({ default: false }),
-  };
-
-  protected slotAware(): boolean {
-    return true;
-  }
-
-  protected setAware(): boolean {
-    return true;
-  }
-
-  async run(): Promise<void> {
-    const { flags } = await this.parse(PreflightProbe);
-    await this.runSetPreflight(flags);
-  }
-}
+const PreflightProbe = makeProbeCommand({ setAware: true, allowPrimary: true, preflight: true });
 
 let config: Config;
 let dir: string;
 let logged: string[];
-
-function spyStore(data: unknown): void {
-  vi.spyOn(
-    BaseCommand.prototype as unknown as { getSetStore: () => SetStore },
-    'getSetStore',
-  ).mockReturnValue({ path: () => '/canned/sets.json', load: () => parseWorktreeSetsFile(data) });
-}
-
-function spyGit(nonCheckouts: string[] = []): void {
-  const fake: Partial<GitRunner> = {
-    branchShowCurrent: async () => 'main',
-    statusPorcelain: async () => '',
-    revParseVerify: async (repoPath: string) => !nonCheckouts.includes(repoPath),
-  };
-  vi.spyOn(
-    BaseCommand.prototype as unknown as { getGitRunner: () => GitRunner },
-    'getGitRunner',
-  ).mockReturnValue(fake as GitRunner);
-}
-
-function spyFresh(prebuilt: boolean): void {
-  vi.spyOn(
-    BaseCommand.prototype as unknown as { getPrepFreshCheck: () => (root: string) => boolean },
-    'getPrepFreshCheck',
-  ).mockReturnValue(() => prebuilt);
-}
-
-function spyActive(activeProjects: string[]): void {
-  const probe: SlotActiveProbe = { isActive: async (_s, project) => activeProjects.includes(project) };
-  vi.spyOn(
-    BaseCommand.prototype as unknown as { getSlotActiveProbe: () => SlotActiveProbe },
-    'getSlotActiveProbe',
-  ).mockReturnValue(probe);
-}
 
 beforeEach(async () => {
   config = await Config.load(PKG_ROOT);
@@ -85,7 +42,7 @@ beforeEach(async () => {
   vi.spyOn(BaseCommand.prototype, 'log').mockImplementation((m) => {
     logged.push(String(m ?? ''));
   });
-  spyActive([]);
+  spySlotActive([]);
 });
 
 afterEach(() => {
@@ -95,9 +52,9 @@ afterEach(() => {
 
 describe('runSetPreflight violations', () => {
   it('a missing path hard-errors before anything runs', async () => {
-    spyStore({ version: 1, sets: { x: { slot: 1, repos: { 'saga-dash': join(dir, 'nope') } } } });
-    spyGit();
-    spyFresh(true);
+    spySetStore(oneSetWithSagaDash(join(dir, 'nope')));
+    spyGitRunner();
+    spyPrepFresh(true);
     await expect(PreflightProbe.run(['--set', 'x', '--dev', join(dir, 'dev')], config)).rejects.toThrow(
       /failed the preflight check[\s\S]*path does not exist/,
     );
@@ -107,9 +64,9 @@ describe('runSetPreflight violations', () => {
     const devRoot = join(dir, 'dev');
     const primary = join(devRoot, 'saga-dash');
     mkdirSync(primary, { recursive: true });
-    spyStore({ version: 1, sets: { x: { slot: 1, repos: { 'saga-dash': primary } } } });
-    spyGit();
-    spyFresh(false);
+    spySetStore(oneSetWithSagaDash(primary));
+    spyGitRunner();
+    spyPrepFresh(false);
 
     await expect(PreflightProbe.run(['--set', 'x', '--dev', devRoot], config)).rejects.toThrow(
       /BUILDABLE entry points at the primary checkout/,
@@ -124,16 +81,10 @@ describe('runSetPreflight violations', () => {
   it('a cross-set buildable collision names the other set — and flags it ACTIVE when its slot is live', async () => {
     const shared = join(dir, 'shared');
     mkdirSync(shared);
-    spyStore({
-      version: 1,
-      sets: {
-        a: { slot: 1, repos: { rostering: shared } },
-        b: { slot: 2, repos: { rostering: shared } },
-      },
-    });
-    spyGit();
-    spyFresh(false);
-    spyActive(['soa-s2']); // set b's slot is LIVE
+    spySetStore(twoSetsSharingCheckout(shared));
+    spyGitRunner();
+    spyPrepFresh(false);
+    spySlotActive(['soa-s2']); // set b's slot is LIVE
 
     await expect(PreflightProbe.run(['--set', 'a', '--dev', join(dir, 'dev')], config)).rejects.toThrow(
       /build collision: set 'b' rostering[\s\S]*slot 2\) is ACTIVE right now/,
@@ -143,17 +94,17 @@ describe('runSetPreflight violations', () => {
   it('no --set = no-op (nothing loaded, nothing logged)', async () => {
     // Store spy intentionally NOT installed: a load would throw on real fs read
     // of a nonexistent canned path — the no-op must never get that far.
-    spyGit();
-    spyFresh(true);
+    spyGitRunner();
+    spyPrepFresh(true);
     await expect(PreflightProbe.run(['--dev', join(dir, 'dev')], config)).resolves.toBeUndefined();
   });
 });
 
 describe('e2e run --set runs the preflight before discovery', () => {
   it('a violating set fails e2e run up front', async () => {
-    spyStore({ version: 1, sets: { x: { slot: 1, repos: { 'saga-dash': join(dir, 'nope') } } } });
-    spyGit();
-    spyFresh(true);
+    spySetStore(oneSetWithSagaDash(join(dir, 'nope')));
+    spyGitRunner();
+    spyPrepFresh(true);
     await expect(
       E2eRun.run(['saga-dash/journey', '--set', 'x', '--dev', join(dir, 'dev')], config),
     ).rejects.toThrow(/failed the preflight check/);

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/slot-guard.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/slot-guard.unit.test.ts
@@ -17,6 +17,7 @@ import { resolve } from 'node:path';
 import { Config } from '@oclif/core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { BaseCommand } from '../../../base-command.js';
+import { restoreEnv, saveEnv } from '../../../__tests__/helpers/env.js';
 import StackReset from '../reset.js';
 import StackRestart from '../restart.js';
 import StackSeed from '../seed.js';
@@ -95,14 +96,13 @@ describe('M13-A: seed + snapshot are slot-aware now', () => {
   });
 
   it('stack snapshot list --slot 3 passes the guard and reads the slot snapshot root', async () => {
-    const saved = process.env.SAGA_MESH_SNAPSHOTS_DIR;
+    const saved = saveEnv(['SAGA_MESH_SNAPSHOTS_DIR']);
     try {
       await expect(SnapshotList.run(['--slot', '3', ...WS], config)).resolves.toBeUndefined();
       // applyInstanceEnv pointed the resolver at the per-slot root.
       expect(process.env.SAGA_MESH_SNAPSHOTS_DIR).toMatch(/snapshots-s3$/);
     } finally {
-      if (saved === undefined) delete process.env.SAGA_MESH_SNAPSHOTS_DIR;
-      else process.env.SAGA_MESH_SNAPSHOTS_DIR = saved;
+      restoreEnv(saved);
     }
   });
 });

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/up-native.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/up-native.int.test.ts
@@ -24,20 +24,15 @@ import type {
   DashFs,
   GitRunner,
   JarWriter,
-  LaunchResult,
   LaunchSpec,
   MeshExec,
-  PgProbe,
-  PortProbe,
   PostOptions,
   PostResult,
-  RunResult,
-  Runner,
   ScriptInvocation,
-  ServiceLauncher,
-  StopResult,
   ViteClear,
 } from '../../../runtime/index.js';
+import { restoreEnv, saveEnv, type EnvSnapshot } from '../../../__tests__/helpers/env.js';
+import { installCoreSeams } from '../../../__tests__/helpers/seams.js';
 import StackUp from '../up.js';
 
 const PKG_ROOT = process.cwd();
@@ -57,14 +52,34 @@ let fleetGenCalls: { localFleetPath: string; outPath: string; tunnelDomain: stri
 
 /** Install fakes for ALL native-path seams. `launchFail` ids answer health-down. */
 function installNativeSeams(launchFail: Set<string> = new Set()): void {
-  launches = [];
-  runs = [];
   posts = [];
   jarWrites = [];
   meshGated = [];
   dashCalls = [];
   recordUps = [];
   fleetGenCalls = [];
+
+  // Shared core battery (helpers/seams.ts): launcher/portProbe/runner-with-
+  // CREATE-DATABASE-tracker/stateful pgProbe/prepFresh/dbGenerateScan/
+  // repoDirCheck (+ silent meshExec/dashFs placeholders this suite RE-SPIES
+  // below with recording fakes). pidBase/prepFresh are EXPLICIT at this call
+  // site by design: pids at 2000+, and NEVER fresh (the fixed /fixed/dev paths
+  // don't exist) ⇒ the R1 prep pass runs.
+  const seams = installCoreSeams({ pidBase: 2000, prepFresh: false, launchFail });
+  launches = seams.launches;
+  runs = seams.runs;
+
+  // Stateful DB existence lives in the core battery: a DB is ABSENT until R2
+  // provision runs its `CREATE DATABASE <name>` psql, after which it EXISTS —
+  // modelling the real `up --reset` order (provision → reset): every DB probes
+  // absent at provision time (so provision CREATEs each), but exists by RESET
+  // time (so the R4 reset's existence probe truncates them rather than skipping
+  // — the live-run BUG 2). The playback DBs (meshProvisioned:false) are NOT
+  // created by R2 provision — their own services create them during launch — so
+  // they already EXIST by reset time. Pre-seed them present so the `--with
+  // playback --reset` truncate path is exercised (mesh-provisioned DBs are added
+  // by the core runner when provision runs their CREATE DATABASE).
+  for (const db of ['transcripts_local', 'insights_local', 'chat_local']) seams.provisioned.add(db);
 
   // Native `--login` seams: a fake devLogin POST (200 + canned Set-Cookies) + a jar
   // capture — so `up --login` mints the native cookie jar with NO real network/fs and
@@ -77,27 +92,12 @@ function installNativeSeams(launchFail: Set<string> = new Set()): void {
   };
   const jar: JarWriter = { write: (path, contents) => jarWrites.push({ path, contents }) };
 
-  const launcher: ServiceLauncher = {
-    async launch(spec: LaunchSpec): Promise<LaunchResult> {
-      launches.push(spec);
-      return { id: spec.id, ok: !launchFail.has(spec.id), pid: 2000 + launches.length };
-    },
-    async stopServices(ids: string[]): Promise<StopResult[]> {
-      return ids.map((id) => ({ id, stopped: true }));
-    },
-  };
+  // RECORDING meshExec/dashFs — this suite asserts the readiness gating and the
+  // dash prelaunch hook calls, so these override the core battery's silent fakes.
   const meshExec: MeshExec = {
     async ready(container: string): Promise<boolean> {
       meshGated.push(container);
       return true;
-    },
-  };
-  const portProbe: PortProbe = {
-    async dockerHolder(): Promise<string | null> {
-      return null;
-    },
-    async listening(): Promise<boolean> {
-      return false;
     },
   };
   const dashFs: DashFs = {
@@ -108,46 +108,6 @@ function installNativeSeams(launchFail: Set<string> = new Set()): void {
     existsFile: () => false,
     remove: (p: string) => dashCalls.push(`remove:${p}`),
     write: (p: string) => dashCalls.push(`write:${p}`),
-  };
-  // Stateful DB existence: a DB is ABSENT until R2 provision runs its
-  // `CREATE DATABASE <name>` psql, after which it EXISTS. This models the real
-  // `up --reset` order (provision → reset): every DB probes absent at provision
-  // time (so provision CREATEs each), but exists by RESET time (so the R4 reset's
-  // existence probe truncates them rather than skipping — the live-run BUG 2).
-  // The playback DBs (meshProvisioned:false) are NOT created by R2 provision — their
-  // own services create them during launch — so they already EXIST by reset time.
-  // Pre-seed them present so the `--with playback --reset` truncate path is exercised
-  // (mesh-provisioned DBs are added below when provision runs their CREATE DATABASE).
-  const provisioned = new Set<string>(['transcripts_local', 'insights_local', 'chat_local']);
-  const runner: Runner = {
-    async run(spec: ScriptInvocation): Promise<RunResult> {
-      runs.push(spec);
-      const ci = spec.args.indexOf('-c');
-      if (ci >= 0) {
-        const m = /CREATE DATABASE (\w+)/.exec(spec.args[ci + 1] ?? '');
-        if (m) provisioned.add(m[1]);
-      }
-      return { code: 0 };
-    },
-  };
-  // M8 native prep pass: a fake pg probe so R2 provision + R3 migrate assert their
-  // PLAN with NO real docker/postgres. Each DB probes ABSENT (until provision CREATEs
-  // it) + table-empty, so provision CREATEs each and migrate takes the `empty →
-  // db:deploy` branch (migrate's branch consults hasMigrationsTable/publicTableCount,
-  // NOT databaseExists, so the stateful existence doesn't perturb it).
-  const pgProbe: PgProbe = {
-    async databaseExists(_c, db): Promise<boolean> {
-      return provisioned.has(db);
-    },
-    async hasMigrationsTable(): Promise<boolean> {
-      return false;
-    },
-    async publicTableCount(): Promise<number> {
-      return 0;
-    },
-    async scalar(): Promise<string> {
-      return '';
-    },
   };
 
   // M9 fakes: an all-up-to-date git seam (so auto-pull runs hermetically — no real git
@@ -166,16 +126,10 @@ function installNativeSeams(launchFail: Set<string> = new Set()): void {
   };
 
   const proto = BaseCommand.prototype as unknown as {
-    getLauncher: () => ServiceLauncher;
     getMeshExec: () => MeshExec;
-    getPortProbe: () => PortProbe;
     getDashFs: () => DashFs;
-    getRunner: () => Runner;
-    getPgProbe: () => PgProbe;
     getGitRunner: () => GitRunner;
     getViteClear: () => ViteClear;
-    getPrepFreshCheck: () => (repoRoot: string) => boolean;
-    getRepoDirCheck: () => (dir: string) => boolean;
     getTunnelMoniker: () => (vendorTunnelSh: string) => Promise<string>;
     getTunnelFleetGen: () => (opts: {
       localFleetPath: string;
@@ -189,7 +143,6 @@ function installNativeSeams(launchFail: Set<string> = new Set()): void {
     getCookiePoster: () => CookiePoster;
     getJarWriter: () => JarWriter;
   };
-  vi.spyOn(proto, 'getLauncher').mockReturnValue(launcher);
   // Native `up --login` seams (fake POST + jar capture) — never a real network/fs, never up.sh.
   vi.spyOn(proto, 'getCookiePoster').mockReturnValue(poster);
   vi.spyOn(proto, 'getJarWriter').mockReturnValue(jar);
@@ -206,19 +159,12 @@ function installNativeSeams(launchFail: Set<string> = new Set()): void {
     recordUps.push({ plan, ctx });
     return { ok: true, message: `✓ recording stack up (mode: ${plan.mode})` };
   });
+  // Re-spying the core battery's meshExec/dashFs returns the SAME spy —
+  // mockReturnValue swaps in the recording fakes without stacking.
   vi.spyOn(proto, 'getMeshExec').mockReturnValue(meshExec);
-  vi.spyOn(proto, 'getPortProbe').mockReturnValue(portProbe);
   vi.spyOn(proto, 'getDashFs').mockReturnValue(dashFs);
-  vi.spyOn(proto, 'getRunner').mockReturnValue(runner);
-  vi.spyOn(proto, 'getPgProbe').mockReturnValue(pgProbe);
   vi.spyOn(proto, 'getGitRunner').mockReturnValue(gitRunner);
   vi.spyOn(proto, 'getViteClear').mockReturnValue(viteClear);
-  // Never fresh in these tests (fixed /fixed/dev paths don't exist) ⇒ R1 prep runs.
-  vi.spyOn(proto, 'getPrepFreshCheck').mockReturnValue(() => false);
-  // The fake workspace paths (--dev /fixed/dev) don't exist on disk; default the
-  // repo-dir check to "present" so services aren't skipped. The skip-when-absent
-  // path is covered explicitly in stack-api.int.test.ts.
-  vi.spyOn(proto, 'getRepoDirCheck').mockReturnValue(() => true);
 }
 
 beforeEach(async () => {
@@ -393,17 +339,13 @@ describe('stack up --slot N — isolated bring-up (M7 Phase 2)', () => {
     'SAGA_MESH_CONNECT_MONGO_CONTAINER',
     'SAGA_MESH_SNAPSHOTS_DIR',
   ];
-  let savedEnv: Record<string, string | undefined>;
+  let savedEnv: EnvSnapshot;
 
   beforeEach(() => {
-    savedEnv = {};
-    for (const k of SLOT_ENV_KEYS) savedEnv[k] = process.env[k];
+    savedEnv = saveEnv(SLOT_ENV_KEYS);
   });
   afterEach(() => {
-    for (const k of SLOT_ENV_KEYS) {
-      if (savedEnv[k] === undefined) delete process.env[k];
-      else process.env[k] = savedEnv[k];
-    }
+    restoreEnv(savedEnv);
   });
 
   it('slot > 0 is a backend + saga-dash/coach frontend sub-stack: dash launches on its offset --port; literal-port backends + connect-web dropped', async () => {

--- a/packages/node/saga-stack-cli/src/commands/stack/down.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/down.ts
@@ -23,7 +23,7 @@ import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command.js';
 import { deriveInstance } from '../../core/derive-instance.js';
 import type { InstanceProfile } from '../../core/derive-instance.js';
-import { meshDown, resolveRepoRoot } from '../../runtime/index.js';
+import { meshDown, repoContextFromFlags, resolveRepoRoot } from '../../runtime/index.js';
 import type { MeshDownResult, ScriptContext, StopServiceResult } from '../../runtime/index.js';
 
 export default class StackDown extends BaseCommand {
@@ -102,10 +102,7 @@ export default class StackDown extends BaseCommand {
     flags: { dev: string; soa?: string },
     profile: InstanceProfile,
   ): Promise<MeshDownResult> {
-    const ctx: ScriptContext = {
-      dev: flags.dev,
-      repoRoots: flags.soa ? { SOA: flags.soa } : {},
-    };
+    const ctx: ScriptContext = repoContextFromFlags(flags as unknown as Record<string, unknown>);
     return meshDown({
       soaRoot: resolveRepoRoot('SOA', ctx),
       runner: this.getRunner(),

--- a/packages/node/saga-stack-cli/src/commands/stack/snapshot/__tests__/snapshot.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/snapshot/__tests__/snapshot.int.test.ts
@@ -12,14 +12,15 @@
  * input is injected through `SnapshotRestore.prototype.localMigrationsFor`.
  */
 
-import { mkdtempSync, rmSync, writeFileSync, statSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { statSync } from 'node:fs';
 import { join } from 'node:path';
 import { Config } from '@oclif/core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { BaseCommand } from '../../../../base-command.js';
 import type { LocalMigrations, SnapshotManifest } from '../../../../core/snapshot/index.js';
 import type { SnapshotIO } from '../../../../runtime/index.js';
+import { useTempSnapshotsDir } from '../../../../__tests__/helpers/env.js';
+import { fakeSnapshotIO, type SnapshotIOCall } from '../../../../__tests__/helpers/snapshot-io.js';
 import SnapshotStore from '../store.js';
 import SnapshotRestore from '../restore.js';
 import SnapshotList from '../list.js';
@@ -29,55 +30,17 @@ import SnapshotDelete from '../delete.js';
 const PKG_ROOT = process.cwd();
 const CANNED_REV = 'mig_001';
 
-interface IOCall {
-  op: string;
-  db?: string;
-  container: string;
-  ownerRole?: string;
-  path?: string;
-}
-
 let config: Config;
 let out: string[];
-let ioCalls: IOCall[];
-let snapDir: string;
+const ioCalls: SnapshotIOCall[] = [];
+const snapDir = useTempSnapshotsDir('saga-snap-');
 
 /** Fake SnapshotIO: records calls; "dumps" write canned bytes so files are real. */
 function installSnapshotIO(opts: { pgRestoreOk?: boolean } = {}): void {
-  ioCalls = [];
-  const fake: SnapshotIO = {
-    async pgDump(db, container, ownerRole, outPath) {
-      ioCalls.push({ op: 'pgDump', db, container, ownerRole, path: outPath });
-      writeFileSync(outPath, `PGDUMP:${db}`);
-    },
-    async pgRestore(db, container, ownerRole, inPath) {
-      ioCalls.push({ op: 'pgRestore', db, container, ownerRole, path: inPath });
-    },
-    async mongoDump(container, dbName, outPath) {
-      ioCalls.push({ op: 'mongoDump', db: dbName, container, path: outPath });
-      writeFileSync(outPath, `MONGO:${dbName}`);
-    },
-    async mongoRestore(container, dbName, inPath) {
-      ioCalls.push({ op: 'mongoRestore', db: dbName, container, path: inPath });
-    },
-    async assertPgRunning(container) {
-      ioCalls.push({ op: 'assertPgRunning', container });
-    },
-    async assertMongoRunning(container) {
-      ioCalls.push({ op: 'assertMongoRunning', container });
-    },
-    async readSchemaRev(db, container) {
-      ioCalls.push({ op: 'readSchemaRev', db, container });
-      return CANNED_REV;
-    },
-    async redisFlushdb(container) {
-      ioCalls.push({ op: 'redisFlushdb', container });
-    },
-    async pgRestoreList(container, inPath) {
-      ioCalls.push({ op: 'pgRestoreList', container, path: inPath });
-      return opts.pgRestoreOk ?? true;
-    },
-  };
+  ioCalls.length = 0;
+  // schemaRev: CANNED_REV so the restore snapshot-ahead guard has a REAL rev to
+  // check against (this suite owns the hard-guard coverage).
+  const fake = fakeSnapshotIO({ ioCalls, schemaRev: CANNED_REV, pgRestoreOk: opts.pgRestoreOk });
   vi.spyOn(
     BaseCommand.prototype as unknown as { getSnapshotIO: () => SnapshotIO },
     'getSnapshotIO',
@@ -104,8 +67,6 @@ function dbsCalled(op: string): string[] {
 
 beforeEach(async () => {
   config = await Config.load(PKG_ROOT);
-  snapDir = mkdtempSync(join(tmpdir(), 'saga-snap-'));
-  process.env.SAGA_MESH_SNAPSHOTS_DIR = snapDir;
   delete process.env.SEED_PROFILE;
   installSnapshotIO();
   installPassingMigrations();
@@ -120,8 +81,6 @@ beforeEach(async () => {
 
 afterEach(() => {
   vi.restoreAllMocks();
-  rmSync(snapDir, { recursive: true, force: true });
-  delete process.env.SAGA_MESH_SNAPSHOTS_DIR;
   delete process.env.SEED_PROFILE;
 });
 
@@ -170,7 +129,7 @@ describe('stack snapshot store — manifest-driven, all 10 pg + connectv3 mongo'
     ).mockImplementation((profile) => {
       appliedSlot = profile.slot;
       for (const [k, v] of Object.entries(profile.containerEnv)) process.env[k] = v;
-      process.env.SAGA_MESH_SNAPSHOTS_DIR = join(snapDir, `s${profile.slot}`);
+      process.env.SAGA_MESH_SNAPSHOTS_DIR = join(snapDir(), `s${profile.slot}`);
     });
 
     await SnapshotStore.run(['--fixture-id', 'slotted', '--slot', '1'], config);
@@ -186,7 +145,7 @@ describe('stack snapshot store — manifest-driven, all 10 pg + connectv3 mongo'
     expect(pg).toContain('iam_local');
     expect(pg).toContain('coach_api');
     // And the dump landed in the slot's (redirected) snapshot root.
-    expect(process.env.SAGA_MESH_SNAPSHOTS_DIR).toBe(join(snapDir, 's1'));
+    expect(process.env.SAGA_MESH_SNAPSHOTS_DIR).toBe(join(snapDir(), 's1'));
   });
 
   it('--with playback adds transcripts/insights/chat', async () => {
@@ -214,7 +173,7 @@ describe('stack snapshot store — manifest-driven, all 10 pg + connectv3 mongo'
     expect(json).toMatchObject({ fixtureId: 'demo', profile: 'full', databases: 11 });
     expect(json.totalBytes).toBeGreaterThan(0);
     // manifest.json exists and parses
-    expect(statSync(join(snapDir, 'demo', 'manifest.json')).size).toBeGreaterThan(0);
+    expect(statSync(join(snapDir(), 'demo', 'manifest.json')).size).toBeGreaterThan(0);
   });
 
   it('refuses to overwrite an existing snapshot without --force', async () => {
@@ -226,7 +185,7 @@ describe('stack snapshot store — manifest-driven, all 10 pg + connectv3 mongo'
 describe('stack snapshot restore — restore-as-owner + guards', () => {
   async function store(extra: string[] = []): Promise<void> {
     await SnapshotStore.run(['--fixture-id', 'demo', ...extra], config);
-    ioCalls = []; // reset so restore assertions see only restore-phase calls
+    ioCalls.length = 0; // reset so restore assertions see only restore-phase calls
     out = []; // and so JSON assertions parse only the restore output
   }
 
@@ -262,10 +221,10 @@ describe('stack snapshot restore — restore-as-owner + guards', () => {
 
   it('PROFILE guard: cross-profile restore is refused, --force bypasses it', async () => {
     await SnapshotStore.run(['--fixture-id', 'demo', '--profile', 'roster'], config);
-    ioCalls = [];
+    ioCalls.length = 0;
     process.env.SEED_PROFILE = 'full';
     await expect(SnapshotRestore.run(['demo'], config)).rejects.toThrow(/profile/i);
-    ioCalls = [];
+    ioCalls.length = 0;
     await expect(SnapshotRestore.run(['demo', '--force'], config)).resolves.toBeUndefined();
     expect(dbsCalled('pgRestore').length).toBeGreaterThan(0);
   });
@@ -290,7 +249,7 @@ describe('stack snapshot restore — restore-as-owner + guards', () => {
 describe('stack snapshot list / validate / delete', () => {
   it('list surfaces the stored snapshot with its profile + DB count', async () => {
     await SnapshotStore.run(['--fixture-id', 'demo', '--profile', 'full'], config);
-    ioCalls = [];
+    ioCalls.length = 0;
     out = [];
     await SnapshotList.run(['--output-json'], config);
     const json = JSON.parse(out.join(''));
@@ -310,7 +269,7 @@ describe('stack snapshot list / validate / delete', () => {
 
   it('validate --deep runs pg_restore --list on each pg dump', async () => {
     await SnapshotStore.run(['--fixture-id', 'demo'], config);
-    ioCalls = [];
+    ioCalls.length = 0;
     await SnapshotValidate.run(['demo', '--deep'], config);
     expect(ioCalls.filter((c) => c.op === 'pgRestoreList')).toHaveLength(10); // pg dumps only
   });

--- a/packages/node/saga-stack-cli/src/commands/stack/snapshot/restore.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/snapshot/restore.ts
@@ -28,7 +28,7 @@ import { BaseCommand } from '../../../base-command.js';
 import { deriveInstance } from '../../../core/derive-instance.js';
 import { computeClosure } from '../../../core/closure.js';
 import { manifest } from '../../../core/manifest/index.js';
-import type { DbId, RepoKey as ManifestRepoKey, ServiceId } from '../../../core/manifest/index.js';
+import type { DbId, ServiceId } from '../../../core/manifest/index.js';
 import { restorePlan, snapshotManifestSchema } from '../../../core/snapshot/index.js';
 import type { LocalMigrations, SnapshotManifest } from '../../../core/snapshot/index.js';
 import {
@@ -38,9 +38,8 @@ import {
   readManifest,
   redisContainer,
   snapshotDir,
-  REPO_ENV_VAR,
 } from '../../../runtime/index.js';
-import type { RepoKey, ScriptContext } from '../../../runtime/index.js';
+import type { ScriptContext } from '../../../runtime/index.js';
 
 export default class SnapshotRestore extends BaseCommand {
   static description =

--- a/packages/node/saga-stack-cli/src/commands/stack/status.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/status.ts
@@ -37,7 +37,8 @@ import { deriveInstance } from '../../core/derive-instance.js';
 import { healthProbes } from '../../core/probe-plan.js';
 import { manifest } from '../../core/manifest/index.js';
 import type { RepoKey, ServiceId } from '../../core/manifest/index.js';
-import { REPO_ENV_VAR, resolveRepoRoot } from '../../runtime/index.js';
+import { resolveRepoRoot } from '../../runtime/index.js';
+import { repoContextFromFlags } from '../../runtime/index.js';
 import type { ScriptContext } from '../../runtime/index.js';
 
 export default class StackStatus extends BaseCommand {
@@ -201,20 +202,9 @@ export interface NotClonedService {
   repoDir: string;
 }
 
-/**
- * Build the `ScriptContext` (dev root + per-repo path pins) from the parsed
- * workspace flags — the same `--dev` / `--<repo>` precedence `stack up`'s
- * `buildRuntime` uses, so status/verify resolve each repo dir identically.
- */
-export function repoContextFromFlags(flags: Record<string, unknown>): ScriptContext {
-  const pinned: Partial<Record<RepoKey, string>> = {};
-  for (const kebab of Object.keys(REPO_ENV_VAR) as (keyof typeof REPO_ENV_VAR)[]) {
-    const value = flags[kebab];
-    if (typeof value === 'string' && value) pinned[REPO_ENV_VAR[kebab] as RepoKey] = value;
-  }
-  const dev = typeof flags.dev === 'string' ? flags.dev : undefined;
-  return { dev, repoRoots: pinned };
-}
+// M15: the ScriptContext builder is now THE shared one in runtime/repos.ts —
+// re-exported so verify/overlay/bootstrap's existing imports keep working.
+export { repoContextFromFlags };
 
 /**
  * Partition a resolved service set by whether each service's sibling-repo checkout

--- a/packages/node/saga-stack-cli/src/commands/stack/up.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/up.ts
@@ -340,12 +340,7 @@ export default class StackUp extends BaseCommand {
     // the sandbox-hosted deps live in the CLOUD and are NOT launched locally. Surface the
     // resulting LAUNCH SET (+ which deps are hosted) so the dry-run reflects reality.
     const slotExcludedSet = new Set<ServiceId>(slotExcluded);
-    const sandboxDrop = new Set<ServiceId>();
-    if (prune.sandboxHybrid) {
-      const keep = new Set<ServiceId>(requested);
-      for (const id of closure.services) if (!keep.has(id)) sandboxDrop.add(id);
-    }
-    if (prune.sandboxServices) for (const id of prune.sandboxServices) sandboxDrop.add(id);
+    const sandboxDrop = sandboxDropSet(prune, requested, closure.services);
     const sandboxHosted = closure.services.filter((id) => sandboxDrop.has(id) && !slotExcludedSet.has(id));
     const launchSet = closure.services.filter((id) => !slotExcludedSet.has(id) && !sandboxDrop.has(id));
 
@@ -448,13 +443,7 @@ export default class StackUp extends BaseCommand {
     // only the run-set; a mode:sandbox dep pulled into the closure never boots locally).
     // The launched services' own mesh/DBs still come up (neededMesh/neededDbs run over
     // this pruned set); the excluded deps' don't. Plain `--only` closure is UNTOUCHED.
-    const sandboxDrop = new Set<ServiceId>();
-    if (prune.sandboxHybrid) {
-      // `--sandbox`: launch the requested run-set ALONE (subtract the pulled-in deps).
-      const keep = new Set<ServiceId>(requested);
-      for (const id of fullClosure.services) if (!keep.has(id)) sandboxDrop.add(id);
-    }
-    if (prune.sandboxServices) for (const id of prune.sandboxServices) sandboxDrop.add(id);
+    const sandboxDrop = sandboxDropSet(prune, requested, fullClosure.services);
 
     const services = fullClosure.services.filter((id) => !excluded.has(id) && !sandboxDrop.has(id));
     const droppedForSlot = fullClosure.services.filter((id) => excluded.has(id));
@@ -712,3 +701,24 @@ type OverlayFlags = NativeFlags & {
   tunnel: boolean;
   record?: string;
 };
+
+/**
+ * BLOCKER-1 (Phase 2): the sandbox/workspace LAUNCH prune, shared verbatim by
+ * the dry-run projection and the native run (M15 dedup — they must never
+ * drift, or the plan lies about what boots). `--sandbox` hybrid launches the
+ * requested run-set ALONE (subtract pulled-in deps); a workspace supplies an
+ * explicit sandbox-hosted service list. Plain `--only` closures are untouched.
+ */
+function sandboxDropSet(
+  prune: LaunchPrune,
+  requested: ServiceId[],
+  closureServices: ServiceId[],
+): Set<ServiceId> {
+  const sandboxDrop = new Set<ServiceId>();
+  if (prune.sandboxHybrid) {
+    const keep = new Set<ServiceId>(requested);
+    for (const id of closureServices) if (!keep.has(id)) sandboxDrop.add(id);
+  }
+  if (prune.sandboxServices) for (const id of prune.sandboxServices) sandboxDrop.add(id);
+  return sandboxDrop;
+}

--- a/packages/node/saga-stack-cli/src/core/flow/resolve.ts
+++ b/packages/node/saga-stack-cli/src/core/flow/resolve.ts
@@ -52,7 +52,7 @@ export interface ResolvedFlow {
   spa: SpaDescriptor;
   /** The resolved flow definition. */
   flow: FlowDef;
-  /** Stages selected for this run (after `throughPhase` / `onlyStages`). */
+  /** Stages selected for this run (after `throughPhase` / `fromPhase`). */
   stages: StageDef[];
   /** Union of selected stages' `requiredSystems` ∪ `{ spa.system, iam-api }` (pre-closure). */
   requiredSystems: ServiceId[];
@@ -98,8 +98,6 @@ export interface ResolveFlowOptions {
   fromPhase?: string | number;
   /** Lane the run targets; validated against `flow.lanes`. Default `'stack'`. */
   lane?: Lane;
-  /** Run only these stage ids (STAGE_ONLY iteration); overrides `throughPhase`. */
-  onlyStages?: string[];
   /** Force headed/headless explicitly (else foreground flows default headed). */
   headed?: boolean;
   /** Keep `optional:true` playback services in the closure (else auto-detected). */
@@ -119,20 +117,6 @@ function stageMatches(stage: StageDef, token: string | number): boolean {
 /** Select the stages to run for this flow + options. */
 function selectStages(flow: FlowDef, opts: ResolveFlowOptions): StageDef[] {
   const { stages } = flow;
-
-  // STAGE_ONLY: an explicit subset (by id / project / phase), in flow order.
-  if (opts.onlyStages && opts.onlyStages.length > 0) {
-    const want = new Set(opts.onlyStages);
-    const sel = stages.filter((s) => want.has(s.id) || want.has(s.project));
-    if (sel.length === 0) {
-      throw new Error(
-        `flow '${flow.name}': no stages match onlyStages [${opts.onlyStages.join(', ')}] (have: ${stages
-          .map((s) => s.id)
-          .join(', ')})`,
-      );
-    }
-    return sel;
-  }
 
   // --through <phase>: progressive ⇒ 1..idx; non-progressive ⇒ the single match.
   if (opts.throughPhase !== undefined) {
@@ -211,9 +195,6 @@ export function resolveFlow(
   if (opts.fromPhase !== undefined) {
     if (!flow.progressive) {
       throw new Error(`flow '${flowName}': --from requires a progressive flow`);
-    }
-    if (opts.onlyStages && opts.onlyStages.length > 0) {
-      throw new Error(`flow '${flowName}': --from cannot combine with an explicit stage subset`);
     }
     if (flow.prerequisite) {
       throw new Error(

--- a/packages/node/saga-stack-cli/src/core/seed/profiles.ts
+++ b/packages/node/saga-stack-cli/src/core/seed/profiles.ts
@@ -1,7 +1,7 @@
 /**
  * Seed profiles + the canonical SeedStep registry (plan §4.1, saga-ed/soa#214).
  *
- * Sourced from up.sh's `seed_*` family (`~1610-1714`):
+ * Sourced from up.sh's `seed_*` family:
  *   seed_iam / seed_sessions / seed_programs / seed_content / seed_playback /
  *   seed_qtf_demo, plus the dev-user re-seed (`node dist/seed-dev-user.js`).
  *
@@ -108,14 +108,14 @@ const MESH_PG_PORT_TOKEN = '${MESH_PG_PORT}';
 const MONGO_CONTAINER_TOKEN = '${SAGA_MESH_CONNECT_MONGO_CONTAINER}';
 const PG_CONTAINER_TOKEN = '${SAGA_MESH_POSTGRES_CONTAINER}';
 
-/** The mesh superuser creds up.sh's playback `*_DB_URL` migrate as (up.sh:235-237). */
+/** The mesh superuser creds up.sh's playback `*_DB_URL` migrate as. */
 function playbackDbUrl(db: DatabaseDef): string {
   return `postgresql://postgres_admin:password123@${MESH_PG_HOST}:${MESH_PG_PORT_TOKEN}/${db.name}`;
 }
 
 /**
- * M8 R5 — a playback DB provisioning step (up.sh `provision_playback_dbs`,
- * up.sh:937-951). The `*-db` package's `seed/local-bootstrap.sql` creates the DB +
+ * M8 R5 — a playback DB provisioning step (up.sh `provision_playback_dbs`).
+ * The `*-db` package's `seed/local-bootstrap.sql` creates the DB +
  * least-privilege app role + grants, piped to the mesh postgres via stdin
  * (`docker exec -i <pg> psql < local-bootstrap.sql`); the tail step then migrates
  * it as MASTER (`postgres_admin`) with `pnpm db:deploy` (a freshly-bootstrapped DB
@@ -181,7 +181,7 @@ function postgresVarSet(db: DatabaseDef, instanceName: string): SeedEnv {
 
 /**
  * The FIXED synthetic-dev PII crypto keys up.sh writes into `$ROSTERING/.env.local`
- * (apply_fixes template, up.sh ~L405-406). The iam seeds REQUIRE these: both
+ * (apply_fixes template). The iam seeds REQUIRE these: both
  * `seed-dev-user.js` and iam's `db:seed` read `PII_CRYPTO_PIIDEKHEX` /
  * `PII_CRYPTO_PIIHMACKEYHEX` off `process.env` and THROW when absent. Deterministic
  * dev fixtures, NOT real secrets — safe as frozen core data (keeps this pure, no
@@ -249,7 +249,7 @@ export function buildSeedRegistry(m: Manifest = manifest): Record<SeedStepId, Se
       env: iamSeedEnv(m),
       requiresServiceUp: [],
       // Best-effort, matching up.sh: BOTH invocations tolerate failure — prep
-      // bootstrap (up.sh:1030) and reset re-seed (up.sh:1596) run it as
+      // bootstrap and reset re-seed run it as
       // `… node dist/seed-dev-user.js … || true`. It refuses to run until the iam
       // registry is seeded (needs `seed:registry` — which up.sh never runs), and
       // the canonical `dev@saga.org` user comes from `db:seed` (the `iam` step)
@@ -306,8 +306,8 @@ export function buildSeedRegistry(m: Manifest = manifest): Record<SeedStepId, Se
       failureMode: 'fatal',
     },
     // scheduling deterministic demo schedules/slots (db:seed, direct). main's
-    // seed_stack full runs seed_scheduling between programs and content (up.sh:1914,
-    // fatal — no `|| true`); added on main after gh_214 branched. Without it a native
+    // seed_stack full runs seed_scheduling between programs and content (fatal —
+    // no `|| true`); added on main after gh_214 branched. Without it a native
     // `--seed full` leaves scheduling unseeded → the Schedule step renders nothing.
     scheduling: {
       id: 'scheduling',
@@ -371,7 +371,7 @@ export function buildSeedRegistry(m: Manifest = manifest): Record<SeedStepId, Se
     // coach progress store (Postgres) — coach-db `db:seed` (coach#155 local-snapshot),
     // DATABASE_URL forced to the mesh :5432 coach_api (== $COACH_DB_URL; coach-db's own
     // default is :5433). main runs it best-effort in seed_stack full after content
-    // (up.sh:1808-1816, `warn` on failure — coach may be absent / coach#155 unmerged).
+    // (`warn` on failure — coach may be absent / coach#155 unmerged).
     //
     // M8 R5: the curriculum mongoimport is now the 'coach-mongo' step below (was
     // OMITTED for lack of stdin redirect; `stdinFile` makes it expressible).
@@ -385,7 +385,7 @@ export function buildSeedRegistry(m: Manifest = manifest): Record<SeedStepId, Se
       requiresServiceUp: [], // direct pg db:seed — offline
       failureMode: 'warn',
     },
-    // M8 R5 — coach curriculum mongoimport (up.sh:1780-1798 seed_coach_mongo_only).
+    // M8 R5 — coach curriculum mongoimport (up.sh `seed_coach_mongo_only`).
     // TWO upserts into the mesh mongo: content_coach.json (single object) →
     // saga_local.content_coach, and content.json (array) → wmlms_local.content —
     // the dbs coach-api's launch_if points at. Curriculum is static committed
@@ -425,7 +425,7 @@ export function buildSeedRegistry(m: Manifest = manifest): Record<SeedStepId, Se
         },
       ],
     },
-    // M8 R5 — playback DB provisioning (bootstrap SQL + migrate; up.sh:937-951),
+    // M8 R5 — playback DB provisioning (bootstrap SQL + migrate),
     // gated under `--with playback`. Precede the fixture seed steps below.
     'transcripts-provision': playbackProvisionStep(m, 'transcripts-provision', 'transcripts-api', 'transcripts_local'),
     'insights-provision': playbackProvisionStep(m, 'insights-provision', 'insights-api', 'insights_local'),

--- a/packages/node/saga-stack-cli/src/core/set/__tests__/worktree-sets.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/set/__tests__/worktree-sets.unit.test.ts
@@ -6,7 +6,6 @@
 
 import { describe, expect, it } from 'vitest';
 import {
-  SET_REPO_KEYS,
   applySetToFlags,
   emptyWorktreeSetsFile,
   nearestRepoKey,
@@ -14,7 +13,6 @@ import {
   resolveSet,
 } from '../worktree-sets.js';
 import type { SetInjectableFlags, WorktreeSet } from '../worktree-sets.js';
-import { REPO_ENV_VAR } from '../../../runtime/repos.js';
 
 const VALID = {
   version: 1,
@@ -79,11 +77,9 @@ describe('parseWorktreeSetsFile', () => {
   });
 });
 
-describe('SET_REPO_KEYS lockstep', () => {
-  it('matches the runtime REPO_ENV_VAR kebab keys exactly (core cannot import runtime)', () => {
-    expect([...SET_REPO_KEYS].sort()).toEqual(Object.keys(REPO_ENV_VAR).sort());
-  });
-
+describe('SET_REPO_KEYS', () => {
+  // M15: the lockstep-with-REPO_ENV_VAR test is retired — runtime/repos.ts now
+  // IMPORTS this list (single source of truth), so divergence is impossible.
   it('nearestRepoKey suggests the closest known key', () => {
     expect(nearestRepoKey('saga-dashh')).toBe('saga-dash');
     expect(nearestRepoKey('rosterin')).toBe('rostering');

--- a/packages/node/saga-stack-cli/src/core/set/worktree-sets.ts
+++ b/packages/node/saga-stack-cli/src/core/set/worktree-sets.ts
@@ -29,9 +29,9 @@
 import { z } from 'zod';
 
 /**
- * The kebab CLI-flag repo keys a set file may use — MUST stay in lockstep with
- * `REPO_ENV_VAR` in `runtime/repos.ts` (core cannot import runtime, so the
- * list is duplicated here and pinned by a unit test against the runtime map).
+ * THE canonical kebab CLI-flag repo keys (M15): `runtime/repos.ts` imports
+ * this list (its `RepoKey` is an alias of `SetRepoKey`), so the set-file
+ * schema, the CLI flags, and the env-var mapping share one source of truth.
  */
 export const SET_REPO_KEYS = [
   'soa',

--- a/packages/node/saga-stack-cli/src/core/snapshot/__tests__/manifest.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/snapshot/__tests__/manifest.unit.test.ts
@@ -52,7 +52,6 @@ const VALID: SnapshotManifest = {
     },
   ],
   systems: ['iam-api', 'connect-api'],
-  flowId: 'flow-x',
 };
 
 describe('snapshot manifest — round-trip', () => {

--- a/packages/node/saga-stack-cli/src/core/snapshot/manifest.ts
+++ b/packages/node/saga-stack-cli/src/core/snapshot/manifest.ts
@@ -10,7 +10,7 @@
  * snapshot-ahead guard; `null` for db-push / mongo DBs that have no migration
  * history), the on-disk dump filename, and its size. `systems` records which
  * services were FULLY captured (all their DBs) so a snapshot can feed the flow
- * layer; `flowId` ties a snapshot to the flow that produced it.
+ * layer.
  *
  * This is the SECOND (and last) place the CLI uses zod+JSON: like `flows.json`,
  * a snapshot manifest is an on-disk artifact written by one run and read by a
@@ -141,8 +141,6 @@ export const snapshotManifestSchema = z.object({
   databases: z.array(snapshotDbSchema),
   /** Services whose FULL db set was captured (feeds the flow layer). */
   systems: z.array(serviceIdSchema).optional(),
-  /** Flow that produced this snapshot, when stored by an e2e flow. */
-  flowId: z.string().optional(),
   /** M14: stage-checkpoint provenance (bake metadata `--from` validates). */
   flow: snapshotFlowBlockSchema.optional(),
 });

--- a/packages/node/saga-stack-cli/src/e2e-checkpoint-exec.ts
+++ b/packages/node/saga-stack-cli/src/e2e-checkpoint-exec.ts
@@ -1,0 +1,140 @@
+/**
+ * M14 stage-checkpoint EXECUTION (split out of e2e-orchestrate in M15): the
+ * restore ceremony a `--from`/prerequisite run performs in place of the
+ * reset+seed (load → flow-level compat verdict → window DB-coverage check →
+ * CheckpointStore.restore), and the per-green-stage bake. Composes the runtime
+ * `CheckpointStore` seam via `ExecDeps.checkpoints` — the type imports from
+ * e2e-orchestrate are TYPE-ONLY (erased), so the module cycle is compile-time
+ * only. `FlowExecError` lives here (both halves throw it); e2e-orchestrate
+ * re-exports it, keeping the command layer's imports stable.
+ */
+
+import { evaluateCheckpoint, checkpointFixtureId, stagePrefixHash } from './core/flow/checkpoint.js';
+import { ENV_OCCURRENCE_DATE, ENV_TERM_END, ENV_TERM_START } from './core/flow/env.js';
+import type { ResolvedFlow } from './core/flow/index.js';
+import type { Manifest, ServiceId } from './core/manifest/index.js';
+import type { SnapshotFlowBlock } from './core/snapshot/index.js';
+import type { ExecDeps, ExecOptions } from './e2e-orchestrate.js';
+
+/** Raised when a native pre-Playwright stage (up/reset/seed/verify/restore) fails. */
+export class FlowExecError extends Error {}
+
+/** M14 §1.2: load + validate + restore the predecessor checkpoint; returns its baked dates. */
+export async function restoreCheckpoint(
+  resolved: ResolvedFlow,
+  deps: ExecDeps,
+  opts: ExecOptions,
+  services: ServiceId[],
+  m: Manifest,
+): Promise<SnapshotFlowBlock['dates']> {
+  const cp = resolved.checkpoint as NonNullable<ResolvedFlow['checkpoint']>;
+  if (deps.checkpoints === undefined) {
+    throw new FlowExecError('--from requires the checkpoint store (internal wiring error)');
+  }
+
+  const fixtureId = checkpointFixtureId(
+    resolved.spa.id,
+    resolved.flow.name,
+    cp.predecessor,
+    cp.predecessorPosition,
+  );
+  const snapshot = deps.checkpoints.load(fixtureId);
+  if (snapshot === null) {
+    // Plan §1.2: list the stages that ARE baked so the fix is self-evident.
+    const baked = resolved.flow.stages
+      .filter((s, i) => deps.checkpoints?.load(checkpointFixtureId(resolved.spa.id, resolved.flow.name, s, i + 1)))
+      .map((s) => s.id);
+    throw new FlowExecError(
+      `no checkpoint '${fixtureId}' — baked stages: ${baked.join(', ') || '(none)'}. Bake first:\n` +
+        `  ss e2e run ${resolved.spa.id}/${resolved.flow.name} --snapshot-stages --headless`,
+    );
+  }
+
+  const verdict = evaluateCheckpoint(
+    snapshot.flow,
+    {
+      spaId: resolved.spa.id,
+      flowName: resolved.flow.name,
+      stageId: cp.predecessor.id,
+      prefixHash: stagePrefixHash(resolved.flow, cp.producingStages),
+      seedProfile: resolved.seedSelection?.profile,
+      currentSpaHead: opts.spaHead?.sha,
+    },
+    deps.now,
+    opts.fromStaleOk === true,
+  );
+
+  // The checkpoint must COVER the window's state: any DB a window stage needs
+  // that the bake never dumped would keep un-reset leftover rows (a full replay
+  // would have reset+seeded it). Bake wider (--through) or re-bake.
+  const dumped = new Set(snapshot.databases.map((d) => d.db));
+  const missing = [...new Set(services.flatMap((id) => m.services[id]?.databases ?? []))].filter(
+    (db) => !dumped.has(db),
+  );
+  if (missing.length > 0) {
+    verdict.violations.push(
+      `the checkpoint does not cover the window's database(s): ${missing.join(', ')} — ` +
+        'it was baked from a narrower closure; re-bake with a wider --through',
+    );
+    verdict.ok = false;
+  }
+
+  for (const w of verdict.warnings) deps.log(`⚠ checkpoint: ${w}`);
+  if (!verdict.ok) {
+    throw new FlowExecError(
+      `checkpoint '${fixtureId}' failed validation:\n` + verdict.violations.map((v) => `  ✗ ${v}`).join('\n'),
+    );
+  }
+
+  const flowBlock = snapshot.flow as SnapshotFlowBlock; // verdict.ok ⇒ present
+  deps.log(`==> restore: ${fixtureId} (baked ${flowBlock.bakedAt}, occurrence ${flowBlock.dates.occurrenceDate})`);
+  try {
+    await deps.checkpoints.restore(snapshot, { currentProfile: resolved.seedSelection?.profile });
+  } catch (err) {
+    throw new FlowExecError((err as Error).message);
+  }
+  return flowBlock.dates;
+}
+
+/** M14 §1.1: overwrite-store the checkpoint for a just-green stage. */
+export async function bakeStageCheckpoint(
+  resolved: ResolvedFlow,
+  stage: ResolvedFlow['stages'][number],
+  services: ServiceId[],
+  env: Record<string, string>,
+  deps: ExecDeps,
+  opts: ExecOptions,
+  m: Manifest,
+): Promise<void> {
+  const checkpoints = deps.checkpoints as NonNullable<ExecDeps['checkpoints']>;
+  const position = resolved.flow.stages.findIndex((s) => s.id === stage.id) + 1;
+  const fixtureId = checkpointFixtureId(resolved.spa.id, resolved.flow.name, stage, position);
+
+  // The bake scope is the SLOT-FILTERED closure's DB set (post-closure exclusion,
+  // same rule as `snapshot store --slot N`) — never dump DBs the slot never provisioned.
+  const dbs = [...new Set(services.flatMap((id) => m.services[id]?.databases ?? []))];
+
+  await checkpoints.bake({
+    fixtureId,
+    // No fabricated default: a seedless flow's checkpoint says so ('unseeded'
+    // never false-matches a real profile in the restore-time double guard).
+    profile: resolved.seedSelection?.profile ?? 'unseeded',
+    dbs,
+    flow: {
+      spa: resolved.spa.id,
+      flow: resolved.flow.name,
+      stageId: stage.id,
+      ...(stage.phase !== undefined ? { phase: stage.phase } : {}),
+      prefixHash: stagePrefixHash(resolved.flow, resolved.flow.stages.slice(0, position)),
+      ...(resolved.seedSelection?.profile !== undefined ? { seedProfile: resolved.seedSelection.profile } : {}),
+      dates: {
+        occurrenceDate: env[ENV_OCCURRENCE_DATE] ?? '',
+        termStart: env[ENV_TERM_START] ?? '',
+        termEnd: env[ENV_TERM_END] ?? '',
+      },
+      ...(opts.spaHead !== undefined ? { spaHead: opts.spaHead } : {}),
+      bakedAt: deps.now.toISOString(),
+    },
+  });
+  deps.log(`==> checkpoint: baked ${fixtureId}`);
+}

--- a/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
+++ b/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
@@ -34,7 +34,8 @@ import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { composeSeedPlan } from './core/seed/compose-seed-plan.js';
 import { computeEnv, ENV_OCCURRENCE_DATE, ENV_TERM_END, ENV_TERM_START } from './core/flow/env.js';
-import { checkpointFixtureId, evaluateCheckpoint, stagePrefixHash } from './core/flow/checkpoint.js';
+import { checkpointFixtureId } from './core/flow/checkpoint.js';
+import { bakeStageCheckpoint, FlowExecError, restoreCheckpoint } from './e2e-checkpoint-exec.js';
 import type { SnapshotFlowBlock } from './core/snapshot/index.js';
 import type { CheckpointStore } from './runtime/checkpoint-store.js';
 import {
@@ -576,8 +577,9 @@ type StageDefLike = ResolvedFlow['stages'][number];
 
 // ── execution ─────────────────────────────────────────────────────────────────
 
-/** Raised when a native pre-Playwright stage (up/reset/seed/verify) fails. */
-export class FlowExecError extends Error {}
+// M15: FlowExecError + the M14 checkpoint restore/bake execution live in
+// e2e-checkpoint-exec.ts; re-exported so run.ts/connect.ts imports are stable.
+export { FlowExecError } from './e2e-checkpoint-exec.js';
 
 /** Dependencies the executor needs from the command (all injected/resolved). */
 export interface ExecDeps {
@@ -864,122 +866,3 @@ export async function executeResolvedFlow(
   return 0;
 }
 
-/** M14 §1.2: load + validate + restore the predecessor checkpoint; returns its baked dates. */
-async function restoreCheckpoint(
-  resolved: ResolvedFlow,
-  deps: ExecDeps,
-  opts: ExecOptions,
-  services: ServiceId[],
-  m: Manifest,
-): Promise<SnapshotFlowBlock['dates']> {
-  const cp = resolved.checkpoint as NonNullable<ResolvedFlow['checkpoint']>;
-  if (deps.checkpoints === undefined) {
-    throw new FlowExecError('--from requires the checkpoint store (internal wiring error)');
-  }
-
-  const fixtureId = checkpointFixtureId(
-    resolved.spa.id,
-    resolved.flow.name,
-    cp.predecessor,
-    cp.predecessorPosition,
-  );
-  const snapshot = deps.checkpoints.load(fixtureId);
-  if (snapshot === null) {
-    // Plan §1.2: list the stages that ARE baked so the fix is self-evident.
-    const baked = resolved.flow.stages
-      .filter((s, i) => deps.checkpoints?.load(checkpointFixtureId(resolved.spa.id, resolved.flow.name, s, i + 1)))
-      .map((s) => s.id);
-    throw new FlowExecError(
-      `no checkpoint '${fixtureId}' — baked stages: ${baked.join(', ') || '(none)'}. Bake first:\n` +
-        `  ss e2e run ${resolved.spa.id}/${resolved.flow.name} --snapshot-stages --headless`,
-    );
-  }
-
-  const verdict = evaluateCheckpoint(
-    snapshot.flow,
-    {
-      spaId: resolved.spa.id,
-      flowName: resolved.flow.name,
-      stageId: cp.predecessor.id,
-      prefixHash: stagePrefixHash(resolved.flow, cp.producingStages),
-      seedProfile: resolved.seedSelection?.profile,
-      currentSpaHead: opts.spaHead?.sha,
-    },
-    deps.now,
-    opts.fromStaleOk === true,
-  );
-
-  // The checkpoint must COVER the window's state: any DB a window stage needs
-  // that the bake never dumped would keep un-reset leftover rows (a full replay
-  // would have reset+seeded it). Bake wider (--through) or re-bake.
-  const dumped = new Set(snapshot.databases.map((d) => d.db));
-  const missing = [...new Set(services.flatMap((id) => m.services[id]?.databases ?? []))].filter(
-    (db) => !dumped.has(db),
-  );
-  if (missing.length > 0) {
-    verdict.violations.push(
-      `the checkpoint does not cover the window's database(s): ${missing.join(', ')} — ` +
-        'it was baked from a narrower closure; re-bake with a wider --through',
-    );
-    verdict.ok = false;
-  }
-
-  for (const w of verdict.warnings) deps.log(`⚠ checkpoint: ${w}`);
-  if (!verdict.ok) {
-    throw new FlowExecError(
-      `checkpoint '${fixtureId}' failed validation:\n` + verdict.violations.map((v) => `  ✗ ${v}`).join('\n'),
-    );
-  }
-
-  const flowBlock = snapshot.flow as SnapshotFlowBlock; // verdict.ok ⇒ present
-  deps.log(`==> restore: ${fixtureId} (baked ${flowBlock.bakedAt}, occurrence ${flowBlock.dates.occurrenceDate})`);
-  try {
-    await deps.checkpoints.restore(snapshot, { currentProfile: resolved.seedSelection?.profile });
-  } catch (err) {
-    throw new FlowExecError((err as Error).message);
-  }
-  return flowBlock.dates;
-}
-
-/** M14 §1.1: overwrite-store the checkpoint for a just-green stage. */
-async function bakeStageCheckpoint(
-  resolved: ResolvedFlow,
-  stage: ResolvedFlow['stages'][number],
-  services: ServiceId[],
-  env: Record<string, string>,
-  deps: ExecDeps,
-  opts: ExecOptions,
-  m: Manifest,
-): Promise<void> {
-  const checkpoints = deps.checkpoints as NonNullable<ExecDeps['checkpoints']>;
-  const position = resolved.flow.stages.findIndex((s) => s.id === stage.id) + 1;
-  const fixtureId = checkpointFixtureId(resolved.spa.id, resolved.flow.name, stage, position);
-
-  // The bake scope is the SLOT-FILTERED closure's DB set (post-closure exclusion,
-  // same rule as `snapshot store --slot N`) — never dump DBs the slot never provisioned.
-  const dbs = [...new Set(services.flatMap((id) => m.services[id]?.databases ?? []))];
-
-  await checkpoints.bake({
-    fixtureId,
-    // No fabricated default: a seedless flow's checkpoint says so ('unseeded'
-    // never false-matches a real profile in the restore-time double guard).
-    profile: resolved.seedSelection?.profile ?? 'unseeded',
-    dbs,
-    flow: {
-      spa: resolved.spa.id,
-      flow: resolved.flow.name,
-      stageId: stage.id,
-      ...(stage.phase !== undefined ? { phase: stage.phase } : {}),
-      prefixHash: stagePrefixHash(resolved.flow, resolved.flow.stages.slice(0, position)),
-      ...(resolved.seedSelection?.profile !== undefined ? { seedProfile: resolved.seedSelection.profile } : {}),
-      dates: {
-        occurrenceDate: env[ENV_OCCURRENCE_DATE] ?? '',
-        termStart: env[ENV_TERM_START] ?? '',
-        termEnd: env[ENV_TERM_END] ?? '',
-      },
-      ...(opts.spaHead !== undefined ? { spaHead: opts.spaHead } : {}),
-      bakedAt: deps.now.toISOString(),
-    },
-  });
-  deps.log(`==> checkpoint: baked ${fixtureId}`);
-}

--- a/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
+++ b/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
@@ -493,7 +493,9 @@ export interface DescribeOptions {
  * Recurses the prerequisite. Touches NO seam, spawns nothing.
  */
 export function describeResolved(resolved: ResolvedFlow, opts: DescribeOptions): ResolvedFlowDescription {
-  const dateEnv = computeEnv(resolved.flow, opts.now);
+  // Computed ONCE; `env` below carries the same date keys (playwrightEnv wraps
+  // computeEnv), so occurrenceDate reads from it instead of recomputing.
+  const env = playwrightEnv(resolved, opts.now, opts.lane, opts.ports);
   const effectiveReset = resolved.reset && !opts.skipReset;
   // Drop the slot's excluded services (literal-port + connect frontends) from the
   // closure so the dry-run matches what a `--slot N` run actually brings up. Empty
@@ -533,8 +535,8 @@ export function describeResolved(resolved: ResolvedFlow, opts: DescribeOptions):
       project: resolved.playwright.project,
       argv: playwrightArgv(resolved, opts.passthrough),
     },
-    occurrenceDate: dateEnv[ENV_OCCURRENCE_DATE] ?? '',
-    env: playwrightEnv(resolved, opts.now, opts.lane, opts.ports),
+    occurrenceDate: env[ENV_OCCURRENCE_DATE] ?? '',
+    env,
     // The prerequisite always builds the end-state headless + owns its own reset;
     // it gets no user passthrough.
     prerequisite: resolved.prerequisite

--- a/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
+++ b/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
@@ -53,12 +53,13 @@ import type { Manifest, RepoKey, ServiceId } from './core/manifest/index.js';
 import { healthProbes } from './core/probe-plan.js';
 import type { Lane } from './core/manifest/index.js';
 import type { ScriptPlan } from './core/flag-map.js';
-import { makeStackApi } from './stack-api.js';
 import type { Runtime, StackApi } from './stack-api.js';
 import {
+  buildRepoEnv,
   loadFlowsFrom,
   REPO_DEFAULT_DIR,
-  REPO_ENV_VAR,
+  repoContextFromFlags,
+  repoOverridesFromFlags,
   resolveRepoRoot,
   resolveVendorScript,
 } from './runtime/index.js';
@@ -162,14 +163,8 @@ export function discoverFlowManifest(spaId: string, flags: FlagBag, env: EnvBag)
  * `$DEV`). Mirrors up.sh's repo-path precedence.
  */
 function overlayRepoEnv(env: EnvBag, flags: FlagBag): EnvBag {
-  const out: EnvBag = { ...env };
-  const dev = str(flags, 'dev');
-  if (dev) out.DEV = dev;
-  for (const kebab of Object.keys(REPO_ENV_VAR) as (keyof typeof REPO_ENV_VAR)[]) {
-    const v = str(flags, kebab);
-    if (v) out[REPO_ENV_VAR[kebab]] = v;
-  }
-  return out;
+  // M15: buildRepoEnv is the ONE flags→env-var overlay (DEV + the repo pins).
+  return { ...env, ...buildRepoEnv(repoOverridesFromFlags(flags)) };
 }
 
 // ── runtime/context assembly (mirrors stack up's buildRuntime) ───────────────
@@ -230,12 +225,7 @@ export function buildStackContext(
   delegate: (plan: ScriptPlan) => Promise<number>,
   profile: InstanceProfile = deriveInstance({ slot: 0 }),
 ): { runtime: Runtime; repoRoots: Record<RepoKey, string> } {
-  const pinned: Partial<Record<RepoKey, string>> = {};
-  for (const kebab of Object.keys(REPO_ENV_VAR) as (keyof typeof REPO_ENV_VAR)[]) {
-    const value = str(flags, kebab);
-    if (value) pinned[REPO_ENV_VAR[kebab] as RepoKey] = value;
-  }
-  const ctx: ScriptContext = { dev: str(flags, 'dev'), repoRoots: pinned };
+  const ctx: ScriptContext = repoContextFromFlags(flags);
 
   const repoRoots = {} as Record<RepoKey, string>;
   for (const repo of Object.keys(REPO_DEFAULT_DIR) as RepoKey[]) {

--- a/packages/node/saga-stack-cli/src/runtime/checkpoint-store.ts
+++ b/packages/node/saga-stack-cli/src/runtime/checkpoint-store.ts
@@ -119,7 +119,6 @@ export function makeCheckpointStore(deps: {
         createdAt: input.flow.bakedAt,
         databases,
         systems: plan.systems,
-        flowId: `${input.flow.spa}/${input.flow.flow}`,
         flow: input.flow,
       });
     },

--- a/packages/node/saga-stack-cli/src/runtime/migrate.ts
+++ b/packages/node/saga-stack-cli/src/runtime/migrate.ts
@@ -1,8 +1,8 @@
 /**
  * R3 — native migrate runner (M8 native prep pass — THE headline).
  *
- * A FAITHFUL port of up.sh's `migrate_db()` (up.sh:738-755, the three-way branch)
- * + the migrate chain (up.sh:1040-1073, canonical order). `profile-empty.sql`
+ * A FAITHFUL port of up.sh's `migrate_db()` (the three-way branch)
+ * + the migrate chain (canonical order). `profile-empty.sql`
  * leaves every app DB table-EMPTY, so without a migrate the fatal seed steps
  * (iam/sessions/programs/scheduling) run against an unmigrated schema and abort.
  * The manifest already carries complete `MigrateSpec` data, but NOTHING executed
@@ -35,7 +35,7 @@
  *     from the package's prisma.config.ts, exactly as up.sh's `( cd "$dir" && … )`.
  *
  * LEDGER (migrate-reset target): ledger_local is NOT a prep-migrate target —
- * up.sh's prep chain (up.sh:1041-1073) has no ledger step. profile-empty.sql
+ * up.sh's prep chain has no ledger step. profile-empty.sql
  * provisions it empty and its schema is (re)built by the R4 reset's migrate-reset
  * (drop + remigrate) against its own owning package, `packages/node/ledger-db`
  * (the VERIFIED schema owner — NOT ads-adm-db). R3 skips any `resetMode:'migrate-reset'`
@@ -210,7 +210,7 @@ export async function migrateClosure(ctx: MigrateContext): Promise<MigrateResult
     }
     if (def.resetMode === 'migrate-reset') {
       // ledger_local (resetMode:'migrate-reset') is NOT a prep-migrate target —
-      // up.sh's prep chain (up.sh:1041-1073) has NO ledger step. profile-empty.sql
+      // up.sh's prep chain has NO ledger step. profile-empty.sql
       // provisions it empty and its schema is (re)built by the R4 reset's
       // migrate-reset (drop + remigrate) against its OWN owning package (ledger-db).
       // Skipping it here keeps R3 faithful to up.sh now that ledger-db is a DISTINCT

--- a/packages/node/saga-stack-cli/src/runtime/prep.ts
+++ b/packages/node/saga-stack-cli/src/runtime/prep.ts
@@ -1,7 +1,7 @@
 /**
  * R1 — native build/prep pass (M8 native prep pass).
  *
- * A FAITHFUL port of up.sh's `prep()` build loop (up.sh:992-1039): over the repos
+ * A FAITHFUL port of up.sh's `prep()` build loop: over the repos
  * of the closure services, run `pnpm install` (idempotent), a best-effort
  * workspace build, and `pnpm db:generate` for the `*-db` packages (which need a
  * generated Prisma client BEFORE their tsup build + runtime import). Without this,
@@ -18,19 +18,19 @@
  * `*-db` packages left the other siblings ungenerated → their build fails → abort.
  * So R1 generates EVERY package in each closure repo that DECLARES `db:generate`
  * (via the injected `dbGenerateScan` seam — a faithful port of up.sh's
- * `for dbpkg in $SDS/packages/node/*; grep -q '"db:generate"'` loop, up.sh:1010-1013),
+ * `for dbpkg in $SDS/packages/node/*; grep -q '"db:generate"'` loop),
  * not just the closure DBs' owners. Absent seam ⇒ fall back to the closure-derived
  * targets (unit tests that don't wire the scan).
  *
  * up.sh fidelity notes:
  *   - Per repo: `pnpm install` → `pnpm db:generate` (all `db:generate` pkgs) → `pnpm build`.
- *   - SAGA_DASH is install-ONLY (up.sh:1015-1019 installs vite but does NOT build —
+ *   - SAGA_DASH is install-ONLY (up.sh installs vite but does NOT build —
  *     it runs via `vite dev`); every other repo builds. This one "install-only"
  *     distinction isn't expressible from the manifest yet (see the report).
  *   - FATAL MAP (MAJOR-C): up.sh's `build_step` defaults NON-fatal (warn+continue)
  *     and is fatal only for QBOARD/RTSM/COACH (their services import workspace
- *     `dist/` at launch, up.sh:1026/1031/1039); ROSTERING/PROGRAM_HUB/SDS builds
- *     (up.sh:995/998/1014) and ALL `db:generate` (`|| true`) are NON-fatal. R1
+ *     `dist/` at launch); ROSTERING/PROGRAM_HUB/SDS builds
+ *     and ALL `db:generate` (`|| true`) are NON-fatal. R1
  *     mirrors this: a non-fatal build/db:generate failure is recorded as a WARNING
  *     and the pass continues; only a FATAL_BUILD_REPOS build (or any `pnpm install`,
  *     which up.sh's `pnpm_install` also aborts on) stops the pass.
@@ -43,7 +43,7 @@
  * (fresh-skip already no-ops a built tree), while R2/R3 stay idempotent.
  *
  * CODEARTIFACT (FLIP 4): `pnpm install` here recovers from an expired CodeArtifact
- * token exactly as up.sh's `pnpm_install` does (up.sh:677-694) — install runs with
+ * token exactly as up.sh's `pnpm_install` does — install runs with
  * `detectUnauthorized`, and on a 401 (`ERR_PNPM_FETCH_401` / `Unauthorized`) R1 runs
  * `pnpm co:login` (the workspace's token-refresh script) and RETRIES the install
  * ONCE. If it still fails, the ORIGINAL failing install step is surfaced (`failed`)
@@ -65,7 +65,7 @@ import type { Runner } from './exec.js';
 
 /**
  * Repos up.sh installs but does NOT build (they run a dev server, not `dist/`).
- * Only SAGA_DASH today (up.sh:1015-1019: `vite dev`, no prebuild). qboard/coach
+ * Only SAGA_DASH today (up.sh: `vite dev`, no prebuild). qboard/coach
  * DO build (their services import workspace `dist/` deps). See the report — this
  * isn't manifest-expressible yet.
  */
@@ -74,12 +74,12 @@ export const INSTALL_ONLY_REPOS: ReadonlySet<RepoKey> = new Set<RepoKey>(['SAGA_
 /**
  * Repos whose `pnpm build` failure is FATAL (aborts the pass) — their services
  * import workspace `dist/` at launch, so an unbuilt tree is a guaranteed crash
- * (up.sh: `build_step … 1`, up.sh:1026/1031/1039). Every other repo's build is
+ * (up.sh: `build_step … 1`). Every other repo's build is
  * NON-fatal (warn + continue), matching up.sh's default `build_step`.
  */
 export const FATAL_BUILD_REPOS: ReadonlySet<RepoKey> = new Set<RepoKey>(['QBOARD', 'RTSM', 'COACH']);
 
-/** up.sh's canonical prep order (up.sh:992-1039). Non-built repos (SOA/FLEEK) omitted. */
+/** up.sh's canonical prep order. Non-built repos (SOA/FLEEK) omitted. */
 const PREP_REPO_ORDER: readonly RepoKey[] = [
   'ROSTERING',
   'PROGRAM_HUB',
@@ -283,7 +283,7 @@ async function prepOneRepo(
   {
     // 1. install (idempotent) — FATAL (up.sh's `pnpm_install` aborts on failure).
     //    FLIP 4: on a CodeArtifact 401 (expired token), refresh via `pnpm co:login`
-    //    and retry the install ONCE (up.sh:677-694). A non-401 failure does NOT
+    //    and retry the install ONCE (mirrors up.sh's `pnpm_install`). A non-401 failure does NOT
     //    trigger the retry; if the retry still fails, the ORIGINAL install step is
     //    surfaced as `failed`.
     const installStep: PrepStep = { repo, kind: 'install', cwd: root, argv: ['install'] };

--- a/packages/node/saga-stack-cli/src/runtime/repos.ts
+++ b/packages/node/saga-stack-cli/src/runtime/repos.ts
@@ -25,24 +25,25 @@
  * keys from `shared-flags.ts` (kebab-case); the env var names are up.sh's.
  */
 
-/** CLI-flag keys for the per-repo overrides — matches `repoFlags` in shared-flags.ts. */
-export type RepoKey =
-  | 'soa'
-  | 'rostering'
-  | 'program-hub'
-  | 'saga-dash'
-  | 'coach'
-  | 'sds'
-  | 'qboard'
-  | 'rtsm'
-  | 'fleek';
+import { SET_REPO_KEYS } from '../core/set/index.js';
+import type { SetRepoKey } from '../core/set/index.js';
+import type { RepoKey as ManifestRepoKey } from '../core/manifest/index.js';
+import type { ScriptContext } from './scripts.js';
+
+/**
+ * CLI-flag keys for the per-repo overrides — matches `repoFlags` in
+ * shared-flags.ts. M15: the kebab list is CANONICAL in core
+ * (`SET_REPO_KEYS`, which the set-file schema also validates against);
+ * this alias keeps the runtime-side name.
+ */
+export type RepoKey = SetRepoKey;
 
 /**
  * Map each `--<repo>` flag to the EXACT env var up.sh reads for that repo's
  * path. (Note `sds` → `SDS`, whose default checkout dir is
  * `student-data-system`, resolved by up.sh — not here.)
  */
-export const REPO_ENV_VAR: Record<RepoKey, string> = {
+export const REPO_ENV_VAR: Record<RepoKey, ManifestRepoKey> = {
   soa: 'SOA',
   rostering: 'ROSTERING',
   'program-hub': 'PROGRAM_HUB',
@@ -83,4 +84,34 @@ export function buildRepoEnv(overrides: RepoOverrides = {}): Record<string, stri
   }
 
   return env;
+}
+
+
+/**
+ * THE Shape-A builder (M15): kebab `--<repo>` flag pins + `--dev` → a
+ * `ScriptContext` keyed by the manifest env-var names. Every command-layer
+ * duplicate (status/verify/overlay/bootstrap, down's inline ctx, the e2e stack
+ * context, BaseCommand.scriptContextFromFlags) routes through here. Accepts an
+ * untyped bag (oclif parsed flags) — non-string values are ignored.
+ */
+export function repoContextFromFlags(flags: Record<string, unknown>): ScriptContext {
+  const repoRoots: Partial<Record<ManifestRepoKey, string>> = {};
+  for (const kebab of SET_REPO_KEYS) {
+    const value = flags[kebab];
+    if (typeof value === 'string' && value) repoRoots[REPO_ENV_VAR[kebab]] = value;
+  }
+  const dev = flags.dev;
+  return { dev: typeof dev === 'string' && dev ? dev : undefined, repoRoots };
+}
+
+/** The Shape-B input builder: the same flag bag → `RepoOverrides` for `buildRepoEnv`. */
+export function repoOverridesFromFlags(flags: Record<string, unknown>): RepoOverrides {
+  const overrides: RepoOverrides = {};
+  const dev = flags.dev;
+  if (typeof dev === 'string' && dev) overrides.dev = dev;
+  for (const kebab of SET_REPO_KEYS) {
+    const value = flags[kebab];
+    if (typeof value === 'string' && value) overrides[kebab] = value;
+  }
+  return overrides;
 }

--- a/packages/node/saga-stack-cli/src/runtime/reset.ts
+++ b/packages/node/saga-stack-cli/src/runtime/reset.ts
@@ -1,7 +1,7 @@
 /**
  * R4 — native reset runner (M8 native prep pass — flips `stack reset` native).
  *
- * A FAITHFUL port of up.sh's `reset_data()` (up.sh:1661-1698): a clean synthetic
+ * A FAITHFUL port of up.sh's `reset_data()`: a clean synthetic
  * baseline BEFORE seeding, so any `--seed` mode is reproducible regardless of prior
  * state (iam groups don't dedup — re-running the roster on a non-empty iam
  * duplicates it). Three destructive ops over the closure's DBs:
@@ -10,7 +10,7 @@
  *      postgres_admin -d <db> -v ON_ERROR_STOP=1 -c "<generic TRUNCATE DO block>"`.
  *      The DO block truncates EVERY public table EXCEPT `_prisma_migrations`, so the
  *      schema + applied-migration history survive and a reset never forces a
- *      re-migrate (up.sh:1663 verbatim). `RESTART IDENTITY CASCADE` clears sequences
+ *      re-migrate (verbatim from up.sh). `RESTART IDENTITY CASCADE` clears sequences
  *      + fk-linked rows — matching up.sh.
  *   2. postgres `resetMode:'migrate-reset'` DBs (ledger_local, decision 2026-06-30 —
  *      NOT in up.sh's truncate list) → `pnpm prisma migrate reset --force`
@@ -18,16 +18,16 @@
  *      not ads-adm-db's) with `DATABASE_URL` forced at the mesh (drop + remigrate to
  *      head; ledger-db configures no prisma seed hook, so reset never seeds).
  *   3. mongo (`connectv3`) → `docker exec <mongoContainer> mongosh --quiet --eval
- *      'db.getSiblingDB("connectv3").dropDatabase()'` (up.sh:1689) — collections
+ *      'db.getSiblingDB("connectv3").dropDatabase()'` — collections
  *      auto-recreate on first write, so a drop IS the empty baseline.
  *
- * The dev-user RE-SEED (up.sh:1695-1696) is NOT done here — the facade runs it
+ * The dev-user RE-SEED is NOT done here — the facade runs it
  * through the existing seed path (`iam-dev-user` SeedStep) after this returns, so
  * the seed env/dotenv handling lives in ONE place.
  *
  * GATING: playback DBs (`meshProvisioned:false` — transcripts/insights/chat) are
  * truncated ONLY under `--with playback`, so a bare reset leaves seeded playback
- * fixtures intact (up.sh:1666-1669, `DO_PLAYBACK`).
+ * fixtures intact (up.sh's `DO_PLAYBACK`).
  *
  * SLOT-AWARE: the psql/mongosh runs go `docker exec <container> …` against the
  * RESOLVED slot containers (`soa-s<N>-postgres-1` / `soa-s<N>-connect-mongo-1` at
@@ -103,7 +103,7 @@ export interface ResetResult {
 }
 
 /**
- * The generic per-DB TRUNCATE DO block — up.sh:1663 verbatim. Truncates every
+ * The generic per-DB TRUNCATE DO block — verbatim from up.sh. Truncates every
  * `public` table EXCEPT `_prisma_migrations` (so the schema + migration history
  * survive; a reset never forces a re-migrate). Exposed for tests + reporting.
  */

--- a/packages/node/saga-stack-cli/src/runtime/set-check.ts
+++ b/packages/node/saga-stack-cli/src/runtime/set-check.ts
@@ -26,7 +26,6 @@ import { deriveInstance } from '../core/derive-instance.js';
 import type { GitRunner } from './git.js';
 import { REPO_DEFAULT_DIR } from './scripts.js';
 import { REPO_ENV_VAR } from './repos.js';
-import type { RepoKey as ManifestRepoKey } from '../core/manifest/index.js';
 import type { SlotActiveProbe } from './slot-active.js';
 
 /** One repo entry's verdicts (also the `set check` JSON row). */
@@ -70,11 +69,6 @@ function safeRealpath(path: string): string | null {
   } catch {
     return null;
   }
-}
-
-/** The env-var key `REPO_DEFAULT_DIR` is keyed by, from a kebab set key. */
-function repoEnvKey(repo: SetRepoKey): ManifestRepoKey {
-  return REPO_ENV_VAR[repo] as ManifestRepoKey;
 }
 
 /** Evaluate one set against the store + live slots. */
@@ -125,7 +119,7 @@ export async function checkWorktreeSet(
 
     // Primary-checkout posture (tenet 4): shared repos must be clean,
     // pre-built, effectively read-only worktrees — never the hot primary.
-    const primary = safeRealpath(join(deps.devRoot, REPO_DEFAULT_DIR[repoEnvKey(repo)]));
+    const primary = safeRealpath(join(deps.devRoot, REPO_DEFAULT_DIR[REPO_ENV_VAR[repo]]));
     if (primary !== null && safeRealpath(entry.path) === primary) {
       if (check.prebuilt) {
         check.warnings.push('points at the primary checkout (pre-built, so running is safe — prefer a worktree)');

--- a/packages/node/saga-stack-cli/src/shared-flags.ts
+++ b/packages/node/saga-stack-cli/src/shared-flags.ts
@@ -82,12 +82,13 @@ export const repoFlags = {
  * corrupt a peer slot. Enforced in `BaseCommand.parse`, opted out per-command via
  * `slotAware()`. Slot 0 (the default) is unaffected everywhere.
  */
+// DELIBERATELY does not enumerate the slot-aware commands (the list drifted
+// twice — each command's `--help` is the source of truth).
 export const SLOT_UNSUPPORTED_COMMAND_MESSAGE =
-  'multi-slot (--slot > 0) is not supported for this command yet — the slot-aware set is ' +
-  "'stack up/status/verify/down/reset/seed/snapshot/login' and 'e2e run'. The rest " +
-  '(restart/overlay/bootstrap/tunnel) operate on shared checkouts, slot-0 state, or fixed ' +
-  'slot-0 ports and would cross slots; run them against slot 0 only. (A --set carrying ' +
-  'slot > 0 hits this same guard.)';
+  'multi-slot (--slot > 0) is not supported for this command — it operates on shared ' +
+  'checkouts, slot-0 state, or fixed slot-0 ports and would cross slots; run it against ' +
+  "slot 0 only. The slot-aware lifecycle commands accept --slot 1..9 (see each command's " +
+  '--help). (A --set carrying slot > 0 hits this same guard.)';
 
 /**
  * The error surfaced when `--set` is passed on a command that cannot thread a
@@ -97,10 +98,11 @@ export const SLOT_UNSUPPORTED_COMMAND_MESSAGE =
  * checkouts. Enforced in `BaseCommand.parse`, opted in per-command via
  * `setAware()`.
  */
+// DELIBERATELY does not enumerate the set-aware commands (see SLOT_… above).
 export const SET_UNSUPPORTED_COMMAND_MESSAGE =
-  '--set is not supported for this command — worktree sets thread repo paths + a slot ' +
-  "into 'stack up/status/verify/down/reset/seed/snapshot' and 'e2e run' (see `ss set list`). " +
-  'This command is slot-0 / primary-checkout only.';
+  '--set is not supported for this command — it is slot-0 / primary-checkout only. ' +
+  'Worktree sets thread repo paths + a slot into the slot-aware lifecycle commands ' +
+  "(see each command's --help, and `ss set list` for your sets).";
 
 export const baseFlags = {
   porcelain: Flags.boolean({

--- a/packages/node/saga-stack-cli/src/stack-api.ts
+++ b/packages/node/saga-stack-cli/src/stack-api.ts
@@ -371,11 +371,6 @@ export interface ResetOutcome {
 }
 
 /** Per-call `up` knobs (reserved; tunnel/tunnelDomain live on the `Runtime`). */
-export interface UpOpts {
-  /** Reserved for future per-call overrides. */
-  readonly _?: never;
-}
-
 /** Optional `verify` knobs. */
 export interface VerifyOpts {
   /** Tokens (service id OR repo name) whose down state does NOT fail the gate. */
@@ -401,7 +396,7 @@ export interface RestartOutcome {
 
 /** The in-process facade (plan §6.3) — M9 adds native `restart`. */
 export interface StackApi {
-  up(closureServices: ServiceId[], opts?: UpOpts): Promise<UpResult>;
+  up(closureServices: ServiceId[]): Promise<UpResult>;
   down(closureServices: ServiceId[]): Promise<DownResult>;
   restart(closureServices: ServiceId[]): Promise<RestartOutcome>;
   reset(closureServices: ServiceId[], opts?: ResetOpts): Promise<ResetOutcome>;
@@ -676,7 +671,7 @@ export function makeStackApi(m: Manifest, runtime: Runtime): StackApi {
   }
 
   return {
-    async up(services: ServiceId[], _opts: UpOpts = {}): Promise<UpResult> {
+    async up(services: ServiceId[]): Promise<UpResult> {
       // 0. AUTO-PULL (M9) — ff-only sibling sync BEFORE anything is built/migrated, so a
       // bare native `up` never runs a checkout silently behind origin (up.sh runs
       // `pull_repos` before mesh_up/prep). Warn-and-continue on every per-repo issue; a


### PR DESCRIPTION
Implements **M15** (`plans/12-simplify-pass.md`) — the scout-grounded simplification sweep over saga-stack-cli. **Zero behavior change by construction**, and verified: five captured CLI outputs (journey/connect dry-runs, slot-1 `--output-json`, `set list`, `snapshot list`) are **byte-identical** to the pre-M15 baseline after every milestone; the suite stays green throughout (868 = the 869 baseline minus the deliberately-retired lockstep test).

Based on the #236 branch (M15 simplifies code that only exists there); GitHub retargets to `gh_214` when #236 merges — per skelly's sequencing call this stays its own PR.

## M15-A — dead surface + drift fixes
Deleted `onlyStages`/STAGE_ONLY (unwired, untested), the write-only `flowId` manifest field, the empty `UpOpts` bag, the redundant `WorkspaceFlags.soa`; de-enumerated both guard messages (the prose lists had **already drifted** — `e2e list` was missing from both; each command's `--help` is now the source of truth); memoized `e2e list`'s per-stage checkpoint verdict (was 2 disk reads per stage); single `computeEnv` in `describeResolved`.

## M15-B — ONE repo-context builder, ONE kebab vocabulary
The seven duplicate `REPO_ENV_VAR` loops now route through `runtime/repos.ts`'s `repoContextFromFlags`/`repoOverridesFromFlags`; `REPO_ENV_VAR` retyped `Record<RepoKey, ManifestRepoKey>` (every conversion cast deleted); the kebab key list is canonical in core (`SET_REPO_KEYS`) with runtime's `RepoKey` an alias — the lockstep test is retired because divergence is now impossible.

## M15-C — shared test harnesses (workflow-implemented, 4 agents, all green first try)
`src/__tests__/helpers/{env,snapshot-io,seams,pw,set-fakes}.ts`: the quadruplicated `installSeams` battery, the SnapshotIO fake, the env save/restore + temp-snapshot-root pattern (the M13 HOME-hazard lesson now lives in ONE place), and the set-command spy trio. Every load-bearing divergence is an explicit named option (the silent `prepFresh` fork is now visible at each call site); the Playwright argv golden anchors stay fully literal with comments saying why. ~612 copied lines removed (net +95 with the documented helpers — single-source-of-truth was the goal, not raw LOC).

## M15-D — splits + comment diet
`e2e-checkpoint-exec.ts` split out of the orchestrator (FlowExecError re-exported; command imports stable); `up.ts`'s duplicated sandbox-prune is one helper; comment diet per skelly's call — the seam-getter pattern documented once (getters stay on the prototype: 21 of them are spied by 13 int-test suites), `up.sh:NNNN` line-number archaeology dropped with all behavioral rationale kept. The `describeResolved` split and the assembler dedup are deliberately deferred (plan Q2).

## Numbers
- 4 commits, 36 files, +1160/−1102 (net +58 — the deletions in src are offset by helper doc-headers; src alone is net −180).
- Lint warnings 83 → 74; tsc/build clean throughout.
- Negative finding recorded in the plan: nothing vestigial on the delegate path (no `--legacy` anywhere; the wrapper machinery is live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)