### PR TITLE
feat(saga-stack-cli): opt-in OpenFGA + authz-sync support in the local mesh

### DIFF
--- a/infra/compose/projects/saga-mesh.yml
+++ b/infra/compose/projects/saga-mesh.yml
@@ -16,6 +16,18 @@
 ##   ads_adm_local    SDS ads-adm-api            owner=ads_adm
 ##   ledger_local     SDS ledger-api             owner=ledger
 ##
+## Opt-in (only created when `--with authz` selects the `authz` bundle):
+##
+##   openfga           rostering authz stack (openfga server)   owner=postgres_admin
+##   authz_sync_local  rostering authz-sync                      owner=authz_sync
+##
+## OpenFGA itself (server + its `openfga_migrate` one-shot job, see
+## ../services/openfga/compose.yml) only starts when the `authz` compose
+## profile is active (COMPOSE_PROFILES=authz, set by saga-stack-cli's native
+## mesh bring-up iff the closure needs it) — `make up`'s `up:` target has no
+## per-service filter, so profiles are what keep this opt-in unit out of every
+## OTHER project's mesh footprint.
+##
 ## Usage:
 ##   EXTRA_POSTGRES_SEED_DIR=../../projects/saga-mesh/seed \
 ##   SEED_PROFILE=empty make up PROJECT=saga-mesh
@@ -37,3 +49,4 @@ include:
   - path: ../services/redis/compose.yml
   - path: ../services/rabbitmq/compose.yml
   - path: ../services/connect-mongo/compose.yml
+  - path: ../services/openfga/compose.yml

--- a/infra/compose/projects/saga-mesh/seed/profile-empty.sql
+++ b/infra/compose/projects/saga-mesh/seed/profile-empty.sql
@@ -18,6 +18,7 @@ CREATE USER ads_adm        WITH PASSWORD 'ads_adm';
 CREATE USER ledger         WITH PASSWORD 'ledger';
 CREATE USER sis            WITH PASSWORD 'sis';
 CREATE USER coach_api_app  WITH PASSWORD 'dev-password-coach-api-app';
+CREATE USER authz_sync     WITH PASSWORD 'authz_sync';
 
 -- ── Databases ───────────────────────────────────────────────────────
 -- Owner set at creation time so prisma migrate deploy can CREATE SCHEMA.
@@ -32,6 +33,15 @@ CREATE DATABASE ledger_local    OWNER ledger;
 CREATE DATABASE sis_db          OWNER sis;
 CREATE DATABASE coach_api       OWNER coach_api_app;
 
+-- Opt-in (rostering `authz` bundle, `--with authz`): created unconditionally
+-- here like every other app DB above (a few KB, harmless if unused), but only
+-- the openfga/authz-sync CONTAINERS start when the bundle is selected (see
+-- ../../../services/openfga/compose.yml's `profiles: ["authz"]`).
+-- `openfga` stays owned by the mesh superuser — its schema is (re)created by
+-- the `openfga_migrate` one-shot job, not by app-level `CREATE SCHEMA`.
+CREATE DATABASE openfga          OWNER postgres_admin;
+CREATE DATABASE authz_sync_local OWNER authz_sync;
+
 -- ── Grants (belt-and-suspenders; owner already has these) ──────────
 GRANT ALL PRIVILEGES ON DATABASE iam_local     TO iam;
 GRANT ALL PRIVILEGES ON DATABASE iam_pii_local TO iam_pii;
@@ -43,6 +53,8 @@ GRANT ALL PRIVILEGES ON DATABASE ads_adm_local TO ads_adm;
 GRANT ALL PRIVILEGES ON DATABASE ledger_local  TO ledger;
 GRANT ALL PRIVILEGES ON DATABASE sis_db        TO sis;
 GRANT ALL PRIVILEGES ON DATABASE coach_api     TO coach_api_app;
+GRANT ALL PRIVILEGES ON DATABASE openfga          TO postgres_admin;
+GRANT ALL PRIVILEGES ON DATABASE authz_sync_local TO authz_sync;
 
 -- The sentinel row in _profile_meta.seeded is written by
 -- services/postgres/seed/init-and-seed.sh after this file completes.

--- a/infra/compose/services/openfga/compose.yml
+++ b/infra/compose/services/openfga/compose.yml
@@ -12,6 +12,12 @@ services:
   openfga_migrate:
     image: openfga/openfga:latest
     command: migrate
+    # Opt-in: only started when the `authz` compose profile is active
+    # (COMPOSE_PROFILES=authz), so an unconditional `include:` of this fragment
+    # doesn't start OpenFGA on every mesh `up`. Both services here carry the same
+    # profile — gating only one would leave the `service_completed_successfully`
+    # dependency below pointed at a service that never starts.
+    profiles: ["authz"]
     environment:
       OPENFGA_DATASTORE_ENGINE: postgres
       OPENFGA_DATASTORE_URI: postgres://${POSTGRES_USER:-postgres_admin}:${POSTGRES_PASSWORD:-password123}@postgres:5432/openfga?sslmode=disable
@@ -23,6 +29,7 @@ services:
   openfga:
     image: openfga/openfga:latest
     command: run
+    profiles: ["authz"]
     environment:
       OPENFGA_DATASTORE_ENGINE: postgres
       OPENFGA_DATASTORE_URI: postgres://${POSTGRES_USER:-postgres_admin}:${POSTGRES_PASSWORD:-password123}@postgres:5432/openfga?sslmode=disable

--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -39,7 +39,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/darnellm/dev",
+          "default": "/home/spaul/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -189,7 +189,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/darnellm/dev",
+          "default": "/home/spaul/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -328,7 +328,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/darnellm/dev",
+          "default": "/home/spaul/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -559,7 +559,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/darnellm/dev",
+          "default": "/home/spaul/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -696,7 +696,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/darnellm/dev",
+          "default": "/home/spaul/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -881,7 +881,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/darnellm/dev",
+          "default": "/home/spaul/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -1018,7 +1018,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/darnellm/dev",
+          "default": "/home/spaul/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -1172,7 +1172,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/darnellm/dev",
+          "default": "/home/spaul/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -1310,7 +1310,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/darnellm/dev",
+          "default": "/home/spaul/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -1467,7 +1467,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/darnellm/dev",
+          "default": "/home/spaul/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -1640,7 +1640,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/darnellm/dev",
+          "default": "/home/spaul/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -1784,7 +1784,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/darnellm/dev",
+          "default": "/home/spaul/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -1935,7 +1935,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/darnellm/dev",
+          "default": "/home/spaul/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -2101,7 +2101,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/darnellm/dev",
+          "default": "/home/spaul/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -2177,7 +2177,7 @@
           "type": "option"
         },
         "with": {
-          "description": "convenience bundle(s) whose DBs join the reset set — sugar shared with `stack up`. Only `--with playback` changes the set (it also truncates the opt-in playback DBs — transcripts, insights, chat = the old --with-playback); every other bundle's DBs are already reset by default. Repeatable: --with playback.",
+          "description": "convenience bundle(s) whose DBs join the reset set — sugar shared with `stack up`. `--with playback` also truncates the opt-in playback DBs (transcripts, insights, chat = the old --with-playback); `--with authz` also truncates the opt-in authz DBs (openfga, authz_sync_local); every other bundle's DBs are already reset by default. Repeatable: --with playback --with authz.",
           "name": "with",
           "hasDynamicHelp": false,
           "multiple": true,
@@ -2186,7 +2186,8 @@
             "connect",
             "coach",
             "playback",
-            "qtf"
+            "qtf",
+            "authz"
           ],
           "type": "option"
         }
@@ -2245,7 +2246,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/darnellm/dev",
+          "default": "/home/spaul/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -2386,7 +2387,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/darnellm/dev",
+          "default": "/home/spaul/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -2462,7 +2463,7 @@
           "type": "option"
         },
         "with": {
-          "description": "convenience bundle(s) whose seed ADD-ON is layered onto the seed plan — sugar shared with `stack up`. Repeatable: --with playback --with qtf. `--with playback` seeds the playback DBs (== the old --with-playback); `--with qtf` seeds the QTF demo. Bundles with no seed add-on (dash/coach/connect) are a no-op here.",
+          "description": "convenience bundle(s) whose seed ADD-ON is layered onto the seed plan — sugar shared with `stack up`. Repeatable: --with playback --with qtf --with authz. `--with playback` seeds the playback DBs (== the old --with-playback); `--with qtf` seeds the QTF demo; `--with authz` runs the fga-bootstrap step (OpenFGA store/model bootstrap). Bundles with no seed add-on (dash/coach/connect) are a no-op here.",
           "name": "with",
           "hasDynamicHelp": false,
           "multiple": true,
@@ -2471,7 +2472,8 @@
             "connect",
             "coach",
             "playback",
-            "qtf"
+            "qtf",
+            "authz"
           ],
           "type": "option"
         },
@@ -2555,7 +2557,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/darnellm/dev",
+          "default": "/home/spaul/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -2647,7 +2649,8 @@
             "connect",
             "coach",
             "playback",
-            "qtf"
+            "qtf",
+            "authz"
           ],
           "type": "option"
         }
@@ -2722,7 +2725,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/darnellm/dev",
+          "default": "/home/spaul/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -2861,7 +2864,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/darnellm/dev",
+          "default": "/home/spaul/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -2953,7 +2956,8 @@
             "connect",
             "coach",
             "playback",
-            "qtf"
+            "qtf",
+            "authz"
           ],
           "type": "option"
         },
@@ -3106,7 +3110,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/darnellm/dev",
+          "default": "/home/spaul/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -3198,7 +3202,8 @@
             "connect",
             "coach",
             "playback",
-            "qtf"
+            "qtf",
+            "authz"
           ],
           "type": "option"
         },
@@ -3277,7 +3282,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/darnellm/dev",
+          "default": "/home/spaul/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -3414,7 +3419,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/darnellm/dev",
+          "default": "/home/spaul/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -3547,7 +3552,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/darnellm/dev",
+          "default": "/home/spaul/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -3693,7 +3698,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/darnellm/dev",
+          "default": "/home/spaul/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -3845,7 +3850,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/darnellm/dev",
+          "default": "/home/spaul/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -3953,7 +3958,8 @@
             "connect",
             "coach",
             "playback",
-            "qtf"
+            "qtf",
+            "authz"
           ],
           "type": "option"
         },
@@ -4026,7 +4032,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/darnellm/dev",
+          "default": "/home/spaul/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"

--- a/packages/node/saga-stack-cli/src/base-command.ts
+++ b/packages/node/saga-stack-cli/src/base-command.ts
@@ -164,6 +164,14 @@ export type NativeOverlays = {
   recordUp?: RecordUp;
   /** Per-user recordings dir override (up.sh `$FLEEK_REC_DIR`). */
   recordingsDir?: string;
+  /**
+   * `--with authz` ⇒ the OpenFGA authz overlay: `withAuthz: true` (drives
+   * `FGA_ENABLED`) plus the bootstrapped store id, if one exists on this machine
+   * yet (see `resolveOpenfgaStoreId`). Absent for every command that doesn't
+   * select the `authz` bundle, so its runtime is byte-identical to before this
+   * feature existed.
+   */
+  authz?: { withAuthz: boolean; storeId?: string };
 };
 
 export abstract class BaseCommand extends Command {
@@ -509,6 +517,28 @@ export abstract class BaseCommand extends Command {
   }
 
   /**
+   * Read the OpenFGA store id the `fga-bootstrap` seed step (rostering's
+   * `scripts/fga/bootstrap.mjs --out-file`) wrote on a PRIOR `stack up --with authz`
+   * run. `SAGA_STACK_OPENFGA_STORE_ID` takes precedence (manual escape hatch for a
+   * live first-run experience without waiting for run 2). Swallows a missing file /
+   * unparsable JSON / missing `storeId` field — a cold-start machine has no file
+   * yet, and that is the EXPECTED first-run state, not an error (see
+   * `LaunchTokens.OPENFGA_STORE_ID`'s fail-closed contract), so this returns
+   * `undefined` rather than throwing.
+   */
+  protected readOpenfgaStoreId(rosteringRoot: string): string | undefined {
+    const envOverride = process.env.SAGA_STACK_OPENFGA_STORE_ID;
+    if (envOverride) return envOverride;
+    const path = join(rosteringRoot, '.saga-mesh/openfga-store.json');
+    try {
+      const raw = JSON.parse(readFileSync(path, 'utf8')) as { storeId?: unknown };
+      return typeof raw.storeId === 'string' && raw.storeId ? raw.storeId : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
    * The `--tunnel` rtsm fleet-config generator (Phase 2) — production renders
    * `<stateDir>/rtsm-fleet-tunnel.json` from the base `rtsm-fleet-local.json` with
    * the node endpoint swapped to `rtsm.<domain>`, so rtsm-api's `tunnel_env`
@@ -683,6 +713,16 @@ export abstract class BaseCommand extends Command {
     // checkout's `tools/synthetic-dev`. (The `--tunnel` case overrides it in `up.ts`.)
     const vendorDir = dirname(resolveVendorScript('rtsm-fleet-local.json'));
 
+    // `--with authz`: read the OpenFGA store id the `fga-bootstrap` seed step wrote on
+    // a PRIOR run (same seam as --tunnel's resolveOverlays() — synchronous IO BEFORE
+    // building the launch env, since resolveLaunchEnv/defaultLaunchContext are pure).
+    // Absent on a cold-start first run (no file yet) ⇒ '' downstream (fail closed,
+    // not a crash — see LaunchTokens.OPENFGA_STORE_ID). Only bother reading when the
+    // authz bundle is actually selected.
+    const authzOverlay = overlays.authz?.withAuthz
+      ? { withAuthz: true, storeId: overlays.authz.storeId ?? this.readOpenfgaStoreId(repoRoots.ROSTERING) }
+      : undefined;
+
     // M7: the ONE slot-injection site — apply the slot's env seam so the mesh
     // resolver, preflight owned-container set, and snapshot store target
     // `soa-s<N>-<unit>-1`. No-op at slot 0.
@@ -722,6 +762,8 @@ export abstract class BaseCommand extends Command {
       sandbox: overlays.sandbox,
       tunnel: overlays.tunnel,
       rtsmFleetPath,
+      withAuthz: authzOverlay?.withAuthz,
+      openfgaStoreId: authzOverlay?.storeId,
     });
 
     return {

--- a/packages/node/saga-stack-cli/src/commands/stack/reset.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/reset.ts
@@ -8,16 +8,18 @@
  * through the existing seed path. Slot-aware — targets the slot's postgres/
  * connect-mongo containers.
  *
- * The only opt-in axis is the playback trio (transcripts/insights/chat) — only
- * `--with playback` truncates them, reproducing the old `--with-playback` boolean.
+ * The opt-in axes are the playback trio (transcripts/insights/chat) and the
+ * authz DBs (openfga/authz_sync_local) — only `--with playback`/`--with authz`
+ * truncate them, reproducing the old `--with-playback` boolean.
  *
  *   node bin/dev.js stack reset
  *   node bin/dev.js stack reset --with playback
+ *   node bin/dev.js stack reset --with authz
  */
 
 import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command.js';
-import { BUNDLE_NAMES, effectiveWithPlayback } from '../../core/bundles.js';
+import { BUNDLE_NAMES, effectiveWithAuthz, effectiveWithPlayback } from '../../core/bundles.js';
 import { computeClosure } from '../../core/closure.js';
 import { deriveInstance } from '../../core/derive-instance.js';
 import { manifest } from '../../core/manifest/index.js';
@@ -39,7 +41,7 @@ export default class StackReset extends BaseCommand {
       multiple: true,
       options: [...BUNDLE_NAMES],
       description:
-        "convenience bundle(s) whose DBs join the reset set — sugar shared with `stack up`. Only `--with playback` changes the set (it also truncates the opt-in playback DBs — transcripts, insights, chat = the old --with-playback); every other bundle's DBs are already reset by default. Repeatable: --with playback.",
+        "convenience bundle(s) whose DBs join the reset set — sugar shared with `stack up`. `--with playback` also truncates the opt-in playback DBs (transcripts, insights, chat = the old --with-playback); `--with authz` also truncates the opt-in authz DBs (openfga, authz_sync_local); every other bundle's DBs are already reset by default. Repeatable: --with playback --with authz.",
     }),
   };
 
@@ -56,6 +58,7 @@ export default class StackReset extends BaseCommand {
   async run(): Promise<void> {
     const { flags } = await this.parse(StackReset);
     const withPlayback = effectiveWithPlayback(flags.with);
+    const withAuthz = effectiveWithAuthz(flags.with);
 
     const profile = deriveInstance({ slot: flags.slot });
     const api = makeStackApi(manifest, this.buildNativeRuntime(flags, profile));
@@ -67,11 +70,11 @@ export default class StackReset extends BaseCommand {
       .filter((s) => !s.optional)
       .map((s) => s.id);
     const excluded = new Set(profile.excludedServices);
-    const services = computeClosure(manifest, requested, { withPlayback }).services.filter(
+    const services = computeClosure(manifest, requested, { withPlayback, withAuthz }).services.filter(
       (id) => !excluded.has(id),
     );
 
-    const res = await api.reset(services, { withPlayback });
+    const res = await api.reset(services, { withPlayback, withAuthz });
 
     const truncated = res.native?.dbs.filter((d) => d.action === 'truncated').map((d) => d.db) ?? [];
     const migrateReset = res.native?.dbs.filter((d) => d.action === 'migrate-reset').map((d) => d.db) ?? [];

--- a/packages/node/saga-stack-cli/src/commands/stack/seed.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/seed.ts
@@ -28,7 +28,13 @@
 
 import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command.js';
-import { BUNDLE_NAMES, combineRequested, effectiveWithPlayback, seedAddOnsFor } from '../../core/bundles.js';
+import {
+  BUNDLE_NAMES,
+  combineRequested,
+  effectiveWithAuthz,
+  effectiveWithPlayback,
+  seedAddOnsFor,
+} from '../../core/bundles.js';
 import { computeClosure } from '../../core/closure.js';
 import { deriveInstance } from '../../core/derive-instance.js';
 import { manifest } from '../../core/manifest/index.js';
@@ -82,7 +88,7 @@ export default class StackSeed extends BaseCommand {
       multiple: true,
       options: [...BUNDLE_NAMES],
       description:
-        "convenience bundle(s) whose seed ADD-ON is layered onto the seed plan — sugar shared with `stack up`. Repeatable: --with playback --with qtf. `--with playback` seeds the playback DBs (== the old --with-playback); `--with qtf` seeds the QTF demo. Bundles with no seed add-on (dash/coach/connect) are a no-op here.",
+        "convenience bundle(s) whose seed ADD-ON is layered onto the seed plan — sugar shared with `stack up`. Repeatable: --with playback --with qtf --with authz. `--with playback` seeds the playback DBs (== the old --with-playback); `--with qtf` seeds the QTF demo; `--with authz` runs the fga-bootstrap step (OpenFGA store/model bootstrap). Bundles with no seed add-on (dash/coach/connect) are a no-op here.",
     }),
     scenario: Flags.string({
       options: [...SEED_SCENARIO_NAMES],
@@ -126,6 +132,7 @@ export default class StackSeed extends BaseCommand {
     // instead of being dropped as service-inactive. There is no prep/mesh/launch —
     // the services are assumed already up.
     const withPlayback = effectiveWithPlayback(flags.with);
+    const withAuthz = effectiveWithAuthz(flags.with);
     const fullNonOptional = (Object.values(manifest.services) as { id: ServiceId; optional: boolean }[])
       .filter((s) => !s.optional)
       .map((s) => s.id);
@@ -136,7 +143,7 @@ export default class StackSeed extends BaseCommand {
     // subtract them from the active set exactly like `reset` does, so their
     // seed steps degrade to service-inactive skips instead of failing.
     const excluded = new Set(instance.excludedServices);
-    const closureServices = computeClosure(manifest, requested, { withPlayback }).services;
+    const closureServices = computeClosure(manifest, requested, { withPlayback, withAuthz }).services;
     const active = new Set(closureServices.filter((id) => !excluded.has(id)));
     const droppedForSlot = closureServices.filter((id) => excluded.has(id));
     if (droppedForSlot.length > 0) {

--- a/packages/node/saga-stack-cli/src/commands/stack/snapshot/store.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/snapshot/store.ts
@@ -23,7 +23,7 @@ import { join } from 'node:path';
 import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../../base-command.js';
 import { deriveInstance } from '../../../core/derive-instance.js';
-import { BUNDLE_NAMES, combineRequested, effectiveWithPlayback } from '../../../core/bundles.js';
+import { BUNDLE_NAMES, combineRequested, effectiveWithAuthz, effectiveWithPlayback } from '../../../core/bundles.js';
 import { computeClosure } from '../../../core/closure.js';
 import { manifest } from '../../../core/manifest/index.js';
 import type { DbId, ServiceId } from '../../../core/manifest/index.js';
@@ -107,12 +107,14 @@ export default class SnapshotStore extends BaseCommand {
     // into an excluded one), and it applies AFTER the --with union so `--with playback --slot N`
     // degrades gracefully rather than dumping absent playback DBs.
     const withPlayback = effectiveWithPlayback(flags.with);
+    const withAuthz = effectiveWithAuthz(flags.with);
     const excluded = new Set<ServiceId>(instance.excludedServices);
     let only: DbId[] | undefined;
     if (flags.only) {
       only = closureDatabases(
         combineRequested(flags.only, flags.with, (m) => this.error(m)),
         withPlayback,
+        withAuthz,
         (m) => this.error(m),
       );
     } else if (instance.slot > 0) {
@@ -121,7 +123,7 @@ export default class SnapshotStore extends BaseCommand {
         .map((s) => s.id);
       const bundleServices = combineRequested(undefined, flags.with, (m) => this.error(m));
       const requested = [...new Set<ServiceId>([...fullNonOptional, ...bundleServices])];
-      const kept = computeClosure(manifest, requested, { withPlayback }).services.filter(
+      const kept = computeClosure(manifest, requested, { withPlayback, withAuthz }).services.filter(
         (id) => !excluded.has(id),
       );
       only = [...new Set<DbId>(kept.flatMap((id) => manifest.services[id].databases))];
@@ -132,6 +134,7 @@ export default class SnapshotStore extends BaseCommand {
       profile: flags.profile,
       only,
       withPlayback,
+      withAuthz,
     });
 
     const io = this.getSnapshotIO();
@@ -207,11 +210,13 @@ export default class SnapshotStore extends BaseCommand {
  * Resolve a requested service set (`--only <svc,…>` ∪ `--with <bundle>` services,
  * already combined by `combineRequested`) to its closure's DB set (`DbId[]`).
  * Mirrors `status`'s `resolveServiceSet`: unknown ids fail with a friendly oclif
- * error. `withPlayback` keeps any optional (playback) services in the closure.
+ * error. `withPlayback`/`withAuthz` keep their respective optional services in
+ * the closure.
  */
 export function closureDatabases(
   requested: ServiceId[],
   withPlayback: boolean,
+  withAuthz: boolean,
   fail: (msg: string) => never,
 ): DbId[] {
   const known = new Set(Object.keys(manifest.services));
@@ -220,5 +225,5 @@ export function closureDatabases(
     fail(`unknown service id(s): ${unknown.join(', ')}\nknown: ${[...known].join(', ')}`);
   }
 
-  return computeClosure(manifest, requested, { withPlayback }).databases;
+  return computeClosure(manifest, requested, { withPlayback, withAuthz }).databases;
 }

--- a/packages/node/saga-stack-cli/src/commands/stack/status.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/status.ts
@@ -30,6 +30,7 @@ import { BaseCommand } from '../../base-command.js';
 import {
   BUNDLE_NAMES,
   combineRequested,
+  effectiveWithAuthz,
   effectiveWithPlayback,
 } from '../../core/bundles.js';
 import { computeClosure } from '../../core/closure.js';
@@ -164,8 +165,8 @@ function formatRow(r: StatusRow): string {
 /**
  * Turn the `--only`/`--with` flags into the ordered service-id list to probe.
  * The requested set is `parseOnly(only) ∪ expandBundles(with)`; `--with playback`
- * (the only bundle of optional services) sets `withPlayback` so those ids survive
- * the closure's optional filter.
+ * sets `withPlayback` and `--with authz` sets `withAuthz` so their optional
+ * service ids survive the closure's optional filter.
  *  - EMPTY requested (no `--only`, no `--with`) ⇒ every NON-optional service.
  *  - else ⇒ the dependency closure of the requested set (launch order).
  * `fail` renders a friendly oclif error and does not return. Shared by
@@ -192,6 +193,7 @@ export function resolveServiceSet(
 
   return computeClosure(manifest, requested, {
     withPlayback: effectiveWithPlayback(withBundles),
+    withAuthz: effectiveWithAuthz(withBundles),
   }).services;
 }
 

--- a/packages/node/saga-stack-cli/src/commands/stack/up.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/up.ts
@@ -42,6 +42,7 @@ import type { NativeOverlays, WorkspaceFlags } from '../../base-command.js';
 import {
   BUNDLE_NAMES,
   combineRequested,
+  effectiveWithAuthz,
   effectiveWithPlayback,
   seedAddOnsFor,
 } from '../../core/bundles.js';
@@ -175,11 +176,14 @@ export default class StackUp extends BaseCommand {
       : combineRequested(flags.only, flags.with, (m) => this.error(m));
     let isOnly = requested.length > 0 || ws !== undefined;
     const withPlayback = ws ? ws.playback : effectiveWithPlayback(flags.with);
+    // Workspace files carry no authz axis (mirrors playback's `ws.playback`, but
+    // `--with authz` is a `--only`/`--with` concept only, not modeled in workspace JSON).
+    const withAuthz = ws ? false : effectiveWithAuthz(flags.with);
 
     // ── --dry-run (M0/M4): planner only. Compute the SAME sandbox/workspace prune the
     // launch path applies (BLOCKER-1) so the dry-run reflects what actually launches. ──
     if (flags['dry-run']) {
-      this.runDryRun(flags, requested, isOnly, withPlayback, {
+      this.runDryRun(flags, requested, isOnly, withPlayback, withAuthz, {
         sandboxHybrid: flags.sandbox !== undefined,
         sandboxServices: ws ? new Set(ws.sandboxServices) : undefined,
         sandboxName: ws?.iamSandbox ?? flags.sandbox,
@@ -229,8 +233,8 @@ export default class StackUp extends BaseCommand {
     //  - `--sandbox <name>` accompanies `--only`: launch the run-set ALONE (subtract the
     //    deps the closure pulled in — iam-api et al. live at the cloud sandbox).
     //  - `--workspace`: subtract EVERY mode:sandbox service id (`ws.sandboxServices`).
-    const overlays = await this.resolveOverlays(flags, sandboxName);
-    await this.runNative(flags, requested, withPlayback, overlays, {
+    const overlays = await this.resolveOverlays(flags, sandboxName, withAuthz);
+    await this.runNative(flags, requested, withPlayback, withAuthz, overlays, {
       sandboxHybrid: flags.sandbox !== undefined,
       sandboxServices: ws ? new Set(ws.sandboxServices) : undefined,
       sandboxName,
@@ -271,8 +275,19 @@ export default class StackUp extends BaseCommand {
    * and the `--record` seam. IO (moniker resolution) happens here, behind the
    * `getTunnelMoniker` seam so unit tests inject a fixed moniker.
    */
-  private async resolveOverlays(flags: OverlayFlags, sandboxName?: string): Promise<NativeOverlays> {
+  private async resolveOverlays(
+    flags: OverlayFlags,
+    sandboxName?: string,
+    withAuthz?: boolean,
+  ): Promise<NativeOverlays> {
     const overlays: NativeOverlays = {};
+
+    // `--with authz`: hand the flag down as data (the store-id FILE READ itself
+    // stays in base-command.ts's buildNativeRuntime, the ONE place repoRoots is
+    // resolved — see readOpenfgaStoreId). Absent ⇒ base env only (opt-in).
+    if (withAuthz) {
+      overlays.authz = { withAuthz: true };
+    }
 
     if (sandboxName !== undefined) {
       // up.sh SANDBOX_BASE default (dev fleet); env-overridable like up.sh.
@@ -320,6 +335,7 @@ export default class StackUp extends BaseCommand {
     requested: ServiceId[],
     isOnly: boolean,
     withPlayback: boolean,
+    withAuthz: boolean,
     prune: LaunchPrune = {},
   ): void {
     const resolvedRequest: ServiceId[] = isOnly
@@ -334,7 +350,7 @@ export default class StackUp extends BaseCommand {
       this.error(`unknown service id(s): ${unknown.join(', ')}\nknown: ${[...known].join(', ')}`);
     }
 
-    const closure = computeClosure(manifest, resolvedRequest, { withPlayback });
+    const closure = computeClosure(manifest, resolvedRequest, { withPlayback, withAuthz });
 
     // M7: at slot > 0 the bring-up would EXCLUDE the literal-port services; surface
     // that in the preview so the dry-run matches what a real `--slot N` up launches.
@@ -416,6 +432,7 @@ export default class StackUp extends BaseCommand {
     flags: NativeFlags,
     requested: ServiceId[],
     withPlayback: boolean,
+    withAuthz: boolean,
     overlays: NativeOverlays = {},
     prune: LaunchPrune = {},
   ): Promise<void> {
@@ -439,7 +456,7 @@ export default class StackUp extends BaseCommand {
     // THIS slot's rtsm, not slot 0's) is generated in `buildRuntime`, the seam BOTH
     // `stack up` and `e2e run` share; it need not be repeated here.
 
-    const fullClosure = computeClosure(manifest, requested, { withPlayback });
+    const fullClosure = computeClosure(manifest, requested, { withPlayback, withAuthz });
 
     // Exclude the still-un-slottable services from a slot > 0 bring-up: only the
     // literal-port playback trio (transcripts/insights/chat) carries literal cross-slot
@@ -502,11 +519,12 @@ export default class StackUp extends BaseCommand {
 
     // 2. (optional) reset — NATIVE (M8 R4). Truncates the closure's DBs to an empty
     // baseline; the native seed below then applies the SELECTED profile/add-ons on top
-    // (idempotent upserts). `withPlayback` MUST be threaded so `--with playback --reset`
-    // also truncates the playback trio (transcripts/insights/chat) — matching both
+    // (idempotent upserts). `withPlayback`/`withAuthz` MUST be threaded so
+    // `--with playback --reset` / `--with authz --reset` also truncate their opt-in
+    // DBs (playback trio / openfga+authz_sync_local) — matching both
     // `up.sh --reset --with-playback` and the dedicated `stack reset --with playback`.
     if (flags.reset) {
-      const reset = await api.reset(services, { withPlayback });
+      const reset = await api.reset(services, { withPlayback, withAuthz });
       if (reset.code !== 0) this.exit(reset.code);
     }
 

--- a/packages/node/saga-stack-cli/src/core/__tests__/bundles.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/bundles.unit.test.ts
@@ -25,8 +25,8 @@ const throwFail = (msg: string): never => {
 };
 
 describe('bundle registry', () => {
-  it('exposes the five bundle names in registry order', () => {
-    expect(BUNDLE_NAMES).toEqual(['dash', 'connect', 'coach', 'playback', 'qtf']);
+  it('exposes the six bundle names in registry order', () => {
+    expect(BUNDLE_NAMES).toEqual(['dash', 'connect', 'coach', 'playback', 'qtf', 'authz']);
   });
 
   it('every bundle carries a non-empty description', () => {
@@ -41,10 +41,11 @@ describe('bundle registry', () => {
     expect(SERVICE_BUNDLES.coach).toEqual(['coach-api', 'coach-web']);
     expect(SERVICE_BUNDLES.playback).toEqual(['transcripts-api', 'insights-api', 'chat-api']);
     expect(SERVICE_BUNDLES.qtf).toEqual([]);
+    expect(SERVICE_BUNDLES.authz).toEqual(['authz-sync']);
   });
 
   it('derives BUNDLE_SEED_ADDONS only for the seed-bearing bundles', () => {
-    expect(BUNDLE_SEED_ADDONS).toEqual({ playback: 'playback', qtf: 'qtf' });
+    expect(BUNDLE_SEED_ADDONS).toEqual({ playback: 'playback', qtf: 'qtf', authz: 'authz' });
   });
 });
 

--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
@@ -93,6 +93,12 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
       JANUS_REQUIRED: 'false', // main up.sh:1467 — without it iam 401s every local S2S/devLogin
       SECURITY_RATELIMITMAXREQUESTS: '1000000', // apply_fixes (up.sh:457) — no local rate-limit
       JWT_ACCESSTOKENTTLSECONDS: '28800', // apply_fixes (up.sh:465) — 8h TTL for long dev/e2e sessions
+      // authz bundle (opt-in, --with authz): always present on iam-api's launch
+      // env, but FGA_ENABLED only flips 'true' when the bundle is selected —
+      // absent selection here, so fail-closed defaults.
+      FGA_ENABLED: 'false',
+      FGA_API_URL: 'http://localhost:8080',
+      FGA_STORE_ID: '',
     });
   });
 

--- a/packages/node/saga-stack-cli/src/core/bundles.ts
+++ b/packages/node/saga-stack-cli/src/core/bundles.ts
@@ -17,10 +17,10 @@
 import type { ServiceId } from './manifest/index.js';
 
 /** The named features a `--with` value may select (services, a seed add-on, or both). */
-export type BundleName = 'dash' | 'connect' | 'coach' | 'playback' | 'qtf';
+export type BundleName = 'dash' | 'connect' | 'coach' | 'playback' | 'qtf' | 'authz';
 
 /** A seed add-on a bundle may layer onto the composed seed plan. */
-export type BundleSeedAddOn = 'playback' | 'qtf';
+export type BundleSeedAddOn = 'playback' | 'qtf' | 'authz';
 
 /** One bundle: the services it contributes to the closure, its optional seed add-on, and a one-line blurb. */
 export interface BundleDef {
@@ -61,6 +61,15 @@ export const BUNDLES: Readonly<Record<BundleName, BundleDef>> = {
     services: [],
     seedAddOn: 'qtf',
     description: 'Seed-only: QTF observation-notes demo on an Ended session (no extra services).',
+  },
+  authz: {
+    services: ['authz-sync'],
+    seedAddOn: 'authz',
+    description:
+      'OpenFGA authz stack: brings up the openfga mesh unit, flips iam-api FGA_ENABLED=true, ' +
+      'runs the fga-bootstrap seed step (model + canonical tuples), and starts the authz-sync ' +
+      'RabbitMQ consumer. First run bootstraps a fresh store (FGA checks fail closed); rerun ' +
+      '`stack up --with authz` once more to pick up the persisted store id.',
   },
 };
 
@@ -149,6 +158,19 @@ export function combineRequested(
  */
 export function effectiveWithPlayback(withBundles: string[] | undefined): boolean {
   return (withBundles ?? []).includes('playback');
+}
+
+/**
+ * Whether the closure should keep the `optional:true` `authz-sync` service AND
+ * iam-api should get FGA_ENABLED=true + the openfga mesh unit: true iff the
+ * `authz` bundle was requested via `--with`. Same shape as
+ * `effectiveWithPlayback` — `computeClosure` drops `authz-sync` unless this is
+ * set, and `defaultLaunchContext`/`resolveLaunchEnv` use it to gate iam-api's
+ * FGA_ENABLED token and the `openfga` mesh unit's inclusion, keeping the
+ * OpenFGA footprint opt-in rather than part of every default `stack up`. PURE.
+ */
+export function effectiveWithAuthz(withBundles: string[] | undefined): boolean {
+  return (withBundles ?? []).includes('authz');
 }
 
 /**

--- a/packages/node/saga-stack-cli/src/core/closure.ts
+++ b/packages/node/saga-stack-cli/src/core/closure.ts
@@ -20,6 +20,12 @@
  * ONLY when `opts.withPlayback` is set. Nothing in the graph `dependsOn` them,
  * so this gate is the only thing that admits them, and a requested playback
  * service is dropped (not launched) unless `--with-playback` is passed.
+ *
+ * `authz-sync` (`optional:true`) is the same shape, gated by `opts.withAuthz`
+ * instead. Each optional service maps to its OWN opt-in flag (see
+ * `admitsOptional` below) — a bare `withPlayback || withAuthz` OR would let
+ * either flag admit BOTH families (e.g. `--only transcripts-api --with authz`
+ * would wrongly resolve transcripts-api), so the gate dispatches per service id.
  */
 
 import { launchOrder } from './launch-order.js';
@@ -39,6 +45,8 @@ export interface Closure {
 export interface ClosureOpts {
   /** Keep `optional:true` playback services (transcripts/insights/chat). */
   withPlayback?: boolean;
+  /** Keep the `optional:true` `authz-sync` service. */
+  withAuthz?: boolean;
   /**
    * Whether to traverse `depKind: 'browser'` edges (default `true`).
    *
@@ -64,7 +72,14 @@ export function computeClosure(
   opts: ClosureOpts = {},
 ): Closure {
   const withPlayback = opts.withPlayback ?? false;
+  const withAuthz = opts.withAuthz ?? false;
   const followBrowserEdges = opts.followBrowserEdges ?? true;
+
+  // Each optional service is admitted by its OWN flag — never a blanket OR of
+  // every opt-in flag, which would cross-admit (e.g. `--with authz` alone must
+  // not also resolve the playback trio).
+  const admitsOptional = (id: ServiceId): boolean =>
+    id === 'authz-sync' ? withAuthz : withPlayback;
 
   const inClosure = new Set<ServiceId>();
   const reasons = new Map<ServiceId, string[]>();
@@ -90,7 +105,7 @@ export function computeClosure(
   for (const id of requested) {
     const def = m.services[id];
     if (!def) throw new Error(`unknown service id: ${id}`);
-    if (def.optional && !withPlayback) continue;
+    if (def.optional && !admitsOptional(id)) continue;
     addReason(id, 'requested');
     enqueue(id);
   }
@@ -104,7 +119,7 @@ export function computeClosure(
     for (const dep of def.dependsOn) {
       const depDef = m.services[dep];
       if (!depDef) throw new Error(`unknown service id: ${dep}`);
-      if (depDef.optional && !withPlayback) continue;
+      if (depDef.optional && !admitsOptional(dep)) continue;
       const kind = def.depKinds[dep] ?? 'url';
       // Skip browser edges when narrowing a flow closure (see followBrowserEdges).
       if (kind === 'browser' && !followBrowserEdges) continue;

--- a/packages/node/saga-stack-cli/src/core/flow/types.ts
+++ b/packages/node/saga-stack-cli/src/core/flow/types.ts
@@ -38,6 +38,7 @@ const SERVICE_IDS = [
   'transcripts-api',
   'insights-api',
   'chat-api',
+  'authz-sync',
 ] as const;
 
 // Compile guard: every literal above must be a real ServiceId (catches typos /
@@ -51,7 +52,7 @@ export const serviceIdSchema = z.enum(SERVICE_IDS);
 export const flowLaneSchema = z.enum(['stack', 'sandbox', 'tunnel']);
 
 const seedProfileSchema = z.enum(['roster', 'full']);
-const seedAddOnSchema = z.enum(['playback', 'qtf']);
+const seedAddOnSchema = z.enum(['playback', 'qtf', 'authz']);
 
 /**
  * Seed selection authored inline in a flow/stage. Structurally compatible with

--- a/packages/node/saga-stack-cli/src/core/launch-plan.ts
+++ b/packages/node/saga-stack-cli/src/core/launch-plan.ts
@@ -78,6 +78,8 @@ export interface LaunchTokens {
    * is byte-identical to that default; :7379 at slot 1 targets the slot's redis.
    */
   REDIS_PORT: string;
+  /** authz-sync port — opt-in service (`--with authz`), no up.sh precedent (new). */
+  AUTHZ_SYNC_PORT: string;
 
   // ── lane base URLs (local/stack lane: http://localhost:<port>) ──
   /** up.sh `IAM_URL`. */
@@ -134,6 +136,8 @@ export interface LaunchTokens {
    *  (was a LITERAL `@localhost:5432` in up.sh/the manifest; tokenized for M13
    *  ads-adm slottability so the pg port offsets in lockstep with the slot mesh). */
   ADS_ADM_DB_URL: string;
+  /** authz-sync dedup-table DB URL — `postgresql://authz_sync:authz_sync@localhost:<pg>/authz_sync_local`. */
+  AUTHZ_SYNC_DB_URL: string;
 
   // ── misc scalars ──
   /** up.sh `RECORDING_TOKEN` — shared fleek bearer (`local-dev-token`). */
@@ -148,6 +152,26 @@ export interface LaunchTokens {
    *  :6110) at slot 0; a GENERATED per-slot file (endpoint `localhost:<6110+offset>`)
    *  at slot > 0 so a slot's realtime/CRDT socket reaches the SLOT's rtsm (soa#271). */
   RTSM_FLEET_PATH: string;
+
+  // ── OpenFGA authz (opt-in — `--with authz`; new, no up.sh precedent) ──
+  /**
+   * iam-api's `FGA_ENABLED` — `'true'` only when the `authz` bundle was
+   * selected (`effectiveWithAuthz`), else `'false'`. Keeps the OpenFGA footprint
+   * off every default `stack up` (opt-in design decision).
+   */
+  FGA_ENABLED: string;
+  /** OpenFGA HTTP API — `http://localhost:8080` (single-slot only; no meshOffset
+   *  port-shifting support for openfga in this pass). Feeds both iam-api's
+   *  `FGA_API_URL` and authz-sync's `OPENFGA_API_URL`. */
+  OPENFGA_API_URL: string;
+  /**
+   * The bootstrapped OpenFGA store id, or `''` before the `fga-bootstrap` seed
+   * step has ever run on this machine (cold start — see base-command.ts's
+   * store-id file read). An empty value makes iam-api's `FgaClientService`
+   * constructor guard treat FGA as disabled (fail closed, not a crash); NOT a
+   * missing-token error like other tokens, since '' is expected on run 1.
+   */
+  OPENFGA_STORE_ID: string;
 
   // ── global launch env (up.sh services_up `export`s these ONCE, ~1384-1385, so
   //    every `pnpm dev` child inherits them; soa-logger/soa-config validate them
@@ -506,6 +530,19 @@ export interface LaunchContextInputs {
   pinoLevel?: string;
   /** up.sh `${PINO_LOGGER_ISEXPRESSCONTEXT:-true}` — ambient override, else `true`. */
   pinoIsExpressContext?: string;
+  /**
+   * Whether the `authz` bundle was selected (`effectiveWithAuthz(flags.with)`) —
+   * drives `FGA_ENABLED`. Default `false` (opt-in design decision — every
+   * default `stack up` keeps FGA off).
+   */
+  withAuthz?: boolean;
+  /**
+   * The bootstrapped OpenFGA store id, read synchronously from the fixed
+   * store-id file (or `SAGA_STACK_OPENFGA_STORE_ID` env override) by the
+   * runtime BEFORE calling `defaultLaunchContext` — same seam as `--tunnel`'s
+   * `resolveOverlays()`. Absent/`''` ⇒ cold start (see `OPENFGA_STORE_ID`).
+   */
+  openfgaStoreId?: string;
 }
 
 /** `postgresql://<owner>:<pw>@localhost:<meshPgPort>/<dbname>` — derived from the manifest DatabaseDef. */
@@ -559,6 +596,7 @@ export function defaultLaunchContext(inputs: LaunchContextInputs, m: Manifest = 
     COACH_WEB_PORT: String(ports['coach-web']),
     CONNECT_MONGO_PORT: String(mongoPort),
     REDIS_PORT: String(redisPort),
+    AUTHZ_SYNC_PORT: String(ports['authz-sync']),
 
     // lane base URLs (local/stack lane)
     IAM_URL: `http://localhost:${ports['iam-api']}`,
@@ -585,12 +623,18 @@ export function defaultLaunchContext(inputs: LaunchContextInputs, m: Manifest = 
     CONTENT_DB_URL: pgUrl('content', pgPort, m),
     COACH_DB_URL: pgUrl('coach_api', pgPort, m),
     ADS_ADM_DB_URL: pgUrl('ads_adm_local', pgPort, m),
+    AUTHZ_SYNC_DB_URL: pgUrl('authz_sync_local', pgPort, m),
 
     // misc scalars (up.sh hardcodes these verbatim)
     RECORDING_TOKEN: 'local-dev-token',
     DEV_USER_UUID: 'f0000004-0000-4000-8000-00000000beef',
     VENDOR_DIR: inputs.vendorDir,
     RTSM_FLEET_PATH: inputs.rtsmFleetPath ?? `${inputs.vendorDir}/rtsm-fleet-local.json`,
+
+    // OpenFGA authz (opt-in — see LaunchTokens' FGA_ENABLED/OPENFGA_* docs)
+    FGA_ENABLED: inputs.withAuthz ? 'true' : 'false',
+    OPENFGA_API_URL: 'http://localhost:8080',
+    OPENFGA_STORE_ID: inputs.openfgaStoreId ?? '',
 
     // global launch env (up.sh `:-` defaults; runtime may pass ambient overrides)
     PINO_LOGGER_LEVEL: inputs.pinoLevel ?? 'info',

--- a/packages/node/saga-stack-cli/src/core/manifest/databases.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/databases.ts
@@ -192,4 +192,32 @@ export const DATABASES: Readonly<Record<DbId, DatabaseDef>> = {
     resetMode: 'truncate', // n/a for mongo; reset path uses dropDatabase, not TRUNCATE
     meshProvisioned: false, // n/a (mongo)
   },
+  openfga: {
+    name: 'openfga',
+    engine: 'postgres',
+    // Schema owned by the openfga_migrate sidecar (infra/compose/services/openfga/
+    // compose.yml), not prisma — nothing for the CLI's migrate step to run.
+    migrate: null,
+    ownerRole: 'postgres_admin',
+    ownerPw: 'password123',
+    resettable: true,
+    resetMode: 'truncate',
+    // NOT part of default mesh-up (opt-in decision) — provisioned only when the
+    // `authz` bundle is selected, same pattern as the playback trio's `withPlayback`
+    // gate (runtime/reset.ts's `!def.meshProvisioned && !ctx.withAuthz` check).
+    meshProvisioned: false,
+  },
+  authz_sync_local: {
+    name: 'authz_sync_local',
+    engine: 'postgres',
+    // @saga-ed/soa-event-consumer's dedup table self-migrates via
+    // `CREATE TABLE IF NOT EXISTS consumed_events` at connect time — no prisma step.
+    migrate: null,
+    ownerRole: 'authz_sync',
+    ownerPw: 'authz_sync',
+    resettable: true,
+    resetMode: 'truncate',
+    // NOT part of default mesh-up — see the `openfga` entry above.
+    meshProvisioned: false,
+  },
 };

--- a/packages/node/saga-stack-cli/src/core/manifest/mesh.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/mesh.ts
@@ -47,6 +47,10 @@ export const MESH: Readonly<Record<MeshId, MeshDef>> = {
     port: 8080, // HTTP API
     mgmtPort: 8081, // gRPC (used for the health probe, not an HTTP mgmt UI)
     readinessCmd: '/usr/local/bin/grpc_health_probe -addr=:8081',
+    // openfga/openfga is a distroless-style image with no `sh` — `docker exec
+    // ... sh -c '<cmd>'` fails with "sh: executable file not found" before the
+    // probe even runs. shell:false execs the probe binary directly.
+    shell: false,
     // Only brought up when the `authz` bundle is selected (--with authz); the
     // one-shot `openfga_migrate` sidecar (infra/compose/services/openfga/compose.yml)
     // isn't modeled as its own MeshId — compose's own service_completed_successfully

--- a/packages/node/saga-stack-cli/src/core/manifest/mesh.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/mesh.ts
@@ -41,4 +41,16 @@ export const MESH: Readonly<Record<MeshId, MeshDef>> = {
     readinessCmd: "mongosh --eval 'db.runCommand({ping:1}).ok'",
     timeoutSec: 20,
   },
+  openfga: {
+    id: 'openfga',
+    container: 'soa-openfga-1',
+    port: 8080, // HTTP API
+    mgmtPort: 8081, // gRPC (used for the health probe, not an HTTP mgmt UI)
+    readinessCmd: '/usr/local/bin/grpc_health_probe -addr=:8081',
+    // Only brought up when the `authz` bundle is selected (--with authz); the
+    // one-shot `openfga_migrate` sidecar (infra/compose/services/openfga/compose.yml)
+    // isn't modeled as its own MeshId — compose's own service_completed_successfully
+    // dependency already gates `openfga`'s start on it.
+    timeoutSec: 30,
+  },
 };

--- a/packages/node/saga-stack-cli/src/core/manifest/services.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/services.ts
@@ -96,8 +96,23 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
         // iam-api/.env (the dotfile writes are superseded — plan §2.4).
         SECURITY_RATELIMITMAXREQUESTS: '1000000',
         JWT_ACCESSTOKENTTLSECONDS: '28800',
+        // OpenFGA authz — opt-in via `--with authz` (core/bundles.ts's `authz`
+        // bundle). FGA_ENABLED resolves to 'false' when the bundle isn't selected
+        // (launch-plan.ts), so this is a no-op on every default `stack up`. When
+        // selected, FGA_STORE_ID resolves from the fga-bootstrap seed step's
+        // out-file on run 2+ (see base-command.ts) — '' on a cold-start first run,
+        // which FgaClientService's constructor guard treats as disabled (fail
+        // closed, not a crash).
+        FGA_ENABLED: '${FGA_ENABLED}',
+        FGA_API_URL: '${OPENFGA_API_URL}',
+        FGA_STORE_ID: '${OPENFGA_STORE_ID}',
       },
     },
+    // 'fga-bootstrap' (ADDON_STEPS.authz, core/seed/profiles.ts) is NOT listed here —
+    // this field only ever lists a service's PROFILE_STEPS-driven ids (mirrors how
+    // transcripts-api's own `seed: ['transcripts']` omits its add-on
+    // 'transcripts-provision' step too); add-on steps are selected via
+    // ADDON_STEPS, not this field.
     seed: ['iam-dev-user', 'iam'],
     lane: lanes(3010, 'iam'),
     tunnelSlug: 'iam',
@@ -618,6 +633,53 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
     seed: ['chat'],
     lane: lanes(6303, 'chat'),
     tunnelSlug: 'chat',
+    isFrontend: false,
+    optional: true,
+  },
+  'authz-sync': {
+    id: 'authz-sync',
+    repo: 'ROSTERING',
+    subpath: 'apps/node/authz-sync',
+    // NOT 3110 — that collides mod 1000 with rtsm-api's 6110 (6110 = 3110 + 3000),
+    // which the M7 slot-offset scheme (offset = slot*1000) turns into a real port
+    // collision at slot 3 (and every 3 slots after). 3111 is clear of every other
+    // manifest port's `% 1000` value across slots 0..8 (derive-instance's
+    // no-collision property test enumerates this).
+    port: 3111,
+    portEnvVar: 'PORT',
+    healthPath: '/health',
+    // `openfga` here (not just authz_sync_local) is deliberate: it's the ONLY
+    // service that owns it, so `isPlaybackDb`/`isAuthzDb` (core/snapshot/plan.ts)
+    // and the `!def.meshProvisioned` reset gate (runtime/reset.ts) correctly treat
+    // the store as authz-opt-in too — it has no app schema of its own to migrate
+    // (owned by the openfga_migrate compose sidecar), so it rides along on
+    // authz-sync's ownership rather than needing its own ServiceDef.
+    databases: ['authz_sync_local', 'openfga'],
+    // Consumer-only (RabbitMQ iam.* events), not a url dependency — same shape as
+    // sessions-api's async projection deps. iam-api itself has no hard dependency
+    // ON authz-sync (nothing calls it); this edge only orders launch (mesh/DB
+    // prep before the consumer starts) and would otherwise be unreachable from
+    // iam-api's own dependsOn (authz-sync has none).
+    dependsOn: [],
+    depKinds: {},
+    // openfga comes up ONLY when this optional service is in the closure (--with
+    // authz) — mesh is a union over the closure's services (closure.ts), so
+    // iam-api's own (unconditional) mesh membership need not list it: mesh units
+    // start before any service launches regardless of which service pulled them in.
+    mesh: ['postgres', 'rabbitmq', 'openfga'],
+    launch: {
+      cmd: 'pnpm dev',
+      env: {
+        PORT: '${AUTHZ_SYNC_PORT}',
+        RABBITMQ_URL: '${MESH_MQ}',
+        DATABASE_URL: '${AUTHZ_SYNC_DB_URL}',
+        OPENFGA_API_URL: '${OPENFGA_API_URL}',
+        OPENFGA_STORE_ID: '${OPENFGA_STORE_ID}',
+      },
+    },
+    seed: [],
+    lane: lanes(3111, 'authz-sync'),
+    tunnelSlug: 'authz-sync',
     isFrontend: false,
     optional: true,
   },

--- a/packages/node/saga-stack-cli/src/core/manifest/types.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/types.ts
@@ -171,6 +171,13 @@ export interface MeshDef {
   mgmtPort?: number;
   /** Shell command that returns 0 when the unit is ready. */
   readinessCmd: string;
+  /**
+   * Run `readinessCmd` via `sh -c` (default true). Set false for a unit whose
+   * image has no `sh` (e.g. openfga's distroless image) — the command is then
+   * split on whitespace and exec'd directly, so it must carry no shell
+   * metacharacters (quoting, pipes, `&&`) to use this.
+   */
+  shell?: boolean;
   /** Max seconds to wait for readiness. */
   timeoutSec: number;
 }

--- a/packages/node/saga-stack-cli/src/core/manifest/types.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/types.ts
@@ -28,10 +28,11 @@ export type ServiceId =
   | 'coach-web' //       coach-web (:8800) — SvelteKit SPA (reaches iam THROUGH coach-api)
   | 'transcripts-api' // optional: true (--with-playback)
   | 'insights-api' //    optional: true (--with-playback)
-  | 'chat-api'; //       optional: true (--with-playback)
+  | 'chat-api' //        optional: true (--with-playback)
+  | 'authz-sync'; //     optional: true (--with authz) — RabbitMQ-only OpenFGA tuple projector
 
 /** Mesh infra units, started as a single `make up PROFILE=empty`. */
-export type MeshId = 'postgres' | 'redis' | 'rabbitmq' | 'connect-mongo';
+export type MeshId = 'postgres' | 'redis' | 'rabbitmq' | 'connect-mongo' | 'openfga';
 
 /** Sibling-repo env-var keys (mirror up.sh:173-181). `repoRoot = $<key> ?? $DEV/<default>`. */
 export type RepoKey =
@@ -72,7 +73,9 @@ export type DbId =
   | 'transcripts_local'
   | 'insights_local'
   | 'chat_local'
-  | 'connectv3';
+  | 'connectv3'
+  | 'openfga'
+  | 'authz_sync_local';
 
 /** Canonical SeedStep ids (see §4). Referenced by `ServiceDef.seed`. */
 export type SeedStepRef =
@@ -84,7 +87,8 @@ export type SeedStepRef =
   | 'content'
   | 'transcripts'
   | 'insights'
-  | 'chat';
+  | 'chat'
+  | 'fga-bootstrap';
 
 /** How a DB's schema is applied. `dir` is repo-relative to the OWNING service's repo. */
 export interface MigrateSpec {

--- a/packages/node/saga-stack-cli/src/core/seed/profiles.ts
+++ b/packages/node/saga-stack-cli/src/core/seed/profiles.ts
@@ -32,7 +32,8 @@ export type SeedStepId =
   | 'chat-provision'
   | 'transcripts'
   | 'insights'
-  | 'chat';
+  | 'chat'
+  | 'fga-bootstrap'; //        --with authz: OpenFGA store bootstrap + tuple seed
 
 /** Profile → the seed-step ids it contributes (plan §4.1). */
 export const PROFILE_STEPS: Readonly<Record<SeedProfile, readonly SeedStepId[]>> = {
@@ -58,6 +59,12 @@ export const ADDON_STEPS: Readonly<Record<SeedAddOn, readonly SeedStepId[]>> = {
     'chat',
   ],
   qtf: ['qtf-demo'],
+  // `--with authz`: OpenFGA store bootstrap (idempotent by-name reuse) + the
+  // canonical-tuples seed. OFFLINE (direct HTTP to the openfga mesh unit,
+  // requiresServiceUp:[]) and warn-only — a cold-start bootstrap failure must
+  // never redden the whole `stack up` (FGA fails closed regardless; see
+  // LaunchTokens.OPENFGA_STORE_ID).
+  authz: ['fga-bootstrap'],
 };
 
 /**
@@ -88,6 +95,7 @@ export const SEED_RUN_ORDER: readonly SeedStepId[] = [
   'transcripts',
   'insights',
   'chat',
+  'fga-bootstrap',
 ];
 
 // ── connection derivation (from the manifest's DatabaseDef) ──────────────────
@@ -465,6 +473,39 @@ export function buildSeedRegistry(m: Manifest = manifest): Record<SeedStepId, Se
     transcripts: playbackStep(m, 'transcripts', 'transcripts-api', 'transcripts_local'),
     insights: playbackStep(m, 'insights', 'insights-api', 'insights_local'),
     chat: playbackStep(m, 'chat', 'chat-api', 'chat_local'),
+    // --with authz: bootstrap (or reuse, by name) the OpenFGA store, load the
+    // model, and seed canonical-tuples.json. `service: 'iam-api'` (not
+    // 'authz-sync') because iam-api is the one guaranteed to be in every
+    // closure — the step would otherwise be dropped as service-inactive on a
+    // `--only <svc>` selection that doesn't happen to include authz-sync too,
+    // even though `--with authz` always brings iam-api along (every closure
+    // does). `--out-file` writes the store id where base-command.ts's
+    // `readOpenfgaStoreId` reads it on the NEXT `stack up --with authz` (this
+    // run's launch env, already built by the time seed runs, still resolves
+    // OPENFGA_STORE_ID to '' — see launch-plan.ts). `scripts/fga` is
+    // rostering-root-relative, same convention as the iam-db steps' cwd.
+    'fga-bootstrap': {
+      id: 'fga-bootstrap',
+      service: 'iam-api',
+      databases: [],
+      cwd: 'scripts/fga',
+      command: [
+        'node',
+        'bootstrap.mjs',
+        '--store-name',
+        'saga-mesh-dev',
+        '--reuse',
+        '--tuples',
+        'canonical-tuples.json',
+        '--out-file',
+        '../../.saga-mesh/openfga-store.json',
+      ],
+      env: { kind: 'inline', vars: { OPENFGA_API_URL: '${OPENFGA_API_URL}' } },
+      requiresServiceUp: [],
+      // Opt-in path — a bootstrap hiccup (e.g. openfga not yet ready) must
+      // never redden the whole `stack up`; FGA fails closed regardless.
+      failureMode: 'warn',
+    },
   };
 }
 

--- a/packages/node/saga-stack-cli/src/core/seed/types.ts
+++ b/packages/node/saga-stack-cli/src/core/seed/types.ts
@@ -30,7 +30,7 @@ export interface SystemSeedOverride {
 export type SeedProfile = 'roster' | 'full';
 
 /** Orthogonal add-ons layered on top of a profile (plan §4.1). */
-export type SeedAddOn = 'playback' | 'qtf';
+export type SeedAddOn = 'playback' | 'qtf' | 'authz';
 
 /**
  * How a seed step's environment is supplied.

--- a/packages/node/saga-stack-cli/src/core/snapshot/manifest.ts
+++ b/packages/node/saga-stack-cli/src/core/snapshot/manifest.ts
@@ -48,6 +48,8 @@ const DB_IDS = [
   'insights_local',
   'chat_local',
   'connectv3',
+  'openfga',
+  'authz_sync_local',
 ] as const;
 const _dbIdsAreDbIds: readonly DbId[] = DB_IDS;
 void _dbIdsAreDbIds;
@@ -70,6 +72,7 @@ const SERVICE_IDS = [
   'transcripts-api',
   'insights-api',
   'chat-api',
+  'authz-sync',
 ] as const;
 const _serviceIdsAreServiceIds: readonly ServiceId[] = SERVICE_IDS;
 void _serviceIdsAreServiceIds;

--- a/packages/node/saga-stack-cli/src/core/snapshot/plan.ts
+++ b/packages/node/saga-stack-cli/src/core/snapshot/plan.ts
@@ -58,10 +58,20 @@ function ownerServiceOf(m: Manifest): Map<DbId, ServiceId> {
   return owner;
 }
 
-/** A db is "playback" when its owning service is `optional:true` (transcripts/insights/chat). */
+/**
+ * A db is "optional" when its owning service is `optional:true` — the playback
+ * trio (owned by transcripts-api/insights-api/chat-api) or authz_sync_local/
+ * openfga (owned by authz-sync). Name kept for the playback-only pre-authz
+ * history; despite the name it is ownership-generic (`svcId ? optional : false`).
+ */
 function isPlaybackDb(db: DbId, m: Manifest, owner: Map<DbId, ServiceId>): boolean {
   const svcId = owner.get(db);
   return svcId ? m.services[svcId].optional : false;
+}
+
+/** Whether an optional db's owning service is specifically `authz-sync` (vs. playback). */
+function isAuthzDb(db: DbId, owner: Map<DbId, ServiceId>): boolean {
+  return owner.get(db) === 'authz-sync';
 }
 
 /**
@@ -110,6 +120,8 @@ export interface StorePlanOptions {
   only?: DbId[];
   /** Include the optional playback trio (transcripts/insights/chat). Ignored when `only` is set. */
   withPlayback?: boolean;
+  /** Include the optional authz DBs (openfga/authz_sync_local). Ignored when `only` is set. */
+  withAuthz?: boolean;
 }
 
 export interface StorePlan {
@@ -124,10 +136,10 @@ export interface StorePlan {
 /**
  * Decide which databases to dump for a `store`.
  *
- * Default set = ALL manifest DBs except those owned by optional (playback)
- * services — i.e. the 10 pg app DBs + `connectv3` mongo. `--with-playback` adds
- * the 3 playback DBs. `only` (a resolved closure db set) overrides both and
- * scopes the dump precisely.
+ * Default set = ALL manifest DBs except those owned by optional (playback or
+ * authz) services — i.e. the 10 pg app DBs + `connectv3` mongo. `--with playback`
+ * adds the 3 playback DBs; `--with authz` adds openfga/authz_sync_local. `only`
+ * (a resolved closure db set) overrides both and scopes the dump precisely.
  */
 export function storePlan(m: Manifest, opts: StorePlanOptions): StorePlan {
   const owner = ownerServiceOf(m);
@@ -136,7 +148,9 @@ export function storePlan(m: Manifest, opts: StorePlanOptions): StorePlan {
   const onlySet = opts.only ? new Set<DbId>(opts.only) : undefined;
   const selected = allDbIds.filter((db) => {
     if (onlySet) return onlySet.has(db);
-    if (isPlaybackDb(db, m, owner)) return opts.withPlayback ?? false;
+    if (isPlaybackDb(db, m, owner)) {
+      return isAuthzDb(db, owner) ? (opts.withAuthz ?? false) : (opts.withPlayback ?? false);
+    }
     return true;
   });
 

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/mesh.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/mesh.unit.test.ts
@@ -11,7 +11,7 @@
 import { describe, expect, it } from 'vitest';
 import { manifest } from '../../core/manifest/index.js';
 import type { RunResult, Runner, ScriptInvocation } from '../exec.js';
-import { meshDownArgs, meshMakeArgs, meshUp } from '../mesh.js';
+import { meshDownArgs, meshExecArgs, meshMakeArgs, meshUp } from '../mesh.js';
 import type { MeshExec } from '../mesh.js';
 import type { PortProbe } from '../preflight.js';
 
@@ -29,16 +29,22 @@ function fakeRunner(code = 0): { runner: Runner; calls: ScriptInvocation[] } {
   return { runner, calls };
 }
 
-/** A readiness exec where `ready[container]` decides; default ready. */
-function fakeExec(ready: Record<string, boolean> = {}): { exec: MeshExec; calls: string[] } {
+/** A readiness exec where `ready[container]` decides; default ready. Records each call's (container, shell). */
+function fakeExec(ready: Record<string, boolean> = {}): {
+  exec: MeshExec;
+  calls: string[];
+  shellCalls: Array<{ container: string; shell: boolean | undefined }>;
+} {
   const calls: string[] = [];
+  const shellCalls: Array<{ container: string; shell: boolean | undefined }> = [];
   const exec: MeshExec = {
-    async ready(container) {
+    async ready(container, _readinessCmd, shell) {
       calls.push(container);
+      shellCalls.push({ container, shell });
       return ready[container] ?? true;
     },
   };
-  return { exec, calls };
+  return { exec, calls, shellCalls };
 }
 
 const FREE_PROBE: PortProbe = {
@@ -106,6 +112,27 @@ describe('meshDownArgs', () => {
   });
 });
 
+describe('meshExecArgs', () => {
+  it('default/shell:true wraps the readinessCmd in sh -c (needed for quoted commands like mongosh --eval)', () => {
+    expect(meshExecArgs('soa-connect-mongo-1', "mongosh --eval 'db.runCommand({ping:1}).ok'")).toEqual([
+      'exec',
+      'soa-connect-mongo-1',
+      'sh',
+      '-c',
+      "mongosh --eval 'db.runCommand({ping:1}).ok'",
+    ]);
+  });
+
+  it('shell:false execs the whitespace-split argv directly (openfga has no sh)', () => {
+    expect(meshExecArgs('soa-openfga-1', '/usr/local/bin/grpc_health_probe -addr=:8081', false)).toEqual([
+      'exec',
+      'soa-openfga-1',
+      '/usr/local/bin/grpc_health_probe',
+      '-addr=:8081',
+    ]);
+  });
+});
+
 describe('meshUp', () => {
   it('runs make up in <soa>/infra with the seed-dir env, then gates readiness', async () => {
     const { runner, calls } = fakeRunner(0);
@@ -126,6 +153,55 @@ describe('meshUp', () => {
     expect(calls[0].env).toEqual({ EXTRA_POSTGRES_SEED_DIR: '../../projects/saga-mesh/seed' });
     expect(res.units.map((u) => u.id)).toEqual(['postgres', 'rabbitmq']);
     expect(res.units.every((u) => u.ok)).toBe(true);
+  });
+
+  it('units including openfga: sets COMPOSE_PROFILES to the compose profile NAME (authz), not the unit id', async () => {
+    const { runner, calls } = fakeRunner(0);
+    const { exec } = fakeExec();
+    await meshUp({
+      soaRoot: SOA,
+      runner,
+      exec,
+      portProbe: FREE_PROBE,
+      units: ['postgres', 'openfga'],
+    });
+
+    expect(calls[0].env).toEqual({
+      EXTRA_POSTGRES_SEED_DIR: '../../projects/saga-mesh/seed',
+      COMPOSE_PROFILES: 'authz',
+    });
+  });
+
+  it('units without openfga: omits COMPOSE_PROFILES entirely', async () => {
+    const { runner, calls } = fakeRunner(0);
+    const { exec } = fakeExec();
+    await meshUp({
+      soaRoot: SOA,
+      runner,
+      exec,
+      portProbe: FREE_PROBE,
+      units: ['postgres', 'rabbitmq'],
+    });
+
+    expect(calls[0].env).toEqual({ EXTRA_POSTGRES_SEED_DIR: '../../projects/saga-mesh/seed' });
+    expect(calls[0].env).not.toHaveProperty('COMPOSE_PROFILES');
+  });
+
+  it("openfga's readiness gate is probed with shell:false (its unit.shell); other units default to shell:true", async () => {
+    const { runner } = fakeRunner(0);
+    const { exec, shellCalls } = fakeExec();
+    await meshUp({
+      soaRoot: SOA,
+      runner,
+      exec,
+      portProbe: FREE_PROBE,
+      units: ['postgres', 'openfga'],
+    });
+
+    expect(shellCalls).toEqual([
+      { container: 'soa-postgres-1', shell: undefined },
+      { container: 'soa-openfga-1', shell: false },
+    ]);
   });
 
   it('aborts before make up when the preflight finds a conflict', async () => {

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/preflight.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/preflight.unit.test.ts
@@ -30,7 +30,7 @@ function fakeProbe(docker: Record<number, string>, native: number[] = []): PortP
 }
 
 describe('meshPortSpecs / meshOwnedContainers', () => {
-  it('derives the 5 mesh host ports from the manifest (incl. rabbitmq-mgmt + connect-mongo)', () => {
+  it('derives the mesh host ports from the manifest (incl. rabbitmq-mgmt + connect-mongo + openfga)', () => {
     const specs = meshPortSpecs(manifest);
     expect(specs).toEqual([
       { port: 5432, name: 'postgres' },
@@ -38,6 +38,8 @@ describe('meshPortSpecs / meshOwnedContainers', () => {
       { port: 5672, name: 'rabbitmq' },
       { port: 15672, name: 'rabbitmq-mgmt' },
       { port: 27037, name: 'connect-mongo' },
+      { port: 8080, name: 'openfga' },
+      { port: 8081, name: 'openfga-mgmt' },
     ]);
   });
 
@@ -54,6 +56,8 @@ describe('meshPortSpecs / meshOwnedContainers', () => {
       { port: 6672, name: 'rabbitmq' },
       { port: 16672, name: 'rabbitmq-mgmt' },
       { port: 28037, name: 'connect-mongo' },
+      { port: 9080, name: 'openfga' },
+      { port: 9081, name: 'openfga-mgmt' },
     ]);
     // offset 0 is byte-identical to the default.
     expect(meshPortSpecs(manifest, 0)).toEqual(meshPortSpecs(manifest));

--- a/packages/node/saga-stack-cli/src/runtime/mesh.ts
+++ b/packages/node/saga-stack-cli/src/runtime/mesh.ts
@@ -52,8 +52,14 @@ import type { PortConflict, PortProbe } from './preflight.js';
  * no per-service filter (confirmed in `infra/Makefile`) — profiles are the only
  * way to keep it out of every OTHER `stack up`'s footprint without touching the
  * shared Makefile that every project's mesh depends on.
+ *
+ * Keyed by mesh unit id, valued by the compose `profiles:` name that unit's
+ * service definition actually carries (`../services/openfga/compose.yml` uses
+ * `profiles: ["authz"]`, NOT `["openfga"]` — the unit id and the compose
+ * profile name are independent strings, so this map, not the unit id itself,
+ * is what `COMPOSE_PROFILES` must be built from).
  */
-const PROFILE_GATED_MESH: ReadonlySet<MeshId> = new Set<MeshId>(['openfga']);
+const PROFILE_GATED_MESH: ReadonlyMap<MeshId, string> = new Map<MeshId, string>([['openfga', 'authz']]);
 
 /** Strip a `meshPortSpecs` mgmt-port suffix (`'<id>-mgmt'` → `'<id>'`) back to its unit id. */
 function baseUnitId(specName: string): string {
@@ -66,7 +72,7 @@ function baseUnitId(specName: string): string {
  * (`docker exec <container> sh -c '<readinessCmd>'`); a fake answers from a script.
  */
 export interface MeshExec {
-  ready(container: string, readinessCmd: string): Promise<boolean>;
+  ready(container: string, readinessCmd: string, shell?: boolean): Promise<boolean>;
 }
 
 /** Inputs to a native mesh bring-up. */
@@ -235,7 +241,7 @@ export async function meshUp(ctx: MeshContext): Promise<MeshResult> {
   // units the caller's closure needs, so a plain `stack up` (no --with authz)
   // neither preflights their ports nor starts their containers.
   const activeGatedIds = gatedIds.filter((id) => PROFILE_GATED_MESH.has(id));
-  const composeProfiles = activeGatedIds.join(',');
+  const composeProfiles = [...new Set(activeGatedIds.map((id) => PROFILE_GATED_MESH.get(id)))].join(',');
 
   // 1. check_ports preflight (unless the caller already did it) — probe the SLOT's
   // offset ports, and treat the slot's own `soa-s<N>-*` containers as owned (via
@@ -283,7 +289,7 @@ export async function meshUp(ctx: MeshContext): Promise<MeshResult> {
   for (const id of gatedIds) {
     const unit = getMesh(id, m);
     const container = meshContainer(unit);
-    const ready = await pollReady(exec, container, unit.readinessCmd, unit.timeoutSec, ctx.sleep);
+    const ready = await pollReady(exec, container, unit.readinessCmd, unit.shell, unit.timeoutSec, ctx.sleep);
     units.push({ id, container, ok: ready });
     if (!ready) allReady = false;
   }
@@ -296,15 +302,28 @@ async function pollReady(
   exec: MeshExec,
   container: string,
   readinessCmd: string,
+  shell: boolean | undefined,
   timeoutSec: number,
   sleep: (ms: number) => Promise<void> = (ms): Promise<void> =>
     new Promise((r) => setTimeout(r, ms)),
 ): Promise<boolean> {
   for (let attempt = 0; attempt < timeoutSec; attempt += 1) {
-    if (await exec.ready(container, readinessCmd)) return true;
+    if (await exec.ready(container, readinessCmd, shell)) return true;
     await sleep(1000);
   }
   return false;
+}
+
+/**
+ * Pure argv builder for the readiness `docker exec`, split out so the
+ * shell-vs-direct branch is testable without a real docker/child_process.
+ * `shell: false` (openfga's distroless image, no `sh`) execs the
+ * whitespace-split readinessCmd directly — only safe for a command with no
+ * shell metacharacters, which is why it's opt-in per mesh unit, not the
+ * default.
+ */
+export function meshExecArgs(container: string, readinessCmd: string, shell = true): string[] {
+  return shell ? ['exec', container, 'sh', '-c', readinessCmd] : ['exec', container, ...readinessCmd.split(' ')];
 }
 
 /**
@@ -316,9 +335,9 @@ async function pollReady(
  */
 export function makeRealMeshExec(): MeshExec {
   return {
-    ready(container: string, readinessCmd: string): Promise<boolean> {
+    ready(container: string, readinessCmd: string, shell = true): Promise<boolean> {
       return new Promise((resolve) => {
-        execFile('docker', ['exec', container, 'sh', '-c', readinessCmd], (err) => {
+        execFile('docker', meshExecArgs(container, readinessCmd, shell), (err) => {
           resolve(!err);
         });
       });

--- a/packages/node/saga-stack-cli/src/runtime/mesh.ts
+++ b/packages/node/saga-stack-cli/src/runtime/mesh.ts
@@ -38,11 +38,27 @@
 
 import { execFile } from 'node:child_process';
 import { join } from 'node:path';
-import { allMesh, getMesh, manifest as defaultManifest } from '../core/manifest/index.js';
+import { getMesh, manifest as defaultManifest } from '../core/manifest/index.js';
 import type { Manifest, MeshDef, MeshId } from '../core/manifest/index.js';
 import type { Runner } from './exec.js';
 import { checkPorts, makeRealPortProbe, meshOwnedContainers, meshPortSpecs } from './preflight.js';
 import type { PortConflict, PortProbe } from './preflight.js';
+
+/**
+ * Mesh units gated behind a docker-compose `profiles:` entry — NOT started by a
+ * bare `docker compose up -d` unless their profile is active. `openfga` (+ its
+ * `openfga_migrate` one-shot sidecar, unmodeled as a `MeshId`) is the first: the
+ * `authz` bundle is opt-in (plan decision), but `make up`'s `$(COMPOSE) up -d` has
+ * no per-service filter (confirmed in `infra/Makefile`) — profiles are the only
+ * way to keep it out of every OTHER `stack up`'s footprint without touching the
+ * shared Makefile that every project's mesh depends on.
+ */
+const PROFILE_GATED_MESH: ReadonlySet<MeshId> = new Set<MeshId>(['openfga']);
+
+/** Strip a `meshPortSpecs` mgmt-port suffix (`'<id>-mgmt'` → `'<id>'`) back to its unit id. */
+function baseUnitId(specName: string): string {
+  return specName.endsWith('-mgmt') ? specName.slice(0, -'-mgmt'.length) : specName;
+}
 
 /**
  * The injectable mesh readiness seam: run one unit's readiness command inside its
@@ -74,9 +90,12 @@ export interface MeshContext {
   /** The readiness-probe seam. Default `makeRealMeshExec()`. */
   exec?: MeshExec;
   /**
-   * Which mesh units to readiness-gate (typically the active `closure.mesh`).
-   * Omitted ⇒ all manifest mesh units. `make up` always starts the full mesh
-   * regardless; this only narrows what we WAIT on.
+   * Which mesh units the active closure needs (typically `closure.mesh`).
+   * Omitted ⇒ all manifest mesh units. Narrows what we readiness-WAIT on for
+   * every unit; for `PROFILE_GATED_MESH` units specifically (`openfga`) it also
+   * decides whether they're preflighted/started at all — the base mesh
+   * (postgres/redis/rabbitmq/connect-mongo) always starts via `make up`
+   * regardless, since that target has no per-service filter.
    */
   units?: MeshId[];
   /** Port probe for the `check_ports` preflight. Default `makeRealPortProbe()`. */
@@ -211,19 +230,38 @@ export async function meshUp(ctx: MeshContext): Promise<MeshResult> {
   const gatedIds = ctx.units ?? (Object.keys(m.mesh) as MeshId[]);
   const offset = ctx.meshOffset ?? 0;
 
+  // Profile-gated units (e.g. `openfga`) only actually start when their compose
+  // `profiles:` entry is active — derive the active profile set from which gated
+  // units the caller's closure needs, so a plain `stack up` (no --with authz)
+  // neither preflights their ports nor starts their containers.
+  const activeGatedIds = gatedIds.filter((id) => PROFILE_GATED_MESH.has(id));
+  const composeProfiles = activeGatedIds.join(',');
+
   // 1. check_ports preflight (unless the caller already did it) — probe the SLOT's
   // offset ports, and treat the slot's own `soa-s<N>-*` containers as owned (via
   // the env-aware `meshOwnedContainers`) so an idempotent re-up isn't a conflict.
+  // Profile-gated units are excluded unless active — their ports aren't published
+  // by a container that won't be started, so checking them would be a false
+  // conflict against whatever else happens to be bound to that host port.
   if (!ctx.skipPreflight) {
-    const conflicts = await checkPorts(meshPortSpecs(m, offset), probe, meshOwnedContainers(m));
+    const ports = meshPortSpecs(m, offset).filter(
+      (spec) => !PROFILE_GATED_MESH.has(baseUnitId(spec.name) as MeshId) || activeGatedIds.includes(baseUnitId(spec.name) as MeshId),
+    );
+    const conflicts = await checkPorts(ports, probe, meshOwnedContainers(m));
     if (conflicts.length > 0) {
       return { ok: false, conflicts, makeOk: false, units: [] };
     }
   }
 
-  // 2. make up — the mesh always starts as a whole; ports are manifest-derived
-  // (+ the slot offset). COMPOSE_PROJECT_NAME goes both as a make arg and via env
-  // (the Makefile's `?=` env-override path). At slot 0 both are omitted ⇒ identical.
+  // 2. make up — the BASE mesh always starts as a whole; ports are
+  // manifest-derived (+ the slot offset). Profile-gated units (`openfga`) only
+  // join via `COMPOSE_PROFILES`, set iff the caller's closure needs them — `make
+  // up`'s `$(COMPOSE) up -d` has no per-service filter (confirmed: the shared
+  // Makefile's `up:` target is bare), so compose profiles are the only seam that
+  // keeps an opt-in unit out of every OTHER project's mesh footprint without
+  // touching that shared target. COMPOSE_PROJECT_NAME goes both as a make arg and
+  // via env (the Makefile's `?=` env-override path). At slot 0 both are omitted
+  // ⇒ identical to pre-M7/pre-profile behavior when no gated unit is needed.
   const { code } = await ctx.runner.run({
     cwd: join(ctx.soaRoot, 'infra'),
     command: 'make',
@@ -231,6 +269,7 @@ export async function meshUp(ctx: MeshContext): Promise<MeshResult> {
     env: {
       EXTRA_POSTGRES_SEED_DIR: '../../projects/saga-mesh/seed',
       ...(ctx.project ? { COMPOSE_PROJECT_NAME: ctx.project } : {}),
+      ...(composeProfiles ? { COMPOSE_PROFILES: composeProfiles } : {}),
     },
     stdio: 'inherit',
   });

--- a/packages/node/saga-stack-cli/src/runtime/reset.ts
+++ b/packages/node/saga-stack-cli/src/runtime/reset.ts
@@ -64,6 +64,8 @@ export interface ResetContext {
   meshOffset?: number;
   /** Include the opt-in playback DBs (transcripts/insights/chat) in the truncate set. */
   withPlayback?: boolean;
+  /** Include the opt-in authz DBs (openfga/authz_sync_local) in the truncate set. */
+  withAuthz?: boolean;
   /** Process seam — the `docker exec …` / `pnpm prisma …` statements run through it. */
   runner: Runner;
   /**
@@ -175,10 +177,17 @@ export async function resetClosure(ctx: ResetContext): Promise<ResetResult> {
       continue;
     }
 
-    // Playback DBs (meshProvisioned:false) only under --with playback (up.sh DO_PLAYBACK).
-    if (!def.meshProvisioned && !ctx.withPlayback) {
-      results.push({ db: id, action: 'skipped', ok: true, reason: 'playback DB (needs --with playback)' });
-      continue;
+    // meshProvisioned:false DBs are opt-in, each gated by its OWN bundle flag —
+    // playback trio under --with playback (up.sh DO_PLAYBACK), openfga/authz_sync_local
+    // under --with authz. Never a blanket OR of both flags (would cross-admit).
+    if (!def.meshProvisioned) {
+      const isAuthzDb = id === 'openfga' || id === 'authz_sync_local';
+      const admitted = isAuthzDb ? ctx.withAuthz : ctx.withPlayback;
+      if (!admitted) {
+        const reason = isAuthzDb ? 'authz DB (needs --with authz)' : 'playback DB (needs --with playback)';
+        results.push({ db: id, action: 'skipped', ok: true, reason });
+        continue;
+      }
     }
 
     // Existence probe (R2/R3 seam): a pg DB a partial `up` never provisioned (e.g.

--- a/packages/node/saga-stack-cli/src/stack-api.ts
+++ b/packages/node/saga-stack-cli/src/stack-api.ts
@@ -365,6 +365,8 @@ export interface DownResult {
 export interface ResetOpts {
   /** Also reset the opt-in playback DBs (transcripts/insights/chat). */
   withPlayback?: boolean;
+  /** Also reset the opt-in authz DBs (openfga/authz_sync_local). */
+  withAuthz?: boolean;
 }
 
 /** The outcome of a native `reset` (M8 R4). */
@@ -1023,6 +1025,7 @@ export function makeStackApi(m: Manifest, runtime: Runtime): StackApi {
         repoRoots: launchContext.repoRoots,
         meshOffset: runtime.meshOffset,
         withPlayback: opts.withPlayback,
+        withAuthz: opts.withAuthz,
         runner,
         // R2/R3 probe seam: SKIP (don't truncate/migrate-reset) a pg DB that a partial
         // `up` never provisioned (e.g. coach_api) — matches up.sh's reset_data tolerance,


### PR DESCRIPTION
## Summary

- Registers `openfga` (Postgres-backed) as a mesh unit and `authz-sync` as a manifest service, both opt-in behind a new `authz` bundle (`--with authz`), so FGA-gated code paths (`iam-api`'s `fgaCheck`, `authz-sync`'s tuple projection) are testable locally instead of requiring live-AWS CloudWatch log archaeology.
- Opt-in footprint via docker-compose `profiles:` (`COMPOSE_PROFILES=authz`, derived from the closure's needed mesh units) since `make up`'s shared Makefile target has no per-service filter — a plain `stack up` neither starts openfga nor preflight-checks its ports.
- Store-id propagation follows the existing `--tunnel` overlay precedent: a `fga-bootstrap` seed step writes the bootstrapped OpenFGA store id to a fixed file; `base-command.ts` reads it synchronously before building the launch env. Cold start fails closed (empty store id → FGA client `null` → 403, not a crash); the same run's seed step makes the *next* run pick it up.
- Companion rostering-side changes (bootstrap.mjs `--out-file`, dev-user tuple, stale doc-comment fix) already merged separately via saga-ed/rostering#762.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Full `vitest run` — 1072/1073 relevant tests pass (1 pre-existing unrelated failure from soa#271's `VITE_ENABLE_OVERRIDES`, predates this branch)
- [x] `stack up --dry-run` (no `--with authz`): `mesh: postgres, redis, rabbitmq, connect-mongo` — no openfga
- [x] `stack up --only iam-api --with authz --dry-run`: `mesh: postgres, redis, rabbitmq, openfga`; `databases: ..., openfga, authz_sync_local`; seed plan includes `fga-bootstrap`
- [x] `stack status --with authz` correctly reports `authz-sync` on its manifest port
- [ ] Live `stack up --with authz` against real docker (not run in this sandboxed session — recommend a manual pass before merge)