### PR TITLE
fix: devLogin `identifier` for the remaining dev-tooling callers (follow-up to #276)

### DIFF
--- a/packages/node/mesh-fixture-cli/src/lib/auth.ts
+++ b/packages/node/mesh-fixture-cli/src/lib/auth.ts
@@ -2,7 +2,8 @@
  * auth — dev-login flow against iam-api.
  *
  * iam-api with AUTH_AUTHENABLED=false exposes `auth.devLogin` which takes
- * { email } and returns a session cookie (`iam_session` or legacy
+ * an `identifier` (uuid | email; rostering#756) and returns a session cookie
+ * (`iam_session` or legacy
  * `iam_dev_session`). We issue a single login per CLI invocation and reuse
  * the cookie across all downstream tRPC calls.
  *
@@ -28,7 +29,9 @@ export async function devLogin(iamUrl: string, email: string): Promise<DevLoginR
   const res = await fetch(new URL('/trpc/auth.devLogin', iamUrl).toString(), {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ email }),
+    // rostering#756: devLogin takes `identifier` (uuid | email). Send both keys
+    // so login works against pre- and post-#756 iam checkouts (extra key is stripped).
+    body: JSON.stringify({ identifier: email, email }),
   });
   const rawBody = await res.text();
   if (!res.ok) {

--- a/packages/node/saga-stack-cli/src/core/login.ts
+++ b/packages/node/saga-stack-cli/src/core/login.ts
@@ -34,7 +34,7 @@ export interface DevLoginRequest {
   url: string;
   /** The `Origin` header — iam's OWN origin (== `iamUrl`); a wrong value is rejected. */
   origin: string;
-  /** `{"email":"<email>"}`. */
+  /** `{"identifier":"<email>","email":"<email>"}` — both keys (see `buildDevLoginRequest`). */
   body: string;
   email: string;
 }

--- a/tools/synthetic-dev/up.sh
+++ b/tools/synthetic-dev/up.sh
@@ -2069,7 +2069,7 @@ login_user(){
   code=$(curl -s -o "$STATE/devlogin.json" -w '%{http_code}' --max-time 10 \
     -X POST "$iam_url/trpc/auth.devLogin" \
     -H 'Content-Type: application/json' -H "Origin: $iam_url" \
-    -c "$COOKIE_JAR" -d "{\"email\":\"$email\"}" 2>/dev/null) || code=000
+    -c "$COOKIE_JAR" -d "{\"identifier\":\"$email\"}" 2>/dev/null) || code=000
   if [[ "$code" != 200 ]]; then
     printf "\033[31m✗\033[0m devLogin failed (HTTP %s) for '%s'.\n" "$code" "$email"
     if [[ "$email" == "$DEFAULT_LOGIN_USER" ]]; then


### PR DESCRIPTION
## What

Finishes the devLogin `identifier` migration for the three dev-tooling callers that [#276](https://github.com/saga-ed/soa/pull/276) didn't cover.

## Why

rostering `6d1029f40d` (rostering#756) renamed iam-api's `auth.devLogin` input from `email` to `identifier` (a `uuid | email` union). Any caller still POSTing the old `{"email": …}` shape now gets an HTTP 400:

```
"path": ["identifier"], "code": "invalid_union",
"expected": "string", "received": "undefined"
```

**Relationship to #276:** #276 (`worktree-fix-browser-login-identifier`) fixed the two `browser-login.mjs` callers — the in-browser Chromium login. This PR is the follow-up for the callers it left behind. Notably, #276 did **not** fix `up.sh`'s headless `--login` curl, which is the session mint that fails *first* in a `./up.sh … --login` run (before the browser step #276 addressed). This was the original symptom that surfaced the whole issue.

## Changes

| File | Fix |
|------|-----|
| `tools/synthetic-dev/up.sh` | headless `--login` curl body `{"email"}` → `{"identifier"}` |
| `packages/node/mesh-fixture-cli/src/lib/auth.ts` | devLogin `fetch` body → `{ identifier, email }` (+ doc) |
| `packages/node/saga-stack-cli/src/core/login.ts` | stale doc comment only — the code already sent both keys |

Backend callers send **both** keys (`{ identifier, email }`), matching the pattern #276 used, so login works against pre- and post-#756 iam checkouts (iam's `z.object()` strips the extra `email`). `up.sh` sends `identifier` alone.

## Verification

- Repo-wide sweep confirms zero remaining `email`-only devLogin payloads.
- Existing `saga-stack-cli` tests already assert the dual-key body; unaffected.
- The two `browser-login.mjs` files are intentionally untouched here (already correct on `main` via #276).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
