### PR TITLE
fix(saga-stack-cli): R1 prep freshness stamp — reprep after ff (closes #256)

### DIFF
--- a/packages/node/saga-stack-cli/src/__tests__/prep-fresh-gate.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/__tests__/prep-fresh-gate.unit.test.ts
@@ -1,0 +1,105 @@
+/**
+ * R1 fresh-skip GATE tests (soa#256) — the production `isRepoBuilt` predicate as
+ * exposed by `BaseCommand.getPrepFreshCheck()`, run against real mkdtemp repo
+ * layouts. "Built" now means artifacts present AND (soa#256) the repo is CURRENT:
+ * a stamp whose { headSha, lockHash } matches the checkout's HEAD + lockfile. This
+ * file is also the issue's mechanical VALIDATION — build a repo, move its HEAD /
+ * lockfile, assert the predicate flips to false ⇒ prep re-runs.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { BaseCommand } from '../base-command.js';
+import { writeStamp } from '../runtime/prep-stamp.js';
+
+const SHA_A = 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0';
+const SHA_B = '0987654321fedcba0987654321fedcba09876543';
+
+// `getPrepFreshCheck` returns `(root) => isRepoBuilt(root)` and never touches
+// `this`, so calling it off the prototype exercises the real production predicate.
+const isRepoBuilt = (
+  BaseCommand.prototype as unknown as { getPrepFreshCheck(): (root: string) => boolean }
+).getPrepFreshCheck();
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'prep-gate-'));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+function put(rel: string, contents: string): void {
+  const abs = join(root, rel);
+  mkdirSync(join(abs, '..'), { recursive: true });
+  writeFileSync(abs, contents);
+}
+
+/** A built node-workspace repo: node_modules + one package `dist/` + a checkout + lockfile. */
+function buildNodeRepo(branch = 'main', sha = SHA_A): void {
+  mkdirSync(join(root, 'node_modules'), { recursive: true });
+  mkdirSync(join(root, 'packages', 'node', 'foo', 'dist'), { recursive: true });
+  put('.git/HEAD', `ref: refs/heads/${branch}\n`);
+  put(`.git/refs/heads/${branch}`, `${sha}\n`);
+  put('pnpm-lock.yaml', 'lockfileVersion: 9\n');
+}
+
+describe('isRepoBuilt — presence + soa#256 staleness gate', () => {
+  it('built + matching stamp ⇒ fresh', () => {
+    buildNodeRepo();
+    writeStamp(root);
+    expect(isRepoBuilt(root)).toBe(true);
+  });
+
+  it('missing dist (never built) ⇒ not fresh (presence fails first)', () => {
+    mkdirSync(join(root, 'node_modules'), { recursive: true });
+    mkdirSync(join(root, 'packages', 'node', 'foo'), { recursive: true }); // workspace, no dist
+    put('.git/HEAD', `ref: refs/heads/main\n`);
+    put('.git/refs/heads/main', `${SHA_A}\n`);
+    writeStamp(root);
+    expect(isRepoBuilt(root)).toBe(false);
+  });
+
+  it('changed lockfile after build ⇒ stale ⇒ not fresh (the case-3 mechanical validation)', () => {
+    buildNodeRepo();
+    writeStamp(root);
+    expect(isRepoBuilt(root)).toBe(true); // steady state
+    put('pnpm-lock.yaml', 'lockfileVersion: 9\ndeps: added\n'); // git pull moved the lockfile
+    expect(isRepoBuilt(root)).toBe(false); // prep re-runs
+  });
+
+  it('moved HEAD after build ⇒ stale ⇒ not fresh (the case-1 mechanical validation)', () => {
+    buildNodeRepo();
+    writeStamp(root);
+    expect(isRepoBuilt(root)).toBe(true);
+    put('.git/refs/heads/main', `${SHA_B}\n`); // git pull advanced HEAD
+    expect(isRepoBuilt(root)).toBe(false);
+  });
+
+  it('missing stamp (first run after upgrade) ⇒ not fresh', () => {
+    buildNodeRepo(); // artifacts present, but never stamped
+    expect(isRepoBuilt(root)).toBe(false);
+  });
+
+  it('non-checkout (no .git) ⇒ presence-only fallback ⇒ fresh with no stamp', () => {
+    mkdirSync(join(root, 'node_modules'), { recursive: true });
+    mkdirSync(join(root, 'packages', 'node', 'foo', 'dist'), { recursive: true });
+    // no .git, no stamp — a deployed/tarball tree stays fresh on presence alone.
+    expect(isRepoBuilt(root)).toBe(true);
+  });
+
+  it('frontend (no node workspace, no dist) ⇒ install + stamp ⇒ fresh', () => {
+    // saga-dash shape: node_modules only, no packages/node|apps/node, so no dist.
+    mkdirSync(join(root, 'node_modules'), { recursive: true });
+    put('.git/HEAD', `ref: refs/heads/main\n`);
+    put('.git/refs/heads/main', `${SHA_A}\n`);
+    put('pnpm-lock.yaml', 'lockfileVersion: 9\n');
+    expect(isRepoBuilt(root)).toBe(false); // installed but unstamped ⇒ not fresh yet
+    writeStamp(root);
+    expect(isRepoBuilt(root)).toBe(true); // stamped ⇒ fresh
+  });
+});

--- a/packages/node/saga-stack-cli/src/__tests__/prep-fresh-gate.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/__tests__/prep-fresh-gate.unit.test.ts
@@ -102,4 +102,26 @@ describe('isRepoBuilt — presence + soa#256 staleness gate', () => {
     writeStamp(root);
     expect(isRepoBuilt(root)).toBe(true); // stamped ⇒ fresh
   });
+
+  it('linked worktree (`.git` is a FILE) drives the gate end-to-end ⇒ stamp then ff ⇒ not fresh', () => {
+    // buildNodeRepo() always makes `.git` a DIRECTORY, so production isRepoBuilt is never
+    // exercised against the worktree layout the parallel-dev feature depends on. Build a
+    // worktree-shaped repo and drive the real predicate through it, then advance HEAD.
+    mkdirSync(join(root, 'node_modules'), { recursive: true });
+    mkdirSync(join(root, 'packages', 'node', 'foo', 'dist'), { recursive: true });
+    put('pnpm-lock.yaml', 'lockfileVersion: 9\n');
+    const commonDir = join(root, '.gitcommon');
+    const wtGitDir = join(commonDir, 'worktrees', 'wt1');
+    mkdirSync(join(commonDir, 'refs', 'heads'), { recursive: true });
+    mkdirSync(wtGitDir, { recursive: true });
+    put('.git', `gitdir: ${wtGitDir}\n`); // `.git` is a FILE, not a directory
+    writeFileSync(join(wtGitDir, 'HEAD'), 'ref: refs/heads/feature\n');
+    writeFileSync(join(wtGitDir, 'commondir'), `${commonDir}\n`);
+    writeFileSync(join(commonDir, 'refs', 'heads', 'feature'), `${SHA_A}\n`);
+
+    writeStamp(root);
+    expect(isRepoBuilt(root)).toBe(true); // stamped worktree at its current HEAD ⇒ fresh
+    writeFileSync(join(commonDir, 'refs', 'heads', 'feature'), `${SHA_B}\n`); // ff advanced HEAD
+    expect(isRepoBuilt(root)).toBe(false); // moved HEAD ⇒ stale ⇒ reprep
+  });
 });

--- a/packages/node/saga-stack-cli/src/base-command.ts
+++ b/packages/node/saga-stack-cli/src/base-command.ts
@@ -42,6 +42,7 @@ import { SET_UNSUPPORTED_COMMAND_MESSAGE, SLOT_UNSUPPORTED_COMMAND_MESSAGE, base
 import { applySetToFlags, resolveSet } from './core/set/index.js';
 import type { SetInjectableFlags, WorktreeSet } from './core/set/index.js';
 import { checkWorktreeSet, makeCheckpointStore, makeSlotActiveProbe } from './runtime/index.js';
+import { stampMatches, writeStamp } from './runtime/prep-stamp.js';
 import type { CheckpointStore, SlotActiveProbe } from './runtime/index.js';
 import type { PullMode } from './core/auto-pull.js';
 import type { InstanceProfile } from './core/derive-instance.js';
@@ -429,6 +430,16 @@ export abstract class BaseCommand extends Command {
   }
 
   /**
+   * soa#256: the R1 stamp writer — after prep builds+installs a repo to completion,
+   * record its current `{ headSha, lockHash }` at `node_modules/.saga-stack-prep-stamp`
+   * so the next run's fresh-check can tell a pulled-but-unbuilt tree from a current
+   * one. Injected (like `getPrepFreshCheck`) so the prep pass stays testable.
+   */
+  protected getPrepStampWriter(): (repoRoot: string) => void {
+    return (repoRoot: string) => writeStamp(repoRoot);
+  }
+
+  /**
    * The R1 `db:generate` scan seam (M8 — BLOCKER-B). Given a repo root, returns
    * the repo-relative dirs of every `packages/node/*` package that DECLARES a
    * `db:generate` script (a faithful port of up.sh's `packages/node/*` scan). R1
@@ -665,6 +676,7 @@ export abstract class BaseCommand extends Command {
       pgProbe: this.getPgProbe(),
       skipPrep: flags['skip-prep'],
       prepIsFresh: this.getPrepFreshCheck(),
+      prepWriteStamp: this.getPrepStampWriter(),
       prepDbGenerateScan: this.getDbGenerateScan(),
       // M13-B: realpath-keyed build lock — two `ss` invocations can never
       // prep-BUILD one checkout concurrently (fresh-skipped repos never lock).
@@ -899,14 +911,12 @@ export abstract class BaseCommand extends Command {
 const NODE_WORKSPACE_DIRS = ['packages/node', 'apps/node'] as const;
 
 /**
- * MAJOR-D: a repo is "built" iff `node_modules` is present AND at least one
- * `packages/node/*` / `apps/node/*` package has a `dist/`. A repo with NO node
- * workspaces (a pure frontend like saga-dash, which is install-only and produces no
- * `dist/`) counts as built once installed. Every `fs` error folds to "not built"
- * (⇒ prep runs), the safe default.
+ * MAJOR-D: a repo has its build ARTIFACTS present iff `node_modules` is present AND
+ * at least one `packages/node/*` / `apps/node/*` package has a `dist/`. A repo with
+ * NO node workspaces (a pure frontend like saga-dash, install-only, no `dist/`)
+ * counts once installed. Every `fs` error folds to "not present" (the safe default).
  */
-function isRepoBuilt(repoRoot: string): boolean {
-  const root = repoRoot.replace(/\/+$/, '');
+function hasBuildArtifacts(root: string): boolean {
   if (!existsSync(`${root}/node_modules`)) return false;
   let sawWorkspace = false;
   for (const ws of NODE_WORKSPACE_DIRS) {
@@ -924,6 +934,24 @@ function isRepoBuilt(repoRoot: string): boolean {
   }
   // No node workspaces at all ⇒ nothing to build; installed is enough (saga-dash).
   return !sawWorkspace;
+}
+
+/**
+ * The R1 fresh-skip predicate. A repo is "built" iff its artifacts are present
+ * (`hasBuildArtifacts`) AND — soa#256 — it is CURRENT: presence alone is
+ * stale-blind, so after `git pull` without a reinstall/rebuild the old check skipped
+ * prep and the stack served stale code. A git checkout is fresh only when its
+ * `node_modules/.saga-stack-prep-stamp` matches the repo's current HEAD + lockfile;
+ * a missing/mismatched/unreadable stamp ⇒ not fresh ⇒ prep re-runs (the same safe
+ * default the presence check already used). A NON-checkout (no `.git`) has no HEAD
+ * to drift against, so it falls back to presence-only — the pre-#256 behaviour,
+ * preserved for deployed/tarball trees that are never stamped.
+ */
+function isRepoBuilt(repoRoot: string): boolean {
+  const root = repoRoot.replace(/\/+$/, '');
+  if (!hasBuildArtifacts(root)) return false;
+  if (!existsSync(`${root}/.git`)) return true; // not a checkout ⇒ presence-only fallback
+  return stampMatches(root);
 }
 
 /**

--- a/packages/node/saga-stack-cli/src/commands/e2e/run.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/run.ts
@@ -243,6 +243,7 @@ export default class E2eRun extends BaseCommand {
       // runs R2 provision + R3 migrate before launch+seed regardless of slot).
       pgProbe: this.getPgProbe(),
       prepIsFresh: this.getPrepFreshCheck(),
+      prepWriteStamp: this.getPrepStampWriter(),
       prepDbGenerateScan: this.getDbGenerateScan(),
       repoDirExists: this.getRepoDirCheck(),
     };

--- a/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
+++ b/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
@@ -189,6 +189,7 @@ export interface StackSeams {
    */
   pgProbe?: PgProbe;
   prepIsFresh?: (repoRoot: string) => boolean;
+  prepWriteStamp?: (repoRoot: string) => void;
   prepDbGenerateScan?: (repoRoot: string) => string[];
   repoDirExists?: (dir: string) => boolean;
   skipPrep?: boolean;
@@ -270,6 +271,7 @@ export function buildStackContext(
     pgProbe: seams.pgProbe,
     skipPrep: seams.skipPrep,
     prepIsFresh: seams.prepIsFresh,
+    prepWriteStamp: seams.prepWriteStamp,
     prepDbGenerateScan: seams.prepDbGenerateScan,
     repoDirExists: seams.repoDirExists,
     // M7 slot > 0 ONLY: namespace the mesh (`soa-s<N>`) + carry the offset so the slot's

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/prep-stamp.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/prep-stamp.unit.test.ts
@@ -1,0 +1,205 @@
+/**
+ * R1 prep freshness STAMP unit tests (soa#256).
+ *
+ * Real mkdtemp dirs stand in for repo checkouts so the git-layout resolution
+ * (`.git/HEAD` ref file / detached / packed-refs / worktree `.git` FILE / no-git)
+ * and the lockfile hashing exercise actual fs reads — no git spawn, no mocks. The
+ * stamp read/write/compare round-trips through the same helpers production uses.
+ */
+
+import { createHash } from 'node:crypto';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  computeFreshness,
+  computeLockHash,
+  readStamp,
+  resolveHeadSha,
+  stampMatches,
+  writeStamp,
+} from '../prep-stamp.js';
+
+const SHA_A = 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0';
+const SHA_B = '0987654321fedcba0987654321fedcba09876543';
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'prep-stamp-'));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+/** Write a file, creating parent dirs. */
+function put(rel: string, contents: string): void {
+  const abs = join(root, rel);
+  mkdirSync(join(abs, '..'), { recursive: true });
+  writeFileSync(abs, contents);
+}
+
+/** A `.git` directory whose HEAD points at a loose branch ref file. */
+function gitDirWithBranch(branch: string, sha: string): void {
+  put('.git/HEAD', `ref: refs/heads/${branch}\n`);
+  put(`.git/refs/heads/${branch}`, `${sha}\n`);
+}
+
+describe('resolveHeadSha — HEAD resolution without spawning git', () => {
+  it('reads a loose branch ref file (`ref: refs/heads/…` → refs/heads/…)', () => {
+    gitDirWithBranch('main', SHA_A);
+    expect(resolveHeadSha(root)).toBe(SHA_A);
+  });
+
+  it('reads a detached HEAD (raw sha in .git/HEAD)', () => {
+    put('.git/HEAD', `${SHA_A}\n`);
+    expect(resolveHeadSha(root)).toBe(SHA_A);
+  });
+
+  it('falls back to packed-refs when the loose ref file is absent', () => {
+    put('.git/HEAD', 'ref: refs/heads/main\n');
+    put(
+      '.git/packed-refs',
+      `# pack-refs with: peeled fully-peeled sorted\n${SHA_B} refs/heads/main\n${SHA_A} refs/tags/v1\n^${SHA_A}\n`,
+    );
+    expect(resolveHeadSha(root)).toBe(SHA_B);
+  });
+
+  it('resolves a linked worktree (.git is a FILE → gitdir → commondir refs)', () => {
+    // Simulate `<main>/.git` as the commondir and a worktree gitdir under it.
+    const commonDir = join(root, '.git');
+    const wtGitDir = join(commonDir, 'worktrees', 'wt1');
+    mkdirSync(wtGitDir, { recursive: true });
+    // The worktree's checkout root has a `.git` FILE pointing at its gitdir.
+    const wtRoot = mkdtempSync(join(tmpdir(), 'prep-stamp-wt-'));
+    try {
+      writeFileSync(join(wtRoot, '.git'), `gitdir: ${wtGitDir}\n`);
+      writeFileSync(join(wtGitDir, 'HEAD'), 'ref: refs/heads/feature\n');
+      writeFileSync(join(wtGitDir, 'commondir'), '../..\n'); // → <root>/.git
+      // The branch ref lives in the COMMONDIR (shared refs), not the worktree gitdir.
+      mkdirSync(join(commonDir, 'refs', 'heads'), { recursive: true });
+      writeFileSync(join(commonDir, 'refs', 'heads', 'feature'), `${SHA_B}\n`);
+      expect(resolveHeadSha(wtRoot)).toBe(SHA_B);
+    } finally {
+      rmSync(wtRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('worktree HEAD resolves via the commondir packed-refs when no loose ref', () => {
+    const commonDir = join(root, '.git');
+    const wtGitDir = join(commonDir, 'worktrees', 'wt1');
+    mkdirSync(wtGitDir, { recursive: true });
+    const wtRoot = mkdtempSync(join(tmpdir(), 'prep-stamp-wt-'));
+    try {
+      writeFileSync(join(wtRoot, '.git'), `gitdir: ${wtGitDir}\n`);
+      writeFileSync(join(wtGitDir, 'HEAD'), 'ref: refs/heads/feature\n');
+      writeFileSync(join(wtGitDir, 'commondir'), '../..\n');
+      writeFileSync(join(commonDir, 'packed-refs'), `${SHA_A} refs/heads/feature\n`);
+      expect(resolveHeadSha(wtRoot)).toBe(SHA_A);
+    } finally {
+      rmSync(wtRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('is `\'\'` when the dir is not a checkout (no .git)', () => {
+    expect(resolveHeadSha(root)).toBe('');
+  });
+
+  it('is `\'\'` on an unrecognised .git file / unresolvable ref', () => {
+    writeFileSync(join(root, '.git'), 'garbage not a gitdir line\n');
+    expect(resolveHeadSha(root)).toBe('');
+  });
+});
+
+describe('computeLockHash — sha256 of pnpm-lock.yaml', () => {
+  it('hashes present lockfile content', () => {
+    put('pnpm-lock.yaml', 'lockfileVersion: 9\n');
+    const expected = createHash('sha256').update('lockfileVersion: 9\n').digest('hex');
+    expect(computeLockHash(root)).toBe(expected);
+  });
+
+  it('is `\'\'` when the lockfile is absent', () => {
+    expect(computeLockHash(root)).toBe('');
+  });
+
+  it('changes when the lockfile content changes', () => {
+    put('pnpm-lock.yaml', 'a\n');
+    const before = computeLockHash(root);
+    put('pnpm-lock.yaml', 'b\n');
+    expect(computeLockHash(root)).not.toBe(before);
+  });
+});
+
+describe('stamp read / write / compare', () => {
+  it('writeStamp records the current { headSha, lockHash } and stampMatches confirms it', () => {
+    gitDirWithBranch('main', SHA_A);
+    put('pnpm-lock.yaml', 'lockfileVersion: 9\n');
+    mkdirSync(join(root, 'node_modules'), { recursive: true });
+
+    writeStamp(root);
+
+    const stamp = readStamp(root);
+    expect(stamp).toEqual(computeFreshness(root));
+    expect(stamp).toEqual({ headSha: SHA_A, lockHash: computeLockHash(root) });
+    expect(stampMatches(root)).toBe(true);
+  });
+
+  it('stampMatches is false when the lockfile changes after stamping (case 3)', () => {
+    gitDirWithBranch('main', SHA_A);
+    put('pnpm-lock.yaml', 'old\n');
+    mkdirSync(join(root, 'node_modules'), { recursive: true });
+    writeStamp(root);
+    expect(stampMatches(root)).toBe(true);
+
+    put('pnpm-lock.yaml', 'new deps added\n'); // saga-dash / program-hub lockfile move
+    expect(stampMatches(root)).toBe(false);
+  });
+
+  it('stampMatches is false when HEAD moves after stamping (case 1)', () => {
+    gitDirWithBranch('main', SHA_A);
+    put('pnpm-lock.yaml', 'lock\n');
+    mkdirSync(join(root, 'node_modules'), { recursive: true });
+    writeStamp(root);
+    expect(stampMatches(root)).toBe(true);
+
+    put('.git/refs/heads/main', `${SHA_B}\n`); // git pull moved HEAD (rostering)
+    expect(stampMatches(root)).toBe(false);
+  });
+
+  it('stampMatches is false when the stamp is missing', () => {
+    gitDirWithBranch('main', SHA_A);
+    mkdirSync(join(root, 'node_modules'), { recursive: true });
+    expect(stampMatches(root)).toBe(false);
+  });
+
+  it('readStamp is null for an unparseable stamp (⇒ stampMatches false)', () => {
+    gitDirWithBranch('main', SHA_A);
+    mkdirSync(join(root, 'node_modules'), { recursive: true });
+    writeFileSync(join(root, 'node_modules', '.saga-stack-prep-stamp'), '{ not json');
+    expect(readStamp(root)).toBeNull();
+    expect(stampMatches(root)).toBe(false);
+  });
+
+  it('readStamp is null when a field is missing/non-string', () => {
+    mkdirSync(join(root, 'node_modules'), { recursive: true });
+    writeFileSync(join(root, 'node_modules', '.saga-stack-prep-stamp'), JSON.stringify({ headSha: SHA_A }));
+    expect(readStamp(root)).toBeNull();
+  });
+
+  it('writeStamp is a no-op when node_modules is absent (nothing installed)', () => {
+    gitDirWithBranch('main', SHA_A);
+    put('pnpm-lock.yaml', 'lock\n');
+    writeStamp(root); // node_modules missing
+    expect(readStamp(root)).toBeNull();
+  });
+
+  it('a non-checkout stamps { headSha: \'\', lockHash } and still round-trips', () => {
+    put('pnpm-lock.yaml', 'lock\n');
+    mkdirSync(join(root, 'node_modules'), { recursive: true });
+    writeStamp(root);
+    expect(readStamp(root)?.headSha).toBe('');
+    expect(stampMatches(root)).toBe(true);
+  });
+});

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/prep-stamp.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/prep-stamp.unit.test.ts
@@ -195,11 +195,45 @@ describe('stamp read / write / compare', () => {
     expect(readStamp(root)).toBeNull();
   });
 
-  it('a non-checkout stamps { headSha: \'\', lockHash } and still round-trips', () => {
+  it('an unresolvable HEAD (headSha \'\') never self-matches ⇒ not fresh (soa#256 guard)', () => {
+    // writeStamp still records headSha:'' when HEAD is unresolvable, but stampMatches must
+    // REFUSE to treat an empty current HEAD as fresh — otherwise a stored '' would blindly
+    // self-match and the HEAD dimension would go dark. In production stampMatches is reached
+    // only for a checkout (isRepoBuilt short-circuits a true non-checkout to fresh before
+    // consulting it), so this guards the exotic/corrupt-`.git` case where HEAD won't resolve.
     put('pnpm-lock.yaml', 'lock\n');
     mkdirSync(join(root, 'node_modules'), { recursive: true });
     writeStamp(root);
     expect(readStamp(root)?.headSha).toBe('');
-    expect(stampMatches(root)).toBe(true);
+    expect(stampMatches(root)).toBe(false);
+  });
+
+  it('worktree round-trip: stamp then advance the branch ref ⇒ flips true→false (soa#256)', () => {
+    // A linked worktree (`.git` is a FILE) — the parallel-dev layout the fix must protect.
+    // Bake a stamp, then advance the shared branch ref (a pull/ff) and assert it goes stale.
+    // Also asserts the stamp records a REAL sha (not ''), catching a regression where
+    // worktree stamping silently writes headSha='' and then always self-matches.
+    const commonDir = join(root, '.git');
+    const wtGitDir = join(commonDir, 'worktrees', 'wt1');
+    mkdirSync(wtGitDir, { recursive: true });
+    const wtRoot = mkdtempSync(join(tmpdir(), 'prep-stamp-wtrt-'));
+    try {
+      writeFileSync(join(wtRoot, '.git'), `gitdir: ${wtGitDir}\n`);
+      writeFileSync(join(wtGitDir, 'HEAD'), 'ref: refs/heads/feature\n');
+      writeFileSync(join(wtGitDir, 'commondir'), '../..\n'); // → <root>/.git
+      mkdirSync(join(commonDir, 'refs', 'heads'), { recursive: true });
+      writeFileSync(join(commonDir, 'refs', 'heads', 'feature'), `${SHA_A}\n`);
+      writeFileSync(join(wtRoot, 'pnpm-lock.yaml'), 'lock\n');
+      mkdirSync(join(wtRoot, 'node_modules'), { recursive: true });
+
+      writeStamp(wtRoot);
+      expect(readStamp(wtRoot)?.headSha).toBe(SHA_A); // resolved a real sha, not ''
+      expect(stampMatches(wtRoot)).toBe(true);
+
+      writeFileSync(join(commonDir, 'refs', 'heads', 'feature'), `${SHA_B}\n`); // ff advanced HEAD
+      expect(stampMatches(wtRoot)).toBe(false);
+    } finally {
+      rmSync(wtRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/prep.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/prep.unit.test.ts
@@ -378,3 +378,89 @@ describe('prepClosure — closure-scoped install/build/db:generate (R1)', () => 
     expect(res.steps.some((s) => s.repo === 'COACH' && s.kind === 'build')).toBe(true);
   });
 });
+
+describe('prepClosure — soa#256 freshness stamp writing', () => {
+  /** Capture the roots the injected stamp writer is called for. */
+  function captureStamps(): { writeStamp: (root: string) => void; stamped: string[] } {
+    const stamped: string[] = [];
+    return { writeStamp: (root) => stamped.push(root), stamped };
+  }
+
+  it('stamps each repo that built+installed to completion (after its build)', async () => {
+    const { runner } = fakeRunner();
+    const { writeStamp, stamped } = captureStamps();
+    const res = await prepClosure({
+      services: ['iam-api', 'programs-api'] as ServiceId[],
+      dbs: ['iam_local'] as DbId[],
+      repoRoots: REPO_ROOTS,
+      runner,
+      isFresh: NEVER_FRESH,
+      writeStamp,
+    });
+    expect(res.ok).toBe(true);
+    expect(stamped).toEqual(['/dev/rostering', '/dev/program-hub']);
+    // the stamp is written AFTER the repo's build step, per repo.
+    const rosteringBuildIdx = res.steps.findIndex((s) => s.repo === 'ROSTERING' && s.kind === 'build');
+    expect(rosteringBuildIdx).toBeGreaterThanOrEqual(0);
+  });
+
+  it('stamps an install-only repo (saga-dash) after its successful install', async () => {
+    const { runner } = fakeRunner();
+    const { writeStamp, stamped } = captureStamps();
+    const res = await prepClosure({
+      services: ['saga-dash'] as ServiceId[],
+      dbs: [],
+      repoRoots: REPO_ROOTS,
+      runner,
+      isFresh: NEVER_FRESH,
+      writeStamp,
+    });
+    expect(res.ok).toBe(true);
+    expect(stamped).toEqual(['/dev/saga-dash']);
+  });
+
+  it('does NOT stamp a repo whose build FAILED fatally (COACH aborts before stamping)', async () => {
+    const { runner } = runnerFailingWhen((s) => s.cwd === '/dev/coach' && s.args[0] === 'build');
+    const { writeStamp, stamped } = captureStamps();
+    const res = await prepClosure({
+      services: ['coach-api'] as ServiceId[],
+      dbs: ['coach_api'] as DbId[],
+      repoRoots: REPO_ROOTS,
+      runner,
+      isFresh: NEVER_FRESH,
+      writeStamp,
+    });
+    expect(res.ok).toBe(false);
+    expect(stamped).toEqual([]);
+  });
+
+  it('does NOT stamp a repo whose build FAILED non-fatally (SDS warns, no stamp ⇒ repreps next run)', async () => {
+    const { runner } = runnerFailingWhen((s) => s.cwd === '/dev/student-data-system' && s.args[0] === 'build');
+    const { writeStamp, stamped } = captureStamps();
+    const res = await prepClosure({
+      services: ['ads-adm-api'] as ServiceId[],
+      dbs: ['ads_adm_local'] as DbId[],
+      repoRoots: REPO_ROOTS,
+      runner,
+      isFresh: NEVER_FRESH,
+      writeStamp,
+    });
+    expect(res.ok).toBe(true); // non-fatal — the pass continues
+    expect(res.warnings.map((w) => `${w.repo}:${w.kind}`)).toEqual(['SDS:build']);
+    expect(stamped).toEqual([]); // …but a failed build is NOT stamped
+  });
+
+  it('does NOT stamp a fresh-skipped repo (no build ran ⇒ its existing stamp stands)', async () => {
+    const { runner } = fakeRunner();
+    const { writeStamp, stamped } = captureStamps();
+    await prepClosure({
+      services: ['iam-api', 'programs-api'] as ServiceId[],
+      dbs: ['iam_local'] as DbId[],
+      repoRoots: REPO_ROOTS,
+      runner,
+      isFresh: (root) => root === '/dev/rostering', // rostering fresh-skips
+      writeStamp,
+    });
+    expect(stamped).toEqual(['/dev/program-hub']); // rostering skipped ⇒ not re-stamped
+  });
+});

--- a/packages/node/saga-stack-cli/src/runtime/index.ts
+++ b/packages/node/saga-stack-cli/src/runtime/index.ts
@@ -23,6 +23,7 @@ export * from './dash-defaults.js';
 export * from './flows.js';
 export * from './pg-probe.js';
 export * from './prep.js';
+export * from './prep-stamp.js';
 export * from './provision.js';
 export * from './migrate.js';
 export * from './reset.js';

--- a/packages/node/saga-stack-cli/src/runtime/prep-stamp.ts
+++ b/packages/node/saga-stack-cli/src/runtime/prep-stamp.ts
@@ -155,12 +155,19 @@ export function readStamp(repoRoot: string): PrepFreshness | null {
 /**
  * True iff a stamp exists at the repo root AND its `{ headSha, lockHash }` equals
  * the repo's freshly-computed values. Missing / unparseable / any-field mismatch ⇒
- * false (⇒ not fresh ⇒ prep re-runs). Never throws — the safe #256 default.
+ * false (⇒ not fresh ⇒ prep re-runs). An UNRESOLVABLE current HEAD (`headSha === ''`)
+ * also ⇒ false, so a stored empty sha can never self-match (`'' === ''`) and leave the
+ * HEAD dimension stale-blind — an exotic/corrupt `.git` layout forces a reprep instead.
+ * Never throws — the safe #256 default.
  */
 export function stampMatches(repoRoot: string): boolean {
   const stamp = readStamp(repoRoot);
   if (!stamp) return false;
   const cur = computeFreshness(repoRoot);
+  // This fn is only consulted for real checkouts (isRepoBuilt short-circuits a
+  // non-checkout on the `.git`-absent branch), so an empty current HEAD here means a
+  // `.git` layout we could not read — fold to not-fresh rather than let '' self-match.
+  if (cur.headSha === '') return false;
   return stamp.headSha === cur.headSha && stamp.lockHash === cur.lockHash;
 }
 

--- a/packages/node/saga-stack-cli/src/runtime/prep-stamp.ts
+++ b/packages/node/saga-stack-cli/src/runtime/prep-stamp.ts
@@ -1,0 +1,181 @@
+/**
+ * R1 prep freshness STAMP (soa#256).
+ *
+ * A repo's fresh-skip must mean "built AND CURRENT," not just "artifacts present."
+ * The presence-only fresh-check let R1 skip a repo that had been `git pull`ed
+ * without a reinstall/rebuild, so the stack served STALE code (three misfires in
+ * the 2026-07-07 flow-run session: one HEAD move, two lockfile changes). This
+ * module stamps each successfully-prepped repo with its current identity and lets
+ * the fresh-check reject a repo whose HEAD or lockfile has since moved.
+ *
+ * The stamp lives at `<repoRoot>/node_modules/.saga-stack-prep-stamp` — inside
+ * `node_modules` so it is always gitignored, travels with the install, and vanishes
+ * when `node_modules` is blown away (correctly forcing a reprep). Content is JSON
+ * `{ headSha, lockHash }`.
+ *
+ * PURITY: every read folds to a safe default — an unresolvable HEAD or absent
+ * lockfile is `''`, a missing/unparseable stamp is a non-match — so the fresh-check
+ * never throws and any error means "not fresh ⇒ prep runs" (the pre-#256 default
+ * that every fs error already folded to).
+ */
+
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
+
+/** The stamp file's path relative to a repo root. */
+const STAMP_REL = 'node_modules/.saga-stack-prep-stamp';
+
+/** A matches a 40-hex git object id (SHA-1). */
+const SHA_RE = /^[0-9a-f]{40}$/i;
+
+/** The freshness identity of a repo checkout: its HEAD commit + lockfile hash. */
+export interface PrepFreshness {
+  /** Current git HEAD sha, or `''` when unresolvable (not a checkout / any read error). */
+  headSha: string;
+  /** sha256 of `pnpm-lock.yaml`, or `''` when the lockfile is absent/unreadable. */
+  lockHash: string;
+}
+
+/** Absolute path to a repo's stamp file. */
+function stampPath(repoRoot: string): string {
+  return join(repoRoot.replace(/\/+$/, ''), STAMP_REL);
+}
+
+/**
+ * Resolve `.git` for a repo root, handling BOTH a normal checkout (`.git` is a
+ * directory) AND a linked worktree (`.git` is a FILE holding `gitdir: <path>`).
+ * Returns the worktree's own gitdir (where its `HEAD` lives) and the COMMONDIR
+ * (where shared `packed-refs`/`refs` live). For a plain checkout the two coincide.
+ * Throws on any unreadable/unrecognised layout (the caller folds that to `''`).
+ */
+function resolveGitDirs(root: string): { gitDir: string; commonDir: string } {
+  const gitPath = join(root, '.git');
+  const st = statSync(gitPath); // throws if absent ⇒ not a checkout
+  if (st.isDirectory()) {
+    return { gitDir: gitPath, commonDir: gitPath };
+  }
+  // `.git` is a file: `gitdir: <abs-or-relative-to-root path>`.
+  const m = /^gitdir:\s*(.+)$/m.exec(readFileSync(gitPath, 'utf8'));
+  if (!m?.[1]) throw new Error('unrecognised .git file');
+  const rawGitDir = m[1].trim();
+  const gitDir = isAbsolute(rawGitDir) ? rawGitDir : resolve(root, rawGitDir);
+  // The commondir (holding shared packed-refs) is named by `<gitDir>/commondir`,
+  // a path relative to the gitdir; absent ⇒ the gitdir is itself the commondir.
+  let commonDir = gitDir;
+  const commonFile = join(gitDir, 'commondir');
+  if (existsSync(commonFile)) {
+    const cd = readFileSync(commonFile, 'utf8').trim();
+    commonDir = isAbsolute(cd) ? cd : resolve(gitDir, cd);
+  }
+  return { gitDir, commonDir };
+}
+
+/** Look up `ref` (e.g. `refs/heads/main`) in the commondir's `packed-refs`; `''` if absent. */
+function resolvePackedRef(commonDir: string, ref: string): string {
+  const packed = join(commonDir, 'packed-refs');
+  if (!existsSync(packed)) return '';
+  for (const line of readFileSync(packed, 'utf8').split('\n')) {
+    // Skip blanks, `# ...` header lines, and `^<peeled-tag>` annotation lines.
+    if (!line || line.startsWith('#') || line.startsWith('^')) continue;
+    const sp = line.indexOf(' ');
+    if (sp < 0) continue;
+    if (line.slice(sp + 1).trim() === ref) {
+      const sha = line.slice(0, sp).trim();
+      return SHA_RE.test(sha) ? sha : '';
+    }
+  }
+  return '';
+}
+
+/**
+ * Resolve a repo's current HEAD sha WITHOUT spawning git. `''` on ANY failure (not
+ * a checkout, unreadable, unrecognised layout) — folds to not-fresh.
+ *
+ * `.git` may be a directory (checkout) or a file (`gitdir: …`, a linked worktree).
+ * `HEAD` is read from the resolved gitdir; a `ref: <path>` is resolved against the
+ * gitdir's then the commondir's loose ref file, then the commondir's `packed-refs`;
+ * a detached HEAD is the raw sha in `HEAD` itself.
+ */
+export function resolveHeadSha(repoRoot: string): string {
+  try {
+    const root = repoRoot.replace(/\/+$/, '');
+    const { gitDir, commonDir } = resolveGitDirs(root);
+    const head = readFileSync(join(gitDir, 'HEAD'), 'utf8').trim();
+    if (!head.startsWith('ref:')) {
+      // Detached HEAD — the raw sha (validated; anything else is not resolvable).
+      return SHA_RE.test(head) ? head : '';
+    }
+    const ref = head.slice(4).trim(); // e.g. refs/heads/main
+    // Loose ref: the worktree's own gitdir first, then the shared commondir.
+    for (const base of gitDir === commonDir ? [gitDir] : [gitDir, commonDir]) {
+      const loose = join(base, ref);
+      if (existsSync(loose)) {
+        const sha = readFileSync(loose, 'utf8').trim();
+        if (SHA_RE.test(sha)) return sha;
+      }
+    }
+    // Packed-refs fallback (always in the commondir).
+    return resolvePackedRef(commonDir, ref);
+  } catch {
+    return '';
+  }
+}
+
+/** sha256 of `<repoRoot>/pnpm-lock.yaml`, or `''` when absent/unreadable. */
+export function computeLockHash(repoRoot: string): string {
+  try {
+    const lock = join(repoRoot.replace(/\/+$/, ''), 'pnpm-lock.yaml');
+    if (!existsSync(lock)) return '';
+    return createHash('sha256').update(readFileSync(lock)).digest('hex');
+  } catch {
+    return '';
+  }
+}
+
+/** The repo's current freshness identity (HEAD + lockfile), each folding safely to `''`. */
+export function computeFreshness(repoRoot: string): PrepFreshness {
+  return { headSha: resolveHeadSha(repoRoot), lockHash: computeLockHash(repoRoot) };
+}
+
+/**
+ * Read + parse a repo's stamp. `null` when it is missing, unreadable, non-JSON, or
+ * missing either string field (⇒ the caller treats it as a non-match ⇒ not fresh).
+ */
+export function readStamp(repoRoot: string): PrepFreshness | null {
+  try {
+    const parsed = JSON.parse(readFileSync(stampPath(repoRoot), 'utf8')) as Partial<PrepFreshness>;
+    if (typeof parsed.headSha !== 'string' || typeof parsed.lockHash !== 'string') return null;
+    return { headSha: parsed.headSha, lockHash: parsed.lockHash };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * True iff a stamp exists at the repo root AND its `{ headSha, lockHash }` equals
+ * the repo's freshly-computed values. Missing / unparseable / any-field mismatch ⇒
+ * false (⇒ not fresh ⇒ prep re-runs). Never throws — the safe #256 default.
+ */
+export function stampMatches(repoRoot: string): boolean {
+  const stamp = readStamp(repoRoot);
+  if (!stamp) return false;
+  const cur = computeFreshness(repoRoot);
+  return stamp.headSha === cur.headSha && stamp.lockHash === cur.lockHash;
+}
+
+/**
+ * Write the freshness stamp for a repo the R1 pass just built+installed to
+ * completion. Best-effort: a write failure is swallowed (a failed stamp costs at
+ * most a needless reprep next run, never a crash mid-pass). `node_modules` is
+ * guaranteed present here (install ran); its absence is still tolerated (skip).
+ */
+export function writeStamp(repoRoot: string): void {
+  try {
+    const path = stampPath(repoRoot);
+    if (!existsSync(dirname(path))) return; // no node_modules ⇒ nothing installed
+    writeFileSync(path, JSON.stringify(computeFreshness(repoRoot)));
+  } catch {
+    // best-effort — a failed stamp only costs a reprep, never correctness.
+  }
+}

--- a/packages/node/saga-stack-cli/src/runtime/prep.ts
+++ b/packages/node/saga-stack-cli/src/runtime/prep.ts
@@ -109,6 +109,15 @@ export interface PrepContext {
    */
   isFresh?: (repoRoot: string) => boolean;
   /**
+   * soa#256 seam: write a repo's freshness stamp (`{ headSha, lockHash }` at
+   * `node_modules/.saga-stack-prep-stamp`) after it builds+installs to completion,
+   * so the next run's `isFresh` can reject a pulled-but-unbuilt tree instead of
+   * fresh-skipping it. Called ONLY for a repo whose build succeeded (a fatally- OR
+   * non-fatally-failed build writes NO stamp ⇒ it repreps next run). Absent ⇒ no
+   * stamp written (unit-test default).
+   */
+  writeStamp?: (repoRoot: string) => void;
+  /**
    * BLOCKER-B seam: given a repo root, the repo-relative dirs of EVERY package that
    * DECLARES a `db:generate` script (up.sh scans `packages/node/*` for
    * `grep -q '"db:generate"'`). These are generated before the whole-workspace
@@ -331,6 +340,7 @@ async function prepOneRepo(
     // 3. build — SAGA_DASH is install-only (vite dev, no prebuild). MAJOR-C: FATAL
     //    only for QBOARD/RTSM/COACH (dist-importing services); ROSTERING/PROGRAM_HUB/
     //    SDS builds are NON-fatal (warn + continue).
+    let buildFailed = false;
     if (!INSTALL_ONLY_REPOS.has(repo)) {
       const build: PrepStep = { repo, kind: 'build', cwd: root, argv: ['build'] };
       if (!(await run(build))) {
@@ -338,8 +348,15 @@ async function prepOneRepo(
           return build;
         }
         warnings.push(build);
+        buildFailed = true;
       }
     }
+
+    // 4. soa#256: stamp the repo iff it built+installed to COMPLETION — install
+    //    succeeded (we reached here) and the build (if any) succeeded. A non-fatal
+    //    build failure writes NO stamp, so next run repreps instead of fresh-skipping
+    //    a broken build. (A FATAL build already returned above, before this.)
+    if (!buildFailed) ctx.writeStamp?.(root);
   }
 
   return null;

--- a/packages/node/saga-stack-cli/src/stack-api.ts
+++ b/packages/node/saga-stack-cli/src/stack-api.ts
@@ -134,6 +134,12 @@ export interface Runtime {
   skipPrep?: boolean;
   /** R1 fresh-skip predicate: is a repo root already built (`node_modules` + `dist`)? */
   prepIsFresh?: (repoRoot: string) => boolean;
+  /**
+   * soa#256: R1 stamp writer — after a repo builds+installs to completion, record
+   * its `{ headSha, lockHash }` so the next fresh-check can reject a pulled-but-
+   * unbuilt tree. Absent ⇒ no stamp written (unit-test default).
+   */
+  prepWriteStamp?: (repoRoot: string) => void;
   /** M13-B: realpath-keyed per-repo build lock — held ⇒ prep fails fast (plan §4 layer 2). */
   prepLock?: PrepRepoLock;
   /**
@@ -806,6 +812,7 @@ export function makeStackApi(m: Manifest, runtime: Runtime): StackApi {
           runner,
           skipPrep: runtime.skipPrep,
           isFresh: runtime.prepIsFresh,
+          writeStamp: runtime.prepWriteStamp,
           dbGenerateScan: runtime.prepDbGenerateScan,
           lock: runtime.prepLock,
           manifest,


### PR DESCRIPTION
## What & why

Fixes **#256** — R1 prep's fresh-skip was *presence-only* (`node_modules` + `dist` present ⇒ skip), so after an auto-pull/ff changed a sibling's source or lockfile, prep skipped the rebuild/reinstall and the stack ran on **stale artifacts**. This makes "built" mean **built AND current**: after a successful prep, each repo is stamped with `{ headSha, lockHash }` at `<repoRoot>/node_modules/.saga-stack-prep-stamp`, and `isRepoBuilt` treats a repo as fresh only when that stamp still matches its current HEAD + lockfile. Any mismatch / missing / unreadable stamp ⇒ not fresh ⇒ prep re-runs (the safe pre-#256 default).

This **continues the existing `fix/256-prep-freshness` branch** (original commit preserved, rebased onto `main`) and adds validation + one hardening commit on top. The original branch is left untouched.

## Real regressions this fixes

All three were hit live on 2026-07-07 running the `ss` getting-started happy path on a freshly-synced box — each a stale-after-ff failure the presence-only check masked:

| Repo | ff changed | Stale symptom | Caught by |
|---|---|---|---|
| **rostering** | HEAD moved (+#760) | `iam-seed-ids/dist` missing `DEMO_MEMBERSHIPS` → seed crash | `headSha` change |
| **program-hub** | lockfile bumped `iam-seed-ids` dev.3→dev.4 | `node_modules` still dev.3 (no reinstall) → seed crash | `lockHash` change |
| **coach** | lockfile added `cors` | `node_modules` missing the `cors` symlink → `coach-api` crash | `lockHash` change |

The not-fresh path runs `pnpm install` **before** build (`prep.ts`), so a bumped version / new dep is actually **relinked**, not merely rebuilt — that's what heals the program-hub and coach cases.

## Validation

Reviewed across five dimensions + two adversarial passes + a real test run:

- **No "mismatch ⇒ fresh" path**; the only unconditional `return true` is gated on `.git` being *absent* (deployed/tarball tree with no HEAD to drift).
- **Stamp written only on prep success** (guarded by the fatal-install/build early-returns) — a broken tree is never frozen as fresh.
- **Linked-worktree HEAD reader is correct** (`.git`-as-file → gitdir + commondir + packed-refs; detached HEAD) — verified against a live worktree; the parallel-dev (`--set`) feature is safe.
- e2e path uses the **same** gate (no stale-blind parallel path).

## Hardening added in this PR (commit `fd7a640`)

The review surfaced one latent **`''`-headSha self-match**: `stampMatches` compared field-by-field, so an *unresolvable* current HEAD (`headSha === ''`) would self-match a stored `''` and leave the HEAD dimension stale-blind (only `lockHash` guarding) — unreachable by the three regressions, but a false-negative for any exotic/corrupt `.git` layout, and contrary to the module's "any error ⇒ not fresh" contract.

- **Fix:** fold an empty current `headSha` to not-fresh in `stampMatches` (checkout-only path; `isRepoBuilt` already short-circuits true non-checkouts before it).
- **Tests (+2):** a **worktree round-trip** through a `.git`-as-file layout (stamp → advance the shared ref → flips `true→false`, and asserts the stamp records a *real* sha, not `''`); and a **gate-level `.git`-as-file** end-to-end test (fixtures previously only ever made `.git` a directory, so that branch of production `isRepoBuilt` was never driven).

**48/48** freshness tests, **976** in the full saga-stack-cli suite, and `tsc --noEmit` all green.

## Landing notes

- **One-time cost:** the first `up`/`cold-start` after merge repreps every repo once (no stamps exist yet), writing the stamps; subsequent runs fresh-skip as fast as before. Intended safe default, not a regression.
- **By-design scope boundary:** freshness identity is HEAD + lockHash only. An *uncommitted working-tree edit* to a source file (no HEAD move, no lockfile change) still fresh-skips — outside #256's committed-HEAD/lockfile scope; noted so it isn't later mistaken for a gate bug.
- Stamp lives inside `node_modules`, so it's gitignored and vanishes when `node_modules` is blown away (correctly forcing a reprep) — no `.gitignore` change needed.

Closes #256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
