### PR TITLE
fix(saga-stack-cli): scope non-dash SPA e2e runs to their own base URL + spec

### DIFF
--- a/packages/node/saga-stack-cli/src/__tests__/e2e-orchestrate-slot.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/__tests__/e2e-orchestrate-slot.unit.test.ts
@@ -19,6 +19,7 @@ import { describe, expect, it } from 'vitest';
 import { deriveInstance } from '../core/derive-instance.js';
 import {
   buildStackContext,
+  playwrightArgv,
   playwrightEnv,
   serviceUrlEnv,
   type StackSeams,
@@ -154,6 +155,16 @@ describe('serviceUrlEnv / playwrightEnv — offset Playwright service URLs', () 
     expect(env.PLAYWRIGHT_IAM_URL).toBe('http://localhost:3010');
   });
 
+  it('a non-dash SPA (coach-web) gets ITS OWN port for PLAYWRIGHT_BASE_URL, not saga-dash\'s (regression: coach-web/dashboard opened :8900 and 500\'d before this fix)', () => {
+    const coachResolved = {
+      flow,
+      spa: { id: 'coach-web', system: 'coach-web' },
+    } as unknown as ResolvedFlow;
+    const env = playwrightEnv(coachResolved, now, 'stack', p0);
+    expect(env.PLAYWRIGHT_BASE_URL).toBe('http://localhost:8800'); // coach-web, NOT :8900 (saga-dash)
+    expect(env.PLAYWRIGHT_IAM_URL).toBe('http://localhost:3010');
+  });
+
   it('playwrightEnv on a DEPLOYED lane does NOT inject localhost URLs (lane.ts owns the hostnames)', () => {
     const env = playwrightEnv(resolved, now, 'sandbox', p1);
     expect(env.PLAYWRIGHT_BASE_URL).toBeUndefined();
@@ -187,5 +198,51 @@ describe('serviceUrlEnv / playwrightEnv — offset Playwright service URLs', () 
     expect(env.PLAYWRIGHT_IAM_URL).toBe('http://localhost:4010');
     // ...while flow.env keeps winning for the date env.
     expect(env.PLAYWRIGHT_OCCURRENCE_DATE).toBe('2026-01-05');
+  });
+});
+
+describe('playwrightArgv — spec scoping (single-spawn only, never on a stage override)', () => {
+  const specResolved = {
+    playwright: {
+      config: 'playwright.config.ts',
+      project: 'chromium',
+      headed: false,
+      spec: 'dashboard/dashboard-authenticated.e2e.smoke.test.ts',
+    },
+  } as unknown as ResolvedFlow;
+
+  it('the single-spawn path (no stage override) pushes the terminal spec — scopes a single-project SPA to just that spec', () => {
+    const argv = playwrightArgv(specResolved);
+    expect(argv).toEqual([
+      'exec',
+      'playwright',
+      'test',
+      '--config=playwright.config.ts',
+      '--project',
+      'chromium',
+      'dashboard/dashboard-authenticated.e2e.smoke.test.ts',
+    ]);
+  });
+
+  it('a stage override (bake/--from per-stage spawn) does NOT push the terminal spec (regression guard: pushing it would filter a non-terminal stage.project to a spec it does not contain, running zero tests)', () => {
+    const argv = playwrightArgv(specResolved, [], { project: 'stage-2-program', noDeps: true });
+    expect(argv).toEqual([
+      'exec',
+      'playwright',
+      'test',
+      '--config=playwright.config.ts',
+      '--project',
+      'stage-2-program',
+      '--no-deps',
+    ]);
+    expect(argv).not.toContain('dashboard/dashboard-authenticated.e2e.smoke.test.ts');
+  });
+
+  it('a flow with no spec (progressive saga-dash flows omit it) never pushes an extra positional arg', () => {
+    const noSpecResolved = {
+      playwright: { config: 'playwright.stack.config.ts', project: 'stage-4-pods', headed: false },
+    } as unknown as ResolvedFlow;
+    const argv = playwrightArgv(noSpecResolved);
+    expect(argv).toEqual(['exec', 'playwright', 'test', '--config=playwright.stack.config.ts', '--project', 'stage-4-pods']);
   });
 });

--- a/packages/node/saga-stack-cli/src/__tests__/helpers/pw.ts
+++ b/packages/node/saga-stack-cli/src/__tests__/helpers/pw.ts
@@ -22,6 +22,8 @@ export interface PwArgvOptions {
   noDeps?: boolean;
   /** Append `--grep-invert <tag>` (pipeline runs exclude e.g. `@interactive`). */
   grepInvert?: string;
+  /** Append the terminal stage's `spec` (scopes the run to just that spec file). */
+  spec?: string;
 }
 
 /** Build the expected `pnpm` args array for a spawned Playwright child. */
@@ -30,5 +32,6 @@ export function pwArgv(opts: PwArgvOptions): string[] {
   if (opts.noDeps) argv.push('--no-deps');
   if (opts.grepInvert !== undefined) argv.push('--grep-invert', opts.grepInvert);
   if (opts.headed) argv.push('--headed');
+  if (opts.spec !== undefined) argv.push(opts.spec);
   return argv;
 }

--- a/packages/node/saga-stack-cli/src/commands/e2e/__tests__/e2e.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/__tests__/e2e.int.test.ts
@@ -169,7 +169,9 @@ describe('e2e run — native orchestration (stack lane)', () => {
     // VARIANT argv (T5): differs from run.int's golden literal pin only in the
     // project — built with the shared pwArgv (the literal shape protection
     // lives in run.int.test.ts's happy-path anchor).
-    expect(pw[0].args).toEqual(pwArgv({ project: 'stage-1-roster', grepInvert: '@interactive' }));
+    expect(pw[0].args).toEqual(
+      pwArgv({ project: 'stage-1-roster', grepInvert: '@interactive', spec: 'roster/csv-upload-view.e2e.test.ts' }),
+    );
     expect(pw[0].env?.PLAYWRIGHT_OCCURRENCE_DATE).toMatch(/^\d{4}-\d{2}-\d{2}$/);
     expect(pw[0].stdio).toBe('inherit');
   });

--- a/packages/node/saga-stack-cli/src/commands/e2e/__tests__/run.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/__tests__/run.int.test.ts
@@ -209,6 +209,7 @@ describe('e2e run — native orchestration (stack lane)', () => {
       'stage-4-pods',
       '--grep-invert',
       '@interactive',
+      'journey/pods.e2e.test.ts',
     ]);
     expect(pw[0].args).not.toContain('--headed');
     expect(pw[0].env?.PLAYWRIGHT_OCCURRENCE_DATE).toMatch(/^\d{4}-\d{2}-\d{2}$/);

--- a/packages/node/saga-stack-cli/src/core/flow/__tests__/coach-web.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/flow/__tests__/coach-web.unit.test.ts
@@ -1,0 +1,112 @@
+/**
+ * coach-web THIRD-SPA onboarding proof (plan §5.3, saga-ed/soa#214; coach e2e/
+ * saga-stack-cli parity task). Unlike connectv3's bundled placeholder, coach-web
+ * already has a REAL Playwright suite, so its `flows.json` is authored directly
+ * in the coach repo (`apps/web/coach-web/e2e/flows.json`) rather than bundled
+ * under `examples/flows/` — this test reads it from the sibling checkout the
+ * same way a real `ss e2e run coach-web/dashboard` discovery would (repo root
+ * derived via `$COACH` / `$DEV/coach`, mirroring `discover.ts`).
+ *
+ * Skips (not fails) when the coach checkout isn't present, since saga-stack-cli
+ * doesn't require every mesh repo to be checked out to run its own unit suite.
+ * `it.skipIf` (not a top-level conditional `describe`) keeps this file a valid
+ * suite either way — vitest errors a file with zero registered tests.
+ *
+ * Path resolution goes through the REAL `flowsCandidatePaths`/`resolveRepoRoot`
+ * (discover.ts) with an EXPLICIT env bag — not live `process.env` — so this test
+ * dogfoods the actual discovery logic without being at the mercy of a stray
+ * ambient `$DEV` (observed in this sandbox: some tool in the pnpm/vitest chain
+ * sets `DEV=1`, which `discover.ts`'s real `$DEV`-as-tree-root convention would
+ * misinterpret).
+ */
+
+// TEST-only fixture read (excluded from the lib build via tsconfig); production
+// core code stays fs-free, guarded by the no-restricted-imports eslint rule.
+// eslint-disable-next-line no-restricted-imports
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { describe, expect, it } from 'vitest';
+import { flowsCandidatePaths } from '../discover.js';
+import { parseFlowManifest } from '../load.js';
+import { resolveFlow } from '../resolve.js';
+import { lookupSpa } from '../spa-registry.js';
+import type { FlowManifest } from '../types.js';
+
+const spa = lookupSpa('coach-web');
+if (!spa) throw new Error('coach-web must be registered in SPA_REGISTRY for this test to run');
+
+// Real HOME + an explicit $COACH passthrough (for a worktree checkout), but a
+// clean env bag otherwise — isolates discovery from ambient vars like the
+// stray `DEV=1` seen in this sandbox's pnpm/vitest chain.
+const CLEAN_ENV = { HOME: homedir(), COACH: process.env.COACH };
+const FLOWS_PATH = flowsCandidatePaths({ spa, env: CLEAN_ENV }).at(-1)!;
+const present = existsSync(FLOWS_PATH);
+
+// Loaded once, lazily, only when present — avoids a top-level readFileSync that
+// would throw even under `it.skipIf`.
+const manifest: FlowManifest | undefined = present
+  ? parseFlowManifest(readFileSync(FLOWS_PATH, 'utf8'), FLOWS_PATH)
+  : undefined;
+
+describe('coach-web flows.json — validates against the one external contract (schema)', () => {
+  it.skipIf(!present)(`parses + zod-validates as a FlowManifest (checkout: ${FLOWS_PATH})`, () => {
+    expect(manifest!.schemaVersion).toBe(1);
+    expect(manifest!.spa.id).toBe('coach-web');
+    expect(manifest!.flows.map((f) => f.name)).toContain('dashboard');
+  });
+
+  it.skipIf(!present)('the authored spa block matches the coach-web service + coach repo layout', () => {
+    expect(manifest!.spa).toMatchObject({
+      id: 'coach-web',
+      system: 'coach-web',
+      repoEnvVar: 'COACH',
+      defaultRepoSubpath: 'coach',
+      appDir: 'apps/web/coach-web',
+      e2eDir: 'apps/web/coach-web/e2e',
+      playwrightConfig: 'playwright.config.ts',
+    });
+  });
+
+  it.skipIf(!present)('coach-web is registered and its descriptor agrees with the authored file', () => {
+    const reg = lookupSpa('coach-web');
+    expect(reg).toBeDefined();
+    expect(reg).toMatchObject(manifest!.spa);
+  });
+
+  describe('dashboard flow — resolves through the SAME resolveFlow/closure engine', () => {
+    it.skipIf(!present)('selects the single non-progressive dashboard stage + its Playwright target', () => {
+      const r = resolveFlow(manifest!, 'dashboard');
+      expect(r.stages.map((s) => s.id)).toEqual(['dashboard']);
+      expect(r.playwright.project).toBe('chromium');
+      expect(r.playwright.config).toBe('playwright.config.ts');
+    });
+
+    it.skipIf(!present)('requiredSystems = the stage systems (coach-web ∪ coach-api ∪ iam-api)', () => {
+      const r = resolveFlow(manifest!, 'dashboard');
+      expect(r.requiredSystems).toEqual(['coach-web', 'coach-api', 'iam-api']);
+    });
+
+    it.skipIf(!present)('closure is exactly {coach-web, coach-api, iam-api} — no unrelated services leak in', () => {
+      const r = resolveFlow(manifest!, 'dashboard');
+      expect([...r.closure.services].sort()).toEqual(['coach-api', 'coach-web', 'iam-api']);
+    });
+
+    it.skipIf(!present)('closure pulls the coach_api pg db + connect-mongo mesh (coach-api dual-store)', () => {
+      const r = resolveFlow(manifest!, 'dashboard');
+      expect(r.closure.databases).toContain('coach_api');
+      expect(r.closure.mesh).toContain('connect-mongo');
+    });
+
+    it.skipIf(!present)('seeds with the full profile (needed for the coach-pg alex fixture) + reset', () => {
+      const r = resolveFlow(manifest!, 'dashboard');
+      expect(r.seedSelection).toMatchObject({ profile: 'full', reset: true });
+      expect(r.reset).toBe(true);
+      expect(r.prerequisite).toBeUndefined();
+    });
+
+    it.skipIf(!present)('supports only the stack lane it declares', () => {
+      expect(() => resolveFlow(manifest!, 'dashboard', { lane: 'stack' })).not.toThrow();
+      expect(() => resolveFlow(manifest!, 'dashboard', { lane: 'sandbox' })).toThrow();
+    });
+  });
+});

--- a/packages/node/saga-stack-cli/src/core/flow/__tests__/resolve.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/flow/__tests__/resolve.unit.test.ts
@@ -97,6 +97,10 @@ describe('resolveFlow — journey --through pods (progressive prefix)', () => {
     expect(r.playwright.grepInvert).toBe('@interactive'); // pipeline default-excludes the AV stage
   });
 
+  it('carries the terminal stage’s spec, scoping the run to just that file (not the whole testMatch)', () => {
+    expect(r.playwright.spec).toBe('journey/pods.e2e.test.ts'); // the --through stage's own spec
+  });
+
   it('carries the flow-level roster seed and resets itself (no prerequisite)', () => {
     expect(r.seedSelection).toMatchObject({ profile: 'roster', reset: true });
     expect(r.reset).toBe(true);

--- a/packages/node/saga-stack-cli/src/core/flow/resolve.ts
+++ b/packages/node/saga-stack-cli/src/core/flow/resolve.ts
@@ -37,6 +37,8 @@ export interface ResolvedPlaywright {
   config: string;
   /** The TERMINAL stage's Playwright `project`; deps chain 1..N (matches check-e2e.sh). */
   project: string;
+  /** The TERMINAL stage's `spec` file, scoping the Playwright invocation to just that spec. */
+  spec?: string;
   /** Playwright `--grep-invert` tag for pipeline runs (e.g. `@interactive`); omitted when the run IS the tagged stage. */
   grepInvert?: string;
   /** Run headed (foreground flows default headed; `--headless` flips it). */
@@ -345,6 +347,7 @@ export function resolveFlow(
       config: manifest.spa.playwrightConfig,
       // Empty window ⇒ no terminal stage ⇒ no project (the executor skips Playwright).
       project: terminal?.project ?? '',
+      spec: terminal?.spec,
       grepInvert,
       headed,
     },

--- a/packages/node/saga-stack-cli/src/core/flow/spa-registry.ts
+++ b/packages/node/saga-stack-cli/src/core/flow/spa-registry.ts
@@ -53,6 +53,24 @@ export const SPA_REGISTRY: Readonly<Record<string, SpaDescriptor>> = Object.free
     // repo-relative to `appDir` (Playwright runs in `appDir`).
     playwrightConfig: 'playwright.config.ts',
   },
+
+  // ── coach-web (the THIRD-SPA proof, coach e2e/saga-stack-cli parity task) ──
+  // `repoEnvVar: 'COACH'` matches `runtime/repos.ts`'s existing `coach: 'COACH'`
+  // mapping; `system: 'coach-web'` and `defaultRepoSubpath: 'coach'` match the
+  // manifest's `coach-web` service (repo `'COACH'`, `core/manifest/services.ts`).
+  // The real `flows.json` is authored in the coach repo at
+  // `apps/web/coach-web/e2e/flows.json` (not bundled here — coach-web already
+  // has a real Playwright suite, unlike connectv3's placeholder).
+  'coach-web': {
+    id: 'coach-web',
+    system: 'coach-web',
+    repoEnvVar: 'COACH',
+    defaultRepoSubpath: 'coach',
+    appDir: 'apps/web/coach-web',
+    e2eDir: 'apps/web/coach-web/e2e',
+    // repo-relative to `appDir` (Playwright runs in `appDir`).
+    playwrightConfig: 'playwright.config.ts',
+  },
 });
 
 /** Look up a known SPA descriptor by id (undefined if not registered). */

--- a/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
+++ b/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
@@ -334,6 +334,17 @@ export function playwrightArgv(
   if (stage?.noDeps) argv.push('--no-deps');
   if (resolved.playwright.grepInvert) argv.push('--grep-invert', resolved.playwright.grepInvert);
   if (resolved.playwright.headed) argv.push('--headed');
+  // Scope the run to the terminal stage's own spec — else Playwright's testMatch
+  // sweeps every spec in the SPA's e2e dir (found running coach-web/dashboard: it
+  // also executed unrelated nav/timer specs). Gated to the single-spawn path only
+  // (no `stage` override): `resolved.playwright.spec` is the TERMINAL stage's spec,
+  // so pushing it during a bake/--from per-stage spawn (`stage.project` overridden
+  // to a non-terminal project) would filter that stage's own project to a spec it
+  // doesn't contain, running zero tests. Progressive flows' per-stage `project`s are
+  // already testMatch-scoped to their own spec by the SPA's Playwright config, so
+  // they don't need this — it's specifically for single-project SPAs like coach-web
+  // where one `chromium` project matches every spec in the dir.
+  if (!stage && resolved.playwright.spec) argv.push(resolved.playwright.spec);
   argv.push(...passthrough);
   return argv;
 }
@@ -345,12 +356,16 @@ export function playwrightArgv(
  * URL as `process.env.PLAYWRIGHT_<X>_URL ?? http://localhost:<base port>`, and the
  * Playwright config's `baseURL` is `PLAYWRIGHT_BASE_URL ?? http://localhost:8900`.
  * By injecting each key from `launchContext.ports[svc]` (= manifest base + slot
- * offset), a slot-1 journey drives saga-dash on :9900 and hits iam :4010 /
- * scheduling :4008 / sessions :4007 / … instead of slot 0's base ports. Keyed to
- * the exact env vars `lane.ts` consumes today (nothing invented).
+ * offset), a slot-1 journey drives the SPA frontend on its offset port and hits
+ * iam :4010 / scheduling :4008 / sessions :4007 / … instead of slot 0's base
+ * ports. Keyed to the exact env vars `lane.ts` consumes today (nothing invented).
+ *
+ * `PLAYWRIGHT_BASE_URL` has no fixed `ServiceId` here — it must resolve to
+ * WHICHEVER SPA's flow is running (`resolved.spa.system`), not always saga-dash.
+ * `serviceUrlEnv`/`playwrightEnv` take that id as a param and default to
+ * `'saga-dash'` only when the caller has no spa context (back-compat).
  */
 export const PLAYWRIGHT_SERVICE_URL_ENV: Readonly<Record<string, ServiceId>> = Object.freeze({
-  PLAYWRIGHT_BASE_URL: 'saga-dash', // the dash frontend origin (Playwright `baseURL`)
   PLAYWRIGHT_IAM_URL: 'iam-api',
   PLAYWRIGHT_SIS_URL: 'sis-api',
   PLAYWRIGHT_PROGRAMS_URL: 'programs-api',
@@ -360,6 +375,9 @@ export const PLAYWRIGHT_SERVICE_URL_ENV: Readonly<Record<string, ServiceId>> = O
   PLAYWRIGHT_CONNECT_URL: 'connect-web',
 });
 
+/** `PLAYWRIGHT_BASE_URL`'s `ServiceId` when no SPA context is available (back-compat). */
+const DEFAULT_BASE_URL_SERVICE: ServiceId = 'saga-dash';
+
 /**
  * Build the stack-lane service-URL env from RESOLVED ports (each = manifest base +
  * slot offset). At slot 0 the ports are the base ports, so this yields the SAME
@@ -367,9 +385,18 @@ export const PLAYWRIGHT_SERVICE_URL_ENV: Readonly<Record<string, ServiceId>> = O
  * carries the `N * 1000` offset. Derived from `launchContext.ports` — never a
  * hardcoded port — so a re-banded/remapped service slots for free. A service with
  * no resolved port is omitted rather than emitting `localhost:undefined`.
+ *
+ * `baseUrlService` picks WHICH service backs `PLAYWRIGHT_BASE_URL` — the running
+ * flow's own SPA frontend (`resolved.spa.system`), defaulting to saga-dash when
+ * the caller has none.
  */
-export function serviceUrlEnv(ports: Partial<Record<ServiceId, number>>): Record<string, string> {
+export function serviceUrlEnv(
+  ports: Partial<Record<ServiceId, number>>,
+  baseUrlService: ServiceId = DEFAULT_BASE_URL_SERVICE,
+): Record<string, string> {
   const env: Record<string, string> = {};
+  const basePort = ports[baseUrlService];
+  if (basePort !== undefined) env.PLAYWRIGHT_BASE_URL = `http://localhost:${basePort}`;
   for (const [key, svc] of Object.entries(PLAYWRIGHT_SERVICE_URL_ENV)) {
     const port = ports[svc];
     if (port !== undefined) env[key] = `http://localhost:${port}`;
@@ -390,6 +417,11 @@ export function serviceUrlEnv(ports: Partial<Record<ServiceId, number>>): Record
  * service URLs are the lane's own hostnames (resolved in `lane.ts`), NOT localhost,
  * so we do NOT inject them. `now` is supplied by the command (`new Date()`); this
  * never reads the clock.
+ *
+ * `PLAYWRIGHT_BASE_URL` is derived from `resolved.spa.system` — the flow's OWN
+ * SPA frontend — not hardcoded to saga-dash, else a non-dash flow's Playwright
+ * run navigates to saga-dash's port and 500s (found running coach-web's
+ * `dashboard` flow: it opened `:8900`, saga-dash's port, instead of coach-web's).
  */
 export function playwrightEnv(
   resolved: ResolvedFlow,
@@ -417,7 +449,7 @@ export function playwrightEnv(
   const env: Record<string, string> = {
     ...computeEnv(resolved.flow, now),
     ...(dateOverrides ?? {}),
-    ...(lane === 'stack' && ports ? serviceUrlEnv(ports) : {}),
+    ...(lane === 'stack' && ports ? serviceUrlEnv(ports, resolved.spa?.system) : {}),
   };
   if (lane !== 'stack') env.PLAYWRIGHT_LANE = lane;
   return env;


### PR DESCRIPTION
## Summary
- Onboards **coach-web** as a third SPA to saga-stack-cli's flow-driven e2e runner (saga-ed/soa#214 §5.3): a `SPA_REGISTRY` row + resolving/executing coach-web's own `flows.json` (companion PR: saga-ed/coach#199 — adds `apps/web/coach-web/e2e/flows.json`).
- Fixes two real bugs found running `ss e2e run coach-web/dashboard` end-to-end against a live saga-stack-cli stack:

**1. `PLAYWRIGHT_BASE_URL` hardcoded to saga-dash for every SPA.** Any non-dash SPA's e2e flow silently navigated to saga-dash's manifest port and 500'd instead of testing the intended SPA. `coach-web/dashboard` opened `:8900` (saga-dash) instead of `:8800` (coach-web). Now `PLAYWRIGHT_BASE_URL` derives from the flow's own `spa.system`, defaulting to `saga-dash` only when no spa context is available (back-compat — existing callers unaffected).

**2. Stage `spec` never threaded into the playwright argv.** `flows.json` stages declare a `spec` field, but the argv builder never pushed it — so a single-project SPA (one `chromium` project matching every spec in its e2e dir, like coach-web) ran its *entire* `testMatch`, not just the flow's own spec. `coach-web/dashboard` also executed unrelated `nav`/`timer` specs riding along in the sweep. Now pushes the terminal stage's spec, but **only on the single-spawn path** — gated off when a `stage` override is present (bake/`--from` per-stage spawns), since pushing the *terminal* stage's spec there would filter a non-terminal `stage.project` to a spec it doesn't contain and run zero tests. saga-dash's progressive per-stage projects are unaffected either way — they're already `testMatch`-scoped to their own spec by the SPA's Playwright config.

## Test plan
- [x] Full suite: 971 passed, 0 failed, 0 regressions (`pnpm exec vitest run`)
- [x] `tsc --noEmit` clean
- [x] New regression tests: `PLAYWRIGHT_BASE_URL` resolves to the flow's own SPA (not saga-dash); `playwrightArgv` pushes spec on single-spawn, omits it on stage-override, and is a no-op when no spec is set
- [x] Proven live: `ss e2e run coach-web/dashboard --spa-path=<coach-web flows.json> --headless` against a real local stack (iam-api + coach-api + coach-web + mesh) — exit 0, correctly navigates to coach-web's own port, runs exactly `dashboard/dashboard-authenticated.e2e.smoke.test.ts` (no nav/timer bleed-in), 1 passed

Companion PR: saga-ed/coach#199