### PR TITLE
seed: run iam seed:registry before dev-user so registry-gated perms exist (#253)

### DIFF
--- a/packages/node/saga-stack-cli/src/__tests__/stack-api.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/__tests__/stack-api.unit.test.ts
@@ -424,7 +424,7 @@ describe('StackApi.seed — offline then online via the Runner', () => {
     const res = await api.seed(plan);
 
     expect(res.ok).toBe(true);
-    expect(res.ran.offline).toEqual(['iam-dev-user', 'iam', 'sessions']);
+    expect(res.ran.offline).toEqual(['iam-registry', 'iam-dev-user', 'iam', 'sessions']);
     expect(res.ran.online).toEqual([]);
     // iam steps run under the iam-db package in PROGRAM_HUB? No — iam-api repo. Assert cwd is resolved (absolute).
     const iamRun = fakes.runs.find((r) => r.args.includes('db:seed') && r.cwd.includes('iam-db'));
@@ -451,7 +451,7 @@ describe('StackApi.seed — offline then online via the Runner', () => {
 
     expect(res.ok).toBe(false);
     expect(res.failed).toBe('iam');
-    expect(res.ran.offline).toEqual(['iam-dev-user']); // ran before the fatal step
+    expect(res.ran.offline).toEqual(['iam-registry', 'iam-dev-user']); // ran before the fatal step
   });
 
   it('a WARN step whose runner THROWS (ENOENT) degrades to a warning, not an unhandled rejection', async () => {
@@ -477,7 +477,7 @@ describe('StackApi.seed — offline then online via the Runner', () => {
     const res = await api.seed(plan); // must resolve, not throw
     expect(res.ok).toBe(true);
     // the throwing warn step is still recorded, and the run continued past it.
-    expect(res.ran.offline).toEqual(['iam-dev-user', 'iam', 'sessions']);
+    expect(res.ran.offline).toEqual(['iam-registry', 'iam-dev-user', 'iam', 'sessions']);
   });
 
   it('a FATAL step whose runner THROWS (ENOENT) aborts the run (ok:false)', async () => {

--- a/packages/node/saga-stack-cli/src/core/seed/__tests__/compose-seed-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/seed/__tests__/compose-seed-plan.unit.test.ts
@@ -24,11 +24,11 @@ const ids = (steps: { id: string }[]): string[] => steps.map((s) => s.id);
 
 describe('composeSeedPlan — gate 1: partial-stack drop', () => {
   it('drops steps whose owning service is not in the active closure', () => {
-    const sel: SeedSelection = { profile: 'full' }; // iam-dev-user, iam, sessions, programs, scheduling, content, coach-pg
+    const sel: SeedSelection = { profile: 'full' }; // iam-registry, iam-dev-user, iam, sessions, programs, scheduling, content, coach-pg
     const plan = composeSeedPlan(sel, set('iam-api'), set());
 
     // Only iam-api's steps survive (and they're offline — no requiresServiceUp).
-    expect(ids(plan.offline)).toEqual(['iam-dev-user', 'iam']);
+    expect(ids(plan.offline)).toEqual(['iam-registry', 'iam-dev-user', 'iam']);
     expect(plan.online).toEqual([]);
 
     // sessions / programs / scheduling / content / coach-pg + coach-mongo dropped as
@@ -41,13 +41,14 @@ describe('composeSeedPlan — gate 1: partial-stack drop', () => {
 });
 
 describe('composeSeedPlan — gate 2: snapshot-skip (service granularity)', () => {
-  const sel: SeedSelection = { profile: 'roster' }; // iam-dev-user, iam, sessions
+  const sel: SeedSelection = { profile: 'roster' }; // iam-registry, iam-dev-user, iam, sessions
   const active = set('iam-api', 'sessions-api');
 
   it('drops a fully-restored service\'s steps; keeps the rest', () => {
     const plan = composeSeedPlan(sel, active, set('iam-api'));
     expect(ids(plan.offline)).toEqual(['sessions']); // sessions-api not restored ⇒ kept
     expect(plan.skipped.filter((s) => s.reason === 'service-restored').map((s) => s.id)).toEqual([
+      'iam-registry',
       'iam-dev-user',
       'iam',
     ]);
@@ -55,7 +56,7 @@ describe('composeSeedPlan — gate 2: snapshot-skip (service granularity)', () =
 
   it('keeps all steps when nothing is restored', () => {
     const plan = composeSeedPlan(sel, active, set());
-    expect(ids(plan.offline)).toEqual(['iam-dev-user', 'iam', 'sessions']);
+    expect(ids(plan.offline)).toEqual(['iam-registry', 'iam-dev-user', 'iam', 'sessions']);
     expect(plan.skipped).toEqual([]);
   });
 
@@ -90,6 +91,7 @@ describe('composeSeedPlan — gate 3: offline / online partition', () => {
     // scheduling + coach-pg + coach-mongo (db:seed / docker-exec, no requiresServiceUp)
     // stay offline. coach-pg + coach-mongo trail content in the canonical run order.
     expect(ids(plan.offline)).toEqual([
+      'iam-registry',
       'iam-dev-user',
       'iam',
       'sessions',
@@ -101,6 +103,27 @@ describe('composeSeedPlan — gate 3: offline / online partition', () => {
     expect(ids(plan.online)).toEqual(['qtf-demo', 'content']);
     expect(plan.skipped).toEqual([]);
   });
+});
+
+describe('composeSeedPlan — iam-registry precedes iam-dev-user (soa#253)', () => {
+  // The registry (Permission/Policy catalog) is an OFFLINE step that iam-dev-user's
+  // dev-admin grant depends on. composeSeedPlan appends offline steps in
+  // SEED_RUN_ORDER position, so iam-registry must land in the OFFLINE batch strictly
+  // before iam-dev-user — deterministically, for every iam-seeding profile.
+  for (const profile of ['roster', 'full'] as const) {
+    it(`${profile}: emits iam-registry before iam-dev-user in the offline batch`, () => {
+      const active = set('iam-api', 'sessions-api', 'programs-api', 'scheduling-api', 'content-api', 'coach-api');
+      const plan = composeSeedPlan({ profile }, active, set());
+      const offlineIds = ids(plan.offline);
+      const reg = offlineIds.indexOf('iam-registry');
+      const dev = offlineIds.indexOf('iam-dev-user');
+      expect(reg).toBeGreaterThanOrEqual(0);
+      expect(dev).toBeGreaterThanOrEqual(0);
+      expect(reg).toBeLessThan(dev);
+      // and it is offline (never deferred online).
+      expect(ids(plan.online)).not.toContain('iam-registry');
+    });
+  }
 });
 
 describe('composeSeedPlan — service with no seed steps', () => {
@@ -121,6 +144,7 @@ describe('composeSeedPlan — selection refinements', () => {
     // M8 R5: each playback DB is provisioned (bootstrap SQL + migrate) BEFORE its
     // fixture seed, so the provision steps precede transcripts/insights/chat.
     expect(ids(plan.offline)).toEqual([
+      'iam-registry',
       'iam-dev-user',
       'iam',
       'sessions',
@@ -136,29 +160,29 @@ describe('composeSeedPlan — selection refinements', () => {
   it('exclude drops a step by id without recording a skip note', () => {
     const sel: SeedSelection = { profile: 'roster', exclude: ['sessions'] };
     const plan = composeSeedPlan(sel, set('iam-api', 'sessions-api'), set());
-    expect(ids(plan.offline)).toEqual(['iam-dev-user', 'iam']);
+    expect(ids(plan.offline)).toEqual(['iam-registry', 'iam-dev-user', 'iam']);
     expect(plan.skipped).toEqual([]); // excluded ≠ skipped (never requested)
   });
 });
 
 describe('composeSeedPlan — per-system profile overrides (M5)', () => {
   it('unions ONLY the named system’s steps at the heavier profile onto a roster base', () => {
-    // base roster = {iam-dev-user, iam, sessions}; override seeds programs-api at
-    // full (adds `programs`) WITHOUT pulling content-api in (the rest stay roster).
+    // base roster = {iam-registry, iam-dev-user, iam, sessions}; override seeds
+    // programs-api at full (adds `programs`) WITHOUT pulling content-api in (rest stay roster).
     const sel: SeedSelection = { profile: 'roster', perSystem: [{ system: 'programs-api', profile: 'full' }] };
     const active = set('iam-api', 'sessions-api', 'programs-api', 'content-api');
     const plan = composeSeedPlan(sel, active, set());
-    expect(ids(plan.offline)).toEqual(['iam-dev-user', 'iam', 'sessions', 'programs']);
+    expect(ids(plan.offline)).toEqual(['iam-registry', 'iam-dev-user', 'iam', 'sessions', 'programs']);
     // content (the other full-only step) is NOT seeded — heterogeneous profiles.
     expect(ids(plan.offline)).not.toContain('content');
   });
 
   it('is a no-op when the override profile adds nothing new for that system', () => {
-    // iam-api already contributes iam-dev-user + iam at roster; overriding it to
-    // full adds no iam-api steps (full’s extra steps belong to other services).
+    // iam-api already contributes iam-registry + iam-dev-user + iam at roster; overriding
+    // it to full adds no iam-api steps (full’s extra steps belong to other services).
     const sel: SeedSelection = { profile: 'roster', perSystem: [{ system: 'iam-api', profile: 'full' }] };
     const plan = composeSeedPlan(sel, set('iam-api', 'sessions-api'), set());
-    expect(ids(plan.offline)).toEqual(['iam-dev-user', 'iam', 'sessions']);
+    expect(ids(plan.offline)).toEqual(['iam-registry', 'iam-dev-user', 'iam', 'sessions']);
   });
 
   it('absent perSystem ⇒ identical to the M4 single-profile shape', () => {
@@ -184,7 +208,7 @@ describe('composeSeedPlan — multi-seed datasets (#221)', () => {
     const stamped = all.filter((s) => varsOf(s)[SEED_DATASET_VAR] === 'ab-topology');
     expect(stamped.map((s) => s.id).sort()).toEqual(['programs', 'scheduling', 'sessions']);
 
-    // Non-triad steps (iam pair) carry NO dataset var.
+    // Non-triad steps (the iam trio: iam-registry/iam-dev-user/iam) carry NO dataset var.
     for (const s of all.filter((x) => !['programs', 'scheduling', 'sessions'].includes(x.id))) {
       expect(varsOf(s)[SEED_DATASET_VAR]).toBeUndefined();
     }
@@ -204,7 +228,7 @@ describe('composeSeedPlan — multi-seed datasets (#221)', () => {
       datasets: [{ system: 'sessions-api', dataset: 'alt' }],
     };
     const plan = composeSeedPlan(sel, set('iam-api', 'sessions-api'), set());
-    expect(ids(plan.offline)).toEqual(['iam-dev-user', 'iam', 'sessions']); // same steps as plain roster
+    expect(ids(plan.offline)).toEqual(['iam-registry', 'iam-dev-user', 'iam', 'sessions']); // same steps as plain roster
     const sessions = plan.offline.find((s) => s.id === 'sessions');
     expect(varsOf(sessions as SeedStep)[SEED_DATASET_VAR]).toBe('alt');
   });

--- a/packages/node/saga-stack-cli/src/core/seed/__tests__/profiles.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/seed/__tests__/profiles.unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildSeedRegistry } from '../profiles.js';
+import { buildSeedRegistry, PROFILE_STEPS, SEED_RUN_ORDER } from '../profiles.js';
 
 // Regression for the soak-uncovered blocker: the iam-dev-user / iam seed steps
 // used an unimplemented `dotenv` SeedEnv kind that spawned the iam-db seed child
@@ -59,5 +59,56 @@ describe('buildSeedRegistry — iam seed env (regression: DATABASE_URL is requir
   // soak's "registry is missing required session permissions" fatal abort.
   it('iam-dev-user is best-effort (warn), mirroring up.sh `|| true`', () => {
     expect(reg['iam-dev-user'].failureMode).toBe('warn');
+  });
+});
+
+// soa#253: the native seed profiles never ran iam's `seed:registry`
+// (iam-db/dist/seed-registry.js), so after rostering added registry-gated nav-tab
+// permissions (view_rosters_tab/view_sessions_tab), seed-dev-user REFUSED the
+// dev-admin grant and the journey /roster stage 500'd. The registry must be its
+// own seed step, ordered FIRST (before iam-dev-user) in every iam-seeding profile.
+describe('buildSeedRegistry — iam-registry step (soa#253)', () => {
+  const reg = buildSeedRegistry();
+
+  it('exists with the seed-registry.js command from the iam-db package', () => {
+    const step = reg['iam-registry'];
+    expect(step.service).toBe('iam-api');
+    expect(step.cwd).toBe('packages/node/iam-db');
+    expect(step.command).toEqual(['node', 'dist/seed-registry.js']);
+  });
+
+  it('is FATAL — the Permission/Policy catalog is a hard prerequisite (not warn like iam-dev-user)', () => {
+    expect(reg['iam-registry'].failureMode).toBe('fatal');
+    expect(reg['iam-dev-user'].failureMode).toBe('warn');
+  });
+
+  it('is OFFLINE (direct DB) — no requiresServiceUp, so it runs pre-launch before iam-dev-user', () => {
+    expect(reg['iam-registry'].requiresServiceUp).toEqual([]);
+  });
+
+  it('carries the SAME iam DB/PII env as iam/iam-dev-user (DATABASE_URL for iam_local)', () => {
+    const step = reg['iam-registry'];
+    expect(step.env.kind).toBe('inline-multi');
+    const vars = (step.env as { vars: Record<string, string> }).vars;
+    expect(vars.DATABASE_URL).toBe('postgresql://iam:iam@localhost:${MESH_PG_PORT}/iam_local');
+    // full iamSeedEnv superset (PII vars) is byte-identical to iam-dev-user's.
+    expect(vars).toEqual((reg['iam-dev-user'].env as { vars: Record<string, string> }).vars);
+  });
+});
+
+describe('seed profiles list iam-registry FIRST in every iam-seeding profile (soa#253)', () => {
+  // Any profile that seeds iam (contains iam-dev-user) MUST place iam-registry at
+  // index 0 — the catalog its dev-admin grant reads. Mutation-check: drop
+  // 'iam-registry' from a profile array and this test fails.
+  for (const [profile, steps] of Object.entries(PROFILE_STEPS)) {
+    if (!steps.includes('iam-dev-user')) continue;
+    it(`${profile} lists iam-registry before iam-dev-user (at index 0)`, () => {
+      expect(steps[0]).toBe('iam-registry');
+      expect(steps.indexOf('iam-registry')).toBeLessThan(steps.indexOf('iam-dev-user'));
+    });
+  }
+
+  it('SEED_RUN_ORDER places iam-registry before iam-dev-user', () => {
+    expect(SEED_RUN_ORDER.indexOf('iam-registry')).toBeLessThan(SEED_RUN_ORDER.indexOf('iam-dev-user'));
   });
 });

--- a/packages/node/saga-stack-cli/src/core/seed/profiles.ts
+++ b/packages/node/saga-stack-cli/src/core/seed/profiles.ts
@@ -17,6 +17,7 @@ import type { SeedAddOn, SeedEnv, SeedProfile, SeedStep } from './types.js';
 
 /** The canonical seed-step ids (superset of `SeedStepRef` — incl. `scheduling`/`coach-pg`). */
 export type SeedStepId =
+  | 'iam-registry' //         soa#253: iam seed:registry (Permission/Policy catalog) — MUST precede iam-dev-user
   | 'iam-dev-user'
   | 'iam'
   | 'sessions'
@@ -35,10 +36,12 @@ export type SeedStepId =
 
 /** Profile → the seed-step ids it contributes (plan §4.1). */
 export const PROFILE_STEPS: Readonly<Record<SeedProfile, readonly SeedStepId[]>> = {
-  roster: ['iam-dev-user', 'iam', 'sessions'],
+  // soa#253: `iam-registry` FIRST — the Permission/Policy catalog that iam-dev-user's
+  // dev-admin grant depends on (registry-gated view_rosters_tab/view_sessions_tab).
+  roster: ['iam-registry', 'iam-dev-user', 'iam', 'sessions'],
   // M8 R5: coach-mongo (curriculum) is now expressible (stdinFile) — un-gated so
   // native `--seed full` seeds BOTH coach stores (mongo curriculum + pg progress).
-  full: ['iam-dev-user', 'iam', 'sessions', 'programs', 'scheduling', 'content', 'coach-pg', 'coach-mongo'],
+  full: ['iam-registry', 'iam-dev-user', 'iam', 'sessions', 'programs', 'scheduling', 'content', 'coach-pg', 'coach-mongo'],
 };
 
 /** Add-on → the seed-step ids it contributes (plan §4.1). */
@@ -64,6 +67,11 @@ export const ADDON_STEPS: Readonly<Record<SeedAddOn, readonly SeedStepId[]>> = {
  * `composeSeedPlan` walks this order so the emitted plan is deterministic.
  */
 export const SEED_RUN_ORDER: readonly SeedStepId[] = [
+  // soa#253: iam-registry is OFFLINE (direct DB, requiresServiceUp:[]) and a hard
+  // prerequisite of iam-dev-user's grant — it MUST lead the order. composeSeedPlan
+  // walks this array and appends offline steps in-order, so its position here (not
+  // requiresServiceUp) is what guarantees it precedes iam-dev-user in the plan.
+  'iam-registry',
   'iam-dev-user',
   'iam',
   'sessions',
@@ -237,6 +245,29 @@ function playbackStep(m: Manifest, id: SeedStepId, service: ServiceId, dbId: DbI
  */
 export function buildSeedRegistry(m: Manifest = manifest): Record<SeedStepId, SeedStep> {
   return {
+    // soa#253 — iam seed:registry (`node dist/seed-registry.js`), the iam
+    // Permission/Policy catalog. Rostering added registry-gated nav-tab permissions
+    // (view_rosters_tab/view_sessions_tab, session perms …a005-000000000053/054/055);
+    // without this catalog seed-dev-user REFUSES the dev-admin grant and journey
+    // /roster 500s. It MUST run before iam-dev-user (which reads the catalog to
+    // provision the grant). OFFLINE (direct DB — requiresServiceUp:[]) and FATAL:
+    // the registry is a hard prerequisite (unlike iam-dev-user, which is warn).
+    // Native reset truncates the Permission/Policy catalog, so a one-off manual
+    // seed:registry is wiped every reset — the profile must own it. seed-registry.js
+    // UPSERTS (rostering side), so re-running it every reset is idempotent/safe.
+    // Same env as iam/iam-dev-user (iamSeedEnv): provides DATABASE_URL for iam_local
+    // (a slot-correct `${MESH_PG_PORT}` token) + PII vars; seed-registry.js needs only
+    // DATABASE_URL, but the iamSeedEnv superset is safe and keeps the iam steps uniform.
+    'iam-registry': {
+      id: 'iam-registry',
+      service: 'iam-api',
+      databases: ['iam_local'],
+      cwd: 'packages/node/iam-db',
+      command: ['node', 'dist/seed-registry.js'],
+      env: iamSeedEnv(m),
+      requiresServiceUp: [],
+      failureMode: 'fatal',
+    },
     // dev-user bootstrap (auth user dev@example.org / DEV_USER_UUID f0000004-…beef).
     // Runs `node dist/seed-dev-user.js` from the iam-db package with the repo dotenv
     // loaded (PII keys), matching up.sh's reset re-seed + prep bootstrap.


### PR DESCRIPTION
## What

Native `ss` seed profiles never ran iam's **`seed:registry`** (`iam-db/dist/seed-registry.js`). After rostering added registry-gated nav-tab permissions (`view_rosters_tab` / `view_sessions_tab`, session perms `…a005-000000000053/054/055`), `seed-dev-user` **refuses** the dev-admin grant ("registry is missing required session permissions — run seed:registry first"), so `empty@saga.org` lacks `dash:view_rosters_tab` and the journey roster stage renders `/roster → 500`. Native reset also truncates the Permission/Policy catalog, so a one-off manual `seed:registry` is wiped on the next reset — the profile itself must own it. Fixes #253.

## Change

- **New `iam-registry` SeedStep** (`core/seed/profiles.ts` `buildSeedRegistry`): cwd `packages/node/iam-db`, command `['node','dist/seed-registry.js']`, `env = iamSeedEnv(m)` (the same DB/PII env `iam`/`iam-dev-user` use — slot-correct `${MESH_PG_PORT}` token so it works at slot > 0), `requiresServiceUp: []`, `failureMode: 'fatal'` (the catalog is a hard prerequisite, unlike `iam-dev-user` which is `warn`). `seed-registry.js` upserts ⇒ idempotent across resets.
- **Ordered FIRST** in every iam-seeding profile — `roster: ['iam-registry', ...]`, `full: ['iam-registry', ...]` — and leads `SEED_RUN_ORDER`. Since `composeSeedPlan` appends offline steps in run-order position (not by `requiresServiceUp`), this deterministically emits `iam-registry` in the **offline** batch strictly before `iam-dev-user`.
- Added `'iam-registry'` to the `SeedStepId` union.

## Findings (as requested)

- **iamSeedEnv / DATABASE_URL:** confirmed `iamSeedEnv(m)` provides `DATABASE_URL = postgresql://iam:iam@localhost:${MESH_PG_PORT}/iam_local` (plus `PII_DATABASE_URL` + PII crypto keys). `seed-registry.js` needs only `DATABASE_URL`, but passing the full superset is safe and keeps the three iam steps uniform.
- **Offline ordering:** the offline/online split is by `requiresServiceUp`, but **within** the offline batch order follows each step's index in `SEED_RUN_ORDER` (the loop walks `SEED_RUN_ORDER` and pushes offline survivors in order). Placing `iam-registry` first in that array is what guarantees it precedes `iam-dev-user` — this is now covered by a dedicated compose test.

## Tests / gates

- New unit tests: registry step shape (cwd/command/fatal/offline/env-equals-iam-dev-user), profile-first ordering (mutation-sensitive — dropping `iam-registry` from a profile fails), `composeSeedPlan` offline precedence for roster + full. Existing offline-list assertions updated.
- Full suite green (953 passed + 14 todo), `tsc` clean, lint 0 errors, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013YC3ntD2edq31EzGps1bxb