### PR TITLE
feat(saga-stack-cli): reclaim an abandoned (STOPPED) prep lock instead of wedging

### DIFF
--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -2998,6 +2998,13 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "yes": {
+          "char": "y",
+          "description": "non-interactive: if a prep lock is held by a STOPPED/abandoned holder (e.g. a suspended `ss stack up`), kill it and reclaim the lock without prompting (CI / agents).",
+          "name": "yes",
+          "allowNo": false,
+          "type": "boolean"
+        },
         "allow-primary": {
           "description": "M13-B escape hatch: let a --set entry point a BUILDABLE repo at the primary $DEV checkout (prep will build your live working copy — tenet 4 says use a clean worktree; the preflight normally refuses).",
           "name": "allow-primary",

--- a/packages/node/saga-stack-cli/src/base-command.ts
+++ b/packages/node/saga-stack-cli/src/base-command.ts
@@ -97,6 +97,7 @@ import type {
   GitRunner,
   HealthProber,
   JarWriter,
+  LockHolder,
   MeshExec,
   OrphanScanner,
   OverlayFs,
@@ -137,6 +138,12 @@ export type NativeRuntimeFlags = WorkspaceFlags & {
   pull?: boolean;
   /** M9 auto-pull: `--no-auto-pull` ⇒ opt out. Undefined for commands that don't declare it. */
   'no-auto-pull'?: boolean;
+  /**
+   * `--yes`: non-interactive. Among other uses, auto-reclaims an abandoned (STOPPED)
+   * prep lock — killing the stopped holder — instead of prompting. Undefined for
+   * commands that don't declare it (⇒ prompt on a TTY, fail fast otherwise).
+   */
+  yes?: boolean;
 };
 
 /**
@@ -547,6 +554,27 @@ export abstract class BaseCommand extends Command {
   }
 
   /**
+   * Decide whether to reclaim a prep lock whose holder is STOPPED/abandoned (soa#266
+   * follow-up). `--yes` ⇒ auto-kill the stopped holder and reclaim (CI / agents);
+   * otherwise prompt on a TTY; with neither, refuse (fail fast — the lock then surfaces
+   * a STOPPED-tagged message telling the user how to reclaim). Only ever called for a
+   * genuinely stopped holder — a running holder is never offered here.
+   */
+  protected async reclaimStoppedPrepLock(flags: NativeRuntimeFlags, holder: LockHolder): Promise<boolean> {
+    const who = `pid ${holder.pid} (slot ${holder.slot}) building ${holder.root} since ${holder.at}`;
+    if (flags.yes) {
+      this.log(`⚠ prep lock held by a STOPPED/abandoned ${who} — killing it and reclaiming (--yes).`);
+      return true;
+    }
+    const confirm = this.getConfirm();
+    if (!confirm.isTTY()) return false;
+    return confirm.prompt(
+      `\n  The prep lock for ${holder.root} is held by a STOPPED pid ${holder.pid} (since ${holder.at}) — ` +
+        `it is suspended and can never finish.\n  Kill it and reclaim the lock? [y/N] `,
+    );
+  }
+
+  /**
    * The cookie-capturing POST seam (M11 — native login) — production is the only
    * place the devLogin POST is made.
    */
@@ -692,7 +720,11 @@ export abstract class BaseCommand extends Command {
       prepDbGenerateScan: this.getDbGenerateScan(),
       // M13-B: realpath-keyed build lock — two `ss` invocations can never
       // prep-BUILD one checkout concurrently (fresh-skipped repos never lock).
-      prepLock: makeRealPrepLock(profile.slot),
+      // soa#266 follow-up: an abandoned (STOPPED) holder is reclaimed per the
+      // command's --yes/TTY policy instead of wedging every future bring-up.
+      prepLock: makeRealPrepLock(profile.slot, {
+        reclaimStopped: (holder) => this.reclaimStoppedPrepLock(flags, holder),
+      }),
       repoDirExists: this.getRepoDirCheck(),
       // M9: the ff-only sibling sync (up.sh `pull_repos`) + its mode, the vite-cache
       // clear (native `restart`), and best-effort Connect AV (slot-0 + connect-in-closure,

--- a/packages/node/saga-stack-cli/src/commands/stack/up.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/up.ts
@@ -114,6 +114,12 @@ export default class StackUp extends BaseCommand {
         'skip the R1 install+build prep pass (NATIVE); R2 DB provision + R3 migrate still run (both idempotent).',
       default: false,
     }),
+    yes: Flags.boolean({
+      char: 'y',
+      description:
+        'non-interactive: if a prep lock is held by a STOPPED/abandoned holder (e.g. a suspended `ss stack up`), kill it and reclaim the lock without prompting (CI / agents).',
+      default: false,
+    }),
     'allow-primary': Flags.boolean({
       description:
         "M13-B escape hatch: let a --set entry point a BUILDABLE repo at the primary $DEV checkout (prep will build your live working copy — tenet 4 says use a clean worktree; the preflight normally refuses).",

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/lock.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/lock.unit.test.ts
@@ -2,12 +2,16 @@
  * M13-B realpath-keyed prep lock: exclusive acquire, who-holds-it failure,
  * stale-lock reaping, and release. Lock files land in the real tmpdir keyed by
  * a mkdtemp-unique repo path, so tests are hermetic per run.
+ *
+ * soa#266 follow-up: the abandoned-(STOPPED)-holder reclaim path — detection via
+ * an injected `procState`, the kill+reclaim decision via `reclaimStopped`, and the
+ * SIGKILL via an injected `killGroup` — so no real pids are signalled in tests.
  */
 
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { makeRealPrepLock, prepLockPath } from '../lock.js';
 
 let repo: string;
@@ -21,20 +25,28 @@ afterEach(() => {
   rmSync(repo, { recursive: true, force: true });
 });
 
+/** Write a held lock owned by THIS process (so `pidAlive` is true) for the reclaim tests. */
+function writeLiveHeldLock(): void {
+  writeFileSync(
+    prepLockPath(repo),
+    JSON.stringify({ pid: process.pid, slot: 7, root: repo, at: '2026-07-08T14:52:52.673Z' }),
+  );
+}
+
 describe('makeRealPrepLock', () => {
-  it('acquires, writes the lock file, and release removes it', () => {
+  it('acquires, writes the lock file, and release removes it', async () => {
     const lock = makeRealPrepLock(1);
-    const res = lock.acquire(repo);
+    const res = await lock.acquire(repo);
     expect(res.ok).toBe(true);
     expect(existsSync(prepLockPath(repo))).toBe(true);
     if (res.ok) res.release();
     expect(existsSync(prepLockPath(repo))).toBe(false);
   });
 
-  it('a second acquire fails fast with who-holds-it (live holder)', () => {
-    const first = makeRealPrepLock(1).acquire(repo);
+  it('a second acquire fails fast with who-holds-it (live holder)', async () => {
+    const first = await makeRealPrepLock(1).acquire(repo);
     expect(first.ok).toBe(true);
-    const second = makeRealPrepLock(2).acquire(repo);
+    const second = await makeRealPrepLock(2).acquire(repo);
     expect(second.ok).toBe(false);
     if (!second.ok) {
       expect(second.holder).toMatch(new RegExp(`pid ${process.pid} \\(slot 1\\)`));
@@ -43,21 +55,94 @@ describe('makeRealPrepLock', () => {
     if (first.ok) first.release();
   });
 
-  it('a STALE lock (dead holder pid) is reaped and retaken', () => {
+  it('a STALE lock (dead holder pid) is reaped and retaken', async () => {
     // pid 2^22-ish beyond typical max: process.kill throws ESRCH ⇒ dead.
-    writeFileSync(
-      prepLockPath(repo),
-      JSON.stringify({ pid: 3999999, slot: 3, root: repo, at: 'past' }),
-    );
-    const res = makeRealPrepLock(1).acquire(repo);
+    writeFileSync(prepLockPath(repo), JSON.stringify({ pid: 3999999, slot: 3, root: repo, at: 'past' }));
+    const res = await makeRealPrepLock(1).acquire(repo);
     expect(res.ok).toBe(true);
     if (res.ok) res.release();
   });
 
-  it('an unreadable lock file counts as stale', () => {
+  it('an unreadable lock file counts as stale', async () => {
     writeFileSync(prepLockPath(repo), '{corrupt');
-    const res = makeRealPrepLock(1).acquire(repo);
+    const res = await makeRealPrepLock(1).acquire(repo);
     expect(res.ok).toBe(true);
     if (res.ok) res.release();
+  });
+
+  describe('abandoned (STOPPED) holder reclaim (soa#266)', () => {
+    it('kills the stopped holder group and retakes when reclaimStopped approves', async () => {
+      writeLiveHeldLock();
+      const killGroup = vi.fn();
+      const reclaimStopped = vi.fn(() => true);
+      const res = await makeRealPrepLock(1, {
+        procState: () => ({ state: 'T', pgid: 4242 }),
+        reclaimStopped,
+        killGroup,
+      }).acquire(repo);
+
+      expect(reclaimStopped).toHaveBeenCalledOnce();
+      expect(killGroup).toHaveBeenCalledWith(4242, process.pid);
+      expect(res.ok).toBe(true);
+      if (res.ok) res.release();
+    });
+
+    it('awaits an async reclaimStopped decision', async () => {
+      writeLiveHeldLock();
+      const killGroup = vi.fn();
+      const res = await makeRealPrepLock(1, {
+        procState: () => ({ state: 'T', pgid: 4242 }),
+        reclaimStopped: async () => true,
+        killGroup,
+      }).acquire(repo);
+      expect(killGroup).toHaveBeenCalledOnce();
+      expect(res.ok).toBe(true);
+      if (res.ok) res.release();
+    });
+
+    it('does NOT kill when reclaimStopped declines — fails fast with a STOPPED-tagged message', async () => {
+      writeLiveHeldLock();
+      const killGroup = vi.fn();
+      const res = await makeRealPrepLock(1, {
+        procState: () => ({ state: 'T', pgid: 4242 }),
+        reclaimStopped: () => false,
+        killGroup,
+      }).acquire(repo);
+
+      expect(killGroup).not.toHaveBeenCalled();
+      expect(res.ok).toBe(false);
+      if (!res.ok) {
+        expect(res.holder).toMatch(/STOPPED\/abandoned/);
+        expect(res.holder).toContain('kill -9 -4242');
+      }
+    });
+
+    it('never offers a RUNNING holder for reclaim — fails fast, unchanged', async () => {
+      writeLiveHeldLock();
+      const reclaimStopped = vi.fn(() => true);
+      const killGroup = vi.fn();
+      const res = await makeRealPrepLock(1, {
+        procState: () => ({ state: 'R', pgid: 4242 }),
+        reclaimStopped,
+        killGroup,
+      }).acquire(repo);
+
+      expect(reclaimStopped).not.toHaveBeenCalled();
+      expect(killGroup).not.toHaveBeenCalled();
+      expect(res.ok).toBe(false);
+      if (!res.ok) expect(res.holder).not.toMatch(/STOPPED/);
+    });
+
+    it('with no reclaim policy, a stopped holder still fails fast (no auto-kill)', async () => {
+      writeLiveHeldLock();
+      const killGroup = vi.fn();
+      const res = await makeRealPrepLock(1, {
+        procState: () => ({ state: 'T', pgid: 4242 }),
+        killGroup,
+      }).acquire(repo);
+      expect(killGroup).not.toHaveBeenCalled();
+      expect(res.ok).toBe(false);
+      if (!res.ok) expect(res.holder).toMatch(/STOPPED\/abandoned/);
+    });
   });
 });

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/prep.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/prep.unit.test.ts
@@ -134,7 +134,7 @@ describe('prepClosure — closure-scoped install/build/db:generate (R1)', () => 
       runner,
       isFresh: (root) => root === '/dev/rostering', // rostering fresh ⇒ must NOT acquire
       lock: {
-        acquire(root) {
+        async acquire(root) {
           acquired.push(root);
           if (root === '/dev/program-hub') {
             return { ok: false, holder: 'pid 123 (slot 2) has been building /dev/program-hub since T' };
@@ -158,7 +158,7 @@ describe('prepClosure — closure-scoped install/build/db:generate (R1)', () => 
       dbs: [] as DbId[],
       repoRoots: REPO_ROOTS,
       runner,
-      lock: { acquire: (root) => ({ ok: true, release: () => released.push(root) }) },
+      lock: { acquire: async (root) => ({ ok: true, release: () => released.push(root) }) },
     });
     expect(res.ok).toBe(true);
     expect(released).toEqual(['/dev/rostering']);

--- a/packages/node/saga-stack-cli/src/runtime/lock.ts
+++ b/packages/node/saga-stack-cli/src/runtime/lock.ts
@@ -8,8 +8,17 @@
  * Mechanism: `O_EXCL`-create `/tmp/saga-stack-prep-<sha1(realpath)>.lock`
  * holding `{pid, slot, root, at}`. Held ⇒ FAIL FAST with who-holds-it (never
  * silently wait — the caller surfaces a pointed error). A stale lock (holder
- * pid dead) is reaped and retaken once. Fresh-skipped repos never acquire
- * (prep is a no-op there — sharing pre-built checkouts stays legal).
+ * pid dead) is reaped and retaken once.
+ *
+ * ABANDONED (STOPPED) HOLDER (soa#266 follow-up): a `kill(pid, 0)` liveness
+ * probe treats a *stopped* (STAT=T, e.g. a Ctrl-Z'd / suspended `ss stack up`)
+ * holder as alive, so its lock never reaped and wedged every future bring-up
+ * indefinitely. We now detect a stopped holder (it can never make progress) and,
+ * when the caller's `reclaimStopped` policy says so (`--yes` auto, or an
+ * interactive prompt), SIGKILL its process group and retake the lock. A
+ * genuinely RUNNING holder is never touched — that is a real concurrent build.
+ * Fresh-skipped repos never acquire (prep is a no-op there — sharing pre-built
+ * checkouts stays legal).
  */
 
 import { createHash } from 'node:crypto';
@@ -19,11 +28,36 @@ import { join } from 'node:path';
 import type { PrepRepoLock } from './prep.js';
 
 /** What the lock file records about its holder (also the error-message body). */
-interface LockHolder {
+export interface LockHolder {
   pid: number;
   slot: number;
   root: string;
   at: string;
+}
+
+/** A live holder's process state, as read from the OS (Linux `/proc/<pid>/stat`). */
+export interface ProcState {
+  /** The single-char Linux state code — `T`/`t` mean stopped (not progressing). */
+  state: string;
+  /** The holder's process-group id, so an abandoned tree is killed as a group. */
+  pgid: number;
+}
+
+/** Tunables + test seams for {@link makeRealPrepLock}. */
+export interface PrepLockOptions {
+  /** Injectable clock (the timestamp is informational). */
+  now?: () => string;
+  /**
+   * Decide what to do about a held lock whose holder is STOPPED/abandoned. Return
+   * true to KILL the holder's process group and reclaim; false/absent ⇒ fail fast
+   * with a STOPPED-tagged who-holds-it message. Only ever called for a *stopped*
+   * holder — a running holder is never offered for reclaim.
+   */
+  reclaimStopped?: (holder: LockHolder) => boolean | Promise<boolean>;
+  /** Read a live pid's process state (default: Linux `/proc`); null ⇒ unknown/dead. */
+  procState?: (pid: number) => ProcState | null;
+  /** Kill an abandoned holder's process group (default: SIGKILL the pgid, then the pid). */
+  killGroup?: (pgid: number, pid: number) => void;
 }
 
 /** The lock file path for a repo root — realpath-keyed so worktree aliases collide. */
@@ -48,12 +82,56 @@ function pidAlive(pid: number): boolean {
 }
 
 /**
- * Build the production lock. `slot` is recorded for the who-holds-it message.
- * `now` is injectable only for tests (the timestamp is informational).
+ * Read a pid's state + process-group from Linux `/proc/<pid>/stat`. The `comm`
+ * field is parenthesised and may itself contain spaces/`)`, so we split AFTER the
+ * last `)`: the remaining fields are `state ppid pgrp …`. Returns null off-Linux
+ * or if the pid vanished (⇒ caller treats as unknown, not stopped).
  */
-export function makeRealPrepLock(slot: number, now: () => string = () => new Date().toISOString()): PrepRepoLock {
+function readProcState(pid: number): ProcState | null {
+  try {
+    const raw = readFileSync(`/proc/${pid}/stat`, 'utf8');
+    const rp = raw.lastIndexOf(')');
+    if (rp < 0) return null;
+    const rest = raw.slice(rp + 2).trim().split(/\s+/);
+    const state = rest[0];
+    const pgid = Number(rest[2]);
+    if (!state) return null;
+    return { state, pgid: Number.isFinite(pgid) ? pgid : pid };
+  } catch {
+    return null;
+  }
+}
+
+/** `T` (stopped) / `t` (traced-stop) ⇒ suspended, can never make build progress. */
+function isStopped(state: ProcState | null): state is ProcState {
+  return state !== null && (state.state === 'T' || state.state === 't');
+}
+
+/** SIGKILL the whole process group (an abandoned `ss` tree), falling back to the bare pid. */
+function killProcGroup(pgid: number, pid: number): void {
+  try {
+    process.kill(-pgid, 'SIGKILL');
+  } catch {
+    try {
+      process.kill(pid, 'SIGKILL');
+    } catch {
+      /* already gone — nothing to reap */
+    }
+  }
+}
+
+/**
+ * Build the production lock. `slot` is recorded for the who-holds-it message.
+ * `opts.now` is injectable only for tests; `opts.procState`/`opts.killGroup` are
+ * test seams for the abandoned-holder path.
+ */
+export function makeRealPrepLock(slot: number, opts: PrepLockOptions = {}): PrepRepoLock {
+  const now = opts.now ?? (() => new Date().toISOString());
+  const procState = opts.procState ?? readProcState;
+  const killGroup = opts.killGroup ?? killProcGroup;
+
   return {
-    acquire(repoRoot: string) {
+    async acquire(repoRoot: string) {
       const path = prepLockPath(repoRoot);
       const body: LockHolder = { pid: process.pid, slot, root: repoRoot, at: now() };
 
@@ -73,11 +151,24 @@ export function makeRealPrepLock(slot: number, now: () => string = () => new Dat
             holder = null;
           }
           if (holder !== null && pidAlive(holder.pid)) {
+            const state = procState(holder.pid);
+            const stopped = isStopped(state);
+            // An abandoned (stopped) holder can never finish. Offer it for reclaim;
+            // on approval, kill its group and retake. A running holder is left alone.
+            if (stopped && opts.reclaimStopped && (await opts.reclaimStopped(holder))) {
+              killGroup(state.pgid, holder.pid);
+              rmSync(path, { force: true });
+              continue;
+            }
+            const base =
+              `pid ${holder.pid} (slot ${holder.slot}) has been building ${holder.root} since ${holder.at} — ` +
+              `lock ${path}`;
             return {
               ok: false as const,
-              holder:
-                `pid ${holder.pid} (slot ${holder.slot}) has been building ${holder.root} since ${holder.at} — ` +
-                `lock ${path}`,
+              holder: stopped
+                ? `${base} — the holder is STOPPED/abandoned and will never finish; ` +
+                  `re-run with --yes to kill it and reclaim, or \`kill -9 -${state.pgid}\``
+                : base,
             };
           }
           // Stale (holder dead or unreadable): reap and retry ONCE.

--- a/packages/node/saga-stack-cli/src/runtime/prep.ts
+++ b/packages/node/saga-stack-cli/src/runtime/prep.ts
@@ -148,7 +148,7 @@ export interface PrepContext {
 
 /** M13-B: the injectable per-repo build lock (production: `makeRealPrepLock`). */
 export interface PrepRepoLock {
-  acquire(repoRoot: string): { ok: true; release: () => void } | { ok: false; holder: string };
+  acquire(repoRoot: string): Promise<{ ok: true; release: () => void } | { ok: false; holder: string }>;
 }
 
 /** One prep step in the executed plan (for reporting + test assertions). */
@@ -265,7 +265,7 @@ export async function prepClosure(ctx: PrepContext): Promise<PrepResult> {
     // M13-B: exclusive realpath-keyed build lock — a held lock fails FAST with
     // who-holds-it (two invocations building one checkout is the race the
     // whole guard family exists to prevent; plan §4 layer 2).
-    const lock = ctx.lock?.acquire(root) ?? { ok: true as const, release: () => {} };
+    const lock = (await ctx.lock?.acquire(root)) ?? { ok: true as const, release: () => {} };
     if (!lock.ok) {
       const step: PrepStep = { repo, kind: 'lock', cwd: root, argv: [], detail: lock.holder };
       steps.push(step);


### PR DESCRIPTION
## Why

Follow-up to #266. That PR made the failure legible — and the real incident it surfaced was a **stuck prep lock held by a *suspended* (`STAT=T`) `ss stack up`**. The lock's liveness probe is `process.kill(pid, 0)`, which **succeeds on a stopped process**, so an abandoned/Ctrl-Z'd bring-up holds its lock forever and every later `up`/`cold-start` dies at the first prep step:

```
prep FAILED — `pnpm ` in COACH (pid 2328128 … has been building /home/skelly/dev/coach …) exited non-zero
```

`cold-start --reinstall` can't fix it either — `docker down -v` never touches a native process. The manual fix was `kill -9 -<pgid>` + remove the lock. This automates that.

## What

Teach the lock to recognise a **not-progressing** holder and reclaim it, respecting `--yes`:

- **Detect STOPPED** via Linux `/proc/<pid>/stat` (state `T`/`t` + the holder's `pgid`). Off-Linux / unreadable ⇒ treated as unknown and **never** auto-killed.
- **`acquire` is now async.** When a held holder is STOPPED, consult the command's reclaim policy:
  - `--yes` → auto-reclaim: **SIGKILL the stopped holder's process group** + retake (CI / agents).
  - interactive TTY → prompt `Kill it and reclaim? [y/N]`.
  - neither → fail fast.
  - A genuinely **RUNNING** holder is never offered for reclaim (real concurrent build — untouched).
- Even without `--yes`, the who-holds-it message now **tags the holder STOPPED** and prints the exact `kill -9 -<pgid>` to reclaim by hand.
- New **`stack up --yes` / `-y`** flag drives the auto path.

Design: detection/kill live in `runtime/lock.ts` behind injectable seams (`procState`, `killGroup`, `reclaimStopped`); the `--yes`-vs-prompt policy lives in the command layer (`base-command.ts#reclaimStoppedPrepLock`), reusing the existing `ConfirmSeam`.

## Tests / verification

- `lock.unit` +5 cases: approve→kill+retake, decline→fail-fast (STOPPED message + `kill -9 -<pgid>`), async decision, RUNNING never offered, no-policy still fails fast — all via injected seams (no real signals).
- `prep.unit` fakes updated for the async `acquire`.
- **Live smoke** against a real `SIGSTOP`'d process in its own group: real `/proc` detection + real process-group `SIGKILL` + reclaim → `{acquired_ok:true, stopped_holder_killed:true}`.
- Full suite **1061 pass**, `check-types` clean, `lint` 0 errors, `build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)