### PR TITLE
fix(saga-stack-cli): keep the builder's $HOME/dev out of oclif.manifest.json

### DIFF
--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -39,7 +39,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "noCacheDefault": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -189,7 +189,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "noCacheDefault": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -328,7 +328,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "noCacheDefault": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -559,7 +559,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "noCacheDefault": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -696,7 +696,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "noCacheDefault": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -881,7 +881,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "noCacheDefault": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -1018,7 +1018,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "noCacheDefault": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -1172,7 +1172,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "noCacheDefault": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -1310,7 +1310,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "noCacheDefault": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -1467,7 +1467,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "noCacheDefault": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -1640,7 +1640,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "noCacheDefault": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -1784,7 +1784,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "noCacheDefault": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -1935,7 +1935,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "noCacheDefault": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -2101,7 +2101,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "noCacheDefault": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -2246,7 +2246,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "noCacheDefault": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -2387,7 +2387,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "noCacheDefault": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -2557,7 +2557,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "noCacheDefault": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -2725,7 +2725,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "noCacheDefault": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -2864,7 +2864,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "noCacheDefault": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -3110,7 +3110,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "noCacheDefault": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -3282,7 +3282,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "noCacheDefault": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -3419,7 +3419,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "noCacheDefault": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -3552,7 +3552,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "noCacheDefault": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -3698,7 +3698,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "noCacheDefault": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -3850,7 +3850,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "noCacheDefault": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -4032,7 +4032,7 @@
         "dev": {
           "description": "sibling-repo workspace root (where the saga repos are checked out)",
           "name": "dev",
-          "default": "/home/spaul/dev",
+          "noCacheDefault": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"

--- a/packages/node/saga-stack-cli/src/shared-flags.ts
+++ b/packages/node/saga-stack-cli/src/shared-flags.ts
@@ -22,8 +22,12 @@
 
 import { Flags } from '@oclif/core';
 
-/** Default sibling-repo workspace root: `$DEV ?? $HOME/dev`. */
-const defaultDevDir = process.env.DEV ?? `${process.env.HOME ?? ''}/dev`;
+/** Default sibling-repo workspace root: `$DEV ?? $HOME/dev`.
+ * Resolved as a function (not a bare string) so the value is computed per-user
+ * at runtime instead of being frozen at `oclif manifest` time — otherwise the
+ * builder's absolute `$HOME/dev` gets baked into the committed/shipped
+ * `oclif.manifest.json`. Paired with `noCacheDefault` on the flag below. */
+const defaultDevDir = async () => process.env.DEV ?? `${process.env.HOME ?? ''}/dev`;
 
 /**
  * Per-repo path-override flags. Each maps a `RepoKey` to a CLI flag that
@@ -137,6 +141,11 @@ export const baseFlags = {
   dev: Flags.string({
     description: 'sibling-repo workspace root (where the saga repos are checked out)',
     default: defaultDevDir,
+    // Keep the resolved absolute path OUT of oclif.manifest.json — `oclif manifest`
+    // passes respectNoCacheDefault, so this omits the default from the generated
+    // (committed + shipped) manifest. It still resolves at runtime via defaultDevDir.
+    noCacheDefault: true,
+    defaultHelp: '$DEV, or $HOME/dev',
   }),
   'state-dir': Flags.string({
     description:


### PR DESCRIPTION
## What Jeff spotted

The committed `oclif.manifest.json` had an absolute home path baked into the `--dev` flag default — `/home/spaul/dev` on `main`, and any `pnpm build` rewrote it to the builder's own home (`/home/skelly/dev`, …).

## Root cause

`shared-flags.ts` defined the `dev` flag as:

```ts
const defaultDevDir = process.env.DEV ?? `${process.env.HOME ?? ''}/dev`;
dev: Flags.string({ default: defaultDevDir })
```

A bare-string default is **resolved at `oclif manifest` time** and cached into the manifest, which is both committed and shipped (`files` in package.json). So the manifest froze whoever's `$HOME/dev` ran the build → spurious, machine-specific diffs on every build.

## Fix

- Make the default an **async function** so oclif treats it as dynamic (the function form of `FlagDefault` must return `Promise<T>`).
- Mark the flag **`noCacheDefault: true`** — `oclif manifest` passes `respectNoCacheDefault`, so `cacheDefaultValue` omits the default from the generated manifest entirely.
- Add `defaultHelp: '$DEV, or $HOME/dev'` so `--help` still documents it.

The value still resolves **per-user at runtime**; nothing about behavior changes.

## Verification

- Regenerated `oclif.manifest.json` contains **zero** `/home/...` paths; the `dev` flag now carries `noCacheDefault: true` and no baked `default`.
- Runtime resolution confirmed: no env → `$HOME/dev`; `$DEV` set → `$DEV`; explicit `--dev` → wins.
- `tsc` (strict) passes. Package test suite: the only failures (`load.unit.test.ts`, `launch-plan.unit.test.ts`) are **pre-existing on `main`** — confirmed by re-running them with this change stashed — and are unrelated (flow-manifest / launch-env, not flag defaults).

🤖 Generated with [Claude Code](https://claude.com/claude-code)