### PR TITLE
feat(saga-stack-cli): `e2e connect --refresh-snapshot` one-command reseed

### DIFF
--- a/packages/node/saga-stack-cli/docs/e2e-flows.md
+++ b/packages/node/saga-stack-cli/docs/e2e-flows.md
@@ -101,10 +101,22 @@ for the general pattern.
 ### 4. connect-session — manual/AV only
 
 ```bash
-ss e2e connect              # builds journey@schedule state, then opens the
-                            # headed interactive room (holds via page.pause)
+ss e2e connect              # RESTORES the journey@schedule checkpoint (when baked),
+                            # else replays journey headless, then opens the headed
+                            # interactive room (holds via page.pause)
 ss e2e connect --reuse      # skip the state rebuild; use the current stack
+ss e2e connect --refresh-snapshot   # re-bake journey@schedule FRESH, then open the room
 ```
+
+`ss e2e connect` restores the `flow-saga-dash-journey-s5-schedule` checkpoint
+instead of replaying journey 1..5 headless — the big accelerant — falling back to
+the full replay when nothing is baked (`--no-prereq-from-snapshot` forces the
+replay). Bake it once with `ss e2e run saga-dash/journey --through schedule
+--snapshot-stages --headless`, or let `--refresh-snapshot` do it inline: it bakes
+the journey checkpoints fresh (headless, `--snapshot-stages`) **then** opens the
+room — the one-command reseed for when the checkpoint has gone stale (>7 days) or
+the journey stages changed. `--refresh-snapshot` requires the default
+`--prereq-from-snapshot` and is mutually exclusive with `--reuse`.
 
 Needs a real mic/cam and your terminal (the AV hold owns the TTY). There is no
 headless version — by design.

--- a/packages/node/saga-stack-cli/src/commands/e2e/__tests__/checkpoint.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/__tests__/checkpoint.int.test.ts
@@ -22,6 +22,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import { BaseCommand } from '../../../base-command.js';
 import type { LaunchSpec, ScriptInvocation, SnapshotIO } from '../../../runtime/index.js';
 import E2eRun from '../run.js';
+import E2eConnect from '../connect.js';
 
 const PKG_ROOT = process.cwd();
 const SOA_ROOT = resolve(PKG_ROOT, '..', '..', '..');
@@ -29,6 +30,7 @@ const DEV_ROOT = '/fixed/dev';
 
 const CKPT_ROSTER = 'flow-saga-dash-journey-s1-roster';
 const CKPT_PROGRAM = 'flow-saga-dash-journey-s2-program';
+const CKPT_SCHEDULE = 'flow-saga-dash-journey-s5-schedule';
 
 let DASH_ROOT: string;
 let config: Config;
@@ -410,6 +412,45 @@ describe('list surfaces (M14-C)', () => {
     await SnapshotList.run(['--porcelain', ...ws()], config);
     const row = logged.find((l) => l.startsWith(CKPT_PROGRAM));
     expect(row?.split('\t')[5]).toBe('saga-dash/journey@program');
+  });
+});
+
+describe('e2e connect --refresh-snapshot (bake the prerequisite fresh, then restore it)', () => {
+  it('bakes journey 1..schedule (one spawn per stage), restores the fresh checkpoint, then opens interactive-connect headed', async () => {
+    await E2eConnect.run(['--refresh-snapshot', ...ws()], config);
+
+    const pw = playwrightRuns();
+    // 5 bake spawns (journey stages 1..5, headless) + 1 live interactive-connect.
+    expect(pw).toHaveLength(6);
+    // The bake ladder: stage-1 keeps its config deps, stages 2..5 break the chain.
+    expect(pw[0]!.args).toContain('stage-1-roster');
+    expect(pw[4]!.args).toContain('stage-5-schedule');
+    expect(pw[4]!.args).not.toContain('--headed');
+    // The live session is LAST, headed, and the prerequisite was RESTORED (not
+    // replayed) — so there is exactly one stage-5-schedule spawn (the bake's).
+    expect(pw[5]!.args).toContain('interactive-connect');
+    expect(pw[5]!.args).toContain('--headed');
+    expect(pw.filter((r) => r.args.includes('stage-5-schedule'))).toHaveLength(1);
+
+    const out = logged.join('\n');
+    expect(out).toContain('refresh-snapshot: baking journey@schedule');
+    expect(out).toContain('restored from checkpoint (replay skipped)');
+
+    // The freshly baked terminal checkpoint is on disk with the right provenance.
+    const schedule = readCkptManifest(CKPT_SCHEDULE);
+    expect((schedule.flow as Record<string, unknown>).stageId).toBe('schedule');
+  });
+
+  it('--refresh-snapshot --reuse is rejected (reuse strips the prerequisite there is nothing to bake)', async () => {
+    await expect(E2eConnect.run(['--refresh-snapshot', '--reuse', ...ws()], config)).rejects.toThrow(
+      /mutually exclusive/,
+    );
+  });
+
+  it('--refresh-snapshot --no-prereq-from-snapshot is rejected (it would bake but never restore)', async () => {
+    await expect(
+      E2eConnect.run(['--refresh-snapshot', '--no-prereq-from-snapshot', ...ws()], config),
+    ).rejects.toThrow(/needs --prereq-from-snapshot/);
   });
 });
 

--- a/packages/node/saga-stack-cli/src/commands/e2e/connect.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/connect.ts
@@ -23,9 +23,18 @@
  * post-session inspect polish is explicitly DEFERRED — the foreground hold is the
  * Playwright `page.pause()` in the spec, unchanged.
  *
+ * `--refresh-snapshot` bakes the journey prerequisite checkpoints FRESH (a headless
+ * replay through `schedule` with `--snapshot-stages`, i.e. `e2e run
+ * saga-dash/journey --through schedule --snapshot-stages --headless`) BEFORE opening
+ * the room, then the normal run restores that just-made checkpoint. It's the
+ * one-command reseed for when the baked journey@schedule has gone stale (>7d cliff)
+ * or the journey stages changed. Requires the default `--prereq-from-snapshot` (it
+ * bakes so that path can restore); mutually exclusive with `--reuse`.
+ *
  *   node bin/dev.js e2e connect
  *   node bin/dev.js e2e connect --reuse -- --debug
  *   node bin/dev.js e2e connect --fake-media
+ *   node bin/dev.js e2e connect --refresh-snapshot
  */
 
 import { Flags } from '@oclif/core';
@@ -55,6 +64,7 @@ export default class E2eConnect extends BaseCommand {
     '<%= config.bin %> <%= command.id %>',
     '<%= config.bin %> <%= command.id %> --reuse -- --debug',
     '<%= config.bin %> <%= command.id %> --fake-media',
+    '<%= config.bin %> <%= command.id %> --refresh-snapshot',
   ];
 
   // Allow trailing playwright passthrough args (after `--`).
@@ -72,6 +82,11 @@ export default class E2eConnect extends BaseCommand {
       description:
         'M14-C: restore the journey@schedule checkpoint (when a valid one is baked) instead of replaying the whole journey headless — the big Connect-session accelerant. Falls back to the replay when absent/invalid; --reuse trumps this entirely.',
     }),
+    'refresh-snapshot': Flags.boolean({
+      default: false,
+      description:
+        'bake the journey prerequisite checkpoints FRESH (headless replay through `schedule`, --snapshot-stages) BEFORE opening the room, then restore that just-made checkpoint — a one-command reseed for when the baked state has gone stale (>7d) or the journey changed. Deterministic fixtureIds ⇒ the bake overwrites. Requires --prereq-from-snapshot (the default); mutually exclusive with --reuse.',
+    }),
     'spa-path': Flags.string({
       description: 'explicit path to a flows.json (file or dir) — highest-priority discovery override',
     }),
@@ -85,6 +100,19 @@ export default class E2eConnect extends BaseCommand {
   async run(): Promise<void> {
     const { argv, flags } = await this.parse(E2eConnect);
     const passthrough = (argv as string[]).filter((a) => a !== CONNECT_FLOW);
+
+    // --refresh-snapshot bakes the journey prerequisite fresh, then restores it.
+    // --reuse strips the prerequisite entirely (nothing to bake); --no-prereq-from-snapshot
+    // would bake but never restore. Reject both up front (manual, not oclif `exclusive:`,
+    // which treats a defaulted value as provided — the M14 lesson).
+    if (flags['refresh-snapshot']) {
+      if (flags.reuse) {
+        this.error('--refresh-snapshot and --reuse are mutually exclusive: --reuse skips the prerequisite entirely, so there is nothing to bake.');
+      }
+      if (!flags['prereq-from-snapshot']) {
+        this.error('--refresh-snapshot needs --prereq-from-snapshot (the default): it bakes the journey checkpoint so the live session can restore it. Drop --no-prereq-from-snapshot.');
+      }
+    }
 
     const disco = discoverFlowManifest(CONNECT_SPA, flags, process.env);
     if (disco.usedBundledExample) {
@@ -122,11 +150,43 @@ export default class E2eConnect extends BaseCommand {
 
     // M14-C: the checkpoint store so the journey prerequisite can be RESTORED
     // instead of replayed (slot-0 command — no instance env needed; --reuse
-    // strips the prerequisite entirely, so nothing to restore there).
+    // strips the prerequisite entirely, so nothing to restore there). Also
+    // needed for --refresh-snapshot's fresh bake of the same prerequisite.
     const checkpoints =
-      toRun.prerequisite !== undefined && flags['prereq-from-snapshot']
+      toRun.prerequisite !== undefined && (flags['prereq-from-snapshot'] || flags['refresh-snapshot'])
         ? this.getCheckpointStore(this.scriptContextFromFlags(flags))
         : undefined;
+
+    // --refresh-snapshot: bake the prerequisite's stage checkpoints FRESH before the
+    // live session — a headless full replay of journey 1..schedule with --snapshot-stages,
+    // exactly `ss e2e run saga-dash/journey --through schedule --snapshot-stages --headless`.
+    // Deterministic fixtureIds ⇒ the bake OVERWRITES any stale checkpoint; the main run
+    // below then restores the just-made journey@schedule (prereq-from-snapshot path).
+    if (flags['refresh-snapshot'] && toRun.prerequisite !== undefined) {
+      const prereq = toRun.prerequisite;
+      // M14 §2.3 (advisory): stamp the SPA checkout HEAD into the bake so a later
+      // restore can WARN on drift. '' sha (not a git checkout) ⇒ omitted.
+      let spaHead: { sha: string; dirty: boolean } | undefined;
+      const spaRepoRoot = appCwd.slice(0, appCwd.length - resolved.spa.appDir.length - 1);
+      const git = this.getGitRunner();
+      const sha = await git.headSha(spaRepoRoot);
+      if (sha !== '') spaHead = { sha, dirty: (await git.statusPorcelain(spaRepoRoot)).trim() !== '' };
+
+      this.log(
+        `==> refresh-snapshot: baking ${prereq.flow.name}@${prereq.stages.at(-1)?.id} checkpoints (headless replay, --snapshot-stages)…`,
+      );
+      try {
+        const bakeCode = await executeResolvedFlow(
+          prereq,
+          { api, runner: seams.runner, appCwd, now, log: (l) => this.log(l), checkpoints },
+          { lane: 'stack', skipReset: false, passthrough: [], snapshotStages: true, prereqFromSnapshot: false, spaHead },
+        );
+        if (bakeCode !== 0) this.error(`--refresh-snapshot: prerequisite bake failed (exit ${bakeCode}).`);
+      } catch (err) {
+        if (err instanceof FlowExecError) this.error(`--refresh-snapshot: ${err.message}`);
+        throw err;
+      }
+    }
 
     try {
       const code = await executeResolvedFlow(


### PR DESCRIPTION
## What

Adds `--refresh-snapshot` to `ss e2e connect`.

`ss e2e connect` already restores the `flow-saga-dash-journey-s5-schedule`
checkpoint instead of replaying journey stages 1..5 headless — that's the
`--prereq-from-snapshot` accelerant (default **on**), the big Connect-session
speedup. But baking that checkpoint was a separate manual step
(`ss e2e run saga-dash/journey --through schedule --snapshot-stages --headless`),
and there was no inline way to refresh it once it went stale.

`--refresh-snapshot` does the bake **and** the run in one command:

1. Bakes the journey prerequisite checkpoints fresh — a headless replay through
   `schedule` with `--snapshot-stages` (deterministic fixtureIds ⇒ overwrites any
   stale checkpoint).
2. Opens the live headed interactive-connect room, which restores the just-made
   `journey@schedule` (no replay).

It's the one-command reseed for when the checkpoint has aged past the 7-day
staleness cliff or the journey stages changed.

## Guards

- Requires the default `--prereq-from-snapshot` (it bakes so that path can
  restore) — errors with `--no-prereq-from-snapshot`.
- Mutually exclusive with `--reuse` (reuse strips the prerequisite entirely, so
  there's nothing to bake).

## Tests

3 new cases in `checkpoint.int.test.ts`:
- bake ladder (journey 1..5, one spawn per stage) → restore fresh checkpoint →
  headed interactive-connect last; asserts exactly one `stage-5-schedule` spawn
  (restored, not replayed) + the terminal checkpoint's on-disk provenance.
- `--refresh-snapshot --reuse` rejected.
- `--refresh-snapshot --no-prereq-from-snapshot` rejected.

Full suite: **1090 pass / 14 todo**, `check-types` clean, lint clean (pre-existing
warnings only). Docs updated in `docs/e2e-flows.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhxLByxq6Vk2qVnAGq27sg