### PR TITLE
docs(saga-stack-cli): restore-race known issue, closure-stop behavior, cold-start lockfile tip

### DIFF
--- a/packages/node/saga-stack-cli/docs/cold-start.md
+++ b/packages/node/saga-stack-cli/docs/cold-start.md
@@ -91,6 +91,12 @@ Expect this to take several minutes (reinstall + rebuild of every repo).
   and `--all-docker` are how you opt into the destruction. `--dry-run` is always safe.
 - **Your uncommitted work is protected.** Phase 3 never switches or resets a repo with tracked
   local changes — it reports `skipped-dirty` and moves on. Commit/stash first if you want it on main.
+- **Lockfile drift: repos are ff'd, never installed.** Phase 3 fast-forwards each sibling to
+  main but cold-start **never runs `pnpm install`** — if a repo's lockfile changed since its
+  last install, phase 4's rebuild can fail or ship stale deps. Before a cold start, pre-switch
+  drifted siblings to main and `pnpm install` them (or just pass `--reinstall`). Observed
+  2026-07-09: rostering + program-hub had small lockfile drift; pre-installing both made the
+  whole cold-start + full journey run green first try (13/13 services, 26/27 journey in 1.0m).
 - **`.env` scaffolding covers templates only.** Phase 5 can only copy a `.env.example` that a repo
   actually ships. A service whose `.env` is gitignored **with no committed example** (e.g. some
   `apps/node/*-api/.env`) is **not** created — those you still provision by hand the first time.

--- a/packages/node/saga-stack-cli/docs/e2e-flows.md
+++ b/packages/node/saga-stack-cli/docs/e2e-flows.md
@@ -184,6 +184,32 @@ ss e2e run saga-dash/journey --from schedule --through schedule -- --debug
 
 Anything after `--` passes straight to Playwright (`--ui`, `--debug`, a grep).
 
+## Narrow-closure runs stop out-of-closure services
+
+A partial run computes the closure of just the stages it will execute — and **stops
+services outside it** (clean SIGTERM). Running e.g.
+
+```bash
+ss e2e run saga-dash/journey --through pods --headless
+```
+
+on a previously-full stack SIGTERMs the services pods doesn't need (observed live
+2026-07-09: sessions-api stopping cleanly). Two practical consequences:
+
+- **The full stack is now partially down.** Bring a stopped service back without a
+  full re-up:
+
+  ```bash
+  ss stack up --only sessions-api --skip-prep
+  ```
+
+- **saga-dash caveat, not an ss bug:** saga-dash's stack-lane stage-0-coherence smoke
+  probes sessions-api **unconditionally** (`pinnedOrStack` short-circuits when
+  `LANE === 'stack'` — see
+  `apps/web/dash/e2e/sandbox/composition-coherence.e2e.smoke.test.ts:113`). So a
+  narrow `--through` run below sessions can fail stage 0 against a service ss itself
+  just stopped. `--from` runs skip stage 0 (`--no-deps`), so they don't hit this.
+
 ## Assessing the flows (background + foreground sweep)
 
 A compact assessment session, in order:
@@ -224,5 +250,10 @@ ss stack down                                               # 7. tidy up
   cosmetic ordering noise; it self-heals and the run continues.
 - **A flaky pass/fail on session durability** — known app flake (gh-186);
   retry once before digging.
+- **A service is down after a partial run** — expected; narrow closures stop
+  out-of-closure services (see above). `ss stack up --only <svc> --skip-prep`.
+- **A service DIES during a `--from` restore** (42P01 in its log) — the
+  restore-vs-poller race; see
+  [snapshots → Known issue](./snapshots.md#known-issue-restore-races-db-polling-services).
 - Full docs: `docs/e2e.md` (flows/stages/checkpoints in depth), `docs/slots.md`
   (parallel stacks), `docs/worktree-sets.md` (multi-worktree development).

--- a/packages/node/saga-stack-cli/docs/snapshots.md
+++ b/packages/node/saga-stack-cli/docs/snapshots.md
@@ -56,6 +56,25 @@ restore refuses rather than silently loading a stale shape — the one blind spo
 `db:seed` doesn't have. Restore-as-owner means row-level ownership/grants survive the round-trip.
 </details>
 
+## Known issue: restore races DB-polling services
+
+Restores run `pg_restore --clean --if-exists` **with services left running** — that's the
+speed premise, and it applies to e2e `--from` checkpoint restores too. Anything polling the
+DB on a tight loop can catch a table mid drop→recreate: program-hub's OutboxRelay polls
+~500ms, and a tick landing in that window gets 42P01
+(`relation "outbox_event" does not exist`); its fatal-error path throws an unhandled
+rejection and the **service process dies**. Observed live 2026-07-09 on programs-api;
+intermittent — an immediate retry of the same run restored green 2/2 in seconds.
+
+Recovery is one command — relaunch the dead service:
+
+```bash
+ss stack up --only programs-api --skip-prep
+```
+
+The coverage guard, by contrast, behaves well: restoring beyond the baked closure fails
+fast with a `re-bake with a wider --through` error instead of half-restoring.
+
 ## When to use which
 
 - **`snapshot restore`** — you want a *specific captured* state back fast (a fixture, a repro).


### PR DESCRIPTION
Three operator-knowledge additions to the saga-stack-cli docs. All three were observed live on 2026-07-09, on a fresh `ss stack cold-start --yes` against main @ 05d68ed.

## 1. snapshots.md — Known issue: restore races DB-polling services

`--from` / snapshot restores run `pg_restore --clean --if-exists` with services left running (the speed premise). program-hub's OutboxRelay polls ~500ms; a tick landing in the drop→recreate window gets 42P01 (`relation "outbox_event" does not exist`), its fatal-error path throws an unhandled rejection, and the service process dies (observed: programs-api; intermittent — an immediate retry was green 2/2 in seconds). Documented the one-command recovery (`ss stack up --only <svc> --skip-prep`) and noted the coverage guard behaves well (fails fast with "re-bake with a wider --through").

There is also a proposed fix direction beyond the docs: quiesce/relaunch services around the restore ceremony, and the relay's halt path shouldn't kill the process — soa-event-outbox 0.1.0-dev.7.

## 2. e2e-flows.md — narrow-closure runs stop out-of-closure services

`ss e2e run saga-dash/journey --through pods` SIGTERMs services outside the closure (observed sessions-api stopping cleanly). Documented the two practical consequences: (a) a previously-full stack is partially down afterwards (recovery command), and (b) a saga-dash caveat — the stack-lane stage-0-coherence smoke probes sessions-api unconditionally (`apps/web/dash/e2e/sandbox/composition-coherence.e2e.smoke.test.ts:113`), so a narrow `--through` run below sessions can fail stage 0 against a service ss itself stopped; `--from` runs skip stage 0 (`--no-deps`). Plus two matching troubleshooting bullets.

## 3. cold-start.md — lockfile drift tip

Cold-start ffs repos to main but never runs `pnpm install`. New Safety & limits bullet: pre-switch drifted siblings to main and install (or use `--reinstall`). Observed: rostering + program-hub had small lockfile drift; pre-installing made cold-start + full journey green first try (13/13 services, 26/27 journey in 1.0m).

Docs only — no code changes. 56 lines added across 3 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)