### PR TITLE
fix(saga-stack-cli): browser-login devLogin sends `identifier` (unbreak `ss stack login --browser`)

### DIFF
--- a/packages/node/saga-stack-cli/vendor/browser-login.mjs
+++ b/packages/node/saga-stack-cli/vendor/browser-login.mjs
@@ -65,7 +65,10 @@ try {
 // /demo page passes).
 const res = await ctx.request.post(`${IAM_URL}/trpc/auth.devLogin`, {
   headers: { 'Content-Type': 'application/json', Origin: IAM_URL },
-  data: { email: EMAIL },
+  // rostering#756: devLogin takes `identifier` (uuid | email); the old `email`-only
+  // body now 400s (identifier undefined). Send both keys — same shape as the
+  // native jar path (core/login.ts buildDevLoginRequest).
+  data: { identifier: EMAIL, email: EMAIL },
 });
 if (!res.ok()) {
   const body = await res.text().catch(() => '');

--- a/tools/synthetic-dev/browser-login.mjs
+++ b/tools/synthetic-dev/browser-login.mjs
@@ -65,7 +65,10 @@ try {
 // /demo page passes).
 const res = await ctx.request.post(`${IAM_URL}/trpc/auth.devLogin`, {
   headers: { 'Content-Type': 'application/json', Origin: IAM_URL },
-  data: { email: EMAIL },
+  // rostering#756: devLogin takes `identifier` (uuid | email); the old `email`-only
+  // body now 400s (identifier undefined). Send both keys — same shape as the
+  // native jar path (core/login.ts buildDevLoginRequest).
+  data: { identifier: EMAIL, email: EMAIL },
 });
 if (!res.ok()) {
   const body = await res.text().catch(() => '');


### PR DESCRIPTION
## What

The vendored `browser-login.mjs` (and its `tools/synthetic-dev` twin) still POSTed `{ email }` to `auth.devLogin`. **rostering#756** changed devLogin to take `identifier` (uuid | email), so the in-browser replay now 400s:

```
AUTOLOGIN_FAIL devLogin HTTP 400 … "path": ["identifier"], "message": "Invalid input"
```

The native cookie jar mints fine (`core/login.ts` was already updated to send `{ identifier, email }`), but `--browser` re-runs devLogin *inside* the Chromium context to land the HttpOnly cookie in the profile — that call is what breaks, so the headful window fails to auto-login and the dash bounces to the Janus redirect.

## Fix

Send `{ identifier, email }` — byte-identical to the native jar path (`core/login.ts` `buildDevLoginRequest`). Applied to both copies (they're kept in sync); `vendor.unit.test.ts` green.

## Impact

Unbreaks `ss stack login --browser` and `ss up --login` (headful auto-login), and the Plan-13 `--hold` browser hand-off. Data-only change to the `.mjs`; no behavior change to the headless jar path.

## Test

- `vendor.unit.test.ts` 4/4 green.
- Verified live: with the fix applied, `empty@saga.org` auto-logs into the dash SESSION attendance view (`AUTOLOGIN_OK`, no Janus bounce) — this is what unblocked today's telemetry standup demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QicocMpRSxQtebX3Rqw3vN