### PR TITLE
walkthrough-video: sandbox-composition recording lane

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ pnpm typecheck      # Type check
 - See `apps/node/claude/testing.md` for Node.js testing patterns (DI, controller loading)
 - See `packages/CLAUDE.md` for package details
 - See `docs/cross-repo-linking-summary.md` for cross-repo package linking (development workflow)
+- See `tools/walkthrough-video/CLAUDE.md` for generating narrated demo videos of any saga-soa frontend
 
 ---
 

--- a/tools/walkthrough-video/CLAUDE.md
+++ b/tools/walkthrough-video/CLAUDE.md
@@ -1,0 +1,20 @@
+# walkthrough-video
+
+Generates narrated MP4/WebM walkthrough videos (synced cursor, voiceover, subtitles) of
+any saga-soa frontend, driven by `saga-stack-cli`. Full guide — architecture, prerequisites,
+running an existing walkthrough, the sandbox-composition lane, authoring a new one, gotchas
+— lives in [README.md](./README.md). Read that before making changes here; this file is
+just the on-ramp.
+
+**To record an existing walkthrough** (e.g. `saga-dash/program-creation`): README.md
+§ "Running an existing walkthrough". Start with `SKIP_NARRATE=1` for a free/fast silent
+smoke pass before spending on real TTS narration.
+
+**To author a new walkthrough** for an app/feature that doesn't have one yet: README.md
+§ "Authoring a new walkthrough" — add an adapter (only if the app has none) plus a
+`steps.mjs` under `walkthroughs/<app>/<feature>/`; the engine in `lib/` is app-agnostic
+and shouldn't need to change.
+
+**Before re-recording a walkthrough that mutates state** (creates/deletes something),
+reset first — see README.md's note under "Running an existing walkthrough". A persona
+that satisfied the script's precondition on the first run usually won't on the second.

--- a/tools/walkthrough-video/README.md
+++ b/tools/walkthrough-video/README.md
@@ -78,6 +78,44 @@ persona — omit it to log in as `ss`'s own default (`dev@saga.org`).
 Output lands at `walkthroughs/<app>/<feature>/video/walkthrough.mp4` (+ `-vp9.webm` sidecar,
 `.srt`).
 
+## Recording against a deployed sandbox composition
+
+`adapters/saga-dash.mjs` has a second lane for recording against an already-deployed
+switchboard sandbox composition instead of a local stack — useful when a walkthrough
+needs data/services only a sandbox has, or you don't want to stand up a local stack.
+No local stack is brought up or torn down; the composition must already exist.
+
+```bash
+export WALKTHROUGH_LANE=sandbox
+export WALKTHROUGH_DASH_URL=https://dash.wootdev.com     # defaults to this if unset
+export WALKTHROUGH_IAM_URL=https://iam.wootdev.com       # defaults to this if unset
+export JANUS_SESSION=<janus_session cookie value>        # from an interactive JumpCloud
+                                                          # gate login — copy from devtools;
+                                                          # required unless the composition
+                                                          # was deployed Janus-off (unsupported
+                                                          # by this adapter today)
+export WALKTHROUGH_PREVIEW_PINS="iam-api=sandbox-<name>,sis-api=sandbox-<name>,programs-api=sandbox-<name>,..."
+export WALKTHROUGH_LOGIN_EMAIL=empty@saga.org            # must be seeded in that composition
+
+node tools/walkthrough-video/lib/make.mjs --walkthrough saga-dash/program-creation
+```
+
+This mirrors saga-dash's own sandbox e2e lane (`apps/web/dash/e2e/run-stack-e2e.sh
+--sandbox`, `PLAYWRIGHT_PREVIEW_PINS`) — same `x-saga-preview-<svc>` cookie-pinning
+mechanism, same real `auth.login` (not `devLogin`, which is forbidden on deployed
+iam-api), same Janus perimeter cookie. `WALKTHROUGH_PREVIEW_PINS` uses the identical
+`svc=variant,svc=variant` format as saga-dash's `PLAYWRIGHT_PREVIEW_PINS` — if you
+copied a composition string from switchboard (`svc:variant,svc:variant,...,_default:main`,
+often URL-encoded), translate it: swap `:` for `=`, drop the `_default:...` entry (not a
+real pin — services you don't pin just aren't listed, and fall through to `main` on
+their own), and URL-decode if needed.
+
+**Known constraint**: recording a walkthrough that mutates state (e.g.
+`program-creation`, which creates a program) against a shared sandbox composition means
+a second recording will start from different UI state unless the composition/persona
+resets between runs. Prefer a read-only walkthrough for a composition you don't control,
+or confirm reset behavior first.
+
 ## Authoring a new walkthrough
 
 1. **If the app has no adapter yet**, add `adapters/<app>.mjs` exporting

--- a/tools/walkthrough-video/README.md
+++ b/tools/walkthrough-video/README.md
@@ -43,9 +43,12 @@ they're not repeated here.
   a local `.env` — the dev key lives in Secrets Manager (`openai-dev-apikey-W3MunH`,
   us-west-2, account 531314149529). `lib/narrate.mjs` fetches it automatically via
   `aws secretsmanager get-secret-value --profile saga-dev` — **Observer-tier profiles
-  (`saga`, `saga-dev`) are denied `GetSecretValue` on this ARN**; set
-  `WALKTHROUGH_AWS_PROFILE` to a profile with access, or set `OPENAI_API_KEY` directly to
-  bypass Secrets Manager entirely (e.g. a throwaway personal key while iterating).
+  (`saga`, `saga-dev`) are denied `GetSecretValue` on this ARN** by design. For routine
+  iteration, set `OPENAI_API_KEY` directly to bypass Secrets Manager entirely (e.g. a
+  throwaway personal key) rather than reaching for an elevated profile. `WALKTHROUGH_AWS_PROFILE`
+  does let you point at a profile with access (e.g. `saga-admin-{dev,prod}`), but that's
+  break-glass — reserve it for an official narrated render, not day-to-day authoring, per
+  the tier-ladder norms in the repo owner's global CLAUDE.md.
 - For a **free/zero-credential iteration tier**, prefer `SKIP_NARRATE=1` (silent render —
   proves out action timing/selectors without any TTS call) over `TTS_ENGINE=edge`. The
   `edge` engine (unofficial `edge-tts` npm wrapper around Microsoft's read-aloud API) is
@@ -76,7 +79,19 @@ FORCE=1        node tools/walkthrough-video/lib/make.mjs --walkthrough saga-dash
 persona — omit it to log in as `ss`'s own default (`dev@saga.org`).
 
 Output lands at `walkthroughs/<app>/<feature>/video/walkthrough.mp4` (+ `-vp9.webm` sidecar,
-`.srt`).
+`.srt`). The `.srt` is also muxed into the MP4 itself as a selectable soft-subtitle track
+(`mov_text`) — captions work whether or not the `.srt` sidecar travels with the file. The
+`-vp9.webm` sidecar has no embedded captions (the container doesn't support `mov_text`);
+pair it with the `.srt` sidecar if you distribute that variant.
+
+**Mutating walkthroughs need a reset between runs.** A script like `program-creation` has
+a precondition (here: zero programs in the org) that its own first action changes. Run it
+twice against the same persona without resetting in between and the second recording drives
+whatever page the app lands on now — not the one the script expects — with no error, just a
+silently wrong video. Before re-recording a mutating walkthrough: `ss stack reset && ss stack seed`,
+or switch to a not-yet-used persona. This applies on the local stack same as the sandbox lane
+(see the "Known constraint" note below) — a persona is "clean" only until the first successful
+run through it.
 
 ## Recording against a deployed sandbox composition
 
@@ -185,9 +200,9 @@ Not built in this pass, but straightforward given the engine/data split:
 
 - A new `adapters/<app>.mjs` + `walkthroughs/<app>/<feature>/steps.mjs` is all a new
   app/feature needs — no engine changes.
-- Multi-voice narration, a background music bed, burned-in captions, multiple output
-  resolutions — see the original doc's "Extending the pipeline" section for the shape of
-  each; none are implemented here yet.
+- Multi-voice narration, a background music bed, burned-in (as opposed to the current
+  soft/selectable) captions, multiple output resolutions — see the original doc's
+  "Extending the pipeline" section for the shape of each; none are implemented here yet.
 - Folding this into `saga-stack-cli` proper as `ss demo record <spa>/<feature>`, once this
   standalone tool has proven itself on a few real walkthroughs.
 - Push-button cloud rendering (Fargate + headless Chromium) — viable, not designed here;

--- a/tools/walkthrough-video/adapters/saga-dash.mjs
+++ b/tools/walkthrough-video/adapters/saga-dash.mjs
@@ -1,15 +1,37 @@
 /**
- * saga-dash adapter — baseUrl + a storageState built from `ss stack login`'s cookie jar.
+ * saga-dash adapter — baseUrl + a storageState, in one of two lanes:
  *
- * `ss stack login --output-json` mints a headless session against iam-api and writes
- * the captured cookies (iam_session JWT + iam_refresh) as a Netscape cookie jar at
- * `<stateDir>/cookies.txt` (saga-stack-cli's `packages/node/saga-stack-cli/src/runtime/login.ts`).
- * This adapter shells out to that command, parses its jar, and converts it into the
- * Playwright `storageState` shape record.mjs hands to `browser.newContext()`.
+ * STACK lane (default) — local synthetic-dev stack. `ss stack login --output-json`
+ * mints a headless session against iam-api and writes the captured cookies
+ * (iam_session JWT + iam_refresh) as a Netscape cookie jar at `<stateDir>/cookies.txt`
+ * (saga-stack-cli's `packages/node/saga-stack-cli/src/runtime/login.ts`). This adapter
+ * shells out to that command, parses its jar, and converts it into the Playwright
+ * `storageState` shape record.mjs hands to `browser.newContext()`.
  *
  * Run `ss stack up --with dash` and `ss stack login` yourself before recording — this
  * adapter mints a fresh jar on every call (session cookies decay if iam restarts; don't
  * try to cache one across runs).
+ *
+ * SANDBOX lane (WALKTHROUGH_LANE=sandbox) — a deployed switchboard composition on
+ * wootdev.com. No local stack. Mints a session via the real `auth.login` (devLogin is
+ * forbidden on deployed iam-api), passes the employee Janus perimeter via a
+ * JANUS_SESSION cookie, and pins backend service routing via `x-saga-preview-*`
+ * cookies — the same mechanism (and cookie names/domain) the saga-dash sandbox e2e
+ * lane uses (apps/web/dash/e2e/fixtures/global-setup.ts:sandboxExtraCookies() +
+ * lane.ts:mintSessionSetCookiesUncached()), reimplemented here since this tool lives in
+ * a separate repo and can't import saga-dash's fixtures directly. See
+ * specs/contracts/drafts/sandbox-preview-header-propagation.spec.md (saga-dash) for
+ * why this must be cookies, not headers: dash-runtime reads `x-saga-preview-*` off
+ * `document.cookie` and re-attaches them as headers on its own XHRs.
+ *
+ * Env (sandbox lane): WALKTHROUGH_DASH_URL (deployed dash origin, e.g.
+ * https://dash.wootdev.com), WALKTHROUGH_IAM_URL (deployed iam-api origin, e.g.
+ * https://iam.wootdev.com — used both to mint the session and to derive the apex
+ * cookie domain), JANUS_SESSION (janus_session cookie value from an interactive
+ * JumpCloud gate login — required unless the composition was deployed Janus-off),
+ * WALKTHROUGH_PREVIEW_PINS ("svc=variant,svc=variant" — same format as saga-dash's
+ * PLAYWRIGHT_PREVIEW_PINS), WALKTHROUGH_SEED_PASSWORD (defaults to 'password123',
+ * matching the e2e harness's seeded-persona convention).
  */
 
 import { execFile } from 'node:child_process';
@@ -18,7 +40,10 @@ import { readFile } from 'node:fs/promises';
 
 const execFileAsync = promisify(execFile);
 
-const BASE_URL = process.env.WALKTHROUGH_DASH_URL ?? 'http://localhost:8900';
+const LANE = process.env.WALKTHROUGH_LANE === 'sandbox' ? 'sandbox' : 'stack';
+
+const BASE_URL =
+  process.env.WALKTHROUGH_DASH_URL ?? (LANE === 'sandbox' ? 'https://dash.wootdev.com' : 'http://localhost:8900');
 const DASH_ORIGIN = new URL(BASE_URL).origin;
 
 /** Parse one Netscape-jar row into a Playwright cookie object. */
@@ -62,7 +87,7 @@ function parseNetscapeJar(contents) {
  * WALKTHROUGH_LOGIN_EMAIL for a walkthrough that needs a specific seeded persona
  * (e.g. an already-rostered, zero-programs org for a program-creation demo).
  */
-async function getStorageState() {
+async function getStackStorageState() {
   const loginArgs = ['stack', 'login', '--output-json'];
   if (process.env.WALKTHROUGH_LOGIN_EMAIL) loginArgs.splice(2, 0, process.env.WALKTHROUGH_LOGIN_EMAIL);
 
@@ -82,6 +107,165 @@ async function getStorageState() {
   const cookies = parseNetscapeJar(jarContents);
 
   return { cookies, origins: [] };
+}
+
+// ── Sandbox lane ────────────────────────────────────────────────────────────
+
+const IAM_URL = process.env.WALKTHROUGH_IAM_URL ?? 'https://iam.wootdev.com';
+const SEED_PASSWORD = process.env.WALKTHROUGH_SEED_PASSWORD ?? 'password123';
+const JANUS_SESSION = process.env.JANUS_SESSION ?? '';
+
+/** Apex of IAM_URL's host (e.g. "iam.wootdev.com" → ".wootdev.com") — mirrors
+ * saga-dash e2e's lane.ts:cookieApexDomain(). */
+function cookieApexDomain() {
+  const host = new URL(IAM_URL).hostname;
+  if (host === 'localhost' || /^[\d.]+$/.test(host)) return host;
+  const parts = host.split('.');
+  return parts.length > 2 ? `.${parts.slice(-2).join('.')}` : `.${host}`;
+}
+
+/** Parse WALKTHROUGH_PREVIEW_PINS ("svc=variant,svc=variant") into a map — same
+ * format as saga-dash e2e's PLAYWRIGHT_PREVIEW_PINS. */
+function previewPins() {
+  const pins = {};
+  for (const pair of (process.env.WALKTHROUGH_PREVIEW_PINS ?? '').split(',')) {
+    const eq = pair.indexOf('=');
+    if (eq <= 0) continue;
+    pins[pair.slice(0, eq).trim()] = pair.slice(eq + 1).trim();
+  }
+  return pins;
+}
+
+/**
+ * Parse one Set-Cookie response header line into a Playwright cookie object.
+ * Prefers the cookie's own Domain= attribute (iam-api sets it to the apex
+ * domain in sandbox) over recomputing one.
+ */
+function parseSetCookie(line) {
+  const [pair, ...attrs] = line.split(';').map((s) => s.trim());
+  const eq = pair.indexOf('=');
+  if (eq < 0) return null;
+  const lower = attrs.map((a) => a.toLowerCase());
+  const domainAttr = attrs.find((a) => a.toLowerCase().startsWith('domain='));
+  const pathAttr = attrs.find((a) => a.toLowerCase().startsWith('path='));
+  const sameSiteAttr = attrs.find((a) => a.toLowerCase().startsWith('samesite='));
+  const sameSite = (sameSiteAttr?.split('=')[1] ?? 'Lax').toLowerCase();
+
+  return {
+    name: pair.slice(0, eq),
+    value: pair.slice(eq + 1),
+    domain: domainAttr ? domainAttr.slice('domain='.length) : new URL(IAM_URL).hostname,
+    path: pathAttr ? pathAttr.slice('path='.length) : '/',
+    expires: -1,
+    httpOnly: lower.includes('httponly'),
+    secure: lower.includes('secure'),
+    sameSite: sameSite === 'strict' ? 'Strict' : sameSite === 'none' ? 'None' : 'Lax',
+  };
+}
+
+/**
+ * Real auth.login (not devLogin, which is forbidden on deployed iam-api). Returns
+ * every Set-Cookie line from the response (iam_session, iam_csrf, possibly more) —
+ * caller must not filter these down before assembling storageState.
+ *
+ * Must attach janus_session as a Cookie header explicitly — unlike a Playwright
+ * browser context, a bare Node fetch() has no cookie jar to carry it automatically,
+ * and auth.login is behind the employee Janus perimeter (401 {"realms":["janus"]}
+ * without it).
+ */
+async function mintSandboxSessionSetCookies(email) {
+  if (!JANUS_SESSION) {
+    throw new Error('mintSandboxSessionSetCookies called without JANUS_SESSION set');
+  }
+  const res = await fetch(`${IAM_URL}/trpc/auth.login`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Origin: DASH_ORIGIN,
+      Cookie: `janus_session=${JANUS_SESSION}`,
+    },
+    body: JSON.stringify({ email, password: SEED_PASSWORD }),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`auth.login ${email} → HTTP ${res.status} ${res.statusText} — ${body}`);
+  }
+  const raw = res.headers.getSetCookie?.() ?? [];
+  if (!raw.some((c) => c.startsWith('iam_session='))) {
+    throw new Error(`auth.login ${email} returned no iam_session cookie — check WALKTHROUGH_SEED_PASSWORD`);
+  }
+  return raw;
+}
+
+/**
+ * Preview-pin + Janus cookies for the sandbox lane's browser context. Preview
+ * cookies MUST be httpOnly:false — dash-runtime's preview-cookies.ts reads them off
+ * document.cookie and re-attaches them as x-saga-preview-<svc> headers on its own
+ * XHRs. The Janus cookie is the opposite (httpOnly:true) — the split is per-purpose,
+ * not per-service.
+ */
+function sandboxExtraCookies() {
+  const domain = cookieApexDomain();
+  const extras = [];
+
+  if (JANUS_SESSION) {
+    extras.push({
+      name: 'janus_session',
+      value: JANUS_SESSION,
+      domain,
+      path: '/',
+      expires: -1,
+      httpOnly: true,
+      secure: true,
+      sameSite: 'Lax',
+    });
+  }
+
+  for (const [svc, variant] of Object.entries(previewPins())) {
+    extras.push({
+      name: `x-saga-preview-${svc}`,
+      value: variant,
+      domain,
+      path: '/',
+      expires: -1,
+      httpOnly: false,
+      secure: true,
+      sameSite: 'Lax',
+    });
+  }
+
+  return extras;
+}
+
+/**
+ * Mint a sandbox session via real auth.login, add Janus + preview-pin cookies, and
+ * return a Playwright storageState object ({cookies, origins: []}).
+ *
+ * Requires JANUS_SESSION (from an interactive JumpCloud gate login) unless the
+ * composition was deployed with the employee Janus perimeter off — this adapter
+ * doesn't know which, so it fails loudly rather than silently recording an
+ * unauthenticated/gated session if JANUS_SESSION is missing.
+ */
+async function getSandboxStorageState() {
+  if (!JANUS_SESSION) {
+    throw new Error(
+      'WALKTHROUGH_LANE=sandbox needs JANUS_SESSION (janus_session cookie from an ' +
+        'interactive JumpCloud gate login — copy the value from devtools). If the ' +
+        'target composition was deployed with the employee Janus perimeter off, this ' +
+        "adapter doesn't yet support that — set JANUS_SESSION anyway or extend this check.",
+    );
+  }
+
+  const email = process.env.WALKTHROUGH_LOGIN_EMAIL ?? 'empty@saga.org';
+  const raw = await mintSandboxSessionSetCookies(email);
+  const cookies = raw.map(parseSetCookie).filter((c) => c !== null);
+  cookies.push(...sandboxExtraCookies());
+
+  return { cookies, origins: [] };
+}
+
+async function getStorageState() {
+  return LANE === 'sandbox' ? getSandboxStorageState() : getStackStorageState();
 }
 
 export default {

--- a/tools/walkthrough-video/lib/stitch.mjs
+++ b/tools/walkthrough-video/lib/stitch.mjs
@@ -8,10 +8,13 @@
  *   video/walkthrough.webm
  *
  * Outputs:
- *   video/walkthrough.mp4          — H.264 + AAC, muxed
+ *   video/walkthrough.mp4          — H.264 + AAC + mov_text soft-subtitle track, muxed
  *   video/walkthrough-vp9.webm     — VP9 + Opus sidecar (avoids the GStreamer/Totem
- *                                    H.264 playback trap on some Linux desktops)
- *   video/walkthrough.srt          — subtitles from cumulative slot timestamps
+ *                                    H.264 playback trap on some Linux desktops; webm
+ *                                    doesn't support mov_text, so this one carries no
+ *                                    subtitle track — use the .srt sidecar with it)
+ *   video/walkthrough.srt          — subtitles from cumulative slot timestamps, also
+ *                                    muxed into walkthrough.mp4 as a selectable track
  */
 
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
@@ -92,15 +95,18 @@ async function concatAudio(paddedPaths, listPath, outPath) {
   ]);
 }
 
-async function muxMp4(videoPath, audioPath, outPath) {
+async function muxMp4(videoPath, audioPath, srtPath, outPath) {
   await execFileAsync('ffmpeg', [
     '-y',
     '-i', videoPath,
     '-i', audioPath,
+    '-i', srtPath,
     '-c:v', 'libx264',
     '-pix_fmt', 'yuv420p',
     '-c:a', 'aac',
     '-b:a', '192k',
+    '-c:s', 'mov_text',
+    '-metadata:s:s:0', 'language=eng',
     '-shortest',
     outPath,
   ]);
@@ -155,14 +161,14 @@ export async function stitch(steps, outDir) {
   const fullAudioPath = path.join(outDir, 'video', 'walkthrough.audio.mp3');
   await concatAudio(paddedPaths, concatListPath, fullAudioPath);
 
+  const srtPath = path.join(videoDir, 'walkthrough.srt');
+  await writeFile(srtPath, buildSrt(steps, slots));
+
   const webmPath = path.join(videoDir, 'walkthrough.webm');
   const mp4Path = path.join(videoDir, 'walkthrough.mp4');
   const vp9Path = path.join(videoDir, 'walkthrough-vp9.webm');
-  await muxMp4(webmPath, fullAudioPath, mp4Path);
+  await muxMp4(webmPath, fullAudioPath, srtPath, mp4Path);
   await muxVp9Sidecar(webmPath, fullAudioPath, vp9Path);
-
-  const srtPath = path.join(videoDir, 'walkthrough.srt');
-  await writeFile(srtPath, buildSrt(steps, slots));
 
   return { mp4Path, vp9Path, srtPath };
 }


### PR DESCRIPTION
## Summary

Adds a second lane to `adapters/saga-dash.mjs` for recording a walkthrough
against an already-deployed switchboard sandbox composition (e.g.
`sandbox-test2`) instead of only a local synthetic-dev stack — set
`WALKTHROUGH_LANE=sandbox`.

Ports the exact cookie-pinning/auth mechanism saga-dash's own sandbox e2e
lane uses (`apps/web/dash/e2e/fixtures/global-setup.ts` +
`lane.ts`), reimplemented here since this tool lives in `soa` and can't
import saga-dash's fixtures directly:

- Real `auth.login` (not `devLogin`, which is forbidden on deployed
  iam-api).
- The employee Janus perimeter passed as a `janus_session` cookie
  (`JANUS_SESSION` env var).
- Backend service routing pinned via `x-saga-preview-<svc>` cookies —
  `httpOnly: false` by design, since dash-runtime reads them off
  `document.cookie` client-side and re-attaches them as headers on its own
  outbound XHRs. Same cookie names, same apex-domain scoping, same
  `WALKTHROUGH_PREVIEW_PINS` format (`svc=variant,svc=variant`) as
  saga-dash's `PLAYWRIGHT_PREVIEW_PINS`.

README documents the new lane, all env vars, and how to translate a
switchboard composition string (`svc:variant,...,_default:main`,
URL-encoded) into `WALKTHROUGH_PREVIEW_PINS`.

## Verification

- Live-verified the session-minting path (`getSandboxStorageState()`)
  against the real `sandbox-test2` composition: `auth.login` as
  `empty@saga.org` succeeded once the Janus cookie was correctly attached
  to the Node-side `fetch()` call (a bare `fetch()` has no cookie jar —
  had to add it explicitly, unlike a browser context), returning a
  correct 10-cookie storageState (`iam_session`, `iam_refresh`,
  `janus_session`, all 7 pinned-service preview cookies) with the
  expected `httpOnly`/`domain` shape.
- The preview-pin cookie→header mechanism itself (not this adapter, but
  the mechanism it reimplements) was independently confirmed live against
  `sandbox-test2` earlier this session via saga-dash's own e2e suite
  (`stage-0-coherence` + `sandbox-preview-headers`, 6/6 passed with these
  exact pins) — confirming the composition is live/routed/seeded and that
  pinning genuinely reaches the deployed dash's outbound requests rather
  than silently falling through to `main`.
- **Full pipeline run against the live sandbox**, end-to-end, with a
  real (fresh, short-lived) `JANUS_SESSION`: `auth.login` succeeded,
  the browser context picked up the minted session + preview-pin
  cookies, and Playwright navigated through real authenticated pages on
  `dash.wootdev.com` routed to `sandbox-test2` (`/programs` →
  `/programs/new`). This confirms the adapter's auth + cookie-pinning +
  browser-driving chain all work correctly against a real deployed
  composition, not just in the session-minting unit check above.

## Not run / known constraint

- A complete `program-creation` walkthrough recording did not finish:
  the script's precondition (`empty@saga.org`'s org has zero programs,
  so `/programs` auto-redirects to `/programs/new/config`) no longer held
  — the shared `sandbox-test2` composition already has a program under
  that persona, so it landed on `/programs/new` instead of the deep-linked
  config route and the script's `waitForURL` timed out. This is exactly
  the state-mutation constraint already called out in the README (a
  state-mutating walkthrough against a shared composition doesn't
  reproduce cleanly on a second run) — not a defect in the adapter or the
  auth/routing mechanism, which is confirmed working above.
- Producing an actual rendered video therefore needs either a
  freshly-reset composition/persona, or a walkthrough script that doesn't
  assume zero-programs starting state. Left for a follow-up rather than
  this PR, since the adapter itself is now verified end-to-end.

## Test plan

- [x] Session-minting verified live against `sandbox-test2`.
- [x] Full pipeline (auth + cookie-pinning + browser navigation) verified
      live against `sandbox-test2` with a real Janus session.
- [ ] Full narrated render producing an actual output video — blocked on
      shared-composition seed state, tracked as a follow-up.
