### PR TITLE
chore: gitignore worktree directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,11 @@ coverage
 # Turbo
 .turbo
 
+# Git worktrees (parallel development)
+/worktrees/
+.worktrees/
+.claude/worktrees/
+
 # Vercel
 .vercel
 


### PR DESCRIPTION
## Summary
- Add `/worktrees/`, `.worktrees/`, and `.claude/worktrees/` to `.gitignore`
- These are the conventions in active use across the fleet (git worktree add, EnterWorktree tool) but weren't ignored — `git status` currently shows `?? worktrees/` at repo root, and `.claude/worktrees/` was only ignored via a global excludesfile, not this repo's own `.gitignore`
- Companion fix to the same gitignore gap already closed in `rostering` and `iac`

## Test plan
- [x] `git check-ignore -v` confirms all three patterns match their respective directories