### PR TITLE
feat(saga-stack-cli): add --fake-media to `ss e2e connect`

### DIFF
--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -6,7 +6,8 @@
       "description": "Open a live interactive Connect session: 1 tutor + 2 students (in-process; builds the journey prerequisite, then a headed Connect room).",
       "examples": [
         "<%= config.bin %> <%= command.id %>",
-        "<%= config.bin %> <%= command.id %> --reuse -- --debug"
+        "<%= config.bin %> <%= command.id %> --reuse -- --debug",
+        "<%= config.bin %> <%= command.id %> --fake-media"
       ],
       "flags": {
         "porcelain": {
@@ -132,6 +133,12 @@
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
+        },
+        "fake-media": {
+          "description": "swap real mic/cam capture for Chromium's synthetic camera (moving test pattern) + mic (beep) and auto-accept the getUserMedia prompt — for a machine with no camera or where v4l2loopback won't build. Sets FAKE_MEDIA=1 on the headed interactive-connect run (mirrors connect-session.sh --fake-media); the journey prerequisite is unaffected.",
+          "name": "fake-media",
+          "allowNo": false,
+          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,

--- a/packages/node/saga-stack-cli/src/commands/e2e/__tests__/e2e.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/__tests__/e2e.int.test.ts
@@ -245,4 +245,23 @@ describe('e2e connect — foreground connect-session entry', () => {
     expect(runs.some((r) => r.command.endsWith('up.sh'))).toBe(false);
     expect(runs.some((r) => r.args.includes('db:seed'))).toBe(false);
   });
+
+  it('--fake-media: pins FAKE_MEDIA=1 on the headed interactive-connect run ONLY, not the journey prerequisite', async () => {
+    await E2eConnect.run(['--fake-media', ...ws()], config);
+    const pw = playwrightRuns();
+    expect(pw).toHaveLength(2);
+    // journey prerequisite (a separate ResolvedFlow) must NOT get FAKE_MEDIA.
+    expect(pw[0].args).toContain('stage-5-schedule');
+    expect(pw[0].env?.FAKE_MEDIA).toBeUndefined();
+    // the headed live session does.
+    expect(pw[1].args).toContain('interactive-connect');
+    expect(pw[1].env?.FAKE_MEDIA).toBe('1');
+  });
+
+  it('bare (no --fake-media): interactive-connect runs with real media (no FAKE_MEDIA)', async () => {
+    await E2eConnect.run([...ws()], config);
+    const pw = playwrightRuns();
+    expect(pw[1].args).toContain('interactive-connect');
+    expect(pw[1].env?.FAKE_MEDIA).toBeUndefined();
+  });
 });

--- a/packages/node/saga-stack-cli/src/commands/e2e/connect.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/connect.ts
@@ -14,12 +14,18 @@
  * against the CURRENT stack state (mirrors connect-session.sh `--reuse`). Anything
  * after `--` passes straight through to Playwright.
  *
+ * `--fake-media` pins `FAKE_MEDIA=1` onto the headed interactive-connect run so
+ * Chromium uses its synthetic camera/mic instead of real capture (mirrors
+ * connect-session.sh `--fake-media`) — for a box with no camera or where
+ * v4l2loopback won't build. The headless journey prerequisite is unaffected.
+ *
  * SCOPE (plan §7.2 "M5"): the orchestration + headed run land here; AV-device /
  * post-session inspect polish is explicitly DEFERRED — the foreground hold is the
  * Playwright `page.pause()` in the spec, unchanged.
  *
  *   node bin/dev.js e2e connect
  *   node bin/dev.js e2e connect --reuse -- --debug
+ *   node bin/dev.js e2e connect --fake-media
  */
 
 import { Flags } from '@oclif/core';
@@ -48,6 +54,7 @@ export default class E2eConnect extends BaseCommand {
   static examples = [
     '<%= config.bin %> <%= command.id %>',
     '<%= config.bin %> <%= command.id %> --reuse -- --debug',
+    '<%= config.bin %> <%= command.id %> --fake-media',
   ];
 
   // Allow trailing playwright passthrough args (after `--`).
@@ -68,6 +75,11 @@ export default class E2eConnect extends BaseCommand {
     'spa-path': Flags.string({
       description: 'explicit path to a flows.json (file or dir) — highest-priority discovery override',
     }),
+    'fake-media': Flags.boolean({
+      default: false,
+      description:
+        "swap real mic/cam capture for Chromium's synthetic camera (moving test pattern) + mic (beep) and auto-accept the getUserMedia prompt — for a machine with no camera or where v4l2loopback won't build. Sets FAKE_MEDIA=1 on the headed interactive-connect run (mirrors connect-session.sh --fake-media); the journey prerequisite is unaffected.",
+    }),
   };
 
   async run(): Promise<void> {
@@ -84,7 +96,13 @@ export default class E2eConnect extends BaseCommand {
     // Foreground + headed by default (the flow is `foreground:true`); --reuse drops
     // the prerequisite + reset entirely, exactly like connect-session.sh.
     const resolved = resolveFlow(disco.manifest, CONNECT_FLOW, { lane: 'stack' });
-    const toRun = flags.reuse ? { ...resolved, prerequisite: undefined } : resolved;
+    const base = flags.reuse ? { ...resolved, prerequisite: undefined } : resolved;
+    // --fake-media pins FAKE_MEDIA=1 into THIS flow's env (merged last by
+    // computeEnv), so it reaches only the connect-session stage (headed
+    // interactive-connect) — not the journey prerequisite, a separate ResolvedFlow.
+    const toRun = flags['fake-media']
+      ? { ...base, flow: { ...base.flow, env: { ...base.flow.env, FAKE_MEDIA: '1' } } }
+      : base;
 
     const appCwd = resolveAppCwd(resolved.spa, flags, process.env);
     const now = new Date();


### PR DESCRIPTION
## What

Adds a first-class `--fake-media` flag to `ss e2e connect`.

`ss e2e connect` runs the `connect-session` flow, which uses **real** mic/cam capture by default (matching `connect-session.sh`). On a box with no camera — or where `v4l2loopback` won't build so `tools/virtual-devices` can't create real V4L2 devices — the only way to run it was to export `FAKE_MEDIA=1` by hand.

`--fake-media` mirrors `connect-session.sh --fake-media`: it pins `FAKE_MEDIA=1` into the connect-session flow's own `env` (merged last by `computeEnv`), so it reaches **only** the headed `interactive-connect` stage. The headless `journey` prerequisite is a separate `ResolvedFlow` and is unaffected.

Downstream, saga-dash's `apps/web/dash/playwright.stack.config.ts` reads `process.env.FAKE_MEDIA === '1'` to add `--use-fake-device-for-media-stream --use-fake-ui-for-media-stream` to Chromium — synthetic camera (moving test pattern) + mic (beep tone), auto-accepting the getUserMedia prompt.

## Usage

```bash
ss e2e connect --fake-media
```

## Changes

- `src/commands/e2e/connect.ts` — new `--fake-media` boolean flag; injects `FAKE_MEDIA=1` into the resolved flow's env; docblock + examples.
- `src/commands/e2e/__tests__/e2e.int.test.ts` — asserts the env reaches `interactive-connect` only (not the journey prerequisite), and stays absent by default.
- `oclif.manifest.json` — regenerated so `--help` shows the flag.

## Verification

- `pnpm check-types` clean
- `pnpm test` — 1087 passed (incl. 2 new)
- `pnpm lint` — 0 errors (pre-existing turbo env-var warnings only)
- `node bin/run.js e2e connect --help` shows the flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)