### PR TITLE
docs(gh_214): scheduling-topology A/B flow — design + green run results

### DIFF
--- a/claude/projects/gh_214/scheduling-topology-flow/01-understanding.md
+++ b/claude/projects/gh_214/scheduling-topology-flow/01-understanding.md
@@ -6,6 +6,42 @@
 > **oracle** for the new flow — what *correct* behavior is — plus where reality currently
 > falls short. Parent: soa#214 · tracker: soa#221 (Flow content → new scenarios).
 
+## Reference legend (how to read the shorthand in this doc)
+
+The body is deliberately terse; every coded reference below is resolvable here.
+
+- **Design-decision codes — `D8`, `D17`** → the resolved-decisions registry
+  `program-hub/specs/context/decisions.md` (headed `## D<n> — …`). Used here:
+  - **D8** — *"Slot regeneration is a known break-deep-links operation."* Slots are
+    **soft-deactivated** (`deactivatedAt`), never hard-deleted, so a re-mint preserves
+    started-session identity and deep links.
+  - **D17** — *"Timezone is owned at the Schedule level."* Exactly one authoritative,
+    non-null IANA tz per `Schedule`; slots/rules carry none and derive it.
+    `UpsertSchedule.timezone` is **required** (fail-loud if ever absent, never a server-tz
+    fallback); `Program.timezone` is only a creation-time prefill.
+- **Issue / PR references:**
+  - **soa#214** — parent effort: the OCLIF CLI for synthetic-dev (saga-stack-cli).
+  - **soa#221** — the saga-stack-cli work tracker; this flow is its
+    *"Flow content → new scenarios"* item.
+  - **saga-dash#226** — *"the VARIES modeling gap"*: the live `createVariesByDayType`
+    path emits **no recurring `slot.created`** for a day-type schedule's base cadence, so
+    `VARIES_BY_DAY_TYPE` schedules don't drive sessions the way weekly ones do. Fully
+    unpacked in **§5**.
+  - **#175 / #189** (branch `feat/rotation-slots-unified`) — the rotation-slots
+    implementation PRs (Kevin Zhang) that introduced the A/B mechanics dissected in **§3**.
+- **`P0c`** — the scheduling **per-date-overrides** workstream/phase; it added the
+  `SlotOccurrenceCancellation`, `OccurrenceTimeOverride`, and `ManualAddition` models (§2).
+- **"stage-N" (e.g. stage-5/6)** — the **saga-dash journey e2e stages**
+  (`saga-dash/apps/web/dash/e2e/journey/*.e2e.test.ts`): **stage-5 = schedule**,
+  **stage-6 = sessions**. Their tRPC-direct `rpcGet` + `expect.poll` pattern is the
+  assertion precedent this flow mirrors (see §6, and `02-flow-design.md` §4).
+- **rrule syntax** (`FREQ=WEEKLY;BYDAY=MO,WE;UNTIL=…`, and `rrule=''`) — RFC 5545 iCalendar
+  recurrence rules. `rrule=''` = a **blank placeholder** that fires no occurrences.
+- **`:NN` after a filename** (e.g. `schema.prisma:101`) — a **line number** in the file
+  named at the start of that section.
+
+---
+
 ## 0. The one-sentence oracle
 
 An **"A/B switch between treatments"** is a program **period with ≥2 rotations**, where

--- a/claude/projects/gh_214/scheduling-topology-flow/02-flow-design.md
+++ b/claude/projects/gh_214/scheduling-topology-flow/02-flow-design.md
@@ -7,6 +7,12 @@
 > (weekday-driven)**. Parent: soa#214 · tracker: soa#221 (Flow content → new scenarios).
 >
 > **This doc is the review gate.** Get it reviewed before mass-authoring the seed + spec.
+>
+> **Shorthand:** coded references (`D<n>` design decisions, issue/PR refs, `stage-N` e2e
+> stages, rrule syntax) are resolved in `01-understanding.md` → *Reference legend*.
+> `D<n>` codes point at `program-hub/specs/context/decisions.md`. treatmentKind is
+> **triple-cased**: `CONNECT|NON_TUTORED` (wire/API), `TUTORING|NON_TUTORED` (Prisma/DB),
+> `tutoring|non_tutored` (event) — assert the **wire** value.
 
 ---
 

--- a/claude/projects/gh_214/scheduling-topology-flow/02-flow-design.md
+++ b/claude/projects/gh_214/scheduling-topology-flow/02-flow-design.md
@@ -1,0 +1,297 @@
+# 02 — Flow design: scheduling-topology (A/B `varies_by_day_type` → sessions)
+
+> The concrete design for the second `flows.json` scenario. Builds on `01-understanding.md`
+> (the oracle) and two code deep-dives (2026-07-02) that pinned every API signature, seed
+> shape, and e2e pattern quoted below. Decisions locked by skelly in `HANDOFF.md`: approach
+> (c) **purpose-built A/B seed, reveal reality**; first pattern **`varies_by_day_type`
+> (weekday-driven)**. Parent: soa#214 · tracker: soa#221 (Flow content → new scenarios).
+>
+> **This doc is the review gate.** Get it reviewed before mass-authoring the seed + spec.
+
+---
+
+## 1. The scenario (one paragraph)
+
+One program, one period, `rotationCount = 2`, `rotationPattern = varies_by_day_type`
+(**weekday-driven** — rotations own weekdays, not day-types) on a **`SAME_EVERY_WEEK`
+schedule**. **Rotation A** meets **Mon + Wed**, **Rotation B** meets **Fri**. Exactly one
+pod (`podX`) is assigned to **both** rotations' slots, with a **different `treatmentKind`
+per slot**: slot-A = `CONNECT` (tutored), slot-B = `NON_TUTORED`. Because sessions are a
+read-time pure function of `(slot rrule) × (slot pod_assignment)`, the *same pod's* realized
+session **switches treatment by weekday**: `CONNECT` on Mon/Wed, `NON_TUTORED` on Fri, with
+no session Tue/Thu and exactly one card per pod per meeting day. This is the minimal true
+A/B: one entity, two rotations, two treatments, switch is emergent.
+
+Why the **weekday** variant and not the **day-type** variant: the day-type variant lives on
+a `VARIES_BY_DAY_TYPE` *schedule*, which is exactly the path that emits **no recurring
+`slot.created`** today (saga-dash#226, `scheduling-api/seed.ts:851`). The weekday variant
+lives on a `SAME_EVERY_WEEK` schedule and is **rotation-managed** — each rotation's slot gets
+a sub-RRULE restricted to its weekdays (`01 §3.2` rule 1). It sidesteps the name-fragile
+day-type join and gives the cleanest deterministic oracle. `split_period` (intra-day) and
+`custom` (date-map) remain explicit follow-ons.
+
+---
+
+## 2. The oracle table (the assertion truth)
+
+Term dates are computed **relative to the run** so the flow never goes stale (mirror the
+journey's `mondayOfCurrentWeek()`, `schedule.e2e.test.ts:37-53`). Let **M0 = Monday of the
+current week = `TERM_START`**; term end = M0 + 6 weeks.
+
+| Offset | Weekday | Rotation fires | Expected slot | `treatmentKind` (wire) | podX sessions |
+|--------|---------|----------------|---------------|------------------------|:-------------:|
+| **M0**   | Mon | **A** | `slotA` (rotationIndex 1) | **`CONNECT`**       | **1** |
+| M0+1     | Tue | none  | —                         | —                   | **0** |
+| **M0+2** | Wed | **A** | `slotA` (rotationIndex 1) | **`CONNECT`**       | **1** |
+| M0+3     | Thu | none  | —                         | —                   | **0** |
+| **M0+4** | Fri | **B** | `slotB` (rotationIndex 2) | **`NON_TUTORED`**   | **1** |
+
+Global invariants across all five dates:
+- **No pod renders > 1 card on any meeting day** (the saga-dash#226 duplicate-slot invariant:
+  one active slot per `(period, rotation)`, `01 §4.2`).
+- Every returned session's `date` equals the queried date; `status = NotStarted`;
+  `viewerPermissionContextGroup = EMPTY_ORG_ID` (proof the authz grant resolved, not a mask —
+  `sessions.e2e.test.ts:161-166`).
+- `slotA` and `slotB` are **distinct** slot ids; `podX`'s session on Mon/Wed carries `slotA`,
+  on Fri carries `slotB`.
+
+**Topology assertions (DB projection tables, optional but high-value — `01 §6`):**
+- `slot_projection`: exactly **2** rows for the period — `rotation_index` 1 and 2, with
+  **distinct** rrules (A restricted to `BYDAY=MO,WE`, B to `BYDAY=FR`). This row is *the* A/B
+  topology; if only 1 row (period-scoped) exists, the gap has bitten (see §6).
+- `pod_assignment_projection`: **2** rows for `podX` — `(slotA → TUTORING)`,
+  `(slotB → NON_TUTORED)` (**Prisma casing**: `TUTORING`, not `CONNECT`; `01 §9`).
+
+---
+
+## 3. Build sequence — API-built (recommended) vs direct-projection (fallback)
+
+**Decision (Q3, recommended): API-built for the rotation emission→projection→read path.**
+That path is exactly where the gap lives (`01 §5`), so driving it through the real APIs is
+what "reveal reality" means. A **purpose-built seed fixture** handles only the *static
+scaffolding* (org + program + period + pods + enrollments + authz grant + warmth); the
+**spec** drives the *A/B-specific* mutations through live tRPC and asserts the reads. This
+split keeps the seed deterministic and puts the mechanism-under-test on the real wire.
+
+### 3a. Seed fixture (deterministic, `only: [scheduling-api, sessions-api]` + programs-api rides along)
+Into the **Empty Org** (`deriveGroupId('emptyOrg') === EMPTY_ORG_ID ===
+52a00136-285b-522c-bc70-0887cf46463a`), reusing the journey's actor precedent:
+1. Program `P` + one period `per` (initially `no_rotation` — the spec flips it) + `podX`
+   (and a second pod `podY` optional, to prove per-pod isolation) + ≥1 student enrollment per
+   pod (SessionView asserts `participants.length ≥ 1`).
+2. **The authz grant + warmth** — reuse `seedEmptyOrgAdminAuthz` (`sessions-api/seed.ts:710`,
+   invoked at `:441`) which grants `DEV_ADMIN_PERMISSIONS` (incl.
+   `sessions:lifecycle_non_hosted_sessions`) on the emptyOrg group, and the two
+   `projectionReadiness.upsert({ warmedAt })` rows (`seed.ts:443-460`) — the read gate is
+   `sessions-api.authz-projection` (`authz-projection.ts:20`); without warmth every read
+   throws `SERVICE_UNAVAILABLE`. **Without the grant, `dayList` masks to 0** (false green).
+
+### 3b. Spec setup — live tRPC (this is the path under test)
+tRPC procedures pinned from code (`rpcGet` = query, `rpcPost` = mutation, both via
+`page.request` carrying the `iam_session` cookie + `x-organization-id: EMPTY_ORG_ID` +
+`...previewHeaders()`; `schedule.e2e.test.ts:97-105`):
+
+1. **programs-api `periods.update`** → `{ id: perId, rotationPattern: 'varies_by_day_type',
+   version }`. Version-guarded (`UpdatePeriodSchema` requires `version`; re-read via
+   `periods.get` for the current version). Changing the pattern **auto-applies
+   `DEFAULT_ROTATION_COUNT_FOR_PATTERN['VARIES_BY_DAY_TYPE'] = 2`**
+   (`periods.service.ts:57-63`), so `rotationCount` becomes 2 without a separate call.
+   (Belt-and-suspenders: `periods.setRotationCount(perId, 2)` is idempotent.)
+2. **programs-api `periods.setRotationConfig`** →
+   ```jsonc
+   { "periodId": perId,
+     "rotations": [
+       { "rotationIndex": 1, "days": ["Monday", "Wednesday"] },
+       { "rotationIndex": 2, "days": ["Friday"] } ],
+     "calendarDays": [] }
+   ```
+   (`SetRotationConfigSchema`; `days` uses **capitalized** `WeekdaySchema`. No `treatmentKind`
+   here — that is a PodAssignment, step 5.) Emits `programs.period_rotation_config.changed.v1`
+   (full-state snapshot) → scheduling-api projects + **remints one slot per `(period,
+   rotation)`**.
+3. **scheduling-api `schedules.upsert`** →
+   ```jsonc
+   { "programId": P, "patternType": "SAME_EVERY_WEEK",
+     "timezone": "America/New_York",
+     "startDate": TERM_START, "endDate": TERM_END,
+     "periodConfigs": [ { "periodId": perId, "colorKey": "blue",
+       "activeDays": ["mon", "wed", "fri"], "startTime": "15:00", "endTime": "16:00" } ] }
+   ```
+   (`UpsertScheduleProcedureSchema`; `activeDays` uses **lowercase** `DayOfWeekSchema`.
+   **Term dates mandatory** — without both, the slot stays a blank `rrule=''` placeholder
+   that drives nothing, `01 §9`.)
+4. **Poll `slots.list({ periodId })` until 2 real slots** (rrule/dtstart non-blank; mirror
+   `listRealSlots`, `schedule.e2e.test.ts:108-111`), then capture `slotA` = the
+   `rotationIndex 1` slot, `slotB` = `rotationIndex 2`. Assert A's rrule is restricted to
+   Mon/Wed and B's to Fri (`BYDAY`). **This poll converging to 2 is the crux** (§6).
+5. **programs-api `podAssignments.upsert`** (×2), gated on the slot existing in programs-api's
+   local `slotProjection` mirror (poll):
+   - `{ podId: podX, slotId: slotA, treatmentKind: 'CONNECT' }`
+   - `{ podId: podX, slotId: slotB, treatmentKind: 'NON_TUTORED' }`
+   (`UpsertPodAssignmentSchema`; wire enum `CONNECT | NON_TUTORED`. Poll
+   `podAssignments.listForPod({ podId })` → 2, mirroring `schedule.e2e.test.ts:225-238`.)
+6. **Assert via `sessions.dayList({ programIds: [P], date })`** for each oracle date (§4).
+
+**Ordering note:** steps 2 and 3 are cross-service async (RabbitMQ). The remint is
+future-only + `sourceTs`-guarded, and either interleaving converges; the **poll in step 4
+absorbs the async** rather than relying on a fixed order. The exact interleaving (does
+`setRotationConfig` before or after `schedules.upsert` matter for the first mint?) is the one
+thing to nail empirically during authoring — see §6/§7.
+
+### 3c. Fallback — direct-projection seed (only if the API path can't bootstrap)
+If the live weekday-`varies_by_day_type` path won't mint 2 slot-scoped rules at all (a hard
+gap, not just latency), fall back to a **direct-projection seed** that fabricates the target
+end-state to isolate the *read engine*: two `slot_projection` rows (rotationIndex 1/2, rrules
+`FREQ=WEEKLY;BYDAY=MO,WE` and `;BYDAY=FR`), matching `recurrence_rule_ref` rows (`ruleId =
+slotId`, `slotId: null`), and two `pod_assignment_projection` rows (`podX→slotA=TUTORING`,
+`podX→slotB=NON_TUTORED`) — the shape the current single-rotation seed *explicitly declines
+to build* (`sessions-api/seed.ts:199`, the VARIES-modeling-gap comment). Green here + red on
+the API path = **the read engine is correct and the gap is upstream in emission/projection**,
+which is itself a precise, valuable finding. Prefer API-built; keep this in the back pocket.
+
+---
+
+## 4. Assertion surface + exact tRPC calls
+
+All reads through **`sessions.dayList`** (input `{ programIds: [P], date }`; envelope keyed by
+programId → `{ periods: PeriodGroup[], adhoc }`, flatten `periods.flatMap(p => p.sessions)` —
+`sessions.e2e.test.ts:131-139`). Our spec's local `SessionView` type **must declare `slotId`
+and `treatmentKind`** (the journey's local interface omits them, but they are real
+`SessionViewSchema` fields — `slotId: string|null`, `treatmentKind` open-enum string).
+
+Per meeting date (M0, M0+2, M0+4):
+```
+const s = dayListSessions(P, date).filter(x => x.podId === podX);
+expect(s).toHaveLength(1);
+expect(s[0].date).toBe(date);
+expect(s[0].status).toBe('NotStarted');
+expect(s[0].slotId).toBe(EXPECTED_SLOT[date]);          // slotA on Mon/Wed, slotB on Fri
+expect(s[0].treatmentKind).toBe(EXPECTED_TREATMENT[date]); // CONNECT / NON_TUTORED  ← THE A/B assertion
+expect(s[0].viewerPermissionContextGroup).toBe(EMPTY_ORG_ID);
+```
+Per non-meeting date (M0+1, M0+3): `expect(dayListSessions(P, date).filter(podX)).toHaveLength(0)`.
+
+Global: across all sessions on any meeting day, `new Set(sessions.map(s => s.podId)).size ===
+sessions.length` (no pod appears twice).
+
+Optional **`rangeList`** cross-check (`{ programIds:[P], from: M0, to: M0+4 }`, ≤31-day cap):
+`sessionsByDate` should have entries only for M0/M0+2/M0+4 with the right treatment each.
+
+Optional **topology** (DB, via a Prisma client in the spec or a `db-*` helper): assert the 2
+`slot_projection` + 2 `pod_assignment_projection` rows per §2.
+
+**Warmth:** don't invent a readiness endpoint — the seed warms `sessions-api.authz-projection`
+(§3a.2); the `expect.poll` on `dayList` itself (timeout 30_000) absorbs any residual
+cold-read `SERVICE_UNAVAILABLE` retry, exactly as the journey polls the composed read rather
+than a warmth flag.
+
+---
+
+## 5. The `flows.json` entry + spec location
+
+Add to `~/dev/saga-dash/apps/web/dash/e2e/flows.json` — **which does not exist yet**; creating
+it also advances the #221 "author real flows.json" item. Shape (validated against
+`flowManifestSchema`; a present-but-invalid file is a hard error, a missing one is tolerated):
+```jsonc
+{ "schemaVersion": 1,
+  "spa": { /* saga-dash descriptor — copy from examples/flows/saga-dash.flows.json */ },
+  "flows": [
+    { "name": "scheduling-topology",
+      "description": "An A/B varies_by_day_type rotation realizes the right session (slot + treatment) per weekday.",
+      "lanes": ["stack"],
+      "progressive": false,
+      "seed": { "reset": true, "profile": "roster" },
+      "stages": [
+        { "id": "topology", "phase": 1, "project": "scheduling-topology",
+          "spec": "scheduling/topology-ab.e2e.test.ts",
+          "requiredSystems": ["scheduling-api", "sessions-api", "programs-api"] } ] } ] }
+```
+Notes grounded in the flow model (`saga-stack-cli/src/core/flow/types.ts` + `examples/flows/README.md`):
+- `spec` is repo-relative under `e2eDir` → physical path
+  `~/dev/saga-dash/apps/web/dash/e2e/scheduling/topology-ab.e2e.test.ts` (new `scheduling/`
+  sibling dir alongside `journey/`, `interactive/`).
+- `project` = the Playwright project name; add a matching project to the saga-dash Playwright
+  config (non-progressive → no `dependencies` chain, unlike journey stages).
+- `requiredSystems` seeds the launch closure; `programs-api` rides along on `event` edges even
+  if omitted, but list it explicitly (we drive `periods.*`/`podAssignments.*` on it).
+- `seed.only` is available in the schema but the example backend flows rely on `profile` +
+  closure to narrow which systems boot; the CLI sub-stack (`--only scheduling-api,sessions-api`)
+  is applied at **stack-up** time, not in the flow's `seed` block.
+- Until saga-dash authors its own `flows.json`, the CLI falls back to the **bundled example**
+  (`examples/flows/saga-dash.flows.json`) via the `BUNDLED_EXAMPLE` registry row; the repo file
+  takes precedence once present (the repo-file preference resolver is an M8 item — for this
+  effort, running the repo file directly is fine).
+
+---
+
+## 6. Reveal plan — what's expected green vs what may go red (and why)
+
+The oracle in §2 is the **intended** behavior. Per `01 §5`, no test proves it end-to-end
+today, so treat these as the failure surfaces to watch. Each red **is the finding**; document
+it verbatim into #221 / saga-dash#226.
+
+| # | Assertion | Expected | Red would mean |
+|---|-----------|:--------:|----------------|
+| R1 | `slots.list` → **2** real slots, distinct rrules (§3b.4) | 🟢 if weekday-`varies_by_day_type` remints per-rotation slots | Only **1** period-scoped slot → weekday variant shares the #226 gap; rotation slots never mint. **The pivotal red.** |
+| R2 | podX Mon/Wed → `CONNECT`, Fri → `NON_TUTORED` (§4) | 🟢 if R1 holds (treatment read verbatim from firing slot's pod_assignment) | If R1 red: one slot fires all 3 days → **same** treatment every day (no switch), or duplicate cards. |
+| R3 | podX has **0** sessions Tue/Thu | 🟢 | A mis-minted period-scoped rule with `BYDAY=MO,WE,FR` (the M-W-F retraction footgun, `01 §3.4`) could still be correct here; the risk is the *inverse* — a rule not restricted to the rotation's weekdays. |
+| R4 | No pod > 1 card per meeting day | 🟢 | Two rival slots firing the same day → duplicate cards (the saga-dash#226 invariant itself). |
+| R5 | `treatmentKind` is the **wire** value `CONNECT` (§4) | 🟢 | If the read surfaced the Prisma `TUTORING`, the triple-enum boundary regressed. |
+
+**Most likely outcome:** R1 is the hinge. If the weekday-driven `varies_by_day_type` path
+mints 2 slot-scoped rules (plausible — it is the rotation-managed `SAME_EVERY_WEEK` path, not
+the day-type-schedule path that #226 documents as broken), **the whole flow goes green and is
+net-new proof** the A/B path works. If R1 is red, the flow has pinpointed that the weekday
+rotation path shares the no-recurring-slot gap — a sharper, reproducible restatement of #226
+than exists today. Either way the flow earns its keep.
+
+---
+
+## 7. Open questions for review (before authoring)
+
+1. **Seed scaffolding mechanism.** §3a assumes a purpose-built fixture creates
+   program/period/pods/enrollments into the Empty Org. Confirm: build that as a new seed entry
+   in `sessions-api`/`scheduling-api` `seed.ts` (deterministic ids via `derive*`), or as a
+   spec `beforeAll` that drives `programs.create`/`pods.create`/enrollment tRPC? Fixture is
+   more deterministic; spec-driven exercises more of the real path. **Recommend fixture for
+   scaffolding, live APIs for the A/B mechanism.**
+2. **One pod or two?** `podX`-in-both-rotations is the minimal A/B. Adding `podY` in only
+   rotation A proves per-pod isolation (podY has no Fri session) at low cost. **Recommend
+   adding podY.**
+3. **Assertion depth (Q4).** Ship v1 as count + treatment + slot per date (§4). Defer
+   SWAP/ABSENT overrides, holidays/cancellations, and a schedule-edit re-projection check to a
+   follow-on (they compound the reveal surface and aren't needed to prove the core switch).
+4. **Interleaving of steps 2↔3** (setRotationConfig vs schedules.upsert first). Needs one
+   empirical run to confirm which order first-mints the 2 slots; the §3b.4 poll makes the flow
+   robust regardless, but document the observed order.
+5. **`treatmentKind` default trap.** `podAssignments.upsert` with no `treatmentKind` defaults
+   to `TUTORING`/`CONNECT` (`pod-assignments.service.ts:149`). We set it explicitly on both,
+   so slot-B must **explicitly** send `NON_TUTORED` (omitting it would silently make B tutored
+   too — a self-inflicted false green to guard against).
+
+---
+
+## 8. Deliverables checklist (feeds §221 "New flow #1")
+
+- [ ] This design doc reviewed (gate).
+- [ ] Purpose-built seed fixture: Empty-Org program + period + podX(+podY) + enrollments +
+      authz grant + warmth (reuse `seedEmptyOrgAdminAuthz`).
+- [ ] `saga-dash/apps/web/dash/e2e/flows.json` (created) + the `scheduling-topology` entry.
+- [ ] Spec `saga-dash/apps/web/dash/e2e/scheduling/topology-ab.e2e.test.ts` (rpcGet/rpcPost +
+      poll patterns from the journey; oracle from §2/§4).
+- [ ] Playwright `scheduling-topology` project wired in the saga-dash config.
+- [ ] Run report: `ss stack up --only scheduling-api,sessions-api` → `ss e2e run
+      saga-dash/scheduling-topology`; capture green/red per §6 → back to #221 / saga-dash#226.
+
+## References
+`01-understanding.md` (oracle) · `HANDOFF.md` (locked decisions). Code (all quoted from the
+two 2026-07-02 deep-dives): programs-api `periods.router.ts:15/45/86/100`,
+`periods.service.ts:57-63/123/195-222/423`, `pod-assignments.router.ts:36`,
+`pod-assignments.service.ts:34-40/149`; scheduling-api `schedules.router.ts:16`,
+`seed.ts:851-890`; sessions-api `sessions.router.ts:62`, `sessions-read.service.ts:310`,
+`authz-projection.ts:20`, `projection-readiness.service.ts`, `seed.ts:199/441-460/710`;
+program-hub-types `periods.ts:32-107`, `scheduling.ts:185-262`, `pod-assignments.ts:25`,
+`sessions.ts:17/131-206/346-350/455-460`; saga-dash `journey/schedule.e2e.test.ts`,
+`journey/sessions.e2e.test.ts`, `data/roster-reset.ts:35`, `data/seed-users.ts:54`; flow model
+`saga-stack-cli/src/core/flow/types.ts:50-150`, `examples/flows/{saga-dash,connectv3}.flows.json`,
+`examples/flows/README.md`.

--- a/claude/projects/gh_214/scheduling-topology-flow/02-flow-design.md
+++ b/claude/projects/gh_214/scheduling-topology-flow/02-flow-design.md
@@ -70,29 +70,54 @@ Global invariants across all five dates:
 
 ---
 
-## 3. Build sequence — API-built (recommended) vs direct-projection (fallback)
+## 3. Build sequence — self-seed the whole scenario in the spec (no new `seed.ts`)
 
-**Decision (Q3, recommended): API-built for the rotation emission→projection→read path.**
-That path is exactly where the gap lives (`01 §5`), so driving it through the real APIs is
-what "reveal reality" means. A **purpose-built seed fixture** handles only the *static
-scaffolding* (org + program + period + pods + enrollments + authz grant + warmth); the
-**spec** drives the *A/B-specific* mutations through live tRPC and asserts the reads. This
-split keeps the seed deterministic and puts the mechanism-under-test on the real wire.
+**Decision (Q1+Q3, resolved by the seed-management research): the flow uses the stock
+`profile: 'roster'` seed and self-seeds its entire scenario in the spec via live tRPC. It
+adds NO service `seed.ts` and NO CLI change.** This is both forced by how `ss` seeds and
+ideal for "reveal reality":
 
-### 3a. Seed fixture (deterministic, `only: [scheduling-api, sessions-api]` + programs-api rides along)
-Into the **Empty Org** (`deriveGroupId('emptyOrg') === EMPTY_ORG_ID ===
-52a00136-285b-522c-bc70-0887cf46463a`), reusing the journey's actor precedent:
-1. Program `P` + one period `per` (initially `no_rotation` — the spec flips it) + `podX`
-   (and a second pod `podY` optional, to prove per-pod isolation) + ≥1 student enrollment per
-   pod (SessionView asserts `participants.length ≥ 1`).
-2. **The authz grant + warmth** — reuse `seedEmptyOrgAdminAuthz` (`sessions-api/seed.ts:710`,
-   invoked at `:441`) which grants `DEV_ADMIN_PERMISSIONS` (incl.
-   `sessions:lifecycle_non_hosted_sessions`) on the emptyOrg group, and the two
-   `projectionReadiness.upsert({ warmedAt })` rows (`seed.ts:443-460`) — the read gate is
-   `sessions-api.authz-projection` (`authz-projection.ts:20`); without warmth every read
-   throws `SERVICE_UNAVAILABLE`. **Without the grant, `dayList` masks to 0** (false green).
+- **`ss` has no per-flow seed.** A flow's `seed` block selects *which* services run their
+  fixed `pnpm db:seed`, not *what data* they produce; each program-hub `seed.ts` is an
+  unconditional demo seed reading only `DATABASE_URL` (no `SEED_PROFILE`/scenario env reaches
+  it — verified across the CLI seed pipeline `compose-seed-plan.ts` / `profiles.ts` /
+  `stack-api.ts`). A bespoke A/B shape can therefore only come from (a) editing a shared
+  `seed.ts` (pollutes the fixed demo for *every* flow, not flow-scopable), (b) a new CLI
+  `addOn` (coarse, enum-closed `playback`/`qtf`, needs CLI-registry + service edits —
+  overkill for one shape), or **(c) self-seeding in the spec** — the established precedent:
+  `journey` and `connect-smoke` both start from `roster` and build their scenario through the
+  stages, touching no `seed.ts`. **We take (c).**
+- **`profile: 'roster'` already provides everything the read path needs on a cold DB.** It
+  runs the `sessions` seed step (`PROFILE_STEPS.roster = ['iam-dev-user','iam','sessions']`),
+  whose `seedDemo` unconditionally seeds `seedEmptyOrgAdminAuthz` (the `empty@saga.org`
+  admin's `DEV_ADMIN_PERMISSIONS` incl. `sessions:lifecycle_non_hosted_sessions` on the
+  emptyOrg group; `sessions-api/seed.ts:710`, invoked `:439-461`) **and** the two
+  `projection_readiness` warmth rows (incl. `sessions-api.authz-projection`, the fail-closed
+  read gate; without warmth every read throws `SERVICE_UNAVAILABLE`, and without the grant
+  `dayList` masks to 0 — a false green). It does **not** run the `programs`/`scheduling` seeds,
+  so nothing pre-built collides with what the spec builds.
+- **Self-seeding maximizes fidelity.** Every entity (program → period → pods → enrollments →
+  rotation config → schedule → pod assignments) flows through the real programs-api /
+  scheduling-api emission → sessions-api projection path — exactly where the gap lives and
+  what the flow must exercise to reveal reality.
 
-### 3b. Spec setup — live tRPC (this is the path under test)
+### 3a. Spec `beforeAll` — bootstrap the scenario entities (programs-api, live tRPC)
+Backend-only (no dash UI), so we self-seed via **tRPC-direct mutations** (the `rpcPost`
+pattern), not the journey's UI clicks — the same programs-api procedures the journey UI drives
+under the hood. Into the **Empty Org** (`x-organization-id: EMPTY_ORG_ID ===
+deriveGroupId('emptyOrg') === 52a00136-285b-522c-bc70-0887cf46463a`):
+1. `programs.create` → program `P` under the Empty Org.
+2. `periods.create` → one period `per` (created `no_rotation`; the pattern is flipped in §3b).
+3. `pods.create` → `podX`, plus `podY` (rotation-A-only) to prove per-pod isolation (§7 Q2).
+4. Enroll ≥1 student per pod (SessionView asserts `participants.length ≥ 1`).
+
+**Authorization note (confirm at author time):** the roster-seeded emptyOrg admin grant
+authorizes reads/writes on a program whose grant-group is the emptyOrg group. A spec-created
+program under `x-organization-id: EMPTY_ORG_ID` should inherit that group — the journey proves
+this for a UI-built program in the same org. The exact programs-api create-procedure
+inputs/names are pinned in §3a-refs (pending the bootstrap-procedure lookup).
+
+### 3b. Spec setup — the A/B build (live tRPC, this is the path under test)
 tRPC procedures pinned from code (`rpcGet` = query, `rpcPost` = mutation, both via
 `page.request` carrying the `iam_session` cookie + `x-organization-id: EMPTY_ORG_ID` +
 `...previewHeaders()`; `schedule.e2e.test.ts:97-105`):
@@ -153,7 +178,11 @@ slotId`, `slotId: null`), and two `pod_assignment_projection` rows (`podX→slot
 `podX→slotB=NON_TUTORED`) — the shape the current single-rotation seed *explicitly declines
 to build* (`sessions-api/seed.ts:199`, the VARIES-modeling-gap comment). Green here + red on
 the API path = **the read engine is correct and the gap is upstream in emission/projection**,
-which is itself a precise, valuable finding. Prefer API-built; keep this in the back pocket.
+which is itself a precise, valuable finding. Prefer self-seed-in-spec; keep this in the back
+pocket. **Cost caveat:** per the seed-management finding, a direct-projection seed can't be a
+per-flow file — it would mean editing the shared `sessions-api/seed.ts` (polluting the fixed
+demo) or adding a CLI `addOn`, so it's a heavier, cross-flow-affecting fallback, not a cheap
+toggle. Only reach for it if §3b's live path proves un-bootstrappable.
 
 ---
 
@@ -186,8 +215,8 @@ Optional **`rangeList`** cross-check (`{ programIds:[P], from: M0, to: M0+4 }`, 
 Optional **topology** (DB, via a Prisma client in the spec or a `db-*` helper): assert the 2
 `slot_projection` + 2 `pod_assignment_projection` rows per §2.
 
-**Warmth:** don't invent a readiness endpoint — the seed warms `sessions-api.authz-projection`
-(§3a.2); the `expect.poll` on `dayList` itself (timeout 30_000) absorbs any residual
+**Warmth:** don't invent a readiness endpoint — the stock `roster` seed warms
+`sessions-api.authz-projection` (§3); the `expect.poll` on `dayList` itself (timeout 30_000) absorbs any residual
 cold-read `SERVICE_UNAVAILABLE` retry, exactly as the journey polls the composed read rather
 than a warmth flag.
 
@@ -255,12 +284,14 @@ than exists today. Either way the flow earns its keep.
 
 ## 7. Open questions for review (before authoring)
 
-1. **Seed scaffolding mechanism.** §3a assumes a purpose-built fixture creates
-   program/period/pods/enrollments into the Empty Org. Confirm: build that as a new seed entry
-   in `sessions-api`/`scheduling-api` `seed.ts` (deterministic ids via `derive*`), or as a
-   spec `beforeAll` that drives `programs.create`/`pods.create`/enrollment tRPC? Fixture is
-   more deterministic; spec-driven exercises more of the real path. **Recommend fixture for
-   scaffolding, live APIs for the A/B mechanism.**
+1. **Seed scaffolding mechanism — RESOLVED (spec `beforeAll`, no `seed.ts`).** The
+   seed-management research settled this: `ss` has no per-flow seed, so a bespoke fixture would
+   mean editing a shared `seed.ts` (pollutes the fixed demo) or a CLI `addOn` (coarse,
+   registry edit). The established precedent (journey, connect-smoke) is to start from stock
+   `profile: 'roster'` and self-seed the scenario in the spec via tRPC. §3 now reflects this;
+   §3a bootstraps program/period/pods via `programs.create`/`periods.create`/`pods.create` +
+   enrollment. The only residual to confirm at author time is the grant-group inheritance
+   (§3a authorization note).
 2. **One pod or two?** `podX`-in-both-rotations is the minimal A/B. Adding `podY` in only
    rotation A proves per-pod isolation (podY has no Fri session) at low cost. **Recommend
    adding podY.**

--- a/claude/projects/gh_214/scheduling-topology-flow/02-flow-design.md
+++ b/claude/projects/gh_214/scheduling-topology-flow/02-flow-design.md
@@ -321,10 +321,18 @@ Authored on saga-dash branch `flow/scheduling-topology-ab` (commit `71899699`).
       poll patterns from the journey; oracle from §2/§4). Typechecks + lints clean.
 - [x] Playwright `scheduling-topology` project wired in `playwright.stack.config.ts`
       (standalone, no dependencies; run targeted).
-- [ ] **Run report (handed off — author-only pass):** bring up scheduling-api + sessions-api +
-      programs-api (seeded `profile: roster`), run `--project scheduling-topology`, capture
-      green/red per §6 → back to #221 / saga-dash#226. Deferred to avoid colliding with the
-      concurrent M8 live DB validations on `gh_214`.
+- [x] **Run report — DONE, GREEN (2026-07-05):** ran `e2e run saga-dash/scheduling-topology
+      --set topo --headless` on the slot-1 sub-stack; `1 passed` twice. Full results,
+      realization table, and the three divergences from this design in **`03-run-results.md`**.
+      Headline: R1 is **green** (weekday `varies_by_day_type` mints 2 per-rotation slots), the
+      A/B switch realizes correctly — but the mint shape is **ANCHOR** (not sub-RRULE), the
+      sessions land in dayList's **`adhoc`** bucket (not `periods`), and the remint has a
+      residual schedule-visibility race the spec heals by **re-applying** the config. Fed to
+      #221 / saga-dash#226.
+
+> **Note on §2/§3b/§6 above:** written during design, they assumed the RRULE mint shape and a
+> `periods`-bucket read, and hypothesized R1 might be red. `03-run-results.md` supersedes those
+> assumptions with observed reality (ANCHOR shape, `adhoc` bucket, R1 green).
 
 ### Author-time notes carried into the run
 - **Participants:** pods created without students (a session composes per

--- a/claude/projects/gh_214/scheduling-topology-flow/02-flow-design.md
+++ b/claude/projects/gh_214/scheduling-topology-flow/02-flow-design.md
@@ -310,15 +310,36 @@ than exists today. Either way the flow earns its keep.
 
 ## 8. Deliverables checklist (feeds §221 "New flow #1")
 
-- [ ] This design doc reviewed (gate).
-- [ ] Purpose-built seed fixture: Empty-Org program + period + podX(+podY) + enrollments +
-      authz grant + warmth (reuse `seedEmptyOrgAdminAuthz`).
-- [ ] `saga-dash/apps/web/dash/e2e/flows.json` (created) + the `scheduling-topology` entry.
-- [ ] Spec `saga-dash/apps/web/dash/e2e/scheduling/topology-ab.e2e.test.ts` (rpcGet/rpcPost +
-      poll patterns from the journey; oracle from §2/§4).
-- [ ] Playwright `scheduling-topology` project wired in the saga-dash config.
-- [ ] Run report: `ss stack up --only scheduling-api,sessions-api` → `ss e2e run
-      saga-dash/scheduling-topology`; capture green/red per §6 → back to #221 / saga-dash#226.
+Authored on saga-dash branch `flow/scheduling-topology-ab` (commit `71899699`).
+
+- [x] Design doc (this file) — self-seed strategy resolved.
+- [x] ~~Purpose-built seed fixture~~ — **dropped**: `ss` has no per-flow seed; the spec
+      self-seeds from stock `profile: roster` (which already seeds `seedEmptyOrgAdminAuthz` +
+      warmth). No `seed.ts` added.
+- [x] `saga-dash/apps/web/dash/e2e/flows.json` (created) + the `scheduling-topology` entry.
+- [x] Spec `saga-dash/apps/web/dash/e2e/scheduling/topology-ab.e2e.test.ts` (rpcGet/rpcPost +
+      poll patterns from the journey; oracle from §2/§4). Typechecks + lints clean.
+- [x] Playwright `scheduling-topology` project wired in `playwright.stack.config.ts`
+      (standalone, no dependencies; run targeted).
+- [ ] **Run report (handed off — author-only pass):** bring up scheduling-api + sessions-api +
+      programs-api (seeded `profile: roster`), run `--project scheduling-topology`, capture
+      green/red per §6 → back to #221 / saga-dash#226. Deferred to avoid colliding with the
+      concurrent M8 live DB validations on `gh_214`.
+
+### Author-time notes carried into the run
+- **Participants:** pods created without students (a session composes per
+  `(date,period,slot,pod)` from the pod_assignment, independent of membership). If the composer
+  suppresses member-less pods, enroll a real iam-seeded roster student
+  (`@saga-ed/iam-seed-ids` `personId('s-N')`, add as an e2e devDependency). Not on the A/B
+  critical path.
+- **Pipeline interaction:** the `scheduling-topology` Playwright project has no `dependencies`,
+  so a bare `playwright test` includes it; since it's "reveal" coverage that may be red until
+  the gap closes, tag-exclude it from default pipeline runs if that red is disruptive.
+- **Input-shape confidences:** `programs.create {name}`+org header, `periods.create
+  {programId,name,rotationPattern}`, `periods.setRotationCount {id,rotationCount}`,
+  `periods.setRotationConfig {periodId,rotations,calendarDays}`, `schedules.upsert {...}`,
+  `podAssignments.upsert {podId,slotId,treatmentKind}` — all pinned from code; any mismatch
+  surfaces immediately as an HTTP 400 zod error on first run.
 
 ## References
 `01-understanding.md` (oracle) · `HANDOFF.md` (locked decisions). Code (all quoted from the

--- a/claude/projects/gh_214/scheduling-topology-flow/03-run-results.md
+++ b/claude/projects/gh_214/scheduling-topology-flow/03-run-results.md
@@ -1,0 +1,113 @@
+# 03 — Run results: scheduling-topology (A/B `varies_by_day_type` → sessions)
+
+> The reveal run, executed 2026-07-05 on the saga-stack-cli slot-1 sub-stack
+> (`node bin/dev.js e2e run saga-dash/scheduling-topology --set topo --headless`).
+> **Outcome: GREEN.** The non-trivial A/B topology realizes CORRECTLY end-to-end;
+> the flow now asserts that realization explicitly. This doc records what went
+> green, the concrete realization proof, and where reality DIVERGED from
+> `02-flow-design.md`. Parent: soa#214 · tracker: soa#221 · related: saga-dash#226.
+
+---
+
+## 1. Result summary
+
+`1 passed` (two consecutive clean full-reset runs, ~13–14s each). The flow stands
+up `iam-api + programs-api + scheduling-api + sessions-api + saga-dash` (closure of
+5), self-seeds the scenario from stock `profile: roster`, and asserts the realized
+sessions. Mint shape observed: **ANCHOR (remint path)** on every run.
+
+## 2. The realized topology (verified live, not just page-rendered)
+
+Program under the Empty Org, one period `varies_by_day_type` rotationCount 2,
+`SAME_EVERY_WEEK` schedule, term = next Monday (M0) .. M0+6wk. Rotation A = Mon/Wed,
+Rotation B = Fri. `podX` in BOTH rotations, `podY` in Rotation A only. Pod
+assignments: podX→slotA=CONNECT, podX→slotB=NON_TUTORED, podY→slotA=CONNECT.
+
+Realized sessions read back through `sessions.dayList` (the composed read model),
+per oracle date:
+
+| Date (2026) | Weekday | podX | podY | slot | treatment (wire) |
+|-------------|---------|:----:|:----:|------|------------------|
+| 07-06 | Mon | 1 | 1 | slotA | **CONNECT** |
+| 07-07 | Tue | 0 | 0 | — | — |
+| 07-08 | Wed | 1 | 1 | slotA | **CONNECT** |
+| 07-09 | Thu | 0 | 0 | — | — |
+| 07-10 | Fri | 1 | **0** | slotB | **NON_TUTORED** |
+
+The **A/B switch is emergent and correct**: the *same pod* (podX) carries `slotA`/
+`CONNECT` on Mon/Wed and `slotB`/`NON_TUTORED` on Fri; `podY` (Rotation A only)
+never realizes on Friday (per-pod isolation holds); no pod renders >1 card on any
+meeting day. These are the exact assertions in `scheduling/topology-ab.e2e.test.ts`
+step 5 (`slotId`, `treatmentKind`, date, per-pod count, `viewerPermissionContextGroup
+= EMPTY_ORG_ID`).
+
+## 3. Concrete assertion surface (what the spec proves)
+
+- **R1 (topology):** exactly **2 real slots** for the period, one per `rotationIndex`,
+  distinct ids. Shape-conditional (anchor vs rrule) — see §4.1.
+- **R2 (the A/B switch):** podX `treatmentKind` = `CONNECT` on Mon/Wed, `NON_TUTORED`
+  on Fri, each on the matching `slotId`. **Green.**
+- **R3:** podX has 0 sessions Tue/Thu. **Green.**
+- **R4:** one card per pod per meeting day (`Set(podIds).size === sessions.length`).
+  **Green.**
+- **R5:** the read surfaces the **wire** enum (`CONNECT`/`NON_TUTORED`), not the
+  Prisma `TUTORING`. **Green.**
+- **Per-pod isolation:** podY meets Mon/Wed, absent Fri. **Green.**
+
+## 4. Divergences from `02-flow-design.md` (record these)
+
+### 4.1 The mint shape is ANCHOR, not RRULE — and that is correct
+The design doc's §2/§3b.4 anticipated per-rotation slots carrying **sub-RRULEs**
+(`BYDAY=MO,WE` / `BYDAY=FR`). Reality: the reactive remint
+(`scheduling-api/event-handlers/programs-projection.ts remintPeriodFutureSlots`)
+**soft-deactivates** the period-scoped `MO,WE,FR` rule and mints one **ANCHOR** slot
+per rotation — `rrule=''`, `dtstart=today`, and a **`manual_addition` per future
+occurrence date** (emitted as `ManualAdditionSetV1` + `OccurrenceTimeOverrideSetV1`
+carrying the 15:00–16:00 window). sessions-api projects these into
+`manual_addition_ref` + `occurrence_time_override_ref`; `expandSchedule` composes an
+occurrence from the manual_addition even with no rrule. **An anchor slot is a REAL
+slot, not a placeholder** — so R1's "real slot" test must key on `dtstart !== ''`, not
+on the rrule. The spec accepts BOTH shapes; only ANCHOR was observed for the
+weekday-`varies_by_day_type` + `SAME_EVERY_WEEK` path.
+
+### 4.2 ANCHOR sessions surface in dayList's `adhoc` bucket, not `periods`
+`dayList` splits its payload into `periods` (rule-origin, grouped) and a flat `adhoc`
+bucket. Because every anchor occurrence carries **`origin: 'manual_addition'`**,
+sessions-api routes these rotation sessions to **`adhoc`**, never into a `periods`
+group. The design doc's §4 assertion (`periods.flatMap(p => p.sessions)`) therefore
+saw **zero** sessions despite a fully correct realization. **Fix:** the spec's
+`dayListSessions` unions BOTH buckets. This is a genuine presentation-layer finding
+for saga-dash#226 — the realized data is correct, but a UI that reads only `periods`
+would not show these rotation sessions.
+
+### 4.3 Upsert-first ordering does NOT fully close the lost-update race
+`02` §3b.4 / the earlier run-2 finding prescribed `schedules.upsert` **before**
+`setRotationConfig` to guarantee the remint. Run-3 showed this is **necessary but not
+sufficient**: the rotation-config consumer projects the new config yet **skips its
+remint** when the just-committed `Schedule` row is not visible to that consumer's
+transaction (`programs-projection.ts` guard `scheduleRow.rows.length === 0 → return`).
+The period then stays **stuck on the single period-scoped `MO,WE,FR` slot — a STABLE
+wrong state** (config projected, schedule present, but only 1 slot, no A/B). **Fix:**
+re-emitting the identical config bumps `source_ts` past the idempotency guard and
+re-runs the remint with the schedule reliably visible, minting the 2 anchor slots
+(verified: a manual re-apply healed a stuck period 1→2). The spec now **re-applies
+`setRotationConfig` until 2 real slots appear** (R1 self-heals). This is a sharper,
+reproducible restatement of the emission/projection race for saga-dash#226.
+
+## 5. What this proves for #221 / #226
+
+The weekday-`varies_by_day_type` A/B path **works end-to-end today** — contrary to
+the design doc's cautious "R1 may be red" hypothesis, the rotation-managed
+`SAME_EVERY_WEEK` remint mints per-rotation slots and sessions realize with the
+correct per-weekday treatment switch. The two real gaps this flow now pins are
+NOT in the core realization but at its edges: (a) rotation sessions are only
+reachable via the `adhoc` bucket (§4.2), and (b) the remint has a schedule-visibility
+race that can strand a period at 1 slot until the config is re-applied (§4.3). Both
+are net-new, reproducible reproductions carried in the spec.
+
+## 6. Deliverables (shipped)
+
+- saga-dash branch `flow/scheduling-topology` (was `…-ab`): `flows.json` (merged with
+  main's journey/ads-adm/connect flows), Playwright `scheduling-topology` project, and
+  the green spec `apps/web/dash/e2e/scheduling/topology-ab.e2e.test.ts`.
+- Run driven from the primary `~/dev/soa` saga-stack-cli against slot-1 set `topo`.

--- a/claude/projects/gh_214/scheduling-topology-flow/README.md
+++ b/claude/projects/gh_214/scheduling-topology-flow/README.md
@@ -43,4 +43,14 @@ plan** (R1 "does the weekday variant mint 2 slot-scoped slots" is the hinge — 
 proof, red = a sharper restatement of saga-dash#226). Step 1 (understanding) remains the
 oracle: the multi-rotation slot-scoped A/B path is contract/engine-supported but **not seeded
 or tested end-to-end today** (VARIES modeling gap / saga-dash#226). Next: review `02` §7 open
-questions → build seed + `flows.json` + spec → run + reveal.
+questions → build `flows.json` + spec → run + reveal.
+
+**Seed strategy resolved (2026-07-02):** `ss` has **no per-flow seed** — its `seed` block
+selects *which* services run their fixed `pnpm db:seed`, not *what data*. So this flow adds
+**no `seed.ts`**: it uses stock `profile: 'roster'` (which already seeds the empty-admin authz
+grant + `projection_readiness` warmth) and **self-seeds its scenario in the spec via tRPC**
+(program → period → pods → rotation config → schedule → pod assignments) — the journey /
+connect-smoke precedent, and the highest-fidelity way to exercise the emission→projection path
+we want to reveal. `02` §3 updated accordingly. Deliverables narrow to: `flows.json` + spec
+(no seed fixture). **Author-only scope this pass** — the reveal run is handed off (the
+scheduling stack must not collide with the concurrent M8 live DB validations on `gh_214`).

--- a/claude/projects/gh_214/scheduling-topology-flow/README.md
+++ b/claude/projects/gh_214/scheduling-topology-flow/README.md
@@ -31,12 +31,16 @@ This is the concrete instance of the "author *new* flow scenarios" work.
   (design → seed → author → run). Decisions locked: purpose-built A/B seed (reveal
   reality); `varies_by_day_type` weekday pattern first. **Read this to pick up the work.**
 - `01-understanding.md` — the synthesized understanding (from parallel code research). ✅ **done**
-- `02-flow-design.md` — the concrete flow scenario + expected behavior + assertions. _(next — pending a design decision, see 01 §8)_
+- `02-flow-design.md` — the concrete flow scenario + expected behavior + assertions. ✅ **drafted (review gate)**
 
 ## Status
-**Step 1 (understanding) complete** — `01-understanding.md` synthesizes three code deep-dives
-into the oracle (what correct A/B-treatment→session behavior is) + the observable assertion
-surfaces. **Key finding:** the multi-rotation slot-scoped A/B-treatment→session path is
-contract- and engine-supported but **not seeded or tested end-to-end today** (the VARIES
-modeling gap / saga-dash#226) — so this flow is net-new coverage and likely drives closing
-that gap. Next: pick the flow scenario (`01-understanding.md` §8 open decisions) → `02-flow-design.md`.
+**Step 2 (flow design) drafted — awaiting review.** `02-flow-design.md` pins the locked
+scenario (weekday `varies_by_day_type`, Rotation A=Mon/Wed=`CONNECT`, B=Fri=`NON_TUTORED`,
+one pod in both) into a precise oracle table, the **API-built** build sequence (exact tRPC
+calls: `periods.update`/`setRotationConfig` → `schedules.upsert` → poll `slots.list` →
+`podAssignments.upsert` → assert `sessions.dayList`), the assertion surface, and a **reveal
+plan** (R1 "does the weekday variant mint 2 slot-scoped slots" is the hinge — green = net-new
+proof, red = a sharper restatement of saga-dash#226). Step 1 (understanding) remains the
+oracle: the multi-rotation slot-scoped A/B path is contract/engine-supported but **not seeded
+or tested end-to-end today** (VARIES modeling gap / saga-dash#226). Next: review `02` §7 open
+questions → build seed + `flows.json` + spec → run + reveal.

--- a/claude/projects/gh_214/scheduling-topology-flow/README.md
+++ b/claude/projects/gh_214/scheduling-topology-flow/README.md
@@ -34,6 +34,19 @@ This is the concrete instance of the "author *new* flow scenarios" work.
 - `02-flow-design.md` — the concrete flow scenario + expected behavior + assertions. ✅ **done**; deliverables **authored** (§8).
 
 ## Status
+**✅ IMPLEMENTED + GREEN (2026-07-05).** The reveal run passed: the non-trivial A/B
+topology (2 pods, distinct per-weekday rotations) realizes CORRECTLY end-to-end and the
+spec now asserts that realization explicitly (slot ↔ pod membership, per-weekday A/B
+treatment switch, per-pod isolation, dates). See **`03-run-results.md`** for the green
+run, the concrete realization table, and three divergences from the original design:
+(1) the mint shape is **ANCHOR** (rrule='' + manual_addition occurrences), not sub-RRULE;
+(2) anchor sessions surface in dayList's **`adhoc`** bucket, not `periods`; (3) upsert-first
+ordering does **not** fully close the remint's schedule-visibility race — the spec
+**re-applies** the config until 2 slots land. All net-new reproductions for soa#221 /
+saga-dash#226. Contrary to the design's cautious "R1 may be red" hypothesis, the weekday
+`varies_by_day_type` path **works today**.
+
+### Historical (design phase)
 **Step 2 (flow design) drafted — awaiting review.** `02-flow-design.md` pins the locked
 scenario (weekday `varies_by_day_type`, Rotation A=Mon/Wed=`CONNECT`, B=Fri=`NON_TUTORED`,
 one pod in both) into a precise oracle table, the **API-built** build sequence (exact tRPC

--- a/claude/projects/gh_214/scheduling-topology-flow/README.md
+++ b/claude/projects/gh_214/scheduling-topology-flow/README.md
@@ -31,7 +31,7 @@ This is the concrete instance of the "author *new* flow scenarios" work.
   (design → seed → author → run). Decisions locked: purpose-built A/B seed (reveal
   reality); `varies_by_day_type` weekday pattern first. **Read this to pick up the work.**
 - `01-understanding.md` — the synthesized understanding (from parallel code research). ✅ **done**
-- `02-flow-design.md` — the concrete flow scenario + expected behavior + assertions. ✅ **drafted (review gate)**
+- `02-flow-design.md` — the concrete flow scenario + expected behavior + assertions. ✅ **done**; deliverables **authored** (§8).
 
 ## Status
 **Step 2 (flow design) drafted — awaiting review.** `02-flow-design.md` pins the locked
@@ -54,3 +54,7 @@ connect-smoke precedent, and the highest-fidelity way to exercise the emission�
 we want to reveal. `02` §3 updated accordingly. Deliverables narrow to: `flows.json` + spec
 (no seed fixture). **Author-only scope this pass** — the reveal run is handed off (the
 scheduling stack must not collide with the concurrent M8 live DB validations on `gh_214`).
+
+**Authored (2026-07-02).** `flows.json` + spec + Playwright project live on saga-dash branch
+`flow/scheduling-topology-ab` (commit `71899699`); the spec typechecks + lints clean. Only the
+reveal run remains (handed off). Design/handoff detail + run notes in `02` §8.


### PR DESCRIPTION
## What

Design docs + run report for the **scheduling-topology** e2e flow (soa#221, parent soa#214). The flow itself ships in saga-dash#355; this branch carries the code-grounded design and the reveal-run findings under `claude/projects/gh_214/scheduling-topology-flow/`.

- `01-understanding.md` — the oracle (scheduling domain, A/B treatment model, session realization).
- `02-flow-design.md` — the concrete scenario, oracle table, build sequence, assertion surface (§8 now marked implemented/green).
- `03-run-results.md` — **new**: the green run, the realization table, and three divergences from the original design.
- `README.md` — status → ✅ implemented + green.

## Outcome

The reveal run passed (`1 passed` twice). The non-trivial A/B topology (2 pods, distinct per-weekday rotations) realizes CORRECTLY end-to-end — contrary to the design's cautious "R1 may be red" hypothesis, the weekday `varies_by_day_type` path works today.

## Divergences recorded (design → reality)

1. **Mint shape is ANCHOR** (`rrule=''` + `manual_addition` occurrences), not the sub-RRULE the design assumed. An anchor slot is a real slot.
2. **Anchor sessions surface in dayList's `adhoc` bucket**, not `periods` — the design's §4 read only `periods` and saw zero despite a correct realization.
3. **Upsert-first ordering does not fully close the remint's schedule-visibility race** — the period can strand at 1 slot; the spec re-applies the config until 2 slots land.

Both (2) and (3) are net-new reproductions for soa#221 / saga-dash#226.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013YC3ntD2edq31EzGps1bxb