### PR TITLE
feat(saga-stack-cli): prep escalates to a wiped reinstall on stale-dep build corruption (closes #260)

### DIFF
--- a/packages/node/saga-stack-cli/src/base-command.ts
+++ b/packages/node/saga-stack-cli/src/base-command.ts
@@ -43,6 +43,7 @@ import { applySetToFlags, resolveSet } from './core/set/index.js';
 import type { SetInjectableFlags, WorktreeSet } from './core/set/index.js';
 import { checkWorktreeSet, makeCheckpointStore, makeSlotActiveProbe } from './runtime/index.js';
 import { stampMatches, writeStamp } from './runtime/prep-stamp.js';
+import { repairStaleDeps } from './runtime/prep-repair.js';
 import type { CheckpointStore, SlotActiveProbe } from './runtime/index.js';
 import type { PullMode } from './core/auto-pull.js';
 import type { InstanceProfile } from './core/derive-instance.js';
@@ -440,6 +441,16 @@ export abstract class BaseCommand extends Command {
   }
 
   /**
+   * soa#260: the R1 prep repair seam — on a build failure, if the repo carries the
+   * stale-`.bin`-shim corruption a plain reprep can't fix (program-hub#335), wipe its
+   * `node_modules` and return true so prep reinstalls + rebuilds once. Injected (like
+   * `getPrepStampWriter`) so the escalation stays unit-testable with a fake.
+   */
+  protected getPrepDepRepairer(): (repoRoot: string) => boolean {
+    return (repoRoot: string) => repairStaleDeps(repoRoot);
+  }
+
+  /**
    * The R1 `db:generate` scan seam (M8 — BLOCKER-B). Given a repo root, returns
    * the repo-relative dirs of every `packages/node/*` package that DECLARES a
    * `db:generate` script (a faithful port of up.sh's `packages/node/*` scan). R1
@@ -677,6 +688,7 @@ export abstract class BaseCommand extends Command {
       skipPrep: flags['skip-prep'],
       prepIsFresh: this.getPrepFreshCheck(),
       prepWriteStamp: this.getPrepStampWriter(),
+      prepRepairDeps: this.getPrepDepRepairer(),
       prepDbGenerateScan: this.getDbGenerateScan(),
       // M13-B: realpath-keyed build lock — two `ss` invocations can never
       // prep-BUILD one checkout concurrently (fresh-skipped repos never lock).

--- a/packages/node/saga-stack-cli/src/commands/e2e/run.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/run.ts
@@ -244,6 +244,7 @@ export default class E2eRun extends BaseCommand {
       pgProbe: this.getPgProbe(),
       prepIsFresh: this.getPrepFreshCheck(),
       prepWriteStamp: this.getPrepStampWriter(),
+      prepRepairDeps: this.getPrepDepRepairer(),
       prepDbGenerateScan: this.getDbGenerateScan(),
       repoDirExists: this.getRepoDirCheck(),
     };

--- a/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
+++ b/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
@@ -190,6 +190,7 @@ export interface StackSeams {
   pgProbe?: PgProbe;
   prepIsFresh?: (repoRoot: string) => boolean;
   prepWriteStamp?: (repoRoot: string) => void;
+  prepRepairDeps?: (repoRoot: string) => boolean | Promise<boolean>;
   prepDbGenerateScan?: (repoRoot: string) => string[];
   repoDirExists?: (dir: string) => boolean;
   skipPrep?: boolean;
@@ -272,6 +273,7 @@ export function buildStackContext(
     skipPrep: seams.skipPrep,
     prepIsFresh: seams.prepIsFresh,
     prepWriteStamp: seams.prepWriteStamp,
+    prepRepairDeps: seams.prepRepairDeps,
     prepDbGenerateScan: seams.prepDbGenerateScan,
     repoDirExists: seams.repoDirExists,
     // M7 slot > 0 ONLY: namespace the mesh (`soa-s<N>`) + carry the offset so the slot's

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/prep-repair.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/prep-repair.unit.test.ts
@@ -1,0 +1,108 @@
+/**
+ * soa#260 prep-repair unit tests. Real tmpdir fixtures (no mocks) exercise the
+ * corruption detector + the node_modules wipe:
+ *   - nodeModulesDirs finds root + workspace-pkg node_modules, excludes `.worktrees`.
+ *   - hasStaleBinShim flags a dangling `.bin` symlink AND a shell shim referencing a
+ *     `.pnpm/<pkg>@<ver>` dir that is gone; false when every ref resolves.
+ *   - wipeNodeModules removes them all, `.worktrees` preserved.
+ *   - repairStaleDeps wipes+true on the signature, false (and leaves the tree) otherwise.
+ */
+
+import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { hasStaleBinShim, nodeModulesDirs, repairStaleDeps, wipeNodeModules } from '../prep-repair.js';
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'prep-repair-'));
+});
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+/** mkdir -p a repo-relative dir. */
+function mkdir(rel: string): string {
+  const abs = join(root, rel);
+  mkdirSync(abs, { recursive: true });
+  return abs;
+}
+/** Write a repo-relative file, creating parents. */
+function put(rel: string, contents: string): void {
+  const abs = join(root, rel);
+  mkdirSync(join(abs, '..'), { recursive: true });
+  writeFileSync(abs, contents);
+}
+
+describe('nodeModulesDirs — root + workspace pkgs, .worktrees excluded', () => {
+  it('finds every node_modules but never descends into one or into .worktrees', () => {
+    mkdir('node_modules/.pnpm/foo@1.0.0'); // nested node_modules must NOT be walked into
+    mkdir('apps/node/programs-api/node_modules');
+    mkdir('packages/core/seed-ids/node_modules');
+    mkdir('.worktrees/fix-1/node_modules'); // a sibling worktree — must be excluded
+    const found = nodeModulesDirs(root).map((p) => p.replace(`${root}/`, '')).sort();
+    expect(found).toEqual([
+      'apps/node/programs-api/node_modules',
+      'node_modules',
+      'packages/core/seed-ids/node_modules',
+    ]);
+  });
+});
+
+describe('hasStaleBinShim — the corruption detector', () => {
+  it('flags a DANGLING .bin symlink (its .pnpm target is gone)', () => {
+    mkdir('node_modules/.bin');
+    symlinkSync(join(root, 'node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/bin/tsc.js'),
+      join(root, 'node_modules/.bin/tsc')); // target does not exist ⇒ dangling
+    expect(hasStaleBinShim(root)).toBe(true);
+  });
+
+  it('flags a shell SHIM referencing a .pnpm/<pkg>@<ver> dir that no longer exists (program-hub#335)', () => {
+    mkdir('node_modules/.pnpm/typescript@6.0.3'); // the version actually present
+    put('apps/node/programs-api/node_modules/.bin/tsc',
+      `#!/bin/sh\nexport NODE_PATH="${root}/node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/node_modules"\nexec node ...\n`);
+    expect(hasStaleBinShim(root)).toBe(true); // 5.9.3 dir is absent
+  });
+
+  it('is false when every .bin shim resolves to a present .pnpm dir', () => {
+    mkdir('node_modules/.pnpm/typescript@6.0.3');
+    put('node_modules/.bin/tsc',
+      `#!/bin/sh\nexport NODE_PATH="${root}/node_modules/.pnpm/typescript@6.0.3/node_modules/typescript/node_modules"\nexec node ...\n`);
+    expect(hasStaleBinShim(root)).toBe(false);
+  });
+
+  it('is false for a repo with no .bin dirs at all', () => {
+    mkdir('node_modules');
+    expect(hasStaleBinShim(root)).toBe(false);
+  });
+});
+
+describe('wipeNodeModules — thorough, .worktrees preserved', () => {
+  it('removes root + workspace node_modules but leaves .worktrees intact', () => {
+    mkdir('node_modules/.pnpm');
+    mkdir('apps/node/programs-api/node_modules/.bin');
+    mkdir('.worktrees/fix-1/node_modules');
+    wipeNodeModules(root);
+    expect(existsSync(join(root, 'node_modules'))).toBe(false);
+    expect(existsSync(join(root, 'apps/node/programs-api/node_modules'))).toBe(false);
+    expect(existsSync(join(root, '.worktrees/fix-1/node_modules'))).toBe(true); // preserved
+  });
+});
+
+describe('repairStaleDeps — the prep seam', () => {
+  it('wipes and returns true on the stale-shim signature', () => {
+    mkdir('node_modules/.bin');
+    symlinkSync(join(root, 'node_modules/.pnpm/gone@1.0.0/x'), join(root, 'node_modules/.bin/tsc'));
+    expect(repairStaleDeps(root)).toBe(true);
+    expect(existsSync(join(root, 'node_modules'))).toBe(false); // wiped
+  });
+
+  it('returns false and leaves node_modules when nothing is repairable', () => {
+    mkdir('node_modules/.pnpm/typescript@6.0.3');
+    put('node_modules/.bin/tsc', `#!/bin/sh\nexec node ${root}/node_modules/.pnpm/typescript@6.0.3/x\n`);
+    expect(repairStaleDeps(root)).toBe(false);
+    expect(existsSync(join(root, 'node_modules'))).toBe(true); // untouched
+  });
+});

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/prep.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/prep.unit.test.ts
@@ -464,3 +464,80 @@ describe('prepClosure — soa#256 freshness stamp writing', () => {
     expect(stamped).toEqual(['/dev/program-hub']); // rostering skipped ⇒ not re-stamped
   });
 });
+
+describe('prepClosure — soa#260 build-failure repair escalation', () => {
+  it('a build failure the repair seam heals ⇒ wipe→reinstall→rebuild, recovered, stamped, no warning', async () => {
+    let repaired = false;
+    const runner: Runner = {
+      async run(spec): Promise<RunResult> {
+        const isBuild = spec.args[0] === 'build';
+        return { code: isBuild && !repaired ? 1 : 0 }; // build fails until the repair wipe runs
+      },
+    };
+    const stamped: string[] = [];
+    const res = await prepClosure({
+      services: ['iam-api'] as ServiceId[], // ROSTERING — non-fatal build
+      dbs: [] as DbId[],
+      repoRoots: REPO_ROOTS,
+      runner,
+      isFresh: NEVER_FRESH,
+      writeStamp: (r) => stamped.push(r),
+      repairStaleDeps: () => {
+        repaired = true;
+        return true;
+      },
+    });
+    expect(res.ok).toBe(true);
+    expect(res.warnings).toHaveLength(0); // healed ⇒ nothing surfaced as a warning
+    expect(stamped).toContain('/dev/rostering'); // recovered ⇒ stamped
+    expect(res.steps.map((s) => s.kind)).toEqual(['install', 'build', 'repair', 'install', 'build']);
+  });
+
+  it('a build failure with NO repairable signature ⇒ normal non-fatal warning, no wipe, not stamped', async () => {
+    const { runner } = runnerFailingWhen((s) => s.args[0] === 'build');
+    const stamped: string[] = [];
+    let asked = 0;
+    const res = await prepClosure({
+      services: ['iam-api'] as ServiceId[],
+      dbs: [] as DbId[],
+      repoRoots: REPO_ROOTS,
+      runner,
+      isFresh: NEVER_FRESH,
+      writeStamp: (r) => stamped.push(r),
+      repairStaleDeps: () => {
+        asked++;
+        return false; // no corruption signature ⇒ do not escalate
+      },
+    });
+    expect(res.ok).toBe(true);
+    expect(asked).toBe(1); // consulted once, found nothing repairable
+    expect(res.warnings.map((w) => w.kind)).toEqual(['build']); // normal non-fatal warning
+    expect(stamped).not.toContain('/dev/rostering'); // failed build ⇒ no stamp
+    expect(res.steps.filter((s) => s.kind === 'repair')).toHaveLength(0); // no wipe
+    expect(res.steps.filter((s) => s.kind === 'install')).toHaveLength(1); // no reinstall
+  });
+
+  it('repair heals a FATAL-build repo ⇒ the pass no longer aborts', async () => {
+    let repaired = false;
+    const runner: Runner = {
+      async run(spec): Promise<RunResult> {
+        const failCoachBuild = spec.args[0] === 'build' && spec.cwd === '/dev/coach' && !repaired;
+        return { code: failCoachBuild ? 1 : 0 };
+      },
+    };
+    const res = await prepClosure({
+      services: ['coach-api'] as ServiceId[], // COACH — fatal build (would abort pre-#260)
+      dbs: [] as DbId[],
+      repoRoots: REPO_ROOTS,
+      runner,
+      isFresh: NEVER_FRESH,
+      repairStaleDeps: (r) => {
+        if (r !== '/dev/coach') return false;
+        repaired = true;
+        return true;
+      },
+    });
+    expect(res.ok).toBe(true); // escalation runs BEFORE the fatal return → healed
+    expect(res.failed).toBeUndefined();
+  });
+});

--- a/packages/node/saga-stack-cli/src/runtime/index.ts
+++ b/packages/node/saga-stack-cli/src/runtime/index.ts
@@ -18,6 +18,7 @@ export * from './snapshot-store.js';
 export * from './launcher.js';
 export * from './mesh.js';
 export * from './preflight.js';
+export * from './prep-repair.js';
 export * from './orphan-audit.js';
 export * from './dash-defaults.js';
 export * from './flows.js';

--- a/packages/node/saga-stack-cli/src/runtime/prep-repair.ts
+++ b/packages/node/saga-stack-cli/src/runtime/prep-repair.ts
@@ -1,0 +1,135 @@
+/**
+ * #260 — repair the `node_modules` corruption a plain reprep can't fix.
+ *
+ * soa#256's freshness stamp TRIGGERS a reprep after a pull/ff, but the reprep's
+ * `pnpm install` is a no-op when pnpm considers `node_modules` already consistent with
+ * the lockfile — even when it is CORRUPT. The known case (program-hub#335): a pnpm
+ * `.bin` shim left pointing at a `.pnpm/<pkg>@<ver>` store path that a version bump
+ * deleted (a stale `.bin/tsc` → `typescript@5.9.3` after a TS 5→6 bump). pnpm sees
+ * lockfile==store and won't regenerate the shim, so the build fails on every `up`;
+ * neither `pnpm install` nor `--force` cures it — only wiping `node_modules` does.
+ *
+ * This module detects that signature cheaply — a `.bin` entry (dangling symlink OR a
+ * shell shim) referencing a `.pnpm/<pkg>@<ver>` dir that no longer exists — and, when
+ * found, wipes EVERY `node_modules` under the repo (root + workspace packages;
+ * `.worktrees` excluded, mirroring the confirmed manual fix) so the follow-up reinstall
+ * relinks clean. Detection is the gate prep uses so a GENUINE compile error never
+ * triggers a (useless, minutes-long) wipe.
+ *
+ * INVARIANT: process/fs IO lives in `src/runtime/**`; these run only on a build failure.
+ */
+
+import { existsSync, lstatSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import type { Dirent } from 'node:fs';
+import { join } from 'node:path';
+
+/** Dirs we never descend into while locating `.bin` shims / `node_modules` to wipe. */
+const SKIP_DIRS: ReadonlySet<string> = new Set(['.git', '.worktrees', 'dist', '.turbo', '.next']);
+
+/** A `.pnpm` store-path segment: `<pkg>@<ver>` (the dir under `node_modules/.pnpm/`). */
+const PNPM_SEG_RE = /[/\\]\.pnpm[/\\]([^/\\\s"':]+)/g;
+
+/**
+ * Every `node_modules` dir under a repo — the root's plus each workspace package's —
+ * with `.worktrees` (sibling worktree checkouts) and other build/vcs dirs excluded.
+ * Walks the SOURCE tree only: a found `node_modules` is recorded but never descended
+ * into, so the huge virtual store is not traversed.
+ */
+export function nodeModulesDirs(repoRoot: string): string[] {
+  const out: string[] = [];
+  const stack = [repoRoot.replace(/\/+$/, '')];
+  while (stack.length > 0) {
+    const dir = stack.pop() as string;
+    let entries: Dirent[];
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue; // unreadable dir ⇒ skip
+    }
+    for (const e of entries) {
+      if (!e.isDirectory()) continue;
+      if (e.name === 'node_modules') {
+        out.push(join(dir, 'node_modules')); // record, do NOT descend
+      } else if (!SKIP_DIRS.has(e.name)) {
+        stack.push(join(dir, e.name));
+      }
+    }
+  }
+  return out;
+}
+
+/** True iff a single `.bin` entry references a `.pnpm/<pkg>@<ver>` dir that is gone. */
+function binEntryIsStale(entryPath: string, pnpmRoot: string): boolean {
+  let st: import('node:fs').Stats;
+  try {
+    st = lstatSync(entryPath);
+  } catch {
+    return false;
+  }
+  if (st.isSymbolicLink()) {
+    // A dangling symlink (its `.pnpm` target is gone) ⇒ existsSync (which follows it) is false.
+    return !existsSync(entryPath);
+  }
+  // A pnpm shell shim: it embeds the store as an absolute `.../.pnpm/<seg>/...` path.
+  let text: string;
+  try {
+    text = readFileSync(entryPath, 'utf8');
+  } catch {
+    return false;
+  }
+  for (const m of text.matchAll(PNPM_SEG_RE)) {
+    const seg = m[1];
+    if (seg && !existsSync(join(pnpmRoot, seg))) return true;
+  }
+  return false;
+}
+
+/**
+ * Does any `.bin` shim in the repo reference a `.pnpm/<pkg>@<ver>` dir that no longer
+ * exists? That is the corruption class a plain `pnpm install` won't self-heal. Returns
+ * on the FIRST hit (cheap); false when everything resolves (⇒ a real build failure).
+ */
+export function hasStaleBinShim(repoRoot: string): boolean {
+  const pnpmRoot = join(repoRoot.replace(/\/+$/, ''), 'node_modules', '.pnpm');
+  for (const nm of nodeModulesDirs(repoRoot)) {
+    const binDir = join(nm, '.bin');
+    let names: string[];
+    try {
+      names = readdirSync(binDir);
+    } catch {
+      continue; // no `.bin` here
+    }
+    for (const name of names) {
+      if (binEntryIsStale(join(binDir, name), pnpmRoot)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Remove EVERY `node_modules` under the repo (root + workspace packages), `.worktrees`
+ * excluded — the confirmed cure for the stale-shim corruption (a root-only wipe leaves
+ * per-package `.bin` shims in place). Best-effort: an unremovable dir is skipped, never
+ * an abort. Longest-path-first so a parent removal can't orphan a child mid-walk.
+ */
+export function wipeNodeModules(repoRoot: string): void {
+  for (const nm of nodeModulesDirs(repoRoot).sort((a, b) => b.length - a.length)) {
+    try {
+      rmSync(nm, { recursive: true, force: true });
+    } catch {
+      // best-effort — a dir we can't remove just means the reinstall relinks around it.
+    }
+  }
+}
+
+/**
+ * The #260 prep repair seam: if a build failure carries the stale-shim signature, wipe
+ * the repo's `node_modules` and return true so prep reinstalls + rebuilds once. Returns
+ * false when there is nothing repairable (⇒ prep applies its normal fatal/non-fatal
+ * build handling). This is the ONLY place a real repair `rm -rf` runs.
+ */
+export function repairStaleDeps(repoRoot: string): boolean {
+  if (!hasStaleBinShim(repoRoot)) return false;
+  wipeNodeModules(repoRoot);
+  return true;
+}

--- a/packages/node/saga-stack-cli/src/runtime/prep.ts
+++ b/packages/node/saga-stack-cli/src/runtime/prep.ts
@@ -118,6 +118,16 @@ export interface PrepContext {
    */
   writeStamp?: (repoRoot: string) => void;
   /**
+   * soa#260 seam: on a build failure, if the repo carries the repairable corruption
+   * signature a plain reprep can't fix (a stale `.bin` shim → a deleted
+   * `.pnpm/<pkg>@<ver>`, program-hub#335), wipe its `node_modules` and return true so
+   * prep reinstalls + rebuilds ONCE. Returns false when there is nothing repairable ⇒
+   * prep applies its normal fatal/non-fatal build handling. Gated on the signature so a
+   * genuine compile error never triggers a (useless, minutes-long) wipe. Absent ⇒ no
+   * escalation (the pre-#260 behaviour; unit-test default).
+   */
+  repairStaleDeps?: (repoRoot: string) => boolean | Promise<boolean>;
+  /**
    * BLOCKER-B seam: given a repo root, the repo-relative dirs of EVERY package that
    * DECLARES a `db:generate` script (up.sh scans `packages/node/*` for
    * `grep -q '"db:generate"'`). These are generated before the whole-workspace
@@ -144,7 +154,7 @@ export interface PrepRepoLock {
 /** One prep step in the executed plan (for reporting + test assertions). */
 export interface PrepStep {
   repo: RepoKey;
-  kind: 'install' | 'db:generate' | 'build' | 'co:login' | 'lock';
+  kind: 'install' | 'db:generate' | 'build' | 'co:login' | 'lock' | 'repair';
   cwd: string;
   /** argv AFTER `pnpm` (e.g. `['install']`, `['db:generate']`, `['build']`, `['co:login']`). */
   argv: string[];
@@ -344,11 +354,17 @@ async function prepOneRepo(
     if (!INSTALL_ONLY_REPOS.has(repo)) {
       const build: PrepStep = { repo, kind: 'build', cwd: root, argv: ['build'] };
       if (!(await run(build))) {
-        if (FATAL_BUILD_REPOS.has(repo)) {
-          return build;
+        // soa#260: a build failure can be `node_modules` corruption a plain reprep can't
+        // fix (a stale `.bin` shim → a `.pnpm/<pkg>@<ver>` the store no longer has). If
+        // the repair seam detects+wipes it, reinstall + rebuild ONCE before falling back
+        // to the normal fatal/non-fatal handling.
+        if (!(await tryRepairAndRebuild(ctx, repo, root, run, steps))) {
+          if (FATAL_BUILD_REPOS.has(repo)) {
+            return build;
+          }
+          warnings.push(build);
+          buildFailed = true;
         }
-        warnings.push(build);
-        buildFailed = true;
       }
     }
 
@@ -360,4 +376,25 @@ async function prepOneRepo(
   }
 
   return null;
+}
+
+/**
+ * soa#260: escalate a build failure that carries the repairable corruption signature.
+ * If `repairStaleDeps` detects+wipes it (returns true), record the repair step and
+ * reinstall + rebuild ONCE; returns true iff the rebuild then SUCCEEDS. No seam / no
+ * signature / a failed reinstall ⇒ false, so the caller applies its normal fatal or
+ * non-fatal build handling. Gated on the seam's signature check so a genuine compile
+ * error never triggers a wipe.
+ */
+async function tryRepairAndRebuild(
+  ctx: PrepContext,
+  repo: RepoKey,
+  root: string,
+  run: (step: PrepStep) => Promise<boolean>,
+  steps: PrepStep[],
+): Promise<boolean> {
+  if ((await ctx.repairStaleDeps?.(root)) !== true) return false;
+  steps.push({ repo, kind: 'repair', cwd: root, argv: ['rm -rf node_modules'] });
+  if (!(await run({ repo, kind: 'install', cwd: root, argv: ['install'] }))) return false;
+  return run({ repo, kind: 'build', cwd: root, argv: ['build'] });
 }

--- a/packages/node/saga-stack-cli/src/stack-api.ts
+++ b/packages/node/saga-stack-cli/src/stack-api.ts
@@ -140,6 +140,12 @@ export interface Runtime {
    * unbuilt tree. Absent ⇒ no stamp written (unit-test default).
    */
   prepWriteStamp?: (repoRoot: string) => void;
+  /**
+   * soa#260: R1 build-failure repair seam — wipe `node_modules` + reinstall/rebuild once
+   * when a build fails on the stale-`.bin`-shim corruption a plain reprep can't fix
+   * (program-hub#335). Absent ⇒ no escalation (unit-test default).
+   */
+  prepRepairDeps?: (repoRoot: string) => boolean | Promise<boolean>;
   /** M13-B: realpath-keyed per-repo build lock — held ⇒ prep fails fast (plan §4 layer 2). */
   prepLock?: PrepRepoLock;
   /**
@@ -813,6 +819,7 @@ export function makeStackApi(m: Manifest, runtime: Runtime): StackApi {
           skipPrep: runtime.skipPrep,
           isFresh: runtime.prepIsFresh,
           writeStamp: runtime.prepWriteStamp,
+          repairStaleDeps: runtime.prepRepairDeps,
           dbGenerateScan: runtime.prepDbGenerateScan,
           lock: runtime.prepLock,
           manifest,


### PR DESCRIPTION
## What & why

soa#256's freshness stamp *triggers* a reprep after a pull/ff, but the reprep's plain `pnpm install` is a **no-op when pnpm sees `lockfile == store`** — even when `node_modules` is corrupt. The concrete case (saga-ed/program-hub#335): a stale `.bin` shim pointing at a `.pnpm/<pkg>@<ver>` store path a version bump deleted (`.bin/tsc` → `typescript@5.9.3` after a TS 5→6 bump). Neither `pnpm install` nor `--force` regenerates the shim, so the build fails on **every** `up` and the repo never earns a stamp (repreps forever).

This closes that remediation gap.

## How

- **`runtime/prep-repair.ts`** (new) — detects the signature cheaply: a `.bin` entry (dangling **symlink** *or* shell **shim**) referencing a `.pnpm/<pkg>@<ver>` dir that no longer exists. On a hit, wipes **every** `node_modules` under the repo (root + workspace packages; **`.worktrees` excluded** — the confirmed cure; a root-only wipe leaves per-package `.bin` shims behind).
- **`runtime/prep.ts`** — on a build failure, `tryRepairAndRebuild` calls the repair seam; if it healed, **reinstall + rebuild once**, then stamp. Gated on the signature so a **genuine compile error never triggers a wipe**. Runs *before* the FATAL-repo abort, so a corrupted qboard/rtsm/coach self-heals too.
- Seam threaded through the same points as the #256 stamp writer (`base-command` → `stack-api` / `e2e-orchestrate` / `e2e run`).

## Behaviour

| build failure | before | after |
|---|---|---|
| stale-shim corruption | repreps forever, never stamps | wipe → reinstall → rebuild → **healed + stamped** |
| genuine compile error | non-fatal warning | non-fatal warning (no wipe — unchanged) |
| corruption in a fatal repo | pass aborts | escalates first → heals → pass continues |

## Tests / verification

- `prep-repair.unit.test.ts` (8): detector (dangling symlink, stale shim, clean, no-`.bin`) + thorough wipe (`.worktrees` preserved) + the seam.
- `prep.unit.test.ts` (+3): heal→stamp→no-warning, no-signature→normal-warning→no-wipe, fatal-repo-heal.
- **1009 suite + `tsc` + lint green.** Rebuilt CLI; **journey e2e 20/20** (no regression; program-hub reprepped + stamped clean).

Closes #260. Refs saga-ed/program-hub#335. Builds on #259 (soa#256).

🤖 Generated with [Claude Code](https://claude.com/claude-code)