### PR TITLE
fix(saga-stack-cli): cold-start --reinstall reinstalls the host repo inline (stop ss self-bricking)

### DIFF
--- a/packages/node/saga-stack-cli/src/commands/stack/cold-start.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/cold-start.ts
@@ -12,7 +12,11 @@
  *   3. REPOS → MAIN  — switch every clean repo back to its default branch + fast-forward to origin.
  *                      A repo with uncommitted TRACKED changes is LEFT AS-IS (never discarded).
  *   4. CLEAN BUILD   — `rm -rf` each repo's `dist/` (defeats prep's fresh-skip) so `up` rebuilds;
- *                      `--reinstall` also removes `node_modules` for a full `pnpm install`.
+ *                      `--reinstall` also removes `node_modules` for a full `pnpm install`. Because
+ *                      that wipes the HOST repo's (soa) `node_modules` — where the running `ss`
+ *                      binary's own @oclif/core lives — soa is reinstalled INLINE right here, so a
+ *                      later prep failure can't brick `ss` (ERR_MODULE_NOT_FOUND); siblings reinstall
+ *                      in step 6's up/prep.
  *   5. ENSURE .ENV   — copy each `.env.example` → `.env` where the `.env` is missing (never
  *                      overwrites), so a fresh clone has the dotenv files the services expect.
  *   6. UP + VERIFY   — `up --reset --seed <profile>` (fresh mesh → provision → migrate → seed) then
@@ -42,6 +46,7 @@ import {
   distScanRoots,
   ensureEnv,
   ensureReposNative,
+  reinstallHostRepo,
   reinstallTargets,
   reposToMain,
   resolveRepoRoot,
@@ -109,7 +114,7 @@ export default class StackColdStart extends BaseCommand {
     this.log(dry ? '▶ cold-start DRY RUN — nothing will be changed:' : '▶ cold-start plan:');
     this.log(`    docker: down -v the '${profile.project}' mesh (containers + volumes)${flags['all-docker'] ? ' + system prune -af --volumes' : ''}`);
     this.log(`    repos:  ${repos.length} siblings → clone-if-missing, switch to main, ff to origin`);
-    this.log(`    build:  rm -rf dist${flags.reinstall ? ' + node_modules' : ''}${flags['skip-clean'] ? ' (SKIPPED)' : ''} → rebuilt by up`);
+    this.log(`    build:  rm -rf dist${flags.reinstall ? ' + node_modules (soa reinstalled inline)' : ''}${flags['skip-clean'] ? ' (SKIPPED)' : ''} → rebuilt by up`);
     this.log(`    env:    scaffold missing .env from .env.example`);
     this.log(`    up:     up --reset --seed ${flags.seed} → verify`);
 
@@ -214,6 +219,31 @@ export default class StackColdStart extends BaseCommand {
           this.log(`  ${n > 0 ? '✓' : '·'} ${repo.name.padEnd(20)} removed ${res.removedDist.length} dist${flags.reinstall ? `, ${res.removedModules.length} node_modules` : ''}`);
         }
       });
+
+      // The clean phase just removed `soa/node_modules` — which is where the RUNNING
+      // `ss` binary's OWN runtime (@oclif/core, …) lives. Reinstall the host repo
+      // INLINE now instead of deferring it to the up/prep pass below: if that pass
+      // failed first (e.g. a wedged prep lock), the empty store would brick every
+      // later `ss` invocation with ERR_MODULE_NOT_FOUND. See runtime/host-reinstall.ts.
+      if (flags.reinstall) {
+        await this.step('4/6 host reinstall — pnpm install in soa (restore ss runtime before up)', async () => {
+          if (dry) {
+            this.log(`    would run: pnpm install in ${soaRoot}`);
+            return;
+          }
+          const result = await reinstallHostRepo(soaRoot, {
+            runner: this.getRunner(),
+            notify: (m) => this.log(m),
+          });
+          if (!result.ok) {
+            this.error(
+              'host-repo `pnpm install` failed — resolve the error above, then re-run ' +
+                '(the ss binary needs its own node_modules to continue).',
+            );
+          }
+          this.log('  ✓ soa node_modules reinstalled — ss runtime restored');
+        });
+      }
     }
 
     // ── STEP 5: ensure .env ──

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/host-reinstall.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/host-reinstall.unit.test.ts
@@ -1,0 +1,83 @@
+/**
+ * host-reinstall unit tests — cold-start's INLINE reinstall of the host repo
+ * (soa) after `--reinstall` wipes its `node_modules` (soa#cold-start).
+ *
+ * Inject a fake Runner and assert the executed PLAN: one `pnpm install` in the
+ * host root; a CodeArtifact 401 forces a single `pnpm co:login` + retry; a
+ * non-401 failure never retries. NO real pnpm.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { RunResult, Runner, ScriptInvocation } from '../exec.js';
+import { reinstallHostRepo } from '../host-reinstall.js';
+
+const ROOT = '/dev/soa';
+
+/** A runner that answers each successive call from a queue of exit results. */
+function scriptedRunner(results: RunResult[]): { runner: Runner; calls: ScriptInvocation[] } {
+  const calls: ScriptInvocation[] = [];
+  const queue = [...results];
+  const runner: Runner = {
+    async run(spec): Promise<RunResult> {
+      calls.push(spec);
+      return queue.shift() ?? { code: 0 };
+    },
+  };
+  return { runner, calls };
+}
+
+describe('reinstallHostRepo — inline host-repo pnpm install', () => {
+  it('runs a single `pnpm install` in the host root and reports ok', async () => {
+    const { runner, calls } = scriptedRunner([{ code: 0 }]);
+
+    const result = await reinstallHostRepo(ROOT, { runner });
+
+    expect(result).toEqual({ ok: true, reloggedIn: false });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ cwd: ROOT, command: 'pnpm', args: ['install'], detectUnauthorized: true });
+  });
+
+  it('on a CodeArtifact 401, refreshes via `pnpm co:login` and retries install once (success)', async () => {
+    // install #1 → 401, co:login → ok, install #2 → ok.
+    const { runner, calls } = scriptedRunner([{ code: 1, unauthorized: true }, { code: 0 }, { code: 0 }]);
+
+    const result = await reinstallHostRepo(ROOT, { runner });
+
+    expect(result).toEqual({ ok: true, reloggedIn: true });
+    expect(calls.map((c) => c.args)).toEqual([['install'], ['co:login'], ['install']]);
+    expect(calls.every((c) => c.cwd === ROOT)).toBe(true);
+  });
+
+  it('on a 401 whose retry still fails, reports not-ok (relogin attempted)', async () => {
+    const { runner, calls } = scriptedRunner([{ code: 1, unauthorized: true }, { code: 0 }, { code: 1, unauthorized: true }]);
+
+    const result = await reinstallHostRepo(ROOT, { runner });
+
+    expect(result).toEqual({ ok: false, reloggedIn: true });
+    expect(calls.map((c) => c.args)).toEqual([['install'], ['co:login'], ['install']]);
+  });
+
+  it('a NON-401 install failure never triggers a co:login retry', async () => {
+    const { runner, calls } = scriptedRunner([{ code: 1 }]);
+
+    const result = await reinstallHostRepo(ROOT, { runner });
+
+    expect(result).toEqual({ ok: false, reloggedIn: false });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args).toEqual(['install']);
+  });
+
+  it('notifies only when a relogin+retry happens', async () => {
+    const notifiedOk: string[] = [];
+    await reinstallHostRepo(ROOT, { runner: scriptedRunner([{ code: 0 }]).runner, notify: (m) => notifiedOk.push(m) });
+    expect(notifiedOk).toEqual([]);
+
+    const notified401: string[] = [];
+    await reinstallHostRepo(ROOT, {
+      runner: scriptedRunner([{ code: 1, unauthorized: true }, { code: 0 }, { code: 0 }]).runner,
+      notify: (m) => notified401.push(m),
+    });
+    expect(notified401).toHaveLength(1);
+    expect(notified401[0]).toMatch(/co:login/);
+  });
+});

--- a/packages/node/saga-stack-cli/src/runtime/host-reinstall.ts
+++ b/packages/node/saga-stack-cli/src/runtime/host-reinstall.ts
@@ -1,0 +1,77 @@
+/**
+ * `host-reinstall` — restore the HOST repo's `node_modules` INLINE during a
+ * `cold-start --reinstall`, before anything relies on it again (soa#cold-start).
+ *
+ * THE BUG THIS CLOSES: cold-start's clean-build phase does `rm -rf node_modules`
+ * in every repo under `--reinstall`, then DEFERS the reinstall to the later
+ * `up`/prep pass. That is fine for the sibling repos — but the repo that hosts
+ * the running `ss` binary (soa) keeps `@oclif/core` and the rest of the CLI's
+ * OWN runtime under `soa/node_modules/.pnpm`. Deleting it mid-run means: if the
+ * subsequent `up`/prep fails BEFORE it reinstalls soa (e.g. a wedged prep lock),
+ * the store stays empty and EVERY later `ss` invocation dies at load with
+ * `ERR_MODULE_NOT_FOUND: @oclif/core` — the tool has bricked its own runtime and
+ * cannot run the step that would fix it. The manual escape was a bare
+ * `pnpm install`; this automates it.
+ *
+ * So cold-start calls `reinstallHostRepo(soaRoot, …)` the instant the clean phase
+ * removes the host repo's `node_modules`, restoring `ss` regardless of whether
+ * the later `up` succeeds. The install mirrors prep's own `pnpm install`
+ * (`src/runtime/prep.ts`): a CodeArtifact 401 (expired token) triggers a single
+ * `pnpm co:login` refresh + retry.
+ *
+ * IO-only: the real spawning lives behind the injected `Runner` seam (`exec.ts`),
+ * so this is unit-tested with a fake runner (no real `pnpm`).
+ */
+
+import type { Runner } from './exec.js';
+
+/** Injected deps for a host-repo reinstall. */
+export interface HostReinstallDeps {
+  /** The process seam — `pnpm install` / `pnpm co:login` run through it. */
+  runner: Runner;
+  /** Progress sink (defaults to a no-op). */
+  notify?: (message: string) => void;
+}
+
+/** The outcome of a host-repo reinstall. */
+export interface HostReinstallResult {
+  /** True iff the final `pnpm install` exited 0. */
+  ok: boolean;
+  /** True iff a CodeArtifact 401 forced a `pnpm co:login` + retry. */
+  reloggedIn: boolean;
+}
+
+/**
+ * Run `pnpm install` in `root` (the host repo), with a single CodeArtifact-401
+ * `pnpm co:login` refresh + retry — exactly prep's install recovery. Pure w.r.t.
+ * IO: every spawn goes through `deps.runner`.
+ */
+export async function reinstallHostRepo(
+  root: string,
+  deps: HostReinstallDeps,
+): Promise<HostReinstallResult> {
+  const notify = deps.notify ?? ((): void => {});
+  const install = (): Promise<import('./exec.js').RunResult> =>
+    deps.runner.run({
+      cwd: root,
+      command: 'pnpm',
+      args: ['install'],
+      env: {},
+      stdio: 'inherit',
+      detectUnauthorized: true,
+    });
+
+  let result = await install();
+  let reloggedIn = false;
+
+  // FLIP 4 parity: an expired CodeArtifact token surfaces as a 401 — refresh via
+  // `pnpm co:login`, then retry the install ONCE (mirrors prep's `prepOneRepo`).
+  if (result.code !== 0 && result.unauthorized) {
+    notify('    CodeArtifact token expired — refreshing (pnpm co:login) and retrying install once');
+    reloggedIn = true;
+    await deps.runner.run({ cwd: root, command: 'pnpm', args: ['co:login'], env: {}, stdio: 'inherit' });
+    result = await install();
+  }
+
+  return { ok: result.code === 0, reloggedIn };
+}

--- a/packages/node/saga-stack-cli/src/runtime/index.ts
+++ b/packages/node/saga-stack-cli/src/runtime/index.ts
@@ -38,6 +38,7 @@ export * from './ensure-repos.js';
 export * from './repos-to-main.js';
 export * from './docker-wipe.js';
 export * from './build-clean.js';
+export * from './host-reinstall.js';
 export * from './env-ensure.js';
 export * from './http-post.js';
 export * from './login.js';


### PR DESCRIPTION
## Why

`ss stack cold-start --reinstall --yes` left the `ss` binary unusable:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@oclif/core' imported from
  /home/skelly/dev/soa/packages/node/saga-stack-cli/bin/run.js
```

**Root cause — the tool bricks its own runtime.** cold-start's clean-build phase (4/6) does `rm -rf node_modules` in every repo under `--reinstall`, then **defers** the reinstall to phase 6's `up`/prep. That is fine for the sibling repos — but it also wipes **`soa/node_modules`**, which is where the *running* `ss` binary's own `@oclif/core` (and the rest of the CLI runtime) lives. If phase 6 fails *before* it reinstalls soa — e.g. the wedged prep lock fixed in #267 — the pnpm store stays empty and **every** subsequent `ss` invocation dies at load with `ERR_MODULE_NOT_FOUND`. The tool has deleted the runtime it needs to run the very step that would restore it. The only escape was a manual `pnpm install`.

## What

Reinstall the **host repo (soa) inline**, the instant the clean phase removes its `node_modules` — before anything relies on it again — so `ss` stays runnable regardless of whether the later `up`/prep pass succeeds. Sibling repos still reinstall in phase 6, unchanged.

- **New `runtime/host-reinstall.ts#reinstallHostRepo(root, {runner, notify})`** — a `pnpm install` in the host root behind the injectable `Runner` seam, with a single CodeArtifact-401 `pnpm co:login` refresh + retry (mirrors prep's own install recovery). IO-only; unit-tested with a fake runner.
- **cold-start phase 4** now calls it against `soaRoot` under `--reinstall`. A failed host install aborts with a pointed message instead of silently leaving a broken store. The plan header + phase-4 docstring note the inline reinstall.

## Tests / verification

- `host-reinstall.unit` **+5**: install ok → `{ok:true}`; 401 → `co:login` + retry ok → `{ok:true, reloggedIn:true}`; 401 retry still fails → `{ok:false}`; non-401 never retries; `notify` fires only on relogin — all via an injected Runner (no real pnpm).
- Full `saga-stack-cli` suite **1066 pass** (was 1061 + 5 new), `check-types` clean, `lint` 0 errors, `build` clean (`oclif.manifest.json` unchanged — no flag/command change).
- **Dry-run smoke:** `ss stack cold-start --dry-run --reinstall` renders the new `4/6 host reinstall — pnpm install in soa` step and `build: … (soa reinstalled inline)`; without `--reinstall` the step is absent.
- **Live repro:** the reported break was reproduced (`node_modules/.pnpm` empty) and fixed by `pnpm install`; this change makes cold-start do that automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)