### PR TITLE
docs(saga-stack-cli): e2e-flows runbook + legacy synthetic-dev ports (accumulating)

### DIFF
--- a/claude/projects/gh_214/plans/14-topo-bug-fixes.md
+++ b/claude/projects/gh_214/plans/14-topo-bug-fixes.md
@@ -1,0 +1,144 @@
+# Plan 14 — fix the two scheduling-topology findings (program-hub#316, #317)
+
+Both bugs were surfaced by the `scheduling-topology` e2e flow (soa#221) and are
+currently masked by test-side workarounds in `topology-ab.e2e.test.ts`. The
+acceptance bar for this plan is therefore concrete: **fix the services, then
+delete the workarounds and the flow stays green** — the flow becomes the
+regression harness for both.
+
+Repo: `program-hub` (both fixes). One branch, two commits (or two small PRs if
+review prefers — they're independent).
+
+---
+
+## Fix 1 — #316: rotation-remint silently skipped on Schedule invisibility
+
+**Site:** `apps/node/scheduling-api/src/event-handlers/programs-projection.ts:316`
+(`if (scheduleRow.rows.length === 0) return;` inside the rotation-config
+consumer's txn).
+
+**Why it's wedged forever:** the idempotency guard at `:300` means a redelivery
+of the same config applies nothing and returns before the remint — so once the
+skip happens, no retry of the SAME event can heal it. Only a fresh
+`setRotationConfig` (bumped `source_ts`) re-runs the remint. Silent + stable.
+
+### Chosen approach: reciprocal trigger (primary) + loud skip (secondary)
+
+**1a. Reciprocal trigger — the invariant fix.** The pair (Schedule row,
+rotation-managed config) can land in either order; today only the config side
+triggers the remint. Add the mirror: in the **schedule-upsert consumer** (same
+file, the handler that projects the Schedule row), after a Schedule INSERT
+(first visibility — not every update), query for existing rotation-managed
+period configs for the program:
+
+```sql
+SELECT "periodId", rotations, "calendarDays", rotation_pattern
+FROM <period-config projection> WHERE "programId" = $1
+  AND rotation_pattern = ANY(ROTATION_MANAGED_PATTERNS)
+```
+
+and run `remintPeriodFutureSlots` for each, **in the same txn** as the schedule
+projection (identical atomicity argument to the existing comment block at
+`:302-309`). Whichever dependency lands second now completes the pair.
+
+- Idempotency: remint after a skip mints from zero live slots → clean; if the
+  config side DID remint already (no race this time), the schedule INSERT path
+  doesn't fire again for updates, so no double-mint. Guard the trigger with
+  "INSERT (or first-visible upsert), not UPDATE" — same `xmax = 0` /
+  rows-affected discrimination the file already uses for the config upsert.
+
+**1b. Loud skip — defense in depth.** At `:316`, when the config upsert
+**applied** (`upserted.rows.length > 0`) but the Schedule row is absent, this
+is no longer "nothing to do" — with 1a it should be transiently impossible, so
+log at WARN with programId/periodId (`remint deferred: schedule not yet
+visible — reciprocal trigger will complete it`). Do NOT nack/retry (1a makes
+retry unnecessary, and nacking inside a multi-event projection consumer risks
+redelivery storms — keep the consumer linear).
+
+### Tests (scheduling-api)
+
+- Unit/integration on the projection handler (existing harness in
+  `__tests__` next to the consumer): (i) config lands BEFORE schedule →
+  schedule-INSERT path remints (slots appear); (ii) schedule before config →
+  existing path unchanged (pin it); (iii) schedule UPDATE does not re-mint;
+  (iv) the WARN fires when config applies with no schedule.
+- The lost-update companion (`schedules.upsert` after `setRotationConfig`,
+  run-2 finding) becomes a regression test: either order converges to 2 slots.
+
+### E2E acceptance
+
+Remove the spec's re-apply workaround (`setRotationConfig`-until-2-slots loop)
+from `topology-ab.e2e.test.ts`; run the flow 3× on slot 1 (the race is timing-
+dependent — repetition is the point): green every time, single `setRotationConfig`.
+
+**Risk:** M — touches an event consumer's transactional behavior; the mint path
+itself (`remintPeriodFutureSlots`) is unchanged and already proven. Bounded by
+the INSERT-only trigger condition.
+
+---
+
+## Fix 2 — #317: dayList buckets by origin, not period membership
+
+**Site:** `apps/node/sessions-api/src/sectors/sessions/sessions-read.service.ts`
+→ `groupIntoDayEntry`: `if (decorated.origin === 'manual_addition') → adhoc`.
+
+Rotation-minted sessions are `manual_addition` **by design** (anchor-slot
+occurrences) and carry a real `periodId` → they vanish from periods-only
+readers despite correct realization.
+
+### Chosen approach: classify by period membership
+
+```ts
+const isPeriodScoped = decorated.periodId !== undefined
+  && periodMeta.has(decorated.periodId);      // membership in model.candidateTuples
+if (!isPeriodScoped) { adhoc.push(decorated); continue; }
+// else: group under its period — origin no longer consulted for bucketing
+```
+
+- `periodMeta` (built from `model.candidateTuples`) is already in scope — the
+  membership test is a Map lookup, no new reads.
+- **Open verification (do FIRST):** confirm true ad-hoc sessions
+  (`adhoc.create` → `sessions-adhoc.service.ts`, `origin: 'manual_addition'`)
+  either carry NO `periodId` or one outside `candidateTuples`. If they can
+  carry a member `periodId`, the discriminator needs a second term (e.g. the
+  synthetic-slot marker adhoc.create stamps) — resolve before coding.
+- Keep `origin` on the view payload untouched (consumers may render a badge);
+  only the BUCKETING changes.
+
+### Tests (sessions-api)
+
+- Extend `sessions-adhoc.unit.spec.test.ts` / the read-service unit suite:
+  (i) rotation-minted session (manual_addition + member periodId) → its period
+  group; (ii) true adhoc session → adhoc bucket (pin the discriminator);
+  (iii) session with unknown periodId → adhoc (no crash, no phantom group).
+- Contract note: this is a **wire-shape behavior change** for dayList — sweep
+  saga-dash consumers reading `adhoc` (the #226 surfaces) to confirm none
+  DEPEND on rotation sessions appearing there; the e2e spec's `dayListSessions`
+  union keeps both suites green through the transition.
+
+### E2E acceptance
+
+Flip `topology-ab.e2e.test.ts`'s oracle back to `periods.flatMap(...)` (delete
+the union workaround) → flow green on slot 1. saga-dash stage-6 sessions
+day-list stays green (its sessions are schedule-originated — unaffected).
+
+**Risk:** S — one predicate + tests; the main risk is the adhoc.create
+discriminator, which the verification step settles up front.
+
+---
+
+## Sequencing & validation
+
+1. Verify the adhoc.create `periodId` shape (Fix 2 pre-check) — 30 min.
+2. Land Fix 2 (small, independent), then Fix 1 on top; program-hub CI + both
+   services' suites green.
+3. Pull program-hub on slot 0, rebuild (mind the fresh-skip trap), then the
+   e2e acceptance: topology flow 3× WITHOUT workarounds on slot 1, journey
+   `--through sessions` on slot 0 (dayList consumers unaffected).
+4. Follow-up spec PR (saga-dash): remove both workarounds + their comments,
+   referencing the fix SHAs.
+
+**Out of scope:** the podAssignments.upsert 404 projection lag (finding 3 —
+eventual-consistency by design; revisit only if it bites a non-test client)
+and any UI change for saga-dash#226 (reads benefit automatically once #317
+lands).

--- a/packages/node/saga-stack-cli/docs/e2e-flows.md
+++ b/packages/node/saga-stack-cli/docs/e2e-flows.md
@@ -1,0 +1,213 @@
+# E2E Flows — a first-time user's runbook
+
+Everything here uses the `ss` CLI (already on your PATH; `node bin/dev.js` from
+`~/dev/soa/packages/node/saga-stack-cli` is the equivalent if it isn't). Every
+command is copy-pasteable. Nothing here requires up.sh.
+
+**See what exists at any moment:**
+
+```bash
+ss e2e list          # every SPA, flow, and stage — plus checkpoint freshness
+```
+
+## The five flows at a glance
+
+| Flow | What it verifies | Runnable? |
+|---|---|---|
+| `saga-dash/journey` | The 8-stage trunk: roster upload → program → enrollment → pods → schedule → sessions → attendance (→ personas, currently skipped upstream) | ✅ |
+| `saga-dash/ads-adm-attendance` | Period-based attendance **persists**: survives reload AND is served back by ads-adm-api | ✅ |
+| `saga-dash/scheduling-topology` | A non-trivial A/B rotation topology **realizes the correct schedule** (dates, slots, treatment switches, per-pod isolation) | ✅ |
+| `saga-dash/connect-session` | A live Connect tutoring room (1 tutor + 2 students, AV) | 🎤 manual (needs mic/cam) |
+| `connectv3/connect-smoke` | connect-web smoke | ❌ not yet — see ToDo |
+
+## Concepts in 60 seconds
+
+- A **flow** is data (`flows.json` in the SPA's repo), not bash: an ordered list
+  of **stages**, each mapping to a Playwright project.
+- A **progressive** flow (journey) runs stages 1..N in order; each stage builds
+  real DB state the next one uses.
+- A **checkpoint** is a DB snapshot baked after a stage goes green. Later runs
+  can `--from <stage>` — restore the snapshot and skip the replay. Checkpoints
+  know when they're stale (`ss e2e list` shows `[checkpoint: re-bake]`).
+- A **prerequisite** flow (ads-adm, connect) needs journey state first — it
+  restores journey's checkpoint automatically instead of replaying it.
+- A **slot** is an isolated stack instance (`--slot 1..9`, offset ports).
+  Slot 0 is your default stack. You never need a slot for a first run.
+
+---
+
+## Running each flow
+
+### 1. journey — the trunk
+
+```bash
+# BACKGROUND (headless — the normal way; brings the stack up, resets + seeds):
+ss e2e run saga-dash/journey --headless
+
+# ...or only part of it (stages 1..4):
+ss e2e run saga-dash/journey --through pods --headless
+
+# FOREGROUND (watch the browser do it):
+ss e2e run saga-dash/journey --through pods --headed
+
+# FIRST RUN TIP: add --snapshot-stages once — it bakes a checkpoint after each
+# green stage, which unlocks all the fast iteration below:
+ss e2e run saga-dash/journey --snapshot-stages --headless
+```
+
+What you'll see per stage: `==> playwright: journey — … --project stage-N-…`
+then a pass count. Stage 8 currently reports `2 skipped` (its describe is
+skipped upstream in saga-dash — expected).
+
+### 2. ads-adm-attendance — persistence scenario
+
+```bash
+ss e2e run saga-dash/ads-adm-attendance --headless    # background
+ss e2e run saga-dash/ads-adm-attendance --headed      # foreground
+```
+
+Watch the log: `==> restore: flow-saga-dash-journey-s5-schedule …` then
+`prerequisite: journey@schedule restored from checkpoint (replay skipped)` —
+that's the checkpoint machinery saving you ~a minute of journey replay. (If no
+valid checkpoint exists it transparently replays journey instead — slower,
+same result.)
+
+### 3. scheduling-topology — realization scenario
+
+```bash
+ss e2e run saga-dash/scheduling-topology --headless   # background
+ss e2e run saga-dash/scheduling-topology --headed     # foreground
+```
+
+Self-seeds from the stock roster profile (no prerequisite). The single stage
+configures a 2-rotation topology through the API and asserts the realized
+sessions day-by-day.
+
+### 4. connect-session — manual/AV only
+
+```bash
+ss e2e connect              # builds journey@schedule state, then opens the
+                            # headed interactive room (holds via page.pause)
+ss e2e connect --reuse      # skip the state rebuild; use the current stack
+```
+
+Needs a real mic/cam and your terminal (the AV hold owns the TTY). There is no
+headless version — by design.
+
+### 5. connectv3/connect-smoke — not runnable yet
+
+The stack half works (`ss` brings up the 8-service closure green), but qboard's
+connectv3 app has **no Playwright harness** (no config, no dependency, no
+`e2e/` dir). See the ToDo section.
+
+---
+
+## Fast iteration with snapshot data
+
+The loop you want when working on stage K of journey:
+
+```bash
+# 1. Once: bake checkpoints (full run, ~1 min):
+ss e2e run saga-dash/journey --snapshot-stages --headless
+
+# 2. Iterate on ONE stage in seconds — restore the state before it, run only it:
+ss e2e run saga-dash/journey --from schedule --through schedule --headless
+
+# 3. Edit the spec / app code, re-run step 2. Each iteration is ~5-10s instead
+#    of a full replay.
+```
+
+Notes:
+- `--from <stage>` restores the **previous** stage's checkpoint, then runs from
+  `<stage>`. Baked dates are reused so date-sensitive stages stay coherent.
+- Checkpoints go stale when the flow definition changes or after 7 days —
+  `ss e2e list` shows `[checkpoint: re-bake]`; re-run step 1 to refresh.
+- Scenario flows get this for free: their journey prerequisite restores from
+  checkpoint automatically (`--no-prereq-from-snapshot` opts out).
+
+## Pausing for manual testing
+
+**Pause BEFORE a stage** (the state is built, the stage hasn't run — you drive
+it by hand in a logged-in browser):
+
+```bash
+ss e2e run saga-dash/journey --to program --hold
+# = build roster state, STOP, mint a dev@saga.org session, open a logged-in
+#   browser. The stack stays up; the banner tells you how to tear down.
+```
+
+**Pause AFTER a stage** (see what the flow produced):
+
+```bash
+ss e2e run saga-dash/journey --through pods --hold
+```
+
+**Instant pause at any boundary** (once checkpoints are baked — this is the
+one to remember):
+
+```bash
+ss e2e run saga-dash/journey --from schedule --to schedule --hold
+# restore checkpoint, run NOTHING, logged-in browser at schedule's doorstep
+# in ~6 seconds.
+```
+
+**Pause at EVERY stage in one run:** not supported as a single command. The
+equivalent walk (each step is seconds after baking):
+
+```bash
+for s in roster program enrollment pods schedule sessions attendance; do
+  ss e2e run saga-dash/journey --from $s --to $s --hold
+  # poke around, close the browser, press on
+done
+```
+
+**Debug a stage inside Playwright** (inspector, step through the spec):
+
+```bash
+ss e2e run saga-dash/journey --from schedule --through schedule -- --debug
+```
+
+Anything after `--` passes straight to Playwright (`--ui`, `--debug`, a grep).
+
+## Assessing the flows (background + foreground sweep)
+
+A compact assessment session, in order:
+
+```bash
+ss e2e run saga-dash/journey --snapshot-stages --headless   # 1. trunk + bake
+ss e2e run saga-dash/ads-adm-attendance --headless          # 2. persistence
+ss e2e run saga-dash/scheduling-topology --headless         # 3. realization
+ss e2e run saga-dash/journey --through pods --headed        # 4. watch one headed
+ss e2e run saga-dash/journey --from schedule --to schedule --hold   # 5. drive one by hand
+ss e2e connect                                              # 6. live room (mic/cam)
+ss stack down                                               # 7. tidy up
+```
+
+(Last full sweep: 2026-07-05 — steps 1-3 all green on main: 22 + 1 + 1 passed.)
+
+## Remaining work — connect flows & connectv3
+
+1. **Connect realtime session-based attendance flow** — phase 2 of the ADS/ADM
+   initiative (period-based shipped 2026-07-05). Shape: prerequisite
+   `journey@sessions` via checkpoint → record attendance through the Connect
+   realtime path → the same persistence assertions (reload + API-direct).
+2. **connect-session headless smoke (optional)** — a variant that stops short
+   of the AV hold so CI can exercise the room-join path.
+3. **connectv3 adoption** — author a repo `flows.json` in qboard (retiring the
+   last bundled-example SPA) AND add the Playwright harness to the connectv3
+   app (config + dependency + `e2e/` dir). The stack closure already comes up
+   green; only the harness is missing.
+
+## If something goes wrong
+
+- **A service fails bring-up with `ERR_MODULE_NOT_FOUND`** — that sibling repo
+  was pulled but not rebuilt; `pnpm install && pnpm build` in that repo. (The
+  prep pass's fresh-skip can't detect stale installs yet.)
+- **`[checkpoint: re-bake]` in `ss e2e list`** — the flow definition changed or
+  the checkpoint aged out; re-run with `--snapshot-stages`.
+- **Two `seed-dev-user … run seed:registry first` errors during seed** — known
+  cosmetic ordering noise; it self-heals and the run continues.
+- **A flaky pass/fail on session durability** — known app flake (gh-186);
+  retry once before digging.
+- Full docs: `docs/e2e.md` (flows/stages/checkpoints in depth), `docs/slots.md`
+  (parallel stacks), `docs/worktree-sets.md` (multi-worktree development).

--- a/packages/node/saga-stack-cli/docs/faq.md
+++ b/packages/node/saga-stack-cli/docs/faq.md
@@ -166,41 +166,6 @@ ss set check topo          # verdicts: prebuilt vs BUILDABLE, drift, collisions,
 which is meaningless for set worktrees (they're SUPPOSED to be on feature
 branches) — `set show`/`set check` ask the right questions for those.
 
-## Why does my PR show `skipping` entries in CI — is something failing?
-
-No. "Version and Publish Packages" and "Create Release Summary" only run on the
-release path (merges to main); on PR events they report `skipping`, which some
-views render with a neutral icon that reads like a failure at a glance. Check
-`gh pr checks <n>` — if nothing says `fail`, you're green.
-
-## A service fails bring-up with `ERR_MODULE_NOT_FOUND` — what happened?
-
-Its sibling repo was pulled but not rebuilt: the prep pass's fresh-skip treats
-`node_modules` + `dist` PRESENCE as fresh, so it won't rebuild after a pull
-changed dependencies. Fix: `pnpm install && pnpm build` in that repo.
-
-<details><summary>Real example</summary>
-
-```
-Error: native bring-up failed at ads-adm-api
-# /tmp/sds-synthetic/ads-adm-api.log:
-Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@saga-ed/soa-postgres'
-  imported from .../ads-adm-api/dist/chunk-2XELNIO7.js
-```
-
-student-data-system had been fast-forwarded that morning; its `dist` predated
-the dependency change. A lockfile-hash-aware freshness check is on the backlog.
-
-</details>
-
-## Why is journey stage 8 (attendance-personas) skipped?
-
-Deliberately, pending saga-dash#280: the SESSION measured-time overlay has no
-data source in a seeded journey (no real tutoring → no dosage telemetry), so
-its UI assertions can't pass yet. The persona/policy half is being revived as a
-partial unskip (live tests green, a tightly-scoped `test.skip` citing #280
-around only the measured-time assertions).
-
 ## Where does everything live?
 
 - CLI: `~/dev/soa/packages/node/saga-stack-cli` (`ss` on PATH)

--- a/packages/node/saga-stack-cli/docs/faq.md
+++ b/packages/node/saga-stack-cli/docs/faq.md
@@ -1,0 +1,211 @@
+# FAQ — How do I …?
+
+Real questions from real sessions, answered with the actual commands and output.
+(Companion to [`e2e-flows.md`](./e2e-flows.md), the first-time-user runbook.)
+
+## How do I see what flows exist and whether their checkpoints are fresh?
+
+`ss e2e list` — every SPA, flow, and stage, with checkpoint freshness annotations.
+
+<details><summary>Example output</summary>
+
+```
+saga-dash  [saga-dash]  /home/skelly/dev/saga-dash/apps/web/dash/e2e/flows.json
+  • journey  (stack/sandbox; progressive, foreground)
+      1. roster  (stage-1-roster)  [checkpoint: re-bake]
+      2. program  (stage-2-program-creation)  [checkpoint: re-bake]
+      3. enrollment  (stage-3-enrollment-periods)
+      ...
+  • ads-adm-attendance  (stack; single)
+      prerequisite: journey through 'schedule'
+      — persistence  (ads-adm-persistence)
+  • scheduling-topology  (stack; single)
+      1. topology  (scheduling-topology)
+```
+
+`[checkpoint]` = valid and restorable via `--from`; `[checkpoint: re-bake]` = exists
+but stale; no tag = never baked.
+
+</details>
+
+## How do I run the journey flow?
+
+```bash
+ss e2e run saga-dash/journey --headless                    # full 8 stages
+ss e2e run saga-dash/journey --through pods --headless     # stages 1..4 only
+ss e2e run saga-dash/journey --snapshot-stages --headless  # full run + bake checkpoints
+```
+
+<details><summary>Example output (per-stage)</summary>
+
+```
+==> playwright: journey — pnpm exec playwright test --config=playwright.stack.config.ts --project stage-1-roster --grep-invert @interactive
+  7 passed (21.0s)
+==> checkpoint: baked flow-saga-dash-journey-s1-roster
+==> playwright: journey — ... --project stage-2-program-creation --no-deps ...
+  3 passed (1.4s)
+==> checkpoint: baked flow-saga-dash-journey-s2-program
+```
+
+</details>
+
+## Why are stages flagged `[checkpoint: re-bake]`?
+
+A checkpoint is a DB snapshot of "what stages 1..K produced", stamped with a
+hash of those stages' definitions. If the flow definition changes (or the
+checkpoint ages past 7 days), restoring it could hand a differently-specified
+stage a mismatched world — so the CLI demands a re-bake instead of restoring
+silently. Fix: re-run with `--snapshot-stages`.
+
+<details><summary>Real example</summary>
+
+When `flows.json` moved from ad-hoc validation files into the saga-dash repo
+(2026-07-05), stage 1-2 checkpoints had been baked against the older definition
+(roster's `requiredSystems` differed). Three different prefix hashes existed for
+"journey stages 1..1" — the baked one, the old tmp file's, and the repo's — so
+the listing correctly flagged `re-bake`. One `--snapshot-stages` run refreshed
+all 8.
+
+</details>
+
+## How do I iterate on ONE stage quickly instead of replaying the whole flow?
+
+Bake once, then restore-and-run just your stage:
+
+```bash
+ss e2e run saga-dash/journey --snapshot-stages --headless             # once (~1 min)
+ss e2e run saga-dash/journey --from schedule --through schedule --headless   # each iteration (~5-10s)
+```
+
+<details><summary>What the restore looks like</summary>
+
+```
+==> restore: flow-saga-dash-journey-s5-schedule (baked 2026-07-06T00:57:13.383Z, occurrence 2026-07-06)
+==> prerequisite: journey@schedule restored from checkpoint (replay skipped)
+==> playwright: ... --project stage-5-schedule ...
+```
+
+Live measurement: full replay 44.9s → `--from` 5.8s.
+
+</details>
+
+## How do I pause a flow for manual testing — is there a "leave the browser open" flag?
+
+`--hold` mints a logged-in dev session and opens a browser when the run stops;
+`--to <stage>` stops BEFORE a stage (its entry state is built, the stage hasn't
+run). The instant version, once checkpoints are baked:
+
+```bash
+ss e2e run saga-dash/journey --from schedule --to schedule --hold   # ~6s to a live browser
+ss e2e run saga-dash/journey --through pods --hold                  # pause AFTER pods
+ss e2e run saga-dash/journey --from schedule --through schedule -- --debug   # Playwright inspector
+```
+
+<details><summary>The held-state banner</summary>
+
+```
+✓ held for manual testing — saga-dash/journey at entry of 'program'
+  slot 1 · services up (2): iam-api, saga-dash
+  logged-in as dev@saga.org · cookie jar → /tmp/sds-synthetic-s1/cookies.txt
+  opening a logged-in browser at http://localhost:9900 (best-effort; a headless host warns)…
+  teardown when done: ss stack down --slot 1
+```
+
+There's no single-command "pause at EVERY stage" — loop `--from $s --to $s --hold`
+per stage instead (seconds each). `foreground` in flows.json is different: it's a
+per-flow authoring choice (connect's AV hold via `page.pause()`).
+
+</details>
+
+## How do I pull the latest main into slot 0 and the worktree slots?
+
+```bash
+ss stack up --pull              # slot 0: ff-only sync of clean, on-branch siblings
+ss stack up --set topo --pull   # slot 1: same, against the set's worktrees
+```
+
+**But note:** `--pull` syncs each checkout's OWN branch from its own upstream. It
+deliberately does NOT merge `origin/main` into a feature worktree — that's a
+history-changing decision `up` won't make for you. See the next question.
+
+## My worktree still shows "behind origin/main" after `--pull` — why, and how do I merge up?
+
+Because `--pull` ≠ merge-up (above). `ss set show <name>` tells you the mainline
+currency and prints the exact command when action is needed:
+
+```bash
+git -C ~/dev/worktrees/saga-dash-topo merge origin/main
+```
+
+<details><summary>Example output</summary>
+
+```
+ads — slot 2  (ADS/ADM period-based persistence flow initiative (slot 2))
+  ✓ saga-dash    @ flow/ads-adm-persistence  (clean)  [⚠ behind origin/main by 22]
+      /home/skelly/dev/worktrees/saga-dash-ads   created from flow/ads-adm-persistence
+      merge up: git -C /home/skelly/dev/worktrees/saga-dash-ads merge origin/main
+```
+
+Currency is as-of your last fetch; `ss set show ads --fetch` refreshes first.
+After merging up, `pnpm install` in the worktree — the prep pass's fresh-skip
+can't detect stale installs (yet).
+
+</details>
+
+## How do I see the source posture of a slot / worktree?
+
+Two commands for two worlds:
+
+```bash
+ss stack verify --full     # slot 0: P1-P4 posture of the DEFAULT checkouts vs origin/main (warn-only)
+ss set show topo           # a worktree set: branch, clean/dirty, provenance, mainline currency
+ss set check topo          # verdicts: prebuilt vs BUILDABLE, drift, collisions, ACTIVE-slot safety
+```
+
+`verify --full` is slot-0-only by design: it asserts "defaults on clean main",
+which is meaningless for set worktrees (they're SUPPOSED to be on feature
+branches) — `set show`/`set check` ask the right questions for those.
+
+## Why does my PR show `skipping` entries in CI — is something failing?
+
+No. "Version and Publish Packages" and "Create Release Summary" only run on the
+release path (merges to main); on PR events they report `skipping`, which some
+views render with a neutral icon that reads like a failure at a glance. Check
+`gh pr checks <n>` — if nothing says `fail`, you're green.
+
+## A service fails bring-up with `ERR_MODULE_NOT_FOUND` — what happened?
+
+Its sibling repo was pulled but not rebuilt: the prep pass's fresh-skip treats
+`node_modules` + `dist` PRESENCE as fresh, so it won't rebuild after a pull
+changed dependencies. Fix: `pnpm install && pnpm build` in that repo.
+
+<details><summary>Real example</summary>
+
+```
+Error: native bring-up failed at ads-adm-api
+# /tmp/sds-synthetic/ads-adm-api.log:
+Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@saga-ed/soa-postgres'
+  imported from .../ads-adm-api/dist/chunk-2XELNIO7.js
+```
+
+student-data-system had been fast-forwarded that morning; its `dist` predated
+the dependency change. A lockfile-hash-aware freshness check is on the backlog.
+
+</details>
+
+## Why is journey stage 8 (attendance-personas) skipped?
+
+Deliberately, pending saga-dash#280: the SESSION measured-time overlay has no
+data source in a seeded journey (no real tutoring → no dosage telemetry), so
+its UI assertions can't pass yet. The persona/policy half is being revived as a
+partial unskip (live tests green, a tightly-scoped `test.skip` citing #280
+around only the measured-time assertions).
+
+## Where does everything live?
+
+- CLI: `~/dev/soa/packages/node/saga-stack-cli` (`ss` on PATH)
+- Flows: `~/dev/saga-dash/apps/web/dash/e2e/flows.json` (repo-authored, per-SPA)
+- Checkpoints/snapshots: `~/.saga-mesh/snapshots` (`snapshots-s<N>` per slot)
+- Worktree sets: `~/.saga-stack/worktree-sets.json` (`$SAGA_STACK_SETS` overrides)
+- Docs: `docs/e2e.md`, `docs/e2e-flows.md` (runbook), `docs/slots.md`,
+  `docs/worktree-sets.md`, `docs/snapshots.md`

--- a/packages/node/saga-stack-cli/docs/snapshots.md
+++ b/packages/node/saga-stack-cli/docs/snapshots.md
@@ -66,3 +66,23 @@ restore refuses rather than silently loading a stale shape — the one blind spo
   flow provenance as a sub-line. See [e2e → Stage checkpoints](./e2e.md#stage-checkpoints--skip-the-replay-m14).
 
 ← [verify](./verify.md) · [e2e →](./e2e.md)
+
+## Porting legacy mesh-fixture fixtures (e.g. `iam-small`, soa#194)
+
+`mesh-fixture-cli` fixtures are authoring scripts (its `iam:*` verbs) plus a
+captured dump. `ss` deliberately does not re-implement the authoring verbs —
+the native recipe composes what already exists:
+
+1. Bring up just the scope: `ss stack up --only iam-api --reset`.
+2. Seed the canonical registry base (permissions/policies), then author the
+   fixture entities — today that is still the legacy script
+   (`packages/node/mesh-fixture-cli/fixtures/<name>/create.sh`), which works
+   fine against a native `ss` stack.
+3. Capture natively: `ss stack snapshot store <name> --only iam-api` — the
+   manifest records profile + schema revisions, and the restore guards
+   (profile-mismatch, snapshot-ahead) apply.
+4. Restore anywhere: `ss stack snapshot restore <name>` (slot-aware).
+
+When per-user roles/personas land (rostering#667), re-author on the same base
+and re-store — the snapshot supersedes the script as the distributable
+artifact.

--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -900,6 +900,12 @@
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
+        },
+        "fetch": {
+          "description": "git fetch each repo first so the mainline-currency report reflects the REMOTE tip (network); without it, currency is as-of the last fetch",
+          "name": "fetch",
+          "allowNo": false,
+          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,

--- a/packages/node/saga-stack-cli/src/__tests__/helpers/set-fakes.ts
+++ b/packages/node/saga-stack-cli/src/__tests__/helpers/set-fakes.ts
@@ -50,12 +50,22 @@ export function spySetStore(data: unknown): void {
  * (default clean), and any path in `nonCheckouts` fails `revParseVerify`.
  */
 export function spyGitRunner(
-  opts: { branches?: Record<string, string>; porcelain?: string; nonCheckouts?: string[] } = {},
+  opts: {
+    branches?: Record<string, string>;
+    porcelain?: string;
+    nonCheckouts?: string[];
+    /** Per-path mainline currency (default: every checkout INCLUDES origin/main). */
+    behindMain?: Record<string, number>;
+  } = {},
 ): void {
   const fake: Partial<GitRunner> = {
     branchShowCurrent: async (repoPath: string) => opts.branches?.[repoPath] ?? 'main',
     statusPorcelain: async () => opts.porcelain ?? '',
     revParseVerify: async (repoPath: string) => !(opts.nonCheckouts ?? []).includes(repoPath),
+    symbolicRefDefault: async () => 'main',
+    fetch: async () => true,
+    isAncestorOfHead: async (repoPath: string) => (opts.behindMain?.[repoPath] ?? 0) === 0,
+    countBehindRef: async (repoPath: string) => opts.behindMain?.[repoPath] ?? 0,
   };
   vi.spyOn(
     BaseCommand.prototype as unknown as { getGitRunner: () => GitRunner },

--- a/packages/node/saga-stack-cli/src/color.ts
+++ b/packages/node/saga-stack-cli/src/color.ts
@@ -1,0 +1,28 @@
+/**
+ * Tiny TTY-aware ANSI palette for human-readable command output.
+ *
+ * NO dependency (chalk et al. are overkill for five codes) and NO color when
+ * it could corrupt machine consumption: enabled only when stdout is a TTY,
+ * `NO_COLOR` is unset (https://no-color.org), and TERM isn't `dumb`. The
+ * `--porcelain` / `--output-json` paths never call these helpers at all, and
+ * tests never see codes (vitest's stdout is not a TTY) — so exact-pin string
+ * assertions stay byte-stable.
+ */
+
+const enabled: boolean =
+  Boolean(process.stdout.isTTY) && process.env.NO_COLOR === undefined && process.env.TERM !== 'dumb';
+
+function wrap(code: string): (s: string) => string {
+  return (s: string) => (enabled ? `[${code}m${s}[0m` : s);
+}
+
+export const green = wrap('32');
+export const red = wrap('31');
+export const yellow = wrap('33');
+export const dim = wrap('2');
+export const bold = wrap('1');
+
+/** Exposed for tests (asserting the gate, not the codes). */
+export function colorEnabled(): boolean {
+  return enabled;
+}

--- a/packages/node/saga-stack-cli/src/color.ts
+++ b/packages/node/saga-stack-cli/src/color.ts
@@ -21,6 +21,7 @@ export const red = wrap('31');
 export const yellow = wrap('33');
 export const dim = wrap('2');
 export const bold = wrap('1');
+export const cyan = wrap('36');
 
 /** Exposed for tests (asserting the gate, not the codes). */
 export function colorEnabled(): boolean {

--- a/packages/node/saga-stack-cli/src/commands/e2e/__tests__/run.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/__tests__/run.int.test.ts
@@ -438,7 +438,7 @@ describe('e2e run — --hold manual-testing handoff (Plan 13)', () => {
     // dev-persona jar minted at slot-0 iam, written to the state dir.
     expect(posts).toHaveLength(1);
     expect(posts[0]?.url).toBe('http://localhost:3010/trpc/auth.devLogin');
-    expect(posts[0]?.opts.body).toBe('{"email":"dev@saga.org"}');
+    expect(posts[0]?.opts.body).toBe('{"identifier":"dev@saga.org","email":"dev@saga.org"}');
     expect(jarWrites).toHaveLength(1);
     expect(jarWrites[0]?.path).toBe('/tmp/sds-synthetic/cookies.txt');
 

--- a/packages/node/saga-stack-cli/src/commands/set/__tests__/set-commands.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/set/__tests__/set-commands.int.test.ts
@@ -90,7 +90,8 @@ describe('set show', () => {
     await SetShow.run(['x'], config);
     const out = logged.join('\n');
     expect(out).toMatch(/x — slot 1/);
-    expect(out).toMatch(/✓ saga-dash.*@ feat\/x \(clean\).*created from feat\/x/);
+    expect(out).toMatch(/✓ saga-dash\s+@ feat\/x\s+\(clean\)/);
+    expect(out).toMatch(/created from feat\/x/);
     expect(out).toMatch(/✗ rostering.*\(missing\)/);
   });
 
@@ -130,7 +131,9 @@ describe('set show — mainline currency', () => {
     spyGitRunner({ branches: { [dash]: 'feat/x' }, behindMain: { [dash]: 7 } });
 
     await SetShow.run(['x'], config);
-    expect(logged.join('\n')).toMatch(/\[⚠ behind origin\/main by 7 — merge up: git -C .*dash merge origin\/main\]/);
+    const out2 = logged.join('\n');
+    expect(out2).toMatch(/\[⚠ behind origin\/main by 7\]/);
+    expect(out2).toMatch(/merge up: git -C .*dash merge origin\/main/);
   });
 
   it('projects mainRef/includesMain/behindMain into --output-json', async () => {

--- a/packages/node/saga-stack-cli/src/commands/set/__tests__/set-commands.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/set/__tests__/set-commands.int.test.ts
@@ -112,6 +112,39 @@ describe('set show', () => {
   });
 });
 
+describe('set show — mainline currency', () => {
+  it('reports [includes origin/main] when the worktree contains the main tip', async () => {
+    const dash = join(dir, 'dash');
+    mkdirSync(dash);
+    spySetStore(oneSetWithSagaDash(dash));
+    spyGitRunner({ branches: { [dash]: 'feat/x' } });
+
+    await SetShow.run(['x'], config);
+    expect(logged.join('\n')).toMatch(/\[includes origin\/main\]/);
+  });
+
+  it('warns with the behind count when the worktree lacks the main tip', async () => {
+    const dash = join(dir, 'dash');
+    mkdirSync(dash);
+    spySetStore(oneSetWithSagaDash(dash));
+    spyGitRunner({ branches: { [dash]: 'feat/x' }, behindMain: { [dash]: 7 } });
+
+    await SetShow.run(['x'], config);
+    expect(logged.join('\n')).toMatch(/\[⚠ behind origin\/main by 7 — merge up\]/);
+  });
+
+  it('projects mainRef/includesMain/behindMain into --output-json', async () => {
+    const dash = join(dir, 'dash');
+    mkdirSync(dash);
+    spySetStore(oneSetWithSagaDash(dash));
+    spyGitRunner({ behindMain: { [dash]: 3 } });
+
+    await SetShow.run(['x', '--output-json'], config);
+    const parsed = JSON.parse(logged.join('\n'));
+    expect(parsed.repos[0]).toMatchObject({ mainRef: 'origin/main', includesMain: false, behindMain: 3 });
+  });
+});
+
 describe('set check', () => {
   it('a clean pre-built set is OK (exit 0)', async () => {
     const dash = join(dir, 'dash');

--- a/packages/node/saga-stack-cli/src/commands/set/__tests__/set-commands.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/set/__tests__/set-commands.int.test.ts
@@ -130,7 +130,7 @@ describe('set show — mainline currency', () => {
     spyGitRunner({ branches: { [dash]: 'feat/x' }, behindMain: { [dash]: 7 } });
 
     await SetShow.run(['x'], config);
-    expect(logged.join('\n')).toMatch(/\[⚠ behind origin\/main by 7 — merge up\]/);
+    expect(logged.join('\n')).toMatch(/\[⚠ behind origin\/main by 7 — merge up: git -C .*dash merge origin\/main\]/);
   });
 
   it('projects mainRef/includesMain/behindMain into --output-json', async () => {

--- a/packages/node/saga-stack-cli/src/commands/set/show.ts
+++ b/packages/node/saga-stack-cli/src/commands/set/show.ts
@@ -124,7 +124,7 @@ export default class SetShow extends BaseCommand {
           ? ''
           : r.includesMain
             ? `  [includes ${r.mainRef}]`
-            : `  [⚠ behind ${r.mainRef} by ${r.behindMain ?? '?'} — merge up]`;
+            : `  [⚠ behind ${r.mainRef} by ${r.behindMain ?? '?'} — merge up: git -C ${r.entry.path} merge ${r.mainRef}]`;
       this.log(
         `  ✓ ${r.repo.padEnd(12)} ${r.entry.path}  @ ${r.branch}${r.dirty ? ' (dirty)' : ' (clean)'}${provenance}${currency}`,
       );

--- a/packages/node/saga-stack-cli/src/commands/set/show.ts
+++ b/packages/node/saga-stack-cli/src/commands/set/show.ts
@@ -12,7 +12,7 @@
  */
 
 import { existsSync } from 'node:fs';
-import { Args } from '@oclif/core';
+import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command.js';
 import { resolveSet } from '../../core/set/index.js';
 import type { SetRepoEntry, SetRepoKey } from '../../core/set/index.js';
@@ -28,6 +28,11 @@ export default class SetShow extends BaseCommand {
 
   static flags = {
     ...BaseCommand.baseFlags,
+    fetch: Flags.boolean({
+      description:
+        'git fetch each repo first so the mainline-currency report reflects the REMOTE tip (network); without it, currency is as-of the last fetch',
+      default: false,
+    }),
   };
 
   async run(): Promise<void> {
@@ -43,17 +48,27 @@ export default class SetShow extends BaseCommand {
     const repos = await Promise.all(
       (Object.entries(set.repos) as [SetRepoKey, SetRepoEntry][]).map(async ([repo, entry]) => {
         if (!existsSync(entry.path)) {
-          return { repo, entry, exists: false, checkout: false, branch: null, dirty: null };
+          return { repo, entry, exists: false, checkout: false, branch: null, dirty: null, mainRef: null, includesMain: null, behindMain: null };
         }
         // branchShowCurrent folds ALL errors to '' — indistinguishable from a
         // real detached HEAD — so probe checkout-ness explicitly first: a dir
         // that is not a git checkout must not render as '@ (detached) (clean)'.
         if (!(await git.revParseVerify(entry.path, 'HEAD'))) {
-          return { repo, entry, exists: true, checkout: false, branch: null, dirty: null };
+          return { repo, entry, exists: true, checkout: false, branch: null, dirty: null, mainRef: null, includesMain: null, behindMain: null };
         }
         const branch = (await git.branchShowCurrent(entry.path)) || '(detached)';
         const dirty = (await git.statusPorcelain(entry.path)).trim() !== '';
-        return { repo, entry, exists: true, checkout: true, branch, dirty };
+        // Mainline currency (as-of last fetch unless --fetch): does this
+        // worktree already CONTAIN origin/<default>? If not, how far behind?
+        if (flags.fetch) await git.fetch(entry.path);
+        const mainRef = `origin/${await git.symbolicRefDefault(entry.path)}`;
+        let includesMain: boolean | null = null;
+        let behindMain: number | null = null;
+        if (await git.revParseVerify(entry.path, mainRef)) {
+          includesMain = await git.isAncestorOfHead(entry.path, mainRef);
+          behindMain = includesMain ? 0 : await git.countBehindRef(entry.path, mainRef); // null = could not compare
+        }
+        return { repo, entry, exists: true, checkout: true, branch, dirty, mainRef, includesMain, behindMain };
       }),
     );
 
@@ -71,6 +86,9 @@ export default class SetShow extends BaseCommand {
               checkout: r.checkout,
               branch: r.branch,
               dirty: r.dirty,
+              mainRef: r.mainRef,
+              includesMain: r.includesMain,
+              behindMain: r.behindMain,
               ...(r.entry.createdBy !== undefined ? { createdBy: r.entry.createdBy } : {}),
               ...(r.entry.createdFrom !== undefined ? { createdFrom: r.entry.createdFrom } : {}),
             })),
@@ -101,8 +119,14 @@ export default class SetShow extends BaseCommand {
         continue;
       }
       const provenance = r.entry.createdFrom !== undefined ? `  created from ${r.entry.createdFrom}` : '';
+      const currency =
+        r.includesMain === null
+          ? ''
+          : r.includesMain
+            ? `  [includes ${r.mainRef}]`
+            : `  [⚠ behind ${r.mainRef} by ${r.behindMain ?? '?'} — merge up]`;
       this.log(
-        `  ✓ ${r.repo.padEnd(12)} ${r.entry.path}  @ ${r.branch}${r.dirty ? ' (dirty)' : ' (clean)'}${provenance}`,
+        `  ✓ ${r.repo.padEnd(12)} ${r.entry.path}  @ ${r.branch}${r.dirty ? ' (dirty)' : ' (clean)'}${provenance}${currency}`,
       );
     }
   }

--- a/packages/node/saga-stack-cli/src/commands/set/show.ts
+++ b/packages/node/saga-stack-cli/src/commands/set/show.ts
@@ -14,6 +14,7 @@
 import { existsSync } from 'node:fs';
 import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command.js';
+import { bold, cyan, dim, green, red, yellow } from '../../color.js';
 import { resolveSet } from '../../core/set/index.js';
 import type { SetRepoEntry, SetRepoKey } from '../../core/set/index.js';
 
@@ -108,26 +109,34 @@ export default class SetShow extends BaseCommand {
       return;
     }
 
-    this.log(`${set.name} — slot ${set.slot}${set.note !== undefined ? `  (${set.note})` : ''}`);
+    this.log(
+      `${bold(`${set.name} — slot ${set.slot}`)}${set.note !== undefined ? dim(`  (${set.note})`) : ''}`,
+    );
     for (const r of repos) {
       if (!r.exists) {
-        this.log(`  ✗ ${r.repo.padEnd(12)} ${r.entry.path}  (missing)`);
+        this.log(`  ${red('✗')} ${bold(r.repo.padEnd(12))} ${dim(r.entry.path)}  ${red('(missing)')}`);
         continue;
       }
       if (!r.checkout) {
-        this.log(`  ✗ ${r.repo.padEnd(12)} ${r.entry.path}  (not a git checkout)`);
+        this.log(`  ${red('✗')} ${bold(r.repo.padEnd(12))} ${dim(r.entry.path)}  ${red('(not a git checkout)')}`);
         continue;
       }
-      const provenance = r.entry.createdFrom !== undefined ? `  created from ${r.entry.createdFrom}` : '';
+      // Row 1: identity + working-tree state + mainline currency (state at a glance).
+      const dirtiness = r.dirty ? yellow('(dirty)') : dim('(clean)');
       const currency =
         r.includesMain === null
           ? ''
           : r.includesMain
-            ? `  [includes ${r.mainRef}]`
-            : `  [⚠ behind ${r.mainRef} by ${r.behindMain ?? '?'} — merge up: git -C ${r.entry.path} merge ${r.mainRef}]`;
-      this.log(
-        `  ✓ ${r.repo.padEnd(12)} ${r.entry.path}  @ ${r.branch}${r.dirty ? ' (dirty)' : ' (clean)'}${provenance}${currency}`,
-      );
+            ? `  ${green(`[includes ${r.mainRef}]`)}`
+            : `  ${yellow(`[⚠ behind ${r.mainRef} by ${r.behindMain ?? '?'}]`)}`;
+      this.log(`  ${green('✓')} ${bold(r.repo.padEnd(12))} @ ${cyan(r.branch ?? '')}  ${dirtiness}${currency}`);
+      // Row 2: where it lives + provenance (reference detail, dimmed).
+      const provenance = r.entry.createdFrom !== undefined ? `   created from ${r.entry.createdFrom}` : '';
+      this.log(dim(`      ${r.entry.path}${provenance}`));
+      // Row 3 (only when action is needed): the copy-pasteable merge-up command.
+      if (r.includesMain === false) {
+        this.log(`      ${yellow('merge up:')} git -C ${r.entry.path} merge ${r.mainRef}`);
+      }
     }
   }
 }

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/login-native.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/login-native.int.test.ts
@@ -101,7 +101,7 @@ describe('stack login — native headless cookie jar', () => {
     expect(posts).toHaveLength(1);
     expect(posts[0]?.url).toBe('http://localhost:3010/trpc/auth.devLogin');
     expect(posts[0]?.opts.origin).toBe('http://localhost:3010');
-    expect(posts[0]?.opts.body).toBe('{"email":"dev@saga.org"}');
+    expect(posts[0]?.opts.body).toBe('{"identifier":"dev@saga.org","email":"dev@saga.org"}');
     // jar written to <stateDir>/cookies.txt with the captured cookies.
     expect(jarWrites).toHaveLength(1);
     expect(jarWrites[0]?.path).toBe('/tmp/sds-synthetic/cookies.txt');
@@ -115,7 +115,7 @@ describe('stack login — native headless cookie jar', () => {
     installPoster(OK_COOKIES);
     installJar();
     await StackLogin.run(['teacher@saga.org', ...WS], config);
-    expect(posts[0]?.opts.body).toBe('{"email":"teacher@saga.org"}');
+    expect(posts[0]?.opts.body).toBe('{"identifier":"teacher@saga.org","email":"teacher@saga.org"}');
   });
 
   it('LOGIN_IAM_URL (tunnel) overrides the localhost iam URL + Origin', async () => {
@@ -159,7 +159,7 @@ describe('stack login — native headless cookie jar', () => {
 
     // the native jar STILL ran (poster + jar), unlike the old up.sh-delegated flow.
     expect(posts).toHaveLength(1);
-    expect(posts[0]?.opts.body).toBe('{"email":"teacher@saga.org"}');
+    expect(posts[0]?.opts.body).toBe('{"identifier":"teacher@saga.org","email":"teacher@saga.org"}');
     expect(jarWrites).toHaveLength(1);
     expect(jarWrites[0]?.path).toBe('/tmp/sds-synthetic/cookies.txt');
 

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/up-native.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/up-native.int.test.ts
@@ -231,7 +231,7 @@ describe('stack up --only — native partial-stack', () => {
     expect(posts).toHaveLength(1);
     expect(posts[0]?.url).toBe('http://localhost:3010/trpc/auth.devLogin');
     expect(posts[0]?.opts.origin).toBe('http://localhost:3010');
-    expect(posts[0]?.opts.body).toBe('{"email":"dev@saga.org"}');
+    expect(posts[0]?.opts.body).toBe('{"identifier":"dev@saga.org","email":"dev@saga.org"}');
     expect(jarWrites).toHaveLength(1);
     expect(jarWrites[0]?.path).toBe('/tmp/sds-synthetic/cookies.txt');
     expect(jarWrites[0]?.contents).toContain('iam_session\tjwt');

--- a/packages/node/saga-stack-cli/src/commands/stack/verify.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/verify.ts
@@ -235,7 +235,7 @@ export default class StackVerify extends BaseCommand {
     this.log(cyan(bold('── service health ──')));
     for (const r of healthRows) {
       this.log(
-        `${r.ok ? green('✓') : red('✗')} ${r.id.padEnd(16)} ${dim(r.url)}  (${r.ok ? String(r.status ?? '') : red('down')})`,
+        `${r.ok ? green('✓') : red('✗')} ${r.id.padEnd(16)} ${dim(r.url)}  (${r.ok ? green(String(r.status ?? '')) : red('down')})`,
       );
     }
 
@@ -255,7 +255,7 @@ export default class StackVerify extends BaseCommand {
     };
     const data = assessData(readings);
     this.log(cyan(bold('── data ──')));
-    for (const c of data.checks) this.log(`${c.ok ? green('✓') : red('✗')} ${c.label}`);
+    for (const c of data.checks) this.log(`${c.ok ? green('✓') : red('✗')} ${dim(c.label)}`);
     for (const note of data.notes) this.log(dim(`· ${note}`));
 
     // 3. NATIVE source-posture (P1–P4) — STRICTLY WARN-ONLY (M12). Emits ✓/⚠/· lines but
@@ -324,8 +324,8 @@ export default class StackVerify extends BaseCommand {
 
 /** Render one posture line with verify.sh's ✓/⚠/· glyphs. */
 function renderPostureLine(l: PostureLine): string {
-  if (l.level === 'ok') return `${green('✓')} ${l.message}`;
-  if (l.level === 'warn') return `${yellow('⚠')} ${l.message}`;
+  if (l.level === 'ok') return `${green('✓')} ${dim(l.message)}`;
+  if (l.level === 'warn') return `${yellow('⚠')} ${dim(l.message)}`;
   return dim(`· ${l.message}`);
 }
 

--- a/packages/node/saga-stack-cli/src/commands/stack/verify.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/verify.ts
@@ -30,7 +30,7 @@
 import { join } from 'node:path';
 import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command.js';
-import { bold, dim, green, red, yellow } from '../../color.js';
+import { bold, cyan, dim, green, red, yellow } from '../../color.js';
 import { BUNDLE_NAMES } from '../../core/bundles.js';
 import { deriveInstance } from '../../core/derive-instance.js';
 import { SYNTH_DEV_DIR } from '../../core/flag-map.js';
@@ -232,7 +232,7 @@ export default class StackVerify extends BaseCommand {
       }),
     );
     const healthDown = healthRows.filter((r) => !r.ok);
-    this.log(dim('── service health ──'));
+    this.log(cyan(bold('── service health ──')));
     for (const r of healthRows) {
       this.log(
         `${r.ok ? green('✓') : red('✗')} ${r.id.padEnd(16)} ${dim(r.url)}  (${r.ok ? String(r.status ?? '') : red('down')})`,
@@ -254,7 +254,7 @@ export default class StackVerify extends BaseCommand {
       mongoReachable: await meshExec.ready(mongoContainer, mongo.readinessCmd),
     };
     const data = assessData(readings);
-    this.log(dim('── data ──'));
+    this.log(cyan(bold('── data ──')));
     for (const c of data.checks) this.log(`${c.ok ? green('✓') : red('✗')} ${c.label}`);
     for (const note of data.notes) this.log(dim(`· ${note}`));
 
@@ -263,12 +263,12 @@ export default class StackVerify extends BaseCommand {
     let postureWarns = 0;
     if (!flags['health-only']) {
       const posture = await this.runPosture(flags);
-      this.log(dim('── source posture ──'));
+      this.log(cyan(bold('── source posture ──')));
       if (!posture.overlayPresent) {
         this.log(dim('· no local overlay — asserting every managed repo on origin/main'));
       }
       for (const l of posture.result.posture) this.log(renderPostureLine(l));
-      this.log(dim('── freshness (behind origin) ──'));
+      this.log(cyan(bold('── freshness (behind origin) ──')));
       for (const l of posture.result.freshness) this.log(renderPostureLine(l));
       postureWarns = [...posture.result.posture, ...posture.result.freshness].filter(
         (l) => l.level === 'warn',

--- a/packages/node/saga-stack-cli/src/commands/stack/verify.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/verify.ts
@@ -30,6 +30,7 @@
 import { join } from 'node:path';
 import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command.js';
+import { bold, dim, green, red, yellow } from '../../color.js';
 import { BUNDLE_NAMES } from '../../core/bundles.js';
 import { deriveInstance } from '../../core/derive-instance.js';
 import { SYNTH_DEV_DIR } from '../../core/flag-map.js';
@@ -231,9 +232,11 @@ export default class StackVerify extends BaseCommand {
       }),
     );
     const healthDown = healthRows.filter((r) => !r.ok);
-    this.log('── service health ──');
+    this.log(dim('── service health ──'));
     for (const r of healthRows) {
-      this.log(`${r.ok ? '✓' : '✗'} ${r.id.padEnd(16)} ${r.url}  (${r.status ?? 'down'})`);
+      this.log(
+        `${r.ok ? green('✓') : red('✗')} ${r.id.padEnd(16)} ${dim(r.url)}  (${r.ok ? String(r.status ?? '') : red('down')})`,
+      );
     }
 
     // 2. native DATA checks (D1–D5). Reads as postgres_admin against the base mesh
@@ -251,21 +254,21 @@ export default class StackVerify extends BaseCommand {
       mongoReachable: await meshExec.ready(mongoContainer, mongo.readinessCmd),
     };
     const data = assessData(readings);
-    this.log('── data ──');
-    for (const c of data.checks) this.log(`${c.ok ? '✓' : '✗'} ${c.label}`);
-    for (const note of data.notes) this.log(`· ${note}`);
+    this.log(dim('── data ──'));
+    for (const c of data.checks) this.log(`${c.ok ? green('✓') : red('✗')} ${c.label}`);
+    for (const note of data.notes) this.log(dim(`· ${note}`));
 
     // 3. NATIVE source-posture (P1–P4) — STRICTLY WARN-ONLY (M12). Emits ✓/⚠/· lines but
     // NEVER contributes to the verdict. Skipped under --health-only (health + DATA only).
     let postureWarns = 0;
     if (!flags['health-only']) {
       const posture = await this.runPosture(flags);
-      this.log('── source posture ──');
+      this.log(dim('── source posture ──'));
       if (!posture.overlayPresent) {
-        this.log('· no local overlay — asserting every managed repo on origin/main');
+        this.log(dim('· no local overlay — asserting every managed repo on origin/main'));
       }
       for (const l of posture.result.posture) this.log(renderPostureLine(l));
-      this.log('── freshness (behind origin) ──');
+      this.log(dim('── freshness (behind origin) ──'));
       for (const l of posture.result.freshness) this.log(renderPostureLine(l));
       postureWarns = [...posture.result.posture, ...posture.result.freshness].filter(
         (l) => l.level === 'warn',
@@ -279,13 +282,13 @@ export default class StackVerify extends BaseCommand {
     const warnSuffix = postureWarns > 0 ? ` (${postureWarns} posture warning(s) — see ⚠ above)` : '';
     this.log(
       passed
-        ? `✓ verify --full: health + data green${warnSuffix}`
-        : `✗ verify --full: ${[
+        ? green(bold(`✓ verify --full: health + data green`)) + (warnSuffix ? yellow(warnSuffix) : '')
+        : red(bold(`✗ verify --full: ${[
             healthOk ? null : `${healthDown.length} service(s) down`,
             data.passed ? null : `${data.checks.filter((c) => !c.ok).length} data check(s) failed`,
           ]
             .filter(Boolean)
-            .join('; ')}${warnSuffix}`,
+            .join('; ')}`)) + (warnSuffix ? yellow(warnSuffix) : ''),
     );
     if (!passed) this.exit(1);
   }
@@ -321,8 +324,9 @@ export default class StackVerify extends BaseCommand {
 
 /** Render one posture line with verify.sh's ✓/⚠/· glyphs. */
 function renderPostureLine(l: PostureLine): string {
-  const glyph = l.level === 'ok' ? '✓' : l.level === 'warn' ? '⚠' : '·';
-  return `${glyph} ${l.message}`;
+  if (l.level === 'ok') return `${green('✓')} ${l.message}`;
+  if (l.level === 'warn') return `${yellow('⚠')} ${l.message}`;
+  return dim(`· ${l.message}`);
 }
 
 /** A rendered verify row. */

--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
@@ -173,7 +173,8 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
       JANUS_REQUIRED: 'false',
       IAM_API_URL: 'http://localhost:3010',
       JWT_ISSUER: 'https://iam.saga.org',
-      ALLOWED_ORIGINS: 'http://localhost:6210',
+      // #222 port: dash joins the CORS allowlist; rtsm wired for private-convos.
+      ALLOWED_ORIGINS: 'http://localhost:6210,http://localhost:8900',
       SESSIONS_API_BASE_URL: 'http://localhost:3007',
       SAGA_API_TARGET: 'https://wootmath.com',
       CONTENT_API_URL: 'http://localhost:3009',
@@ -183,6 +184,7 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
       LIVEKIT_API_SECRET: 'devsecret',
       RECORDING_SERVICE_TOKEN: 'local-dev-token',
       RECORDER_URL_TEMPLATE: 'http://127.0.0.1:7890',
+      RTSM_API_URL: 'http://localhost:6110',
       FLEEK_TOPOLOGY_JSON:
         '{"cityMap":{"_default":"ws://localhost:7880"},"nodes":{"local":{"url":"ws://localhost:7880"}}}',
     });

--- a/packages/node/saga-stack-cli/src/core/__tests__/login.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/login.unit.test.ts
@@ -48,7 +48,7 @@ describe('buildDevLoginRequest — origin-checked devLogin POST', () => {
     expect(req.url).toBe('http://localhost:3010/trpc/auth.devLogin');
     // Origin is iam's OWN origin — a wrong value is rejected by iam's origin-check.
     expect(req.origin).toBe(iamUrl);
-    expect(req.body).toBe('{"email":"teacher@saga.org"}');
+    expect(req.body).toBe('{"identifier":"teacher@saga.org","email":"teacher@saga.org"}');
     expect(req.email).toBe('teacher@saga.org');
   });
 

--- a/packages/node/saga-stack-cli/src/core/login.ts
+++ b/packages/node/saga-stack-cli/src/core/login.ts
@@ -64,7 +64,9 @@ export function buildDevLoginRequest(email: string, iamUrl: string): DevLoginReq
   return {
     url: `${iamUrl}${DEVLOGIN_PATH}`,
     origin: iamUrl,
-    body: JSON.stringify({ email }),
+    // rostering#756: devLogin takes `identifier` (uuid | email). Both keys are
+    // sent so the jar mints against pre- and post-#756 iam checkouts.
+    body: JSON.stringify({ identifier: email, email }),
     email,
   };
 }

--- a/packages/node/saga-stack-cli/src/core/manifest/services.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/services.ts
@@ -344,7 +344,9 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
         JANUS_REQUIRED: 'false',
         IAM_API_URL: '${IAM_URL}',
         JWT_ISSUER: 'https://iam.saga.org',
-        ALLOWED_ORIGINS: '${CONNECT_WEB_URL}',
+        // #222 port: dash calls connect-api cross-origin (journey attendance /
+        // connect embeds) — without DASH_URL in the allowlist those are CORS-blocked.
+        ALLOWED_ORIGINS: '${CONNECT_WEB_URL},${DASH_URL}',
         SESSIONS_API_BASE_URL: 'http://localhost:3007',
         SAGA_API_TARGET: '${SAGA_API_TARGET}',
         CONTENT_API_URL: '${CONTENT_API_URL}',
@@ -352,6 +354,11 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
         LIVEKIT_URL: 'ws://localhost:7880',
         LIVEKIT_API_KEY: 'devkey',
         LIVEKIT_API_SECRET: 'devsecret',
+        // #222 port: point the private-convos supervisor at the local rtsm so
+        // server-side dark-corner enforcement runs (otherwise connect-api logs
+        // "private-convos registry disabled" and private conversations aren't
+        // enforced). Tokenized (up.sh hardcoded :6110) so slots stay correct.
+        RTSM_API_URL: '${RTSM_URL}',
         RECORDING_SERVICE_TOKEN: '${RECORDING_TOKEN}',
         RECORDER_URL_TEMPLATE: 'http://127.0.0.1:${RECORDER_CONTROL_PORT}',
         FLEEK_TOPOLOGY_JSON:

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/login.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/login.unit.test.ts
@@ -49,7 +49,7 @@ describe('nativeLogin', () => {
     // origin-checked POST at the devLogin endpoint
     expect(calls[0]?.url).toBe('http://localhost:3010/trpc/auth.devLogin');
     expect(calls[0]?.opts.origin).toBe('http://localhost:3010');
-    expect(calls[0]?.opts.body).toBe('{"email":"dev@saga.org"}');
+    expect(calls[0]?.opts.body).toBe('{"identifier":"dev@saga.org","email":"dev@saga.org"}');
     // jar written at the state-dir path, Netscape-formatted
     expect(writes).toHaveLength(1);
     expect(writes[0]?.path).toBe('/tmp/sds-synthetic/cookies.txt');

--- a/packages/node/saga-stack-cli/src/runtime/git.ts
+++ b/packages/node/saga-stack-cli/src/runtime/git.ts
@@ -62,6 +62,8 @@ export interface GitRunner {
   // ── M10 overlay-engine verbs (refresh-suite.sh refresh_repo / reset) ──
   /** `git rev-parse --verify --quiet <ref>` exited 0 — the ref exists (origin/<base>, origin/<b>, or local/integration). */
   revParseVerify(repoPath: string, ref: string): Promise<boolean>;
+  /** `git merge-base --is-ancestor <ancestor> HEAD` exited 0 — HEAD already contains <ancestor>. */
+  isAncestorOfHead(repoPath: string, ancestor: string): Promise<boolean>;
   /** `git checkout -B <branch> <startPoint>` — (re)create+switch to a branch at a start point (untracked files survive). */
   checkoutB(repoPath: string, branch: string, startPoint: string): Promise<boolean>;
   /** `git merge [--no-ff] [--no-edit] <ref>` — true iff it exited 0 (false ⇒ conflict, caller aborts). */
@@ -171,6 +173,9 @@ export function makeRealGitRunner(): GitRunner {
     // ── M10 overlay-engine verbs ──
     revParseVerify(repoPath: string, ref: string): Promise<boolean> {
       return gitOk(repoPath, ['rev-parse', '--verify', '--quiet', ref]);
+    },
+    isAncestorOfHead(repoPath: string, ancestor: string): Promise<boolean> {
+      return gitOk(repoPath, ['merge-base', '--is-ancestor', ancestor, 'HEAD']);
     },
     checkoutB(repoPath: string, branch: string, startPoint: string): Promise<boolean> {
       return gitOk(repoPath, ['checkout', '-B', branch, startPoint]);

--- a/packages/node/saga-stack-cli/src/runtime/set-check.ts
+++ b/packages/node/saga-stack-cli/src/runtime/set-check.ts
@@ -117,6 +117,17 @@ export async function checkWorktreeSet(
       check.warnings.push(`branch drift: @ ${check.branch}, created from ${entry.createdFrom}`);
     }
 
+    // WARN-only mainline currency: --pull syncs a worktree's OWN branch, so a
+    // set can silently trail main; say so with the exact command (as-of the
+    // last fetch — the preflight adds no network).
+    const mainRef = `origin/${await deps.git.symbolicRefDefault(entry.path)}`;
+    if ((await deps.git.revParseVerify(entry.path, mainRef)) && !(await deps.git.isAncestorOfHead(entry.path, mainRef))) {
+      const behind = await deps.git.countBehindRef(entry.path, mainRef);
+      check.warnings.push(
+        `behind ${mainRef} by ${behind ?? '?'} — merge up: git -C ${entry.path} merge ${mainRef}`,
+      );
+    }
+
     // Primary-checkout posture (tenet 4): shared repos must be clean,
     // pre-built, effectively read-only worktrees — never the hot primary.
     const primary = safeRealpath(join(deps.devRoot, REPO_DEFAULT_DIR[REPO_ENV_VAR[repo]]));


### PR DESCRIPTION
A copy-pasteable runbook for the five e2e flows: what each tests, background (`--headless`) and foreground (`--headed`) runs, snapshot-checkpoint fast iteration (`--snapshot-stages` / `--from`), pausing for manual testing (`--to`/`--hold`, per-stage walk, `-- --debug`), a compact assessment sweep, the remaining connect/connectv3 ToDos, and troubleshooting. Written for a first-time user; every command verified against the current CLI surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)