### PR TITLE
fix(saga-stack-cli): unbreak the lone red soa test (saga-dash launch env drift)

### DIFF
--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
@@ -168,7 +168,13 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
   });
 
   it('saga-dash', () => {
-    expect(env('saga-dash')).toEqual({ VITE_ADS_ADM_REAL: 'true', VITE_SESSION_MEASURED: 'true' });
+    // VITE_ENABLE_OVERRIDES added in soa#271 LAYER 3 (dc1e85d) — the ?mode=session
+    // dev override gate; services.ts sets it unconditionally on the stack dash.
+    expect(env('saga-dash')).toEqual({
+      VITE_ADS_ADM_REAL: 'true',
+      VITE_SESSION_MEASURED: 'true',
+      VITE_ENABLE_OVERRIDES: 'true',
+    });
   });
 
   it('connect-api (incl. RABBITMQ_URL — main up.sh:1614)', () => {


### PR DESCRIPTION
## The recurring red test — new instance

The single failing test in the repo-wide **PR Test Summary** (1645 pass / **1 fail**), which surfaces on unrelated PRs like #276, is:

```
launch-plan.unit.test.ts > resolveLaunchEnv — faithful to up.sh services_up (stack lane) > saga-dash
```

### Root cause
soa#271 LAYER 3 (`dc1e85d`, merged via #272) added a third env var to saga-dash's stack-lane launch env in `services.ts:332`:

```ts
VITE_ENABLE_OVERRIDES: 'true',  // ?mode=session dev override gate
```

…but nobody updated this test's hardcoded expectation, which still lists only 2 keys. Code emits 3 → test asserts 2 → red. It's **live on `main`** (HEAD `eba5497`), not specific to any feature branch — which is why it showed up on #276's summary even though #276 (browser-login `identifier` fix) is unrelated to launch env.

### Not the same bug as before
This is the same *class* as the earlier `resolveScript` drift (`97c33ca`, "the 1 red test on every soa PR") — a stale hardcoded assertion — but a **new instance in a different test**. That fix is still in place; this is separate drift introduced afterward.

### Fix
One-line test update: add `VITE_ENABLE_OVERRIDES: 'true'` to the expected object.

Verified: `launch-plan.unit.test.ts` 25/25 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)