### PR TITLE
feat(saga-stack-cli): ss set create / rm — M13-C worktree-set concierge

### DIFF
--- a/packages/node/saga-stack-cli/docs/getting-started.md
+++ b/packages/node/saga-stack-cli/docs/getting-started.md
@@ -328,27 +328,33 @@ stack. See **[integration.md](./integration.md)**.
 ### 8b. A feature branch on slot 1 — via a worktree set
 
 To run a branch **without disturbing slot 0**, put it in a git worktree and bind it to a slot with a
-**worktree set**. There's no `ss` worktree helper yet — create the worktree with plain git, then
-register the set (a hand-edited JSON map of repo→path, bound to a slot):
+**worktree set**. `ss set create` is the one-command concierge — it does the `git worktree add` (new
+branch here), `pnpm install`s the worktree so the prep fresh-skip guard is happy, and records the set
+in `~/.saga-stack/worktree-sets.json` with provenance (`createdBy: ss`), bound to the slot:
 
 ```bash
-# 1. worktree + branch (plain git), then pre-install so the prep fresh-skip guard is happy
+ss set create feat-sched --slot 1 --repo saga-dash \
+  --path ~/dev/worktrees/saga-dash-sched --branch feat/sched-tweak
+```
+
+<details><summary>What it did — and the manual equivalent</summary>
+
+`--branch` is created if new, **attached** if it already exists; `--base <ref>` sets the start point
+(default: the primary checkout's HEAD). Skip the install with `--no-install`. The slot is part of the
+set (1–9; slot 0 is the baseline). Equivalent by hand (still fully supported — the file is
+hand-editable, and `$SAGA_STACK_SETS` overrides its location):
+
+```bash
 git -C ~/dev/saga-dash worktree add ~/dev/worktrees/saga-dash-sched -b feat/sched-tweak
 ( cd ~/dev/worktrees/saga-dash-sched && pnpm install )
+# then add to ~/.saga-stack/worktree-sets.json:
+#   { "version": 1, "sets": { "feat-sched": { "slot": 1,
+#       "repos": { "saga-dash": "~/dev/worktrees/saga-dash-sched" } } } }
 ```
+</details>
 
-Register it in `~/.saga-stack/worktree-sets.json` (or `$SAGA_STACK_SETS`) — the `slot` is part of
-the set (1–9; slot 0 is reserved for the baseline):
-
-```jsonc
-{ "version": 1, "sets": {
-    "feat-sched": { "slot": 1, "note": "scheduling tweak",
-                    "repos": { "saga-dash": "~/dev/worktrees/saga-dash-sched" } }
-} }
-```
-
-Validate, bring it up, and run a flow — all on slot 1, addressed by `--set` (which supplies the slot
-and pins the repo to your worktree; the rest of the closure comes from your default checkouts):
+Bring it up and run a flow — all on slot 1, addressed by `--set` (which supplies the slot and pins
+the repo to your worktree; the rest of the closure comes from your default checkouts):
 
 ```bash
 ss set check feat-sched                                         # preflight: paths, build posture, drift
@@ -368,25 +374,19 @@ mechanism for running a branch on its own slot. `--set` plus a conflicting `--sl
 
 ### 8c. A second branch on slot 2 — a different worktree, a different flow
 
-Repeat with another worktree bound to **slot 2** — the two run fully isolated, side by side:
+Repeat with another worktree bound to **slot 2** (unique slot — two sets can't share one):
 
 ```bash
-git -C ~/dev/saga-dash worktree add ~/dev/worktrees/saga-dash-conn -b feat/connect-polish
-( cd ~/dev/worktrees/saga-dash-conn && pnpm install )
-```
-
-Add a second set (unique slot — two sets can't share one):
-
-```jsonc
-"feat-conn": { "slot": 2, "note": "connect polish",
-               "repos": { "saga-dash": "~/dev/worktrees/saga-dash-conn" } }
-```
-
-```bash
+ss set create feat-conn --slot 2 --repo saga-dash \
+  --path ~/dev/worktrees/saga-dash-conn --branch feat/connect-polish
 ss set check feat-conn
 ss stack up --set feat-conn
 ss e2e run --set feat-conn saga-dash/connect-session --headless   # a different flow, on slot 2
 ```
+
+Tear a set down when you're done — `ss set rm feat-conn` drops the set (worktrees left on disk), or
+`ss set rm feat-conn --and-worktrees --yes` also `git worktree remove`s the worktrees `ss` created
+(a hand-recorded checkout is never touched).
 
 Slot 1 (`feat-sched`) and slot 2 (`feat-conn`) now hold independent stacks on different branches —
 different ports, DBs and pidfiles — so `journey` on slot 1 and `connect-session` on slot 2 never
@@ -472,7 +472,7 @@ and **[worktree-sets.md](./worktree-sets.md)**.
 | `ss stack seed [--with …] [--scenario …]` / `reset` | Seed a running stack (add-ons + named datasets/scenarios) / truncate to an empty baseline + re-seed | [sub-stacks](./sub-stacks-and-bundles.md) |
 | `ss stack snapshot store\|restore\|list` | Save/restore a known-good DB state in seconds | [snapshots](./snapshots.md) |
 | `ss e2e run\|list\|connect` | Run/discover data-driven flows; open a live Connect session | [e2e](./e2e.md) |
-| `ss set list\|show\|check` + `--set <name>` | Named worktree sets: parallel dev contexts (repo map + slot) for `up`/`e2e run`/… | [worktree-sets](./worktree-sets.md) |
+| `ss set create\|rm\|list\|show\|check` + `--set <name>` | Named worktree sets: create/tear-down a worktree+branch+slot binding, then run `up`/`e2e run`/… against it | [worktree-sets](./worktree-sets.md) |
 | `ss stack overlay\|bootstrap\|login\|tunnel` | Integration workflows (in-flight PRs, one-command bring-up, personas, sharing) | [integration](./integration.md) |
 | `ss stack cold-start [--dry-run] [--all-docker]` | Clean slate: docker wipe (`down -v`) → repos to main → clean build → `.env` → up → verify (destructive; slot-0) | [cold-start](./cold-start.md) |
 | `ss stack down [--mesh] [--slot N]` | Stop the stack natively | [slots](./slots.md) |

--- a/packages/node/saga-stack-cli/docs/worktree-sets.md
+++ b/packages/node/saga-stack-cli/docs/worktree-sets.md
@@ -89,17 +89,19 @@ This exact scenario is validated live (see PR soa#236): parallel feature context
 with its own flows, interpretable against a clean-main control.
 
 ```bash
-# worktrees (ss records paths in the MVP; `set create` lands in M13-C)
-git -C ~/dev/saga-dash worktree add ~/dev/worktrees/saga-dash-a feat/x
-git -C ~/dev/saga-dash worktree add ~/dev/worktrees/saga-dash-b flow/topology
-(cd ~/dev/worktrees/saga-dash-a && pnpm install)     # pre-build ⇒ fresh-skip
-(cd ~/dev/worktrees/saga-dash-b && pnpm install)
-# …author each worktree's apps/web/dash/e2e/flows.json, define sets a@1 b@2, then:
+# ss set create (M13-C) does the worktree add + pnpm install + records the set:
+ss set create a --slot 1 --repo saga-dash --path ~/dev/worktrees/saga-dash-a --branch feat/x
+ss set create b --slot 2 --repo saga-dash --path ~/dev/worktrees/saga-dash-b --branch flow/topology
+# …author each worktree's apps/web/dash/e2e/flows.json, then:
 
 ss e2e run saga-dash/journey --through schedule      # baseline: main, slot 0
 ss e2e run --set a saga-dash/my-flow-a &             # concurrently…
 ss e2e run --set b saga-dash/my-flow-b &             # …on slots 1 and 2
 ```
+
+Tear a set down with `ss set rm <name>` (drops the set) or `ss set rm <name> --and-worktrees --yes`
+(also `git worktree remove`s the worktrees `ss` created — `createdBy: ss`; hand-recorded paths are
+never touched). The set file stays hand-editable, and `$SAGA_STACK_SETS` overrides its location.
 
 Each run's Playwright output shows its own worktree (spec paths + flow/stage lists come
 from that worktree's `flows.json`); containers/volumes/state/DBs stay disjoint per slot.
@@ -114,8 +116,8 @@ from that worktree's `flows.json`); containers/volumes/state/DBs stay disjoint p
   building is what the guard refuses).
 - ACTIVE in `ss set list` is **derived live** (state-dir pids + compose containers) —
   there is no recorded state to go stale.
-- Fast-follows: `ss set create --from-branches` / `rm --and-worktrees` (M13-C), an
-  `e2e run --baseline` clean-main preflight (M13-D). Plan of record:
+- `ss set create` / `set rm [--and-worktrees]` (M13-C) are now shipped (above). Remaining
+  fast-follow: an `e2e run --baseline` clean-main preflight (M13-D). Plan of record:
   `soa/claude/projects/gh_214/plans/10-m13-worktree-sets.md`.
 
 ← [Slots](./slots.md) · [e2e](./e2e.md)

--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -651,6 +651,197 @@
         "check.js"
       ]
     },
+    "set:create": {
+      "aliases": [],
+      "args": {
+        "name": {
+          "description": "set name (must be unused)",
+          "name": "name",
+          "required": true
+        }
+      },
+      "description": "Create a worktree set: git worktree add (new/existing branch) off the primary checkout, pnpm install, and record it in the sets file (createdBy: ss). Single repo per call.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> sched --slot 1 --repo saga-dash --path ~/dev/worktrees/saga-dash-sched --branch feat/sched",
+        "<%= config.bin %> <%= command.id %> topo --slot 2 --repo saga-dash --path ~/dev/worktrees/saga-dash-topo --branch flow/topology --no-install"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "slot the set binds (1..9; slot 0 is the primary-checkout baseline)",
+          "name": "slot",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "default": "/home/skelly/dev",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "repo": {
+          "description": "repo to make a worktree for",
+          "name": "repo",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "soa",
+            "rostering",
+            "program-hub",
+            "saga-dash",
+            "coach",
+            "sds",
+            "qboard",
+            "rtsm",
+            "fleek"
+          ],
+          "type": "option"
+        },
+        "path": {
+          "description": "worktree checkout path (recorded verbatim; `~` stays portable)",
+          "name": "path",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "branch": {
+          "description": "branch to check out — created if new, attached if it exists (default: the set name)",
+          "name": "branch",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "base": {
+          "description": "start point for a NEW branch (default: the primary checkout HEAD, e.g. main)",
+          "name": "base",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "note": {
+          "description": "optional note stored on the set",
+          "name": "note",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "install": {
+          "description": "pnpm install in the new worktree so `--set` up/e2e fresh-skip (use --no-install to skip)",
+          "name": "install",
+          "allowNo": true,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "set:create",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "set",
+        "create.js"
+      ]
+    },
     "set:list": {
       "aliases": [],
       "args": {},
@@ -780,6 +971,161 @@
         "commands",
         "set",
         "list.js"
+      ]
+    },
+    "set:rm": {
+      "aliases": [],
+      "args": {
+        "name": {
+          "description": "set name (see `set list`)",
+          "name": "name",
+          "required": true
+        }
+      },
+      "description": "Remove a worktree set from the sets file. --and-worktrees also `git worktree remove`s the ss-created worktrees (createdBy: ss); hand-recorded paths are never touched.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> sched",
+        "<%= config.bin %> <%= command.id %> sched --and-worktrees --yes"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "default": "/home/skelly/dev",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "and-worktrees": {
+          "description": "also `git worktree remove` the worktrees ss created (createdBy: ss); requires --yes",
+          "name": "and-worktrees",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "force": {
+          "description": "pass --force to `git worktree remove` (a dirty/locked worktree)",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "yes": {
+          "description": "confirm the destructive --and-worktrees removal (required with it)",
+          "name": "yes",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "set:rm",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "set",
+        "rm.js"
       ]
     },
     "set:show": {

--- a/packages/node/saga-stack-cli/src/commands/set/__tests__/set-create-rm.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/set/__tests__/set-create-rm.int.test.ts
@@ -1,0 +1,236 @@
+/**
+ * `set create` / `set rm` (M13-C) — in-process, seams faked on BaseCommand.prototype:
+ * the set store (in-memory, capturing `save`), the git runner (`worktreeAdd`/
+ * `worktreeRemove`/`revParseVerify`), and the pnpm Runner. Real fs only for the primary
+ * checkout's `.git` (create's existence gate) and the worktree-path collision gate.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Config } from '@oclif/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BaseCommand } from '../../../base-command.js';
+import { parseWorktreeSetsFile, type WorktreeSetsFile } from '../../../core/set/index.js';
+import type { GitRunner, SetStore } from '../../../runtime/index.js';
+import type { Runner, ScriptInvocation } from '../../../runtime/exec.js';
+import SetCreate from '../create.js';
+import SetRm from '../rm.js';
+
+const PKG_ROOT = process.cwd();
+let config: Config;
+let dir: string;
+let devRoot: string;
+let saved: WorktreeSetsFile | null;
+let gitCalls: { verb: string; args: unknown[] }[];
+let runCalls: ScriptInvocation[];
+
+const empty = (): WorktreeSetsFile => parseWorktreeSetsFile({ version: 1, sets: {} });
+const primary = (): string => join(devRoot, 'saga-dash');
+
+function installStore(initial: WorktreeSetsFile): void {
+  let current = initial;
+  saved = null;
+  const store: SetStore = {
+    path: () => join(dir, 'sets.json'),
+    load: () => current,
+    loadRaw: () => current,
+    save: (f) => {
+      current = f;
+      saved = f;
+    },
+  };
+  vi.spyOn(BaseCommand.prototype as unknown as { getSetStore: () => SetStore }, 'getSetStore').mockReturnValue(store);
+}
+
+function installGit(
+  opts: { branchExists?: boolean; addOk?: boolean; addErr?: string; removeOk?: boolean; removeErr?: string } = {},
+): void {
+  const fake: Partial<GitRunner> = {
+    revParseVerify: async () => opts.branchExists ?? false,
+    worktreeAdd: async (repoPath, worktreePath, ref, o) => {
+      gitCalls.push({ verb: 'add', args: [repoPath, worktreePath, ref, o] });
+      return { ok: opts.addOk ?? true, stderr: opts.addErr ?? '' };
+    },
+    worktreeRemove: async (repoPath, worktreePath, o) => {
+      gitCalls.push({ verb: 'remove', args: [repoPath, worktreePath, o] });
+      return { ok: opts.removeOk ?? true, stderr: opts.removeErr ?? '' };
+    },
+  };
+  vi.spyOn(BaseCommand.prototype as unknown as { getGitRunner: () => GitRunner }, 'getGitRunner').mockReturnValue(fake as GitRunner);
+}
+
+beforeEach(async () => {
+  config = await Config.load(PKG_ROOT);
+  dir = mkdtempSync(join(tmpdir(), 'set-crud-'));
+  devRoot = join(dir, 'dev');
+  mkdirSync(join(devRoot, 'saga-dash', '.git'), { recursive: true }); // the primary checkout
+  gitCalls = [];
+  runCalls = [];
+  vi.spyOn(BaseCommand.prototype, 'log').mockImplementation(() => {});
+  const runner: Runner = {
+    async run(spec) {
+      runCalls.push(spec);
+      return { code: 0 };
+    },
+  };
+  vi.spyOn(BaseCommand.prototype as unknown as { getRunner: () => Runner }, 'getRunner').mockReturnValue(runner);
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('set create', () => {
+  it('worktree-adds a NEW branch off the primary and records the set (createdBy ss, createdFrom)', async () => {
+    installStore(empty());
+    installGit({ branchExists: false });
+    const wt = join(dir, 'wt-dash');
+    await SetCreate.run(
+      ['sched', '--slot', '1', '--repo', 'saga-dash', '--path', wt, '--branch', 'feat/x', '--dev', devRoot, '--no-install'],
+      config,
+    );
+    expect(gitCalls).toEqual([{ verb: 'add', args: [primary(), wt, 'feat/x', { newBranch: true, startPoint: undefined }] }]);
+    expect(saved!.sets.sched!.slot).toBe(1);
+    expect(saved!.sets.sched!.repos['saga-dash']).toEqual({ path: wt, createdBy: 'ss', createdFrom: 'feat/x' });
+    expect(runCalls).toHaveLength(0); // --no-install
+  });
+
+  it('defaults the branch to the set name and runs pnpm install in the worktree', async () => {
+    installStore(empty());
+    installGit({ branchExists: false });
+    const wt = join(dir, 'wt-dash');
+    await SetCreate.run(['sched', '--slot', '1', '--repo', 'saga-dash', '--path', wt, '--dev', devRoot], config);
+    expect(saved!.sets.sched!.repos['saga-dash']!.createdFrom).toBe('sched'); // default branch = name
+    expect(runCalls).toHaveLength(1);
+    expect(runCalls[0]!.cwd).toBe(wt);
+    expect(runCalls[0]!.args).toEqual(['install']);
+  });
+
+  it('attaches an EXISTING branch (no -b)', async () => {
+    installStore(empty());
+    installGit({ branchExists: true });
+    const wt = join(dir, 'wt-dash');
+    await SetCreate.run(
+      ['sched', '--slot', '1', '--repo', 'saga-dash', '--path', wt, '--branch', 'existing', '--dev', devRoot, '--no-install'],
+      config,
+    );
+    expect(gitCalls[0]!.args[3]).toEqual({ newBranch: false, startPoint: undefined });
+  });
+
+  it('passes --base as the start point for a new branch', async () => {
+    installStore(empty());
+    installGit({ branchExists: false });
+    const wt = join(dir, 'wt-dash');
+    await SetCreate.run(
+      ['sched', '--slot', '1', '--repo', 'saga-dash', '--path', wt, '--branch', 'feat/x', '--base', 'main', '--dev', devRoot, '--no-install'],
+      config,
+    );
+    expect(gitCalls[0]!.args[3]).toEqual({ newBranch: true, startPoint: 'main' });
+  });
+
+  it('rejects slot 0', async () => {
+    installStore(empty());
+    installGit();
+    await expect(
+      SetCreate.run(['s', '--slot', '0', '--repo', 'saga-dash', '--path', join(dir, 'wt'), '--dev', devRoot, '--no-install'], config),
+    ).rejects.toThrow(/--slot must be 1..9/);
+  });
+
+  it('rejects a duplicate set name (before touching git)', async () => {
+    installStore(parseWorktreeSetsFile({ version: 1, sets: { sched: { slot: 2, repos: { rostering: '/wt/r' } } } }));
+    installGit();
+    await expect(
+      SetCreate.run(['sched', '--slot', '1', '--repo', 'saga-dash', '--path', join(dir, 'wt'), '--dev', devRoot, '--no-install'], config),
+    ).rejects.toThrow(/already exists/);
+    expect(gitCalls).toHaveLength(0);
+  });
+
+  it('rejects a slot already owned', async () => {
+    installStore(parseWorktreeSetsFile({ version: 1, sets: { other: { slot: 1, repos: { rostering: '/wt/r' } } } }));
+    installGit();
+    await expect(
+      SetCreate.run(['sched', '--slot', '1', '--repo', 'saga-dash', '--path', join(dir, 'wt'), '--dev', devRoot, '--no-install'], config),
+    ).rejects.toThrow(/slot 1 is already owned/);
+  });
+
+  it('rejects when the worktree path already exists', async () => {
+    installStore(empty());
+    installGit();
+    const wt = join(dir, 'exists');
+    mkdirSync(wt);
+    await expect(
+      SetCreate.run(['sched', '--slot', '1', '--repo', 'saga-dash', '--path', wt, '--dev', devRoot, '--no-install'], config),
+    ).rejects.toThrow(/already exists/);
+  });
+
+  it('rejects when the primary checkout is missing', async () => {
+    installStore(empty());
+    installGit();
+    const emptyDev = join(dir, 'emptydev');
+    mkdirSync(emptyDev);
+    await expect(
+      SetCreate.run(['sched', '--slot', '1', '--repo', 'saga-dash', '--path', join(dir, 'wt'), '--dev', emptyDev, '--no-install'], config),
+    ).rejects.toThrow(/primary checkout for 'saga-dash' not found/);
+  });
+
+  it('surfaces a git worktree add failure (and does not record the set)', async () => {
+    installStore(empty());
+    installGit({ addOk: false, addErr: "fatal: 'x' already checked out" });
+    await expect(
+      SetCreate.run(['sched', '--slot', '1', '--repo', 'saga-dash', '--path', join(dir, 'wt'), '--dev', devRoot, '--no-install'], config),
+    ).rejects.toThrow(/git worktree add failed.*already checked out/);
+    expect(saved).toBeNull();
+  });
+});
+
+describe('set rm', () => {
+  const oneSsSet = (): WorktreeSetsFile =>
+    parseWorktreeSetsFile({
+      version: 1,
+      sets: { sched: { slot: 1, repos: { 'saga-dash': { path: '/wt/dash', createdBy: 'ss', createdFrom: 'feat/x' } } } },
+    });
+
+  it('drops only the set entry by default (worktrees left on disk)', async () => {
+    installStore(oneSsSet());
+    installGit();
+    await SetRm.run(['sched', '--dev', devRoot], config);
+    expect(gitCalls).toHaveLength(0);
+    expect(saved!.sets.sched).toBeUndefined();
+  });
+
+  it('--and-worktrees --yes removes the ss-created worktree and the set', async () => {
+    installStore(oneSsSet());
+    installGit();
+    await SetRm.run(['sched', '--and-worktrees', '--yes', '--dev', devRoot], config);
+    expect(gitCalls).toEqual([{ verb: 'remove', args: [primary(), '/wt/dash', { force: false }] }]);
+    expect(saved!.sets.sched).toBeUndefined();
+  });
+
+  it('passes --force through to git worktree remove', async () => {
+    installStore(oneSsSet());
+    installGit();
+    await SetRm.run(['sched', '--and-worktrees', '--yes', '--force', '--dev', devRoot], config);
+    expect(gitCalls[0]!.args[2]).toEqual({ force: true });
+  });
+
+  it('--and-worktrees without --yes errors (destructive)', async () => {
+    installStore(oneSsSet());
+    installGit();
+    await expect(SetRm.run(['sched', '--and-worktrees', '--dev', devRoot], config)).rejects.toThrow(/re-run with --yes/);
+  });
+
+  it('NEVER removes a hand-recorded (non-ss) worktree, but still drops the set', async () => {
+    installStore(parseWorktreeSetsFile({ version: 1, sets: { sched: { slot: 1, repos: { 'saga-dash': '/wt/hand' } } } }));
+    installGit();
+    await SetRm.run(['sched', '--and-worktrees', '--yes', '--dev', devRoot], config);
+    expect(gitCalls).toHaveLength(0); // skipped — not createdBy ss
+    expect(saved!.sets.sched).toBeUndefined();
+  });
+
+  it('unknown set errors', async () => {
+    installStore(empty());
+    installGit();
+    await expect(SetRm.run(['nope', '--dev', devRoot], config)).rejects.toThrow(/unknown set 'nope'/);
+  });
+});

--- a/packages/node/saga-stack-cli/src/commands/set/create.ts
+++ b/packages/node/saga-stack-cli/src/commands/set/create.ts
@@ -1,0 +1,144 @@
+/**
+ * `saga-stack set create <name>` — the M13-C concierge for a worktree set (plan §5,
+ * saga-ed/soa#214). Collapses the hand-managed 8b flow — `git worktree add` +
+ * hand-edit `~/.saga-stack/worktree-sets.json` — into one command:
+ *
+ *   1. `git -C <primary> worktree add [-b <branch>] <path> [<base>]` off the repo's
+ *      PRIMARY checkout (`<dev>/<default-dir>`), attaching an existing `--branch` or
+ *      creating a new one (default: the set name);
+ *   2. best-effort `pnpm install` in the new worktree (satisfies the prep fresh-skip
+ *      guard so `--set` up/e2e don't rebuild from cold) — skip with `--no-install`;
+ *   3. record the set in the sets file with `createdBy: 'ss'` + `createdFrom: <branch>`
+ *      (the provenance that later gates `set rm --and-worktrees` and powers the drift
+ *      report in `set check`).
+ *
+ * SLOT-AWARE so `--slot 1..9` (the slot the set binds) passes the central guard; the
+ * set OWNS its slot, so the write is refused if that slot is already taken. Single-repo
+ * per invocation (the common case — most sets pin one repo); multi-repo sets stay
+ * hand-editable.
+ *
+ *   ss set create sched --slot 1 --repo saga-dash --path ~/dev/worktrees/saga-dash-sched --branch feat/sched
+ */
+
+import { Args, Flags } from '@oclif/core';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname } from 'node:path';
+import { BaseCommand } from '../../base-command.js';
+import {
+  SET_REPO_KEYS,
+  withSetAdded,
+  type SetRepoKey,
+  type WorktreeSet,
+} from '../../core/set/index.js';
+import {
+  REPO_DEFAULT_DIR,
+  REPO_ENV_VAR,
+  normalizeSetPath,
+  resolveDevRoot,
+} from '../../runtime/index.js';
+
+export default class SetCreate extends BaseCommand {
+  static description =
+    'Create a worktree set: git worktree add (new/existing branch) off the primary checkout, pnpm install, and record it in the sets file (createdBy: ss). Single repo per call.';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> sched --slot 1 --repo saga-dash --path ~/dev/worktrees/saga-dash-sched --branch feat/sched',
+    '<%= config.bin %> <%= command.id %> topo --slot 2 --repo saga-dash --path ~/dev/worktrees/saga-dash-topo --branch flow/topology --no-install',
+  ];
+
+  static args = {
+    name: Args.string({ description: 'set name (must be unused)', required: true }),
+  };
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    slot: Flags.integer({
+      description: 'slot the set binds (1..9; slot 0 is the primary-checkout baseline)',
+      required: true,
+    }),
+    repo: Flags.string({
+      description: 'repo to make a worktree for',
+      options: [...SET_REPO_KEYS],
+      required: true,
+    }),
+    path: Flags.string({ description: 'worktree checkout path (recorded verbatim; `~` stays portable)', required: true }),
+    branch: Flags.string({ description: 'branch to check out — created if new, attached if it exists (default: the set name)' }),
+    base: Flags.string({ description: 'start point for a NEW branch (default: the primary checkout HEAD, e.g. main)' }),
+    note: Flags.string({ description: 'optional note stored on the set' }),
+    install: Flags.boolean({
+      description: 'pnpm install in the new worktree so `--set` up/e2e fresh-skip (use --no-install to skip)',
+      default: true,
+      allowNo: true,
+    }),
+  };
+
+  // `--slot 1..9` is data (the slot the set binds), not a run-target — opt past the guard.
+  protected slotAware(): boolean {
+    return true;
+  }
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(SetCreate);
+    const name = args.name;
+    const repo = flags.repo as SetRepoKey;
+
+    if (flags.slot < 1 || flags.slot > 9) {
+      return this.error(`--slot must be 1..9 (slot 0 is the primary-checkout baseline); got ${flags.slot}.`);
+    }
+
+    const store = this.getSetStore();
+    const file = store.loadRaw();
+    // Fail BEFORE touching git if the name/slot are taken (withSetAdded's guards).
+    for (const [n, s] of Object.entries(file.sets)) {
+      if (n === name) return this.error(`a set named '${name}' already exists — pick another name or \`ss set rm ${name}\` first.`);
+      if (s.slot === flags.slot) return this.error(`slot ${flags.slot} is already owned by set '${n}' — pick another slot (1..9).`);
+    }
+
+    // Primary checkout of the repo (`<dev>/<default-dir>`) — the clone worktrees branch off.
+    const ctx = this.scriptContextFromFlags(flags);
+    const primary = `${resolveDevRoot(ctx).replace(/\/+$/, '')}/${REPO_DEFAULT_DIR[REPO_ENV_VAR[repo]]}`;
+    if (!existsSync(`${primary}/.git`)) {
+      return this.error(`primary checkout for '${repo}' not found at ${primary} — clone it first (or pass --dev).`);
+    }
+
+    // Expand the worktree path for the fs/git ops; STORE it verbatim (portable `~`).
+    const expanded = normalizeSetPath(flags.path, homedir(), dirname(store.path()));
+    if (existsSync(expanded)) {
+      return this.error(`worktree path already exists: ${expanded} — remove it or choose another --path.`);
+    }
+
+    const git = this.getGitRunner();
+    const branch = flags.branch ?? name;
+    const branchExists = await git.revParseVerify(primary, `refs/heads/${branch}`);
+
+    this.log(`▶ git worktree add ${expanded} ${branchExists ? `(attach ${branch})` : `(-b ${branch}${flags.base ? ` from ${flags.base}` : ''})`}`);
+    const added = await git.worktreeAdd(primary, expanded, branch, {
+      newBranch: !branchExists,
+      startPoint: branchExists ? undefined : flags.base,
+    });
+    if (!added.ok) {
+      return this.error(`git worktree add failed for ${repo}: ${added.stderr || '(no git output)'}`);
+    }
+
+    // Best-effort install so the prep fresh-skip guard is satisfied (8b).
+    if (flags.install) {
+      this.log(`▶ pnpm install in ${expanded} (skip with --no-install)`);
+      const res = await this.getRunner().run({ cwd: expanded, command: 'pnpm', args: ['install'], env: {}, stdio: 'inherit' });
+      if (res.code !== 0) this.log(`⚠ pnpm install exited ${res.code} — the worktree exists; install it by hand before \`--set ${name}\``);
+    }
+
+    // Record the set (verbatim path + provenance) and persist.
+    const entry = { path: flags.path, createdBy: 'ss' as const, createdFrom: branch };
+    const set: WorktreeSet = {
+      name,
+      slot: flags.slot,
+      repos: { [repo]: entry } as Partial<Record<SetRepoKey, typeof entry>>,
+      ...(flags.note !== undefined ? { note: flags.note } : {}),
+    };
+    store.save(withSetAdded(file, set));
+
+    this.log(`✓ set '${name}' → slot ${flags.slot}, ${repo} @ ${branch}`);
+    this.log(`  next: ss set check ${name}  ·  ss stack up --set ${name}  ·  ss e2e run --set ${name} <flow>`);
+  }
+}

--- a/packages/node/saga-stack-cli/src/commands/set/rm.ts
+++ b/packages/node/saga-stack-cli/src/commands/set/rm.ts
@@ -1,0 +1,82 @@
+/**
+ * `saga-stack set rm <name>` — remove a worktree set (M13-C, plan §5). By default this
+ * only drops the set from `~/.saga-stack/worktree-sets.json` (the worktrees on disk are
+ * left untouched — non-destructive). With `--and-worktrees` it ALSO `git worktree
+ * remove`s the worktrees, but ONLY the ones `ss set create` made (`createdBy: 'ss'`) —
+ * a hand-recorded path (your own checkout / a worktree you made) is never removed.
+ *
+ * Removing worktrees is destructive, so `--and-worktrees` requires `--yes`; a dirty or
+ * locked worktree needs `--force` (passed straight to `git worktree remove`).
+ *
+ *   ss set rm sched                      # drop the set entry only
+ *   ss set rm sched --and-worktrees --yes   # also remove the ss-created worktree(s)
+ */
+
+import { Args, Flags } from '@oclif/core';
+import { BaseCommand } from '../../base-command.js';
+import { resolveSet, withSetRemoved, type SetRepoKey } from '../../core/set/index.js';
+import { REPO_DEFAULT_DIR, REPO_ENV_VAR, resolveDevRoot } from '../../runtime/index.js';
+
+export default class SetRm extends BaseCommand {
+  static description =
+    'Remove a worktree set from the sets file. --and-worktrees also `git worktree remove`s the ss-created worktrees (createdBy: ss); hand-recorded paths are never touched.';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> sched',
+    '<%= config.bin %> <%= command.id %> sched --and-worktrees --yes',
+  ];
+
+  static args = {
+    name: Args.string({ description: 'set name (see `set list`)', required: true }),
+  };
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    'and-worktrees': Flags.boolean({
+      description: 'also `git worktree remove` the worktrees ss created (createdBy: ss); requires --yes',
+      default: false,
+    }),
+    force: Flags.boolean({ description: 'pass --force to `git worktree remove` (a dirty/locked worktree)', default: false }),
+    yes: Flags.boolean({ description: 'confirm the destructive --and-worktrees removal (required with it)', default: false }),
+  };
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(SetRm);
+    const name = args.name;
+
+    const store = this.getSetStore();
+    let set;
+    try {
+      set = resolveSet(store.load(), name); // load() ⇒ expanded paths for git worktree remove
+    } catch (err) {
+      return this.error((err as Error).message);
+    }
+
+    if (flags['and-worktrees']) {
+      if (!flags.yes) {
+        return this.error('--and-worktrees removes worktrees from disk — re-run with --yes to confirm.');
+      }
+      const ctx = this.scriptContextFromFlags(flags);
+      const git = this.getGitRunner();
+      for (const repo of Object.keys(set.repos) as SetRepoKey[]) {
+        const entry = set.repos[repo];
+        if (entry === undefined) continue;
+        if (entry.createdBy !== 'ss') {
+          this.log(`  · ${repo.padEnd(12)} left as-is (not ss-created): ${entry.path}`);
+          continue;
+        }
+        const primary = `${resolveDevRoot(ctx).replace(/\/+$/, '')}/${REPO_DEFAULT_DIR[REPO_ENV_VAR[repo]]}`;
+        const removed = await git.worktreeRemove(primary, entry.path, { force: flags.force });
+        if (removed.ok) {
+          this.log(`  ✓ ${repo.padEnd(12)} worktree removed: ${entry.path}`);
+        } else {
+          this.log(`  ✗ ${repo.padEnd(12)} git worktree remove failed: ${removed.stderr || '(no output)'}${flags.force ? '' : ' — retry with --force if dirty'}`);
+        }
+      }
+    }
+
+    // Drop the set from the file (loadRaw ⇒ other sets' verbatim `~` paths survive).
+    store.save(withSetRemoved(store.loadRaw(), name).file);
+    this.log(`✓ set '${name}' removed${flags['and-worktrees'] ? '' : ' (worktrees left on disk — use --and-worktrees to remove them too)'}`);
+  }
+}

--- a/packages/node/saga-stack-cli/src/core/set/__tests__/mutate.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/set/__tests__/mutate.unit.test.ts
@@ -1,0 +1,81 @@
+/**
+ * M13-C pure mutation tests — serialize (on-disk shape), withSetAdded (name/slot
+ * conflict guards), withSetRemoved. No IO; the store round-trips these.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  parseWorktreeSetsFile,
+  serializeWorktreeSetsFile,
+  withSetAdded,
+  withSetRemoved,
+  type WorktreeSet,
+} from '../worktree-sets.js';
+
+const emptyFile = () => parseWorktreeSetsFile({ version: 1, sets: {} });
+const setSched: WorktreeSet = {
+  name: 'sched',
+  slot: 1,
+  repos: { 'saga-dash': { path: '~/dev/worktrees/saga-dash-sched', createdBy: 'ss', createdFrom: 'feat/sched' } },
+  note: 'scheduling tweak',
+};
+
+describe('serializeWorktreeSetsFile', () => {
+  it('keys sets by name, drops the name field, emits object form for created entries', () => {
+    const file = withSetAdded(emptyFile(), setSched);
+    expect(serializeWorktreeSetsFile(file)).toEqual({
+      version: 1,
+      sets: {
+        sched: {
+          slot: 1,
+          repos: { 'saga-dash': { path: '~/dev/worktrees/saga-dash-sched', createdBy: 'ss', createdFrom: 'feat/sched' } },
+          note: 'scheduling tweak',
+        },
+      },
+    });
+  });
+
+  it('emits a BARE STRING for a hand-authored entry with no provenance', () => {
+    const file = parseWorktreeSetsFile({ version: 1, sets: { a: { slot: 3, repos: { rostering: '/wt/r' } } } });
+    expect(serializeWorktreeSetsFile(file).sets.a.repos.rostering).toBe('/wt/r');
+  });
+
+  it('round-trips through parse unchanged (serialize ∘ parse = id)', () => {
+    const file = withSetAdded(emptyFile(), setSched);
+    expect(parseWorktreeSetsFile(serializeWorktreeSetsFile(file))).toEqual(file);
+  });
+});
+
+describe('withSetAdded', () => {
+  it('adds a set without mutating the input', () => {
+    const before = emptyFile();
+    const after = withSetAdded(before, setSched);
+    expect(Object.keys(before.sets)).toEqual([]); // input untouched
+    expect(after.sets.sched?.slot).toBe(1);
+  });
+
+  it('rejects a duplicate name', () => {
+    const file = withSetAdded(emptyFile(), setSched);
+    expect(() => withSetAdded(file, { ...setSched, slot: 2 })).toThrow(/already exists/);
+  });
+
+  it('rejects a slot already owned by another set', () => {
+    const file = withSetAdded(emptyFile(), setSched);
+    expect(() => withSetAdded(file, { ...setSched, name: 'other' })).toThrow(/slot 1 is already owned by set 'sched'/);
+  });
+});
+
+describe('withSetRemoved', () => {
+  it('removes a set and returns it, input untouched', () => {
+    const file = withSetAdded(emptyFile(), setSched);
+    const { file: after, removed } = withSetRemoved(file, 'sched');
+    expect(removed.name).toBe('sched');
+    expect(after.sets.sched).toBeUndefined();
+    expect(file.sets.sched).toBeDefined(); // input untouched
+  });
+
+  it('throws on an unknown set (listing known names)', () => {
+    const file = withSetAdded(emptyFile(), setSched);
+    expect(() => withSetRemoved(file, 'nope')).toThrow(/unknown set 'nope'.*Known sets: sched/);
+  });
+});

--- a/packages/node/saga-stack-cli/src/core/set/worktree-sets.ts
+++ b/packages/node/saga-stack-cli/src/core/set/worktree-sets.ts
@@ -182,6 +182,72 @@ export function parseWorktreeSetsFile(data: unknown): WorktreeSetsFile {
   return { version: WORKTREE_SETS_VERSION, sets };
 }
 
+/** The on-disk JSON shape (sets keyed by name, `name` field dropped, entries object-or-string). */
+export interface WorktreeSetsFileOnDisk {
+  version: typeof WORKTREE_SETS_VERSION;
+  sets: Record<string, { slot: number; repos: Record<string, SetRepoEntry | string>; note?: string }>;
+}
+
+/**
+ * Serialize a validated in-memory file back to the on-disk JSON shape (M13-C `set
+ * create`/`rm` write path). The inverse of `parseWorktreeSetsFile`: sets are keyed by
+ * name (the `name` field is dropped), and a repo entry is emitted as a BARE STRING when
+ * it carries no provenance (matching hand-authored files) or as `{path, createdBy?,
+ * createdFrom?}` when `ss set create` stamped it. Paths are written VERBATIM (a `~` the
+ * caller stored stays portable — the store re-expands it on load).
+ */
+export function serializeWorktreeSetsFile(file: WorktreeSetsFile): WorktreeSetsFileOnDisk {
+  const sets: WorktreeSetsFileOnDisk['sets'] = {};
+  for (const [name, set] of Object.entries(file.sets)) {
+    const repos: Record<string, SetRepoEntry | string> = {};
+    for (const key of Object.keys(set.repos) as SetRepoKey[]) {
+      const e = set.repos[key];
+      if (e === undefined) continue;
+      repos[key] =
+        e.createdBy !== undefined || e.createdFrom !== undefined
+          ? {
+              path: e.path,
+              ...(e.createdBy !== undefined ? { createdBy: e.createdBy } : {}),
+              ...(e.createdFrom !== undefined ? { createdFrom: e.createdFrom } : {}),
+            }
+          : e.path;
+    }
+    sets[name] = { slot: set.slot, repos, ...(set.note !== undefined ? { note: set.note } : {}) };
+  }
+  return { version: WORKTREE_SETS_VERSION, sets };
+}
+
+/**
+ * Return a NEW file with `set` added. Throws the pointed user-facing error when the name
+ * is already taken or the slot is already owned by another set (the same one-set-per-slot
+ * invariant `parseWorktreeSetsFile` enforces, checked here BEFORE any fs write).
+ */
+export function withSetAdded(file: WorktreeSetsFile, set: WorktreeSet): WorktreeSetsFile {
+  if (file.sets[set.name] !== undefined) {
+    throw new Error(`worktree-sets: a set named '${set.name}' already exists — pick another name or \`ss set rm ${set.name}\` first.`);
+  }
+  for (const [name, existing] of Object.entries(file.sets)) {
+    if (existing.slot === set.slot) {
+      throw new Error(`worktree-sets: slot ${set.slot} is already owned by set '${name}' — slots are one-per-set; pick another (1..9).`);
+    }
+  }
+  return { version: file.version, sets: { ...file.sets, [set.name]: set } };
+}
+
+/** Return a NEW file with set `name` removed, plus the removed set. Throws if unknown. */
+export function withSetRemoved(file: WorktreeSetsFile, name: string): { file: WorktreeSetsFile; removed: WorktreeSet } {
+  const removed = file.sets[name];
+  if (removed === undefined) {
+    const names = Object.keys(file.sets);
+    throw new Error(
+      `worktree-sets: unknown set '${name}'.` + (names.length ? ` Known sets: ${names.join(', ')}.` : ' No sets are defined.'),
+    );
+  }
+  const sets = { ...file.sets };
+  delete sets[name];
+  return { file: { version: file.version, sets }, removed };
+}
+
 /**
  * Resolve a `--set <name>` against the store. Throws the user-facing
  * unknown-set error (listing the known names) so the caller can pass it

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/set-store.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/set-store.unit.test.ts
@@ -4,10 +4,11 @@
  * normalization (~ expansion, relative-against-file-dir resolution).
  */
 
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { withSetAdded } from '../../core/set/index.js';
 import { makeRealSetStore, normalizeSetPath, setsFilePath } from '../set-store.js';
 
 let dir: string;
@@ -86,5 +87,43 @@ describe('makeRealSetStore().load', () => {
     );
     const store = makeRealSetStore({ SAGA_STACK_SETS: file }, '/home/u');
     expect(() => store.load()).toThrow(/both declare slot 1/);
+  });
+});
+
+describe('makeRealSetStore().save + loadRaw (M13-C write path)', () => {
+  it('save writes JSON that load reads back; load expands ~, loadRaw keeps it verbatim', () => {
+    const file = join(dir, 'sets.json');
+    const store = makeRealSetStore({ SAGA_STACK_SETS: file }, '/home/u');
+    store.save(
+      withSetAdded(store.loadRaw(), {
+        name: 'sched',
+        slot: 1,
+        repos: { 'saga-dash': { path: '~/wt/dash', createdBy: 'ss', createdFrom: 'feat/x' } },
+      }),
+    );
+    expect(store.load().sets.sched!.repos['saga-dash']!.path).toBe('/home/u/wt/dash'); // expanded
+    expect(store.loadRaw().sets.sched!.repos['saga-dash']).toEqual({
+      path: '~/wt/dash',
+      createdBy: 'ss',
+      createdFrom: 'feat/x',
+    }); // verbatim
+  });
+
+  it('save creates the parent dir when absent (~/.saga-stack)', () => {
+    const file = join(dir, 'nested', 'deep', 'sets.json');
+    const store = makeRealSetStore({ SAGA_STACK_SETS: file }, '/home/u');
+    store.save(withSetAdded(store.loadRaw(), { name: 'a', slot: 2, repos: { rostering: { path: '/wt/r' } } }));
+    expect(store.load().sets.a!.slot).toBe(2);
+  });
+
+  it('a mutating round-trip preserves other sets’ verbatim ~ paths (loadRaw → save)', () => {
+    const file = join(dir, 'sets.json');
+    writeFileSync(file, JSON.stringify({ version: 1, sets: { keep: { slot: 5, repos: { rostering: '~/wt/keep' } } } }));
+    const store = makeRealSetStore({ SAGA_STACK_SETS: file }, '/home/u');
+    store.save(
+      withSetAdded(store.loadRaw(), { name: 'new', slot: 6, repos: { 'saga-dash': { path: '~/wt/new', createdBy: 'ss' } } }),
+    );
+    const raw = JSON.parse(readFileSync(file, 'utf8')) as { sets: Record<string, { repos: Record<string, unknown> }> };
+    expect(raw.sets.keep!.repos.rostering).toBe('~/wt/keep'); // NOT rewritten to absolute
   });
 });

--- a/packages/node/saga-stack-cli/src/runtime/git.ts
+++ b/packages/node/saga-stack-cli/src/runtime/git.ts
@@ -113,6 +113,31 @@ export interface GitRunner {
    * non-zero exit folds to false ⇒ the caller aborts with a clear message).
    */
   clone(url: string, dir: string): Promise<boolean>;
+
+  // ── M13-C worktree verbs (`ss set create` / `set rm --and-worktrees`) ──
+  /**
+   * `git -C <repo> worktree add [-b <branch>] <path> [<startPoint>]` — create a linked
+   * worktree. `opts.newBranch` uses `-b <ref>` (git fails if the branch already exists);
+   * otherwise `<ref>` is an existing branch/commit to check out. Returns `{ok, stderr}` so
+   * the command can surface git's reason (path exists, branch checked out elsewhere, …).
+   */
+  worktreeAdd(
+    repoPath: string,
+    worktreePath: string,
+    ref: string,
+    opts?: { newBranch?: boolean; startPoint?: string },
+  ): Promise<GitTryResult>;
+  /**
+   * `git -C <repo> worktree remove [--force] <path>` — remove a linked worktree. Returns
+   * `{ok, stderr}`; without `--force`, git refuses a dirty/locked worktree (surfaced).
+   */
+  worktreeRemove(repoPath: string, worktreePath: string, opts?: { force?: boolean }): Promise<GitTryResult>;
+}
+
+/** A git verb that reports success + git's stderr (for a pointed user-facing failure). */
+export interface GitTryResult {
+  ok: boolean;
+  stderr: string;
 }
 
 /** Run `git -C <repoPath> …args`; resolve trimmed stdout (`''` on any error). NEVER throws. */
@@ -129,6 +154,15 @@ function gitOk(repoPath: string, args: string[]): Promise<boolean> {
   return new Promise((resolve) => {
     execFile('git', ['-C', repoPath, ...args], { encoding: 'utf8' }, (err) => {
       resolve(!err);
+    });
+  });
+}
+
+/** Run `git -C <repoPath> …args`; resolve `{ok, stderr}` (git's reason on failure). NEVER throws. */
+function gitTry(repoPath: string, args: string[]): Promise<GitTryResult> {
+  return new Promise((resolve) => {
+    execFile('git', ['-C', repoPath, ...args], { encoding: 'utf8' }, (err, _stdout, stderr) => {
+      resolve({ ok: !err, stderr: (stderr ?? '').toString().trim() });
     });
   });
 }
@@ -225,6 +259,29 @@ export function makeRealGitRunner(): GitRunner {
         child.on('error', () => resolve(false));
         child.on('close', (code) => resolve(code === 0));
       });
+    },
+
+    // ── M13-C worktree verbs ──
+    worktreeAdd(
+      repoPath: string,
+      worktreePath: string,
+      ref: string,
+      opts: { newBranch?: boolean; startPoint?: string } = {},
+    ): Promise<GitTryResult> {
+      const args = ['worktree', 'add'];
+      if (opts.newBranch) {
+        args.push('-b', ref, worktreePath);
+        if (opts.startPoint !== undefined && opts.startPoint !== '') args.push(opts.startPoint);
+      } else {
+        args.push(worktreePath, ref);
+      }
+      return gitTry(repoPath, args);
+    },
+    worktreeRemove(repoPath: string, worktreePath: string, opts: { force?: boolean } = {}): Promise<GitTryResult> {
+      const args = ['worktree', 'remove'];
+      if (opts.force) args.push('--force');
+      args.push(worktreePath);
+      return gitTry(repoPath, args);
     },
   };
 }

--- a/packages/node/saga-stack-cli/src/runtime/set-store.ts
+++ b/packages/node/saga-stack-cli/src/runtime/set-store.ts
@@ -17,10 +17,10 @@
  * `getRunner`/`getGitRunner`/`getSnapshotIO`.
  */
 
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
-import { emptyWorktreeSetsFile, parseWorktreeSetsFile } from '../core/set/index.js';
+import { emptyWorktreeSetsFile, parseWorktreeSetsFile, serializeWorktreeSetsFile } from '../core/set/index.js';
 import type { SetRepoKey, WorktreeSetsFile } from '../core/set/index.js';
 
 /** A `process.env`-shaped lookup, injectable for tests. */
@@ -32,6 +32,17 @@ export interface SetStore {
   path(): string;
   /** Parse the sets file; a missing file yields the empty store. */
   load(): WorktreeSetsFile;
+  /**
+   * Parse the sets file WITHOUT `~`/relative path expansion (M13-C mutation path). The
+   * `set create`/`rm` verbs load-raw → mutate → `save`, so other sets' hand-authored `~`
+   * paths survive the round-trip verbatim instead of being rewritten to absolute.
+   */
+  loadRaw(): WorktreeSetsFile;
+  /**
+   * Write the file back as pretty JSON, creating the parent dir. Round-trip VALIDATED
+   * (re-parses the serialized form) so a malformed set is never persisted.
+   */
+  save(file: WorktreeSetsFile): void;
 }
 
 /** `$SAGA_STACK_SETS` override, else `~/.saga-stack/worktree-sets.json`. */
@@ -71,6 +82,24 @@ export function makeRealSetStore(env: EnvLookup = process.env, home: string = ho
         }
       }
       return parsed;
+    },
+    loadRaw(): WorktreeSetsFile {
+      if (!existsSync(file)) return emptyWorktreeSetsFile();
+      let data: unknown;
+      try {
+        data = JSON.parse(readFileSync(file, 'utf8'));
+      } catch (err) {
+        throw new Error(`worktree-sets: ${file} is not valid JSON: ${(err as Error).message}`);
+      }
+      return parseWorktreeSetsFile(data); // no path normalization — verbatim, for round-trip
+    },
+    save(next: WorktreeSetsFile): void {
+      // Round-trip validate: a set that would fail a future load (bad slot, dup, etc.)
+      // must never reach disk.
+      const onDisk = serializeWorktreeSetsFile(next);
+      parseWorktreeSetsFile(onDisk);
+      mkdirSync(dirname(file), { recursive: true });
+      writeFileSync(file, `${JSON.stringify(onDisk, null, 2)}\n`);
     },
   };
 }


### PR DESCRIPTION
## What & why

8b/8c of the getting-started guide required plain `git worktree add` + **hand-editing** `~/.saga-stack/worktree-sets.json`. This adds the concierge the schema was already scaffolded for (the reserved `createdBy: 'ss'` field) — closing the **M13-C** fast-follow of #214.

## Commands

**`ss set create <name> --slot N --repo <key> --path <p> [--branch <b>] [--base <ref>] [--no-install]`**
- `git worktree add` off the repo's **primary** checkout — creates `--branch` if new, **attaches** it if it exists; `--base` sets the start point (default: primary HEAD).
- best-effort `pnpm install` in the worktree (satisfies the prep fresh-skip guard; `--no-install` skips).
- records the set with `createdBy: 'ss'` + `createdFrom: <branch>`.
- slot-aware; refuses a taken name/slot, an existing path, or a missing primary **before** touching git.

**`ss set rm <name> [--and-worktrees] [--force] [--yes]`**
- drops the set (worktrees left on disk by default);
- `--and-worktrees` (requires `--yes`) also `git worktree remove`s **only** the worktrees `ss` created — a hand-recorded path is never removed; `--force` for a dirty/locked worktree.

The sets file stays hand-editable and `$SAGA_STACK_SETS` still overrides its location — the manual path is documented as the equivalent.

## Plumbing (same seam/core-runtime split as the rest)
- **core** (pure): `serializeWorktreeSetsFile`, `withSetAdded`/`withSetRemoved` (name/slot conflict guards).
- **SetStore**: `loadRaw` (verbatim — round-trip fidelity for other sets' `~` paths) + `save` (round-trip-validated write, `mkdir -p`).
- **GitRunner**: `worktreeAdd`/`worktreeRemove` returning `{ok, stderr}` for pointed failures.

## Tests / verification
- **+37**: pure mutate (8), store save/loadRaw round-trip (3), command int suite (16 — new/existing branch, `--base`, install, every guard, rm ss-only + non-ss skip + `--yes` gate).
- **1045 suite + `tsc` + lint green.**
- **Verified live end-to-end**: `create` → `show`/`check` → `rm --and-worktrees` on a real saga-dash worktree (hermetic via `$SAGA_STACK_SETS`, free slot) — worktree + branch created and removed, set file round-tripped.

Docs: 8b/8c + `worktree-sets.md` updated to lead with the commands.

Closes the M13-C fast-follow for #214.

🤖 Generated with [Claude Code](https://claude.com/claude-code)