### PR TITLE
test(saga-stack-cli): pin vendored browser-login payload + repair two red-on-main expectations

### DIFF
--- a/packages/node/saga-stack-cli/src/core/__tests__/browser-login-lockstep.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/browser-login-lockstep.unit.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Lockstep pin: the vendored `browser-login.mjs` must send the same devLogin
+ * payload shape as `core/login.ts` (`{ identifier, email }`, rostering#756).
+ *
+ * The vendored script is run as-is by `ss stack login --browser` and the
+ * `e2e run --hold` autologin (resolveVendorScript — no build step), so it is
+ * invisible to type-checking and to the `buildDevLoginRequest` unit pin. It
+ * has silently drifted to the legacy `{ email }`-only body more than once,
+ * which 400s against post-rostering#756 iam-api (AUTOLOGIN_FAIL). This test
+ * reads the script's source so that drift fails CI instead of a live run.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const vendoredPath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../../vendor/browser-login.mjs',
+);
+
+describe('vendored browser-login.mjs — devLogin payload lockstep with core/login', () => {
+  it('sends `identifier` alongside `email` (rostering#756)', () => {
+    const source = readFileSync(vendoredPath, 'utf8');
+    expect(source).toContain('identifier: EMAIL');
+    // The legacy email-only body 400s (zod invalid_union at `identifier`).
+    expect(source).not.toMatch(/data:\s*\{\s*email:\s*EMAIL\s*\}/);
+  });
+});

--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
@@ -174,7 +174,11 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
   });
 
   it('saga-dash', () => {
-    expect(env('saga-dash')).toEqual({ VITE_ADS_ADM_REAL: 'true', VITE_SESSION_MEASURED: 'true' });
+    expect(env('saga-dash')).toEqual({
+      VITE_ADS_ADM_REAL: 'true',
+      VITE_SESSION_MEASURED: 'true',
+      VITE_ENABLE_OVERRIDES: 'true',
+    });
   });
 
   it('connect-api (incl. RABBITMQ_URL — main up.sh:1614)', () => {

--- a/packages/node/saga-stack-cli/src/core/flow/__tests__/load.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/flow/__tests__/load.unit.test.ts
@@ -26,12 +26,12 @@ const EXAMPLE_PATH = fileURLToPath(
 const EXAMPLE_TEXT = readFileSync(EXAMPLE_PATH, 'utf8');
 
 describe('parseFlowManifest — the bundled example validates', () => {
-  it('parses against the zod schema and exposes the spa + two flows', () => {
+  it('parses against the zod schema and exposes the spa + bundled flows', () => {
     const m = parseFlowManifest(EXAMPLE_TEXT, EXAMPLE_PATH);
     expect(m.schemaVersion).toBe(1);
     expect(m.spa.id).toBe('saga-dash');
     expect(m.spa.system).toBe('saga-dash');
-    expect(m.flows.map((f) => f.name)).toEqual(['journey', 'connect-session']);
+    expect(m.flows.map((f) => f.name)).toEqual(['journey', 'connect-session', 'connect-add-student']);
   });
 
   it('strips unknown top-level keys (the example carries a $comment annotation)', () => {
@@ -90,7 +90,7 @@ describe('loadFlowManifest — injectable reader seam (no disk IO)', () => {
       return EXAMPLE_TEXT;
     });
     expect(reads).toEqual(['/virtual/flows.json']);
-    expect(m.flows.map((f) => f.name)).toEqual(['journey', 'connect-session']);
+    expect(m.flows.map((f) => f.name)).toEqual(['journey', 'connect-session', 'connect-add-student']);
   });
 
   it('wraps a reader error in a path-tagged message', () => {


### PR DESCRIPTION
## What this is now (rebuilt after #281 landed)

The original 4-site devLogin fix landed independently on main (#281 / 8199c57) — thanks! This PR is rebuilt onto current main and keeps only what main still lacks:

1. **`browser-login-lockstep.unit.test.ts` (new)** — pins the vendored `browser-login.mjs` devLogin payload to `core/login.ts`'s shape. The vendored script runs as-is (resolveVendorScript, no build/type-check), and this exact drift has now recurred five times across `--browser`/`--hold` autologin; the pin makes the sixth fail CI instead of a live run.
2. **`launch-plan.unit.test.ts`** — the saga-dash expectation gains `VITE_ENABLE_OVERRIDES` (dc1e85d added it to the manifest without updating the pin; suite red on main since #272).
3. **`load.unit.test.ts`** — the bundled-example expectation gains `connect-add-student` (6b6571f mirrored the flow into the bundled saga-dash.flows.json without updating the pin; also red on main).

## Verification

`pnpm test` in saga-stack-cli on this branch: **all green** (was 3 failed on origin/main across launch-plan + load).

🤖 Generated with [Claude Code](https://claude.com/claude-code)