### PR TITLE
fix(synthetic-dev): up.sh auto-login sends devLogin `identifier` (rostering#756)

### DIFF
--- a/tools/synthetic-dev/up.sh
+++ b/tools/synthetic-dev/up.sh
@@ -2069,7 +2069,7 @@ login_user(){
   code=$(curl -s -o "$STATE/devlogin.json" -w '%{http_code}' --max-time 10 \
     -X POST "$iam_url/trpc/auth.devLogin" \
     -H 'Content-Type: application/json' -H "Origin: $iam_url" \
-    -c "$COOKIE_JAR" -d "{\"email\":\"$email\"}" 2>/dev/null) || code=000
+    -c "$COOKIE_JAR" -d "{\"identifier\":\"$email\",\"email\":\"$email\"}" 2>/dev/null) || code=000
   if [[ "$code" != 200 ]]; then
     printf "\033[31m✗\033[0m devLogin failed (HTTP %s) for '%s'.\n" "$code" "$email"
     if [[ "$email" == "$DEFAULT_LOGIN_USER" ]]; then


### PR DESCRIPTION
## What

`up.sh`'s `--login` / `login_user()` auto-login POSTs to `iam-api`'s `auth.devLogin` with a stale request body:

```
-d "{\"email\":\"$email\"}"
```

**rostering#756** (merged 2026-07-06) renamed the `DevLoginSchema` input field from `email` to `identifier` (a `uuid | email` union) as a **breaking** change. The old key is gone, and `identifier` is required — so `{"email": ...}` now fails validation and `up.sh --login` **400s against a current iam-api**.

`saga-stack-cli` was already updated to send `{ identifier, email }` (soa `6c87a91`), but this raw-curl shell path was missed by that fix.

## Change

One line — send both keys, matching the `saga-stack-cli` client convention:

```
-d "{\"identifier\":\"$email\",\"email\":\"$email\"}"
```

(`email` is ignored by the schema but kept for parity with the TS client / any consumer reading the payload.)

## Scope / risk

Dev-only synthetic-dev tooling; no runtime/prod impact. `devLogin` is `FORBIDDEN` when `AUTH_ENABLED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)