### PR TITLE
gh_221: multi-seed composition (datasets/scenarios) + coach-deferral guards (b/c/d)

### DIFF
--- a/packages/node/saga-stack-cli/docs/getting-started.md
+++ b/packages/node/saga-stack-cli/docs/getting-started.md
@@ -50,7 +50,7 @@ Bring the synthetic dev stack up/down, seed, reset, verify, and log in.
   stack status     Show per-service health, probing manifest-derived endpoints.
   stack verify     Verify the stack: native health gate (+ --full data + source-posture).
   stack reset      Truncate the data DBs to an empty baseline + re-seed the dev user.
-  stack seed       Seed a running stack (--with playback|qtf add-ons).
+  stack seed       Seed a running stack (--with add-ons; --scenario/--dataset named datasets; --dry-run).
   stack snapshot   Store / restore / list / validate / delete native DB snapshots.
   stack overlay    Overlay your in-flight PRs onto a main-based stack.
   stack bootstrap  Stand the stack up on main (ensure repos → up → seed → verify).
@@ -232,7 +232,7 @@ slot-safe — it stops exactly the pids *this* stack recorded, never a host-glob
 |---|---|---|
 | `ss stack up [--only\|--with] [--slot N]` | Bring up a sub-stack (or full stack), native prep→migrate→launch→seed | [sub-stacks](./sub-stacks-and-bundles.md) · [slots](./slots.md) |
 | `ss stack status` / `verify [--full]` | Health (read-only) / gating health + data + posture | [verify](./verify.md) |
-| `ss stack seed [--with …]` / `reset` | Seed a running stack / truncate to an empty baseline + re-seed | [sub-stacks](./sub-stacks-and-bundles.md) |
+| `ss stack seed [--with …] [--scenario …]` / `reset` | Seed a running stack (add-ons + named datasets/scenarios) / truncate to an empty baseline + re-seed | [sub-stacks](./sub-stacks-and-bundles.md) |
 | `ss stack snapshot store\|restore\|list` | Save/restore a known-good DB state in seconds | [snapshots](./snapshots.md) |
 | `ss e2e run\|list\|connect` | Run/discover data-driven flows; open a live Connect session | [e2e](./e2e.md) |
 | `ss set list\|show\|check` + `--set <name>` | Named worktree sets: parallel dev contexts (repo map + slot) for `up`/`e2e run`/… | [worktree-sets](./worktree-sets.md) |

--- a/packages/node/saga-stack-cli/docs/sub-stacks-and-bundles.md
+++ b/packages/node/saga-stack-cli/docs/sub-stacks-and-bundles.md
@@ -73,6 +73,22 @@ ss stack seed                 # default roster
 ss stack seed --with playback # + the playback fixtures
 ```
 
+**Named datasets & scenarios** (multi-seed, #221): `profile` says *how much* to seed;
+a **dataset** names *which* fixture a system seeds (`SEED_DATASET=<name>` reaches that
+system's `db:seed`). A **scenario** is a named, coupled set of per-system datasets that
+must apply together — e.g. `ab-topology` stamps the programs/scheduling/sessions triad.
+A scenario that cannot apply coherently (a member inactive, restored, or not selected
+by the profile) is an **error**, never a silent partial seed.
+
+```bash
+ss stack seed full --scenario ab-topology            # coupled cross-system dataset
+ss stack seed full --dataset sessions-api=alt        # one system's named dataset
+ss stack seed full --scenario ab-topology --dry-run  # print the stamped plan, seed nothing
+```
+
+Flows can carry the same keys in their `flows.json` seed block
+(`"seed": { "profile": "full", "scenario": "ab-topology" }`).
+
 <details><summary>Seeds in place — profile + add-ons, offline steps first, then online</summary>
 
 ```

--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -1934,6 +1934,29 @@
             "qtf"
           ],
           "type": "option"
+        },
+        "scenario": {
+          "description": "named cross-system dataset scenario (#221 multi-seed) — stamps SEED_DATASET onto every step of the scenario's coupled systems (e.g. ab-topology ⇒ programs/scheduling/sessions), so the coupled dataset is applied together or not at all.",
+          "name": "scenario",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "ab-topology"
+          ],
+          "type": "option"
+        },
+        "dataset": {
+          "description": "per-system named dataset (#221 multi-seed), '<system>=<name>' — stamps SEED_DATASET=<name> onto that system's selected seed steps. Repeatable; merges with --scenario (a conflicting name for the same system errors).",
+          "name": "dataset",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "dry-run": {
+          "description": "print the composed seed plan (with any stamped datasets) and exit without seeding.",
+          "name": "dry-run",
+          "allowNo": false,
+          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,

--- a/packages/node/saga-stack-cli/src/__tests__/e2e-orchestrate-skip.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/__tests__/e2e-orchestrate-skip.unit.test.ts
@@ -1,0 +1,136 @@
+/**
+ * `executeResolvedFlow` — repo-absent skip wiring (#221 coach-deferral d).
+ *
+ * `stack up` warns-and-skips a service whose sibling repo isn't cloned (plus its
+ * hard dependents). This suite pins the SAME seed-active-set pattern downstream
+ * in the e2e orchestrator: a service `up()` reported skipped must be
+ *  - dropped from the composed seed plan (its steps degrade to
+ *    `service-inactive` skip notes, never spawned against a missing checkout),
+ *  - dropped from the verify probe list (a never-launched service must not
+ *    redden the run), and
+ *  - surfaced as a warning line.
+ *
+ * Offline + deterministic: fake StackApi + Runner; the bundled example
+ * flows.json supplies the resolved journey flow. No processes, no network.
+ */
+
+// eslint-disable-next-line no-restricted-imports -- test fixture read; production core stays fs-free
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { parseFlowManifest } from '../core/flow/load.js';
+import { resolveFlow } from '../core/flow/resolve.js';
+import type { ServiceId } from '../core/manifest/index.js';
+import type { SeedPlan } from '../core/seed/index.js';
+import { executeResolvedFlow } from '../e2e-orchestrate.js';
+import type { RunResult, ScriptInvocation } from '../runtime/index.js';
+import type { HealthProbe, StackApi, UpResult, UpSkip } from '../stack-api.js';
+
+const EXAMPLE = fileURLToPath(new URL('../../examples/flows/saga-dash.flows.json', import.meta.url));
+const flowManifest = parseFlowManifest(readFileSync(EXAMPLE, 'utf8'), EXAMPLE);
+
+interface Captured {
+  upServices: ServiceId[][];
+  seedPlans: SeedPlan[];
+  verifyProbes: HealthProbe[][];
+  playwright: ScriptInvocation[];
+  logs: string[];
+}
+
+/** Fake StackApi: up() reports `skips`; seed/verify/reset record + succeed. */
+function makeFakes(skips: UpSkip[]): { api: StackApi; cap: Captured } {
+  const cap: Captured = { upServices: [], seedPlans: [], verifyProbes: [], playwright: [], logs: [] };
+  const api: StackApi = {
+    async up(services: ServiceId[]): Promise<UpResult> {
+      cap.upServices.push(services);
+      return {
+        ok: true,
+        mesh: { ok: true } as UpResult['mesh'],
+        launched: [],
+        skipped: skips,
+      };
+    },
+    async down() {
+      return { stopped: [] };
+    },
+    async restart() {
+      throw new Error('unused');
+    },
+    async reset() {
+      return { code: 0 };
+    },
+    async seed(plan: SeedPlan) {
+      cap.seedPlans.push(plan);
+      return { ok: true, ran: { offline: [], online: [] }, skipped: plan.skipped };
+    },
+    async verify(probes: HealthProbe[]) {
+      cap.verifyProbes.push(probes);
+      return { passed: true, rows: [] };
+    },
+  };
+  return { api, cap };
+}
+
+async function run(skips: UpSkip[]): Promise<{ code: number; cap: Captured }> {
+  const { api, cap } = makeFakes(skips);
+  const code = await executeResolvedFlow(
+    resolveFlow(flowManifest, 'journey', { headed: false }),
+    {
+      api,
+      runner: {
+        async run(spec: ScriptInvocation): Promise<RunResult> {
+          cap.playwright.push(spec);
+          return { code: 0 };
+        },
+      },
+      appCwd: '/virtual/saga-dash/apps/web/dash',
+      now: new Date('2026-07-01T12:00:00Z'),
+      log: (line: string) => cap.logs.push(line),
+    },
+    { lane: 'stack', skipReset: false, passthrough: [] },
+  );
+  return { code, cap };
+}
+
+const SESSIONS_SKIP: UpSkip = {
+  id: 'sessions-api',
+  repo: 'PROGRAM_HUB',
+  repoDir: '/dev/program-hub',
+  message: 'sessions-api skipped — repo dir /dev/program-hub not present (PROGRAM_HUB repo not cloned)',
+};
+
+describe('executeResolvedFlow — honours up() repo-absent skips (#221 d)', () => {
+  it('drops a skipped service from the seed active set AND the verify probes; warns; still exits 0', async () => {
+    const { code, cap } = await run([SESSIONS_SKIP]);
+    expect(code).toBe(0);
+
+    // Seed: the journey roster profile normally seeds sessions — with
+    // sessions-api skipped, its step degrades to a service-inactive skip note.
+    expect(cap.seedPlans).toHaveLength(1);
+    const plan = cap.seedPlans[0] as SeedPlan;
+    const planned = [...plan.offline, ...plan.online];
+    expect(planned.map((s) => s.id)).toContain('iam'); // the rest still seeds
+    expect(planned.some((s) => s.service === 'sessions-api')).toBe(false);
+    expect(plan.skipped.some((n) => n.service === 'sessions-api' && n.reason === 'service-inactive')).toBe(true);
+
+    // Verify: no probe for the never-launched service.
+    expect(cap.verifyProbes).toHaveLength(1);
+    const probeIds = (cap.verifyProbes[0] as HealthProbe[]).map((p) => p.id);
+    expect(probeIds).not.toContain('sessions-api');
+    expect(probeIds).toContain('iam-api');
+
+    // The skip is surfaced as a warning line.
+    expect(cap.logs.some((l) => l.includes('sessions-api skipped'))).toBe(true);
+
+    // Playwright still ran (the skip guard keeps the run green).
+    expect(cap.playwright).toHaveLength(1);
+  });
+
+  it('no skips ⇒ full closure seeded and probed (baseline unchanged)', async () => {
+    const { code, cap } = await run([]);
+    expect(code).toBe(0);
+    const plan = cap.seedPlans[0] as SeedPlan;
+    expect([...plan.offline, ...plan.online].some((s) => s.service === 'sessions-api')).toBe(true);
+    expect((cap.verifyProbes[0] as HealthProbe[]).map((p) => p.id)).toContain('sessions-api');
+  });
+});

--- a/packages/node/saga-stack-cli/src/__tests__/stack-api.int.test.ts
+++ b/packages/node/saga-stack-cli/src/__tests__/stack-api.int.test.ts
@@ -339,3 +339,61 @@ describe('StackApi — up() then seed() run the composed offline-THEN-online pla
     expect(demoPolls?.cwd).toBe('/dev/vendor'); // VENDORED seed-demo-polls.mjs dir (VENDOR_DIR token)
   });
 });
+
+describe('StackApi — up() transitively skips HARD dependents of a repo-absent service (#221 coach-deferral b)', () => {
+  it('PROGRAM_HUB absent: connect-api (url dep on sessions/content) is skipped; connect-web (browser deps) still launches', async () => {
+    const { runtime, fakes } = makeRuntime();
+    runtime.repoDirExists = (dir: string) => dir !== REPO_ROOTS.PROGRAM_HUB;
+    const api = makeStackApi(manifest, runtime);
+
+    // closure(connect-web) = connect-web + connect-api + rtsm-api + iam-api +
+    // sessions-api + content-api (+ their PROGRAM_HUB upstreams).
+    const closure = computeClosure(manifest, ['connect-web'] as ServiceId[]);
+    const res = await api.up(closure.services);
+
+    // Warn, never fail.
+    expect(res.ok).toBe(true);
+
+    // PROGRAM_HUB services are repo-absent skips; connect-api is a TRANSITIVE skip.
+    const skippedIds = res.skipped.map((s) => s.id);
+    expect(skippedIds).toContain('sessions-api');
+    expect(skippedIds).toContain('content-api');
+    expect(skippedIds).toContain('connect-api');
+
+    // The transitive skip attributes the missing upstream + the root-cause repo.
+    const connect = res.skipped.find((s) => s.id === 'connect-api');
+    expect(connect?.repo).toBe('PROGRAM_HUB');
+    expect(connect?.message).toMatch(/depends on (sessions|content)-api, which was skipped/);
+
+    // connect-web's deps are ALL `browser` edges — it must NOT be skipped.
+    expect(skippedIds).not.toContain('connect-web');
+    const launchedIds = fakes.launches.map((l) => l.id);
+    expect(launchedIds).toContain('connect-web');
+    expect(launchedIds).toContain('iam-api');
+    expect(launchedIds).toContain('rtsm-api');
+    expect(launchedIds).not.toContain('connect-api');
+  });
+
+  it('PROGRAM_HUB absent: ads-adm-api (s2s dep on sessions-api) is skipped across repos', async () => {
+    const { runtime, fakes } = makeRuntime();
+    runtime.repoDirExists = (dir: string) => dir !== REPO_ROOTS.PROGRAM_HUB;
+    const api = makeStackApi(manifest, runtime);
+
+    const res = await api.up(['iam-api', 'sessions-api', 'ads-adm-api'] as ServiceId[]);
+
+    expect(res.ok).toBe(true);
+    const ads = res.skipped.find((s) => s.id === 'ads-adm-api');
+    expect(ads).toBeDefined();
+    expect(ads?.message).toMatch(/depends on sessions-api, which was skipped/);
+    expect(ads?.repo).toBe('PROGRAM_HUB'); // root cause, not the SDS checkout (present)
+    expect(fakes.launches.map((l) => l.id)).toEqual(['iam-api']);
+  });
+
+  it('no propagation when every repo is present', async () => {
+    const { runtime } = makeRuntime();
+    runtime.repoDirExists = () => true;
+    const api = makeStackApi(manifest, runtime);
+    const res = await api.up(['iam-api', 'sessions-api', 'ads-adm-api'] as ServiceId[]);
+    expect(res.skipped).toEqual([]);
+  });
+});

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/seed-native.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/seed-native.int.test.ts
@@ -139,3 +139,64 @@ describe('stack seed — native seed runner (FLIP 2)', () => {
     expect(runs.some((r) => r.command.endsWith('up.sh'))).toBe(false);
   });
 });
+
+describe('stack seed — multi-seed datasets (#221)', () => {
+  it('full --scenario ab-topology: stamps SEED_DATASET onto the triad seed runs only', async () => {
+    await StackSeed.run(['full', '--scenario', 'ab-topology', '--output-json', ...WS], config);
+    expect(runs.some((r) => r.command.endsWith('up.sh'))).toBe(false);
+
+    // The triad's db:seed runs carry the stamped var…
+    const stamped = runs.filter((r) => r.env?.SEED_DATASET === 'ab-topology');
+    expect(stamped.length).toBe(3); // programs + scheduling + sessions
+    // …and the iam dev-user seed does NOT.
+    const devUser = runs.find((r) => r.args.some((a) => a.includes('seed-dev-user')));
+    expect(devUser?.env?.SEED_DATASET).toBeUndefined();
+    expect(seededJson().ok).toBe(true);
+  });
+
+  it('--dataset <system>=<name> stamps just that system', async () => {
+    await StackSeed.run(['--dataset', 'sessions-api=alt', '--output-json', ...WS], config);
+    const stamped = runs.filter((r) => r.env?.SEED_DATASET === 'alt');
+    expect(stamped.length).toBe(1); // the sessions step only (roster profile)
+  });
+
+  it('--dry-run: prints the composed labeled plan and runs NOTHING', async () => {
+    await StackSeed.run(['full', '--scenario', 'ab-topology', '--dry-run', '--output-json', ...WS], config);
+    expect(runs).toEqual([]); // no seed step spawned
+    const line = logged.find((l) => l.trim().startsWith('{'));
+    const j = JSON.parse(String(line)) as { dryRun: boolean; offline: string[]; scenario?: string };
+    expect(j.dryRun).toBe(true);
+    expect(j.scenario).toBe('ab-topology');
+    expect(j.offline).toContain('programs [SEED_DATASET=ab-topology]');
+    expect(j.offline).toContain('iam-dev-user'); // unstamped steps keep plain labels
+  });
+
+  it('rejects a malformed --dataset value', async () => {
+    await expect(StackSeed.run(['--dataset', 'sessions-api', ...WS], config)).rejects.toThrow(
+      /--dataset expects <system>=<name>/,
+    );
+    expect(runs).toEqual([]);
+  });
+
+  it('rejects an unknown --dataset service id, listing the known ids', async () => {
+    await expect(StackSeed.run(['--dataset', 'nope-api=x', ...WS], config)).rejects.toThrow(
+      /unknown service id 'nope-api'/,
+    );
+  });
+
+  it('COHERENCE at the command layer: roster --scenario ab-topology errors (triad not selected)', async () => {
+    // roster never selects programs/scheduling steps ⇒ the coupled scenario
+    // cannot apply coherently ⇒ surfaced as a command error, nothing seeded.
+    await expect(StackSeed.run(['--scenario', 'ab-topology', ...WS], config)).rejects.toThrow(
+      /cannot be applied coherently/,
+    );
+    expect(runs).toEqual([]);
+  });
+
+  it('CONFLICT: --scenario plus a different --dataset for the same system errors', async () => {
+    await expect(
+      StackSeed.run(['full', '--scenario', 'ab-topology', '--dataset', 'programs-api=other', ...WS], config),
+    ).rejects.toThrow(/conflicting datasets/);
+    expect(runs).toEqual([]);
+  });
+});

--- a/packages/node/saga-stack-cli/src/commands/stack/seed.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/seed.ts
@@ -15,8 +15,15 @@
  * it cannot drift from `--with`. A bundle with no seed add-on (`--with dash`/
  * `coach`/`connect`) is a harmless no-op here.
  *
+ * MULTI-SEED (#221): `--scenario <name>` applies a named cross-system dataset
+ * scenario (e.g. `ab-topology` stamps `SEED_DATASET=ab-topology` onto the
+ * programs/scheduling/sessions steps); a repeatable `--dataset <system>=<name>`
+ * names one system's dataset directly. `--dry-run` prints the composed plan
+ * (with any stamped datasets) without touching the stack.
+ *
  *   node bin/dev.js stack seed
  *   node bin/dev.js stack seed full --with playback
+ *   node bin/dev.js stack seed full --scenario ab-topology --dry-run
  */
 
 import { Args, Flags } from '@oclif/core';
@@ -27,8 +34,31 @@ import { deriveInstance } from '../../core/derive-instance.js';
 import { manifest } from '../../core/manifest/index.js';
 import type { ServiceId } from '../../core/manifest/index.js';
 import { composeSeedPlan } from '../../core/seed/compose-seed-plan.js';
-import type { SeedAddOn, SeedProfile, SeedSelection } from '../../core/seed/types.js';
+import { SEED_SCENARIO_NAMES, SeedDatasetError, seedStepLabel } from '../../core/seed/datasets.js';
+import type { SeedScenarioName, SystemSeedDataset } from '../../core/seed/datasets.js';
+import type { SeedAddOn, SeedPlan, SeedProfile, SeedSelection } from '../../core/seed/types.js';
 import { makeStackApi } from '../../stack-api.js';
+
+/** Parse repeatable `--dataset <system>=<name>` values (validated against the manifest). */
+export function parseDatasetFlags(
+  values: string[] | undefined,
+  fail: (msg: string) => never,
+): SystemSeedDataset[] | undefined {
+  if (!values || values.length === 0) return undefined;
+  const known = new Set(Object.keys(manifest.services));
+  return values.map((raw) => {
+    const eq = raw.indexOf('=');
+    const system = eq >= 0 ? raw.slice(0, eq) : '';
+    const dataset = eq >= 0 ? raw.slice(eq + 1) : '';
+    if (system === '' || dataset === '') {
+      fail(`--dataset expects <system>=<name>, got '${raw}'`);
+    }
+    if (!known.has(system)) {
+      fail(`--dataset: unknown service id '${system}'\nknown: ${[...known].join(', ')}`);
+    }
+    return { system: system as ServiceId, dataset };
+  });
+}
 
 export default class StackSeed extends BaseCommand {
   static description = 'Seed a running stack (native).';
@@ -53,6 +83,19 @@ export default class StackSeed extends BaseCommand {
       options: [...BUNDLE_NAMES],
       description:
         "convenience bundle(s) whose seed ADD-ON is layered onto the seed plan — sugar shared with `stack up`. Repeatable: --with playback --with qtf. `--with playback` seeds the playback DBs (== the old --with-playback); `--with qtf` seeds the QTF demo. Bundles with no seed add-on (dash/coach/connect) are a no-op here.",
+    }),
+    scenario: Flags.string({
+      options: [...SEED_SCENARIO_NAMES],
+      description:
+        'named cross-system dataset scenario (#221 multi-seed) — stamps SEED_DATASET onto every step of the scenario\'s coupled systems (e.g. ab-topology ⇒ programs/scheduling/sessions), so the coupled dataset is applied together or not at all.',
+    }),
+    dataset: Flags.string({
+      multiple: true,
+      description:
+        "per-system named dataset (#221 multi-seed), '<system>=<name>' — stamps SEED_DATASET=<name> onto that system's selected seed steps. Repeatable; merges with --scenario (a conflicting name for the same system errors).",
+    }),
+    'dry-run': Flags.boolean({
+      description: 'print the composed seed plan (with any stamped datasets) and exit without seeding.',
     }),
   };
 
@@ -103,8 +146,46 @@ export default class StackSeed extends BaseCommand {
       );
     }
 
-    const selection: SeedSelection = { profile, addOns };
-    const plan = composeSeedPlan(selection, active, new Set<ServiceId>());
+    // #221 multi-seed: scenario + per-system datasets (compose stamps SEED_DATASET
+    // onto clones of the selected steps and enforces scenario coherence).
+    const datasets = parseDatasetFlags(flags.dataset, (m) => this.error(m));
+    const selection: SeedSelection = {
+      profile,
+      addOns,
+      ...(flags.scenario ? { scenario: flags.scenario as SeedScenarioName } : {}),
+      ...(datasets ? { datasets } : {}),
+    };
+    let plan: SeedPlan;
+    try {
+      plan = composeSeedPlan(selection, active, new Set<ServiceId>());
+    } catch (err) {
+      if (err instanceof SeedDatasetError) this.error(err.message);
+      throw err;
+    }
+
+    if (flags['dry-run']) {
+      this.emit(
+        flags,
+        {
+          native: true,
+          dryRun: true,
+          profile,
+          addOns,
+          ...(flags.scenario ? { scenario: flags.scenario } : {}),
+          ...(datasets ? { datasets } : {}),
+          offline: plan.offline.map((s) => seedStepLabel(s)),
+          online: plan.online.map((s) => seedStepLabel(s)),
+          skipped: plan.skipped.map((s) => ({ id: s.id, reason: s.reason })),
+        },
+        [
+          `seed plan (dry-run, profile ${profile}${flags.scenario ? `, scenario ${flags.scenario}` : ''}):`,
+          `  offline: ${plan.offline.map((s) => seedStepLabel(s)).join(', ') || '(none)'}`,
+          `  online:  ${plan.online.map((s) => seedStepLabel(s)).join(', ') || '(none)'}`,
+          `  skipped: ${plan.skipped.map((s) => `${s.id} (${s.reason})`).join(', ') || '(none)'}`,
+        ],
+      );
+      return;
+    }
 
     const api = makeStackApi(manifest, this.buildNativeRuntime(flags, instance));
     const seeded = await api.seed(plan);

--- a/packages/node/saga-stack-cli/src/core/flow/__tests__/load.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/flow/__tests__/load.unit.test.ts
@@ -107,3 +107,47 @@ describe('loadFlowManifest — injectable reader seam (no disk IO)', () => {
     );
   });
 });
+
+describe('parseFlowManifest — multi-seed scenario/datasets in seed blocks (#221)', () => {
+  type SeedBlock = Record<string, unknown>;
+  const withSeed = (seed: SeedBlock): string => {
+    const doc = JSON.parse(EXAMPLE_TEXT) as { flows: { seed?: SeedBlock }[] };
+    doc.flows[0].seed = seed;
+    return JSON.stringify(doc);
+  };
+
+  it('accepts a flow seed with a known scenario + per-system datasets', () => {
+    const m = parseFlowManifest(
+      withSeed({
+        profile: 'full',
+        scenario: 'ab-topology',
+        datasets: [{ system: 'content-api', dataset: 'qtf-demo' }],
+      }),
+    );
+    const journey = m.flows.find((f) => f.name === 'journey');
+    expect(journey?.seed?.scenario).toBe('ab-topology');
+    expect(journey?.seed?.datasets).toEqual([{ system: 'content-api', dataset: 'qtf-demo' }]);
+  });
+
+  it('rejects an unknown scenario name (closed enum)', () => {
+    expect(() => parseFlowManifest(withSeed({ profile: 'full', scenario: 'nope' }))).toThrow(
+      /failed schema validation/,
+    );
+  });
+
+  it('rejects a dataset entry with an unknown system id', () => {
+    expect(() =>
+      parseFlowManifest(
+        withSeed({ profile: 'full', datasets: [{ system: 'not-a-service', dataset: 'x' }] }),
+      ),
+    ).toThrow(/failed schema validation/);
+  });
+
+  it('rejects an empty dataset name (min(1))', () => {
+    expect(() =>
+      parseFlowManifest(
+        withSeed({ profile: 'full', datasets: [{ system: 'sessions-api', dataset: '' }] }),
+      ),
+    ).toThrow(/failed schema validation/);
+  });
+});

--- a/packages/node/saga-stack-cli/src/core/flow/types.ts
+++ b/packages/node/saga-stack-cli/src/core/flow/types.ts
@@ -13,6 +13,7 @@
 
 import { z } from 'zod';
 import type { ServiceId } from '../manifest/index.js';
+import { SEED_SCENARIO_NAMES } from '../seed/datasets.js';
 import type { SeedSelection } from '../seed/index.js';
 
 /**
@@ -67,6 +68,13 @@ export const seedSelectionSchema = z.object({
   perSystem: z.array(z.object({ system: serviceIdSchema, profile: seedProfileSchema })).optional(),
   only: z.array(serviceIdSchema).optional(),
   exclude: z.array(z.string()).optional(),
+  // #221 multi-seed: named cross-system scenario + per-system dataset overrides
+  // (the IDENTITY axis — see core/seed/datasets.ts). Mirrored from the canonical
+  // `SeedSelection` in the SAME change (the compile guard below).
+  scenario: z.enum(SEED_SCENARIO_NAMES).optional(),
+  datasets: z
+    .array(z.object({ system: serviceIdSchema, dataset: z.string().min(1) }))
+    .optional(),
 });
 
 // Compile guard: the canonical SeedSelection must satisfy this schema's shape.

--- a/packages/node/saga-stack-cli/src/core/manifest/__tests__/consistency.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/__tests__/consistency.unit.test.ts
@@ -13,6 +13,7 @@
 import { describe, expect, it } from 'vitest';
 import { serviceIdSchema } from '../../flow/types.js';
 import { buildSeedRegistry } from '../../seed/profiles.js';
+import { safeParseSnapshotManifest, snapshotDbSchema } from '../../snapshot/manifest.js';
 import { REPO_DEFAULT_DIR } from '../../../runtime/scripts.js';
 import { manifest } from '../index.js';
 import type { DbId, RepoKey, ServiceId } from '../index.js';
@@ -74,5 +75,33 @@ describe('manifest consistency — every edge resolves', () => {
     const env = manifest.services['iam-api'].launch.env;
     expect(env.SECURITY_RATELIMITMAXREQUESTS).toBe('1000000');
     expect(env.JWT_ACCESSTOKENTTLSECONDS).toBe('28800');
+  });
+});
+
+describe('manifest consistency — snapshot zod enums are EXHAUSTIVE (#221 coach-deferral c)', () => {
+  // Guards the same drift class as the flow-enum test, but for the SECOND
+  // hand-maintained enum pair (`snapshot/manifest.ts`): adding a service or DB to
+  // the manifest without extending the snapshot enums would make `snapshot store`
+  // output unparseable by `validate`/`restore`.
+  it('every manifest DbId parses as a snapshot manifest database entry', () => {
+    for (const [db, def] of Object.entries(manifest.databases)) {
+      const entry = {
+        db,
+        engine: def.engine,
+        ownerRole: def.ownerRole,
+        schemaRev: null,
+        file: `${db}.dump`,
+      };
+      const parsed = snapshotDbSchema.safeParse(entry);
+      expect(parsed.success, `DbId '${db}' missing from snapshot/manifest.ts DB_IDS`).toBe(true);
+    }
+  });
+
+  it('every manifest ServiceId parses in a snapshot manifest systems[] list', () => {
+    const base = { schemaVersion: 1, fixtureId: 'fx', profile: 'full', databases: [] };
+    for (const id of SERVICE_IDS) {
+      const parsed = safeParseSnapshotManifest({ ...base, systems: [id] });
+      expect(parsed.success, `ServiceId '${id}' missing from snapshot/manifest.ts SERVICE_IDS`).toBe(true);
+    }
   });
 });

--- a/packages/node/saga-stack-cli/src/core/seed/__tests__/compose-seed-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/seed/__tests__/compose-seed-plan.unit.test.ts
@@ -16,7 +16,8 @@
 import { describe, expect, it } from 'vitest';
 import type { ServiceId } from '../../manifest/index.js';
 import { composeSeedPlan } from '../compose-seed-plan.js';
-import type { SeedSelection } from '../types.js';
+import { SEED_DATASET_VAR, SeedDatasetError } from '../datasets.js';
+import type { SeedSelection, SeedStep } from '../types.js';
 
 const set = (...ids: ServiceId[]): Set<ServiceId> => new Set(ids);
 const ids = (steps: { id: string }[]): string[] => steps.map((s) => s.id);
@@ -167,5 +168,84 @@ describe('composeSeedPlan — per-system profile overrides (M5)', () => {
     const b = composeSeedPlan({ ...base, perSystem: [] }, active, set());
     expect(ids(a.offline)).toEqual(ids(b.offline));
     expect(ids(a.online)).toEqual(ids(b.online));
+  });
+});
+
+describe('composeSeedPlan — multi-seed datasets (#221)', () => {
+  const TRIAD_ACTIVE = set('iam-api', 'sessions-api', 'programs-api', 'scheduling-api');
+  const fullSel: SeedSelection = { profile: 'full', scenario: 'ab-topology' };
+  const varsOf = (s: SeedStep): Record<string, string> =>
+    s.env.kind === 'dotenv' ? {} : s.env.vars;
+
+  it("scenario stamps SEED_DATASET onto the triad's steps and ONLY those", () => {
+    const plan = composeSeedPlan(fullSel, TRIAD_ACTIVE, set());
+    const all = [...plan.offline, ...plan.online];
+
+    const stamped = all.filter((s) => varsOf(s)[SEED_DATASET_VAR] === 'ab-topology');
+    expect(stamped.map((s) => s.id).sort()).toEqual(['programs', 'scheduling', 'sessions']);
+
+    // Non-triad steps (iam pair) carry NO dataset var.
+    for (const s of all.filter((x) => !['programs', 'scheduling', 'sessions'].includes(x.id))) {
+      expect(varsOf(s)[SEED_DATASET_VAR]).toBeUndefined();
+    }
+  });
+
+  it('stamping CLONES — the frozen registry is untouched (a later plain compose is unstamped)', () => {
+    composeSeedPlan(fullSel, TRIAD_ACTIVE, set());
+    const plain = composeSeedPlan({ profile: 'full' }, TRIAD_ACTIVE, set());
+    for (const s of [...plain.offline, ...plain.online]) {
+      expect(varsOf(s)[SEED_DATASET_VAR]).toBeUndefined();
+    }
+  });
+
+  it('a per-system dataset stamps just that system (identity axis; step selection unchanged)', () => {
+    const sel: SeedSelection = {
+      profile: 'roster',
+      datasets: [{ system: 'sessions-api', dataset: 'alt' }],
+    };
+    const plan = composeSeedPlan(sel, set('iam-api', 'sessions-api'), set());
+    expect(ids(plan.offline)).toEqual(['iam-dev-user', 'iam', 'sessions']); // same steps as plain roster
+    const sessions = plan.offline.find((s) => s.id === 'sessions');
+    expect(varsOf(sessions as SeedStep)[SEED_DATASET_VAR]).toBe('alt');
+  });
+
+  it('partition is unchanged by stamping (a stamped online step stays online)', () => {
+    const sel: SeedSelection = {
+      profile: 'full',
+      datasets: [{ system: 'content-api', dataset: 'qtf-alt' }],
+    };
+    const active = set('iam-api', 'sessions-api', 'programs-api', 'scheduling-api', 'content-api');
+    const plan = composeSeedPlan(sel, active, set());
+    const content = plan.online.find((s) => s.id === 'content');
+    expect(varsOf(content as SeedStep)[SEED_DATASET_VAR]).toBe('qtf-alt');
+  });
+
+  it('COHERENCE: an inactive triad member fails the whole scenario (never a half-applied triad)', () => {
+    // scheduling-api missing from the active set ⇒ its step drops as
+    // service-inactive ⇒ the coupled ab-topology dataset CANNOT apply coherently.
+    const active = set('iam-api', 'sessions-api', 'programs-api');
+    expect(() => composeSeedPlan(fullSel, active, set())).toThrow(SeedDatasetError);
+    expect(() => composeSeedPlan(fullSel, active, set())).toThrow(/scheduling-api \(service-inactive\)/);
+  });
+
+  it('COHERENCE: a snapshot-restored triad member fails the scenario too', () => {
+    expect(() => composeSeedPlan(fullSel, TRIAD_ACTIVE, set('programs-api'))).toThrow(
+      /programs-api \(service-restored\)/,
+    );
+  });
+
+  it('COHERENCE: a profile that never selects a mapped system explains the miss', () => {
+    // roster selects no programs/scheduling steps at all (they are full-only).
+    const sel: SeedSelection = { profile: 'roster', scenario: 'ab-topology' };
+    expect(() => composeSeedPlan(sel, TRIAD_ACTIVE, set())).toThrow(/no step selected/);
+  });
+
+  it('CONFLICT: --dataset naming a different dataset for a scenario system throws', () => {
+    const sel: SeedSelection = {
+      profile: 'full',
+      scenario: 'ab-topology',
+      datasets: [{ system: 'programs-api', dataset: 'other' }],
+    };
+    expect(() => composeSeedPlan(sel, TRIAD_ACTIVE, set())).toThrow(/conflicting datasets/);
   });
 });

--- a/packages/node/saga-stack-cli/src/core/seed/__tests__/datasets.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/seed/__tests__/datasets.unit.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Named seed datasets + scenarios unit tests (saga-ed/soa#221 multi-seed).
+ *
+ * `resolveDatasetMap` is the pure resolution step: scenario expansion first,
+ * explicit per-system datasets merged on top, with a same-system conflict being
+ * an authoring ERROR (one `SEED_DATASET` var per step — never a silent merge).
+ *
+ * PURE: no docker/pnpm/network.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { ServiceId } from '../../manifest/index.js';
+import { composeSeedPlan } from '../compose-seed-plan.js';
+import {
+  resolveDatasetMap,
+  SEED_SCENARIO_NAMES,
+  SEED_SCENARIOS,
+  SeedDatasetError,
+  seedStepLabel,
+} from '../datasets.js';
+import type { SeedScenarioName } from '../datasets.js';
+
+describe('resolveDatasetMap — scenario expansion', () => {
+  it('ab-topology expands to the coupled programs/scheduling/sessions triad', () => {
+    const map = resolveDatasetMap({ scenario: 'ab-topology' });
+    expect(map.get('programs-api')).toBe('ab-topology');
+    expect(map.get('scheduling-api')).toBe('ab-topology');
+    expect(map.get('sessions-api')).toBe('ab-topology');
+    expect(map.size).toBe(3);
+  });
+
+  it('an empty selection resolves to an empty map', () => {
+    expect(resolveDatasetMap({}).size).toBe(0);
+  });
+
+  it('every registered scenario name expands to a non-empty dataset set', () => {
+    for (const name of SEED_SCENARIO_NAMES) {
+      expect(SEED_SCENARIOS[name].length).toBeGreaterThan(0);
+      expect(resolveDatasetMap({ scenario: name }).size).toBe(SEED_SCENARIOS[name].length);
+    }
+  });
+
+  it('throws SeedDatasetError on a scenario name outside the registry (runtime guard)', () => {
+    expect(() => resolveDatasetMap({ scenario: 'nope' as SeedScenarioName })).toThrow(SeedDatasetError);
+  });
+});
+
+describe('resolveDatasetMap — explicit datasets + merge', () => {
+  it('datasets alone map each named system', () => {
+    const map = resolveDatasetMap({
+      datasets: [{ system: 'content-api', dataset: 'qtf-demo' }],
+    });
+    expect(map.get('content-api')).toBe('qtf-demo');
+    expect(map.size).toBe(1);
+  });
+
+  it('explicit datasets merge ON TOP of a scenario (disjoint system)', () => {
+    const map = resolveDatasetMap({
+      scenario: 'ab-topology',
+      datasets: [{ system: 'content-api', dataset: 'qtf-demo' }],
+    });
+    expect(map.get('content-api')).toBe('qtf-demo');
+    expect(map.get('programs-api')).toBe('ab-topology');
+    expect(map.size).toBe(4);
+  });
+
+  it('a REDUNDANT (same-name) entry for a scenario system is accepted', () => {
+    const map = resolveDatasetMap({
+      scenario: 'ab-topology',
+      datasets: [{ system: 'programs-api', dataset: 'ab-topology' }],
+    });
+    expect(map.get('programs-api')).toBe('ab-topology');
+    expect(map.size).toBe(3);
+  });
+
+  it('a CONFLICTING name for a scenario system throws SeedDatasetError', () => {
+    expect(() =>
+      resolveDatasetMap({
+        scenario: 'ab-topology',
+        datasets: [{ system: 'programs-api', dataset: 'other' }],
+      }),
+    ).toThrow(/conflicting datasets for programs-api.*'ab-topology' vs 'other'/);
+  });
+
+  it('two conflicting explicit entries for the same system throw too', () => {
+    expect(() =>
+      resolveDatasetMap({
+        datasets: [
+          { system: 'sessions-api', dataset: 'a' },
+          { system: 'sessions-api', dataset: 'b' },
+        ],
+      }),
+    ).toThrow(SeedDatasetError);
+  });
+});
+
+describe('seedStepLabel — shared dry-run printer', () => {
+  it('labels a stamped step with [SEED_DATASET=<name>] and leaves plain steps as bare ids', () => {
+    const plan = composeSeedPlan(
+      { profile: 'full', scenario: 'ab-topology' },
+      new Set<ServiceId>(['iam-api', 'sessions-api', 'programs-api', 'scheduling-api']),
+      new Set<ServiceId>(),
+    );
+    const labels = [...plan.offline, ...plan.online].map((s) => seedStepLabel(s));
+    expect(labels).toContain('programs [SEED_DATASET=ab-topology]');
+    expect(labels).toContain('iam-dev-user'); // unstamped ⇒ bare id
+  });
+});

--- a/packages/node/saga-stack-cli/src/core/seed/compose-seed-plan.ts
+++ b/packages/node/saga-stack-cli/src/core/seed/compose-seed-plan.ts
@@ -18,13 +18,56 @@
  *   3. partition — split the survivors into `offline` / `online` by
  *      `requiresServiceUp` (online = deferred until those services are up).
  *
+ * MULTI-SEED (#221): a `scenario`/`datasets` selection resolves to a per-system
+ * dataset map (`resolveDatasetMap`). Each SURVIVING step whose service is in the
+ * map is emitted as a CLONE with `SEED_DATASET=<name>` added to its env vars —
+ * the ONLY place the frozen registry is ever varied per selection. After the
+ * gates, coherence is enforced: every mapped system must have contributed at
+ * least one stamped step, else the compose THROWS (`SeedDatasetError`) — a
+ * coupled scenario (the triad) must never be half-applied (multiseed-research §1).
+ *
  * PURE: no IO. Operates over the frozen registry derived from the manifest.
  */
 
 import type { ServiceId } from '../manifest/index.js';
+import { SEED_DATASET_VAR, SeedDatasetError, resolveDatasetMap } from './datasets.js';
 import { ADDON_STEPS, PROFILE_STEPS, SEED_RUN_ORDER, SEED_STEPS } from './profiles.js';
 import type { SeedStepId } from './profiles.js';
 import type { SeedPlan, SeedSelection, SeedStep, SkipNote } from './types.js';
+
+/**
+ * Clone `step` with `SEED_DATASET=<dataset>` stamped into its env var bag —
+ * recursively stamping any nested `optionalSteps` owned by a mapped service.
+ * The registry object itself is never mutated (it stays frozen); a `dotenv`
+ * env kind has no var bag to stamp, so a dataset on such a step is rejected.
+ */
+function stampDataset(step: SeedStep, datasetsBySystem: Map<ServiceId, string>): SeedStep {
+  const dataset = datasetsBySystem.get(step.service);
+  const optionalSteps = step.optionalSteps?.map((sub) => stampDataset(sub, datasetsBySystem));
+  if (dataset === undefined) {
+    return optionalSteps === undefined ? step : { ...step, optionalSteps };
+  }
+  if (step.env.kind === 'dotenv') {
+    throw new SeedDatasetError(
+      `seed step '${step.id}' (${step.service}) uses the dotenv env kind — a named dataset cannot be stamped onto it`,
+    );
+  }
+  return {
+    ...step,
+    env: { kind: step.env.kind, vars: { ...step.env.vars, [SEED_DATASET_VAR]: dataset } },
+    ...(optionalSteps === undefined ? {} : { optionalSteps }),
+  };
+}
+
+/** Collect every dataset-mapped system `step` (or a nested optionalStep) covers. */
+function recordStamped(
+  step: SeedStep,
+  datasetsBySystem: Map<ServiceId, string>,
+  stampedSystems: Set<ServiceId>,
+): void {
+  if (datasetsBySystem.has(step.service)) stampedSystems.add(step.service);
+  for (const sub of step.optionalSteps ?? []) recordStamped(sub, datasetsBySystem, stampedSystems);
+}
 
 export function composeSeedPlan(
   sel: SeedSelection,
@@ -47,6 +90,11 @@ export function composeSeedPlan(
 
   const onlyServices = sel.only ? new Set<ServiceId>(sel.only) : undefined;
   const excludeIds = sel.exclude ? new Set<string>(sel.exclude) : undefined;
+
+  // #221 multi-seed: scenario ∪ datasets → one per-system dataset map (throws
+  // SeedDatasetError on a conflicting/unknown selection).
+  const datasetsBySystem = resolveDatasetMap(sel);
+  const stampedSystems = new Set<ServiceId>();
 
   const offline: SeedStep[] = [];
   const online: SeedStep[] = [];
@@ -88,9 +136,32 @@ export function composeSeedPlan(
       continue;
     }
 
+    // #221 multi-seed: stamp the dataset onto a CLONE of the surviving step.
+    // Record every mapped system the emitted step reaches (incl. nested
+    // optionalSteps) so coherence sees a system stamped only via a sub-step.
+    const emitted = stampDataset(step, datasetsBySystem);
+    recordStamped(emitted, datasetsBySystem, stampedSystems);
+
     // Gate 3: partition offline vs online.
-    if (step.requiresServiceUp.length > 0) online.push(step);
-    else offline.push(step);
+    if (emitted.requiresServiceUp.length > 0) online.push(emitted);
+    else offline.push(emitted);
+  }
+
+  // #221 multi-seed coherence: every mapped system must have contributed at
+  // least one stamped step — a coupled scenario (the triad) half-applied is the
+  // one cross-system hazard this feature introduces, so it is an ERROR, never a
+  // silent partial seed. The skip notes explain WHY a system missed (inactive /
+  // restored); a system absent from them was simply never selected (profile too
+  // light, or narrowed out by only/exclude).
+  const unapplied = [...datasetsBySystem.keys()].filter((s) => !stampedSystems.has(s));
+  if (unapplied.length > 0) {
+    const why = unapplied.map((s) => {
+      const note = skipped.find((n) => n.service === s);
+      return `${s} (${note ? note.reason : 'no step selected — check profile/perSystem/only/exclude'})`;
+    });
+    throw new SeedDatasetError(
+      `dataset selection cannot be applied coherently — no seed step ran for: ${why.join('; ')}`,
+    );
   }
 
   return { offline, online, skipped };

--- a/packages/node/saga-stack-cli/src/core/seed/datasets.ts
+++ b/packages/node/saga-stack-cli/src/core/seed/datasets.ts
@@ -1,0 +1,112 @@
+/**
+ * Named seed DATASETS + cross-system SCENARIOS (saga-ed/soa#221, multi-seed
+ * composition — `claude/projects/gh_214/multiseed-research.md` Option C, with
+ * Option A as the transport for the coupled core).
+ *
+ * Two layers, per the research recommendation:
+ *  - the MECHANICAL unit is per-system: `{system → dataset}` reaches individual
+ *    seed steps as a `SEED_DATASET=<name>` env var stamped onto a compose-time
+ *    CLONE of the frozen registry step (the house `SEED_DEMO_ONLY` pattern —
+ *    the repo's single `db:seed` branches on the var);
+ *  - the AUTHORED unit is a SCENARIO: a named, internally-coherent set of
+ *    per-system datasets that must be applied together (the scheduling/programs/
+ *    sessions triad derives ids from the same positional catalogs, so selecting
+ *    `ab-topology` for scheduling but not programs is not a valid state).
+ *
+ * Dataset is IDENTITY (which fixture); profile stays QUANTITY (how much) — the
+ * axes are orthogonal, so a dataset never changes WHICH steps are selected, only
+ * what the selected steps seed. Coherence (a scenario cannot be half-applied) is
+ * enforced by `composeSeedPlan` after the gates run.
+ *
+ * PURE: types + frozen data + resolution helpers; zero IO.
+ */
+
+import type { ServiceId } from '../manifest/index.js';
+import type { SeedStep } from './types.js';
+
+/** Per-system named-dataset selection (identity axis; `profile` is quantity). */
+export interface SystemSeedDataset {
+  system: ServiceId;
+  dataset: string;
+}
+
+/**
+ * Env var stamped onto a cloned seed step so the owning repo's `db:seed` can
+ * branch to the named dataset (exact precedent: `SEED_DEMO_ONLY`).
+ */
+export const SEED_DATASET_VAR = 'SEED_DATASET';
+
+/** The closed set of scenario names (grow append-only, like the seed-id catalogs). */
+export const SEED_SCENARIO_NAMES = ['ab-topology'] as const;
+export type SeedScenarioName = (typeof SEED_SCENARIO_NAMES)[number];
+
+/**
+ * Scenario registry: scenario → the coherent per-system dataset map it expands
+ * to. `ab-topology` is the motivating A/B day-type case: programs declares the
+ * rotation topology, scheduling mints per-(period,rotation) slots, sessions
+ * projects per-rotation — all three read the same append-only id catalogs, so
+ * they must move together (multiseed-research §1, §6).
+ */
+export const SEED_SCENARIOS: Readonly<Record<SeedScenarioName, readonly SystemSeedDataset[]>> =
+  Object.freeze({
+    'ab-topology': [
+      { system: 'programs-api', dataset: 'ab-topology' },
+      { system: 'scheduling-api', dataset: 'ab-topology' },
+      { system: 'sessions-api', dataset: 'ab-topology' },
+    ],
+  });
+
+/** A dataset/scenario selection that cannot compose into a coherent plan. */
+export class SeedDatasetError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SeedDatasetError';
+  }
+}
+
+/**
+ * Resolve `scenario` ∪ explicit `datasets` into ONE per-system dataset map.
+ * The scenario expands first; explicit entries then merge on top. Two entries
+ * naming DIFFERENT datasets for the same system conflict (there is one
+ * `SEED_DATASET` var per step) — that is an authoring error, not a merge.
+ */
+export function resolveDatasetMap(sel: {
+  scenario?: SeedScenarioName;
+  datasets?: readonly SystemSeedDataset[];
+}): Map<ServiceId, string> {
+  const map = new Map<ServiceId, string>();
+
+  const merge = (entry: SystemSeedDataset, source: string): void => {
+    const existing = map.get(entry.system);
+    if (existing !== undefined && existing !== entry.dataset) {
+      throw new SeedDatasetError(
+        `conflicting datasets for ${entry.system}: '${existing}' vs '${entry.dataset}' (${source})`,
+      );
+    }
+    map.set(entry.system, entry.dataset);
+  };
+
+  if (sel.scenario !== undefined) {
+    const expansion = SEED_SCENARIOS[sel.scenario];
+    if (expansion === undefined) {
+      throw new SeedDatasetError(
+        `unknown seed scenario '${sel.scenario}' — known: ${SEED_SCENARIO_NAMES.join(', ')}`,
+      );
+    }
+    for (const entry of expansion) merge(entry, `scenario '${sel.scenario}'`);
+  }
+  for (const entry of sel.datasets ?? []) merge(entry, 'datasets');
+
+  return map;
+}
+
+/**
+ * Render a plan step id for humans, suffixed `[SEED_DATASET=<name>]` when a
+ * dataset was stamped onto it — shared by the `stack seed --dry-run` and
+ * `e2e run --dry-run` printers so the two views cannot drift.
+ */
+export function seedStepLabel(step: SeedStep): string {
+  const vars = step.env.kind === 'dotenv' ? undefined : step.env.vars;
+  const dataset = vars?.[SEED_DATASET_VAR];
+  return dataset === undefined ? step.id : `${step.id} [${SEED_DATASET_VAR}=${dataset}]`;
+}

--- a/packages/node/saga-stack-cli/src/core/seed/index.ts
+++ b/packages/node/saga-stack-cli/src/core/seed/index.ts
@@ -21,3 +21,12 @@ export {
 } from './profiles.js';
 export type { SeedStepId } from './profiles.js';
 export { composeSeedPlan } from './compose-seed-plan.js';
+export {
+  resolveDatasetMap,
+  SEED_DATASET_VAR,
+  SEED_SCENARIO_NAMES,
+  SEED_SCENARIOS,
+  SeedDatasetError,
+  seedStepLabel,
+} from './datasets.js';
+export type { SeedScenarioName, SystemSeedDataset } from './datasets.js';

--- a/packages/node/saga-stack-cli/src/core/seed/types.ts
+++ b/packages/node/saga-stack-cli/src/core/seed/types.ts
@@ -12,6 +12,7 @@
  */
 
 import type { DbId, ServiceId } from '../manifest/index.js';
+import type { SeedScenarioName, SystemSeedDataset } from './datasets.js';
 
 /**
  * Per-system seed override (plan §4.1 / §5, M5). Seeds ONE system's steps at a
@@ -130,4 +131,19 @@ export interface SeedSelection {
   only?: ServiceId[];
   /** Drop these step ids (`stack seed --exclude <id,…>`). */
   exclude?: string[];
+  /**
+   * Named cross-system SCENARIO (#221 multi-seed): expands to a coherent
+   * per-system dataset map (see `SEED_SCENARIOS`) so a coupled dataset (the
+   * scheduling/programs/sessions triad) cannot be half-selected. Merges with
+   * `datasets`; a conflicting entry for the same system is a compose error.
+   */
+  scenario?: SeedScenarioName;
+  /**
+   * Per-system named datasets (#221 multi-seed): the IDENTITY axis, orthogonal
+   * to `profile`/`perSystem` (quantity). Never changes WHICH steps are selected —
+   * each selected step whose service is named here is emitted as a compose-time
+   * clone with `SEED_DATASET=<name>` in its env, and the owning repo's single
+   * `db:seed` branches on it (the `SEED_DEMO_ONLY` house pattern).
+   */
+  datasets?: SystemSeedDataset[];
 }

--- a/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
+++ b/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
@@ -767,6 +767,16 @@ export async function executeResolvedFlow(
       throw new FlowExecError(`native bring-up failed${up.failedAt ? ` at ${up.failedAt}` : ''}`);
     }
 
+    // #221 coach-deferral (d): honour `up`'s repo-absent skips downstream — the
+    // same seed-active-set pattern `stack up` uses. A skipped service (repo not
+    // cloned, or a hard dependent of one) must not be SEEDED (its steps would
+    // spawn-crash on the missing checkout dir) nor VERIFIED (probing a service
+    // that was never launched would redden the run the skip guard tried to keep
+    // green). Its steps degrade to `service-inactive` skip notes instead.
+    const upSkipped = new Set(up.skipped.map((s) => s.id));
+    const activeServices = services.filter((id) => !upSkipped.has(id));
+    for (const s of up.skipped) deps.log(`⚠ ${s.message}`);
+
     // 2a. M14 --from: restore the predecessor stage's checkpoint — the state
     // source replacing the reset+seed AND the Playwright replay of stages
     // 1..from-1. Gated on resolved.checkpoint (never on effectiveReset:
@@ -792,7 +802,7 @@ export async function executeResolvedFlow(
         throw new FlowExecError(`reset failed (native exit ${reset.code})`);
       }
       if (resolved.seedSelection) {
-        const plan = composeSeedPlan(resolved.seedSelection, new Set(services), new Set<ServiceId>());
+        const plan = composeSeedPlan(resolved.seedSelection, new Set(activeServices), new Set<ServiceId>());
         const seeded = await deps.api.seed(plan);
         if (!seeded.ok) throw new FlowExecError(`seed failed at ${seeded.failed}`);
       }
@@ -801,7 +811,7 @@ export async function executeResolvedFlow(
     }
 
     // 3. verify (tolerate the SPA's own frontend service being red — branch posture / dev server).
-    const probes = healthProbes(m, services);
+    const probes = healthProbes(m, activeServices);
     const verified = await deps.api.verify(probes, { tolerate: [resolved.spa.system] });
     if (!verified.passed) {
       const down = verified.rows.filter((r) => !r.ok && !r.tolerated).map((r) => r.id);

--- a/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
+++ b/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
@@ -33,6 +33,7 @@
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { composeSeedPlan } from './core/seed/compose-seed-plan.js';
+import { seedStepLabel } from './core/seed/datasets.js';
 import { computeEnv, ENV_OCCURRENCE_DATE, ENV_TERM_END, ENV_TERM_START } from './core/flow/env.js';
 import { checkpointFixtureId } from './core/flow/checkpoint.js';
 import { bakeStageCheckpoint, FlowExecError, restoreCheckpoint } from './e2e-checkpoint-exec.js';
@@ -498,8 +499,9 @@ export function describeResolved(resolved: ResolvedFlow, opts: DescribeOptions):
       ? (() => {
           const plan = composeSeedPlan(resolved.seedSelection, new Set(services), new Set<ServiceId>());
           return {
-            offline: plan.offline.map((s) => s.id),
-            online: plan.online.map((s) => s.id),
+            // #221 multi-seed: labels carry any stamped dataset (shared printer).
+            offline: plan.offline.map((s) => seedStepLabel(s)),
+            online: plan.online.map((s) => seedStepLabel(s)),
             skipped: plan.skipped.map((s) => ({ id: s.id, reason: s.reason })),
           };
         })()

--- a/packages/node/saga-stack-cli/src/stack-api.ts
+++ b/packages/node/saga-stack-cli/src/stack-api.ts
@@ -746,6 +746,41 @@ export function makeStackApi(m: Manifest, runtime: Runtime): StackApi {
         }
       }
 
+      // 3b. transitively skip DEPENDENTS of a skipped service (#221 coach-deferral b):
+      // a present service whose HARD runtime dependency (url/s2s/event — NOT a
+      // frontend's `browser` fetch edge, which doesn't gate the process booting)
+      // was repo-absent-skipped would launch orphaned and crash/misbehave against a
+      // missing upstream — e.g. connect-api launching without a cloned rostering
+      // (iam-api). Skip it too (warn, same philosophy: a missing checkout never
+      // reddens the stack), attributing the root-cause absent repo. Fixpoint loop:
+      // skips propagate down chains (a → b → c).
+      let propagated = true;
+      while (propagated) {
+        propagated = false;
+        const skippedIds = new Map(skipped.map((s) => [s.id, s] as const));
+        const survivors: ServiceId[] = [];
+        for (const id of launchable) {
+          const def = getService(id, manifest);
+          const missing = def.dependsOn.find(
+            (dep) => skippedIds.has(dep) && def.depKinds[dep] !== 'browser',
+          );
+          if (missing === undefined) {
+            survivors.push(id);
+            continue;
+          }
+          const cause = skippedIds.get(missing)!;
+          skipped.push({
+            id,
+            repo: cause.repo,
+            repoDir: cause.repoDir,
+            message: `${id} skipped — depends on ${missing}, which was skipped (repo dir ${cause.repoDir} not present — ${cause.repo} repo not cloned)`,
+          });
+          propagated = true;
+        }
+        launchable.length = 0;
+        launchable.push(...survivors);
+      }
+
       // 3.5. NATIVE PREP PASS (M8) — between mesh-up and the launch waves, in order
       // R1 build → R2 provision → R3 migrate, so a fresh checkout/volume provisions +
       // migrates ITSELF instead of relying on a prior up.sh run. Runs ONLY when the


### PR DESCRIPTION
Implements the remaining CLI-side items from the #221 tracker (post-#235).

## What's in here

### Multi-seed composition (`--scenario` / `--dataset` / `--dry-run`)
Per `claude/projects/gh_214/multiseed-research.md` (Option C, Option A transport):
- **Dataset = IDENTITY, profile = QUANTITY** — a per-system named dataset never changes *which* steps are selected; each surviving step whose service is mapped is emitted as a compose-time **clone** with `SEED_DATASET=<name>` in its env (the `SEED_DEMO_ONLY` house pattern; the frozen registry is never mutated).
- **Scenarios** are named, coupled per-system dataset sets: `ab-topology` stamps the programs/scheduling/sessions triad. `composeSeedPlan` enforces **coherence** after the gates — a mapped system with no stamped step (inactive / restored / not selected) throws `SeedDatasetError`; a coupled scenario can never be half-applied. Conflicting names for one system are an authoring error.
- Surfaces: `stack seed [--scenario <name>] [--dataset <system>=<name>] [--dry-run]`; the same `scenario`/`datasets` keys in `flows.json` seed blocks (zod + compile guard); both dry-run printers share `seedStepLabel` (`programs [SEED_DATASET=ab-topology]`).

### Coach-deferral guards (#221 list items b, c, d)
- **(b)** `StackApi.up` transitively skips HARD dependents (`url`/`s2s`/`event` — never a frontend `browser` edge) of a repo-absent-skipped service (fixpoint over chains, root-cause repo attributed). No more orphaned launches against a missing cross-repo upstream.
- **(d)** `executeResolvedFlow` honours `up()`'s skips downstream (same seed-active-set pattern as `stack up`): skipped services are dropped from the composed seed plan and the verify probes, and warned — a missing checkout never reddens an e2e run.
- **(c)** manifest consistency test now guards the `snapshot/manifest.ts` zod enums for **exhaustiveness** (every manifest DbId/ServiceId must parse), closing the drift class where a new service/DB breaks snapshot store/validate/restore.

### Already shipped — verified, no code needed
- **(a)** `stdinFile` SeedStep (coach-mongo curriculum) — landed as M8 R5.
- **meshProvisioned DB provisioning fallback** (`coach_api` role+db, up.sh:1061-1067 parity) — landed as `runtime/provision.ts` R2.
- **Bundle aliases (`--with <bundle>`)** — landed with `resolveServiceSet` + `stack bundle` (shared across up/status/verify/seed/reset).

### Explicitly out of scope
- saga-dash `flows.json` adoption + the scheduling-topology flow (owned by the concurrent flow initiatives).
- #280 stage-8 telemetry (saga-dash side).

## Validation
- 904 unit/int tests green (36 new: datasets resolution, compose stamping + coherence, seed-command flags incl. error paths, flows.json schema, transitive skip, e2e skip wiring, snapshot-enum exhaustiveness), `tsc` clean, eslint 0 errors.
- Built-CLI `--dry-run` runs: happy path (labeled stamped plan), incoherent `roster --scenario`, conflicting `--scenario`+`--dataset`, unknown system id — all exit 2 with clear messages; `e2e run --dry-run` over a scenario-bearing flows.json composes + prints labels.
- No live stacks were brought up (slots in use by other agents).

Tracker: saga-ed/soa#221

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013YC3ntD2edq31EzGps1bxb