### PR TITLE
ads-adm-api slottable (portEnvVar + token DB URL + un-exclude) + slot-correct verify/migrate

### DIFF
--- a/packages/node/saga-stack-cli/src/commands/e2e/__tests__/run.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/__tests__/run.int.test.ts
@@ -288,11 +288,28 @@ describe('e2e run — slot isolation (M7)', () => {
     expect(env.PLAYWRIGHT_SESSIONS_URL).toBe('http://localhost:3007');
   });
 
-  it('--slot 1 real run: ads-adm-api LAUNCHES in-slot, Playwright env drives the OFFSET URLs, reset is native (not up.sh)', async () => {
+  it('--slot 1 real run: ads-adm-api LAUNCHES in-slot, verify probes OFFSET ports, Playwright env drives the OFFSET URLs, reset is native (not up.sh)', async () => {
+    // Record every health-probe URL: the e2e verify step must probe the SLOT's
+    // offset ports, never the manifest base ports (a base-port probe reads slot
+    // 0's services — false-PASS off a healthy slot 0 / false-FAIL when slot 0 is
+    // down, observed live at slot 2 with a green ads-adm-api on :7005).
+    const probed: string[] = [];
+    vi.spyOn(BaseCommand.prototype as never, 'getProber' as never).mockReturnValue({
+      async probe(url: string) {
+        probed.push(url);
+        return { ok: true, status: 200 };
+      },
+    } as never);
+
     await E2eRun.run(
       ['journey', '--through', 'attendance', '--headless', '--slot', '1', ...ws()],
       config,
     );
+
+    // verify probed ads-adm-api (and iam) on the slot's OFFSET ports only.
+    expect(probed).toContain('http://localhost:6005/health'); // ads-adm 5005 + 1000
+    expect(probed).toContain('http://localhost:4010/health'); // iam 3010 + 1000
+    expect(probed.some((u) => u.includes(':5005') || u.includes(':3010'))).toBe(false);
 
     // ads-adm-api (required by the attendance stage) is slottable — LAUNCHED at
     // slot 1 on its offset port, told its listen port via EXPRESS_SERVER_PORT.

--- a/packages/node/saga-stack-cli/src/commands/e2e/__tests__/run.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/__tests__/run.int.test.ts
@@ -248,16 +248,18 @@ describe('e2e run — slot isolation (M7)', () => {
   }
 
   it('--slot 1 --dry-run: no hard-error (slotAware), OFFSET service URLs, excluded service dropped', async () => {
-    // The full journey closure includes ads-adm-api (attendance) — an excluded
-    // service at slot > 0. --slot 1 must be ACCEPTED (was a hard-error before slotAware).
+    // The full journey closure includes ads-adm-api (attendance) — SLOTTABLE
+    // now (tokenized env + EXPRESS_SERVER_PORT injection), so it STAYS in the
+    // slot's closure. --slot 1 must be ACCEPTED (was a hard-error before slotAware).
     await E2eRun.run(['journey', '--slot', '1', '--dry-run', '--output-json', ...ws()], config);
 
     const json = dryRunJson();
     const closure = json.closure as { services: string[] };
     const env = json.env as Record<string, string>;
 
-    // excluded literal-port service dropped from the slot's closure.
-    expect(closure.services).not.toContain('ads-adm-api');
+    // ads-adm-api is slottable — kept in the slot's closure; connect stays excluded.
+    expect(closure.services).toContain('ads-adm-api');
+    expect(closure.services).not.toContain('connect-api');
     expect(closure.services).toContain('iam-api');
     expect(closure.services).toContain('scheduling-api');
 
@@ -266,6 +268,7 @@ describe('e2e run — slot isolation (M7)', () => {
     expect(env.PLAYWRIGHT_IAM_URL).toBe('http://localhost:4010');
     expect(env.PLAYWRIGHT_SCHEDULING_URL).toBe('http://localhost:4008');
     expect(env.PLAYWRIGHT_SESSIONS_URL).toBe('http://localhost:4007');
+    expect(env.PLAYWRIGHT_ADS_ADM_URL).toBe('http://localhost:6005'); // 5005 + 1000
   });
 
   it('--slot 0 --dry-run: BASE service URLs, excluded service PRESENT (byte-identical)', async () => {
@@ -285,15 +288,19 @@ describe('e2e run — slot isolation (M7)', () => {
     expect(env.PLAYWRIGHT_SESSIONS_URL).toBe('http://localhost:3007');
   });
 
-  it('--slot 1 real run: launches EXCLUDE the literal-port service, Playwright env drives the OFFSET URLs, reset is native (not up.sh)', async () => {
+  it('--slot 1 real run: ads-adm-api LAUNCHES in-slot, Playwright env drives the OFFSET URLs, reset is native (not up.sh)', async () => {
     await E2eRun.run(
       ['journey', '--through', 'attendance', '--headless', '--slot', '1', ...ws()],
       config,
     );
 
-    // ads-adm-api (required by the attendance stage) is EXCLUDED at slot 1 — never launched.
-    expect(launches.map((s) => s.id)).not.toContain('ads-adm-api');
-    // …but the slottable backends still come up on their offset ports.
+    // ads-adm-api (required by the attendance stage) is slottable — LAUNCHED at
+    // slot 1 on its offset port, told its listen port via EXPRESS_SERVER_PORT.
+    const adsAdm = launches.find((s) => s.id === 'ads-adm-api');
+    expect(adsAdm).toBeDefined();
+    expect(adsAdm?.healthUrl).toContain(':6005'); // 5005 + 1000, not slot 0's :5005
+    expect(adsAdm?.env.EXPRESS_SERVER_PORT).toBe('6005');
+    // …and the other slottable backends still come up on their offset ports.
     expect(launches.map((s) => s.id)).toContain('iam-api');
     const iam = launches.find((s) => s.id === 'iam-api');
     expect(iam?.healthUrl).toContain(':4010'); // offset launch, not :3010

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/status-verify.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/status-verify.int.test.ts
@@ -386,9 +386,10 @@ describe('stack verify --full — FULLY NATIVE: health + DATA + posture, NOTHING
 
 describe('stack verify --slot N — backend + saga-dash/coach gate on offset ports (M7 Phase 2)', () => {
   // Still excluded at slot > 0 (non-optional): the literal-port connect-api +
-  // connect-web (depends on it) + ads-adm-api. saga-dash/coach-web are NO LONGER
-  // excluded — they listen on their offset port now.
-  const EXCLUDED = ['connect-api', 'connect-web', 'ads-adm-api'] as const;
+  // connect-web (depends on it). saga-dash/coach-web are NO LONGER excluded —
+  // they listen on their offset port now — and neither is ads-adm-api
+  // (tokenized env + EXPRESS_SERVER_PORT listen-port injection).
+  const EXCLUDED = ['connect-api', 'connect-web'] as const;
 
   it('slot > 0 excludes only the un-slottable backends + connect-web; gates saga-dash/coach on offset ports', async () => {
     await StackVerify.run(['--slot', '1', ...WS], config);
@@ -406,15 +407,16 @@ describe('stack verify --slot N — backend + saga-dash/coach gate on offset por
     expect(probed).toContain(iamUrl);
     expect(iamUrl).toContain(`:${manifest.services['iam-api'].port + 1000}`);
 
-    // the saga-dash + coach-web frontends ARE gated now, on their offset ports.
-    for (const id of ['saga-dash', 'coach-web'] as const) {
+    // the saga-dash + coach-web frontends ARE gated now, on their offset ports —
+    // and so is ads-adm-api (slottable: gated on :6005, its own slot's port).
+    for (const id of ['saga-dash', 'coach-web', 'ads-adm-api'] as const) {
       const url = `http://localhost:${profile.portOverrides[id]}${manifest.services[id].healthPath}`;
       expect(probed).toContain(url);
       expect(url).toContain(`:${manifest.services[id].port + 1000}`);
     }
 
-    // exactly the slottable set: 13 non-optional minus the 3 still-excluded = 10.
-    expect(probed).toHaveLength(10);
+    // exactly the slottable set: 13 non-optional minus the 2 still-excluded = 11.
+    expect(probed).toHaveLength(11);
   });
 
   it('slot 0 verify is byte-identical: probes every non-optional service on base ports', async () => {

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/up-native.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/up-native.int.test.ts
@@ -365,11 +365,13 @@ describe('stack up --slot N — isolated bring-up (M7 Phase 2)', () => {
     const dash = launches.find((s) => s.id === 'saga-dash');
     expect(dash?.command).toBe('pnpm');
     expect(dash?.args).toEqual(['dev', '--port', '9900']); // 8900 + slot 1 offset
+    // … ads-adm-api is slottable now (tokenized env + EXPRESS_SERVER_PORT
+    // injection) and launches in-slot …
+    expect(ids).toContain('ads-adm-api');
     // … but the still-un-slottable services are dropped from the slot bring-up:
     // connect-web (depends on the un-tokenized connect-api) …
     expect(ids).not.toContain('connect-web');
     // … and the literal-port backends (bypass the offset).
-    expect(ids).not.toContain('ads-adm-api');
     expect(ids).not.toContain('connect-api');
     expect(ids).not.toContain('transcripts-api');
     expect(ids).not.toContain('insights-api');
@@ -419,9 +421,9 @@ describe('stack up --slot N — isolated bring-up (M7 Phase 2)', () => {
     expect(ids).toContain('sessions-api');
     expect(ids).toContain('saga-dash'); // frontend now slottable via --port
     expect(ids).toContain('coach-web');
+    expect(ids).toContain('ads-adm-api'); // slottable (tokenized env + port injection)
     expect(ids).not.toContain('connect-api');
     expect(ids).not.toContain('connect-web');
-    expect(ids).not.toContain('ads-adm-api');
 
     // mesh came up under the slot project on offset ports (soa-s1, +1000).
     const makeUp = runs.find((r) => r.command === 'make');

--- a/packages/node/saga-stack-cli/src/commands/stack/snapshot/__tests__/snapshot.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/snapshot/__tests__/snapshot.int.test.ts
@@ -136,12 +136,13 @@ describe('stack snapshot store — manifest-driven, all 10 pg + connectv3 mongo'
     expect(appliedSlot).toBe(1);
     const pg = dbsCalled('pgDump');
     // The slot-excluded literal-port services' DBs are never provisioned in
-    // soa-s1 and must not be dumped. NOTE post-closure filtering is load-
-    // bearing: saga-dash's browser edge pulls ads-adm-api back into the
-    // closure, so a requested-set pre-filter would still dump ads_adm_local.
-    expect(pg).not.toContain('ads_adm_local');
+    // soa-s1 and must not be dumped (post-closure filtering — a closure edge
+    // like connect-web's -> connect-api would defeat a requested-set pre-filter).
     expect(dbsCalled('mongoDump')).toEqual([]); // connect-api (connectv3) is excluded
-    // …while the slottable backends still are:
+    // …while the slottable backends' DBs still are — including ads-adm-api's
+    // (slottable since the tokenized-env + EXPRESS_SERVER_PORT change):
+    expect(pg).toContain('ads_adm_local');
+    expect(pg).toContain('ledger_local');
     expect(pg).toContain('iam_local');
     expect(pg).toContain('coach_api');
     // And the dump landed in the slot's (redirected) snapshot root.

--- a/packages/node/saga-stack-cli/src/commands/stack/snapshot/store.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/snapshot/store.ts
@@ -103,7 +103,7 @@ export default class SnapshotStore extends BaseCommand {
     // nonexistent DBs and fail. Scope the DEFAULT set to the non-excluded
     // closure. The exclusion MUST apply POST-closure (like `up`/`reset`):
     // filtering the requested set first is defeated by closure edges pulling
-    // an excluded service back in (e.g. saga-dash's browser edge → ads-adm-api),
+    // an excluded service back in (e.g. connect-web's edge → connect-api),
     // and it applies AFTER the --with union so `--with playback --slot N`
     // degrades gracefully rather than dumping absent playback DBs.
     const withPlayback = effectiveWithPlayback(flags.with);

--- a/packages/node/saga-stack-cli/src/commands/stack/up.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/up.ts
@@ -431,7 +431,7 @@ export default class StackUp extends BaseCommand {
 
     const fullClosure = computeClosure(manifest, requested, { withPlayback });
 
-    // Exclude the literal-port backends (ads-adm-api/connect-api/playback trio) AND
+    // Exclude the literal-port backends (connect-api/playback trio) AND
     // the browser frontends (saga-dash/connect-web/coach-web — no listen-port seam)
     // from a slot > 0 bring-up: they'd collide with / split-brain onto slot 0 (see
     // SLOT_EXCLUDED_SERVICES). So slot > 0 is a BACKEND sub-stack. Empty at slot 0,

--- a/packages/node/saga-stack-cli/src/core/__tests__/derive-instance.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/derive-instance.unit.test.ts
@@ -107,13 +107,12 @@ describe('literal-port service exclusion (plan §6)', () => {
     expect(slotExcludedServices(0)).toEqual([]);
   });
 
-  it('slot > 0 excludes the literal-port backends + connect-web, but NOT saga-dash/coach-web', () => {
+  it('slot > 0 excludes the literal-port backends + connect-web, but NOT saga-dash/coach-web/ads-adm-api', () => {
     const excluded = deriveInstance({ slot: 1 }).excludedServices;
     expect(excluded).toEqual([...SLOT_EXCLUDED_SERVICES]);
     expect(new Set(excluded)).toEqual(
       new Set([
         // literal-port backends (bypass the offset)
-        'ads-adm-api',
         'connect-api',
         'transcripts-api',
         'insights-api',
@@ -125,6 +124,9 @@ describe('literal-port service exclusion (plan §6)', () => {
     // saga-dash & coach-web listen on their offset port now (launch-seam --port).
     expect(excluded).not.toContain('saga-dash');
     expect(excluded).not.toContain('coach-web');
+    // ads-adm-api is slottable now: tokenized launch env + EXPRESS_SERVER_PORT
+    // listen-port injection (M13 seam) — no longer excluded.
+    expect(excluded).not.toContain('ads-adm-api');
     expect(slotExcludedServices(3)).toEqual([...SLOT_EXCLUDED_SERVICES]);
   });
 });

--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.slot.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.slot.unit.test.ts
@@ -64,6 +64,7 @@ describe('defaultLaunchContext meshOffset — mesh connection strings offset in 
       ctx.tokens.SESSIONS_DB_URL,
       ctx.tokens.CONTENT_DB_URL,
       ctx.tokens.COACH_DB_URL,
+      ctx.tokens.ADS_ADM_DB_URL,
     ]) {
       expect(portOf(url)).toBe(pgBase + offset);
     }
@@ -130,5 +131,47 @@ describe('M13 listen-port fix — portEnvVar services are TOLD their offset port
     });
     const env = resolveLaunchEnv('iam-api', 'stack', ctx1);
     expect(env.PORT).toBe(String(manifest.services['iam-api'].port + 1000));
+  });
+});
+
+describe('ads-adm-api slottability — tokenized env + EXPRESS_SERVER_PORT injection', () => {
+  const slotCtx = (slot: number) => {
+    const p = deriveInstance({ slot });
+    return defaultLaunchContext({
+      ...baseInputs,
+      portOverrides: p.portOverrides,
+      meshOffset: p.meshOffset,
+    });
+  };
+
+  it('slot 1: launch env carries EXPRESS_SERVER_PORT=<5005+1000> (listen-port seam)', () => {
+    const env = resolveLaunchEnv('ads-adm-api', 'stack', slotCtx(1));
+    expect(env.EXPRESS_SERVER_PORT).toBe(String(manifest.services['ads-adm-api'].port + 1000));
+  });
+
+  it('slot 2: every cross-service/mesh URL dials the SLOT (+2000), never slot 0', () => {
+    const env = resolveLaunchEnv('ads-adm-api', 'stack', slotCtx(2));
+    expect(env.EXPRESS_SERVER_PORT).toBe('7005'); // 5005 + 2000
+    expect(env.SESSIONS_API_CLIENT_BASEURL).toBe('http://localhost:5007'); // 3007 + 2000
+    expect(env.IAM_API_CLIENT_BASEURL).toBe('http://localhost:5010/trpc'); // 3010 + 2000
+    expect(env.IAM_API_URL).toBe('http://localhost:5010');
+    expect(env.CORS_ORIGIN).toBe('http://localhost:10900'); // dash 8900 + 2000
+    expect(portOf(env.DATABASE_URL)).toBe(getMesh('postgres').port + 2000);
+    expect(portOf(env.ADS_ADM_DATABASE_URL)).toBe(getMesh('postgres').port + 2000);
+    expect(portOf(env.RABBITMQ_URL)).toBe(getMesh('rabbitmq').port + 2000);
+    // no base-port literal survives anywhere in the resolved env.
+    for (const v of Object.values(env)) {
+      expect(v).not.toMatch(/localhost:(3007|3010|5432|5672|8900)\b/);
+    }
+  });
+
+  it('slot 0: byte-identical to the pre-tokenization literals (no injection)', () => {
+    const env = resolveLaunchEnv('ads-adm-api', 'stack', slotCtx(0));
+    expect(env.EXPRESS_SERVER_PORT).toBeUndefined(); // no offset ⇒ no injection
+    expect(env.SESSIONS_API_CLIENT_BASEURL).toBe('http://localhost:3007');
+    expect(env.IAM_API_CLIENT_BASEURL).toBe('http://localhost:3010/trpc');
+    expect(env.ADS_ADM_DATABASE_URL).toBe('postgresql://ads_adm:ads_adm@localhost:5432/ads_adm_local');
+    expect(env.DATABASE_URL).toBe('postgresql://ads_adm:ads_adm@localhost:5432/ads_adm_local');
+    expect(env.CORS_ORIGIN).toBe('http://localhost:8900');
   });
 });

--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
@@ -143,7 +143,7 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
     });
   });
 
-  it('ads-adm-api (literal hardcoded deps, matching up.sh)', () => {
+  it('ads-adm-api (tokenized env resolves to exactly up.sh literals at base ports)', () => {
     expect(env('ads-adm-api')).toEqual({
       ADS_ADM_SCHEDULE_PROVIDER: 'program-hub',
       SESSIONS_API_CLIENT_BASEURL: 'http://localhost:3007',

--- a/packages/node/saga-stack-cli/src/core/derive-instance.ts
+++ b/packages/node/saga-stack-cli/src/core/derive-instance.ts
@@ -22,7 +22,7 @@
  *
  * SLOT > 0 IS A BACKEND + saga-dash/coach FRONTEND SUB-STACK (connect excluded
  * pending tokenization). Slot > 0 brings up the backend mesh + services —
- * `iam/programs/scheduling/sessions/content/sis/rtsm/coach-api` + the mesh — PLUS
+ * `iam/programs/scheduling/sessions/content/sis/rtsm/coach-api/ads-adm-api` + the mesh — PLUS
  * the `saga-dash` and `coach-web` frontends, which now listen on their OFFSET port
  * (the launch seam appends `--port <base+offset>` to their `pnpm dev`; vite honours
  * the last `--port`, overriding the port baked into the repo dev script / vite
@@ -57,10 +57,15 @@ export const SLOT_PORT_STRIDE = 1000;
  *   they would still dial slot 0's ports (postgres :5432, sessions :3007, iam
  *   :3010, dash CORS :8900, EXPRESS_SERVER_PORT 6301-6303, livekit ws :7880) and
  *   silently corrupt / collide with the default stack:
- *     - `ads-adm-api`    — literal `@localhost:5432`, `:3007`, `:3010`, CORS `:8900`.
  *     - `connect-api`    — literal `SESSIONS_API_BASE_URL :3007` + livekit `ws :7880`;
  *                          would read/write slot 0's stateful sessions-api.
  *     - the playback trio — literal `POSTGRES_PORT '5432'` + `EXPRESS_SERVER_PORT`.
+ *
+ *   `ads-adm-api` is NO LONGER excluded: its launch env is fully tokenized
+ *   (`${ADS_ADM_DB_URL}` / `${SESSIONS_PORT}` / `${IAM_URL}` / `${DASH_URL}`)
+ *   and its listen port is env-driven (`portEnvVar: 'EXPRESS_SERVER_PORT'`,
+ *   injected by the M13 listen-port seam at offset slots), so it both LISTENS
+ *   on and DIALS its own slot's ports.
  *
  *   `connect-web` FRONTEND — depends on `connect-api` (a browser edge), which is
  *   excluded above for its un-tokenized literal ports. connect-web itself now has
@@ -82,7 +87,6 @@ export const SLOT_PORT_STRIDE = 1000;
  */
 export const SLOT_EXCLUDED_SERVICES: readonly ServiceId[] = [
   // literal-port backends (bypass the offset)
-  'ads-adm-api',
   'connect-api',
   'transcripts-api',
   'insights-api',

--- a/packages/node/saga-stack-cli/src/core/launch-plan.ts
+++ b/packages/node/saga-stack-cli/src/core/launch-plan.ts
@@ -51,6 +51,9 @@ export interface LaunchTokens {
   IAM_PORT: string;
   /** sis-api port — up.sh `SIS_PORT` (3100). */
   SIS_PORT: string;
+  /** sessions-api port (3007) — ads-adm-api's SESSIONS_API_CLIENT_BASEURL (was a
+   *  literal `:3007` in up.sh; tokenized for M13 ads-adm slottability). */
+  SESSIONS_PORT: string;
   /** content-api port — up.sh `CONTENT_PORT` (3009; default :3010 collides with iam). */
   CONTENT_PORT: string;
   /** connect-api port — up.sh `CONNECT_API_PORT` (6106). */
@@ -117,6 +120,10 @@ export interface LaunchTokens {
   CONTENT_DB_URL: string;
   /** up.sh `COACH_DB_URL` — `postgresql://coach_api_app:dev-password-coach-api-app@localhost:5432/coach_api`. */
   COACH_DB_URL: string;
+  /** ads-adm DB URL — `postgresql://ads_adm:ads_adm@localhost:<pg>/ads_adm_local`
+   *  (was a LITERAL `@localhost:5432` in up.sh/the manifest; tokenized for M13
+   *  ads-adm slottability so the pg port offsets in lockstep with the slot mesh). */
+  ADS_ADM_DB_URL: string;
 
   // ── misc scalars ──
   /** up.sh `RECORDING_TOKEN` — shared fleek bearer (`local-dev-token`). */
@@ -523,6 +530,7 @@ export function defaultLaunchContext(inputs: LaunchContextInputs, m: Manifest = 
     // ports (string form)
     IAM_PORT: String(ports['iam-api']),
     SIS_PORT: String(ports['sis-api']),
+    SESSIONS_PORT: String(ports['sessions-api']),
     CONTENT_PORT: String(ports['content-api']),
     CONNECT_API_PORT: String(ports['connect-api']),
     RTSM_PORT: String(ports['rtsm-api']),
@@ -555,6 +563,7 @@ export function defaultLaunchContext(inputs: LaunchContextInputs, m: Manifest = 
     SESSIONS_DB_URL: pgUrl('sessions', pgPort, m),
     CONTENT_DB_URL: pgUrl('content', pgPort, m),
     COACH_DB_URL: pgUrl('coach_api', pgPort, m),
+    ADS_ADM_DB_URL: pgUrl('ads_adm_local', pgPort, m),
 
     // misc scalars (up.sh hardcodes these verbatim)
     RECORDING_TOKEN: 'local-dev-token',

--- a/packages/node/saga-stack-cli/src/core/manifest/databases.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/databases.ts
@@ -115,7 +115,17 @@ export const DATABASES: Readonly<Record<DbId, DatabaseDef>> = {
   ads_adm_local: {
     name: 'ads_adm_local',
     engine: 'postgres',
-    migrate: { dir: 'packages/node/ads-adm-db', cmd: 'prisma migrate deploy' },
+    // ads-adm-db's prisma.config.ts reads `DATABASE_URL ?? ADS_ADM_DATABASE_URL`
+    // (its `import 'dotenv/config'` never overrides a pre-set var), and the
+    // package .env bakes the base-port localhost URL. Injecting DATABASE_URL
+    // (slot-offset-correct pgUrl) makes a slot > 0 migrate land on the SLOT's
+    // mesh pg instead of slot 0's :5432 (ads-adm slottability); at slot 0 the
+    // injected URL is byte-identical to the baked .env value.
+    migrate: {
+      dir: 'packages/node/ads-adm-db',
+      cmd: 'prisma migrate deploy',
+      migrateEnvVar: 'DATABASE_URL',
+    },
     ownerRole: 'ads_adm',
     ownerPw: 'ads_adm',
     resettable: true,

--- a/packages/node/saga-stack-cli/src/core/manifest/services.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/services.ts
@@ -236,7 +236,12 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
     repo: 'SDS',
     subpath: 'apps/node/ads-adm-api',
     port: 5005,
-    portEnvVar: null,
+    // ads-adm-api reads its listen port via DotenvConfigManager +
+    // ExpressServerEnvSchema → EXPRESS_SERVER_* (verified in its
+    // inversify.config.ts / config/schemas.ts; the repo .env bakes
+    // EXPRESS_SERVER_PORT=5005 but dotenv never overrides real env, so the
+    // M13 listen-port injection wins at slot > 0 and is absent at slot 0).
+    portEnvVar: 'EXPRESS_SERVER_PORT',
     healthPath: '/health',
     databases: ['ads_adm_local', 'ledger_local'],
     dependsOn: ['iam-api', 'sessions-api'],
@@ -244,16 +249,20 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
     mesh: ['postgres', 'rabbitmq'],
     launch: {
       cmd: 'pnpm dev',
+      // Fully tokenized (ads-adm slottability): every cross-service/mesh URL
+      // resolves through the launch context, so a slot > 0 ads-adm-api dials
+      // ITS slot's sessions/iam/postgres/dash — never slot 0's. At slot 0
+      // the tokens expand to exactly the old literals (byte-identity holds).
       env: {
         ADS_ADM_SCHEDULE_PROVIDER: 'program-hub',
-        SESSIONS_API_CLIENT_BASEURL: 'http://localhost:3007',
-        IAM_API_CLIENT_BASEURL: 'http://localhost:3010/trpc',
+        SESSIONS_API_CLIENT_BASEURL: 'http://localhost:${SESSIONS_PORT}',
+        IAM_API_CLIENT_BASEURL: '${IAM_URL}/trpc',
         IAM_API_URL: '${IAM_URL}',
         JWT_ISSUER: 'https://iam.saga.org',
         SERVICE_TOKEN_SERVICESLUG: 'ads-adm-api',
-        ADS_ADM_DATABASE_URL: 'postgresql://ads_adm:ads_adm@localhost:5432/ads_adm_local',
-        DATABASE_URL: 'postgresql://ads_adm:ads_adm@localhost:5432/ads_adm_local',
-        CORS_ORIGIN: 'http://localhost:8900',
+        ADS_ADM_DATABASE_URL: '${ADS_ADM_DB_URL}',
+        DATABASE_URL: '${ADS_ADM_DB_URL}',
+        CORS_ORIGIN: '${DASH_URL}',
         RABBITMQ_URL: '${MESH_MQ}',
       },
     },

--- a/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
+++ b/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
@@ -801,7 +801,13 @@ export async function executeResolvedFlow(
     }
 
     // 3. verify (tolerate the SPA's own frontend service being red — branch posture / dev server).
-    const probes = healthProbes(m, services);
+    // deps.ports (launchContext.ports, offset-carrying) is REQUIRED here: without it
+    // the probes hit the manifest BASE ports, i.e. slot 0's services — a slot-N
+    // verify would false-PASS off a healthy slot-0 stack (cross-slot masking) and
+    // false-FAIL when slot 0's counterpart is down even though the slot's own
+    // service is green (observed: slot-2 ads-adm-api healthy on :7005, verify
+    // probing :5005). At slot 0 `ports` equals the base ports — byte-identical.
+    const probes = healthProbes(m, services, deps.ports);
     const verified = await deps.api.verify(probes, { tolerate: [resolved.spa.system] });
     if (!verified.passed) {
       const down = verified.rows.filter((r) => !r.ok && !r.tolerated).map((r) => r.id);

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/migrate.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/migrate.unit.test.ts
@@ -190,6 +190,26 @@ describe('migrateClosure — canonical order + the three-way branch (R3)', () =>
     // exactly ONE migrate ran, in the ads-adm-db package (ledger-db is NOT prep-migrated).
     expect(calls).toHaveLength(1);
     expect(calls[0].cwd).toBe('/dev/student-data-system/packages/node/ads-adm-db');
+    // The injected DATABASE_URL (ads-adm-db's prisma.config reads it FIRST, over
+    // the package .env's ADS_ADM_DATABASE_URL) is the base mesh URL at slot 0 —
+    // byte-identical to the .env value the pre-injection path relied on.
+    expect(calls[0].env.DATABASE_URL).toBe('postgresql://ads_adm:ads_adm@localhost:5432/ads_adm_local');
+  });
+
+  it('ads_adm_local at slot > 0: injected DATABASE_URL carries the OFFSET mesh port (slottability)', async () => {
+    const { runner, calls } = fakeRunner();
+    await migrateClosure({
+      ...base,
+      pgContainer: 'soa-s2-postgres-1',
+      meshOffset: 2000,
+      dbs: ['ads_adm_local'] as DbId[],
+      runner,
+      probe: fakeProbe(),
+    });
+    // Without the injection the FIXED step ran with NO env, so ads-adm-db's own
+    // .env pointed prisma at slot 0's :5432 (observed live at slot 2 — the migrate
+    // landed cross-slot). 5432 + 2000 = 7432, the slot's OWN mesh pg.
+    expect(calls[0].env.DATABASE_URL).toBe('postgresql://ads_adm:ads_adm@localhost:7432/ads_adm_local');
   });
 
   it('skips mongo (connectv3) and playback DBs (not mesh-provisioned)', async () => {

--- a/packages/node/saga-stack-cli/src/runtime/dash-defaults.ts
+++ b/packages/node/saga-stack-cli/src/runtime/dash-defaults.ts
@@ -62,9 +62,11 @@ export const DASH_LOCAL_SERVICES: Readonly<Record<string, ServiceId>> = {
   // clients), so a slot's config.local.json MUST offset them too — else a slot > 0
   // dash keeps the base config.json ports (ads-adm 5005 / transcripts 6302 = SLOT
   // 0's services) and a stage-7 attendance WRITE silently corrupts slot 0's
-  // ads-adm projection. ads-adm-api is excluded from slot > 0 bring-up, so the
-  // offset port (6005 at slot 1) has nothing listening ⇒ the call fails LOUD
-  // (connection refused) instead of writing cross-slot — the corruption gate.
+  // ads-adm projection. ads-adm-api is SLOTTABLE now (tokenized env +
+  // EXPRESS_SERVER_PORT injection), so the offset port (6005 at slot 1) is the
+  // slot's OWN ads-adm-api; transcripts-api remains excluded at slot > 0, where
+  // its offset port has nothing listening ⇒ that call fails LOUD (connection
+  // refused) instead of writing cross-slot — the corruption gate.
   'ads-adm': 'ads-adm-api',
   'transcripts-api': 'transcripts-api',
 };


### PR DESCRIPTION
## What

Makes `ads-adm-api` slottable (the M13 listen-port pattern, cf. 5e27dd1) and fixes two latent cross-slot bugs the first live slot-N ads-adm run surfaced.

### Slottability (commit 1)
- **`core/manifest/services.ts`** — `ads-adm-api` gets `portEnvVar: 'EXPRESS_SERVER_PORT'` (its server reads `ExpressServerEnvSchema` via `DotenvConfigManager`; dotenv-flow never overrides real env, so the M13 injection wins at slot > 0 and is absent at slot 0). Launch env fully tokenized: `${ADS_ADM_DB_URL}`, `${SESSIONS_PORT}`, `${IAM_URL}`, `${DASH_URL}` (CORS), `${MESH_MQ}` — no base-port literal survives at slot > 0.
- **`core/launch-plan.ts`** — new `SESSIONS_PORT` + `ADS_ADM_DB_URL` tokens (pgUrl-derived, offset in lockstep with the slot mesh).
- **`core/derive-instance.ts`** — `ads-adm-api` removed from `SLOT_EXCLUDED_SERVICES`; slot-N closures/bring-up/verify/snapshot all include it now (comments updated at each exclusion-consumer: `up.ts`, `dash-defaults.ts`, snapshot `store.ts`).

### Cross-slot fixes (commit 2)
- **e2e verify probed BASE ports** — `healthProbes()` in `e2e-orchestrate` was built without the resolved ports: a slot-N `e2e run` verify false-PASSED off a healthy slot 0 (latent for every M13 service) and false-FAILED when slot 0's counterpart was down (observed live: slot-2 ads-adm-api green on `:7005`, verify probing `:5005`). Now passes `deps.ports`.
- **`ads_adm_local` migrate hit slot 0's `:5432`** — the FIXED `prisma migrate deploy` step injected no env, so `ads-adm-db`'s own `.env` won (observed live: every other DB migrated on the slot's `:7432`, ads_adm on `:5432`). Added `migrateEnvVar: 'DATABASE_URL'` (its prisma.config prefers it over the `.env` fallback).

## Slot-0 byte-identity
Held throughout: the existing regression tests pin the slot-0 launch env to the exact up.sh literals; the new slot-N tests mirror 5e27dd1's (EXPRESS_SERVER_PORT injection, every cross-service/mesh URL dials the slot, no base-port literal in the resolved env; migrate URL at slot 0 == the baked `.env` value byte-for-byte).

## Evidence (live, worktree-set slot 2)
- `saga-dash/ads-adm-attendance` flow (saga-dash PR: flow/ads-adm-persistence) green on slot 2: ads-adm-api launched on `:7005` (`EXPRESS_SERVER_PORT=7005`), dialing sessions `:5007`, iam `:5010`, pg `:7432`, mq `:7672`, CORS `:10900`.
- Recorded PERIOD attendance persisted in `soa-s2-postgres-1/ads_adm_local` and was served back by the API after a hard kill + relaunch of the service.
- 872 tests green (868 baseline + 4), tsc + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013YC3ntD2edq31EzGps1bxb