### PR TITLE
fix(saga-stack-cli): stack up names the failing phase instead of "(unknown)"

### DIFF
--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/up-failure.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/up-failure.unit.test.ts
@@ -1,0 +1,140 @@
+/**
+ * `describeUpFailure` — the pure phase-attribution behind `stack up`'s failure line.
+ *
+ * Regression for the soa cheatsheet diagnosis: a native-prep-pass failure (R1 build/install
+ * → R2 provision → R3 migrate) returns `ok:false` with NO `failedAt`, and used to fall through
+ * to the launch branch and misreport as `service launch FAILED at (unknown)`. These tests pin
+ * that each phase now names the real culprit, and that the mesh + genuine-launch branches are
+ * unchanged.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { describeUpFailure, type UpFailureView } from '../up.js';
+
+/** A healthy mesh (no conflicts, make ok, all units ready) — the common prefix of the deeper phases. */
+const okMesh: UpFailureView['mesh'] = {
+    conflicts: [],
+    makeOk: true,
+    units: [
+        { id: 'postgres', ok: true },
+        { id: 'redis', ok: true },
+    ],
+};
+
+describe('describeUpFailure — mesh phase', () => {
+    it('reports host port conflicts, one ✗ line each', () => {
+        const lines = describeUpFailure({
+            mesh: { conflicts: [{ message: 'postgres :5432 in use' }], makeOk: true, units: [] },
+        });
+        expect(lines).toEqual([
+            'mesh preflight FAILED — host port conflicts:',
+            '  ✗ postgres :5432 in use',
+        ]);
+    });
+
+    it('reports a non-zero `make up`', () => {
+        const lines = describeUpFailure({ mesh: { conflicts: [], makeOk: false, units: [] } });
+        expect(lines).toEqual(['mesh bring-up FAILED (`make up` exited non-zero)']);
+    });
+
+    it('names the mesh units that never became ready', () => {
+        const lines = describeUpFailure({
+            mesh: {
+                conflicts: [],
+                makeOk: true,
+                units: [
+                    { id: 'postgres', ok: true },
+                    { id: 'rabbitmq', ok: false },
+                    { id: 'redis', ok: false },
+                ],
+            },
+        });
+        expect(lines).toEqual(['mesh units never became ready: rabbitmq, redis']);
+    });
+});
+
+describe('describeUpFailure — native prep pass (the (unknown) regression)', () => {
+    it('names the failing repo + step for a prep (R1) failure instead of (unknown)', () => {
+        const lines = describeUpFailure({
+            mesh: okMesh,
+            prep: { ok: false, failed: { repo: 'SAGA_DASH', kind: 'build', argv: ['build'] } },
+        });
+        expect(lines).toEqual([
+            'prep FAILED — `pnpm build` in SAGA_DASH exited non-zero — see the streamed output above',
+        ]);
+        expect(lines[0]).not.toContain('(unknown)');
+    });
+
+    it('includes the lock holder detail when present', () => {
+        const lines = describeUpFailure({
+            mesh: okMesh,
+            prep: {
+                ok: false,
+                failed: { repo: 'ROSTERING', kind: 'lock', argv: ['install'], detail: 'held by pid 4242' },
+            },
+        });
+        expect(lines).toEqual([
+            'prep FAILED — `pnpm install` in ROSTERING (held by pid 4242) exited non-zero — see the streamed output above',
+        ]);
+    });
+
+    it('falls back to a generic prep line when no failed step is attached', () => {
+        const lines = describeUpFailure({ mesh: okMesh, prep: { ok: false } });
+        expect(lines).toEqual([
+            'prep FAILED — a build/install step exited non-zero; see the streamed output above',
+        ]);
+    });
+
+    it('names the DB for a provision (R2) failure', () => {
+        const lines = describeUpFailure({
+            mesh: okMesh,
+            prep: { ok: true },
+            provision: { ok: false, failed: 'sessions' },
+        });
+        expect(lines).toEqual([
+            'DB provision FAILED on sessions — role/database create exited non-zero; see the streamed output above',
+        ]);
+    });
+
+    it('names the DB for a migrate (R3) failure', () => {
+        const lines = describeUpFailure({
+            mesh: okMesh,
+            prep: { ok: true },
+            provision: { ok: true },
+            migrate: { ok: false, failed: 'iam_local' },
+        });
+        expect(lines).toEqual([
+            'migrate FAILED on iam_local — `prisma migrate` exited non-zero; see the streamed output above',
+        ]);
+    });
+
+    it('prefers the earliest failing phase (prep) when several are unhealthy', () => {
+        const lines = describeUpFailure({
+            mesh: okMesh,
+            prep: { ok: false, failed: { repo: 'PROGRAM_HUB', kind: 'db:generate', argv: ['db:generate'] } },
+            provision: { ok: false, failed: 'programs' },
+            migrate: { ok: false, failed: 'programs' },
+        });
+        expect(lines).toEqual([
+            'prep FAILED — `pnpm db:generate` in PROGRAM_HUB exited non-zero — see the streamed output above',
+        ]);
+    });
+});
+
+describe('describeUpFailure — launch phase', () => {
+    it('names the failed service when a launch wave went unhealthy', () => {
+        const lines = describeUpFailure({
+            mesh: okMesh,
+            prep: { ok: true },
+            provision: { ok: true },
+            migrate: { ok: true },
+            failedAt: 'iam-api',
+        });
+        expect(lines).toEqual(['service launch FAILED at iam-api — it never became healthy']);
+    });
+
+    it('still degrades to (unknown) only for a genuinely unattributed launch failure', () => {
+        const lines = describeUpFailure({ mesh: okMesh, prep: { ok: true }, provision: { ok: true }, migrate: { ok: true } });
+        expect(lines).toEqual(['service launch FAILED at (unknown) — it never became healthy']);
+    });
+});

--- a/packages/node/saga-stack-cli/src/commands/stack/up.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/up.ts
@@ -638,22 +638,64 @@ export default class StackUp extends BaseCommand {
 
   /** Print a structured failure when the native bring-up did not reach all-healthy. */
   private logUpFailure(up: Awaited<ReturnType<StackApi['up']>>): void {
-    if (up.mesh.conflicts.length > 0) {
-      this.log('mesh preflight FAILED — host port conflicts:');
-      for (const c of up.mesh.conflicts) this.log(`  ✗ ${c.message}`);
-      return;
-    }
-    if (!up.mesh.makeOk) {
-      this.log('mesh bring-up FAILED (`make up` exited non-zero)');
-      return;
-    }
-    const downUnits = up.mesh.units.filter((u) => !u.ok).map((u) => u.id);
-    if (downUnits.length > 0) {
-      this.log(`mesh units never became ready: ${downUnits.join(', ')}`);
-      return;
-    }
-    this.log(`service launch FAILED at ${up.failedAt ?? '(unknown)'} — it never became healthy`);
+    for (const line of describeUpFailure(up)) this.log(line);
   }
+}
+
+/**
+ * Structural subset of the up-result that {@link describeUpFailure} reads — the full
+ * `Awaited<ReturnType<StackApi['up']>>` is assignable to it (literal ids widen to string).
+ */
+export interface UpFailureView {
+  mesh: {
+    conflicts: readonly { readonly message: string }[];
+    makeOk: boolean;
+    units: readonly { readonly id: string; readonly ok: boolean }[];
+  };
+  prep?: { ok: boolean; failed?: { repo: string; kind: string; argv: readonly string[]; detail?: string } };
+  provision?: { ok: boolean; failed?: string };
+  migrate?: { ok: boolean; failed?: string };
+  failedAt?: string;
+}
+
+/**
+ * Map a failed bring-up to the human failure lines. Pure (no IO) so the branch logic is
+ * unit-testable. The order mirrors `StackApi.up()`'s phases: mesh → native prep pass
+ * (R1 build/install → R2 provision → R3 migrate) → launch waves. The prep/provision/migrate
+ * phases return `ok:false` with NO `failedAt`, so before this fix any failure there fell
+ * through to the launch line and misreported as `service launch FAILED at (unknown)` (soa
+ * cheatsheet diagnosis). Now each phase names the real culprit — the failing repo/step or DB.
+ */
+export function describeUpFailure(up: UpFailureView): string[] {
+  if (up.mesh.conflicts.length > 0) {
+    return ['mesh preflight FAILED — host port conflicts:', ...up.mesh.conflicts.map((c) => `  ✗ ${c.message}`)];
+  }
+  if (!up.mesh.makeOk) {
+    return ['mesh bring-up FAILED (`make up` exited non-zero)'];
+  }
+  const downUnits = up.mesh.units.filter((u) => !u.ok).map((u) => u.id);
+  if (downUnits.length > 0) {
+    return [`mesh units never became ready: ${downUnits.join(', ')}`];
+  }
+  if (up.prep && !up.prep.ok) {
+    const f = up.prep.failed;
+    return [
+      f
+        ? `prep FAILED — \`pnpm ${f.argv.join(' ')}\` in ${f.repo}${f.detail ? ` (${f.detail})` : ''} exited non-zero — see the streamed output above`
+        : 'prep FAILED — a build/install step exited non-zero; see the streamed output above',
+    ];
+  }
+  if (up.provision && !up.provision.ok) {
+    return [
+      `DB provision FAILED${up.provision.failed ? ` on ${up.provision.failed}` : ''} — role/database create exited non-zero; see the streamed output above`,
+    ];
+  }
+  if (up.migrate && !up.migrate.ok) {
+    return [
+      `migrate FAILED${up.migrate.failed ? ` on ${up.migrate.failed}` : ''} — \`prisma migrate\` exited non-zero; see the streamed output above`,
+    ];
+  }
+  return [`service launch FAILED at ${up.failedAt ?? '(unknown)'} — it never became healthy`];
 }
 
 // Local flag shapes (subset of the parsed StackUp flags each path reads).


### PR DESCRIPTION
## Problem

A failed `ss stack up` was printing:

```
✓ connect AV up — livekit :7880 + coturn (qboard compose)
service launch FAILED at (unknown) — it never became healthy
```

The `(unknown)` is a mis-attribution. `StackApi.up()` runs a **native prep pass** — R1 build/install → R2 DB provision → R3 migrate — *before* the launch waves. Those phases return `ok:false` with **no `failedAt`** (only a failed launch wave sets it). `logUpFailure` only special-cased mesh failures, so a prep/provision/migrate failure fell through to the launch branch and printed `service launch FAILED at (unknown)` — even though nothing ever launched (`launched: []`). The real error (a `pnpm build`/`install` or `prisma migrate` non-zero exit) had already streamed above, but the summary line pointed the wrong way.

Surfaced while diagnosing a real stack-down: even a clean `cold-start --reinstall` (fresh mesh, clean rebuild, all repos on main) reproduced the `(unknown)` line, proving the message was hiding the actual phase.

## Fix

- Extract the failure-line logic into a **pure, IO-free `describeUpFailure(up): string[]`** so the branch attribution is unit-testable (matches the repo's pure-helper test pattern).
- Add branches for the prep pass, in phase order, each naming the real culprit:
  - `prep FAILED — \`pnpm build\` in SAGA_DASH exited non-zero — see the streamed output above`
  - `DB provision FAILED on sessions — role/database create exited non-zero; …`
  - `migrate FAILED on iam_local — \`prisma migrate\` exited non-zero; …`
- `logUpFailure` is now a thin logger over the helper. **Mesh and genuine launch-wave paths are unchanged** — `(unknown)` now appears only for a truly unattributed launch failure.

## Tests

New `up-failure.unit.test.ts` (11 cases): mesh conflicts / `make up` / down-units, each prep-pass phase (incl. lock-holder detail and the no-`failed` fallback), earliest-phase precedence, and both launch-wave branches (named service + the residual `(unknown)`).

- `pnpm check-types` — clean (confirms the full `up` result is structurally assignable to `UpFailureView`)
- `pnpm test` (up suites) — 46 passed + 11 new
- `pnpm lint` — 0 errors; `pnpm build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)