### PR TITLE
Split walkthrough-video narration/timing into a markdown script format

### DIFF
--- a/tools/walkthrough-video/.gitignore
+++ b/tools/walkthrough-video/.gitignore
@@ -1,4 +1,4 @@
-# Generated per-walkthrough artifacts — steps.mjs is the only thing worth committing.
+# Generated per-walkthrough artifacts — steps.mjs and script.md are the only things worth committing.
 walkthroughs/**/chunks/
 walkthroughs/**/chunks-padded/
 walkthroughs/**/chunks-meta.json

--- a/tools/walkthrough-video/README.md
+++ b/tools/walkthrough-video/README.md
@@ -18,13 +18,22 @@ still applies, just with the engine centralized.
 ```
 adapters/<app>.mjs                 →  baseUrl + getStorageState()  (per-app, ~30 lines)
 walkthroughs/<app>/<feature>/
-  steps.mjs                        →  narration + Playwright actions  (per-feature, the real work)
+  steps.mjs                        →  Playwright actions, keyed by step id  (per-feature)
+  script.md                        →  narration + tailSlack, keyed by the same step id
 
-lib/narrate.mjs   (OpenAI TTS, content-hash cached)  ─┐
-lib/record.mjs    (Playwright + cursor overlay)       ├─  app-agnostic engine, written once
-lib/stitch.mjs    (ffmpeg mux + SRT)                  │
-lib/make.mjs      (orchestrator)                     ─┘
+lib/script.mjs    (parses script.md, merges onto steps.mjs by id) ─┐
+lib/narrate.mjs   (OpenAI TTS, content-hash cached)                │
+lib/record.mjs    (Playwright + cursor overlay)                    ├─  app-agnostic engine
+lib/stitch.mjs    (ffmpeg mux + SRT)                                │
+lib/make.mjs      (orchestrator: loads both files, merges, runs)  ─┘
 ```
+
+Narration/timing (`script.md`) and Playwright actions (`steps.mjs`) are deliberately
+split: prose is easy to iterate on in markdown, while actions need arbitrary
+Playwright power that a markdown DSL can't express cleanly. `make.mjs` loads both and
+merges them by step id before handing the combined `STEPS` array to narrate/record/
+stitch — those three files are unchanged by this split, they still just see
+`{id, narration, tailSlack, action}`.
 
 Sync model: `slot[N] = max(actionDuration[N], narrationDuration[N]) + tailSlack[N]`.
 `record.mjs` waits that long before step N+1; `stitch.mjs` pads each narration chunk with
@@ -140,7 +149,8 @@ or confirm reset behavior first.
    writes, and converts it. If your app doesn't use `saga-stack-cli`'s login, or doesn't
    need cookies at all, write whatever fits — the contract is just that return shape.
 
-2. **Write `walkthroughs/<app>/<feature>/steps.mjs`**:
+2. **Write `walkthroughs/<app>/<feature>/steps.mjs`** — one entry per step, `id` +
+   `action` only (no narration here):
 
    ```js
    import { smoothClick } from '../../../lib/record.mjs';
@@ -148,24 +158,42 @@ or confirm reset behavior first.
    export const STEPS = [
      {
        id: '00-intro',
-       narration: 'Welcome to the X feature walkthrough...',
        action: async (page) => {
          await page.goto('/feature');
          await page.waitForSelector('.feature-shell', { timeout: 15000 });
        },
-       tailSlack: 600,
      },
      // ...
      {
        id: '99-outro',
-       narration: 'That is the X feature. Thanks for watching.',
        action: async (page) => { await page.waitForTimeout(500); },
-       tailSlack: 1500,
      },
    ];
    ```
 
-3. Run it per the recipe above.
+3. **Write the paired `walkthroughs/<app>/<feature>/script.md`** — one `## <id>`
+   heading per step (must match `steps.mjs`'s `id` exactly), narration prose as the
+   body, and an optional trailing `tailSlack: <ms>` line:
+
+   ```md
+   ## 00-intro
+
+   Welcome to the X feature walkthrough...
+
+   tailSlack: 600
+
+   ## 99-outro
+
+   That is the X feature. Thanks for watching.
+
+   tailSlack: 1500
+   ```
+
+   `make.mjs` loads both files and merges them by id — `lib/script.mjs` throws if a
+   step id exists in one file but not the other, so a stale script or stale
+   `steps.mjs` fails loudly instead of silently dropping a step.
+
+4. Run it per the recipe above.
 
 ### Authoring tips (from the original doc — still apply)
 

--- a/tools/walkthrough-video/lib/make.mjs
+++ b/tools/walkthrough-video/lib/make.mjs
@@ -15,6 +15,7 @@ import { fileURLToPath } from 'node:url';
 import { narrateAll } from './narrate.mjs';
 import { record } from './record.mjs';
 import { stitch } from './stitch.mjs';
+import { loadScript } from './script.mjs';
 
 const TOOL_ROOT = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 
@@ -41,8 +42,11 @@ async function main() {
   const walkthroughDir = path.join(TOOL_ROOT, 'walkthroughs', app, feature);
   const outDir = walkthroughDir;
 
-  const { STEPS } = await import(path.join(walkthroughDir, 'steps.mjs'));
+  const { STEPS: jsSteps } = await import(path.join(walkthroughDir, 'steps.mjs'));
   const { default: adapter } = await import(path.join(TOOL_ROOT, 'adapters', `${app}.mjs`));
+
+  const scriptPath = path.join(walkthroughDir, 'script.md');
+  const STEPS = await loadScript(scriptPath, jsSteps);
 
   if (process.env.SKIP_NARRATE !== '1') {
     console.log(`[narrate] ${STEPS.length} steps…`);

--- a/tools/walkthrough-video/lib/script.mjs
+++ b/tools/walkthrough-video/lib/script.mjs
@@ -1,0 +1,93 @@
+/**
+ * script.mjs — parse a walkthrough's `.md` script into per-step narration + tailSlack,
+ * and merge it onto the `{id, action}` entries exported by that walkthrough's steps.mjs.
+ *
+ * Format (one `##` heading per step, id must match steps.mjs's step.id):
+ *
+ *   ## 00-intro
+ *
+ *   Welcome to the walkthrough. Prose can span multiple lines and
+ *   paragraphs — it's joined with single spaces into one narration string.
+ *
+ *   tailSlack: 800
+ *
+ *   ## 01-name
+ *
+ *   Next paragraph of narration.
+ *
+ * `tailSlack: <ms>` is optional and, if present, must be the last line of the step's
+ * body (a bare `key: value` line, not part of the narration prose). Steps with no
+ * tailSlack line default to 0, matching the prior inline-JS default.
+ */
+
+import { readFile } from 'node:fs/promises';
+
+const HEADING_RE = /^##\s+(\S+)\s*$/;
+const TAIL_SLACK_RE = /^tailSlack:\s*(\d+)\s*$/i;
+
+/**
+ * Parse `.md` script text into an ordered array of `{id, narration, tailSlack}`.
+ */
+export function parseScript(markdown) {
+  const lines = markdown.split('\n');
+  const steps = [];
+  let current = null;
+
+  const flush = () => {
+    if (!current) return;
+    current.narration = current.narrationLines.join(' ').replace(/\s+/g, ' ').trim();
+    delete current.narrationLines;
+    steps.push(current);
+  };
+
+  for (const line of lines) {
+    const heading = line.match(HEADING_RE);
+    if (heading) {
+      flush();
+      current = { id: heading[1], narrationLines: [], tailSlack: 0 };
+      continue;
+    }
+    if (!current) continue;
+
+    const tailSlack = line.match(TAIL_SLACK_RE);
+    if (tailSlack) {
+      current.tailSlack = Number.parseInt(tailSlack[1], 10);
+      continue;
+    }
+
+    const trimmed = line.trim();
+    if (trimmed) current.narrationLines.push(trimmed);
+  }
+  flush();
+
+  return steps;
+}
+
+/**
+ * Read `scriptPath` and merge its parsed `{id, narration, tailSlack}` onto the
+ * `{id, action}` entries in `jsSteps` (from steps.mjs), matched by id. Throws if the
+ * two lists disagree on which ids exist, so a stale script or stale steps.mjs fails
+ * loudly instead of silently dropping a step.
+ */
+export async function loadScript(scriptPath, jsSteps) {
+  const markdown = await readFile(scriptPath, 'utf8');
+  const scriptSteps = parseScript(markdown);
+
+  const scriptById = new Map(scriptSteps.map((s) => [s.id, s]));
+  const jsById = new Map(jsSteps.map((s) => [s.id, s]));
+
+  const missingFromScript = jsSteps.map((s) => s.id).filter((id) => !scriptById.has(id));
+  const missingFromJs = scriptSteps.map((s) => s.id).filter((id) => !jsById.has(id));
+  if (missingFromScript.length || missingFromJs.length) {
+    throw new Error(
+      `script.mjs: step id mismatch between ${scriptPath} and steps.mjs — ` +
+        `missing from script: [${missingFromScript.join(', ')}]; ` +
+        `missing from steps.mjs: [${missingFromJs.join(', ')}]`,
+    );
+  }
+
+  return jsSteps.map((jsStep) => {
+    const { narration, tailSlack } = scriptById.get(jsStep.id);
+    return { ...jsStep, narration, tailSlack };
+  });
+}

--- a/tools/walkthrough-video/walkthroughs/saga-dash/program-creation/script.md
+++ b/tools/walkthrough-video/walkthroughs/saga-dash/program-creation/script.md
@@ -1,0 +1,54 @@
+## 00-intro
+
+Welcome to the program creation walkthrough in Saga Dash. We'll start from
+the Programs page and create a brand new program from scratch.
+
+tailSlack: 800
+
+## 01-name
+
+Since this district has no programs yet, we're dropped straight into the
+new program form. First, we give it a name: "Walkthrough Demo Program".
+
+tailSlack: 500
+
+## 02-timezone
+
+Next, the program time zone — we pick Central Time, America Chicago.
+
+tailSlack: 500
+
+## 03-address
+
+Address details are optional, but filling them in helps identify the
+program later. We enter one two three West Madison Street, Chicago.
+
+tailSlack: 500
+
+## 04-state-zip
+
+Then the state — Illinois — and the ZIP code, six oh six oh one.
+
+tailSlack: 500
+
+## 05-save
+
+With everything filled in, we click Save. Saga Dash creates the program and
+takes us straight to its overview page.
+
+tailSlack: 1000
+
+## 06-overview
+
+And there it is — the new program overview, showing the name we chose.
+Saga Dash also flags that the program still needs people enrolled before
+it can go live.
+
+tailSlack: 1200
+
+## 99-outro
+
+That's the full program creation flow — name, time zone, address, and
+save. Thanks for watching.
+
+tailSlack: 1500

--- a/tools/walkthrough-video/walkthroughs/saga-dash/program-creation/steps.mjs
+++ b/tools/walkthrough-video/walkthroughs/saga-dash/program-creation/steps.mjs
@@ -1,5 +1,5 @@
 /**
- * Narrated walkthrough: creating a new program in saga-dash.
+ * Walkthrough: creating a new program in saga-dash.
  *
  * Mirrors the real e2e coverage in
  * apps/web/dash/e2e/journey/program-creation.e2e.test.ts (saga-stack-cli flow
@@ -9,6 +9,8 @@
  * apps/web/dash/e2e/data/seed-users.ts), so `/programs` auto-redirects to
  * `/programs/new/config`. Record with:
  *   WALKTHROUGH_LOGIN_EMAIL=empty@saga.org node lib/make.mjs --walkthrough saga-dash/program-creation
+ *
+ * Narration + timing live in the paired script.md, keyed by step id — see script.mjs.
  */
 
 import { smoothClick } from '../../../lib/record.mjs';
@@ -18,84 +20,56 @@ const PROGRAM_NAME = 'Walkthrough Demo Program';
 export const STEPS = [
   {
     id: '00-intro',
-    narration:
-      "Welcome to the program creation walkthrough in Saga Dash. We'll start from " +
-      'the Programs page and create a brand new program from scratch.',
     action: async (page) => {
       await page.goto('/programs');
       await page.waitForURL('**/programs/new/config', { timeout: 15000 });
       await page.waitForSelector('#pd-name', { timeout: 15000 });
     },
-    tailSlack: 800,
   },
   {
     id: '01-name',
-    narration:
-      "Since this district has no programs yet, we're dropped straight into the new " +
-      `program form. First, we give it a name: "${PROGRAM_NAME}".`,
     action: async (page) => {
       await page.locator('#pd-name').fill(PROGRAM_NAME);
     },
-    tailSlack: 500,
   },
   {
     id: '02-timezone',
-    narration: 'Next, the program time zone — we pick Central Time, America Chicago.',
     action: async (page) => {
       await page.locator('.field-timezone select').selectOption('America/Chicago');
     },
-    tailSlack: 500,
   },
   {
     id: '03-address',
-    narration:
-      'Address details are optional, but filling them in helps identify the program later. ' +
-      'We enter one two three West Madison Street, Chicago.',
     action: async (page) => {
       await page.locator('#pd-address').fill('123 W Madison St');
       await page.locator('#pd-city').fill('Chicago');
     },
-    tailSlack: 500,
   },
   {
     id: '04-state-zip',
-    narration: 'Then the state — Illinois — and the ZIP code, six oh six oh one.',
     action: async (page) => {
       await page.locator('.field-state select').selectOption('IL');
       await page.locator('#pd-zip').fill('60601');
     },
-    tailSlack: 500,
   },
   {
     id: '05-save',
-    narration:
-      "With everything filled in, we click Save. Saga Dash creates the program and takes " +
-      'us straight to its overview page.',
     action: async (page) => {
       const saveButton = page.getByRole('button', { name: 'Save', exact: true });
       await smoothClick(page, saveButton);
       await page.waitForURL('**/programs/*/config', { timeout: 15000 });
     },
-    tailSlack: 1000,
   },
   {
     id: '06-overview',
-    narration:
-      'And there it is — the new program overview, showing the name we chose. Saga Dash ' +
-      'also flags that the program still needs people enrolled before it can go live.',
     action: async (page) => {
       await page.waitForSelector(`text=${PROGRAM_NAME}`, { timeout: 10000 });
     },
-    tailSlack: 1200,
   },
   {
     id: '99-outro',
-    narration:
-      "That's the full program creation flow — name, time zone, address, and save. " +
-      'Thanks for watching.',
     action: async (page) => {
       await page.waitForTimeout(500);
     },
-    tailSlack: 1500,
   },
 ];


### PR DESCRIPTION
## Summary

- Narration text and the `tailSlack` timing knob move out of `steps.mjs` into a paired per-feature `script.md` — one `## <id>` heading per step, prose body, optional trailing `tailSlack: <ms>` line, keyed to the same step id `steps.mjs` uses.
- `steps.mjs` reduces to `{id, action}` — Playwright logic only, no embedded narration prose. Single source of truth for narration, per the locked design decision (actions stay in JS; a markdown action-DSL was considered and rejected as more work for a poor fit).
- New `lib/script.mjs` parses `script.md` and merges it onto `steps.mjs`'s entries by id, throwing on any id mismatch between the two files (stale script or stale steps.mjs fails loudly, not silently).
- `lib/make.mjs` is the only engine file that changes — it loads both files and merges before handing `STEPS` to `narrate`/`record`/`stitch`, which are otherwise untouched (they only ever consumed `{id, narration, tailSlack, action}` off the array).
- Ported the `program-creation` walkthrough to the new split as the worked example — narration content itself is unchanged, just relocated.
- Timing stays fully derived (`slot = max(actionDuration, narrationDuration) + tailSlack`) — no duration/scene-length field was added to the markdown format, by design.
- README updated to describe the new two-file authoring flow.

## Verification

- `node --check` on all changed/new `.mjs` files (syntax clean).
- Directly exercised `parseScript`/`loadScript` against the real `program-creation/script.md`: correctly parses all 8 steps, merges narration+tailSlack onto stub `{id, action}` steps by id, and throws on a deliberately truncated step list (mismatch guard).
- **Not run**: a full `narrate → record → stitch` render. `playwright` isn't installed in this fresh worktree (needs root `pnpm install`) and record requires a live `ss stack up` dash instance. The pipeline files downstream of the merge point (`narrate.mjs`/`record.mjs`/`stitch.mjs`) are unchanged, but an actual rendered video against the new script.md has not been produced — that's the real end-to-end check and it's outstanding.

## Out of scope

`soa/docs/how-to-narrated-walkthrough-video.md` still references a dead branch/path from before the engine generalized (unrelated pre-existing staleness, not touched by this PR).

## Test plan

- [ ] `pnpm install` at repo root, then run `node lib/make.mjs --walkthrough saga-dash/program-creation` (or `SKIP_NARRATE=1` for a silent/free pass) against a live `ss stack up --with dash` to confirm the merged script actually drives a real render.
- [ ] Spot-check the generated SRT against `script.md`'s prose.