### PR TITLE
manifest: iam-api slot-correct DB/MQ env (cross-slot leak at slot>0)

### DIFF
--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.slot.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.slot.unit.test.ts
@@ -58,6 +58,11 @@ describe('defaultLaunchContext meshOffset — mesh connection strings offset in 
 
   it('offsets every *_DB_URL (postgres port)', () => {
     for (const url of [
+      // IAM_DB_URL / IAM_PII_DB_URL: the iam-api SERVER's runtime URLs (gh_214
+      // acceptance find — without launch-env injection iam-api inherited
+      // $ROSTERING/.env's :5432 and dialed slot 0's postgres at slot > 0).
+      ctx.tokens.IAM_DB_URL,
+      ctx.tokens.IAM_PII_DB_URL,
       ctx.tokens.SIS_DB_URL,
       ctx.tokens.PROGRAMS_DB_URL,
       ctx.tokens.SCHEDULING_DB_URL,

--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
@@ -81,6 +81,15 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
       MAIL_FRONTEND_BASE_URL: 'http://localhost:3010/demo',
       REDIS_HOST: 'localhost',
       REDIS_PORT: '6379', // slot 0 base — offset-aware (:7379 at slot 1), see launch-plan.slot test
+      // Slot-pinned DB URLs (gh_214 acceptance find): without these the SERVER inherits
+      // $ROSTERING/.env's literal :5432 and dials slot 0's postgres at slot > 0 while
+      // migrate/seed (slot-correct seedEnv) hit the slot mesh. At slot 0 these expand
+      // to the same literals .env baked, so byte-identity with up.sh holds.
+      DATABASE_URL: 'postgresql://iam:iam@localhost:5432/iam_local',
+      PII_DATABASE_URL: 'postgresql://iam_pii:iam_pii@localhost:5432/iam_pii_local',
+      // Slot-pinned broker URL (same find): iam's OutboxRelay otherwise inherits
+      // $ROSTERING/.env.local's literal :5672 and publishes iam.* to slot 0's rabbit.
+      RABBITMQ_URL: 'amqp://rabbitmq_admin:password123@localhost:5672',
       JANUS_REQUIRED: 'false', // main up.sh:1467 — without it iam 401s every local S2S/devLogin
       SECURITY_RATELIMITMAXREQUESTS: '1000000', // apply_fixes (up.sh:457) — no local rate-limit
       JWT_ACCESSTOKENTTLSECONDS: '28800', // apply_fixes (up.sh:465) — 8h TTL for long dev/e2e sessions

--- a/packages/node/saga-stack-cli/src/core/launch-plan.ts
+++ b/packages/node/saga-stack-cli/src/core/launch-plan.ts
@@ -108,6 +108,16 @@ export interface LaunchTokens {
   MESH_MQ: string;
   /** up.sh `CONNECT_MONGO_URI` — `mongodb://localhost:27037/connectv3`. */
   CONNECT_MONGO_URI: string;
+  /** iam-api runtime DB URL — `postgresql://iam:iam@localhost:<pg>/iam_local`.
+   *  up.sh relied on `$ROSTERING/.env` carrying a literal `:5432` URL, and the
+   *  native launch env silently inherited that fallback: at slot N the iam-api
+   *  SERVER dialed slot 0's postgres while its migrations/seeds (slot-correct
+   *  seedEnv) went to the slot mesh — a split-brain masked by the deterministic
+   *  seed UUIDs. Tokenized so the launch env pins the same slot-offset URL the
+   *  seed layer derives (they share pgUrl, so they can never drift). */
+  IAM_DB_URL: string;
+  /** iam-api PII DB URL — `postgresql://iam_pii:iam_pii@localhost:<pg>/iam_pii_local` (see IAM_DB_URL). */
+  IAM_PII_DB_URL: string;
   /** up.sh `SIS_DB_URL`. */
   SIS_DB_URL: string;
   /** up.sh `PROGRAMS_DB_URL`. */
@@ -557,6 +567,8 @@ export function defaultLaunchContext(inputs: LaunchContextInputs, m: Manifest = 
     // mesh broker + connection strings
     MESH_MQ: `amqp://rabbitmq_admin:password123@localhost:${mqPort}`,
     CONNECT_MONGO_URI: `mongodb://localhost:${mongoPort}/connectv3`,
+    IAM_DB_URL: pgUrl('iam_local', pgPort, m),
+    IAM_PII_DB_URL: pgUrl('iam_pii_local', pgPort, m),
     SIS_DB_URL: pgUrl('sis_db', pgPort, m),
     PROGRAMS_DB_URL: pgUrl('programs', pgPort, m),
     SCHEDULING_DB_URL: pgUrl('scheduling', pgPort, m),

--- a/packages/node/saga-stack-cli/src/core/manifest/services.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/services.ts
@@ -68,6 +68,22 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
         // slot 0's redis (ECONNREFUSED alone, or split-brain onto slot 0).
         REDIS_HOST: 'localhost',
         REDIS_PORT: '${REDIS_PORT}',
+        // iam-api's dotenv chain falls back to $ROSTERING/.env, which bakes
+        // LITERAL :5432 DATABASE_URL/PII_DATABASE_URL — so at slot > 0 the
+        // SERVER dialed slot 0's postgres while its migrate/seed steps (slot-
+        // correct seedEnv) hit the slot mesh: a split-brain that deterministic
+        // seed UUIDs masked (devLogin "worked" against slot 0's iam_local).
+        // dotenv never overrides real env, so injecting here wins at every slot
+        // and expands to the exact legacy literals at slot 0 (byte-identity).
+        DATABASE_URL: '${IAM_DB_URL}',
+        PII_DATABASE_URL: '${IAM_PII_DB_URL}',
+        // Same class, third instance: iam-api's OutboxRelay reads RABBITMQ_URL
+        // with a $ROSTERING/.env.local fallback baking LITERAL :5672 — so at
+        // slot > 0 iam.* events published to slot 0's broker while the slot's
+        // consumers (sessions-api iam-projection et al.) listen on the slot
+        // mesh. MESH_MQ expands to the same rabbitmq_admin URL at the slot's
+        // offset port (:5672 at slot 0 — byte-identity with .env.local holds).
+        RABBITMQ_URL: '${MESH_MQ}',
         // On a fresh clone iam-api/.env doesn't exist, so JANUS_REQUIRED fail-safes
         // to `required` → iam 401s every local S2S call + devLogin ({"realms":["janus"]}).
         // main's up.sh sets it (services_up ~1467, added after gh_214 branched); the CLI


### PR DESCRIPTION
iam-api's launch env lacked DATABASE_URL/PII_DATABASE_URL/RABBITMQ_URL — at slot>0 it silently used **slot 0's** postgres and rabbit via the rostering/.env fallback (deterministic seed UUIDs masked it). Found during plan-16 acceptance: the browsable-viewer user 'validated' on slot 1 had actually landed in slot 0's iam DB.

Fix follows the 5e27dd1/#242 tokenization pattern: IAM_DB_URL/IAM_PII_DB_URL tokens (slot-pg-port lockstep) + MESH_MQ; slot-0 byte-identical. Live-verified during acceptance: iam-api on :6432, sessions-api consuming slot-1 iam events, zero new slot-0 connections.

933 tests green, tsc/lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)