### PR TITLE
gh_214 plan-16 docs: browsable flow worlds (hermetic-flow viewer pattern)

### DIFF
--- a/claude/projects/gh_214/plans/16-browsable-flow-worlds.md
+++ b/claude/projects/gh_214/plans/16-browsable-flow-worlds.md
@@ -1,0 +1,83 @@
+# Plan 16 — browsable flow worlds (hermetic flows seed their own viewer)
+
+**Problem.** The `scheduling-topology` e2e flow builds its world in an isolated
+Empty Org, entirely via API. The dash UI scopes program browsing to the
+signed-in user's own districts (`groups.getByUser kind='district'` — no org
+switcher), and the stock `dev@saga.org` only carries Seed District — so nobody
+could manually inspect the flow's world in a browser.
+
+**Proven facts (live debugging, 2026-07-07):**
+
+- dev@saga.org's UI selector shows only Seed District programs.
+- Adding a **bare** `group_membership` for dev into the org did NOT change the
+  mint's district context.
+- The CLI's `ss stack login` accepts arbitrary emails (M11) — it rides
+  `auth.devLogin`, so anything devLogin-able is CLI-loggable.
+
+**Goal.** The topology flow seeds ONE browsable admin user INSIDE its org —
+fixed email `ab-topology-admin@saga.org` — so a human can
+
+```bash
+ss stack login ab-topology-admin@saga.org --slot 1 --browser
+```
+
+and see the program/sessions in the dash UI.
+
+---
+
+## Chosen authoring path (verified live on slot 1 before spec'ing)
+
+All over the REAL iam-api tRPC surface, as the seeded org admin
+(`empty@saga.org`) — the `journey/attendance-personas.e2e.test.ts` precedent.
+On the stack lane the write gates (CSRF / janus `iam-admin` / FGA) all no-op,
+so a bare `iam_session` cookie authorizes them.
+
+1. **Probe** `auth.devLogin(ab-topology-admin@saga.org)` — a 200 means the
+   user survives from a prior run against the same DB (reuse); a 401 means
+   create. (Probe-first is load-bearing: `users.create` rejects a duplicate
+   username with HTTP 500, not a typed CONFLICT.)
+2. **Create** (miss only): `users.create { username, role:'ADMIN',
+   profile.screenName, pii:{ email, nameFirst, nameLast } }`. The `pii.email`
+   is what makes the user devLogin-able — the mint resolves email → user via
+   the PII email-hash index.
+3. **Membership**: `groups.addMembers { groupId: EMPTY_ORG_ID, members:
+   [{ userId, personaId, source:'manual' }] }` where `personaId` is the
+   **seeded Empty-Org ADMIN persona** (resolved via `personas.listForGroup`
+   by `role==='ADMIN'`, not a hardcoded id). This mirrors empty@saga.org's own
+   membership shape exactly: full dash admin bundle (44 permissions incl.
+   `dash:view_sessions_tab` + `dash:view_admin_panel`). `addMembers` upserts ⇒
+   idempotent on reuse.
+4. **Assertions** (the flow's browsability stage, loud on regression):
+   devLogin mints 200; `groups.getByUser kind='district'` includes the org
+   (the dash selector source); the org's `getMyPermissions` entry carries the
+   two nav permissions; `programs.list` **as the viewer** contains the program
+   the run just built.
+
+**Why this path** (vs alternatives considered):
+
+- *Reuse the seeded persona, don't create one* — the Empty Org already seeds
+  exactly one ADMIN persona (`#438` one-persona-per-role assumption); creating
+  another would violate that assumption and drift from empty@'s shape.
+- *Not the sis-api CSV path* — roster CSV creates students/tutors/staff, not
+  org admins, and drags in materialized-view lag for no benefit.
+- *Not a new iam-db seed* — the flow's org world is API-built by design
+  (hermetic); the viewer belongs to the same world-building stage, and the
+  flow asserting its own mint keeps the manual-inspection CL from rotting.
+- *Not empty@saga.org as the documented viewer* — empty@ is the roster-CSV
+  suite's mutable actor (deactivation sweeps etc.); a dedicated fixed identity
+  keeps the browsing contract independent of other suites' churn.
+
+## What shipped
+
+- **saga-dash** (`e2e/stage8-partial-unskip`, rides PR #376):
+  `topology-ab.e2e.test.ts` grew a trailing serial test
+  `the world is browsable: ab-topology-admin@saga.org mints and sees the
+  program` + header note 5. Skipped on the sandbox lane (devLogin is
+  FORBIDDEN on deployed iam).
+- **soa** (`docs/hermetic-flow-viewer`): `saga-stack-cli/docs/e2e-flows.md`
+  (manual-verification CL in the scheduling-topology section), `docs/faq.md`
+  ("How do I manually inspect a hermetic flow's world in the browser?"), and
+  this plan.
+
+**Gate:** `ss e2e run saga-dash/scheduling-topology --headless --slot 1` green
+(2 passed) with the new stage, 2026-07-07.

--- a/packages/node/saga-stack-cli/docs/e2e-flows.md
+++ b/packages/node/saga-stack-cli/docs/e2e-flows.md
@@ -83,6 +83,21 @@ Self-seeds from the stock roster profile (no prerequisite). The single stage
 configures a 2-rotation topology through the API and asserts the realized
 sessions day-by-day.
 
+**Manually inspect the world it built** — the flow seeds a browsable admin
+inside its (otherwise invisible) Empty Org world, so after a green run:
+
+```bash
+ss stack login ab-topology-admin@saga.org --slot <N> --browser
+# → auto-logged-in Chromium; pick "Empty Org" — the AB Topology program's
+#   A/B sessions land on next week's Mon/Wed/Fri.
+```
+
+Don't reach for `dev@saga.org` here — the dash scopes program browsing to the
+signed-in user's own districts (no org switcher), and dev@ only carries Seed
+District, so the flow's world is invisible to it. See
+[the FAQ entry](./faq.md#how-do-i-manually-inspect-a-hermetic-flows-world-in-the-browser)
+for the general pattern.
+
 ### 4. connect-session — manual/AV only
 
 ```bash

--- a/packages/node/saga-stack-cli/docs/faq.md
+++ b/packages/node/saga-stack-cli/docs/faq.md
@@ -117,6 +117,41 @@ per-flow authoring choice (connect's AV hold via `page.pause()`).
 
 </details>
 
+## How do I manually inspect a hermetic flow's world in the browser?
+
+Log in as the **browsable persona the flow itself seeds**, not as `dev@saga.org`:
+
+```bash
+# scheduling-topology (after a green run — stack still up):
+ss stack login ab-topology-admin@saga.org --slot 1 --browser
+```
+
+The pattern: a hermetic flow builds its world via API inside an isolated org
+(scheduling-topology uses the Empty Org), and the dash scopes program browsing
+to the **signed-in user's own districts** — there is no org switcher. The stock
+`dev@saga.org` only carries Seed District, so a hermetic flow's world is
+invisible to it (verified live 2026-07-07: even adding a bare
+`group_membership` for dev into the org did not surface it in dev's district
+context — a proper persona-carrying membership is what the flow seeds
+instead). So each such flow seeds ONE admin user
+INSIDE its org — fixed, documented email; org-admin persona with the full dash
+nav bundle — as part of its world-building stage, and asserts the login mint
+works so a broken viewer fails the flow loudly.
+
+`ss stack login <email>` accepts any seeded/flow-seeded email (it rides the
+same `auth.devLogin` the flow asserts); `--browser` opens an auto-logged-in
+Chromium against the slot's dash.
+
+Currently seeded flow viewers:
+
+| Flow | Browsable login | World |
+|---|---|---|
+| `saga-dash/scheduling-topology` | `ab-topology-admin@saga.org` | Empty Org → "AB Topology …" program (A/B sessions next Mon/Wed/Fri) |
+
+(The journey flow needs no special viewer — it builds its world in Seed
+District, which `dev@saga.org` already carries; `--hold` opens that browser
+for you.)
+
 ## How do I pull the latest main into slot 0 and the worktree slots?
 
 ```bash


### PR DESCRIPTION
## What

Docs for **plan 16 — browsable flow worlds**: hermetic e2e flows seed their own browsable admin persona so a human can inspect the world they build in the dash UI.

- `packages/node/saga-stack-cli/docs/e2e-flows.md` — scheduling-topology section gains the manual-inspection CL:
  ```bash
  ss stack login ab-topology-admin@saga.org --slot <N> --browser
  ```
- `packages/node/saga-stack-cli/docs/faq.md` — new entry **"How do I manually inspect a hermetic flow's world in the browser?"**: the flow-seeds-a-browsable-persona pattern, the login CL, and why `dev@saga.org` can't see hermetic worlds (dash scopes program browsing to the signed-in user's own districts; no org switcher; a bare group_membership doesn't surface it).
- `claude/projects/gh_214/plans/16-browsable-flow-worlds.md` — plan scope, the chosen iam authoring path (probe devLogin → users.create with pii.email → groups.addMembers with the seeded Empty-Org ADMIN persona), alternatives rejected, verification record.

## Why

The scheduling-topology flow builds its world in an isolated Empty Org via API; until plan 16 nobody could open that world in a browser. The spec half (the flow's browsability stage in `topology-ab.e2e.test.ts`) rides saga-dash PR #376 (`e2e/stage8-partial-unskip`, commit 7a9c8043).

## Verification

- Authoring path proven live on slot 1 (manual API sequence + devLogin mint 200 + program list visible as the viewer) BEFORE spec'ing.
- Flow green on slot 1 with the new stage: `ss e2e run saga-dash/scheduling-topology --headless --slot 1` → **2 passed** — both the fresh-DB create path and the no-reset reuse path.
- `ss stack login ab-topology-admin@saga.org --slot 1 --porcelain` → `ok=true status=200`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013YC3ntD2edq31EzGps1bxb