### PR TITLE
launcher: kill the service process GROUP on stop + post-down orphan audit (#249)

### DIFF
--- a/packages/node/saga-stack-cli/src/base-command.ts
+++ b/packages/node/saga-stack-cli/src/base-command.ts
@@ -62,6 +62,7 @@ import {
   makeRealJarWriter,
   makeRealLauncher,
   makeRealMeshExec,
+  makeRealOrphanScanner,
   makeRealPgProbe,
   makeRealOverlayFs,
   makeRealPortProbe,
@@ -92,6 +93,7 @@ import type {
   HealthProber,
   JarWriter,
   MeshExec,
+  OrphanScanner,
   OverlayFs,
   PgProbe,
   PortProbe,
@@ -367,6 +369,16 @@ export abstract class BaseCommand extends Command {
    */
   protected getServiceStopper(): ServiceStopper {
     return (stateDir: string) => stopServices(stateDir);
+  }
+
+  /**
+   * The post-down orphan-audit seam (saga-ed/soa#249) — production is the ONLY
+   * place `ss -lptnH` / `lsof` run to find sockets still LISTENing on the slot's
+   * resolved service-port band after a teardown. `down` uses it to turn a
+   * silently-surviving watch child (a stale-build server) into a loud warning.
+   */
+  protected getOrphanScanner(): OrphanScanner {
+    return makeRealOrphanScanner();
   }
 
   /**

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/wrappers.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/wrappers.int.test.ts
@@ -24,7 +24,12 @@ import { resolve } from 'node:path';
 import { Config } from '@oclif/core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { BaseCommand } from '../../../base-command.js';
-import type { RunResult, ScriptInvocation, StopServiceResult } from '../../../runtime/index.js';
+import type {
+  OrphanListener,
+  RunResult,
+  ScriptInvocation,
+  StopServiceResult,
+} from '../../../runtime/index.js';
 import StackUp from '../up.js';
 import StackDown from '../down.js';
 import StackOverlay from '../overlay.js';
@@ -77,6 +82,37 @@ function installFakeStopper(result: StopServiceResult[]): { stopCalls: string[] 
   return { stopCalls };
 }
 
+/**
+ * Install a fake post-down orphan scanner on the BaseCommand prototype
+ * (saga-ed/soa#249). Records the port band each audit scanned and returns the
+ * canned survivors — so no real `ss`/`lsof` ever runs under test.
+ */
+function installFakeScanner(survivors: OrphanListener[]): { scanCalls: number[][] } {
+  const scanCalls: number[][] = [];
+  vi.spyOn(
+    BaseCommand.prototype as unknown as { getOrphanScanner: () => unknown },
+    'getOrphanScanner',
+  ).mockReturnValue({
+    async scan(ports: number[]): Promise<OrphanListener[]> {
+      scanCalls.push(ports);
+      return survivors;
+    },
+  });
+  return { scanCalls };
+}
+
+/** Capture (and suppress) every `this.log` line — the audit warnings assert on these. */
+function captureLog(): string[] {
+  const out: string[] = [];
+  vi.spyOn(
+    BaseCommand.prototype as unknown as { log: (msg?: string) => void },
+    'log',
+  ).mockImplementation((msg?: string) => {
+    out.push(String(msg ?? ''));
+  });
+  return out;
+}
+
 beforeEach(async () => {
   config = await Config.load(PKG_ROOT);
   installFakeRunner(0);
@@ -125,6 +161,13 @@ describe('stack up — FULLY NATIVE (Phase 2: --sandbox/--tunnel/--record/--work
 
 describe('stack down — native slot-safe teardown at every slot (no up.sh)', () => {
   const INFRA_DIR = resolve(SOA_ROOT, 'infra');
+
+  // Every down run performs the post-down orphan audit (saga-ed/soa#249); fake
+  // it CLEAN by default so no real `ss`/`lsof` runs. The survivor cases below
+  // re-spy with canned survivors (re-vi.spyOn replaces the fake cleanly).
+  beforeEach(() => {
+    installFakeScanner([]);
+  });
 
   it('slot 0 (bare) stops services NATIVELY against /tmp/sds-synthetic (never up.sh)', async () => {
     const { stopCalls } = installFakeStopper([{ id: 'iam-api', pid: 200, outcome: 'term' }]);
@@ -206,6 +249,53 @@ describe('stack down — native slot-safe teardown at every slot (no up.sh)', ()
     expect(calls[0].cwd).toBe(INFRA_DIR);
     expect(calls[0].args).toEqual(['down', 'COMPOSE_PROJECT_NAME=soa-s1', 'PROJECT=saga-mesh']);
     expect(calls[0].env).toEqual({ COMPOSE_PROJECT_NAME: 'soa-s1' });
+  });
+
+  // ── post-down orphan audit (saga-ed/soa#249) ──
+
+  it('post-down audit scans the slot band and warns LOUD per survivor (pid + port + kill hint)', async () => {
+    installFakeStopper([{ id: 'programs-api', pid: 200, outcome: 'term' }]);
+    const { scanCalls } = installFakeScanner([
+      { port: 4006, pid: 873122, command: 'node' }, // the issue's exact scenario: orphaned watch child
+      { port: 4010 }, // survivor whose holder isn't visible
+    ]);
+    const out = captureLog();
+
+    await StackDown.run(['--slot', '1', ...WS], config);
+
+    // The audited band is slot 1's RESOLVED service ports (base + 1000) for every
+    // service the slot's closure could launch: programs-api 3006→4006 and iam-api
+    // 3010→4010 in; the slot-excluded connect-api/connect-web (7106/7210) OUT.
+    expect(scanCalls).toHaveLength(1);
+    expect(scanCalls[0]).toContain(4006);
+    expect(scanCalls[0]).toContain(4010);
+    expect(scanCalls[0]).not.toContain(7106);
+    expect(scanCalls[0]).not.toContain(7210);
+
+    const warnings = out.filter((l) => l.startsWith('⚠'));
+    expect(warnings).toHaveLength(3); // 1 header + 2 survivors
+    expect(warnings[0]).toContain('ORPHANS SURVIVED down — 2 listener(s)');
+    expect(warnings[1]).toContain(
+      'port 4006 (programs-api): pid 873122 (node) — kill it:  kill -9 873122',
+    );
+    expect(warnings[2]).toContain(
+      'port 4010 (iam-api): holder not visible — find it:  sudo lsof -iTCP:4010 -sTCP:LISTEN',
+    );
+  });
+
+  it('post-down audit is SILENT when the band is clean (slot 0 scans base ports)', async () => {
+    installFakeStopper([{ id: 'iam-api', pid: 200, outcome: 'term' }]);
+    const { scanCalls } = installFakeScanner([]);
+    const out = captureLog();
+
+    await StackDown.run([...WS], config);
+
+    // The audit RAN — against slot 0's base ports (offset 0; nothing excluded at slot 0).
+    expect(scanCalls).toHaveLength(1);
+    expect(scanCalls[0]).toContain(3006); // programs-api base
+    expect(scanCalls[0]).toContain(6106); // connect-api included at slot 0
+    // …but stayed silent: no orphan warning lines.
+    expect(out.some((l) => l.includes('ORPHAN'))).toBe(false);
   });
 });
 

--- a/packages/node/saga-stack-cli/src/commands/stack/down.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/down.ts
@@ -23,8 +23,14 @@ import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command.js';
 import { deriveInstance } from '../../core/derive-instance.js';
 import type { InstanceProfile } from '../../core/derive-instance.js';
+import type { ServiceId } from '../../core/manifest/index.js';
 import { meshDown, repoContextFromFlags, resolveRepoRoot } from '../../runtime/index.js';
-import type { MeshDownResult, ScriptContext, StopServiceResult } from '../../runtime/index.js';
+import type {
+  MeshDownResult,
+  OrphanListener,
+  ScriptContext,
+  StopServiceResult,
+} from '../../runtime/index.js';
 
 export default class StackDown extends BaseCommand {
   static description =
@@ -79,6 +85,15 @@ export default class StackDown extends BaseCommand {
     const stopped = await stopper(stateDir);
     this.reportStopped(profile, stateDir, stopped);
 
+    // ── POST-DOWN ORPHAN AUDIT (saga-ed/soa#249). ──
+    // The group-kill above reaps every RECORDED pid's whole subtree, but a watch
+    // child orphaned by an older build (or a pidfile lost to a crashed up) survives
+    // invisibly — and then serves a STALE build to the next bring-up. Scan the
+    // slot's resolved service-port band for sockets still LISTENing and warn LOUD,
+    // naming pid + port + a paste-ready kill hint. Silent when clean; never fails
+    // the teardown.
+    await this.auditOrphans(profile);
+
     if (!flags.mesh) return;
 
     // ── --mesh: ALSO tear the mesh down (inverse of up.sh mesh_up's
@@ -108,6 +123,46 @@ export default class StackDown extends BaseCommand {
       runner: this.getRunner(),
       project: profile.slot === 0 ? undefined : profile.project,
     });
+  }
+
+  /**
+   * Post-down orphan audit (saga-ed/soa#249): scan the slot's RESOLVED
+   * service-port band — every service the slot's closure could launch (the
+   * profile's `portOverrides`, minus the slot's `excludedServices`) — for sockets
+   * still LISTENing after the teardown, and warn loudly per survivor with pid +
+   * port + a paste-ready kill hint. The scan runs through the injectable
+   * `OrphanScanner` seam (no raw exec here); any scanner failure degrades open
+   * (reports nothing), so the audit can never fail `down` itself.
+   */
+  private async auditOrphans(profile: InstanceProfile): Promise<void> {
+    const excluded = new Set<ServiceId>(profile.excludedServices);
+    const portToService = new Map<number, ServiceId>();
+    for (const [id, port] of Object.entries(profile.portOverrides) as [ServiceId, number][]) {
+      if (!excluded.has(id)) portToService.set(port, id);
+    }
+
+    const survivors = await this.getOrphanScanner().scan([...portToService.keys()]);
+    if (survivors.length === 0) return; // clean teardown — stay silent.
+
+    this.log(
+      `⚠ ORPHANS SURVIVED down — ${survivors.length} listener(s) still on slot ` +
+        `${profile.slot}'s service ports (likely watch children of an older build; ` +
+        'they will serve STALE code to the next up):',
+    );
+    for (const s of survivors) {
+      this.log(`⚠   ${this.describeOrphan(s, portToService.get(s.port))}`);
+    }
+  }
+
+  /** One survivor line: `port 4011 (programs-api): pid 873122 (node) — kill it:  kill -9 873122`. */
+  private describeOrphan(s: OrphanListener, service: ServiceId | undefined): string {
+    const who = service ?? 'unknown service';
+    const hint =
+      s.pid !== undefined
+        ? `kill it:  kill -9 ${s.pid}`
+        : `find it:  sudo lsof -iTCP:${s.port} -sTCP:LISTEN`;
+    const holder = s.pid !== undefined ? `pid ${s.pid}${s.command ? ` (${s.command})` : ''}` : 'holder not visible';
+    return `port ${s.port} (${who}): ${holder} — ${hint}`;
   }
 
   /**

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/launcher.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/launcher.unit.test.ts
@@ -10,6 +10,13 @@
 
 import { describe, expect, it, vi } from 'vitest';
 import { makeRealLauncher, pidFilePath, stopServices } from '../launcher.js';
+
+// Mock node:child_process so the DEFAULT SpawnFn's options can be pinned (the
+// injectable `deps.spawn` seam sits ABOVE the `detached: true` flag, so only a
+// module mock can observe it). Every other test in this file injects its own
+// fake spawn, so the mock is inert there.
+const spawnMock = vi.hoisted(() => vi.fn());
+vi.mock('node:child_process', () => ({ spawn: spawnMock }));
 import type {
   ChildLike,
   LaunchResult,
@@ -158,6 +165,45 @@ describe('makeRealLauncher.launch', () => {
 
     const res = await launcher.launch(SPEC);
     expect(res).toEqual({ id: 'iam-api', ok: false });
+  });
+
+  it('DEFAULT spawn pins detached:true (own pgid — the group-kill contract, saga-ed/soa#249)', async () => {
+    // No `deps.spawn` ⇒ the default node:child_process wrapper runs (mocked above).
+    // `detached: true` is LOAD-BEARING: it makes the child a process-group LEADER
+    // whose pgid == the recorded pid, which is what lets `stopServices(stateDir)`
+    // reap the whole `pnpm dev → tsup --watch → node dist` subtree via kill(-pid).
+    spawnMock.mockReset();
+    spawnMock.mockReturnValue({ pid: 4242, unref: () => {}, on: () => {} });
+    const { prober } = seqProber([false, true]);
+    const writePid = vi.fn();
+    const launcher = makeRealLauncher({
+      stateDir: STATE,
+      prober,
+      writePid,
+      openLog: () => 'ignore',
+      ensureDir: () => {},
+      sleep: async () => {},
+    });
+
+    const res = await launcher.launch(SPEC);
+
+    expect(res).toEqual({ id: 'iam-api', ok: true, pid: 4242 });
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [command, args, opts] = spawnMock.mock.calls[0] as [
+      string,
+      string[],
+      { cwd: string; env: Record<string, string>; detached: boolean; stdio: unknown[] },
+    ];
+    expect(command).toBe('pnpm');
+    expect(args).toEqual(['dev']);
+    expect(opts.cwd).toBe('/repo/iam-api');
+    expect(opts.detached).toBe(true); // ← the pin: revert ⇒ this fails
+    expect(opts.stdio).toEqual(['ignore', 'ignore', 'ignore']);
+    // Parent env first, per-service launch env wins.
+    expect(opts.env.PORT).toBe('3010');
+    expect(opts.env.AUTH_DEVUSERID).toBe('beef');
+    // The pid recorded IS the group leader's pid (pid == pgid under detached).
+    expect(writePid).toHaveBeenCalledWith(pidFilePath(STATE, 'iam-api'), 4242);
   });
 });
 

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/orphan-audit.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/orphan-audit.unit.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Post-down orphan-audit seam (saga-ed/soa#249) — real-scanner logic with an
+ * injected capture fake: the `ss -lptnH` parse (pid/command extraction, port
+ * filtering, v4/v6 duplicate collapse), the per-port `lsof -Fpc` fallback when
+ * `ss` is unavailable, and the degrade-open contract (any capture failure ⇒
+ * "no survivors", never a throw). NO real exec is touched.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { SS_CANDIDATES, makeRealOrphanScanner, parseSsRow } from '../orphan-audit.js';
+
+const SS_OUT = [
+  // survivor on 4006 with visible owner (own process — the launcher's orphan case).
+  'LISTEN 0 511          *:4006       *:*    users:(("node",pid=873122,fd=27))',
+  // same socket's v6 row WITHOUT the process column — must collapse, keeping the pid row.
+  'LISTEN 0 511       [::]:4006      [::]:*',
+  // survivor on 4010, owner not visible (foreign process).
+  'LISTEN 0 128    0.0.0.0:4010    0.0.0.0:*',
+  // listener OUTSIDE the audited band — must be filtered out.
+  'LISTEN 0 4096 127.0.0.1:5432  0.0.0.0:*    users:(("docker-proxy",pid=999,fd=4))',
+].join('\n');
+
+describe('parseSsRow', () => {
+  it('extracts port + pid + command from a full row', () => {
+    expect(parseSsRow('LISTEN 0 511 *:4006 *:* users:(("node",pid=873122,fd=27))')).toEqual({
+      port: 4006,
+      pid: 873122,
+      command: 'node',
+    });
+  });
+
+  it('handles an IPv6 local address and a missing process column', () => {
+    expect(parseSsRow('LISTEN 0 511 [::]:4010 [::]:*')).toEqual({ port: 4010 });
+  });
+
+  it('returns null for a malformed or non-LISTEN row (the shadowed-ss junk guard)', () => {
+    expect(parseSsRow('')).toBeNull();
+    expect(parseSsRow('LISTEN 0 511')).toBeNull();
+    // Bare `ss` on a dev machine can BE the saga-stack CLI (pnpm bin shadowing
+    // iproute2) — its usage/error text must never parse as a listener.
+    expect(parseSsRow('› Error: command -lptnH not found')).toBeNull();
+    expect(parseSsRow('ESTAB 0 0 127.0.0.1:4006 127.0.0.1:51234')).toBeNull();
+  });
+});
+
+describe('makeRealOrphanScanner.scan — ss path', () => {
+  it('reports only the audited ports, with pid/command when visible, sorted by port', async () => {
+    const calls: Array<[string, string[]]> = [];
+    const scanner = makeRealOrphanScanner(async (cmd, args) => {
+      calls.push([cmd, args]);
+      return cmd === SS_CANDIDATES[0] ? SS_OUT : '';
+    });
+
+    const survivors = await scanner.scan([4010, 4006, 4008]);
+
+    // ONE ss enumeration off the first usable candidate — never a per-port exec.
+    expect(calls).toEqual([[SS_CANDIDATES[0], ['-lptnH']]]);
+    expect(survivors).toEqual([
+      { port: 4006, pid: 873122, command: 'node' }, // pid row won over the bare v6 row
+      { port: 4010 }, // holder not visible — still reported
+      // 4008 clean — absent; 5432 outside the band — filtered.
+    ]);
+  });
+
+  it('walks the candidate ladder past absent binaries AND a shadowed bare `ss` (junk output)', async () => {
+    // /usr/sbin/ss + /usr/bin/ss absent (''); bare `ss` IS the saga-stack CLI
+    // (pnpm bin shadowing iproute2) emitting usage junk — no LISTEN row parses,
+    // so the scanner must fall through to lsof rather than report "clean".
+    const calls: string[] = [];
+    const scanner = makeRealOrphanScanner(async (cmd, args) => {
+      calls.push(cmd);
+      if (cmd === 'ss') return '› Error: command -lptnH not found\nUSAGE\n  $ ss [COMMAND]\n';
+      if (cmd === 'lsof') return args.includes('-iTCP:4006') ? 'p873122\ncnode\n' : '';
+      return '';
+    });
+
+    const survivors = await scanner.scan([4006]);
+
+    expect(calls).toEqual([...SS_CANDIDATES, 'lsof']);
+    expect(survivors).toEqual([{ port: 4006, pid: 873122, command: 'node' }]);
+  });
+
+  it('returns [] without exec for an empty port band', async () => {
+    let called = false;
+    const scanner = makeRealOrphanScanner(async () => {
+      called = true;
+      return SS_OUT;
+    });
+    expect(await scanner.scan([])).toEqual([]);
+    expect(called).toBe(false);
+  });
+});
+
+describe('makeRealOrphanScanner.scan — lsof fallback + degrade-open', () => {
+  it('falls back to per-port lsof -Fpc when ss yields nothing', async () => {
+    const lsofCalls: string[][] = [];
+    const scanner = makeRealOrphanScanner(async (cmd, args) => {
+      if (SS_CANDIDATES.includes(cmd)) return ''; // every ss candidate missing/failed
+      lsofCalls.push(args);
+      // survivor only on 4006; terse -Fpc output: p<pid> then c<command>.
+      return args.includes('-iTCP:4006') ? 'p873122\ncnode\n' : '';
+    });
+
+    const survivors = await scanner.scan([4010, 4006]);
+
+    expect(lsofCalls).toEqual([
+      ['-nP', '-iTCP:4006', '-sTCP:LISTEN', '-Fpc'],
+      ['-nP', '-iTCP:4010', '-sTCP:LISTEN', '-Fpc'],
+    ]);
+    expect(survivors).toEqual([{ port: 4006, pid: 873122, command: 'node' }]);
+  });
+
+  it('degrades open (no survivors) when both ss and lsof are unavailable', async () => {
+    const scanner = makeRealOrphanScanner(async () => '');
+    expect(await scanner.scan([4006, 4010])).toEqual([]);
+  });
+});

--- a/packages/node/saga-stack-cli/src/runtime/index.ts
+++ b/packages/node/saga-stack-cli/src/runtime/index.ts
@@ -18,6 +18,7 @@ export * from './snapshot-store.js';
 export * from './launcher.js';
 export * from './mesh.js';
 export * from './preflight.js';
+export * from './orphan-audit.js';
 export * from './dash-defaults.js';
 export * from './flows.js';
 export * from './pg-probe.js';

--- a/packages/node/saga-stack-cli/src/runtime/orphan-audit.ts
+++ b/packages/node/saga-stack-cli/src/runtime/orphan-audit.ts
@@ -1,0 +1,150 @@
+/**
+ * Post-down orphan audit (saga-ed/soa#249 — the warning layer).
+ *
+ * `stack down` group-kills every pid recorded under the slot's state dir
+ * (`stopServices(stateDir)` — SIGTERM→grace→SIGKILL of the whole process group).
+ * That closes the launch-side hole, but the FAILURE MODE the issue documents —
+ * a `tsup --watch` / vite watch child orphaned by an OLDER build (or a pidfile
+ * lost to a crashed `up`) surviving teardown and silently serving a STALE build
+ * on the slot's ports — is invisible unless someone goes looking. This audit
+ * makes it loud: after the service stop, scan the slot's RESOLVED service-port
+ * band for sockets still LISTENing and report each survivor with its pid, port,
+ * and a ready-to-paste kill hint.
+ *
+ * The scan is an injectable seam (`OrphanScanner`) in the same family as the
+ * preflight `PortProbe` (preflight.ts) — production shells out (`ss -lptnH`,
+ * falling back to per-port `lsof`), tests inject a fake, and the command layer
+ * never execs anything raw. Like the preflight probe, every branch folds errors
+ * into a safe answer: a missing `ss`/`lsof` reports "no survivors" (degrades
+ * open) rather than failing the teardown.
+ *
+ * INVARIANT (plan hard constraint): host/process IO lives only in
+ * `src/runtime/**`; `src/core/**` never imports this and stays pure.
+ */
+
+import { execFile } from 'node:child_process';
+
+/** A socket still LISTENing on an audited port after `down`. */
+export interface OrphanListener {
+  /** The audited (slot-resolved) port the survivor holds. */
+  port: number;
+  /** Owning pid, when the scanner could see it (own processes need no sudo). */
+  pid?: number;
+  /** Owning command name (e.g. `node`), when visible. */
+  command?: string;
+}
+
+/**
+ * The injectable post-down listener scan. `scan(ports)` answers which of the
+ * given ports STILL have a LISTEN socket, with the holder's pid/command when
+ * visible. Production wires `makeRealOrphanScanner()`; tests pass a fake.
+ */
+export interface OrphanScanner {
+  scan(ports: number[]): Promise<OrphanListener[]>;
+}
+
+/**
+ * Injectable low-level dep of the real scanner: run a command and capture its
+ * stdout ('' on ANY failure — never throws). Overridden in unit tests to feed
+ * canned `ss`/`lsof` output with no real exec.
+ */
+export type CaptureFn = (command: string, args: string[]) => Promise<string>;
+
+/** Default capture: `execFile`, folding every error into '' (missing binary, non-zero exit). */
+function defaultCapture(command: string, args: string[]): Promise<string> {
+  return new Promise((resolve) => {
+    execFile(command, args, { encoding: 'utf8' }, (err, stdout) => {
+      resolve(err ? '' : (stdout ?? '').toString());
+    });
+  });
+}
+
+/**
+ * `ss` candidates, most-trusted first. The BARE name comes LAST because this
+ * very CLI ships a `ss` bin (saga-stack), and a pnpm-linked bin dir commonly
+ * shadows iproute2's `ss` on exactly the dev machines this audit runs on — a
+ * bare exec would hit the CLI, not the socket tool. An absolute candidate that
+ * doesn't exist folds to '' (skipped); junk output (no parseable LISTEN row)
+ * also advances the ladder.
+ */
+export const SS_CANDIDATES: readonly string[] = ['/usr/sbin/ss', '/usr/bin/ss', 'ss'];
+
+/**
+ * Parse one `ss -lptnH` row into `{ port, pid?, command? }`, or null when the
+ * row isn't a LISTEN we can read. Row shape (no header):
+ *   `LISTEN 0 511 *:4011 *:* users:(("node",pid=873122,fd=27))`
+ * Column 3 is the local `addr:port`; the trailing process column is present
+ * only for sockets whose owner we can inspect (own processes — no sudo needed,
+ * which covers everything the launcher ever spawned). The LISTEN guard doubles
+ * as the junk detector for a shadowed `ss` (see `SS_CANDIDATES`).
+ */
+export function parseSsRow(line: string): OrphanListener | null {
+  const cols = line.trim().split(/\s+/);
+  if (cols[0] !== 'LISTEN') return null;
+  const local = cols[3];
+  if (!local) return null;
+  const portMatch = /[:.](\d+)$/.exec(local);
+  if (!portMatch) return null;
+  const port = Number.parseInt(portMatch[1] ?? '', 10);
+  if (!Number.isInteger(port)) return null;
+  const proc = /users:\(\("([^"]*)",pid=(\d+)/.exec(line);
+  return {
+    port,
+    ...(proc ? { command: proc[1] ?? '', pid: Number.parseInt(proc[2] ?? '', 10) } : {}),
+  };
+}
+
+/**
+ * The production scanner. One `ss -lptnH` enumerates every LISTEN socket with
+ * pid/command (own processes visible without sudo); rows are filtered to the
+ * audited ports. When `ss` is unavailable/empty, degrade to per-port
+ * `lsof -nP -iTCP:<port> -sTCP:LISTEN -Fpc` (terse output: `p<pid>` / `c<cmd>`
+ * lines). Both ladders fold failure into "no survivors" — the audit must never
+ * make `down` itself fail.
+ */
+export function makeRealOrphanScanner(capture: CaptureFn = defaultCapture): OrphanScanner {
+  return {
+    async scan(ports: number[]): Promise<OrphanListener[]> {
+      if (ports.length === 0) return [];
+      const wanted = new Set(ports);
+
+      for (const bin of SS_CANDIDATES) {
+        const ss = await capture(bin, ['-lptnH']);
+        if (!ss.trim()) continue; // binary absent / failed — next candidate.
+        const rows = ss
+          .split('\n')
+          .map(parseSsRow)
+          .filter((r): r is OrphanListener => r !== null);
+        // Non-empty output with ZERO parseable LISTEN rows ⇒ junk (e.g. the
+        // saga-stack CLI shadowing `ss` and printing usage) — next candidate,
+        // NEVER "no survivors" off garbage.
+        if (rows.length === 0) continue;
+        const found = new Map<number, OrphanListener>();
+        for (const row of rows) {
+          if (!wanted.has(row.port)) continue;
+          // Prefer a row that names the pid (ss lists v4+v6 rows for one socket).
+          const prev = found.get(row.port);
+          if (!prev || (prev.pid === undefined && row.pid !== undefined)) {
+            found.set(row.port, row);
+          }
+        }
+        return [...found.values()].sort((a, b) => a.port - b.port);
+      }
+
+      // lsof fallback (ss missing): -Fpc emits `p<pid>` then `c<command>` per process.
+      const survivors: OrphanListener[] = [];
+      for (const port of [...wanted].sort((a, b) => a - b)) {
+        const out = await capture('lsof', ['-nP', `-iTCP:${port}`, '-sTCP:LISTEN', '-Fpc']);
+        if (!out.trim()) continue;
+        const pidMatch = /^p(\d+)$/m.exec(out);
+        const cmdMatch = /^c(.+)$/m.exec(out);
+        survivors.push({
+          port,
+          ...(pidMatch ? { pid: Number.parseInt(pidMatch[1] ?? '', 10) } : {}),
+          ...(cmdMatch ? { command: cmdMatch[1] ?? '' } : {}),
+        });
+      }
+      return survivors;
+    },
+  };
+}


### PR DESCRIPTION
Closes #249.

## What landed where

The **process-group kill** (fix direction 1) was already on `main` (M7 Phase 3, commit 305828e): `makeRealLauncher` spawns each service `detached: true` (child = group leader, pgid == recorded pid; the pid file keeps its existing single-pid format because pid == pgid), and the dir-scoped `stopServices(stateDir)` that `stack down --slot N` / native `restart` drive signals the GROUP (`kill(-pid)`) with SIGTERM→grace→SIGKILL escalation, a bare-pid ESRCH fallback (back-compat with stacks brought up by pre-group-leader builds), and a post-SIGKILL liveness re-check. Slot 0 and slot N share this path.

This PR closes the two remaining #249 holes:

### 1. Post-down orphan audit (the warning layer)
After the service stop, `down` scans the slot's **resolved service-port band** (the profile's `portOverrides` minus the slot's `excludedServices` — the ports the closure would use) for sockets still LISTENing, and warns loudly per survivor:

```
⚠ ORPHANS SURVIVED down — 2 listener(s) still on slot 1's service ports (likely watch children of an older build; they will serve STALE code to the next up):
⚠   port 4006 (programs-api): pid 1253090 (MainThread) — kill it:  kill -9 1253090
⚠   port 4010 (iam-api): pid 1253020 (MainThread) — kill it:  kill -9 1253020
```

Silent when clean; never fails the teardown. New injectable seam `OrphanScanner` (`runtime/orphan-audit.ts`, `BaseCommand.getOrphanScanner()` — same family as the preflight `PortProbe`); production runs `ss -lptnH` through an absolute-path candidate ladder (`/usr/sbin/ss` → `/usr/bin/ss` → `ss` — the bare name last because **this CLI itself installs a shadowing `ss` bin** on dev machines), with a junk-output guard and a per-port `lsof -Fpc` fallback; every failure degrades open.

### 2. Detached-spawn pin
The injectable `SpawnFn` seam sits *above* the `detached: true` flag, so nothing failed if it was dropped — yet it is the whole group-kill contract (pid == pgid). A module-mock test now pins `detached: true` + stdio shape + env merge.

## Tests
- +11 tests, suite **944 passed + 14 todo** (baseline 933 + 14); `tsc` clean, lint 0 errors.
- Mutation-checked: reverting `kill(-pid)` → `kill(pid)` fails 5 tests; reverting `detached: true` fails the new pin.

## Live proof (slot 1, the issue's exact scenario)
- `stack up --only programs-api --slot 1` → 2 services, 12-pid trees (`pnpm dev` → `sh` → `tsup --watch` → esbuild + `node dist/main.js`), every member pgid == recorded pid, ports held by the grandchildren.
- `stack down --slot 1` (this build) → **all 12 tree pids gone, zero LISTENers on 4006/4010, pidfiles unlinked, audit silent**.
- Audit demo: throwaway listener planted on 4009 → `down` printed `⚠ port 4009 (content-api): pid 1247245 … kill -9 1247245`.
- Before-fix repro (leader-only kill mutated into the build): `down` claimed "stopped: iam-api, programs-api" while **6 survivors** remained — including both port-holding `node dist/main.js` grandchildren still LISTENing on 4006/4010 (the stale-serve trap) — and the new audit named both with exact pid/port/kill hints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013YC3ntD2edq31EzGps1bxb