### PR TITLE
feat(saga-stack-cli): `stack verify --all-slots` — report every active slot

### DIFF
--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -39,7 +39,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "default": "/home/skelly/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -189,7 +189,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "default": "/home/skelly/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -328,7 +328,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "default": "/home/skelly/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -559,7 +559,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "default": "/home/skelly/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -696,7 +696,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "default": "/home/skelly/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -881,7 +881,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "default": "/home/skelly/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -1018,7 +1018,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "default": "/home/skelly/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -1172,7 +1172,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "default": "/home/skelly/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -1310,7 +1310,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "default": "/home/skelly/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -1467,7 +1467,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "default": "/home/skelly/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -1640,7 +1640,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "default": "/home/skelly/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -1784,7 +1784,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "default": "/home/skelly/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -1935,7 +1935,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "default": "/home/skelly/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -2101,7 +2101,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "default": "/home/skelly/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -2246,7 +2246,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "default": "/home/skelly/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -2387,7 +2387,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "default": "/home/skelly/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -2557,7 +2557,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "default": "/home/skelly/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -2725,7 +2725,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "default": "/home/skelly/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -2864,7 +2864,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "default": "/home/skelly/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -3110,7 +3110,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "default": "/home/skelly/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -3225,6 +3225,12 @@
           "name": "full",
           "allowNo": false,
           "type": "boolean"
+        },
+        "all-slots": {
+          "description": "report EVERY active slot (0..9) instead of a single --slot. A slot is active when its state dir holds a live service pid or its soa-s<N> compose project has running containers (the `ss set list` ACTIVE probe). Each slot gets its own health section (offset ports); with --full each also gets its own DATA section read against THAT slot’s soa-s<N> mesh, and the shared source-posture runs ONCE. Cannot be combined with --slot N>0 or --set (those target one slot). --only/--with are ignored.",
+          "name": "all-slots",
+          "allowNo": false,
+          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
@@ -3282,7 +3288,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "default": "/home/skelly/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -3419,7 +3425,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "default": "/home/skelly/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -3552,7 +3558,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "default": "/home/skelly/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -3698,7 +3704,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "default": "/home/skelly/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -3850,7 +3856,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "default": "/home/skelly/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -4032,7 +4038,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "default": "/home/skelly/dev",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/status-verify.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/status-verify.int.test.ts
@@ -29,6 +29,7 @@ import type {
   PgProbe,
   RunResult,
   ScriptInvocation,
+  SlotActiveProbe,
 } from '../../../runtime/index.js';
 import StackStatus from '../status.js';
 import StackVerify from '../verify.js';
@@ -415,5 +416,114 @@ describe('stack verify --slot N — backend + saga-dash/coach gate on offset por
     await StackVerify.run([...WS], config);
     expect(probed).toContain(DASH_URL); // frontends gated at slot 0
     expect(probed).toHaveLength(13);
+  });
+});
+
+/** Fake SlotActiveProbe: a slot is active iff its number is in `activeSlots`. */
+function installSlotActive(activeSlots: number[]): void {
+  const active = new Set(activeSlots);
+  const probe: SlotActiveProbe = {
+    async isActive(_stateDir: string, project: string): Promise<boolean> {
+      const slot = project === 'soa' ? 0 : Number.parseInt(project.replace('soa-s', ''), 10);
+      return active.has(slot);
+    },
+  };
+  vi.spyOn(
+    BaseCommand.prototype as unknown as { getSlotActiveProbe: () => SlotActiveProbe },
+    'getSlotActiveProbe',
+  ).mockReturnValue(probe);
+}
+
+/** Fully-green DATA probes that RECORD the postgres container each read hit (to assert
+ *  per-slot mesh selection). Returns the captured container-name list. */
+function installCapturingDataProbes(): { pgContainers: string[] } {
+  const pgContainers: string[] = [];
+  const pg: PgProbe = {
+    async databaseExists(): Promise<boolean> { return true; },
+    async hasMigrationsTable(c): Promise<boolean> { pgContainers.push(c); return true; },
+    async publicTableCount(): Promise<number> { return 0; },
+    async scalar(c, _db, sql): Promise<string> {
+      pgContainers.push(c);
+      if (sql.includes('FROM users WHERE')) return '1';
+      if (sql.includes('FROM users')) return '205';
+      if (sql.includes('personas')) return '6';
+      return '';
+    },
+  };
+  const mesh: MeshExec = { async ready(): Promise<boolean> { return true; } };
+  const proto = BaseCommand.prototype as unknown as {
+    getPgProbe: () => PgProbe;
+    getMeshExec: () => MeshExec;
+  };
+  vi.spyOn(proto, 'getPgProbe').mockReturnValue(pg);
+  vi.spyOn(proto, 'getMeshExec').mockReturnValue(mesh);
+  return { pgContainers };
+}
+
+describe('stack verify --all-slots — report every ACTIVE slot (0..9)', () => {
+  it('no active slots ⇒ resolves (exit 0) with a "no active slots" note, probing nothing', async () => {
+    installSlotActive([]);
+    await expect(StackVerify.run(['--all-slots', ...WS], config)).resolves.toBeUndefined();
+    expect(probed).toHaveLength(0);
+    expect(out.some((l) => l.includes('no active slots'))).toBe(true);
+  });
+
+  it('health-only: renders a section per active slot on that slot’s offset ports (slots 0 + 2)', async () => {
+    installSlotActive([0, 2]);
+    await StackVerify.run(['--all-slots', ...WS], config);
+    const s2 = deriveInstance({ slot: 2 });
+    const iam2 = `http://localhost:${s2.portOverrides['iam-api']}${manifest.services['iam-api'].healthPath}`;
+    // slot 0's base iam + slot 2's +2000 iam were both probed.
+    expect(probed).toContain(`http://localhost:${manifest.services['iam-api'].port}${manifest.services['iam-api'].healthPath}`);
+    expect(probed).toContain(iam2);
+    // one section header per active slot; slots 1 + 3..9 are inactive ⇒ absent.
+    expect(out.some((l) => l.includes('── slot 0 (soa)'))).toBe(true);
+    expect(out.some((l) => l.includes('── slot 2 (soa-s2)'))).toBe(true);
+    expect(out.some((l) => l.includes('── slot 1'))).toBe(false);
+    expect(out.some((l) => l.includes('✓ verify --all-slots: 2/2 active slot(s) green'))).toBe(true);
+  });
+
+  it('--full: each active slot reads DATA against ITS OWN soa-s<N> mesh, posture runs ONCE', async () => {
+    installSlotActive([0, 2]);
+    const { pgContainers } = installCapturingDataProbes();
+    installPostureSeams(); // clean, no overlay
+    const priorEnv = process.env.SAGA_MESH_POSTGRES_CONTAINER;
+    await StackVerify.run(['--full', '--all-slots', ...WS], config);
+    // slot 2's DATA read hit the soa-s2 postgres; slot 0's hit the base container.
+    expect(pgContainers).toContain('soa-s2-postgres-1');
+    expect(pgContainers).toContain('soa-postgres-1');
+    // the per-slot env scoping is fully restored afterwards (no leak).
+    expect(process.env.SAGA_MESH_POSTGRES_CONTAINER).toBe(priorEnv);
+    // source posture rendered EXACTLY once (shared checkouts), not per slot.
+    expect(out.filter((l) => l.includes('── source posture')).length).toBe(1);
+    expect(runnerCalls).toHaveLength(0); // still nothing delegated to verify.sh
+  });
+
+  it('HARD-FAILS (exit 1) naming the failing slot when a service is down in one slot', async () => {
+    installSlotActive([0, 2]);
+    // take slot 2's iam-api down (its +2000 port); slot 0 stays green.
+    const s2 = deriveInstance({ slot: 2 });
+    const iam2 = `http://localhost:${s2.portOverrides['iam-api']}${manifest.services['iam-api'].healthPath}`;
+    installProber([iam2]); // independent of the slot-active spy above
+    await expect(StackVerify.run(['--all-slots', ...WS], config)).rejects.toMatchObject({
+      oclif: { exit: 1 },
+    });
+    expect(out.some((l) => l.includes('1/2 active slot(s) failing') && l.includes('slot(s) 2'))).toBe(true);
+  });
+
+  it('--all-slots with an explicit --slot N>0 is a hard error (mutually exclusive targeting)', async () => {
+    installSlotActive([0]);
+    await expect(StackVerify.run(['--all-slots', '--slot', '3', ...WS], config)).rejects.toMatchObject({
+      oclif: { exit: 2 },
+    });
+  });
+
+  it('--output-json emits a per-slot array with activeSlots + a combined verdict', async () => {
+    installSlotActive([0, 2]);
+    await StackVerify.run(['--all-slots', '--output-json', ...WS], config);
+    const json = JSON.parse(out.join('\n'));
+    expect(json.activeSlots).toEqual([0, 2]);
+    expect(json.slots.map((s: { slot: number }) => s.slot)).toEqual([0, 2]);
+    expect(json.passed).toBe(true);
   });
 });

--- a/packages/node/saga-stack-cli/src/commands/stack/verify.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/verify.ts
@@ -32,13 +32,14 @@ import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command.js';
 import { bold, cyan, dim, green, red, yellow } from '../../color.js';
 import { BUNDLE_NAMES } from '../../core/bundles.js';
-import { deriveInstance } from '../../core/derive-instance.js';
+import { INSTANCE_ENV_KEYS, deriveInstance } from '../../core/derive-instance.js';
+import type { InstanceProfile } from '../../core/derive-instance.js';
 import { SYNTH_DEV_DIR } from '../../core/flag-map.js';
 import { healthProbes } from '../../core/probe-plan.js';
 import { getMesh, manifest } from '../../core/manifest/index.js';
 import type { ServiceId } from '../../core/manifest/index.js';
 import { DATA_SQL, assessData } from '../../core/verify-data.js';
-import type { DataReadings } from '../../core/verify-data.js';
+import type { DataAssessment, DataReadings } from '../../core/verify-data.js';
 import { parseOverlayTsv } from '../../core/overlay-tsv.js';
 import type { PostureLine } from '../../core/verify-posture.js';
 import { assessPosture, meshContainer, resolveOverlayRepo, resolveRepoRoot } from '../../runtime/index.js';
@@ -83,6 +84,11 @@ export default class StackVerify extends BaseCommand {
         'run the CANONICAL complete check FULLY NATIVELY: native health gate + native DATA (D1–D5) + native source-posture (P1–P4). --health-only skips the posture/freshness pass.',
       default: false,
     }),
+    'all-slots': Flags.boolean({
+      description:
+        'report EVERY active slot (0..9) instead of a single --slot. A slot is active when its state dir holds a live service pid or its soa-s<N> compose project has running containers (the `ss set list` ACTIVE probe). Each slot gets its own health section (offset ports); with --full each also gets its own DATA section read against THAT slot’s soa-s<N> mesh, and the shared source-posture runs ONCE. Cannot be combined with --slot N>0 or --set (those target one slot). --only/--with are ignored.',
+      default: false,
+    }),
   };
 
   /** M7 Phase 2: the native health gate probes a slot's offset ports at slot > 0. */
@@ -97,6 +103,18 @@ export default class StackVerify extends BaseCommand {
 
   async run(): Promise<void> {
     const { flags } = await this.parse(StackVerify);
+
+    // ── --all-slots: report EVERY active slot (0..9), not a single --slot. ──
+    if (flags['all-slots']) {
+      if (flags.set) {
+        this.error('--all-slots enumerates every active slot; drop --set (a set is bound to one slot).');
+      }
+      if (flags.slot > 0) {
+        this.error('--all-slots enumerates every active slot; drop --slot (it targets one slot).');
+      }
+      await this.runAllSlots(flags);
+      return;
+    }
 
     // ── --full: FULLY NATIVE — native health + native DATA (D1–D5) + native posture. ──
     // M12: the source-posture (P1–P4) checks are now NATIVE too (warn-only), so `stack
@@ -241,19 +259,7 @@ export default class StackVerify extends BaseCommand {
 
     // 2. native DATA checks (D1–D5). Reads as postgres_admin against the base mesh
     // containers (documented divergence from verify.sh's `-U iam` — same rows).
-    const pg = this.getPgProbe();
-    const meshExec = this.getMeshExec();
-    const pgContainer = meshContainer(getMesh('postgres', manifest));
-    const mongo = getMesh('connect-mongo', manifest);
-    const mongoContainer = meshContainer(mongo);
-    const readings: DataReadings = {
-      usersRaw: await pg.scalar(pgContainer, 'iam_local', DATA_SQL.users),
-      devIdRaw: await pg.scalar(pgContainer, 'iam_local', DATA_SQL.devId),
-      adminPersonasRaw: await pg.scalar(pgContainer, 'iam_local', DATA_SQL.adminPersonas),
-      sisMigrated: await pg.hasMigrationsTable(pgContainer, 'sis_db'),
-      mongoReachable: await meshExec.ready(mongoContainer, mongo.readinessCmd),
-    };
-    const data = assessData(readings);
+    const data = await this.readSlotData();
     this.log(cyan(bold('── data ──')));
     for (const c of data.checks) this.log(`${c.ok ? green('✓') : red('✗')} ${dim(c.label)}`);
     for (const note of data.notes) this.log(dim(`· ${note}`));
@@ -291,6 +297,222 @@ export default class StackVerify extends BaseCommand {
             .join('; ')}`)) + (warnSuffix ? yellow(warnSuffix) : ''),
     );
     if (!passed) this.exit(1);
+  }
+
+  /**
+   * `--all-slots`: report EVERY active slot (0..9) instead of a single `--slot`. A
+   * slot is ACTIVE per the shared `SlotActiveProbe` (a live service pid under its
+   * state dir OR a running `soa`/`soa-s<N>` compose project — the same probe `ss set
+   * list` uses). Each active slot gets its own health gate on its offset ports; under
+   * `--full` each ALSO gets its own DATA gate read against THAT slot's `soa-s<N>` mesh
+   * (via `withSlotEnv`), and the SHARED source-posture runs ONCE (warn-only). Exit 1
+   * iff any active slot's health (+ data) is red — posture never flips the verdict.
+   */
+  private async runAllSlots(flags: AllSlotsFlags): Promise<void> {
+    if (flags.only || (flags.with && flags.with.length > 0)) {
+      this.warn('--only/--with are ignored with --all-slots (each active slot is verified over its full required set).');
+    }
+
+    const probe = this.getSlotActiveProbe();
+    const profiles = Array.from({ length: 10 }, (_, slot) => deriveInstance({ slot }));
+    const activity = await Promise.all(
+      profiles.map(async (p) => ({ profile: p, active: await probe.isActive(p.stateDir, p.project) })),
+    );
+    const active = activity.filter((a) => a.active).map((a) => a.profile);
+
+    if (active.length === 0) {
+      if (flags['output-json']) {
+        this.log(JSON.stringify({ slots: [], activeSlots: [], passed: true }, null, 2));
+      } else if (flags.porcelain) {
+        this.log('activeSlots=');
+        this.log('passed=true');
+      } else {
+        this.log(
+          yellow('verify --all-slots: no active slots — none have a live service pid or a running soa[-s<N>] project.'),
+        );
+      }
+      return; // nothing up ⇒ nothing to fail ⇒ exit 0.
+    }
+
+    // Gathered SEQUENTIALLY: the --full DATA read mutates process.env (per-slot mesh
+    // container selection via withSlotEnv), so slots must not overlap.
+    const reports: SlotReport[] = [];
+    for (const profile of active) reports.push(await this.checkSlot(flags, profile));
+
+    // Source posture is a property of the SHARED checkouts, not any one slot — run it
+    // ONCE (warn-only, --full only, skipped under --health-only), like single-slot --full.
+    let posture: Awaited<ReturnType<StackVerify['runPosture']>> | undefined;
+    let postureWarns = 0;
+    if (flags.full && !flags['health-only']) {
+      posture = await this.runPosture(flags);
+      postureWarns = [...posture.result.posture, ...posture.result.freshness].filter(
+        (l) => l.level === 'warn',
+      ).length;
+    }
+
+    const passed = reports.every((r) => r.passed);
+
+    if (flags['output-json']) {
+      this.log(
+        JSON.stringify(
+          {
+            slots: reports.map((r) => ({
+              slot: r.slot,
+              project: r.project,
+              services: r.rows.map((row) => ({ id: row.id, url: row.url, ok: row.ok, status: row.status ?? null })),
+              notCloned: r.notCloned.map((n) => ({ id: n.id, repo: n.repo, repoDir: n.repoDir })),
+              data: r.data ? { checks: r.data.checks, notes: r.data.notes, passed: r.data.passed } : null,
+              summary: { total: r.rows.length, up: r.up, down: r.rows.length - r.up },
+              passed: r.passed,
+            })),
+            posture: posture
+              ? {
+                  overlayPresent: posture.overlayPresent,
+                  warnings: postureWarns,
+                  posture: posture.result.posture,
+                  freshness: posture.result.freshness,
+                }
+              : null,
+            activeSlots: active.map((p) => p.slot),
+            passed,
+          },
+          null,
+          2,
+        ),
+      );
+    } else if (flags.porcelain) {
+      for (const r of reports) {
+        for (const row of r.rows) this.log(`s${r.slot}.${row.id}=${row.ok ? 'up' : 'down'}`);
+        for (const n of r.notCloned) this.log(`s${r.slot}.${n.id}=not-cloned`);
+        if (r.data) for (const c of r.data.checks) this.log(`s${r.slot}.${c.id}=${c.ok ? 'ok' : 'fail'}`);
+        this.log(`s${r.slot}.passed=${r.passed}`);
+      }
+      this.log(`activeSlots=${active.map((p) => p.slot).join(',')}`);
+      this.log(`passed=${passed}`);
+    } else {
+      for (const r of reports) {
+        this.log(
+          cyan(bold(`── slot ${r.slot} (${r.project}) — ${r.passed ? green('green') : red('red')} — ${r.up}/${r.rows.length} up ──`)),
+        );
+        for (const row of r.rows) this.log(formatRow(row));
+        for (const n of r.notCloned) {
+          this.log(`⚠ ${n.id.padEnd(16)} ${n.repoDir}  (not cloned: ${n.repo} repo not present)`);
+        }
+        if (r.data) {
+          for (const c of r.data.checks) this.log(`  ${c.ok ? green('✓') : red('✗')} ${dim(c.label)}`);
+          for (const note of r.data.notes) this.log(dim(`  · ${note}`));
+        }
+      }
+      if (posture) {
+        this.log(cyan(bold('── source posture (shared checkouts) ──')));
+        if (!posture.overlayPresent) {
+          this.log(dim('· no local overlay — asserting every managed repo on origin/main'));
+        }
+        for (const l of posture.result.posture) this.log(renderPostureLine(l));
+        this.log(cyan(bold('── freshness (behind origin) ──')));
+        for (const l of posture.result.freshness) this.log(renderPostureLine(l));
+      }
+      const failed = reports.filter((r) => !r.passed);
+      const warnSuffix = postureWarns > 0 ? yellow(` (${postureWarns} posture warning(s) — see ⚠ above)`) : '';
+      this.log(
+        passed
+          ? green(bold(`✓ verify --all-slots: ${reports.length}/${reports.length} active slot(s) green`)) + warnSuffix
+          : red(
+              bold(
+                `✗ verify --all-slots: ${failed.length}/${reports.length} active slot(s) failing — slot(s) ${failed
+                  .map((r) => r.slot)
+                  .join(', ')}`,
+              ),
+            ) + warnSuffix,
+      );
+    }
+
+    if (!passed) this.exit(1);
+  }
+
+  /**
+   * Health-gate one slot: probe its full required (non-optional) service set on that
+   * slot's offset ports, dropping the slot's excluded literal-port services at slot > 0
+   * (they aren't brought up there). A service whose sibling repo isn't cloned is reported
+   * not-cloned, not failed — matching `stack up`'s skip guard.
+   */
+  private async probeSlotHealth(
+    flags: AllSlotsFlags,
+    profile: InstanceProfile,
+  ): Promise<{ rows: VerifyRow[]; notCloned: ReturnType<typeof partitionByRepoPresence>['notCloned'] }> {
+    const excluded = new Set(profile.excludedServices);
+    let ids = Object.values(manifest.services)
+      .filter((s) => !s.optional)
+      .map((s) => s.id);
+    if (profile.slot > 0) ids = ids.filter((id) => !excluded.has(id));
+
+    const ctx = repoContextFromFlags(flags as unknown as Record<string, unknown>);
+    const { probe, notCloned } = partitionByRepoPresence(ids, ctx, this.getRepoDirCheck());
+    const probes = healthProbes(manifest, probe, profile.portOverrides);
+    const prober = this.getProber();
+    const rows = await Promise.all(
+      probes.map(async (p): Promise<VerifyRow> => {
+        const r = await prober.probe(p.url);
+        return { id: p.id, url: p.url, ok: r.ok, status: r.status, tolerated: false };
+      }),
+    );
+    return { rows, notCloned };
+  }
+
+  /** Health (+ DATA under --full) for one slot, folded into a pass/fail `SlotReport`. */
+  private async checkSlot(flags: AllSlotsFlags, profile: InstanceProfile): Promise<SlotReport> {
+    const { rows, notCloned } = await this.probeSlotHealth(flags, profile);
+    const up = rows.filter((r) => r.ok).length;
+    const data = flags.full ? await this.withSlotEnv(profile, () => this.readSlotData()) : undefined;
+    const passed = up === rows.length && (!data || data.passed);
+    return { slot: profile.slot, project: profile.project, rows, notCloned, data, up, passed };
+  }
+
+  /**
+   * Gather + assess the native DATA checks (D1–D5) against the mesh containers CURRENTLY
+   * selected by `process.env` (`SAGA_MESH_*_CONTAINER`). At slot 0 those resolve to the base
+   * `soa-*` containers; under `--all-slots` the caller wraps this in `withSlotEnv` so it hits
+   * that slot's `soa-s<N>-*` mesh. IO-only (the pg/mesh seams); the pure verdict is `assessData`.
+   */
+  private async readSlotData(): Promise<DataAssessment> {
+    const pg = this.getPgProbe();
+    const meshExec = this.getMeshExec();
+    const pgContainer = meshContainer(getMesh('postgres', manifest));
+    const mongo = getMesh('connect-mongo', manifest);
+    const mongoContainer = meshContainer(mongo);
+    const readings: DataReadings = {
+      usersRaw: await pg.scalar(pgContainer, 'iam_local', DATA_SQL.users),
+      devIdRaw: await pg.scalar(pgContainer, 'iam_local', DATA_SQL.devId),
+      adminPersonasRaw: await pg.scalar(pgContainer, 'iam_local', DATA_SQL.adminPersonas),
+      sisMigrated: await pg.hasMigrationsTable(pgContainer, 'sis_db'),
+      mongoReachable: await meshExec.ready(mongoContainer, mongo.readinessCmd),
+    };
+    return assessData(readings);
+  }
+
+  /**
+   * Run `fn` with ONLY this slot's mesh/snapshot env applied, restoring the prior values
+   * afterwards — so an all-slots sweep reads each slot's OWN `soa-s<N>-*` containers without
+   * leaking one slot's `SAGA_MESH_*_CONTAINER` into the next. Slot 0 carries an empty
+   * container env, so `applyInstanceEnv` alone would NOT clear a prior slot's keys; we
+   * snapshot + delete the fixed `INSTANCE_ENV_KEYS` set first, then restore in a `finally`.
+   */
+  private async withSlotEnv<T>(profile: InstanceProfile, fn: () => Promise<T>): Promise<T> {
+    const saved = new Map<string, string | undefined>();
+    for (const k of INSTANCE_ENV_KEYS) {
+      saved.set(k, process.env[k]);
+      delete process.env[k];
+    }
+    this.applyInstanceEnv(profile);
+    try {
+      return await fn();
+    } finally {
+      for (const k of INSTANCE_ENV_KEYS) {
+        const v = saved.get(k);
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      }
+    }
   }
 
   /**
@@ -336,6 +558,32 @@ interface VerifyRow {
   ok: boolean;
   status?: number;
   tolerated: boolean;
+}
+
+/** The subset of parsed verify flags the `--all-slots` path reads. */
+interface AllSlotsFlags {
+  full: boolean;
+  'health-only': boolean;
+  'output-json': boolean;
+  porcelain: boolean;
+  only?: string;
+  with?: string[];
+  dev: string;
+  soa?: string;
+  slot: number;
+  set?: string;
+}
+
+/** One active slot's folded health (+ optional DATA) verdict. */
+interface SlotReport {
+  slot: number;
+  project: string;
+  rows: VerifyRow[];
+  notCloned: ReturnType<typeof partitionByRepoPresence>['notCloned'];
+  data?: DataAssessment;
+  /** Count of health rows that answered up. */
+  up: number;
+  passed: boolean;
 }
 
 /** Human line, with a `(tolerated)` annotation for a down-but-tolerated service. */

--- a/packages/node/saga-stack-cli/src/core/derive-instance.ts
+++ b/packages/node/saga-stack-cli/src/core/derive-instance.ts
@@ -50,6 +50,24 @@ import type { Manifest, ServiceId } from './manifest/index.js';
 export const SLOT_PORT_STRIDE = 1000;
 
 /**
+ * Every `process.env` key an `InstanceProfile` may set via `applyInstanceEnv`
+ * (the five `SAGA_MESH_*_CONTAINER` overrides from `containerEnvFor` + the
+ * snapshot root). This is the RESTORE set for scoping ONE slot's env inside a
+ * multi-slot sweep (`verify --all-slots`): slot 0 carries an EMPTY container env,
+ * so applying it does not clear a prior slot's keys — the caller must snapshot +
+ * delete this fixed list, apply the profile, then restore. Keep in lock-step with
+ * `containerEnvFor` + `applyInstanceEnv`.
+ */
+export const INSTANCE_ENV_KEYS = [
+  'SAGA_MESH_POSTGRES_CONTAINER',
+  'SAGA_MESH_REDIS_CONTAINER',
+  'SAGA_MESH_RABBITMQ_CONTAINER',
+  'SAGA_MESH_MONGO_CONTAINER',
+  'SAGA_MESH_CONNECT_MONGO_CONTAINER',
+  'SAGA_MESH_SNAPSHOTS_DIR',
+] as const;
+
+/**
  * Services EXCLUDED from a slot > 0 bring-up (plan §6 collision matrix). All
  * would CLOBBER or SPLIT-BRAIN onto slot 0:
  *


### PR DESCRIPTION
## What

Adds `--all-slots` to `ss stack verify`. Today verify targets a single `--slot` (default 0), so `ss stack verify` "only shows slot 0". `--all-slots` enumerates **every active slot (0..9)** and prints one section per slot.

- **Discovery:** reuses the existing `SlotActiveProbe` seam (the same probe `ss set list`'s ACTIVE column uses) — a slot is active when its state dir holds a live service pid **or** its `soa`/`soa-s<N>` compose project has running containers.
- **Health per slot:** each active slot's full required set is probed on its offset ports.
- **`--full` DATA per slot:** each slot's D1–D5 checks read **that slot's own `soa-s<N>` mesh**. New `withSlotEnv` + `INSTANCE_ENV_KEYS` scope each slot's `containerEnv` around the reads and restore it after, so one slot's `SAGA_MESH_*_CONTAINER` never leaks into the next (slot 0's empty env would otherwise fail to reset a prior slot). This lifts the single-slot `--full` slot>0 refusal **for the all-slots path only**.
- **Posture once:** source-posture (P1–P4) is a property of the shared checkouts, so it runs a single time, warn-only.
- **Verdict:** exit 1 iff any active slot's health (+ data) is red; posture never flips it. `--output-json` / `--porcelain` gain a per-slot shape.
- **Guards:** rejects an explicit `--slot N>0` or `--set` (those target one slot); `--only`/`--with` ignored.

`readSlotData()` was extracted so single-slot `--full` and the per-slot path share the DATA read.

## Live output

```
── slot 0 (soa) — green — 13/13 up ──
  ✓ iam roster seeded — users=259
  ...
── slot 1 (soa-s1) — red — 11/13 up ──
  ✗ coach-api  http://localhost:7105/health  (down)
✗ verify --all-slots: 1/2 active slot(s) failing — slot(s) 1   (exit 1)
```

## Tests

6 new integration cases in `status-verify.int.test.ts` (no active slots; per-slot offset probing; `--full` per-slot mesh selection asserting `soa-s2-postgres-1` + env restore; hard-fail naming the failing slot; `--slot N` conflict; JSON shape). Full package suite green except a pre-existing, unrelated `core/flow/load.unit.test.ts` failure (fails identically on `main`). Typecheck + build clean; lint warnings-only (pre-existing turbo env warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)