### PR TITLE
fix(saga-stack-cli): make resolveScript test CI-safe (the 1 red test on every soa PR)

### DIFF
--- a/packages/node/saga-stack-cli/src/runtime/__tests__/scripts.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/scripts.unit.test.ts
@@ -8,12 +8,21 @@
  * here for both SOA (synthetic-dev) and SAGA_DASH (e2e). No process is spawned.
  */
 
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { ScriptLocator } from '../../core/flag-map.js';
 import { resolveDevRoot, resolveRepoRoot, resolveScript, scriptCwd } from '../scripts.js';
 
 const ENV_KEYS = ['DEV', 'SOA', 'SAGA_DASH', 'HOME'] as const;
 let saved: Record<string, string | undefined>;
+
+// The real soa checkout root, derived from THIS test file's own location — NOT from
+// $SOA/$HOME, which resolve to a non-existent `$HOME/dev/soa` under CI (where the checkout
+// lives at `/home/runner/work/soa/soa`), making the existence-guard assertion below fail on
+// every PR. `up.sh` is git-tracked at `tools/synthetic-dev/up.sh`, so a location-derived root
+// is deterministic in every environment. From `src/runtime/__tests__` the repo root is 6 up.
+const SOA_CHECKOUT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..', '..', '..');
 
 beforeEach(() => {
   saved = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
@@ -77,10 +86,11 @@ describe('scriptCwd', () => {
 
 describe('resolveScript', () => {
   it('returns the absolute path when the script exists', () => {
-    // Point at the real soa checkout (read-only; the script is NOT executed).
-    const soa = saved.SOA ?? `${saved.HOME ?? ''}/dev/soa`;
-    const path = resolveScript(UP, { repoRoots: { SOA: soa } });
-    expect(path).toBe(`${soa}/tools/synthetic-dev/up.sh`);
+    // Point at the real soa checkout (read-only; the script is NOT executed). Derive the
+    // root from this file's location (SOA_CHECKOUT) so it holds in CI too, where $SOA/$HOME
+    // resolve elsewhere — see the SOA_CHECKOUT note above.
+    const path = resolveScript(UP, { repoRoots: { SOA: SOA_CHECKOUT } });
+    expect(path).toBe(join(SOA_CHECKOUT, UP.relPath));
   });
 
   it('throws a pointed error (naming the relPath + repo) when the script is missing', () => {


### PR DESCRIPTION
## Why

Every soa PR's **PR Test Summary** shows the same result:

| Status | Suites | Tests |
|--------|--------|-------|
| ✅ Passed | 563 | 1638 |
| ❌ Failed | 0 | **1** |

That lone red test — consistent across all PRs, never blocking (its suite stays green) — is:

```
packages/node/saga-stack-cli/src/runtime/__tests__/scripts.unit.test.ts
  > resolveScript > returns the absolute path when the script exists

saga-stack: could not find tools/synthetic-dev/up.sh at /home/runner/dev/soa/tools/synthetic-dev/up.sh
  resolved SOA root: /home/runner/dev/soa
```

**Root cause — environment coupling.** The test resolves the "real soa checkout" from `$SOA ?? $HOME/dev/soa`. In CI `$SOA` is unset and `$HOME=/home/runner`, so it looks for `up.sh` under `/home/runner/dev/soa` — but the GitHub Actions checkout lives at `/home/runner/work/soa/soa`, so `resolveScript`'s `existsSync` guard throws. It only passes locally because the dev box happens to keep its checkout at `$HOME/dev/soa`.

## What

Derive the checkout root from the **test file's own location** (`import.meta.url`, 6 dirs up to the repo root) instead of env vars. `up.sh` is git-tracked at `tools/synthetic-dev/up.sh`, so a location-derived root is deterministic in every environment. The test keeps its intent — assert the resolved path against a checkout that genuinely contains the script — while no longer depending on *where* the checkout sits.

One-file change; no production code touched.

## Verification

- The previously-red test now passes with **`$SOA`/`$DEV` unset and `HOME=/tmp/bogus`** — the exact CI shape that broke it.
- Full `saga-stack-cli` suite **1061 pass**, `check-types` clean, `lint` 0 errors.
- Identified by downloading the run's `test-results-node-saga-stack-cli` artifact (the 47 KB outlier among ~1 KB peers) and parsing the vitest JSON: `numFailedTests: 1`, this test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)