### PR TITLE
Add reusable narrated walkthrough-video harness

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "co:whoami": "npm whoami --registry=https://saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/"
   },
   "devDependencies": {
+    "edge-tts": "1.0.1",
+    "playwright": "1.61.1",
     "prettier": "^3.5.3",
     "syncpack": "14.0.0-alpha.16",
     "turbo": "^2.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,12 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      edge-tts:
+        specifier: 1.0.1
+        version: 1.0.1(typescript@5.8.2)
+      playwright:
+        specifier: 1.61.1
+        version: 1.61.1
       prettier:
         specifier: ^3.5.3
         version: 3.7.4
@@ -35,7 +41,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@26.1.0)(jsdom@25.0.1)
+        version: 1.6.1(@types/node@26.1.1)(jsdom@25.0.1)
 
   apps/node/gql-api:
     dependencies:
@@ -487,7 +493,7 @@ importers:
         version: 6.21.0(@aws-sdk/credential-providers@3.1054.0)(socks@2.8.7)
       mysql2:
         specifier: ^3.0.0
-        version: 3.20.0(@types/node@26.1.0)
+        version: 3.20.0(@types/node@26.1.1)
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -500,7 +506,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.6.1
-        version: 1.6.1(@types/node@26.1.0)(jsdom@25.0.1)
+        version: 1.6.1(@types/node@26.1.1)(jsdom@25.0.1)
 
   packages/core/config:
     dependencies:
@@ -803,13 +809,13 @@ importers:
         version: 14.5.0
       '@types/node':
         specifier: latest
-        version: 25.9.3
+        version: 26.1.1
       '@types/supertest':
         specifier: ^6.0.3
         version: 6.0.3
       '@vitest/coverage-v8':
         specifier: ^1.5.0
-        version: 1.6.1(vitest@1.6.1(@types/node@25.9.3)(jsdom@25.0.1))
+        version: 1.6.1(vitest@1.6.1(@types/node@26.1.1)(jsdom@25.0.1))
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -821,7 +827,7 @@ importers:
         version: 7.16.0
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@25.9.3)(jsdom@25.0.1)
+        version: 1.6.1(@types/node@26.1.1)(jsdom@25.0.1)
 
   packages/node/api-util:
     dependencies:
@@ -837,7 +843,7 @@ importers:
         version: link:../../core/typescript-config
       '@types/node':
         specifier: latest
-        version: 25.9.3
+        version: 26.1.1
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -874,7 +880,7 @@ importers:
         version: link:../../core/typescript-config
       '@types/node':
         specifier: latest
-        version: 25.9.3
+        version: 26.1.1
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -1182,7 +1188,7 @@ importers:
         version: 5.0.6
       '@types/node':
         specifier: latest
-        version: 25.9.3
+        version: 26.1.1
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -1191,7 +1197,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@25.9.3)(jsdom@25.0.1)
+        version: 1.6.1(@types/node@26.1.1)(jsdom@25.0.1)
 
   packages/node/health:
     devDependencies:
@@ -1279,7 +1285,7 @@ importers:
         version: link:../../core/typescript-config
       '@types/node':
         specifier: latest
-        version: 25.9.3
+        version: 26.1.1
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -1304,7 +1310,7 @@ importers:
         version: link:../../core/typescript-config
       '@types/node':
         specifier: latest
-        version: 26.0.0
+        version: 26.1.1
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -1332,13 +1338,13 @@ importers:
         version: link:../../core/typescript-config
       '@types/node':
         specifier: latest
-        version: 25.9.3
+        version: 26.1.1
       '@types/uuid':
         specifier: ^10.0.0
         version: 10.0.0
       oclif:
         specifier: ^4.22.93
-        version: 4.23.0(@types/node@25.9.3)
+        version: 4.23.0(@types/node@26.1.1)
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
@@ -1552,7 +1558,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@26.1.0)(jsdom@25.0.1)
+        version: 1.6.1(@types/node@26.1.1)(jsdom@25.0.1)
 
   packages/node/pubsub-server:
     dependencies:
@@ -1586,7 +1592,7 @@ importers:
         version: link:../../core/typescript-config
       '@types/node':
         specifier: latest
-        version: 25.9.3
+        version: 26.1.1
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -1595,7 +1601,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@25.9.3)(jsdom@25.0.1)
+        version: 1.6.1(@types/node@26.1.1)(jsdom@25.0.1)
 
   packages/node/rabbitmq:
     dependencies:
@@ -1663,7 +1669,7 @@ importers:
         version: 8.5.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@26.1.0)(jsdom@25.0.1)
+        version: 1.6.1(@types/node@26.1.1)(jsdom@25.0.1)
 
   packages/node/saga-stack-cli:
     dependencies:
@@ -1682,10 +1688,10 @@ importers:
         version: link:../../core/typescript-config
       '@types/node':
         specifier: latest
-        version: 26.1.0
+        version: 26.1.1
       oclif:
         specifier: ^4.22.93
-        version: 4.23.0(@types/node@26.1.0)
+        version: 4.23.0(@types/node@26.1.1)
       tsx:
         specifier: ^4.20.3
         version: 4.21.0
@@ -1694,7 +1700,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@26.1.0)(jsdom@25.0.1)
+        version: 1.6.1(@types/node@26.1.1)(jsdom@25.0.1)
 
   packages/node/test-util:
     dependencies:
@@ -1732,7 +1738,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@26.1.0)(jsdom@25.0.1)
+        version: 1.6.1(@types/node@26.1.1)(jsdom@25.0.1)
 
   packages/web/ui:
     dependencies:
@@ -3977,6 +3983,7 @@ packages:
   '@opentelemetry/propagation-utils@0.30.16':
     resolution: {integrity: sha512-ZVQ3Z/PQ+2GQlrBfbMMMT0U7MzvYZLCPP800+ooyaBqm4hMvuQHfP028gB9/db0mwkmyEAMad9houukUVxhwcw==}
     engines: {node: '>=14'}
+    deprecated: The use of process spans has been removed from Messaging Semantic Conventions. It is now recommended to connect pub/sub spans via Span Links. See https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/ for details.
     peerDependencies:
       '@opentelemetry/api': ^1.0.0
 
@@ -5084,14 +5091,8 @@ packages:
   '@types/node@24.0.12':
     resolution: {integrity: sha512-LtOrbvDf5ndC9Xi+4QZjVL0woFymF/xSTKZKPgrrl7H7XoeDvnD+E2IclKVDyaK9UM756W/3BXqSU+JEHopA9g==}
 
-  '@types/node@25.9.3':
-    resolution: {integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==}
-
-  '@types/node@26.0.0':
-    resolution: {integrity: sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==}
-
-  '@types/node@26.1.0':
-    resolution: {integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==}
+  '@types/node@26.1.1':
+    resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
 
   '@types/pg-pool@2.0.6':
     resolution: {integrity: sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ==}
@@ -6363,6 +6364,11 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  edge-tts@1.0.1:
+    resolution: {integrity: sha512-Yv5S4y5k3bWC+0iyD6PDCOI0SLpBN5B1Mv6apgyWjhHzU8GDrBMv6BvT9lZBY5O/4Ow7KFcYaItXC/H0BFmewA==}
+    peerDependencies:
+      typescript: ^5.0.0
+
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
@@ -6886,6 +6892,11 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -8449,6 +8460,16 @@ packages:
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
@@ -9580,9 +9601,6 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-
-  undici-types@7.24.6:
-    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
   undici-types@7.8.0:
     resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
@@ -12392,70 +12410,40 @@ snapshots:
 
   '@inquirer/ansi@1.0.2': {}
 
-  '@inquirer/checkbox@4.3.2(@types/node@25.9.3)':
+  '@inquirer/checkbox@4.3.2(@types/node@26.1.1)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@25.9.3)
+      '@inquirer/core': 10.3.2(@types/node@26.1.1)
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@25.9.3)
+      '@inquirer/type': 3.0.10(@types/node@26.1.1)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 25.9.3
-
-  '@inquirer/checkbox@4.3.2(@types/node@26.1.0)':
-    dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@26.1.0)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@26.1.0)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 26.1.0
+      '@types/node': 26.1.1
 
   '@inquirer/confirm@3.2.0':
     dependencies:
       '@inquirer/core': 9.2.1
       '@inquirer/type': 1.5.5
 
-  '@inquirer/confirm@5.1.21(@types/node@25.9.3)':
+  '@inquirer/confirm@5.1.21(@types/node@26.1.1)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.9.3)
-      '@inquirer/type': 3.0.10(@types/node@25.9.3)
+      '@inquirer/core': 10.3.2(@types/node@26.1.1)
+      '@inquirer/type': 3.0.10(@types/node@26.1.1)
     optionalDependencies:
-      '@types/node': 25.9.3
+      '@types/node': 26.1.1
 
-  '@inquirer/confirm@5.1.21(@types/node@26.1.0)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@26.1.0)
-      '@inquirer/type': 3.0.10(@types/node@26.1.0)
-    optionalDependencies:
-      '@types/node': 26.1.0
-
-  '@inquirer/core@10.3.2(@types/node@25.9.3)':
+  '@inquirer/core@10.3.2(@types/node@26.1.1)':
     dependencies:
       '@inquirer/ansi': 1.0.2
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@25.9.3)
+      '@inquirer/type': 3.0.10(@types/node@26.1.1)
       cli-width: 4.1.0
       mute-stream: 2.0.0
       signal-exit: 4.1.0
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 25.9.3
-
-  '@inquirer/core@10.3.2(@types/node@26.1.0)':
-    dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@26.1.0)
-      cli-width: 4.1.0
-      mute-stream: 2.0.0
-      signal-exit: 4.1.0
-      wrap-ansi: 6.2.0
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 26.1.0
+      '@types/node': 26.1.1
 
   '@inquirer/core@9.2.1':
     dependencies:
@@ -12472,37 +12460,21 @@ snapshots:
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.3
 
-  '@inquirer/editor@4.2.23(@types/node@25.9.3)':
+  '@inquirer/editor@4.2.23(@types/node@26.1.1)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.9.3)
-      '@inquirer/external-editor': 1.0.3(@types/node@25.9.3)
-      '@inquirer/type': 3.0.10(@types/node@25.9.3)
+      '@inquirer/core': 10.3.2(@types/node@26.1.1)
+      '@inquirer/external-editor': 1.0.3(@types/node@26.1.1)
+      '@inquirer/type': 3.0.10(@types/node@26.1.1)
     optionalDependencies:
-      '@types/node': 25.9.3
+      '@types/node': 26.1.1
 
-  '@inquirer/editor@4.2.23(@types/node@26.1.0)':
+  '@inquirer/expand@4.0.23(@types/node@26.1.1)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@26.1.0)
-      '@inquirer/external-editor': 1.0.3(@types/node@26.1.0)
-      '@inquirer/type': 3.0.10(@types/node@26.1.0)
-    optionalDependencies:
-      '@types/node': 26.1.0
-
-  '@inquirer/expand@4.0.23(@types/node@25.9.3)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.9.3)
-      '@inquirer/type': 3.0.10(@types/node@25.9.3)
+      '@inquirer/core': 10.3.2(@types/node@26.1.1)
+      '@inquirer/type': 3.0.10(@types/node@26.1.1)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 25.9.3
-
-  '@inquirer/expand@4.0.23(@types/node@26.1.0)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@26.1.0)
-      '@inquirer/type': 3.0.10(@types/node@26.1.0)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 26.1.0
+      '@types/node': 26.1.1
 
   '@inquirer/external-editor@1.0.3(@types/node@22.19.3)':
     dependencies:
@@ -12518,19 +12490,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.0.12
 
-  '@inquirer/external-editor@1.0.3(@types/node@25.9.3)':
+  '@inquirer/external-editor@1.0.3(@types/node@26.1.1)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 25.9.3
-
-  '@inquirer/external-editor@1.0.3(@types/node@26.1.0)':
-    dependencies:
-      chardet: 2.1.1
-      iconv-lite: 0.7.2
-    optionalDependencies:
-      '@types/node': 26.1.0
+      '@types/node': 26.1.1
 
   '@inquirer/figures@1.0.15': {}
 
@@ -12539,113 +12504,59 @@ snapshots:
       '@inquirer/core': 9.2.1
       '@inquirer/type': 1.5.5
 
-  '@inquirer/input@4.3.1(@types/node@25.9.3)':
+  '@inquirer/input@4.3.1(@types/node@26.1.1)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.9.3)
-      '@inquirer/type': 3.0.10(@types/node@25.9.3)
+      '@inquirer/core': 10.3.2(@types/node@26.1.1)
+      '@inquirer/type': 3.0.10(@types/node@26.1.1)
     optionalDependencies:
-      '@types/node': 25.9.3
+      '@types/node': 26.1.1
 
-  '@inquirer/input@4.3.1(@types/node@26.1.0)':
+  '@inquirer/number@3.0.23(@types/node@26.1.1)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@26.1.0)
-      '@inquirer/type': 3.0.10(@types/node@26.1.0)
+      '@inquirer/core': 10.3.2(@types/node@26.1.1)
+      '@inquirer/type': 3.0.10(@types/node@26.1.1)
     optionalDependencies:
-      '@types/node': 26.1.0
+      '@types/node': 26.1.1
 
-  '@inquirer/number@3.0.23(@types/node@25.9.3)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.9.3)
-      '@inquirer/type': 3.0.10(@types/node@25.9.3)
-    optionalDependencies:
-      '@types/node': 25.9.3
-
-  '@inquirer/number@3.0.23(@types/node@26.1.0)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@26.1.0)
-      '@inquirer/type': 3.0.10(@types/node@26.1.0)
-    optionalDependencies:
-      '@types/node': 26.1.0
-
-  '@inquirer/password@4.0.23(@types/node@25.9.3)':
+  '@inquirer/password@4.0.23(@types/node@26.1.1)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@25.9.3)
-      '@inquirer/type': 3.0.10(@types/node@25.9.3)
+      '@inquirer/core': 10.3.2(@types/node@26.1.1)
+      '@inquirer/type': 3.0.10(@types/node@26.1.1)
     optionalDependencies:
-      '@types/node': 25.9.3
+      '@types/node': 26.1.1
 
-  '@inquirer/password@4.0.23(@types/node@26.1.0)':
+  '@inquirer/prompts@7.10.1(@types/node@26.1.1)':
     dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@26.1.0)
-      '@inquirer/type': 3.0.10(@types/node@26.1.0)
+      '@inquirer/checkbox': 4.3.2(@types/node@26.1.1)
+      '@inquirer/confirm': 5.1.21(@types/node@26.1.1)
+      '@inquirer/editor': 4.2.23(@types/node@26.1.1)
+      '@inquirer/expand': 4.0.23(@types/node@26.1.1)
+      '@inquirer/input': 4.3.1(@types/node@26.1.1)
+      '@inquirer/number': 3.0.23(@types/node@26.1.1)
+      '@inquirer/password': 4.0.23(@types/node@26.1.1)
+      '@inquirer/rawlist': 4.1.11(@types/node@26.1.1)
+      '@inquirer/search': 3.2.2(@types/node@26.1.1)
+      '@inquirer/select': 4.4.2(@types/node@26.1.1)
     optionalDependencies:
-      '@types/node': 26.1.0
+      '@types/node': 26.1.1
 
-  '@inquirer/prompts@7.10.1(@types/node@25.9.3)':
+  '@inquirer/rawlist@4.1.11(@types/node@26.1.1)':
     dependencies:
-      '@inquirer/checkbox': 4.3.2(@types/node@25.9.3)
-      '@inquirer/confirm': 5.1.21(@types/node@25.9.3)
-      '@inquirer/editor': 4.2.23(@types/node@25.9.3)
-      '@inquirer/expand': 4.0.23(@types/node@25.9.3)
-      '@inquirer/input': 4.3.1(@types/node@25.9.3)
-      '@inquirer/number': 3.0.23(@types/node@25.9.3)
-      '@inquirer/password': 4.0.23(@types/node@25.9.3)
-      '@inquirer/rawlist': 4.1.11(@types/node@25.9.3)
-      '@inquirer/search': 3.2.2(@types/node@25.9.3)
-      '@inquirer/select': 4.4.2(@types/node@25.9.3)
-    optionalDependencies:
-      '@types/node': 25.9.3
-
-  '@inquirer/prompts@7.10.1(@types/node@26.1.0)':
-    dependencies:
-      '@inquirer/checkbox': 4.3.2(@types/node@26.1.0)
-      '@inquirer/confirm': 5.1.21(@types/node@26.1.0)
-      '@inquirer/editor': 4.2.23(@types/node@26.1.0)
-      '@inquirer/expand': 4.0.23(@types/node@26.1.0)
-      '@inquirer/input': 4.3.1(@types/node@26.1.0)
-      '@inquirer/number': 3.0.23(@types/node@26.1.0)
-      '@inquirer/password': 4.0.23(@types/node@26.1.0)
-      '@inquirer/rawlist': 4.1.11(@types/node@26.1.0)
-      '@inquirer/search': 3.2.2(@types/node@26.1.0)
-      '@inquirer/select': 4.4.2(@types/node@26.1.0)
-    optionalDependencies:
-      '@types/node': 26.1.0
-
-  '@inquirer/rawlist@4.1.11(@types/node@25.9.3)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.9.3)
-      '@inquirer/type': 3.0.10(@types/node@25.9.3)
+      '@inquirer/core': 10.3.2(@types/node@26.1.1)
+      '@inquirer/type': 3.0.10(@types/node@26.1.1)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 25.9.3
+      '@types/node': 26.1.1
 
-  '@inquirer/rawlist@4.1.11(@types/node@26.1.0)':
+  '@inquirer/search@3.2.2(@types/node@26.1.1)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@26.1.0)
-      '@inquirer/type': 3.0.10(@types/node@26.1.0)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 26.1.0
-
-  '@inquirer/search@3.2.2(@types/node@25.9.3)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.9.3)
+      '@inquirer/core': 10.3.2(@types/node@26.1.1)
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@25.9.3)
+      '@inquirer/type': 3.0.10(@types/node@26.1.1)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 25.9.3
-
-  '@inquirer/search@3.2.2(@types/node@26.1.0)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@26.1.0)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@26.1.0)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 26.1.0
+      '@types/node': 26.1.1
 
   '@inquirer/select@2.5.0':
     dependencies:
@@ -12655,25 +12566,15 @@ snapshots:
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.3
 
-  '@inquirer/select@4.4.2(@types/node@25.9.3)':
+  '@inquirer/select@4.4.2(@types/node@26.1.1)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@25.9.3)
+      '@inquirer/core': 10.3.2(@types/node@26.1.1)
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@25.9.3)
+      '@inquirer/type': 3.0.10(@types/node@26.1.1)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 25.9.3
-
-  '@inquirer/select@4.4.2(@types/node@26.1.0)':
-    dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@26.1.0)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@26.1.0)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 26.1.0
+      '@types/node': 26.1.1
 
   '@inquirer/type@1.5.5':
     dependencies:
@@ -12683,13 +12584,9 @@ snapshots:
     dependencies:
       mute-stream: 1.0.0
 
-  '@inquirer/type@3.0.10(@types/node@25.9.3)':
+  '@inquirer/type@3.0.10(@types/node@26.1.1)':
     optionalDependencies:
-      '@types/node': 25.9.3
-
-  '@inquirer/type@3.0.10(@types/node@26.1.0)':
-    optionalDependencies:
-      '@types/node': 26.1.0
+      '@types/node': 26.1.1
 
   '@inversifyjs/common@1.4.0': {}
 
@@ -12865,18 +12762,9 @@ snapshots:
     dependencies:
       '@oclif/core': 4.10.5
 
-  '@oclif/plugin-not-found@3.2.80(@types/node@25.9.3)':
+  '@oclif/plugin-not-found@3.2.80(@types/node@26.1.1)':
     dependencies:
-      '@inquirer/prompts': 7.10.1(@types/node@25.9.3)
-      '@oclif/core': 4.10.5
-      ansis: 3.17.0
-      fast-levenshtein: 3.0.0
-    transitivePeerDependencies:
-      - '@types/node'
-
-  '@oclif/plugin-not-found@3.2.80(@types/node@26.1.0)':
-    dependencies:
-      '@inquirer/prompts': 7.10.1(@types/node@26.1.0)
+      '@inquirer/prompts': 7.10.1(@types/node@26.1.1)
       '@oclif/core': 4.10.5
       ansis: 3.17.0
       fast-levenshtein: 3.0.0
@@ -14967,15 +14855,7 @@ snapshots:
     dependencies:
       undici-types: 7.8.0
 
-  '@types/node@25.9.3':
-    dependencies:
-      undici-types: 7.24.6
-
-  '@types/node@26.0.0':
-    dependencies:
-      undici-types: 8.3.0
-
-  '@types/node@26.1.0':
+  '@types/node@26.1.1':
     dependencies:
       undici-types: 8.3.0
 
@@ -15345,7 +15225,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@1.6.1(vitest@1.6.1(@types/node@25.9.3)(jsdom@25.0.1))':
+  '@vitest/coverage-v8@1.6.1(vitest@1.6.1(@types/node@26.1.1)(jsdom@25.0.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -15360,7 +15240,7 @@ snapshots:
       std-env: 3.10.0
       strip-literal: 2.1.1
       test-exclude: 6.0.0
-      vitest: 1.6.1(@types/node@25.9.3)(jsdom@25.0.1)
+      vitest: 1.6.1(@types/node@26.1.1)(jsdom@25.0.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -16317,6 +16197,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.3(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
@@ -16482,6 +16366,14 @@ snapshots:
       gopd: 1.2.0
 
   eastasianwidth@0.2.0: {}
+
+  edge-tts@1.0.1(typescript@5.8.2):
+    dependencies:
+      typescript: 5.8.2
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   ee-first@1.1.1: {}
 
@@ -16689,8 +16581,8 @@ snapshots:
       '@typescript-eslint/parser': 8.50.0(eslint@8.57.1)(typescript@5.8.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -16733,21 +16625,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 8.57.1
-      get-tsconfig: 4.13.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.15
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -16763,14 +16640,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.50.0(eslint@8.57.1)(typescript@5.8.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -16785,7 +16662,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -16796,7 +16673,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -17399,6 +17276,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -17767,7 +17647,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -17779,7 +17659,7 @@ snapshots:
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -18614,9 +18494,9 @@ snapshots:
 
   mute-stream@2.0.0: {}
 
-  mysql2@3.20.0(@types/node@26.1.0):
+  mysql2@3.20.0(@types/node@26.1.1):
     dependencies:
-      '@types/node': 26.1.0
+      '@types/node': 26.1.1
       aws-ssl-profiles: 1.1.2
       denque: 2.1.0
       generate-function: 2.3.1
@@ -18803,7 +18683,7 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
-  oclif@4.23.0(@types/node@25.9.3):
+  oclif@4.23.0(@types/node@26.1.1):
     dependencies:
       '@aws-sdk/client-cloudfront': 3.1009.0
       '@aws-sdk/client-s3': 3.1014.0
@@ -18812,38 +18692,7 @@ snapshots:
       '@inquirer/select': 2.5.0
       '@oclif/core': 4.9.0
       '@oclif/plugin-help': 6.2.44
-      '@oclif/plugin-not-found': 3.2.80(@types/node@25.9.3)
-      '@oclif/plugin-warn-if-update-available': 3.1.60
-      ansis: 3.17.0
-      async-retry: 1.3.3
-      change-case: 4.1.2
-      debug: 4.4.3(supports-color@8.1.1)
-      ejs: 3.1.10
-      find-yarn-workspace-root: 2.0.0
-      fs-extra: 8.1.0
-      github-slugger: 2.0.0
-      got: 13.0.0
-      lodash: 4.18.1
-      normalize-package-data: 6.0.2
-      semver: 7.7.4
-      sort-package-json: 2.15.1
-      tiny-jsonc: 1.0.2
-      validate-npm-package-name: 5.0.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - aws-crt
-      - supports-color
-
-  oclif@4.23.0(@types/node@26.1.0):
-    dependencies:
-      '@aws-sdk/client-cloudfront': 3.1009.0
-      '@aws-sdk/client-s3': 3.1014.0
-      '@inquirer/confirm': 3.2.0
-      '@inquirer/input': 2.3.0
-      '@inquirer/select': 2.5.0
-      '@oclif/core': 4.9.0
-      '@oclif/plugin-help': 6.2.44
-      '@oclif/plugin-not-found': 3.2.80(@types/node@26.1.0)
+      '@oclif/plugin-not-found': 3.2.80(@types/node@26.1.1)
       '@oclif/plugin-warn-if-update-available': 3.1.60
       ansis: 3.17.0
       async-retry: 1.3.3
@@ -19173,6 +19022,14 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.8.0
       pathe: 2.0.3
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 
@@ -20549,8 +20406,6 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici-types@7.24.6: {}
-
   undici-types@7.8.0: {}
 
   undici-types@8.3.0: {}
@@ -20674,31 +20529,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@1.6.1(@types/node@25.9.3):
+  vite-node@1.6.1(@types/node@26.1.1):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       pathe: 1.1.2
       picocolors: 1.1.1
-      vite: 5.4.21(@types/node@25.9.3)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  vite-node@1.6.1(@types/node@26.1.0):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.3(supports-color@8.1.1)
-      pathe: 1.1.2
-      picocolors: 1.1.1
-      vite: 5.4.21(@types/node@26.1.0)
+      vite: 5.4.21(@types/node@26.1.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -20746,22 +20583,13 @@ snapshots:
       '@types/node': 24.0.12
       fsevents: 2.3.3
 
-  vite@5.4.21(@types/node@25.9.3):
+  vite@5.4.21(@types/node@26.1.1):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
       rollup: 4.53.5
     optionalDependencies:
-      '@types/node': 25.9.3
-      fsevents: 2.3.3
-
-  vite@5.4.21(@types/node@26.1.0):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.5.6
-      rollup: 4.53.5
-    optionalDependencies:
-      '@types/node': 26.1.0
+      '@types/node': 26.1.1
       fsevents: 2.3.3
 
   vitest@1.6.1(@types/node@24.0.12)(jsdom@25.0.1):
@@ -20799,7 +20627,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@1.6.1(@types/node@25.9.3)(jsdom@25.0.1):
+  vitest@1.6.1(@types/node@26.1.1)(jsdom@25.0.1):
     dependencies:
       '@vitest/expect': 1.6.1
       '@vitest/runner': 1.6.1
@@ -20808,7 +20636,7 @@ snapshots:
       '@vitest/utils': 1.6.1
       acorn-walk: 8.3.4
       chai: 4.5.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       execa: 8.0.1
       local-pkg: 0.5.1
       magic-string: 0.30.21
@@ -20818,46 +20646,11 @@ snapshots:
       strip-literal: 2.1.1
       tinybench: 2.9.0
       tinypool: 0.8.4
-      vite: 5.4.21(@types/node@25.9.3)
-      vite-node: 1.6.1(@types/node@25.9.3)
+      vite: 5.4.21(@types/node@26.1.1)
+      vite-node: 1.6.1(@types/node@26.1.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 25.9.3
-      jsdom: 25.0.1
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  vitest@1.6.1(@types/node@26.1.0)(jsdom@25.0.1):
-    dependencies:
-      '@vitest/expect': 1.6.1
-      '@vitest/runner': 1.6.1
-      '@vitest/snapshot': 1.6.1
-      '@vitest/spy': 1.6.1
-      '@vitest/utils': 1.6.1
-      acorn-walk: 8.3.4
-      chai: 4.5.0
-      debug: 4.4.3(supports-color@8.1.1)
-      execa: 8.0.1
-      local-pkg: 0.5.1
-      magic-string: 0.30.21
-      pathe: 1.1.2
-      picocolors: 1.1.1
-      std-env: 3.10.0
-      strip-literal: 2.1.1
-      tinybench: 2.9.0
-      tinypool: 0.8.4
-      vite: 5.4.21(@types/node@26.1.0)
-      vite-node: 1.6.1(@types/node@26.1.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 26.1.0
+      '@types/node': 26.1.1
       jsdom: 25.0.1
     transitivePeerDependencies:
       - less

--- a/tools/walkthrough-video/.gitignore
+++ b/tools/walkthrough-video/.gitignore
@@ -1,0 +1,7 @@
+# Generated per-walkthrough artifacts — steps.mjs is the only thing worth committing.
+walkthroughs/**/chunks/
+walkthroughs/**/chunks-padded/
+walkthroughs/**/chunks-meta.json
+walkthroughs/**/durations.json
+walkthroughs/**/slots.json
+walkthroughs/**/video/

--- a/tools/walkthrough-video/README.md
+++ b/tools/walkthrough-video/README.md
@@ -35,19 +35,23 @@ they're not repeated here.
 ## Prerequisites
 
 - Node 20+, `ffmpeg` + `ffprobe` on PATH (`apt install ffmpeg`).
-- Playwright installed somewhere resolvable — this tool has no `package.json` of its own
-  (no build step, ESM, Node-native, matching `tools/integration-walkthrough`'s convention).
-  Run it with a `node_modules/playwright` on the module resolution path, e.g. from a
-  workspace package that already depends on `@playwright/test`, or `pnpm add -w -D playwright`
-  at the soa root.
+- `playwright` (root devDependency, already added — `pnpm install` at the soa root picks
+  it up like any other workspace dep).
 - `saga-stack-cli` (`ss`) installed and on PATH — see
   `packages/node/saga-stack-cli/README.md` § Install.
-- An OpenAI API key for narration. **Do not** put one in a local `.env` — the dev key lives
-  in Secrets Manager (`openai-dev-apikey-W3MunH`, us-west-2, account 531314149529).
-  `lib/narrate.mjs` fetches it automatically via
-  `aws secretsmanager get-secret-value --profile saga-dev` (override the profile with
-  `WALKTHROUGH_AWS_PROFILE`, or set `OPENAI_API_KEY` directly to bypass Secrets Manager
-  entirely — e.g. for a throwaway personal key while iterating).
+- An OpenAI API key for narration (the default `TTS_ENGINE=openai`). **Do not** put one in
+  a local `.env` — the dev key lives in Secrets Manager (`openai-dev-apikey-W3MunH`,
+  us-west-2, account 531314149529). `lib/narrate.mjs` fetches it automatically via
+  `aws secretsmanager get-secret-value --profile saga-dev` — **Observer-tier profiles
+  (`saga`, `saga-dev`) are denied `GetSecretValue` on this ARN**; set
+  `WALKTHROUGH_AWS_PROFILE` to a profile with access, or set `OPENAI_API_KEY` directly to
+  bypass Secrets Manager entirely (e.g. a throwaway personal key while iterating).
+- For a **free/zero-credential iteration tier**, prefer `SKIP_NARRATE=1` (silent render —
+  proves out action timing/selectors without any TTS call) over `TTS_ENGINE=edge`. The
+  `edge` engine (unofficial `edge-tts` npm wrapper around Microsoft's read-aloud API) is
+  wired in but **known broken as of 2026-07**: its hardcoded auth token returns 403
+  (Microsoft rotates/blocks it periodically — out of our control). Kept as a pluggable
+  option in case it's patched upstream; don't rely on it today.
 
 ## Running an existing walkthrough
 
@@ -63,8 +67,8 @@ export WALKTHROUGH_LOGIN_EMAIL=empty@saga.org
 node tools/walkthrough-video/lib/make.mjs --walkthrough saga-dash/program-creation
 
 # Iterate cheaply:
-SKIP_NARRATE=1 node tools/walkthrough-video/lib/make.mjs --walkthrough saga-dash/program-creation  # re-record only
-SKIP_RECORD=1  node tools/walkthrough-video/lib/make.mjs --walkthrough saga-dash/program-creation  # re-stitch only
+SKIP_NARRATE=1 node tools/walkthrough-video/lib/make.mjs --walkthrough saga-dash/program-creation  # silent render — no TTS call, action-timed slots only
+SKIP_RECORD=1  node tools/walkthrough-video/lib/make.mjs --walkthrough saga-dash/program-creation  # re-stitch only (reuses last recorded video)
 FORCE=1        node tools/walkthrough-video/lib/make.mjs --walkthrough saga-dash/program-creation  # force re-synth all narration
 ```
 

--- a/tools/walkthrough-video/README.md
+++ b/tools/walkthrough-video/README.md
@@ -1,0 +1,152 @@
+# walkthrough-video
+
+Turn a click-through demo of any saga-soa frontend into a narrated MP4/WebM with synced
+cursor, voiceover, and SRT subtitles — reusable across repos, driven by `saga-stack-cli`.
+
+Output is a 2–5 minute video suitable for: exec demos, async PR walkthroughs, onboarding,
+release notes. Re-render whenever the feature it covers changes significantly.
+
+Design note: this generalizes the pattern first prototyped and documented in
+`../../docs/how-to-narrated-walkthrough-video.md` (validated against an SDS demo, May 2026).
+That doc describes a copy-per-repo pattern; this tool instead keeps the **engine**
+(`lib/`) here in soa, app-agnostic, with only a thin per-app **adapter** and per-feature
+**step data** varying. Read the doc for the underlying sync model and known gotchas — it
+still applies, just with the engine centralized.
+
+## Architecture
+
+```
+adapters/<app>.mjs                 →  baseUrl + getStorageState()  (per-app, ~30 lines)
+walkthroughs/<app>/<feature>/
+  steps.mjs                        →  narration + Playwright actions  (per-feature, the real work)
+
+lib/narrate.mjs   (OpenAI TTS, content-hash cached)  ─┐
+lib/record.mjs    (Playwright + cursor overlay)       ├─  app-agnostic engine, written once
+lib/stitch.mjs    (ffmpeg mux + SRT)                  │
+lib/make.mjs      (orchestrator)                     ─┘
+```
+
+Sync model: `slot[N] = max(actionDuration[N], narrationDuration[N]) + tailSlack[N]`.
+`record.mjs` waits that long before step N+1; `stitch.mjs` pads each narration chunk with
+trailing silence to fill its slot. See the doc above for the full rationale + gotchas
+(GStreamer/Totem H.264 playback trap on Linux, locator-targeting-the-wrong-row, etc.) —
+they're not repeated here.
+
+## Prerequisites
+
+- Node 20+, `ffmpeg` + `ffprobe` on PATH (`apt install ffmpeg`).
+- Playwright installed somewhere resolvable — this tool has no `package.json` of its own
+  (no build step, ESM, Node-native, matching `tools/integration-walkthrough`'s convention).
+  Run it with a `node_modules/playwright` on the module resolution path, e.g. from a
+  workspace package that already depends on `@playwright/test`, or `pnpm add -w -D playwright`
+  at the soa root.
+- `saga-stack-cli` (`ss`) installed and on PATH — see
+  `packages/node/saga-stack-cli/README.md` § Install.
+- An OpenAI API key for narration. **Do not** put one in a local `.env` — the dev key lives
+  in Secrets Manager (`openai-dev-apikey-W3MunH`, us-west-2, account 531314149529).
+  `lib/narrate.mjs` fetches it automatically via
+  `aws secretsmanager get-secret-value --profile saga-dev` (override the profile with
+  `WALKTHROUGH_AWS_PROFILE`, or set `OPENAI_API_KEY` directly to bypass Secrets Manager
+  entirely — e.g. for a throwaway personal key while iterating).
+
+## Running an existing walkthrough
+
+```bash
+ss stack up --with dash        # bring up just what saga-dash needs
+
+# The bundled example (program-creation) needs the `empty@saga.org` persona — an
+# already-rostered org with zero programs, baked into the IAM seed. The adapter
+# re-mints its own session on every run via `ss stack login`, so set the persona
+# once via env rather than calling `ss stack login` yourself first:
+export WALKTHROUGH_LOGIN_EMAIL=empty@saga.org
+
+node tools/walkthrough-video/lib/make.mjs --walkthrough saga-dash/program-creation
+
+# Iterate cheaply:
+SKIP_NARRATE=1 node tools/walkthrough-video/lib/make.mjs --walkthrough saga-dash/program-creation  # re-record only
+SKIP_RECORD=1  node tools/walkthrough-video/lib/make.mjs --walkthrough saga-dash/program-creation  # re-stitch only
+FORCE=1        node tools/walkthrough-video/lib/make.mjs --walkthrough saga-dash/program-creation  # force re-synth all narration
+```
+
+`WALKTHROUGH_LOGIN_EMAIL` is only needed when a walkthrough requires a specific seeded
+persona — omit it to log in as `ss`'s own default (`dev@saga.org`).
+
+Output lands at `walkthroughs/<app>/<feature>/video/walkthrough.mp4` (+ `-vp9.webm` sidecar,
+`.srt`).
+
+## Authoring a new walkthrough
+
+1. **If the app has no adapter yet**, add `adapters/<app>.mjs` exporting
+   `{ baseUrl, getStorageState() }`. `getStorageState()` must return a Playwright
+   `storageState` object (`{cookies, origins}`). `adapters/saga-dash.mjs` is the reference:
+   it shells out to `ss stack login --output-json`, reads the Netscape cookie jar it
+   writes, and converts it. If your app doesn't use `saga-stack-cli`'s login, or doesn't
+   need cookies at all, write whatever fits — the contract is just that return shape.
+
+2. **Write `walkthroughs/<app>/<feature>/steps.mjs`**:
+
+   ```js
+   import { smoothClick } from '../../../lib/record.mjs';
+
+   export const STEPS = [
+     {
+       id: '00-intro',
+       narration: 'Welcome to the X feature walkthrough...',
+       action: async (page) => {
+         await page.goto('/feature');
+         await page.waitForSelector('.feature-shell', { timeout: 15000 });
+       },
+       tailSlack: 600,
+     },
+     // ...
+     {
+       id: '99-outro',
+       narration: 'That is the X feature. Thanks for watching.',
+       action: async (page) => { await page.waitForTimeout(500); },
+       tailSlack: 1500,
+     },
+   ];
+   ```
+
+3. Run it per the recipe above.
+
+### Authoring tips (from the original doc — still apply)
+
+- Write narration for the ear: "S D S" not "SDS", "K P I" not "KPI".
+- One beat per step — don't cram multiple actions/sentences into one.
+- Use `tailSlack` (ms) to give visual weight to important moments.
+- Scope locators to visible text (`.filter({ hasText: 'Emma Johnson' })`) rather than
+  `.first()` — the first row in a list is often a header or the wrong entity.
+- Use `smoothClick(page, locator)` (exported from `lib/record.mjs`) for all clicks — it
+  glides the cursor overlay to the target before clicking, so the recording reads as a
+  real cursor, not a teleporting dot.
+- Add `await page.waitForTimeout(2000)` after actions that trigger a route change or data
+  fetch, so the next step's locator is guaranteed to exist.
+- If the recorder logs `⚠ action exceeded audio`, either add more narration to that step,
+  tighten the action's waits, or split the step in two.
+
+## Known gotchas
+
+Carried over from the original design doc (still relevant):
+
+- **GStreamer/Totem H.264 playback trap on Linux** — if a rendered MP4 won't play in GNOME
+  Videos, open it in a browser or `mpv` instead, or use the `-vp9.webm` sidecar (emitted by
+  default in `stitch.mjs` for this reason).
+- **Session cookies decay** — the adapter re-mints a session on every `make.mjs` run; don't
+  try to cache one across renders.
+- **Page navigation can reset in-app state** — prefer in-app navigation (clicking a route
+  link) over `page.goto()` when a step depends on state set up by a prior step.
+
+## Extending
+
+Not built in this pass, but straightforward given the engine/data split:
+
+- A new `adapters/<app>.mjs` + `walkthroughs/<app>/<feature>/steps.mjs` is all a new
+  app/feature needs — no engine changes.
+- Multi-voice narration, a background music bed, burned-in captions, multiple output
+  resolutions — see the original doc's "Extending the pipeline" section for the shape of
+  each; none are implemented here yet.
+- Folding this into `saga-stack-cli` proper as `ss demo record <spa>/<feature>`, once this
+  standalone tool has proven itself on a few real walkthroughs.
+- Push-button cloud rendering (Fargate + headless Chromium) — viable, not designed here;
+  this pass targets local-only.

--- a/tools/walkthrough-video/adapters/saga-dash.mjs
+++ b/tools/walkthrough-video/adapters/saga-dash.mjs
@@ -1,0 +1,91 @@
+/**
+ * saga-dash adapter — baseUrl + a storageState built from `ss stack login`'s cookie jar.
+ *
+ * `ss stack login --output-json` mints a headless session against iam-api and writes
+ * the captured cookies (iam_session JWT + iam_refresh) as a Netscape cookie jar at
+ * `<stateDir>/cookies.txt` (saga-stack-cli's `packages/node/saga-stack-cli/src/runtime/login.ts`).
+ * This adapter shells out to that command, parses its jar, and converts it into the
+ * Playwright `storageState` shape record.mjs hands to `browser.newContext()`.
+ *
+ * Run `ss stack up --with dash` and `ss stack login` yourself before recording — this
+ * adapter mints a fresh jar on every call (session cookies decay if iam restarts; don't
+ * try to cache one across runs).
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { readFile } from 'node:fs/promises';
+
+const execFileAsync = promisify(execFile);
+
+const BASE_URL = process.env.WALKTHROUGH_DASH_URL ?? 'http://localhost:8900';
+const DASH_ORIGIN = new URL(BASE_URL).origin;
+
+/** Parse one Netscape-jar row into a Playwright cookie object. */
+function parseNetscapeLine(line) {
+  if (!line || line.startsWith('#') && !line.startsWith('#HttpOnly_')) return null;
+  const httpOnly = line.startsWith('#HttpOnly_');
+  const rest = httpOnly ? line.slice('#HttpOnly_'.length) : line;
+  const parts = rest.split('\t');
+  if (parts.length < 7) return null;
+  const [rawDomain, includeSubdomains, path, secure, expires, name, value] = parts;
+  // Netscape's includeSubdomains flag maps to Playwright's leading-dot domain convention.
+  const domain = includeSubdomains === 'TRUE' && !rawDomain.startsWith('.') ? `.${rawDomain}` : rawDomain;
+
+  return {
+    name,
+    value,
+    domain,
+    path,
+    // Netscape jars store 0 for session cookies; Playwright wants -1 for "session".
+    expires: Number(expires) > 0 ? Number(expires) : -1,
+    httpOnly,
+    secure: secure === 'TRUE',
+    sameSite: 'Lax',
+  };
+}
+
+function parseNetscapeJar(contents) {
+  return contents
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter((line) => line.length > 0 && !(line.startsWith('#') && !line.startsWith('#HttpOnly_')))
+    .map(parseNetscapeLine)
+    .filter((c) => c !== null);
+}
+
+/**
+ * Run `ss stack login`, parse the resulting cookie jar, and return a Playwright
+ * storageState object ({cookies, origins: []}) ready for `browser.newContext()`.
+ *
+ * Defaults to `ss`'s own default persona (dev@saga.org). Override with
+ * WALKTHROUGH_LOGIN_EMAIL for a walkthrough that needs a specific seeded persona
+ * (e.g. an already-rostered, zero-programs org for a program-creation demo).
+ */
+async function getStorageState() {
+  const loginArgs = ['stack', 'login', '--output-json'];
+  if (process.env.WALKTHROUGH_LOGIN_EMAIL) loginArgs.splice(2, 0, process.env.WALKTHROUGH_LOGIN_EMAIL);
+
+  const { stdout } = await execFileAsync('ss', loginArgs).catch((err) => {
+    throw new Error(
+      `\`ss stack login\` failed — is the stack up (\`ss stack up --with dash\`)? ` +
+        `Original error: ${err.message}`,
+    );
+  });
+
+  const result = JSON.parse(stdout);
+  if (!result.ok) {
+    throw new Error(`ss stack login reported failure (status ${result.status}) — see its output above.`);
+  }
+
+  const jarContents = await readFile(result.jarPath, 'utf8');
+  const cookies = parseNetscapeJar(jarContents);
+
+  return { cookies, origins: [] };
+}
+
+export default {
+  baseUrl: BASE_URL,
+  origin: DASH_ORIGIN,
+  getStorageState,
+};

--- a/tools/walkthrough-video/lib/make.mjs
+++ b/tools/walkthrough-video/lib/make.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+/**
+ * make.mjs — one-shot orchestrator: narrate → record → stitch for a given walkthrough.
+ *
+ *   node lib/make.mjs --walkthrough saga-dash/entity-pages
+ *   SKIP_NARRATE=1 node lib/make.mjs --walkthrough saga-dash/entity-pages   # iterate on actions/timing
+ *   SKIP_RECORD=1  node lib/make.mjs --walkthrough saga-dash/entity-pages  # iterate on stitch/SRT
+ *
+ * Does NOT bring the stack up/down itself — run `ss stack up --with dash` (and
+ * `ss stack login`) first. See README.md for the full recipe.
+ */
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { narrateAll } from './narrate.mjs';
+import { record } from './record.mjs';
+import { stitch } from './stitch.mjs';
+
+const TOOL_ROOT = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+
+function parseArgs(argv) {
+  const args = { walkthrough: null };
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === '--walkthrough') {
+      args.walkthrough = argv[i + 1];
+      i += 1;
+    }
+  }
+  return args;
+}
+
+async function main() {
+  const { walkthrough } = parseArgs(process.argv.slice(2));
+  if (!walkthrough || !walkthrough.includes('/')) {
+    console.error('Usage: node lib/make.mjs --walkthrough <app>/<feature>');
+    console.error('Example: node lib/make.mjs --walkthrough saga-dash/entity-pages');
+    process.exit(1);
+  }
+
+  const [app, feature] = walkthrough.split('/');
+  const walkthroughDir = path.join(TOOL_ROOT, 'walkthroughs', app, feature);
+  const outDir = walkthroughDir;
+
+  const { STEPS } = await import(path.join(walkthroughDir, 'steps.mjs'));
+  const { default: adapter } = await import(path.join(TOOL_ROOT, 'adapters', `${app}.mjs`));
+
+  if (process.env.SKIP_NARRATE !== '1') {
+    console.log(`[narrate] ${STEPS.length} steps…`);
+    await narrateAll(STEPS, outDir);
+  } else {
+    console.log('[narrate] skipped (SKIP_NARRATE=1)');
+  }
+
+  if (process.env.SKIP_RECORD !== '1') {
+    console.log(`[record] driving ${adapter.baseUrl}…`);
+    await record(STEPS, adapter, outDir);
+  } else {
+    console.log('[record] skipped (SKIP_RECORD=1)');
+  }
+
+  console.log('[stitch] muxing + generating SRT…');
+  const { mp4Path, vp9Path, srtPath } = await stitch(STEPS, outDir);
+
+  console.log('\nDone:');
+  console.log(`  ${mp4Path}`);
+  console.log(`  ${vp9Path}`);
+  console.log(`  ${srtPath}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tools/walkthrough-video/lib/narrate.mjs
+++ b/tools/walkthrough-video/lib/narrate.mjs
@@ -1,0 +1,156 @@
+/**
+ * narrate.mjs — per-step OpenAI TTS synthesis with content-hash caching.
+ *
+ * Reads a walkthrough's steps.mjs (STEPS array of {id, narration, ...}), synthesizes
+ * one MP3 per step via OpenAI's /v1/audio/speech, and writes:
+ *   chunks/<id>.mp3       — the synthesized narration audio
+ *   durations.json        — { [id]: durationSeconds } (via ffprobe)
+ *   chunks-meta.json      — { [id]: { hash, model, voice } } — the cache key
+ *
+ * Caching: a step is only re-synthesized if sha256(model + voice + narration) differs
+ * from what's recorded in chunks-meta.json for that id. Set FORCE=1 to bypass.
+ */
+
+import { createHash } from 'node:crypto';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const TTS_MODEL = process.env.TTS_MODEL ?? 'tts-1-hd';
+const TTS_VOICE = process.env.TTS_VOICE ?? 'onyx';
+const FORCE = process.env.FORCE === '1';
+
+// Dev OpenAI key lives in Secrets Manager, not a local .env — see README § Prerequisites.
+const OPENAI_SECRET_ARN =
+  'arn:aws:secretsmanager:us-west-2:531314149529:secret:openai-dev-apikey-W3MunH';
+const AWS_PROFILE = process.env.WALKTHROUGH_AWS_PROFILE ?? 'saga-dev';
+
+let cachedApiKey = null;
+
+async function resolveApiKey() {
+  if (cachedApiKey) return cachedApiKey;
+  if (process.env.OPENAI_API_KEY) {
+    cachedApiKey = process.env.OPENAI_API_KEY;
+    return cachedApiKey;
+  }
+
+  const { stdout } = await execFileAsync('aws', [
+    'secretsmanager', 'get-secret-value',
+    '--secret-id', OPENAI_SECRET_ARN,
+    '--profile', AWS_PROFILE,
+    '--query', 'SecretString',
+    '--output', 'text',
+  ]).catch((err) => {
+    throw new Error(
+      `Failed to fetch OpenAI key from Secrets Manager (${OPENAI_SECRET_ARN}, profile ` +
+        `${AWS_PROFILE}). Set OPENAI_API_KEY directly to bypass, or check AWS auth. ` +
+        `Original error: ${err.message}`,
+    );
+  });
+
+  const raw = stdout.trim();
+  // The secret may be a bare string or a JSON blob like {"apiKey":"sk-..."}.
+  try {
+    const parsed = JSON.parse(raw);
+    cachedApiKey = parsed.apiKey ?? parsed.OPENAI_API_KEY ?? parsed.key ?? raw;
+  } catch {
+    cachedApiKey = raw;
+  }
+  return cachedApiKey;
+}
+
+function hashFor(model, voice, narration) {
+  return createHash('sha256').update(`${model}\n${voice}\n${narration}`).digest('hex');
+}
+
+async function readJsonIfExists(filePath, fallback) {
+  if (!existsSync(filePath)) return fallback;
+  try {
+    return JSON.parse(await readFile(filePath, 'utf8'));
+  } catch {
+    return fallback;
+  }
+}
+
+async function probeDurationSeconds(filePath) {
+  const { stdout } = await execFileAsync('ffprobe', [
+    '-v', 'error',
+    '-show_entries', 'format=duration',
+    '-of', 'default=noprint_wrappers=1:nokey=1',
+    filePath,
+  ]);
+  return Number.parseFloat(stdout.trim());
+}
+
+async function synthesize(narration) {
+  const apiKey = await resolveApiKey();
+
+  const res = await fetch('https://api.openai.com/v1/audio/speech', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: TTS_MODEL,
+      voice: TTS_VOICE,
+      input: narration,
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`OpenAI TTS request failed: ${res.status} ${res.statusText} — ${body}`);
+  }
+
+  return Buffer.from(await res.arrayBuffer());
+}
+
+/**
+ * Synthesize narration audio for every step in `steps`, writing outputs under `outDir`.
+ * Returns { durations: {[id]: seconds} } for record.mjs's slot-timing math.
+ */
+export async function narrateAll(steps, outDir) {
+  const chunksDir = path.join(outDir, 'chunks');
+  await mkdir(chunksDir, { recursive: true });
+
+  const metaPath = path.join(outDir, 'chunks-meta.json');
+  const durationsPath = path.join(outDir, 'durations.json');
+  const prevMeta = await readJsonIfExists(metaPath, {});
+  const prevDurations = await readJsonIfExists(durationsPath, {});
+
+  const meta = {};
+  const durations = {};
+
+  for (const step of steps) {
+    const hash = hashFor(TTS_MODEL, TTS_VOICE, step.narration);
+    const mp3Path = path.join(chunksDir, `${step.id}.mp3`);
+    const cacheHit =
+      !FORCE &&
+      prevMeta[step.id]?.hash === hash &&
+      existsSync(mp3Path) &&
+      typeof prevDurations[step.id] === 'number';
+
+    if (cacheHit) {
+      meta[step.id] = prevMeta[step.id];
+      durations[step.id] = prevDurations[step.id];
+      console.log(`  ${step.id}: cache hit`);
+      continue;
+    }
+
+    console.log(`  ${step.id}: synthesizing (${TTS_MODEL}/${TTS_VOICE})…`);
+    const audio = await synthesize(step.narration);
+    await writeFile(mp3Path, audio);
+    durations[step.id] = await probeDurationSeconds(mp3Path);
+    meta[step.id] = { hash, model: TTS_MODEL, voice: TTS_VOICE };
+  }
+
+  await writeFile(metaPath, JSON.stringify(meta, null, 2));
+  await writeFile(durationsPath, JSON.stringify(durations, null, 2));
+
+  return { durations };
+}

--- a/tools/walkthrough-video/lib/narrate.mjs
+++ b/tools/walkthrough-video/lib/narrate.mjs
@@ -1,14 +1,25 @@
 /**
- * narrate.mjs — per-step OpenAI TTS synthesis with content-hash caching.
+ * narrate.mjs — per-step TTS synthesis with content-hash caching.
  *
  * Reads a walkthrough's steps.mjs (STEPS array of {id, narration, ...}), synthesizes
- * one MP3 per step via OpenAI's /v1/audio/speech, and writes:
+ * one MP3 per step via a pluggable TTS engine, and writes:
  *   chunks/<id>.mp3       — the synthesized narration audio
  *   durations.json        — { [id]: durationSeconds } (via ffprobe)
  *   chunks-meta.json      — { [id]: { hash, model, voice } } — the cache key
  *
- * Caching: a step is only re-synthesized if sha256(model + voice + narration) differs
- * from what's recorded in chunks-meta.json for that id. Set FORCE=1 to bypass.
+ * Engines (TTS_ENGINE env, default "openai"):
+ *   openai — tts-1-hd/onyx by default. Needs OPENAI_API_KEY, or an AWS profile that can
+ *            read the dev key from Secrets Manager (see README § Prerequisites).
+ *   edge   — free, no API key, no AWS creds. Microsoft Edge's online TTS via the `edge-tts`
+ *            npm package (unofficial, reverse-engineered). KNOWN BROKEN as of 2026-07: its
+ *            hardcoded auth token returns 403 (Microsoft periodically rotates/blocks it —
+ *            out of our control to fix). Kept as a pluggable option in case it starts
+ *            working again or gets patched upstream; don't rely on it today. For a free/
+ *            cheap iteration tier, use SKIP_NARRATE=1 instead (silent render) rather than
+ *            this engine.
+ *
+ * Caching: a step is only re-synthesized if sha256(engine + model + voice + narration)
+ * differs from what's recorded in chunks-meta.json for that id. Set FORCE=1 to bypass.
  */
 
 import { createHash } from 'node:crypto';
@@ -17,14 +28,28 @@ import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { tts as edgeTts } from 'edge-tts/out/index.js';
 
 const execFileAsync = promisify(execFile);
 
-const TTS_MODEL = process.env.TTS_MODEL ?? 'tts-1-hd';
-const TTS_VOICE = process.env.TTS_VOICE ?? 'onyx';
+const TTS_ENGINE = process.env.TTS_ENGINE ?? 'openai';
 const FORCE = process.env.FORCE === '1';
 
+const ENGINE_DEFAULTS = {
+  edge: { model: 'edge-tts', voice: process.env.TTS_VOICE ?? 'en-US-GuyNeural' },
+  openai: { model: process.env.TTS_MODEL ?? 'tts-1-hd', voice: process.env.TTS_VOICE ?? 'onyx' },
+};
+
+if (!ENGINE_DEFAULTS[TTS_ENGINE]) {
+  throw new Error(`Unknown TTS_ENGINE "${TTS_ENGINE}" — expected "edge" or "openai".`);
+}
+
+const { model: TTS_MODEL, voice: TTS_VOICE } = ENGINE_DEFAULTS[TTS_ENGINE];
+
 // Dev OpenAI key lives in Secrets Manager, not a local .env — see README § Prerequisites.
+// Note: Observer-tier profiles (saga, saga-dev) are denied GetSecretValue on this ARN —
+// set WALKTHROUGH_AWS_PROFILE to a profile with access, or set OPENAI_API_KEY to bypass
+// Secrets Manager entirely. Only consulted when TTS_ENGINE=openai.
 const OPENAI_SECRET_ARN =
   'arn:aws:secretsmanager:us-west-2:531314149529:secret:openai-dev-apikey-W3MunH';
 const AWS_PROFILE = process.env.WALKTHROUGH_AWS_PROFILE ?? 'saga-dev';
@@ -63,8 +88,8 @@ async function resolveApiKey() {
   return cachedApiKey;
 }
 
-function hashFor(model, voice, narration) {
-  return createHash('sha256').update(`${model}\n${voice}\n${narration}`).digest('hex');
+function hashFor(engine, model, voice, narration) {
+  return createHash('sha256').update(`${engine}\n${model}\n${voice}\n${narration}`).digest('hex');
 }
 
 async function readJsonIfExists(filePath, fallback) {
@@ -86,7 +111,7 @@ async function probeDurationSeconds(filePath) {
   return Number.parseFloat(stdout.trim());
 }
 
-async function synthesize(narration) {
+async function synthesizeOpenai(narration) {
   const apiKey = await resolveApiKey();
 
   const res = await fetch('https://api.openai.com/v1/audio/speech', {
@@ -110,6 +135,14 @@ async function synthesize(narration) {
   return Buffer.from(await res.arrayBuffer());
 }
 
+async function synthesizeEdge(narration) {
+  return Buffer.from(await edgeTts(narration, { voice: TTS_VOICE }));
+}
+
+async function synthesize(narration) {
+  return TTS_ENGINE === 'edge' ? synthesizeEdge(narration) : synthesizeOpenai(narration);
+}
+
 /**
  * Synthesize narration audio for every step in `steps`, writing outputs under `outDir`.
  * Returns { durations: {[id]: seconds} } for record.mjs's slot-timing math.
@@ -127,7 +160,7 @@ export async function narrateAll(steps, outDir) {
   const durations = {};
 
   for (const step of steps) {
-    const hash = hashFor(TTS_MODEL, TTS_VOICE, step.narration);
+    const hash = hashFor(TTS_ENGINE, TTS_MODEL, TTS_VOICE, step.narration);
     const mp3Path = path.join(chunksDir, `${step.id}.mp3`);
     const cacheHit =
       !FORCE &&
@@ -142,11 +175,11 @@ export async function narrateAll(steps, outDir) {
       continue;
     }
 
-    console.log(`  ${step.id}: synthesizing (${TTS_MODEL}/${TTS_VOICE})…`);
+    console.log(`  ${step.id}: synthesizing (${TTS_ENGINE}/${TTS_MODEL}/${TTS_VOICE})…`);
     const audio = await synthesize(step.narration);
     await writeFile(mp3Path, audio);
     durations[step.id] = await probeDurationSeconds(mp3Path);
-    meta[step.id] = { hash, model: TTS_MODEL, voice: TTS_VOICE };
+    meta[step.id] = { hash, engine: TTS_ENGINE, model: TTS_MODEL, voice: TTS_VOICE };
   }
 
   await writeFile(metaPath, JSON.stringify(meta, null, 2));

--- a/tools/walkthrough-video/lib/record.mjs
+++ b/tools/walkthrough-video/lib/record.mjs
@@ -80,6 +80,7 @@ export async function record(steps, adapter, outDir) {
 
   const browser = await chromium.launch();
   const context = await browser.newContext({
+    baseURL: adapter.baseUrl,
     viewport: VIEWPORT,
     storageState,
     recordVideo: { dir: videoDir, size: VIEWPORT },

--- a/tools/walkthrough-video/lib/record.mjs
+++ b/tools/walkthrough-video/lib/record.mjs
@@ -1,0 +1,131 @@
+/**
+ * record.mjs — drive a Playwright-scriptable web app through a walkthrough's STEPS,
+ * recording video and measuring each step's actual on-screen duration so stitch.mjs
+ * can pad narration to match.
+ *
+ * App-agnostic: takes an `adapter` (baseUrl + getStorageState()) and a `steps` array
+ * ({id, narration, action(page), tailSlack?}). Nothing here is saga-dash-specific —
+ * that lives in adapters/<app>.mjs and walkthroughs/<app>/<feature>/steps.mjs.
+ *
+ * Sync model: slot[N] = max(actionDuration[N], narrationDuration[N]) + tailSlack[N].
+ * The recorder waits exactly that long before moving to step N+1 — it does not need
+ * durations.json to run, but uses it (when present) to right-size each wait.
+ */
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { chromium } from 'playwright';
+
+const VIEWPORT = { width: 1440, height: 900 };
+
+const CURSOR_OVERLAY = `
+(() => {
+  const cursor = document.createElement('div');
+  cursor.id = '__walkthrough_cursor__';
+  Object.assign(cursor.style, {
+    position: 'fixed',
+    zIndex: '2147483647',
+    width: '26px',
+    height: '26px',
+    borderRadius: '50%',
+    background: 'rgba(220, 38, 38, 0.55)',
+    border: '2px solid rgba(220, 38, 38, 0.9)',
+    pointerEvents: 'none',
+    transition: 'left 220ms ease-out, top 220ms ease-out, transform 120ms ease-out',
+    transform: 'translate(-50%, -50%)',
+    left: '-100px',
+    top: '-100px',
+  });
+  document.documentElement.appendChild(cursor);
+  window.__moveWalkthroughCursor = (x, y) => {
+    cursor.style.left = x + 'px';
+    cursor.style.top = y + 'px';
+  };
+  window.__clickWalkthroughCursor = () => {
+    cursor.style.transform = 'translate(-50%, -50%) scale(0.7)';
+    setTimeout(() => { cursor.style.transform = 'translate(-50%, -50%) scale(1)'; }, 120);
+  };
+})();
+`;
+
+/** Move the cursor overlay to a locator's center with a smooth multi-step glide. */
+export async function smoothClick(page, locator) {
+  const box = await locator.boundingBox().catch(() => null);
+  if (box) {
+    const x = box.x + box.width / 2;
+    const y = box.y + box.height / 2;
+    await page.evaluate(([px, py]) => window.__moveWalkthroughCursor?.(px, py), [x, y]);
+    await page.mouse.move(x, y, { steps: 18 });
+    await page.waitForTimeout(120);
+    await page.evaluate(() => window.__clickWalkthroughCursor?.());
+  }
+  await locator.click();
+}
+
+/**
+ * Run every step in `steps` against `adapter`, recording video to `outDir/video`.
+ * Returns { slots: {[id]: {audio, action, slot}} } — also written to slots.json.
+ */
+export async function record(steps, adapter, outDir) {
+  const durationsPath = path.join(outDir, 'durations.json');
+  const durations = existsSync(durationsPath)
+    ? JSON.parse(await readFile(durationsPath, 'utf8'))
+    : {};
+
+  const videoDir = path.join(outDir, 'video');
+  await mkdir(videoDir, { recursive: true });
+
+  const storageState = await adapter.getStorageState();
+
+  const browser = await chromium.launch();
+  const context = await browser.newContext({
+    viewport: VIEWPORT,
+    storageState,
+    recordVideo: { dir: videoDir, size: VIEWPORT },
+  });
+  await context.addInitScript(CURSOR_OVERLAY);
+
+  const page = await context.newPage();
+  await page.goto(adapter.baseUrl, { waitUntil: 'domcontentloaded' });
+
+  const slots = {};
+
+  for (const step of steps) {
+    const narrationDuration = durations[step.id] ?? 0;
+    const tailSlack = (step.tailSlack ?? 0) / 1000;
+
+    const actionStart = Date.now();
+    await step.action(page);
+    const actionDuration = (Date.now() - actionStart) / 1000;
+
+    const slot = Math.max(actionDuration, narrationDuration) + tailSlack;
+    if (actionDuration > narrationDuration + 0.05) {
+      console.warn(
+        `  ⚠ ${step.id}: action (${actionDuration.toFixed(1)}s) exceeded audio (${narrationDuration.toFixed(1)}s)`,
+      );
+    }
+    console.log(
+      `  ${step.id}: audio=${narrationDuration.toFixed(1)}s action=${actionDuration.toFixed(1)}s slot=${slot.toFixed(1)}s`,
+    );
+
+    const remaining = slot - actionDuration;
+    if (remaining > 0) await page.waitForTimeout(remaining * 1000);
+
+    slots[step.id] = { audio: narrationDuration, action: actionDuration, slot };
+  }
+
+  await context.close();
+  await browser.close();
+
+  const recordedVideoPath = await page.video()?.path().catch(() => null);
+  const finalWebmPath = path.join(videoDir, 'walkthrough.webm');
+  if (recordedVideoPath && recordedVideoPath !== finalWebmPath && existsSync(recordedVideoPath)) {
+    const { rename } = await import('node:fs/promises');
+    await rename(recordedVideoPath, finalWebmPath);
+  }
+
+  await writeFile(path.join(outDir, 'slots.json'), JSON.stringify(slots, null, 2));
+
+  return { slots };
+}

--- a/tools/walkthrough-video/lib/stitch.mjs
+++ b/tools/walkthrough-video/lib/stitch.mjs
@@ -15,6 +15,7 @@
  */
 
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
@@ -47,9 +48,27 @@ function buildSrt(steps, slots) {
 }
 
 /**
+ * Generate `targetSeconds` of silence at `outPath` — used when a step has no narration
+ * chunk (SKIP_NARRATE=1 runs), so the audio track still spans the full recorded video.
+ */
+async function silenceOfLength(targetSeconds, outPath) {
+  await execFileAsync('ffmpeg', [
+    '-y',
+    '-f', 'lavfi',
+    '-i', 'anullsrc=r=48000:cl=stereo',
+    '-t', `${Math.max(targetSeconds, 0.1)}`,
+    outPath,
+  ]);
+}
+
+/**
  * Pad `mp3Path` with trailing silence to reach `targetSeconds`, writing `outPath`.
  */
 async function padToSlot(mp3Path, targetSeconds, outPath) {
+  if (!existsSync(mp3Path)) {
+    await silenceOfLength(targetSeconds, outPath);
+    return;
+  }
   await execFileAsync('ffmpeg', [
     '-y',
     '-i', mp3Path,

--- a/tools/walkthrough-video/lib/stitch.mjs
+++ b/tools/walkthrough-video/lib/stitch.mjs
@@ -1,0 +1,149 @@
+/**
+ * stitch.mjs — pad each narration chunk to its recorded slot, concat into one audio
+ * track, mux it onto the recorded video, and emit an SRT built from slot timestamps.
+ *
+ * Inputs (all under a walkthrough's outDir, produced by narrate.mjs + record.mjs):
+ *   chunks/<id>.mp3      — per-step narration audio
+ *   slots.json           — { [id]: { audio, action, slot } } (seconds), in step order
+ *   video/walkthrough.webm
+ *
+ * Outputs:
+ *   video/walkthrough.mp4          — H.264 + AAC, muxed
+ *   video/walkthrough-vp9.webm     — VP9 + Opus sidecar (avoids the GStreamer/Totem
+ *                                    H.264 playback trap on some Linux desktops)
+ *   video/walkthrough.srt          — subtitles from cumulative slot timestamps
+ */
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+function srtTimestamp(totalSeconds) {
+  const ms = Math.round(totalSeconds * 1000);
+  const h = Math.floor(ms / 3_600_000);
+  const m = Math.floor((ms % 3_600_000) / 60_000);
+  const s = Math.floor((ms % 60_000) / 1000);
+  const millis = ms % 1000;
+  const pad = (n, len = 2) => String(n).padStart(len, '0');
+  return `${pad(h)}:${pad(m)}:${pad(s)},${pad(millis, 3)}`;
+}
+
+function buildSrt(steps, slots) {
+  let cursor = 0;
+  const blocks = [];
+  steps.forEach((step, i) => {
+    const slot = slots[step.id]?.slot ?? 0;
+    const start = cursor;
+    const end = cursor + slot;
+    blocks.push(
+      `${i + 1}\n${srtTimestamp(start)} --> ${srtTimestamp(end)}\n${step.narration}\n`,
+    );
+    cursor = end;
+  });
+  return blocks.join('\n');
+}
+
+/**
+ * Pad `mp3Path` with trailing silence to reach `targetSeconds`, writing `outPath`.
+ */
+async function padToSlot(mp3Path, targetSeconds, outPath) {
+  await execFileAsync('ffmpeg', [
+    '-y',
+    '-i', mp3Path,
+    '-af', `apad=whole_dur=${targetSeconds}`,
+    '-ar', '48000',
+    '-ac', '2',
+    outPath,
+  ]);
+}
+
+async function concatAudio(paddedPaths, listPath, outPath) {
+  const listContents = paddedPaths.map((p) => `file '${path.resolve(p)}'`).join('\n');
+  await writeFile(listPath, listContents);
+  await execFileAsync('ffmpeg', [
+    '-y',
+    '-f', 'concat',
+    '-safe', '0',
+    '-i', listPath,
+    '-c', 'copy',
+    outPath,
+  ]);
+}
+
+async function muxMp4(videoPath, audioPath, outPath) {
+  await execFileAsync('ffmpeg', [
+    '-y',
+    '-i', videoPath,
+    '-i', audioPath,
+    '-c:v', 'libx264',
+    '-pix_fmt', 'yuv420p',
+    '-c:a', 'aac',
+    '-b:a', '192k',
+    '-shortest',
+    outPath,
+  ]);
+}
+
+async function muxVp9Sidecar(webmPath, audioPath, outPath) {
+  await execFileAsync('ffmpeg', [
+    '-y',
+    '-i', webmPath,
+    '-i', audioPath,
+    '-c:v', 'libvpx-vp9',
+    '-crf', '32',
+    '-b:v', '0',
+    '-deadline', 'good',
+    '-cpu-used', '4',
+    '-pix_fmt', 'yuv420p',
+    '-r', '25',
+    '-c:a', 'libopus',
+    '-b:a', '96k',
+    '-ar', '48000',
+    '-ac', '2',
+    '-shortest',
+    '-f', 'webm',
+    outPath,
+  ]);
+}
+
+/**
+ * Run the full stitch stage for one walkthrough. `steps` is the STEPS array (order
+ * matters — it's the SRT/audio-concat order); `outDir` holds chunks/slots/video per
+ * the layout above.
+ */
+export async function stitch(steps, outDir) {
+  const videoDir = path.join(outDir, 'video');
+  await mkdir(videoDir, { recursive: true });
+
+  const slots = JSON.parse(await readFile(path.join(outDir, 'slots.json'), 'utf8'));
+
+  const paddedDir = path.join(outDir, 'chunks-padded');
+  await mkdir(paddedDir, { recursive: true });
+
+  const paddedPaths = [];
+  for (const step of steps) {
+    const mp3Path = path.join(outDir, 'chunks', `${step.id}.mp3`);
+    const slotSeconds = slots[step.id]?.slot ?? 0;
+    const paddedPath = path.join(paddedDir, `${step.id}.mp3`);
+    await padToSlot(mp3Path, slotSeconds, paddedPath);
+    paddedPaths.push(paddedPath);
+  }
+
+  const concatListPath = path.join(paddedDir, 'concat-list.txt');
+  const fullAudioPath = path.join(outDir, 'video', 'walkthrough.audio.mp3');
+  await concatAudio(paddedPaths, concatListPath, fullAudioPath);
+
+  const webmPath = path.join(videoDir, 'walkthrough.webm');
+  const mp4Path = path.join(videoDir, 'walkthrough.mp4');
+  const vp9Path = path.join(videoDir, 'walkthrough-vp9.webm');
+  await muxMp4(webmPath, fullAudioPath, mp4Path);
+  await muxVp9Sidecar(webmPath, fullAudioPath, vp9Path);
+
+  const srtPath = path.join(videoDir, 'walkthrough.srt');
+  await writeFile(srtPath, buildSrt(steps, slots));
+
+  return { mp4Path, vp9Path, srtPath };
+}

--- a/tools/walkthrough-video/walkthroughs/saga-dash/program-creation/steps.mjs
+++ b/tools/walkthrough-video/walkthroughs/saga-dash/program-creation/steps.mjs
@@ -1,0 +1,101 @@
+/**
+ * Narrated walkthrough: creating a new program in saga-dash.
+ *
+ * Mirrors the real e2e coverage in
+ * apps/web/dash/e2e/journey/program-creation.e2e.test.ts (saga-stack-cli flow
+ * `saga-dash/journey`, stage `program`) — same route, same form fields, same
+ * selectors. Precondition: the `empty@saga.org` persona (an already-rostered org
+ * with zero programs, baked into the IAM seed — see
+ * apps/web/dash/e2e/data/seed-users.ts), so `/programs` auto-redirects to
+ * `/programs/new/config`. Record with:
+ *   WALKTHROUGH_LOGIN_EMAIL=empty@saga.org node lib/make.mjs --walkthrough saga-dash/program-creation
+ */
+
+import { smoothClick } from '../../../lib/record.mjs';
+
+const PROGRAM_NAME = 'Walkthrough Demo Program';
+
+export const STEPS = [
+  {
+    id: '00-intro',
+    narration:
+      "Welcome to the program creation walkthrough in Saga Dash. We'll start from " +
+      'the Programs page and create a brand new program from scratch.',
+    action: async (page) => {
+      await page.goto('/programs');
+      await page.waitForURL('**/programs/new/config', { timeout: 15000 });
+      await page.waitForSelector('#pd-name', { timeout: 15000 });
+    },
+    tailSlack: 800,
+  },
+  {
+    id: '01-name',
+    narration:
+      "Since this district has no programs yet, we're dropped straight into the new " +
+      `program form. First, we give it a name: "${PROGRAM_NAME}".`,
+    action: async (page) => {
+      await page.locator('#pd-name').fill(PROGRAM_NAME);
+    },
+    tailSlack: 500,
+  },
+  {
+    id: '02-timezone',
+    narration: 'Next, the program time zone — we pick Central Time, America Chicago.',
+    action: async (page) => {
+      await page.locator('.field-timezone select').selectOption('America/Chicago');
+    },
+    tailSlack: 500,
+  },
+  {
+    id: '03-address',
+    narration:
+      'Address details are optional, but filling them in helps identify the program later. ' +
+      'We enter one two three West Madison Street, Chicago.',
+    action: async (page) => {
+      await page.locator('#pd-address').fill('123 W Madison St');
+      await page.locator('#pd-city').fill('Chicago');
+    },
+    tailSlack: 500,
+  },
+  {
+    id: '04-state-zip',
+    narration: 'Then the state — Illinois — and the ZIP code, six oh six oh one.',
+    action: async (page) => {
+      await page.locator('.field-state select').selectOption('IL');
+      await page.locator('#pd-zip').fill('60601');
+    },
+    tailSlack: 500,
+  },
+  {
+    id: '05-save',
+    narration:
+      "With everything filled in, we click Save. Saga Dash creates the program and takes " +
+      'us straight to its overview page.',
+    action: async (page) => {
+      const saveButton = page.getByRole('button', { name: 'Save', exact: true });
+      await smoothClick(page, saveButton);
+      await page.waitForURL('**/programs/*/config', { timeout: 15000 });
+    },
+    tailSlack: 1000,
+  },
+  {
+    id: '06-overview',
+    narration:
+      'And there it is — the new program overview, showing the name we chose. Saga Dash ' +
+      'also flags that the program still needs people enrolled before it can go live.',
+    action: async (page) => {
+      await page.waitForSelector(`text=${PROGRAM_NAME}`, { timeout: 10000 });
+    },
+    tailSlack: 1200,
+  },
+  {
+    id: '99-outro',
+    narration:
+      "That's the full program creation flow — name, time zone, address, and save. " +
+      'Thanks for watching.',
+    action: async (page) => {
+      await page.waitForTimeout(500);
+    },
+    tailSlack: 1500,
+  },
+];


### PR DESCRIPTION
## Summary

Adds `tools/walkthrough-video/` — a reusable, app-agnostic harness for producing narrated demo videos (synced cursor, TTS voiceover, SRT subtitles) of any saga-soa frontend, driven by `saga-stack-cli` for local stack lifecycle.

Generalizes `docs/how-to-narrated-walkthrough-video.md` (prototyped once against an SDS demo in May 2026, on a `saga-dash@sds_92` branch that no longer exists) into an **engine vs. data** split so it lives once here instead of being copy-pasted per repo:

- `lib/narrate.mjs`, `lib/record.mjs`, `lib/stitch.mjs`, `lib/make.mjs` — app-agnostic engine (pluggable TTS with content-hash caching, Playwright + cursor overlay + slot timing, ffmpeg mux + SRT + VP9 sidecar).
- `adapters/saga-dash.mjs` — the one per-app piece needed so far; shells out to `ss stack login --output-json`, parses its Netscape cookie jar, converts to a Playwright `storageState`.
- `walkthroughs/saga-dash/program-creation/steps.mjs` — a real worked example mirroring `apps/web/dash/e2e/journey/program-creation.e2e.test.ts`'s selectors exactly (same route, same form fields).

TTS defaults to OpenAI (`tts-1-hd`/`onyx`), key pulled from Secrets Manager rather than a local `.env` — see `narrate.mjs`. An `edge` engine option exists for free/no-credential narration but is currently non-functional (see Known issues).

## Verification status: LIVE-VERIFIED end to end

Ran the full pipeline against a real local stack (`ss stack up --with dash`) and produced a real `walkthrough.mp4` (9.8s, 195KB) + VP9 sidecar + synced SRT, frame-checked against the actual rendered saga-dash program overview page. Playwright drove the real program-creation flow (name → timezone → address → state/zip → Save → overview verification) via the `ss stack login`-based auth adapter.

Three real bugs surfaced and fixed along the way (see commit `090bbf0`):

- **record.mjs** was missing `baseURL` on the Playwright context, so `steps.mjs`'s relative `page.goto('/programs')` calls failed outright.
- **stitch.mjs** assumed every step has a narration mp3 and crashed under `SKIP_NARRATE=1`; now generates silence via ffmpeg's `anullsrc` for missing chunks.
- **saga-dash itself** had a stale workspace link: `@saga-ed/dash-global-search` wasn't symlinked into `node_modules`, causing a 500 on every page via `TopBar.svelte`. Fixed with `pnpm install` + `ss stack restart` (app-level issue, not part of this harness, but blocked verification until found).

Also fixed two pre-existing environment issues unrelated to this change, hit while bringing the stack up:
- Stale `dist/` in `program-hub`'s `program-hub-service-kit` (missing `slotNotProjected` export) — rebuilt.
- Same staleness class in `program-hub`'s `programs-events` package — rebuilt via full `pnpm build` (turbo).

## Known issues

- **`edge` TTS engine is broken.** The unofficial `edge-tts` npm wrapper's hardcoded Microsoft auth token returns 403 (Microsoft periodically rotates/blocks it — outside our control). Kept as a pluggable option in case it's patched upstream. For a free/zero-credential iteration tier, use `SKIP_NARRATE=1` (silent, action-timed render) instead.
- **OpenAI Secrets Manager read needs a non-Observer AWS profile.** `saga`/`saga-dev` (Observer tier) are explicitly denied `GetSecretValue` on the dev OpenAI key (it lives in a different/prod-tier account than Observer-dev covers). Set `WALKTHROUGH_AWS_PROFILE` to a profile with access, or set `OPENAI_API_KEY` directly to bypass Secrets Manager. A fully-narrated (non-`SKIP_NARRATE`) render has not yet been produced in this environment for that reason — the silent render is the verified path so far.

## Test plan

- [x] `node --check` on every new file
- [x] Live render: `ss stack up --with dash` + `SKIP_NARRATE=1 WALKTHROUGH_LOGIN_EMAIL=empty@saga.org node tools/walkthrough-video/lib/make.mjs --walkthrough saga-dash/program-creation` — confirmed `walkthrough.mp4`/`-vp9.webm`/`.srt` output, correct in-app flow, frame-verified
- [ ] A fully-narrated OpenAI render, once an AWS profile with Secrets Manager access (or a pasted `OPENAI_API_KEY`) is available
- [ ] Re-run with `SKIP_RECORD=1` after a narration-only edit — confirm fast re-stitch
- [ ] Edit one step's narration, re-run without `FORCE=1` — confirm only that step's audio re-synthesizes (cache hit on the rest)
