### PR TITLE
fix(saga-stack-cli): cold-start rebuilds the host CLI dist inline too (finish the self-brick fix)

### DIFF
--- a/packages/node/saga-stack-cli/src/commands/stack/cold-start.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/cold-start.ts
@@ -12,11 +12,13 @@
  *   3. REPOS → MAIN  — switch every clean repo back to its default branch + fast-forward to origin.
  *                      A repo with uncommitted TRACKED changes is LEFT AS-IS (never discarded).
  *   4. CLEAN BUILD   — `rm -rf` each repo's `dist/` (defeats prep's fresh-skip) so `up` rebuilds;
- *                      `--reinstall` also removes `node_modules` for a full `pnpm install`. Because
- *                      that wipes the HOST repo's (soa) `node_modules` — where the running `ss`
- *                      binary's own @oclif/core lives — soa is reinstalled INLINE right here, so a
- *                      later prep failure can't brick `ss` (ERR_MODULE_NOT_FOUND); siblings reinstall
- *                      in step 6's up/prep.
+ *                      `--reinstall` also removes `node_modules` for a full `pnpm install`. This
+ *                      wipes the HOST repo's (soa) OWN runtime — the `dist/commands/**` and (under
+ *                      `--reinstall`) the `node_modules/@oclif/core` the running `ss` loads from —
+ *                      and step 6's up only builds the SERVICE repos, never soa. So soa is restored
+ *                      INLINE right here: reinstall (under `--reinstall`) + a CLI rebuild (always),
+ *                      or the next `ss` command dies with MODULE_NOT_FOUND even after a green run.
+ *                      Siblings still reinstall/rebuild in step 6's up/prep.
  *   5. ENSURE .ENV   — copy each `.env.example` → `.env` where the `.env` is missing (never
  *                      overwrites), so a fresh clone has the dotenv files the services expect.
  *   6. UP + VERIFY   — `up --reset --seed <profile>` (fresh mesh → provision → migrate → seed) then
@@ -44,8 +46,10 @@ import {
   bootstrapRepos,
   composeDownVArgs,
   distScanRoots,
+  HOST_CLI_PACKAGE,
   ensureEnv,
   ensureReposNative,
+  rebuildHostCli,
   reinstallHostRepo,
   reinstallTargets,
   reposToMain,
@@ -114,7 +118,7 @@ export default class StackColdStart extends BaseCommand {
     this.log(dry ? '▶ cold-start DRY RUN — nothing will be changed:' : '▶ cold-start plan:');
     this.log(`    docker: down -v the '${profile.project}' mesh (containers + volumes)${flags['all-docker'] ? ' + system prune -af --volumes' : ''}`);
     this.log(`    repos:  ${repos.length} siblings → clone-if-missing, switch to main, ff to origin`);
-    this.log(`    build:  rm -rf dist${flags.reinstall ? ' + node_modules (soa reinstalled inline)' : ''}${flags['skip-clean'] ? ' (SKIPPED)' : ''} → rebuilt by up`);
+    this.log(`    build:  rm -rf dist${flags.reinstall ? ' + node_modules' : ''}${flags['skip-clean'] ? ' (SKIPPED)' : ''} → rebuilt by up (soa CLI restored inline)`);
     this.log(`    env:    scaffold missing .env from .env.example`);
     this.log(`    up:     up --reset --seed ${flags.seed} → verify`);
 
@@ -244,6 +248,29 @@ export default class StackColdStart extends BaseCommand {
           this.log('  ✓ soa node_modules reinstalled — ss runtime restored');
         });
       }
+
+      // The clean phase also `rm -rf`'d soa's `dist/` — including the saga-stack-cli
+      // `dist/commands/**` the RUNNING `ss` binary discovers its commands from. Phase 6's up
+      // only builds the SERVICE repos (never soa), so rebuild the host CLI INLINE now or the
+      // next `ss` command dies with MODULE_NOT_FOUND — even after a green cold-start. Runs even
+      // WITHOUT --reinstall (dist is always removed). See runtime/host-reinstall.ts#rebuildHostCli.
+      await this.step('4/6 host rebuild — turbo build the ss CLI in soa (restore dist before up)', async () => {
+        if (dry) {
+          this.log(`    would run: pnpm turbo run build --filter=${HOST_CLI_PACKAGE} in ${soaRoot}`);
+          return;
+        }
+        const result = await rebuildHostCli(soaRoot, {
+          runner: this.getRunner(),
+          notify: (m) => this.log(m),
+        });
+        if (!result.ok) {
+          this.error(
+            'host CLI `turbo build` failed — resolve the error above, then re-run ' +
+              '(the ss binary needs its own dist/ to continue).',
+          );
+        }
+        this.log('  ✓ soa saga-stack-cli dist rebuilt — ss commands restored');
+      });
     }
 
     // ── STEP 5: ensure .env ──

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/host-reinstall.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/host-reinstall.unit.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, expect, it } from 'vitest';
 import type { RunResult, Runner, ScriptInvocation } from '../exec.js';
-import { reinstallHostRepo } from '../host-reinstall.js';
+import { HOST_CLI_PACKAGE, rebuildHostCli, reinstallHostRepo } from '../host-reinstall.js';
 
 const ROOT = '/dev/soa';
 
@@ -79,5 +79,34 @@ describe('reinstallHostRepo — inline host-repo pnpm install', () => {
     });
     expect(notified401).toHaveLength(1);
     expect(notified401[0]).toMatch(/co:login/);
+  });
+});
+
+describe('rebuildHostCli — inline host-CLI dist rebuild', () => {
+  it('runs `turbo run build --filter=<cli>` in the host root and reports ok', async () => {
+    const { runner, calls } = scriptedRunner([{ code: 0 }]);
+
+    const result = await rebuildHostCli(ROOT, { runner });
+
+    expect(result).toEqual({ ok: true });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      cwd: ROOT,
+      command: 'pnpm',
+      args: ['turbo', 'run', 'build', `--filter=${HOST_CLI_PACKAGE}`],
+    });
+  });
+
+  it('reports not-ok when the build exits non-zero', async () => {
+    const { runner, calls } = scriptedRunner([{ code: 1 }]);
+
+    const result = await rebuildHostCli(ROOT, { runner });
+
+    expect(result).toEqual({ ok: false });
+    expect(calls).toHaveLength(1);
+  });
+
+  it('targets the saga-stack-cli package (the dist the ss binary loads)', () => {
+    expect(HOST_CLI_PACKAGE).toBe('@saga-ed/saga-stack-cli');
   });
 });

--- a/packages/node/saga-stack-cli/src/runtime/host-reinstall.ts
+++ b/packages/node/saga-stack-cli/src/runtime/host-reinstall.ts
@@ -1,26 +1,28 @@
 /**
- * `host-reinstall` — restore the HOST repo's `node_modules` INLINE during a
- * `cold-start --reinstall`, before anything relies on it again (soa#cold-start).
+ * `host-reinstall` — restore the HOST repo's own runtime (`node_modules` AND
+ * `dist`) INLINE during a `cold-start`, before anything relies on it (soa#cold-start).
  *
- * THE BUG THIS CLOSES: cold-start's clean-build phase does `rm -rf node_modules`
- * in every repo under `--reinstall`, then DEFERS the reinstall to the later
- * `up`/prep pass. That is fine for the sibling repos — but the repo that hosts
- * the running `ss` binary (soa) keeps `@oclif/core` and the rest of the CLI's
- * OWN runtime under `soa/node_modules/.pnpm`. Deleting it mid-run means: if the
- * subsequent `up`/prep fails BEFORE it reinstalls soa (e.g. a wedged prep lock),
- * the store stays empty and EVERY later `ss` invocation dies at load with
- * `ERR_MODULE_NOT_FOUND: @oclif/core` — the tool has bricked its own runtime and
- * cannot run the step that would fix it. The manual escape was a bare
- * `pnpm install`; this automates it.
+ * THE BUG THIS CLOSES: cold-start's clean-build phase `rm -rf`s each repo's `dist`
+ * (always) and `node_modules` (under `--reinstall`), then DEFERS the rebuild/reinstall
+ * to the later `up`/prep pass. That is fine for the sibling SERVICE repos — but soa,
+ * which hosts the running `ss` binary, is NOT a service in the up-closure, so phase 6
+ * never touches it. And soa is exactly where the CLI's own runtime lives:
+ *   - `@oclif/core` + the rest of the dep tree under `soa/node_modules/.pnpm`, and
+ *   - the compiled command files under `soa/packages/node/saga-stack-cli/dist/commands/**`.
+ * Wiping either and not restoring it bricks EVERY later `ss` invocation —
+ * `ERR_MODULE_NOT_FOUND: @oclif/core` (missing node_modules) or
+ * `MODULE_NOT_FOUND: …/dist/commands/stack/<cmd>.js` (missing dist) — even after a
+ * fully GREEN cold-start. The manual escape was `pnpm install` + a rebuild; this
+ * automates both.
  *
- * So cold-start calls `reinstallHostRepo(soaRoot, …)` the instant the clean phase
- * removes the host repo's `node_modules`, restoring `ss` regardless of whether
- * the later `up` succeeds. The install mirrors prep's own `pnpm install`
- * (`src/runtime/prep.ts`): a CodeArtifact 401 (expired token) triggers a single
- * `pnpm co:login` refresh + retry.
+ * So cold-start calls, the instant the clean phase removes soa's runtime:
+ *   - `reinstallHostRepo(soaRoot, …)` under `--reinstall` — `pnpm install`, mirroring
+ *     prep's own recovery (a CodeArtifact 401 triggers a `pnpm co:login` refresh + retry).
+ *   - `rebuildHostCli(soaRoot, …)` always — `turbo run build` for the CLI package, since
+ *     the clean removes soa's `dist` even without `--reinstall`.
  *
  * IO-only: the real spawning lives behind the injected `Runner` seam (`exec.ts`),
- * so this is unit-tested with a fake runner (no real `pnpm`).
+ * so both are unit-tested with a fake runner (no real `pnpm`/`turbo`).
  */
 
 import type { Runner } from './exec.js';
@@ -74,4 +76,39 @@ export async function reinstallHostRepo(
   }
 
   return { ok: result.code === 0, reloggedIn };
+}
+
+/** The workspace name of the ss CLI package — the `dist/` the running binary loads. */
+export const HOST_CLI_PACKAGE = '@saga-ed/saga-stack-cli';
+
+/** The outcome of a host-CLI rebuild. */
+export interface RebuildHostCliResult {
+  /** True iff the `turbo run build` exited 0. */
+  ok: boolean;
+}
+
+/**
+ * Rebuild the host CLI package's `dist/` — a `turbo run build --filter=<HOST_CLI_PACKAGE>`
+ * in the host repo root.
+ *
+ * THE SECOND HALF of the cold-start self-brick (the first is `reinstallHostRepo`): the clean
+ * phase `rm -rf`s every `<pkg>/dist` under soa — INCLUDING the saga-stack-cli
+ * `dist/commands/**` the running `ss` binary discovers its commands from — and it does so
+ * EVEN WITHOUT `--reinstall`. Phase 6's up/prep only builds the SERVICE repos in the
+ * up-closure, never soa itself, so nothing restores that `dist/`. Without an inline rebuild the
+ * next `ss` command dies with `MODULE_NOT_FOUND: …/dist/commands/stack/<cmd>.js` — even after a
+ * fully green cold-start. turbo restores the CLI (and any build-time deps) from the graph.
+ *
+ * IO-only: the spawn goes through the injected `Runner` seam, so this is unit-tested with a
+ * fake runner (no real turbo/tsc).
+ */
+export async function rebuildHostCli(root: string, deps: HostReinstallDeps): Promise<RebuildHostCliResult> {
+  const result = await deps.runner.run({
+    cwd: root,
+    command: 'pnpm',
+    args: ['turbo', 'run', 'build', `--filter=${HOST_CLI_PACKAGE}`],
+    env: {},
+    stdio: 'inherit',
+  });
+  return { ok: result.code === 0 };
 }


### PR DESCRIPTION
## Why

Follow-up to #268. Live repro — `ss stack cold-start --reinstall --yes` ran to **full success**:

```
verify: PASS — 13/13 required services up
✓ cold-start complete — you're on a clean, seeded synthetic-dev baseline on main.
skelly-> ss stack verify --full
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@oclif/core' … / …/dist/commands/stack/<cmd>.js
```

**The self-brick has two halves, and #268 only closed one.** cold-start's clean phase `rm -rf`s each repo's `dist/` (always) and `node_modules` (under `--reinstall`), then defers restoration to phase 6's `up`/prep. But phase 6 only builds the **service repos in the up-closure** — soa is the CLI *host*, not a service, so **nothing in phase 6 ever restores soa**. soa is exactly where the running `ss` binary's runtime lives:

- `node_modules/@oclif/core` — **fixed by #268** (inline reinstall).
- `packages/node/saga-stack-cli/dist/commands/**` — **still wiped**, and removed **even without `--reinstall`**.

So every cold-start left `ss` bricked with `MODULE_NOT_FOUND` on the next command — even a fully green one.

## What

Rebuild the host CLI **inline** right after the clean, **always** (not just under `--reinstall`), alongside #268's `node_modules` reinstall.

- **New `runtime/host-reinstall.ts#rebuildHostCli(root, {runner})`** — a `turbo run build --filter=@saga-ed/saga-stack-cli` in the host root, behind the injectable `Runner` seam. The CLI has **no workspace runtime deps** (verified), so this restores everything the `ss` binary loads. Adds `HOST_CLI_PACKAGE`.
- **cold-start phase 4** runs it unconditionally (when not `--skip-clean`), after the reinstall step; a failed build aborts with a pointed message instead of a silently broken `dist`.

## Tests / verification

- `host-reinstall.unit` **+3** (8 total): build ok → `{ok:true}`, non-zero build → `{ok:false}`, targets `@saga-ed/saga-stack-cli` — via a fake Runner (no real turbo).
- Full `saga-stack-cli` suite **1069 pass**, `check-types` clean, `lint` 0 errors.
- **Dry-run smoke:** `--reinstall` shows both `4/6 host reinstall` and `4/6 host rebuild`; **without** `--reinstall` the **rebuild still runs** (dist is always removed) and the reinstall is absent.
- **Live:** the exact break in the repro above was resolved by hand with `pnpm install` + `turbo run build --filter=@saga-ed/saga-stack-cli`; this automates both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)