### PR TITLE
feat(saga-stack-cli): e2e --capture + preserved run traces + `e2e traces` (exploratory review v1)

### DIFF
--- a/packages/node/saga-stack-cli/docs/e2e-flows.md
+++ b/packages/node/saga-stack-cli/docs/e2e-flows.md
@@ -4,6 +4,9 @@ Everything here uses the `ss` CLI (already on your PATH; `node bin/dev.js` from
 `~/dev/soa/packages/node/saga-stack-cli` is the equivalent if it isn't). Every
 command is copy-pasteable. Nothing here requires up.sh.
 
+**Reviewing what a run did** (per-action traces, preserved artifacts,
+`--capture` / `ss e2e traces`): [e2e-review.md](e2e-review.md).
+
 **See what exists at any moment:**
 
 ```bash

--- a/packages/node/saga-stack-cli/docs/e2e-review.md
+++ b/packages/node/saga-stack-cli/docs/e2e-review.md
@@ -91,19 +91,43 @@ prerequisite):
 Every line is paste-ready; the `cd` prefix matters because `show-trace` must
 run where Playwright is installed (the SPA's app dir).
 
+### The whole-run HTML report
+
+A `--capture` run also emits Playwright's HTML reporter locally (the SPA
+stack config adds `html` + `json` under `PLAYWRIGHT_CAPTURE=all`, `open:
+'never'`), giving ONE browsable page for the entire run — every scenario,
+its named `test.step` phases, and embedded trace links. The report dir is
+preserved beside the stage dirs:
+
+```
+<runsRoot>/<runId>/<spa>/<flow>/playwright-report[-N]/
+```
+
+One report per SPAWN (the default path = one report for the whole run; the
+per-stage ladder yields one per stage spawn, numerically suffixed). The
+review block leads with its paste-ready line:
+
+```
+cd <spa app dir> && pnpm exec playwright show-report <preserved dir>
+```
+
+The machine-readable `results.json` sibling lands in the SPA app dir (not
+preserved yet — read it right after a run for pass/fail counts).
+
 ### `ss e2e traces [--flow <spa>/<flow>] [--open]`
 
-Lists preserved runs newest-first with their show-trace commands. `--open`
-launches the viewer on the newest preserved trace (best-effort: a headless
-host warns, never errors). Slot-aware like the run command.
+Lists preserved runs newest-first — whole-run reports first, then per-stage
+show-trace commands. `--open` PREFERS the newest preserved HTML report
+(`show-report`) and falls back to the newest trace (`show-trace`);
+best-effort either way (a headless host warns, never errors). Slot-aware
+like the run command.
 
 ## Deferred (explicitly)
 
 - **Milestone capture profile** — a middle profile between light and heavy
   keyed on `test.step()` density; waits until more flows adopt steps.
-- **`ss e2e review`** — an HTML-report variant (Playwright's HTML reporter
-  bundles all stages into one browsable page); the per-trace viewer covers
-  the need today.
+- **Preserving `results.json`** — the json summary stays in the SPA app dir
+  for now; preserve it alongside the report if a consumer appears.
 - **Retention/pruning** — `e2e-runs/` grows by ~10-40 MB per captured run;
   manual cleanup for now (`rm -rf <stateDir>/e2e-runs/<runId>`), a `--prune`
   knob when it hurts.

--- a/packages/node/saga-stack-cli/docs/e2e-review.md
+++ b/packages/node/saga-stack-cli/docs/e2e-review.md
@@ -1,0 +1,119 @@
+# E2E exploratory review — capture, preserved traces, `e2e traces`
+
+Proposal + shipped-v1 doc in one (house style). Companion to
+[e2e-flows.md](e2e-flows.md), which covers running flows; this covers
+**reviewing what a run actually did**.
+
+## Motivation
+
+> "I want to confirm the flow tests what it claims — run it headed, or walk
+> me through it step by step with something I can look at." — the review ask
+> that motivated this (Nathan, saga-dash#426 review, 2026-07-09).
+
+Two beliefs, from the exploratory-testing practice the flows grew out of:
+
+1. **Flows set worlds up; traces explain them.** An e2e flow's job is to
+   build a real world and pin contracts. A REVIEWER's job is different: they
+   need to see the world being built — which button was clicked, what the
+   page showed, which API call fired. Playwright traces already carry exactly
+   that (per-action film strip, DOM snapshots, network log); the tooling gap
+   was that nothing turned "review this flow" into "here are the traces".
+2. **The artifacts must survive the next run.** Playwright wipes
+   `test-results/` at run start. The observed footgun: a reviewer runs the
+   flow themselves and thereby deletes the very traces they meant to open.
+   Preservation must be automatic, not an instruction in a doc.
+
+Capture has costs (slower runs, disk), so it is profiled:
+
+- **light (default)** — trace only on a retried failure (Playwright's
+  `on-first-retry`), no preservation on green. Byte-identical to before.
+- **heavy on demand (`--capture`)** — `PLAYWRIGHT_CAPTURE=all`: per-action
+  trace + video for EVERY test, preserved after every spawn. The review mode.
+- **milestones (deferred)** — named `test.step()` blocks make the film strip
+  read as narrative ("create period from Schedule step → enroll people →
+  assert converged world") without heavyweight capture. The SPA side adopts
+  `test.step` freely today (saga-dash's periods-ordering flow is the first);
+  a CLI-side "steps only" profile waits until step density across flows makes
+  it worth a knob.
+
+Failure messages follow the observation-first rule (state what was OBSERVED,
+then the hypotheses) — a guard that asserts one confident cause misdiagnoses.
+That convention lives in the SPA repos' support kits; the CLI's own review
+output sticks to facts (paths, counts, exit codes).
+
+## What shipped (v1)
+
+### `ss e2e run <flow> --capture`
+
+Injects `PLAYWRIGHT_CAPTURE=all` into the Playwright child — the knob the
+SPA's stack config already honours (saga-dash `playwright.stack.config.ts`:
+trace `on` + video `on` for every test). The prerequisite build never
+inherits it (a prerequisite is a build step, not the thing under review);
+a RED prerequisite spawn is still preserved (below).
+
+### Artifact preservation
+
+After EVERY Playwright spawn that warrants it — every spawn of a `--capture`
+run, and any FAILED spawn regardless — the run copies artifact files
+(`trace.zip`, videos, failure screenshots, `error-context.md`) out of the
+SPA's `test-results/` into:
+
+```
+<stateDir>/e2e-runs/<runId>/<spaId>/<flowName>/<stageId>/<original-dir-name>/
+```
+
+- `runId` is the run's single wall-clock read, filesystem-safe and lexically
+  chronological (`2026-07-09_14-05-03`).
+- `stageId` is attributed from the Playwright result-dir name's `-<project>`
+  suffix (longest project first; `-retryN` stripped); projects that are not
+  flow stages (dependency gates like `stage-0-coherence`) land in `_other`.
+- Preservation runs per SPAWN because the per-stage ladder (`--snapshot-stages`
+  / `--from`) and a prerequisite's replay each wipe the previous spawn's
+  `test-results/`.
+- `<stateDir>` is slot-aware (`/tmp/sds-synthetic` at slot 0), so slotted runs
+  preserve into their own tree. It is scratch space — durable across runs,
+  not across host cleanup; copy a run elsewhere to archive it.
+
+### The end-of-run review block
+
+A run that preserved anything prints, win or lose (including a red
+prerequisite):
+
+```
+── review this run ─ saga-dash/periods-ordering
+   preserved: /tmp/sds-synthetic/e2e-runs/2026-07-09_14-05-03/saga-dash/periods-ordering
+   stage ordering — 7 trace(s):
+     cd ~/dev/saga-dash/apps/web/dash && pnpm exec playwright show-trace /tmp/…/ordering/…/trace.zip
+     …
+   list preserved runs any time: ss e2e traces
+```
+
+Every line is paste-ready; the `cd` prefix matters because `show-trace` must
+run where Playwright is installed (the SPA's app dir).
+
+### `ss e2e traces [--flow <spa>/<flow>] [--open]`
+
+Lists preserved runs newest-first with their show-trace commands. `--open`
+launches the viewer on the newest preserved trace (best-effort: a headless
+host warns, never errors). Slot-aware like the run command.
+
+## Deferred (explicitly)
+
+- **Milestone capture profile** — a middle profile between light and heavy
+  keyed on `test.step()` density; waits until more flows adopt steps.
+- **`ss e2e review`** — an HTML-report variant (Playwright's HTML reporter
+  bundles all stages into one browsable page); the per-trace viewer covers
+  the need today.
+- **Retention/pruning** — `e2e-runs/` grows by ~10-40 MB per captured run;
+  manual cleanup for now (`rm -rf <stateDir>/e2e-runs/<runId>`), a `--prune`
+  knob when it hurts.
+- **Video reliability** — `PLAYWRIGHT_CAPTURE=all` requests video, but green
+  runs have been observed producing traces only; the trace film strip covers
+  the same ground, so v1 does not chase it.
+
+## Pointers
+
+- Run mechanics + flow anatomy: [e2e-flows.md](e2e-flows.md)
+- SPA-side conventions (test.step naming, observation-first guard messages,
+  locator ladder): the SPA repo's `.claude/rules/testing.md` +
+  `e2e/support/README.md` (saga-dash).

--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -681,761 +681,6 @@
         "traces.js"
       ]
     },
-    "set:check": {
-      "aliases": [],
-      "args": {
-        "name": {
-          "description": "set name (see `set list`)",
-          "name": "name",
-          "required": true
-        }
-      },
-      "description": "Validate a worktree set: paths, buildable-vs-prebuilt, branch drift (warn), primary-checkout posture, cross-set build collisions. Exit 1 on violations.",
-      "examples": [
-        "<%= config.bin %> <%= command.id %> journey-fix"
-      ],
-      "flags": {
-        "porcelain": {
-          "description": "machine-readable output; no color, minimal noise",
-          "name": "porcelain",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
-          "name": "slot",
-          "default": 0,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "output-json": {
-          "description": "emit structured JSON on stdout instead of human-readable text",
-          "name": "output-json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "set": {
-          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
-          "name": "set",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dev": {
-          "description": "sibling-repo workspace root (where the saga repos are checked out)",
-          "name": "dev",
-          "noCacheDefault": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
-          "name": "state-dir",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "soa": {
-          "description": "override path to the soa repo checkout",
-          "name": "soa",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rostering": {
-          "description": "override path to the rostering repo checkout",
-          "name": "rostering",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "program-hub": {
-          "description": "override path to the program-hub repo checkout",
-          "name": "program-hub",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "saga-dash": {
-          "description": "override path to the saga-dash repo checkout",
-          "name": "saga-dash",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "coach": {
-          "description": "override path to the coach repo checkout",
-          "name": "coach",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "sds": {
-          "description": "override path to the sds (student-data-system) repo checkout",
-          "name": "sds",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "qboard": {
-          "description": "override path to the qboard repo checkout",
-          "name": "qboard",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rtsm": {
-          "description": "override path to the rtsm repo checkout",
-          "name": "rtsm",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fleek": {
-          "description": "override path to the fleek repo checkout",
-          "name": "fleek",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "set:check",
-      "pluginAlias": "@saga-ed/saga-stack-cli",
-      "pluginName": "@saga-ed/saga-stack-cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "set",
-        "check.js"
-      ]
-    },
-    "set:create": {
-      "aliases": [],
-      "args": {
-        "name": {
-          "description": "set name (must be unused)",
-          "name": "name",
-          "required": true
-        }
-      },
-      "description": "Create a worktree set: git worktree add (new/existing branch) off the primary checkout, pnpm install, and record it in the sets file (createdBy: ss). Single repo per call.",
-      "examples": [
-        "<%= config.bin %> <%= command.id %> sched --slot 1 --repo saga-dash --path ~/dev/worktrees/saga-dash-sched --branch feat/sched",
-        "<%= config.bin %> <%= command.id %> topo --slot 2 --repo saga-dash --path ~/dev/worktrees/saga-dash-topo --branch flow/topology --no-install"
-      ],
-      "flags": {
-        "porcelain": {
-          "description": "machine-readable output; no color, minimal noise",
-          "name": "porcelain",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "slot": {
-          "description": "slot the set binds (1..9; slot 0 is the primary-checkout baseline)",
-          "name": "slot",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "output-json": {
-          "description": "emit structured JSON on stdout instead of human-readable text",
-          "name": "output-json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "set": {
-          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
-          "name": "set",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dev": {
-          "description": "sibling-repo workspace root (where the saga repos are checked out)",
-          "name": "dev",
-          "noCacheDefault": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
-          "name": "state-dir",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "soa": {
-          "description": "override path to the soa repo checkout",
-          "name": "soa",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rostering": {
-          "description": "override path to the rostering repo checkout",
-          "name": "rostering",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "program-hub": {
-          "description": "override path to the program-hub repo checkout",
-          "name": "program-hub",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "saga-dash": {
-          "description": "override path to the saga-dash repo checkout",
-          "name": "saga-dash",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "coach": {
-          "description": "override path to the coach repo checkout",
-          "name": "coach",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "sds": {
-          "description": "override path to the sds (student-data-system) repo checkout",
-          "name": "sds",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "qboard": {
-          "description": "override path to the qboard repo checkout",
-          "name": "qboard",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rtsm": {
-          "description": "override path to the rtsm repo checkout",
-          "name": "rtsm",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fleek": {
-          "description": "override path to the fleek repo checkout",
-          "name": "fleek",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "repo": {
-          "description": "repo to make a worktree for",
-          "name": "repo",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "options": [
-            "soa",
-            "rostering",
-            "program-hub",
-            "saga-dash",
-            "coach",
-            "sds",
-            "qboard",
-            "rtsm",
-            "fleek"
-          ],
-          "type": "option"
-        },
-        "path": {
-          "description": "worktree checkout path (recorded verbatim; `~` stays portable)",
-          "name": "path",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "branch": {
-          "description": "branch to check out — created if new, attached if it exists (default: the set name)",
-          "name": "branch",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "base": {
-          "description": "start point for a NEW branch (default: the primary checkout HEAD, e.g. main)",
-          "name": "base",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "note": {
-          "description": "optional note stored on the set",
-          "name": "note",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "install": {
-          "description": "pnpm install in the new worktree so `--set` up/e2e fresh-skip (use --no-install to skip)",
-          "name": "install",
-          "allowNo": true,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "set:create",
-      "pluginAlias": "@saga-ed/saga-stack-cli",
-      "pluginName": "@saga-ed/saga-stack-cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "set",
-        "create.js"
-      ]
-    },
-    "set:list": {
-      "aliases": [],
-      "args": {},
-      "description": "List the worktree sets (name, slot, live ACTIVE state, repos) from the sets file (read-only).",
-      "examples": [
-        "<%= config.bin %> <%= command.id %>",
-        "<%= config.bin %> <%= command.id %> --output-json"
-      ],
-      "flags": {
-        "porcelain": {
-          "description": "machine-readable output; no color, minimal noise",
-          "name": "porcelain",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
-          "name": "slot",
-          "default": 0,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "output-json": {
-          "description": "emit structured JSON on stdout instead of human-readable text",
-          "name": "output-json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "set": {
-          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
-          "name": "set",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dev": {
-          "description": "sibling-repo workspace root (where the saga repos are checked out)",
-          "name": "dev",
-          "noCacheDefault": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
-          "name": "state-dir",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "soa": {
-          "description": "override path to the soa repo checkout",
-          "name": "soa",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rostering": {
-          "description": "override path to the rostering repo checkout",
-          "name": "rostering",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "program-hub": {
-          "description": "override path to the program-hub repo checkout",
-          "name": "program-hub",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "saga-dash": {
-          "description": "override path to the saga-dash repo checkout",
-          "name": "saga-dash",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "coach": {
-          "description": "override path to the coach repo checkout",
-          "name": "coach",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "sds": {
-          "description": "override path to the sds (student-data-system) repo checkout",
-          "name": "sds",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "qboard": {
-          "description": "override path to the qboard repo checkout",
-          "name": "qboard",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rtsm": {
-          "description": "override path to the rtsm repo checkout",
-          "name": "rtsm",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fleek": {
-          "description": "override path to the fleek repo checkout",
-          "name": "fleek",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "set:list",
-      "pluginAlias": "@saga-ed/saga-stack-cli",
-      "pluginName": "@saga-ed/saga-stack-cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "set",
-        "list.js"
-      ]
-    },
-    "set:rm": {
-      "aliases": [],
-      "args": {
-        "name": {
-          "description": "set name (see `set list`)",
-          "name": "name",
-          "required": true
-        }
-      },
-      "description": "Remove a worktree set from the sets file. --and-worktrees also `git worktree remove`s the ss-created worktrees (createdBy: ss); hand-recorded paths are never touched.",
-      "examples": [
-        "<%= config.bin %> <%= command.id %> sched",
-        "<%= config.bin %> <%= command.id %> sched --and-worktrees --yes"
-      ],
-      "flags": {
-        "porcelain": {
-          "description": "machine-readable output; no color, minimal noise",
-          "name": "porcelain",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
-          "name": "slot",
-          "default": 0,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "output-json": {
-          "description": "emit structured JSON on stdout instead of human-readable text",
-          "name": "output-json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "set": {
-          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
-          "name": "set",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dev": {
-          "description": "sibling-repo workspace root (where the saga repos are checked out)",
-          "name": "dev",
-          "noCacheDefault": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
-          "name": "state-dir",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "soa": {
-          "description": "override path to the soa repo checkout",
-          "name": "soa",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rostering": {
-          "description": "override path to the rostering repo checkout",
-          "name": "rostering",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "program-hub": {
-          "description": "override path to the program-hub repo checkout",
-          "name": "program-hub",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "saga-dash": {
-          "description": "override path to the saga-dash repo checkout",
-          "name": "saga-dash",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "coach": {
-          "description": "override path to the coach repo checkout",
-          "name": "coach",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "sds": {
-          "description": "override path to the sds (student-data-system) repo checkout",
-          "name": "sds",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "qboard": {
-          "description": "override path to the qboard repo checkout",
-          "name": "qboard",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rtsm": {
-          "description": "override path to the rtsm repo checkout",
-          "name": "rtsm",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fleek": {
-          "description": "override path to the fleek repo checkout",
-          "name": "fleek",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "and-worktrees": {
-          "description": "also `git worktree remove` the worktrees ss created (createdBy: ss); requires --yes",
-          "name": "and-worktrees",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "force": {
-          "description": "pass --force to `git worktree remove` (a dirty/locked worktree)",
-          "name": "force",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "yes": {
-          "description": "confirm the destructive --and-worktrees removal (required with it)",
-          "name": "yes",
-          "allowNo": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "set:rm",
-      "pluginAlias": "@saga-ed/saga-stack-cli",
-      "pluginName": "@saga-ed/saga-stack-cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "set",
-        "rm.js"
-      ]
-    },
-    "set:show": {
-      "aliases": [],
-      "args": {
-        "name": {
-          "description": "set name (see `set list`)",
-          "name": "name",
-          "required": true
-        }
-      },
-      "description": "Show one worktree set: slot, repos, and each repo’s live branch + dirty state (read-only).",
-      "examples": [
-        "<%= config.bin %> <%= command.id %> journey-fix"
-      ],
-      "flags": {
-        "porcelain": {
-          "description": "machine-readable output; no color, minimal noise",
-          "name": "porcelain",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
-          "name": "slot",
-          "default": 0,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "output-json": {
-          "description": "emit structured JSON on stdout instead of human-readable text",
-          "name": "output-json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "set": {
-          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
-          "name": "set",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dev": {
-          "description": "sibling-repo workspace root (where the saga repos are checked out)",
-          "name": "dev",
-          "noCacheDefault": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
-          "name": "state-dir",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "soa": {
-          "description": "override path to the soa repo checkout",
-          "name": "soa",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rostering": {
-          "description": "override path to the rostering repo checkout",
-          "name": "rostering",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "program-hub": {
-          "description": "override path to the program-hub repo checkout",
-          "name": "program-hub",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "saga-dash": {
-          "description": "override path to the saga-dash repo checkout",
-          "name": "saga-dash",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "coach": {
-          "description": "override path to the coach repo checkout",
-          "name": "coach",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "sds": {
-          "description": "override path to the sds (student-data-system) repo checkout",
-          "name": "sds",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "qboard": {
-          "description": "override path to the qboard repo checkout",
-          "name": "qboard",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rtsm": {
-          "description": "override path to the rtsm repo checkout",
-          "name": "rtsm",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fleek": {
-          "description": "override path to the fleek repo checkout",
-          "name": "fleek",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fetch": {
-          "description": "git fetch each repo first so the mainline-currency report reflects the REMOTE tip (network); without it, currency is as-of the last fetch",
-          "name": "fetch",
-          "allowNo": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "set:show",
-      "pluginAlias": "@saga-ed/saga-stack-cli",
-      "pluginName": "@saga-ed/saga-stack-cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "set",
-        "show.js"
-      ]
-    },
     "stack:bootstrap": {
       "aliases": [],
       "args": {},
@@ -3413,6 +2658,761 @@
         "commands",
         "stack",
         "verify.js"
+      ]
+    },
+    "set:check": {
+      "aliases": [],
+      "args": {
+        "name": {
+          "description": "set name (see `set list`)",
+          "name": "name",
+          "required": true
+        }
+      },
+      "description": "Validate a worktree set: paths, buildable-vs-prebuilt, branch drift (warn), primary-checkout posture, cross-set build collisions. Exit 1 on violations.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> journey-fix"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "set:check",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "set",
+        "check.js"
+      ]
+    },
+    "set:create": {
+      "aliases": [],
+      "args": {
+        "name": {
+          "description": "set name (must be unused)",
+          "name": "name",
+          "required": true
+        }
+      },
+      "description": "Create a worktree set: git worktree add (new/existing branch) off the primary checkout, pnpm install, and record it in the sets file (createdBy: ss). Single repo per call.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> sched --slot 1 --repo saga-dash --path ~/dev/worktrees/saga-dash-sched --branch feat/sched",
+        "<%= config.bin %> <%= command.id %> topo --slot 2 --repo saga-dash --path ~/dev/worktrees/saga-dash-topo --branch flow/topology --no-install"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "slot the set binds (1..9; slot 0 is the primary-checkout baseline)",
+          "name": "slot",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "repo": {
+          "description": "repo to make a worktree for",
+          "name": "repo",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "soa",
+            "rostering",
+            "program-hub",
+            "saga-dash",
+            "coach",
+            "sds",
+            "qboard",
+            "rtsm",
+            "fleek"
+          ],
+          "type": "option"
+        },
+        "path": {
+          "description": "worktree checkout path (recorded verbatim; `~` stays portable)",
+          "name": "path",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "branch": {
+          "description": "branch to check out — created if new, attached if it exists (default: the set name)",
+          "name": "branch",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "base": {
+          "description": "start point for a NEW branch (default: the primary checkout HEAD, e.g. main)",
+          "name": "base",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "note": {
+          "description": "optional note stored on the set",
+          "name": "note",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "install": {
+          "description": "pnpm install in the new worktree so `--set` up/e2e fresh-skip (use --no-install to skip)",
+          "name": "install",
+          "allowNo": true,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "set:create",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "set",
+        "create.js"
+      ]
+    },
+    "set:list": {
+      "aliases": [],
+      "args": {},
+      "description": "List the worktree sets (name, slot, live ACTIVE state, repos) from the sets file (read-only).",
+      "examples": [
+        "<%= config.bin %> <%= command.id %>",
+        "<%= config.bin %> <%= command.id %> --output-json"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "set:list",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "set",
+        "list.js"
+      ]
+    },
+    "set:rm": {
+      "aliases": [],
+      "args": {
+        "name": {
+          "description": "set name (see `set list`)",
+          "name": "name",
+          "required": true
+        }
+      },
+      "description": "Remove a worktree set from the sets file. --and-worktrees also `git worktree remove`s the ss-created worktrees (createdBy: ss); hand-recorded paths are never touched.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> sched",
+        "<%= config.bin %> <%= command.id %> sched --and-worktrees --yes"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "and-worktrees": {
+          "description": "also `git worktree remove` the worktrees ss created (createdBy: ss); requires --yes",
+          "name": "and-worktrees",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "force": {
+          "description": "pass --force to `git worktree remove` (a dirty/locked worktree)",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "yes": {
+          "description": "confirm the destructive --and-worktrees removal (required with it)",
+          "name": "yes",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "set:rm",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "set",
+        "rm.js"
+      ]
+    },
+    "set:show": {
+      "aliases": [],
+      "args": {
+        "name": {
+          "description": "set name (see `set list`)",
+          "name": "name",
+          "required": true
+        }
+      },
+      "description": "Show one worktree set: slot, repos, and each repo’s live branch + dirty state (read-only).",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> journey-fix"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fetch": {
+          "description": "git fetch each repo first so the mainline-currency report reflects the REMOTE tip (network); without it, currency is as-of the last fetch",
+          "name": "fetch",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "set:show",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "set",
+        "show.js"
       ]
     },
     "stack:bundle:list": {

--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -659,7 +659,7 @@
           "type": "option"
         },
         "open": {
-          "description": "launch `playwright show-trace` on the newest preserved trace (best-effort; a headless host warns)",
+          "description": "open the newest preserved run: PREFERS the whole-run HTML report (`playwright show-report`) when one exists, else falls back to the newest trace (`show-trace`). Best-effort; a headless host warns.",
           "name": "open",
           "allowNo": false,
           "type": "boolean"

--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -7,7 +7,8 @@
       "examples": [
         "<%= config.bin %> <%= command.id %>",
         "<%= config.bin %> <%= command.id %> --reuse -- --debug",
-        "<%= config.bin %> <%= command.id %> --fake-media"
+        "<%= config.bin %> <%= command.id %> --fake-media",
+        "<%= config.bin %> <%= command.id %> --refresh-snapshot"
       ],
       "flags": {
         "porcelain": {
@@ -125,6 +126,12 @@
           "description": "M14-C: restore the journey@schedule checkpoint (when a valid one is baked) instead of replaying the whole journey headless — the big Connect-session accelerant. Falls back to the replay when absent/invalid; --reuse trumps this entirely.",
           "name": "prereq-from-snapshot",
           "allowNo": true,
+          "type": "boolean"
+        },
+        "refresh-snapshot": {
+          "description": "bake the journey prerequisite checkpoints FRESH (headless replay through `schedule`, --snapshot-stages) BEFORE opening the room, then restore that just-made checkpoint — a one-command reseed for when the baked state has gone stale (>7d) or the journey changed. Deterministic fixtureIds ⇒ the bake overwrites. Requires --prereq-from-snapshot (the default); mutually exclusive with --reuse.",
+          "name": "refresh-snapshot",
+          "allowNo": false,
           "type": "boolean"
         },
         "spa-path": {
@@ -302,7 +309,8 @@
       "examples": [
         "<%= config.bin %> <%= command.id %> journey --through pods --dry-run",
         "<%= config.bin %> <%= command.id %> saga-dash/journey --through 2 --headless",
-        "<%= config.bin %> <%= command.id %> journey --skip-reset -- --debug"
+        "<%= config.bin %> <%= command.id %> journey --skip-reset -- --debug",
+        "<%= config.bin %> <%= command.id %> saga-dash/periods-ordering --capture --headless"
       ],
       "flags": {
         "porcelain": {
@@ -504,6 +512,12 @@
           "name": "dry-run",
           "allowNo": false,
           "type": "boolean"
+        },
+        "capture": {
+          "description": "exploratory-review capture: run Playwright with PLAYWRIGHT_CAPTURE=all (per-action trace + video on every test) and PRESERVE the artifacts under <stateDir>/e2e-runs/<runId>/ (Playwright wipes test-results/ at the next run's start). A FAILED stage's artifacts are preserved even without this flag. Review with `e2e traces`.",
+          "name": "capture",
+          "allowNo": false,
+          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
@@ -520,6 +534,151 @@
         "commands",
         "e2e",
         "run.js"
+      ]
+    },
+    "e2e:traces": {
+      "aliases": [],
+      "args": {},
+      "description": "List preserved e2e run traces (from `e2e run --capture` / failed stages), newest first, with paste-ready show-trace commands.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %>",
+        "<%= config.bin %> <%= command.id %> --flow saga-dash/periods-ordering",
+        "<%= config.bin %> <%= command.id %> --open"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "flow": {
+          "description": "filter to one flow ('<spa>/<flow>' or a bare '<flow>' across SPAs)",
+          "name": "flow",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "open": {
+          "description": "launch `playwright show-trace` on the newest preserved trace (best-effort; a headless host warns)",
+          "name": "open",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "e2e:traces",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "e2e",
+        "traces.js"
       ]
     },
     "set:check": {

--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -681,6 +681,761 @@
         "traces.js"
       ]
     },
+    "set:check": {
+      "aliases": [],
+      "args": {
+        "name": {
+          "description": "set name (see `set list`)",
+          "name": "name",
+          "required": true
+        }
+      },
+      "description": "Validate a worktree set: paths, buildable-vs-prebuilt, branch drift (warn), primary-checkout posture, cross-set build collisions. Exit 1 on violations.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> journey-fix"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "set:check",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "set",
+        "check.js"
+      ]
+    },
+    "set:create": {
+      "aliases": [],
+      "args": {
+        "name": {
+          "description": "set name (must be unused)",
+          "name": "name",
+          "required": true
+        }
+      },
+      "description": "Create a worktree set: git worktree add (new/existing branch) off the primary checkout, pnpm install, and record it in the sets file (createdBy: ss). Single repo per call.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> sched --slot 1 --repo saga-dash --path ~/dev/worktrees/saga-dash-sched --branch feat/sched",
+        "<%= config.bin %> <%= command.id %> topo --slot 2 --repo saga-dash --path ~/dev/worktrees/saga-dash-topo --branch flow/topology --no-install"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "slot the set binds (1..9; slot 0 is the primary-checkout baseline)",
+          "name": "slot",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "repo": {
+          "description": "repo to make a worktree for",
+          "name": "repo",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "soa",
+            "rostering",
+            "program-hub",
+            "saga-dash",
+            "coach",
+            "sds",
+            "qboard",
+            "rtsm",
+            "fleek"
+          ],
+          "type": "option"
+        },
+        "path": {
+          "description": "worktree checkout path (recorded verbatim; `~` stays portable)",
+          "name": "path",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "branch": {
+          "description": "branch to check out — created if new, attached if it exists (default: the set name)",
+          "name": "branch",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "base": {
+          "description": "start point for a NEW branch (default: the primary checkout HEAD, e.g. main)",
+          "name": "base",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "note": {
+          "description": "optional note stored on the set",
+          "name": "note",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "install": {
+          "description": "pnpm install in the new worktree so `--set` up/e2e fresh-skip (use --no-install to skip)",
+          "name": "install",
+          "allowNo": true,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "set:create",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "set",
+        "create.js"
+      ]
+    },
+    "set:list": {
+      "aliases": [],
+      "args": {},
+      "description": "List the worktree sets (name, slot, live ACTIVE state, repos) from the sets file (read-only).",
+      "examples": [
+        "<%= config.bin %> <%= command.id %>",
+        "<%= config.bin %> <%= command.id %> --output-json"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "set:list",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "set",
+        "list.js"
+      ]
+    },
+    "set:rm": {
+      "aliases": [],
+      "args": {
+        "name": {
+          "description": "set name (see `set list`)",
+          "name": "name",
+          "required": true
+        }
+      },
+      "description": "Remove a worktree set from the sets file. --and-worktrees also `git worktree remove`s the ss-created worktrees (createdBy: ss); hand-recorded paths are never touched.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> sched",
+        "<%= config.bin %> <%= command.id %> sched --and-worktrees --yes"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "and-worktrees": {
+          "description": "also `git worktree remove` the worktrees ss created (createdBy: ss); requires --yes",
+          "name": "and-worktrees",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "force": {
+          "description": "pass --force to `git worktree remove` (a dirty/locked worktree)",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "yes": {
+          "description": "confirm the destructive --and-worktrees removal (required with it)",
+          "name": "yes",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "set:rm",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "set",
+        "rm.js"
+      ]
+    },
+    "set:show": {
+      "aliases": [],
+      "args": {
+        "name": {
+          "description": "set name (see `set list`)",
+          "name": "name",
+          "required": true
+        }
+      },
+      "description": "Show one worktree set: slot, repos, and each repo’s live branch + dirty state (read-only).",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> journey-fix"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fetch": {
+          "description": "git fetch each repo first so the mainline-currency report reflects the REMOTE tip (network); without it, currency is as-of the last fetch",
+          "name": "fetch",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "set:show",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "set",
+        "show.js"
+      ]
+    },
     "stack:bootstrap": {
       "aliases": [],
       "args": {},
@@ -2658,761 +3413,6 @@
         "commands",
         "stack",
         "verify.js"
-      ]
-    },
-    "set:check": {
-      "aliases": [],
-      "args": {
-        "name": {
-          "description": "set name (see `set list`)",
-          "name": "name",
-          "required": true
-        }
-      },
-      "description": "Validate a worktree set: paths, buildable-vs-prebuilt, branch drift (warn), primary-checkout posture, cross-set build collisions. Exit 1 on violations.",
-      "examples": [
-        "<%= config.bin %> <%= command.id %> journey-fix"
-      ],
-      "flags": {
-        "porcelain": {
-          "description": "machine-readable output; no color, minimal noise",
-          "name": "porcelain",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
-          "name": "slot",
-          "default": 0,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "output-json": {
-          "description": "emit structured JSON on stdout instead of human-readable text",
-          "name": "output-json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "set": {
-          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
-          "name": "set",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dev": {
-          "description": "sibling-repo workspace root (where the saga repos are checked out)",
-          "name": "dev",
-          "noCacheDefault": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
-          "name": "state-dir",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "soa": {
-          "description": "override path to the soa repo checkout",
-          "name": "soa",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rostering": {
-          "description": "override path to the rostering repo checkout",
-          "name": "rostering",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "program-hub": {
-          "description": "override path to the program-hub repo checkout",
-          "name": "program-hub",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "saga-dash": {
-          "description": "override path to the saga-dash repo checkout",
-          "name": "saga-dash",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "coach": {
-          "description": "override path to the coach repo checkout",
-          "name": "coach",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "sds": {
-          "description": "override path to the sds (student-data-system) repo checkout",
-          "name": "sds",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "qboard": {
-          "description": "override path to the qboard repo checkout",
-          "name": "qboard",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rtsm": {
-          "description": "override path to the rtsm repo checkout",
-          "name": "rtsm",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fleek": {
-          "description": "override path to the fleek repo checkout",
-          "name": "fleek",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "set:check",
-      "pluginAlias": "@saga-ed/saga-stack-cli",
-      "pluginName": "@saga-ed/saga-stack-cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "set",
-        "check.js"
-      ]
-    },
-    "set:create": {
-      "aliases": [],
-      "args": {
-        "name": {
-          "description": "set name (must be unused)",
-          "name": "name",
-          "required": true
-        }
-      },
-      "description": "Create a worktree set: git worktree add (new/existing branch) off the primary checkout, pnpm install, and record it in the sets file (createdBy: ss). Single repo per call.",
-      "examples": [
-        "<%= config.bin %> <%= command.id %> sched --slot 1 --repo saga-dash --path ~/dev/worktrees/saga-dash-sched --branch feat/sched",
-        "<%= config.bin %> <%= command.id %> topo --slot 2 --repo saga-dash --path ~/dev/worktrees/saga-dash-topo --branch flow/topology --no-install"
-      ],
-      "flags": {
-        "porcelain": {
-          "description": "machine-readable output; no color, minimal noise",
-          "name": "porcelain",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "slot": {
-          "description": "slot the set binds (1..9; slot 0 is the primary-checkout baseline)",
-          "name": "slot",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "output-json": {
-          "description": "emit structured JSON on stdout instead of human-readable text",
-          "name": "output-json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "set": {
-          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
-          "name": "set",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dev": {
-          "description": "sibling-repo workspace root (where the saga repos are checked out)",
-          "name": "dev",
-          "noCacheDefault": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
-          "name": "state-dir",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "soa": {
-          "description": "override path to the soa repo checkout",
-          "name": "soa",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rostering": {
-          "description": "override path to the rostering repo checkout",
-          "name": "rostering",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "program-hub": {
-          "description": "override path to the program-hub repo checkout",
-          "name": "program-hub",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "saga-dash": {
-          "description": "override path to the saga-dash repo checkout",
-          "name": "saga-dash",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "coach": {
-          "description": "override path to the coach repo checkout",
-          "name": "coach",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "sds": {
-          "description": "override path to the sds (student-data-system) repo checkout",
-          "name": "sds",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "qboard": {
-          "description": "override path to the qboard repo checkout",
-          "name": "qboard",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rtsm": {
-          "description": "override path to the rtsm repo checkout",
-          "name": "rtsm",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fleek": {
-          "description": "override path to the fleek repo checkout",
-          "name": "fleek",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "repo": {
-          "description": "repo to make a worktree for",
-          "name": "repo",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "options": [
-            "soa",
-            "rostering",
-            "program-hub",
-            "saga-dash",
-            "coach",
-            "sds",
-            "qboard",
-            "rtsm",
-            "fleek"
-          ],
-          "type": "option"
-        },
-        "path": {
-          "description": "worktree checkout path (recorded verbatim; `~` stays portable)",
-          "name": "path",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "branch": {
-          "description": "branch to check out — created if new, attached if it exists (default: the set name)",
-          "name": "branch",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "base": {
-          "description": "start point for a NEW branch (default: the primary checkout HEAD, e.g. main)",
-          "name": "base",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "note": {
-          "description": "optional note stored on the set",
-          "name": "note",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "install": {
-          "description": "pnpm install in the new worktree so `--set` up/e2e fresh-skip (use --no-install to skip)",
-          "name": "install",
-          "allowNo": true,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "set:create",
-      "pluginAlias": "@saga-ed/saga-stack-cli",
-      "pluginName": "@saga-ed/saga-stack-cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "set",
-        "create.js"
-      ]
-    },
-    "set:list": {
-      "aliases": [],
-      "args": {},
-      "description": "List the worktree sets (name, slot, live ACTIVE state, repos) from the sets file (read-only).",
-      "examples": [
-        "<%= config.bin %> <%= command.id %>",
-        "<%= config.bin %> <%= command.id %> --output-json"
-      ],
-      "flags": {
-        "porcelain": {
-          "description": "machine-readable output; no color, minimal noise",
-          "name": "porcelain",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
-          "name": "slot",
-          "default": 0,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "output-json": {
-          "description": "emit structured JSON on stdout instead of human-readable text",
-          "name": "output-json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "set": {
-          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
-          "name": "set",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dev": {
-          "description": "sibling-repo workspace root (where the saga repos are checked out)",
-          "name": "dev",
-          "noCacheDefault": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
-          "name": "state-dir",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "soa": {
-          "description": "override path to the soa repo checkout",
-          "name": "soa",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rostering": {
-          "description": "override path to the rostering repo checkout",
-          "name": "rostering",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "program-hub": {
-          "description": "override path to the program-hub repo checkout",
-          "name": "program-hub",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "saga-dash": {
-          "description": "override path to the saga-dash repo checkout",
-          "name": "saga-dash",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "coach": {
-          "description": "override path to the coach repo checkout",
-          "name": "coach",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "sds": {
-          "description": "override path to the sds (student-data-system) repo checkout",
-          "name": "sds",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "qboard": {
-          "description": "override path to the qboard repo checkout",
-          "name": "qboard",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rtsm": {
-          "description": "override path to the rtsm repo checkout",
-          "name": "rtsm",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fleek": {
-          "description": "override path to the fleek repo checkout",
-          "name": "fleek",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "set:list",
-      "pluginAlias": "@saga-ed/saga-stack-cli",
-      "pluginName": "@saga-ed/saga-stack-cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "set",
-        "list.js"
-      ]
-    },
-    "set:rm": {
-      "aliases": [],
-      "args": {
-        "name": {
-          "description": "set name (see `set list`)",
-          "name": "name",
-          "required": true
-        }
-      },
-      "description": "Remove a worktree set from the sets file. --and-worktrees also `git worktree remove`s the ss-created worktrees (createdBy: ss); hand-recorded paths are never touched.",
-      "examples": [
-        "<%= config.bin %> <%= command.id %> sched",
-        "<%= config.bin %> <%= command.id %> sched --and-worktrees --yes"
-      ],
-      "flags": {
-        "porcelain": {
-          "description": "machine-readable output; no color, minimal noise",
-          "name": "porcelain",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
-          "name": "slot",
-          "default": 0,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "output-json": {
-          "description": "emit structured JSON on stdout instead of human-readable text",
-          "name": "output-json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "set": {
-          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
-          "name": "set",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dev": {
-          "description": "sibling-repo workspace root (where the saga repos are checked out)",
-          "name": "dev",
-          "noCacheDefault": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
-          "name": "state-dir",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "soa": {
-          "description": "override path to the soa repo checkout",
-          "name": "soa",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rostering": {
-          "description": "override path to the rostering repo checkout",
-          "name": "rostering",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "program-hub": {
-          "description": "override path to the program-hub repo checkout",
-          "name": "program-hub",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "saga-dash": {
-          "description": "override path to the saga-dash repo checkout",
-          "name": "saga-dash",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "coach": {
-          "description": "override path to the coach repo checkout",
-          "name": "coach",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "sds": {
-          "description": "override path to the sds (student-data-system) repo checkout",
-          "name": "sds",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "qboard": {
-          "description": "override path to the qboard repo checkout",
-          "name": "qboard",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rtsm": {
-          "description": "override path to the rtsm repo checkout",
-          "name": "rtsm",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fleek": {
-          "description": "override path to the fleek repo checkout",
-          "name": "fleek",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "and-worktrees": {
-          "description": "also `git worktree remove` the worktrees ss created (createdBy: ss); requires --yes",
-          "name": "and-worktrees",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "force": {
-          "description": "pass --force to `git worktree remove` (a dirty/locked worktree)",
-          "name": "force",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "yes": {
-          "description": "confirm the destructive --and-worktrees removal (required with it)",
-          "name": "yes",
-          "allowNo": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "set:rm",
-      "pluginAlias": "@saga-ed/saga-stack-cli",
-      "pluginName": "@saga-ed/saga-stack-cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "set",
-        "rm.js"
-      ]
-    },
-    "set:show": {
-      "aliases": [],
-      "args": {
-        "name": {
-          "description": "set name (see `set list`)",
-          "name": "name",
-          "required": true
-        }
-      },
-      "description": "Show one worktree set: slot, repos, and each repo’s live branch + dirty state (read-only).",
-      "examples": [
-        "<%= config.bin %> <%= command.id %> journey-fix"
-      ],
-      "flags": {
-        "porcelain": {
-          "description": "machine-readable output; no color, minimal noise",
-          "name": "porcelain",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
-          "name": "slot",
-          "default": 0,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "output-json": {
-          "description": "emit structured JSON on stdout instead of human-readable text",
-          "name": "output-json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "set": {
-          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
-          "name": "set",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dev": {
-          "description": "sibling-repo workspace root (where the saga repos are checked out)",
-          "name": "dev",
-          "noCacheDefault": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
-          "name": "state-dir",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "soa": {
-          "description": "override path to the soa repo checkout",
-          "name": "soa",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rostering": {
-          "description": "override path to the rostering repo checkout",
-          "name": "rostering",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "program-hub": {
-          "description": "override path to the program-hub repo checkout",
-          "name": "program-hub",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "saga-dash": {
-          "description": "override path to the saga-dash repo checkout",
-          "name": "saga-dash",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "coach": {
-          "description": "override path to the coach repo checkout",
-          "name": "coach",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "sds": {
-          "description": "override path to the sds (student-data-system) repo checkout",
-          "name": "sds",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "qboard": {
-          "description": "override path to the qboard repo checkout",
-          "name": "qboard",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rtsm": {
-          "description": "override path to the rtsm repo checkout",
-          "name": "rtsm",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fleek": {
-          "description": "override path to the fleek repo checkout",
-          "name": "fleek",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fetch": {
-          "description": "git fetch each repo first so the mainline-currency report reflects the REMOTE tip (network); without it, currency is as-of the last fetch",
-          "name": "fetch",
-          "allowNo": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "set:show",
-      "pluginAlias": "@saga-ed/saga-stack-cli",
-      "pluginName": "@saga-ed/saga-stack-cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "set",
-        "show.js"
       ]
     },
     "stack:bundle:list": {

--- a/packages/node/saga-stack-cli/src/__tests__/e2e-orchestrate-capture.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/__tests__/e2e-orchestrate-capture.unit.test.ts
@@ -1,0 +1,114 @@
+/**
+ * `executeResolvedFlow` — exploratory-review capture wiring (docs/e2e-review.md).
+ *
+ * Pins the three seams `e2e run --capture` adds, offline (fake StackApi +
+ * Runner, the bundled example flows.json):
+ *   1. `playwrightEnv(…, capture)` — PLAYWRIGHT_CAPTURE=all rides the child env
+ *      iff capture; absent otherwise (byte-identical default).
+ *   2. the preservation hook fires after EVERY spawn of a --capture run, and
+ *      after a RED spawn without it — never after a green non-capture spawn.
+ *   3. a red spawn's exit code still propagates unchanged.
+ */
+
+// eslint-disable-next-line no-restricted-imports -- test fixture read; production core stays fs-free
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { parseFlowManifest } from '../core/flow/load.js';
+import { resolveFlow } from '../core/flow/resolve.js';
+import type { SeedPlan } from '../core/seed/index.js';
+import { executeResolvedFlow, playwrightEnv } from '../e2e-orchestrate.js';
+import type { RunResult, ScriptInvocation } from '../runtime/index.js';
+import type { HealthProbe, StackApi } from '../stack-api.js';
+
+const EXAMPLE = fileURLToPath(new URL('../../examples/flows/saga-dash.flows.json', import.meta.url));
+const flowManifest = parseFlowManifest(readFileSync(EXAMPLE, 'utf8'), EXAMPLE);
+
+function makeApi(): StackApi {
+  return {
+    async up() {
+      return { ok: true, mesh: { ok: true } as never, launched: [], skipped: [] };
+    },
+    async down() {
+      return { stopped: [] };
+    },
+    async restart() {
+      throw new Error('unused');
+    },
+    async reset() {
+      return { code: 0 };
+    },
+    async seed(plan: SeedPlan) {
+      return { ok: true, ran: { offline: [], online: [] }, skipped: plan.skipped };
+    },
+    async verify(_probes: HealthProbe[]) {
+      return { passed: true, rows: [] };
+    },
+  };
+}
+
+async function run(opts: { capture?: boolean; playwrightCode?: number }): Promise<{
+  code: number;
+  spawnedEnvs: Array<Record<string, string> | undefined>;
+  preserveCalls: Array<{ flowName: string; stages: readonly { id: string; project: string }[] }>;
+}> {
+  const spawnedEnvs: Array<Record<string, string> | undefined> = [];
+  const preserveCalls: Array<{ flowName: string; stages: readonly { id: string; project: string }[] }> = [];
+  const code = await executeResolvedFlow(
+    resolveFlow(flowManifest, 'journey', { headed: false }),
+    {
+      api: makeApi(),
+      runner: {
+        async run(spec: ScriptInvocation): Promise<RunResult> {
+          spawnedEnvs.push(spec.env);
+          return { code: opts.playwrightCode ?? 0 };
+        },
+      },
+      appCwd: '/virtual/saga-dash/apps/web/dash',
+      now: new Date('2026-07-01T12:00:00Z'),
+      log: () => {},
+      preserveTraces: (frame) => {
+        preserveCalls.push({ flowName: frame.flowName, stages: frame.stages });
+      },
+    },
+    { lane: 'stack', skipReset: false, passthrough: [], capture: opts.capture },
+  );
+  return { code, spawnedEnvs, preserveCalls };
+}
+
+describe('playwrightEnv — capture knob', () => {
+  const resolved = resolveFlow(flowManifest, 'journey', { headed: false });
+  const now = new Date('2026-07-01T12:00:00Z');
+
+  it('injects PLAYWRIGHT_CAPTURE=all iff capture', () => {
+    expect(playwrightEnv(resolved, now, 'stack', undefined, undefined, true).PLAYWRIGHT_CAPTURE).toBe('all');
+    expect(playwrightEnv(resolved, now, 'stack')).not.toHaveProperty('PLAYWRIGHT_CAPTURE');
+    expect(playwrightEnv(resolved, now, 'stack', undefined, undefined, false)).not.toHaveProperty(
+      'PLAYWRIGHT_CAPTURE',
+    );
+  });
+});
+
+describe('executeResolvedFlow — preservation hook firing rules', () => {
+  it('--capture green: env carries the knob and the hook fires with the flow frame', async () => {
+    const { code, spawnedEnvs, preserveCalls } = await run({ capture: true });
+    expect(code).toBe(0);
+    expect(spawnedEnvs[0]?.PLAYWRIGHT_CAPTURE).toBe('all');
+    expect(preserveCalls).toHaveLength(1);
+    expect(preserveCalls[0].flowName).toBe('journey');
+    expect(preserveCalls[0].stages.map((s) => s.id)).toContain('roster');
+  });
+
+  it('green without --capture: no knob, no preservation (byte-identical default)', async () => {
+    const { code, spawnedEnvs, preserveCalls } = await run({});
+    expect(code).toBe(0);
+    expect(spawnedEnvs[0]).not.toHaveProperty('PLAYWRIGHT_CAPTURE');
+    expect(preserveCalls).toHaveLength(0);
+  });
+
+  it('RED without --capture: the failure artifacts are preserved and the code propagates', async () => {
+    const { code, preserveCalls } = await run({ playwrightCode: 7 });
+    expect(code).toBe(7);
+    expect(preserveCalls).toHaveLength(1);
+  });
+});

--- a/packages/node/saga-stack-cli/src/commands/e2e/run.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/run.ts
@@ -33,6 +33,9 @@ import { deriveInstance } from '../../core/derive-instance.js';
 import { manifest as serviceManifest } from '../../core/manifest/index.js';
 import type { Lane } from '../../core/manifest/index.js';
 import type { ScriptPlan } from '../../core/flag-map.js';
+import { reviewBlockLines, runIdFrom } from '../../core/e2e-review.js';
+import type { PreservedRunRecord } from '../../core/e2e-review.js';
+import { preserveSpawnArtifacts } from '../../runtime/index.js';
 import { makeStackApi } from '../../stack-api.js';
 import {
   buildStackContext,
@@ -54,6 +57,7 @@ export default class E2eRun extends BaseCommand {
     '<%= config.bin %> <%= command.id %> journey --through pods --dry-run',
     '<%= config.bin %> <%= command.id %> saga-dash/journey --through 2 --headless',
     '<%= config.bin %> <%= command.id %> journey --skip-reset -- --debug',
+    '<%= config.bin %> <%= command.id %> saga-dash/periods-ordering --capture --headless',
   ];
 
   // One required positional ([<spa>/]<flow>) + trailing playwright passthrough (after `--`).
@@ -126,6 +130,13 @@ export default class E2eRun extends BaseCommand {
     'dry-run': Flags.boolean({
       description: 'plan only: print the resolved flow + closure + seed plan + playwright argv + occurrence date; touch nothing',
       default: false,
+    }),
+    capture: Flags.boolean({
+      default: false,
+      description:
+        'exploratory-review capture: run Playwright with PLAYWRIGHT_CAPTURE=all (per-action trace + video on every ' +
+        'test) and PRESERVE the artifacts under <stateDir>/e2e-runs/<runId>/ (Playwright wipes test-results/ at the ' +
+        "next run's start). A FAILED stage's artifacts are preserved even without this flag. Review with `e2e traces`.",
     }),
   };
 
@@ -221,6 +232,7 @@ export default class E2eRun extends BaseCommand {
         prereqFromSnapshot: flags['prereq-from-snapshot'],
         to: flags.to,
         hold: flags.hold,
+        capture: flags.capture,
       });
       this.emit(flags, { dryRun: true, ...desc } as unknown as Record<string, unknown>, dryRunLines(desc));
       return;
@@ -274,6 +286,29 @@ export default class E2eRun extends BaseCommand {
       if (sha !== '') spaHead = { sha, dirty: (await git.statusPorcelain(spaRepoRoot)).trim() !== '' };
     }
 
+    // Exploratory-review preservation (docs/e2e-review.md): copy each spawn's
+    // artifacts out of the SPA's test-results/ (which Playwright wipes at the
+    // next run's start) into <stateDir>/e2e-runs/<runId>/…. Fires on every
+    // spawn of a --capture run and on any RED spawn regardless; the review
+    // block below prints the paste-ready show-trace lines.
+    const runsRoot = `${stateDir}/e2e-runs`;
+    const runId = runIdFrom(now);
+    const preserved: PreservedRunRecord[] = [];
+    const preserveTraces = (frame: {
+      appCwd: string;
+      spaId: string;
+      flowName: string;
+      stages: readonly { id: string; project: string }[];
+    }): void => {
+      const record = preserveSpawnArtifacts(frame, { runsRoot, runId, warn: (l) => this.warn(l) });
+      if (record.groups.length > 0) preserved.push(record);
+    };
+    const printReviewBlock = (): void => {
+      for (const record of preserved) {
+        for (const line of reviewBlockLines(record, appCwd)) this.log(line);
+      }
+    };
+
     try {
       const code = await executeResolvedFlow(
         resolved,
@@ -287,6 +322,7 @@ export default class E2eRun extends BaseCommand {
           ports: runtime.launchContext.ports,
           excluded,
           checkpoints,
+          preserveTraces,
         },
         {
           lane,
@@ -296,8 +332,10 @@ export default class E2eRun extends BaseCommand {
           fromStaleOk: flags['from-stale-ok'],
           spaHead,
           prereqFromSnapshot: flags['prereq-from-snapshot'],
+          capture: flags.capture,
         },
       );
+      printReviewBlock();
       if (code !== 0) this.exit(code);
 
       // Plan 13 --hold: the window is green and the stack stays up — hand off a
@@ -314,6 +352,10 @@ export default class E2eRun extends BaseCommand {
         });
       }
     } catch (err) {
+      // A red PREREQUISITE surfaces as FlowExecError after its spawn's
+      // artifacts were already preserved — print the review block so the
+      // reviewer gets the failure traces before the error exits.
+      printReviewBlock();
       if (err instanceof FlowExecError) this.error(err.message);
       throw err;
     }
@@ -432,6 +474,9 @@ function dryRunLines(d: ReturnType<typeof describeResolved>): string[] {
   }
   if (d.hold) {
     lines.push('hold: after green, mint the dev cookie jar + open a logged-in browser (the stack stays up)');
+  }
+  if (d.env.PLAYWRIGHT_CAPTURE === 'all') {
+    lines.push('capture: PLAYWRIGHT_CAPTURE=all (per-action trace + video; artifacts preserved under <stateDir>/e2e-runs)');
   }
   lines.push(
     `PLAYWRIGHT_OCCURRENCE_DATE: ${d.occurrenceDate}`,

--- a/packages/node/saga-stack-cli/src/commands/e2e/traces.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/traces.ts
@@ -18,7 +18,7 @@
 import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command.js';
 import { deriveInstance } from '../../core/derive-instance.js';
-import { newestTrace, tracesListingLines } from '../../core/e2e-review.js';
+import { newestReport, newestTrace, tracesListingLines } from '../../core/e2e-review.js';
 import { lookupSpa, parseFlowRef } from '../../core/flow/index.js';
 import { listPreservedRuns } from '../../runtime/index.js';
 import { resolveAppCwd } from '../../e2e-orchestrate.js';
@@ -40,7 +40,9 @@ export default class E2eTraces extends BaseCommand {
     }),
     open: Flags.boolean({
       default: false,
-      description: 'launch `playwright show-trace` on the newest preserved trace (best-effort; a headless host warns)',
+      description:
+        'open the newest preserved run: PREFERS the whole-run HTML report (`playwright show-report`) when one ' +
+        'exists, else falls back to the newest trace (`show-trace`). Best-effort; a headless host warns.',
     }),
   };
 
@@ -89,6 +91,7 @@ export default class E2eTraces extends BaseCommand {
           runId: r.runId,
           spa: r.spaId,
           flow: r.flowName,
+          reports: r.reports,
           stages: r.stages.map((s) => ({ stage: s.stageId, traces: s.traces })),
         })),
       },
@@ -96,26 +99,36 @@ export default class E2eTraces extends BaseCommand {
     );
 
     if (flags.open) {
-      const newest = newestTrace(runs);
-      if (newest === null) {
-        this.warn('--open: no preserved trace to open.');
+      // PREFER the whole-run HTML report (one browsable page: all scenarios,
+      // named steps, embedded trace links); fall back to the newest trace.
+      const report = newestReport(runs);
+      const target = report
+        ? { spaId: report.spaId, path: report.report, subcommand: 'show-report' }
+        : ((): { spaId: string; path: string; subcommand: string } | null => {
+            const t = newestTrace(runs);
+            return t ? { spaId: t.spaId, path: t.trace, subcommand: 'show-trace' } : null;
+          })();
+      if (target === null) {
+        this.warn('--open: no preserved report or trace to open.');
         return;
       }
-      const cwd = appCwdOf(newest.spaId);
+      const cwd = appCwdOf(target.spaId);
       if (cwd === null) {
-        this.warn(`--open: cannot resolve a playwright install for spa '${newest.spaId}' — open it manually.`);
+        this.warn(`--open: cannot resolve a playwright install for spa '${target.spaId}' — open it manually.`);
         return;
       }
-      this.log(`opening ${newest.trace} (close the viewer to return)…`);
+      this.log(`opening ${target.path} via ${target.subcommand} (close the viewer to return)…`);
       const { code } = await this.getRunner().run({
         cwd,
         command: 'pnpm',
-        args: ['exec', 'playwright', 'show-trace', newest.trace],
+        args: ['exec', 'playwright', target.subcommand, target.path],
         env: {},
         stdio: 'inherit',
       });
       if (code !== 0) {
-        this.warn(`--open: show-trace exited ${code} (headless host? open the trace on a machine with a display).`);
+        this.warn(
+          `--open: ${target.subcommand} exited ${code} (headless host? open it on a machine with a display).`,
+        );
       }
     }
   }

--- a/packages/node/saga-stack-cli/src/commands/e2e/traces.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/traces.ts
@@ -95,7 +95,7 @@ export default class E2eTraces extends BaseCommand {
           stages: r.stages.map((s) => ({ stage: s.stageId, traces: s.traces })),
         })),
       },
-      [`preserved e2e runs — ${runsRoot}`, ...tracesListingLines(runs, appCwdOf)],
+      [`# preserved e2e runs — ${runsRoot}`, ...tracesListingLines(runs, appCwdOf)],
     );
 
     if (flags.open) {

--- a/packages/node/saga-stack-cli/src/commands/e2e/traces.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/traces.ts
@@ -1,0 +1,122 @@
+/**
+ * `saga-stack e2e traces` — list PRESERVED e2e run artifacts (exploratory
+ * review v1, docs/e2e-review.md).
+ *
+ * `e2e run --capture` (and any failed stage) copies each Playwright spawn's
+ * artifacts out of the SPA's `test-results/` — which Playwright wipes at the
+ * next run's start — into `<stateDir>/e2e-runs/<runId>/<spa>/<flow>/<stage>/`.
+ * This command lists those preserved runs NEWEST-FIRST with a paste-ready
+ * `show-trace` line per trace, and `--open` launches the trace viewer on the
+ * newest one (best-effort: a headless host warns, never errors — the listing
+ * already printed).
+ *
+ *   node bin/dev.js e2e traces
+ *   node bin/dev.js e2e traces --flow saga-dash/periods-ordering
+ *   node bin/dev.js e2e traces --open
+ */
+
+import { Flags } from '@oclif/core';
+import { BaseCommand } from '../../base-command.js';
+import { deriveInstance } from '../../core/derive-instance.js';
+import { newestTrace, tracesListingLines } from '../../core/e2e-review.js';
+import { lookupSpa, parseFlowRef } from '../../core/flow/index.js';
+import { listPreservedRuns } from '../../runtime/index.js';
+import { resolveAppCwd } from '../../e2e-orchestrate.js';
+
+export default class E2eTraces extends BaseCommand {
+  static description =
+    'List preserved e2e run traces (from `e2e run --capture` / failed stages), newest first, with paste-ready show-trace commands.';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --flow saga-dash/periods-ordering',
+    '<%= config.bin %> <%= command.id %> --open',
+  ];
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    flow: Flags.string({
+      description: "filter to one flow ('<spa>/<flow>' or a bare '<flow>' across SPAs)",
+    }),
+    open: Flags.boolean({
+      default: false,
+      description: 'launch `playwright show-trace` on the newest preserved trace (best-effort; a headless host warns)',
+    }),
+  };
+
+  /** Preserved runs are per-slot state (`<stateDir>/e2e-runs`), so honour --slot/--set. */
+  protected slotAware(): boolean {
+    return true;
+  }
+
+  protected setAware(): boolean {
+    return true;
+  }
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(E2eTraces);
+
+    const profile = deriveInstance({ slot: flags.slot });
+    const stateDir = flags['state-dir'] ?? profile.stateDir;
+    const runsRoot = `${stateDir}/e2e-runs`;
+
+    let runs = listPreservedRuns(runsRoot);
+    if (flags.flow !== undefined) {
+      const ref = parseFlowRef(flags.flow);
+      runs = runs.filter(
+        (r) => r.flowName === ref.flowName && (ref.spaId === undefined || r.spaId === ref.spaId),
+      );
+    }
+
+    // The `cd` prefix per spa: show-trace must run where Playwright is
+    // installed (the SPA's app dir). An unknown spa id (foreign tree) prints
+    // the bare path instead — memoized so we warn once per spa at most.
+    const appCwds = new Map<string, string | null>();
+    const appCwdOf = (spaId: string): string | null => {
+      const hit = appCwds.get(spaId);
+      if (hit !== undefined) return hit;
+      const spa = lookupSpa(spaId);
+      const cwd = spa ? resolveAppCwd(spa, flags, process.env) : null;
+      appCwds.set(spaId, cwd);
+      return cwd;
+    };
+
+    this.emit(
+      flags,
+      {
+        runsRoot,
+        runs: runs.map((r) => ({
+          runId: r.runId,
+          spa: r.spaId,
+          flow: r.flowName,
+          stages: r.stages.map((s) => ({ stage: s.stageId, traces: s.traces })),
+        })),
+      },
+      [`preserved e2e runs — ${runsRoot}`, ...tracesListingLines(runs, appCwdOf)],
+    );
+
+    if (flags.open) {
+      const newest = newestTrace(runs);
+      if (newest === null) {
+        this.warn('--open: no preserved trace to open.');
+        return;
+      }
+      const cwd = appCwdOf(newest.spaId);
+      if (cwd === null) {
+        this.warn(`--open: cannot resolve a playwright install for spa '${newest.spaId}' — open it manually.`);
+        return;
+      }
+      this.log(`opening ${newest.trace} (close the viewer to return)…`);
+      const { code } = await this.getRunner().run({
+        cwd,
+        command: 'pnpm',
+        args: ['exec', 'playwright', 'show-trace', newest.trace],
+        env: {},
+        stdio: 'inherit',
+      });
+      if (code !== 0) {
+        this.warn(`--open: show-trace exited ${code} (headless host? open the trace on a machine with a display).`);
+      }
+    }
+  }
+}

--- a/packages/node/saga-stack-cli/src/core/__tests__/e2e-review.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/e2e-review.unit.test.ts
@@ -1,0 +1,161 @@
+/**
+ * `core/e2e-review` — pure helpers for the exploratory-review capture path
+ * (docs/e2e-review.md): run ids, trace-dir → stage attribution, artifact
+ * matching, and the printed review/listing blocks. No fs, no clock.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  isArtifactFile,
+  newestTrace,
+  OTHER_STAGE_BUCKET,
+  reviewBlockLines,
+  runIdFrom,
+  stageForTraceDir,
+  tracesListingLines,
+} from '../e2e-review.js';
+import type { PreservedRunRecord, PreservedRunListing } from '../e2e-review.js';
+
+describe('runIdFrom', () => {
+  it('is filesystem-safe and lexically chronological (local time, second precision)', () => {
+    expect(runIdFrom(new Date(2026, 6, 9, 14, 5, 3))).toBe('2026-07-09_14-05-03');
+    const earlier = runIdFrom(new Date(2026, 6, 9, 9, 59, 59));
+    const later = runIdFrom(new Date(2026, 6, 9, 10, 0, 0));
+    expect(earlier < later).toBe(true);
+  });
+});
+
+describe('stageForTraceDir', () => {
+  const stages = [
+    { id: 'ordering', project: 'periods-ordering' },
+    { id: 'roster', project: 'stage-1-roster' },
+  ];
+
+  it('attributes by -<project> suffix', () => {
+    expect(
+      stageForTraceDir('scheduling-periods-orderin-1cd67-riod-without-re-creating-it-periods-ordering', stages),
+    ).toBe('ordering');
+    expect(stageForTraceDir('roster-csv-upload-view-ab123-fresh-upload-stage-1-roster', stages)).toBe('roster');
+  });
+
+  it('strips a -retryN suffix before matching (retried attempts)', () => {
+    expect(stageForTraceDir('spec-ab123-title-periods-ordering-retry1', stages)).toBe('ordering');
+  });
+
+  it('prefers the LONGEST matching project (a project that suffixes another cannot steal)', () => {
+    const overlapping = [
+      { id: 'short', project: 'ordering' },
+      { id: 'long', project: 'periods-ordering' },
+    ];
+    expect(stageForTraceDir('spec-ab-title-periods-ordering', overlapping)).toBe('long');
+    expect(stageForTraceDir('spec-ab-title-ordering', overlapping)).toBe('short');
+  });
+
+  it('returns null for a project that is not a flow stage (dependency gates)', () => {
+    expect(stageForTraceDir('sandbox-composition-coherence-ab-iam-serves-stage-0-coherence', stages)).toBeNull();
+  });
+});
+
+describe('isArtifactFile', () => {
+  it('keeps traces, videos, screenshots and the error context; drops the rest', () => {
+    expect(isArtifactFile('trace.zip')).toBe(true);
+    expect(isArtifactFile('trace-1.zip')).toBe(true);
+    expect(isArtifactFile('video.webm')).toBe(true);
+    expect(isArtifactFile('test-failed-1.png')).toBe(true);
+    expect(isArtifactFile('error-context.md')).toBe(true);
+    expect(isArtifactFile('anything.txt')).toBe(false);
+  });
+});
+
+const record: PreservedRunRecord = {
+  spaId: 'saga-dash',
+  flowName: 'periods-ordering',
+  root: '/state/e2e-runs/2026-07-09_14-05-03/saga-dash/periods-ordering',
+  groups: [
+    {
+      stageId: 'ordering',
+      artifacts: [
+        { dirName: 'd1', file: 'trace.zip', absPath: '/state/…/ordering/d1/trace.zip' },
+        { dirName: 'd1', file: 'video.webm', absPath: '/state/…/ordering/d1/video.webm' },
+      ],
+    },
+    {
+      stageId: OTHER_STAGE_BUCKET,
+      artifacts: [{ dirName: 'd2', file: 'test-failed-1.png', absPath: '/state/…/_other/d2/test-failed-1.png' }],
+    },
+  ],
+};
+
+describe('reviewBlockLines', () => {
+  it('prints the preserved root + a paste-ready cd-prefixed show-trace line per trace', () => {
+    const lines = reviewBlockLines(record, '/repo/apps/web/dash');
+    expect(lines[0]).toContain('saga-dash/periods-ordering');
+    expect(lines).toContain(`   preserved: ${record.root}`);
+    expect(lines).toContain(
+      '     cd /repo/apps/web/dash && pnpm exec playwright show-trace /state/…/ordering/d1/trace.zip',
+    );
+    // A group with artifacts but no trace says so instead of printing nothing.
+    expect(lines.some((l) => l.includes('no trace.zip — screenshots/error context only'))).toBe(true);
+  });
+
+  it('caps the per-stage lines and points at the stage dir beyond the cap', () => {
+    const many: PreservedRunRecord = {
+      ...record,
+      groups: [
+        {
+          stageId: 'ordering',
+          artifacts: Array.from({ length: 10 }, (_, i) => ({
+            dirName: `d${i}`,
+            file: 'trace.zip',
+            absPath: `/state/…/ordering/d${i}/trace.zip`,
+          })),
+        },
+      ],
+    };
+    const lines = reviewBlockLines(many, '/repo');
+    expect(lines.filter((l) => l.includes('show-trace'))).toHaveLength(8);
+    expect(lines.some((l) => l.includes('… 2 more under'))).toBe(true);
+  });
+});
+
+const listing: PreservedRunListing[] = [
+  {
+    runId: '2026-07-09_15-00-00',
+    spaId: 'saga-dash',
+    flowName: 'periods-ordering',
+    stages: [{ stageId: 'ordering', traces: ['/runs/a/trace.zip'] }],
+  },
+  {
+    runId: '2026-07-09_09-00-00',
+    spaId: 'unknown-spa',
+    flowName: 'journey',
+    stages: [{ stageId: 'roster', traces: ['/runs/b/trace.zip'] }],
+  },
+];
+
+describe('tracesListingLines', () => {
+  it('says how to produce a run when none are preserved', () => {
+    expect(tracesListingLines([], () => null)[0]).toContain('--capture');
+  });
+
+  it('prints cd-prefixed lines for resolvable SPAs and a bare-path note otherwise', () => {
+    const lines = tracesListingLines(listing, (spa) => (spa === 'saga-dash' ? '/repo/apps/web/dash' : null));
+    expect(lines[0]).toContain('2026-07-09_15-00-00  saga-dash/periods-ordering  (1 trace(s))');
+    expect(lines[1]).toBe('    [ordering] cd /repo/apps/web/dash && pnpm exec playwright show-trace /runs/a/trace.zip');
+    expect(lines.some((l) => l.includes('spa repo not resolved'))).toBe(true);
+  });
+});
+
+describe('newestTrace', () => {
+  it('returns the first trace of the newest-first listing', () => {
+    expect(newestTrace(listing)).toEqual({ spaId: 'saga-dash', trace: '/runs/a/trace.zip' });
+  });
+
+  it('skips runs without traces and returns null when nothing has one', () => {
+    expect(newestTrace([{ ...listing[0], stages: [] }, listing[1]])).toEqual({
+      spaId: 'unknown-spa',
+      trace: '/runs/b/trace.zip',
+    });
+    expect(newestTrace([])).toBeNull();
+  });
+});

--- a/packages/node/saga-stack-cli/src/core/__tests__/e2e-review.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/e2e-review.unit.test.ts
@@ -89,23 +89,29 @@ const record: PreservedRunRecord = {
 };
 
 describe('reviewBlockLines', () => {
-  it('prints the preserved root + a paste-ready cd-prefixed show-trace line per trace', () => {
+  it('prints a paste-ready cd-prefixed show-trace line per trace (report line first)', () => {
     const lines = reviewBlockLines(record, '/repo/apps/web/dash');
     expect(lines[0]).toContain('saga-dash/periods-ordering');
-    expect(lines).toContain(`   preserved: ${record.root}`);
+    expect(lines).toContain(`# preserved: ${record.root}`);
     expect(lines).toContain(
-      '     cd /repo/apps/web/dash && pnpm exec playwright show-trace /state/…/ordering/d1/trace.zip',
+      'cd /repo/apps/web/dash && pnpm exec playwright show-trace /state/…/ordering/d1/trace.zip',
     );
     // The whole-run HTML report leads the block with a show-report line.
     expect(lines).toContain(
-      '     cd /repo/apps/web/dash && pnpm exec playwright show-report ' +
+      'cd /repo/apps/web/dash && pnpm exec playwright show-report ' +
         '/state/e2e-runs/2026-07-09_14-05-03/saga-dash/periods-ordering/playwright-report',
     );
     // A group with artifacts but no trace says so instead of printing nothing.
     expect(lines.some((l) => l.includes('no trace.zip — screenshots/error context only'))).toBe(true);
   });
 
-  it('caps the per-stage lines and points at the stage dir beyond the cap', () => {
+  it('every line is paste-safe: a runnable command or a # comment — never a bare path', () => {
+    for (const l of reviewBlockLines(record, '/repo/apps/web/dash')) {
+      expect(l.trim()).toMatch(/^(#|cd |ls |ss )/);
+    }
+  });
+
+  it('caps the per-stage lines and points at the stage dir beyond the cap (runnably)', () => {
     const many: PreservedRunRecord = {
       ...record,
       groups: [
@@ -121,7 +127,7 @@ describe('reviewBlockLines', () => {
     };
     const lines = reviewBlockLines(many, '/repo');
     expect(lines.filter((l) => l.includes('show-trace'))).toHaveLength(8);
-    expect(lines.some((l) => l.includes('… 2 more under'))).toBe(true);
+    expect(lines.some((l) => l.startsWith('ls ') && l.includes('# … 2 more trace(s)'))).toBe(true);
   });
 });
 
@@ -147,12 +153,14 @@ describe('tracesListingLines', () => {
     expect(tracesListingLines([], () => null)[0]).toContain('--capture');
   });
 
-  it('prints cd-prefixed lines for resolvable SPAs and a bare-path note otherwise', () => {
+  it('prints command-first lines (stage tag as a trailing comment); unresolved SPAs comment out', () => {
     const lines = tracesListingLines(listing, (spa) => (spa === 'saga-dash' ? '/repo/apps/web/dash' : null));
     expect(lines[0]).toContain('2026-07-09_15-00-00  saga-dash/periods-ordering  (1 trace(s), 1 report(s))');
-    expect(lines[1]).toBe('    [report] cd /repo/apps/web/dash && pnpm exec playwright show-report /runs/a/playwright-report');
-    expect(lines[2]).toBe('    [ordering] cd /repo/apps/web/dash && pnpm exec playwright show-trace /runs/a/trace.zip');
+    expect(lines[1]).toBe('cd /repo/apps/web/dash && pnpm exec playwright show-report /runs/a/playwright-report  # report');
+    expect(lines[2]).toBe('cd /repo/apps/web/dash && pnpm exec playwright show-trace /runs/a/trace.zip  # ordering');
     expect(lines.some((l) => l.includes('spa repo not resolved'))).toBe(true);
+    // Paste-safety: every line is a runnable command or a # comment.
+    for (const l of lines) expect(l.trim()).toMatch(/^(#|cd )/);
   });
 });
 

--- a/packages/node/saga-stack-cli/src/core/__tests__/e2e-review.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/e2e-review.unit.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   isArtifactFile,
+  newestReport,
   newestTrace,
   OTHER_STAGE_BUCKET,
   reviewBlockLines,
@@ -71,6 +72,7 @@ const record: PreservedRunRecord = {
   spaId: 'saga-dash',
   flowName: 'periods-ordering',
   root: '/state/e2e-runs/2026-07-09_14-05-03/saga-dash/periods-ordering',
+  reports: ['/state/e2e-runs/2026-07-09_14-05-03/saga-dash/periods-ordering/playwright-report'],
   groups: [
     {
       stageId: 'ordering',
@@ -93,6 +95,11 @@ describe('reviewBlockLines', () => {
     expect(lines).toContain(`   preserved: ${record.root}`);
     expect(lines).toContain(
       '     cd /repo/apps/web/dash && pnpm exec playwright show-trace /state/…/ordering/d1/trace.zip',
+    );
+    // The whole-run HTML report leads the block with a show-report line.
+    expect(lines).toContain(
+      '     cd /repo/apps/web/dash && pnpm exec playwright show-report ' +
+        '/state/e2e-runs/2026-07-09_14-05-03/saga-dash/periods-ordering/playwright-report',
     );
     // A group with artifacts but no trace says so instead of printing nothing.
     expect(lines.some((l) => l.includes('no trace.zip — screenshots/error context only'))).toBe(true);
@@ -124,12 +131,14 @@ const listing: PreservedRunListing[] = [
     spaId: 'saga-dash',
     flowName: 'periods-ordering',
     stages: [{ stageId: 'ordering', traces: ['/runs/a/trace.zip'] }],
+    reports: ['/runs/a/playwright-report'],
   },
   {
     runId: '2026-07-09_09-00-00',
     spaId: 'unknown-spa',
     flowName: 'journey',
     stages: [{ stageId: 'roster', traces: ['/runs/b/trace.zip'] }],
+    reports: [],
   },
 ];
 
@@ -140,9 +149,21 @@ describe('tracesListingLines', () => {
 
   it('prints cd-prefixed lines for resolvable SPAs and a bare-path note otherwise', () => {
     const lines = tracesListingLines(listing, (spa) => (spa === 'saga-dash' ? '/repo/apps/web/dash' : null));
-    expect(lines[0]).toContain('2026-07-09_15-00-00  saga-dash/periods-ordering  (1 trace(s))');
-    expect(lines[1]).toBe('    [ordering] cd /repo/apps/web/dash && pnpm exec playwright show-trace /runs/a/trace.zip');
+    expect(lines[0]).toContain('2026-07-09_15-00-00  saga-dash/periods-ordering  (1 trace(s), 1 report(s))');
+    expect(lines[1]).toBe('    [report] cd /repo/apps/web/dash && pnpm exec playwright show-report /runs/a/playwright-report');
+    expect(lines[2]).toBe('    [ordering] cd /repo/apps/web/dash && pnpm exec playwright show-trace /runs/a/trace.zip');
     expect(lines.some((l) => l.includes('spa repo not resolved'))).toBe(true);
+  });
+});
+
+describe('newestReport', () => {
+  it('prefers the newest run that preserved a whole-run report', () => {
+    expect(newestReport(listing)).toEqual({ spaId: 'saga-dash', report: '/runs/a/playwright-report' });
+  });
+
+  it('returns null when no run preserved one (--open falls back to show-trace)', () => {
+    expect(newestReport([listing[1]])).toBeNull();
+    expect(newestReport([])).toBeNull();
   });
 });
 

--- a/packages/node/saga-stack-cli/src/core/e2e-review.ts
+++ b/packages/node/saga-stack-cli/src/core/e2e-review.ts
@@ -1,0 +1,180 @@
+/**
+ * `e2e-review` — PURE helpers for the exploratory-review capture path
+ * (`e2e run --capture` + preserved run traces + `e2e traces`).
+ *
+ * Motivation (docs/e2e-review.md): flows set worlds up; traces explain them.
+ * Playwright WIPES `test-results/` at the start of the next run, so any trace
+ * a reviewer wanted to open is gone the moment they re-run — the observed
+ * footgun. The runtime side (`runtime/trace-preserve.ts`) copies artifacts to
+ * `<stateDir>/e2e-runs/<runId>/…` right after each Playwright spawn; this
+ * module owns the pure math: run ids, trace-dir → stage attribution, and the
+ * printed review block. Core purity rules apply: no clocks (the caller passes
+ * `now`), no fs, no env.
+ */
+
+/** A flow stage's identity as the review path needs it. */
+export interface StageRef {
+  id: string;
+  project: string;
+}
+
+/** One preserved artifact file (absolute destination path). */
+export interface PreservedArtifact {
+  /** The original Playwright test-results dir name (provenance: spec+test+project). */
+  dirName: string;
+  /** File name within the dir (trace.zip, video.webm, *.png, error-context.md). */
+  file: string;
+  /** Absolute preserved path. */
+  absPath: string;
+}
+
+/** Preserved artifacts grouped under the flow stage that produced them. */
+export interface PreservedStageGroup {
+  /** The stage id, or `_other` for projects that are not flow stages (e.g. dependency gates). */
+  stageId: string;
+  artifacts: PreservedArtifact[];
+}
+
+/** One spawn's preservation record (what the review block prints). */
+export interface PreservedRunRecord {
+  spaId: string;
+  flowName: string;
+  /** Absolute root the artifacts were preserved under (`<runsRoot>/<runId>/<spa>/<flow>`). */
+  root: string;
+  groups: PreservedStageGroup[];
+}
+
+/** Bucket id for trace dirs whose project is not one of the flow's stages. */
+export const OTHER_STAGE_BUCKET = '_other';
+
+/**
+ * A filesystem-safe, lexically-sortable run id from the command's single
+ * wall-clock read (`now = new Date()` at the command layer — core never reads
+ * the clock). Local time, second precision: `2026-07-09_14-05-33`.
+ */
+export function runIdFrom(now: Date): string {
+  const p = (n: number): string => String(n).padStart(2, '0');
+  return (
+    `${now.getFullYear()}-${p(now.getMonth() + 1)}-${p(now.getDate())}` +
+    `_${p(now.getHours())}-${p(now.getMinutes())}-${p(now.getSeconds())}`
+  );
+}
+
+/**
+ * Attribute a Playwright test-results dir to the flow stage that produced it.
+ *
+ * Playwright names result dirs `<spec-slug>-<hash>-<title-slug>-<project>`
+ * (with an optional `-retryN` AFTER the project on retried attempts). The
+ * PROJECT is the only stable stage key in the name, so we match stages by
+ * `-<project>` suffix — LONGEST project first, so a project that is a suffix
+ * of another (`ordering` vs `periods-ordering`) can never steal its dirs.
+ * Returns the stage id, or null when no stage's project matches (dependency
+ * gates like `stage-0-coherence` run in the same spawn but are not stages).
+ */
+export function stageForTraceDir(dirName: string, stages: readonly StageRef[]): string | null {
+  const base = dirName.replace(/-retry\d+$/, '');
+  const byLongestProject = [...stages].sort((a, b) => b.project.length - a.project.length);
+  for (const stage of byLongestProject) {
+    if (base === stage.project || base.endsWith(`-${stage.project}`)) return stage.id;
+  }
+  return null;
+}
+
+/**
+ * Is this file worth preserving from a test-results dir? Traces are the
+ * point; videos ride along when Playwright wrote one; failure screenshots and
+ * the error-context markdown make a red run reviewable even when retries=0
+ * left no trace.
+ */
+export function isArtifactFile(name: string): boolean {
+  return (
+    name === 'trace.zip' ||
+    name.endsWith('.webm') ||
+    name.endsWith('.png') ||
+    name === 'error-context.md' ||
+    /^trace.*\.zip$/.test(name)
+  );
+}
+
+/** How many show-trace lines the review block prints per stage before eliding. */
+const REVIEW_LINES_PER_STAGE = 8;
+
+/**
+ * The end-of-run "review this run" block: the preserved root plus one
+ * PASTE-READY `show-trace` line per preserved trace (capped per stage —
+ * beyond the cap it points at the stage dir). `show-trace` must run where
+ * Playwright is installed, so every line carries the `cd <appCwd> &&` prefix.
+ */
+export function reviewBlockLines(record: PreservedRunRecord, appCwd: string): string[] {
+  const lines: string[] = [
+    `── review this run ─ ${record.spaId}/${record.flowName}`,
+    `   preserved: ${record.root}`,
+  ];
+  for (const group of record.groups) {
+    const traces = group.artifacts.filter((a) => a.file.endsWith('.zip'));
+    const extras = group.artifacts.length - traces.length;
+    lines.push(`   stage ${group.stageId} — ${traces.length} trace(s)${extras > 0 ? ` + ${extras} other artifact(s)` : ''}:`);
+    for (const t of traces.slice(0, REVIEW_LINES_PER_STAGE)) {
+      lines.push(`     cd ${appCwd} && pnpm exec playwright show-trace ${t.absPath}`);
+    }
+    if (traces.length > REVIEW_LINES_PER_STAGE) {
+      lines.push(`     … ${traces.length - REVIEW_LINES_PER_STAGE} more under ${record.root}/${group.stageId}/`);
+    }
+    if (traces.length === 0 && group.artifacts.length > 0) {
+      lines.push(`     (no trace.zip — screenshots/error context only; see ${record.root}/${group.stageId}/)`);
+    }
+  }
+  lines.push(`   list preserved runs any time: ss e2e traces`);
+  return lines;
+}
+
+/** A preserved run as `e2e traces` lists it (scanned back off disk). */
+export interface PreservedRunListing {
+  runId: string;
+  spaId: string;
+  flowName: string;
+  /** Absolute per-stage trace paths, in stage order as found. */
+  stages: { stageId: string; traces: string[] }[];
+}
+
+/**
+ * The `e2e traces` listing lines, newest run first (run ids are lexically
+ * chronological by construction). `appCwdOf` supplies the `cd` prefix per spa
+ * (null ⇒ the spa's repo could not be resolved; the line says so once).
+ */
+export function tracesListingLines(
+  runs: readonly PreservedRunListing[],
+  appCwdOf: (spaId: string) => string | null,
+): string[] {
+  if (runs.length === 0) {
+    return ['no preserved e2e runs found — produce one with: ss e2e run <flow> --capture (or any failing run)'];
+  }
+  const lines: string[] = [];
+  for (const run of runs) {
+    const total = run.stages.reduce((n, s) => n + s.traces.length, 0);
+    lines.push(`${run.runId}  ${run.spaId}/${run.flowName}  (${total} trace(s))`);
+    const appCwd = appCwdOf(run.spaId);
+    for (const stage of run.stages) {
+      for (const t of stage.traces) {
+        lines.push(
+          appCwd === null
+            ? `    [${stage.stageId}] ${t}  (spa repo not resolved — run show-trace from a playwright install)`
+            : `    [${stage.stageId}] cd ${appCwd} && pnpm exec playwright show-trace ${t}`,
+        );
+      }
+    }
+  }
+  return lines;
+}
+
+/** The newest trace zip across a listing (what `e2e traces --open` opens). Null when none. */
+export function newestTrace(runs: readonly PreservedRunListing[]): { spaId: string; trace: string } | null {
+  // Listings arrive newest-first; take the first run that actually has a trace.
+  for (const run of runs) {
+    for (const stage of run.stages) {
+      const [first] = stage.traces;
+      if (first !== undefined) return { spaId: run.spaId, trace: first };
+    }
+  }
+  return null;
+}

--- a/packages/node/saga-stack-cli/src/core/e2e-review.ts
+++ b/packages/node/saga-stack-cli/src/core/e2e-review.ts
@@ -108,35 +108,36 @@ export function isArtifactFile(name: string): boolean {
 const REVIEW_LINES_PER_STAGE = 8;
 
 /**
- * The end-of-run "review this run" block: the preserved root plus one
- * PASTE-READY `show-trace` line per preserved trace (capped per stage —
- * beyond the cap it points at the stage dir). `show-trace` must run where
- * Playwright is installed, so every line carries the `cd <appCwd> &&` prefix.
+ * The end-of-run "review this run" block. EVERY line is paste-safe: either a
+ * COMPLETE runnable command (`cd <appCwd> && pnpm exec playwright …` —
+ * show-trace/show-report must run where Playwright is installed) or a `#`
+ * shell comment — never a bare path (pasting one earns "Permission denied",
+ * the observed reviewer papercut).
  */
 export function reviewBlockLines(record: PreservedRunRecord, appCwd: string): string[] {
   const lines: string[] = [
-    `── review this run ─ ${record.spaId}/${record.flowName}`,
-    `   preserved: ${record.root}`,
+    `# ── review this run ─ ${record.spaId}/${record.flowName}`,
+    `# preserved: ${record.root}`,
   ];
   for (const report of record.reports) {
-    lines.push(`   whole-run report (all scenarios, named steps, embedded traces):`);
-    lines.push(`     cd ${appCwd} && pnpm exec playwright show-report ${report}`);
+    lines.push(`# whole-run report (all scenarios, named steps, embedded traces):`);
+    lines.push(`cd ${appCwd} && pnpm exec playwright show-report ${report}`);
   }
   for (const group of record.groups) {
     const traces = group.artifacts.filter((a) => a.file.endsWith('.zip'));
     const extras = group.artifacts.length - traces.length;
-    lines.push(`   stage ${group.stageId} — ${traces.length} trace(s)${extras > 0 ? ` + ${extras} other artifact(s)` : ''}:`);
+    lines.push(`# stage ${group.stageId} — ${traces.length} trace(s)${extras > 0 ? ` + ${extras} other artifact(s)` : ''}:`);
     for (const t of traces.slice(0, REVIEW_LINES_PER_STAGE)) {
-      lines.push(`     cd ${appCwd} && pnpm exec playwright show-trace ${t.absPath}`);
+      lines.push(`cd ${appCwd} && pnpm exec playwright show-trace ${t.absPath}`);
     }
     if (traces.length > REVIEW_LINES_PER_STAGE) {
-      lines.push(`     … ${traces.length - REVIEW_LINES_PER_STAGE} more under ${record.root}/${group.stageId}/`);
+      lines.push(`ls ${record.root}/${group.stageId}/  # … ${traces.length - REVIEW_LINES_PER_STAGE} more trace(s)`);
     }
     if (traces.length === 0 && group.artifacts.length > 0) {
-      lines.push(`     (no trace.zip — screenshots/error context only; see ${record.root}/${group.stageId}/)`);
+      lines.push(`ls ${record.root}/${group.stageId}/  # no trace.zip — screenshots/error context only`);
     }
   }
-  lines.push(`   list preserved runs any time: ss e2e traces`);
+  lines.push(`ss e2e traces  # list preserved runs any time`);
   return lines;
 }
 
@@ -161,28 +162,30 @@ export function tracesListingLines(
   appCwdOf: (spaId: string) => string | null,
 ): string[] {
   if (runs.length === 0) {
-    return ['no preserved e2e runs found — produce one with: ss e2e run <flow> --capture (or any failing run)'];
+    return ['# no preserved e2e runs found — produce one with: ss e2e run <flow> --capture (or any failing run)'];
   }
+  // Paste-safety contract (same as the review block): every line is either a
+  // complete runnable command or a `#` comment — never a bare path.
   const lines: string[] = [];
   for (const run of runs) {
     const total = run.stages.reduce((n, s) => n + s.traces.length, 0);
     lines.push(
-      `${run.runId}  ${run.spaId}/${run.flowName}  (${total} trace(s)${run.reports.length > 0 ? `, ${run.reports.length} report(s)` : ''})`,
+      `# ${run.runId}  ${run.spaId}/${run.flowName}  (${total} trace(s)${run.reports.length > 0 ? `, ${run.reports.length} report(s)` : ''})`,
     );
     const appCwd = appCwdOf(run.spaId);
     for (const report of run.reports) {
       lines.push(
         appCwd === null
-          ? `    [report] ${report}  (spa repo not resolved — run show-report from a playwright install)`
-          : `    [report] cd ${appCwd} && pnpm exec playwright show-report ${report}`,
+          ? `# ${report}  (report; spa repo not resolved — run show-report from a playwright install)`
+          : `cd ${appCwd} && pnpm exec playwright show-report ${report}  # report`,
       );
     }
     for (const stage of run.stages) {
       for (const t of stage.traces) {
         lines.push(
           appCwd === null
-            ? `    [${stage.stageId}] ${t}  (spa repo not resolved — run show-trace from a playwright install)`
-            : `    [${stage.stageId}] cd ${appCwd} && pnpm exec playwright show-trace ${t}`,
+            ? `# ${t}  (${stage.stageId}; spa repo not resolved — run show-trace from a playwright install)`
+            : `cd ${appCwd} && pnpm exec playwright show-trace ${t}  # ${stage.stageId}`,
         );
       }
     }

--- a/packages/node/saga-stack-cli/src/core/e2e-review.ts
+++ b/packages/node/saga-stack-cli/src/core/e2e-review.ts
@@ -42,6 +42,14 @@ export interface PreservedRunRecord {
   /** Absolute root the artifacts were preserved under (`<runsRoot>/<runId>/<spa>/<flow>`). */
   root: string;
   groups: PreservedStageGroup[];
+  /**
+   * Preserved Playwright HTML report dirs (absolute) — ONE per spawn that
+   * emitted `playwright-report/` (capture runs do; see the SPA stack config's
+   * PLAYWRIGHT_CAPTURE reporter block). The default single-spawn path yields
+   * one whole-run report; the per-stage ladder yields one per stage spawn
+   * (suffixed to avoid collisions).
+   */
+  reports: string[];
 }
 
 /** Bucket id for trace dirs whose project is not one of the flow's stages. */
@@ -110,6 +118,10 @@ export function reviewBlockLines(record: PreservedRunRecord, appCwd: string): st
     `── review this run ─ ${record.spaId}/${record.flowName}`,
     `   preserved: ${record.root}`,
   ];
+  for (const report of record.reports) {
+    lines.push(`   whole-run report (all scenarios, named steps, embedded traces):`);
+    lines.push(`     cd ${appCwd} && pnpm exec playwright show-report ${report}`);
+  }
   for (const group of record.groups) {
     const traces = group.artifacts.filter((a) => a.file.endsWith('.zip'));
     const extras = group.artifacts.length - traces.length;
@@ -135,6 +147,8 @@ export interface PreservedRunListing {
   flowName: string;
   /** Absolute per-stage trace paths, in stage order as found. */
   stages: { stageId: string; traces: string[] }[];
+  /** Preserved whole-run HTML report dirs (absolute). */
+  reports: string[];
 }
 
 /**
@@ -152,8 +166,17 @@ export function tracesListingLines(
   const lines: string[] = [];
   for (const run of runs) {
     const total = run.stages.reduce((n, s) => n + s.traces.length, 0);
-    lines.push(`${run.runId}  ${run.spaId}/${run.flowName}  (${total} trace(s))`);
+    lines.push(
+      `${run.runId}  ${run.spaId}/${run.flowName}  (${total} trace(s)${run.reports.length > 0 ? `, ${run.reports.length} report(s)` : ''})`,
+    );
     const appCwd = appCwdOf(run.spaId);
+    for (const report of run.reports) {
+      lines.push(
+        appCwd === null
+          ? `    [report] ${report}  (spa repo not resolved — run show-report from a playwright install)`
+          : `    [report] cd ${appCwd} && pnpm exec playwright show-report ${report}`,
+      );
+    }
     for (const stage of run.stages) {
       for (const t of stage.traces) {
         lines.push(
@@ -167,7 +190,20 @@ export function tracesListingLines(
   return lines;
 }
 
-/** The newest trace zip across a listing (what `e2e traces --open` opens). Null when none. */
+/**
+ * The newest preserved HTML report across a listing — `e2e traces --open`
+ * PREFERS this over a single trace (one browsable page for the whole run).
+ * Null when no run preserved a report.
+ */
+export function newestReport(runs: readonly PreservedRunListing[]): { spaId: string; report: string } | null {
+  for (const run of runs) {
+    const [first] = run.reports;
+    if (first !== undefined) return { spaId: run.spaId, report: first };
+  }
+  return null;
+}
+
+/** The newest trace zip across a listing (the `--open` fallback when no report exists). Null when none. */
 export function newestTrace(runs: readonly PreservedRunListing[]): { spaId: string; trace: string } | null {
   // Listings arrive newest-first; take the first run that actually has a trace.
   for (const run of runs) {

--- a/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
+++ b/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
@@ -434,6 +434,13 @@ export function playwrightEnv(
    * `PLAYWRIGHT_*_URL` keys.
    */
   dateOverrides?: Record<string, string>,
+  /**
+   * Exploratory-review capture (`e2e run --capture`, docs/e2e-review.md):
+   * inject `PLAYWRIGHT_CAPTURE=all`, the knob the SPA's stack config already
+   * honours (per-action trace + video on EVERY test, not just retried
+   * failures). Omitted (default) ⇒ the env is byte-identical to today.
+   */
+  capture?: boolean,
 ): Record<string, string> {
   // The date env (with `flow.env` merged LAST inside `computeEnv`) comes first, so
   // a flow's own env keeps winning for the occurrence-date clamp. Then, on the
@@ -447,6 +454,7 @@ export function playwrightEnv(
     ...computeEnv(resolved.flow, now),
     ...(dateOverrides ?? {}),
     ...(lane === 'stack' && ports ? serviceUrlEnv(ports) : {}),
+    ...(capture === true ? { PLAYWRIGHT_CAPTURE: 'all' } : {}),
   };
   if (lane !== 'stack') env.PLAYWRIGHT_LANE = lane;
   return env;
@@ -513,6 +521,8 @@ export interface DescribeOptions {
    * literal-port playback-trio backends that would collide with slot 0. Empty at slot 0.
    */
   excluded?: Set<ServiceId>;
+  /** Exploratory-review capture (`--capture`) — surfaces PLAYWRIGHT_CAPTURE in the projected env. */
+  capture?: boolean;
 }
 
 /**
@@ -524,7 +534,7 @@ export interface DescribeOptions {
 export function describeResolved(resolved: ResolvedFlow, opts: DescribeOptions): ResolvedFlowDescription {
   // Computed ONCE; `env` below carries the same date keys (playwrightEnv wraps
   // computeEnv), so occurrenceDate reads from it instead of recomputing.
-  const env = playwrightEnv(resolved, opts.now, opts.lane, opts.ports);
+  const env = playwrightEnv(resolved, opts.now, opts.lane, opts.ports, undefined, opts.capture);
   const effectiveReset = resolved.reset && !opts.skipReset;
   // Drop the slot's excluded services (literal-port playback-trio backends) from the
   // closure so the dry-run matches what a `--slot N` run actually brings up. Empty
@@ -577,9 +587,10 @@ export function describeResolved(resolved: ResolvedFlow, opts: DescribeOptions):
           ...opts,
           passthrough: [],
           skipReset: false,
-          // --to/--hold apply to the MAIN flow only, never the prerequisite build.
+          // --to/--hold/--capture apply to the MAIN flow only, never the prerequisite build.
           to: undefined,
           hold: false,
+          capture: undefined,
         })
       : null,
     checkpoint: resolved.checkpoint
@@ -663,6 +674,23 @@ export interface ExecDeps {
    * (the second caller, `e2e connect`, never sets it).
    */
   checkpoints?: CheckpointStore;
+  /**
+   * Exploratory-review preservation hook (docs/e2e-review.md): called after
+   * EVERY Playwright spawn that warrants preservation — every spawn of a
+   * `--capture` run, and any RED spawn regardless (whatever artifacts exist:
+   * retry traces, failure screenshots, error context). Playwright wipes
+   * test-results/ at the next run's start, so this must fire per spawn (the
+   * per-stage ladder and a prerequisite's replay each wipe the previous
+   * spawn's artifacts). Rides down the prerequisite recursion via `deps`, so
+   * a red prerequisite replay is preserved too. Absent ⇒ no preservation
+   * (the second caller, `e2e connect`, never sets it).
+   */
+  preserveTraces?: (frame: {
+    appCwd: string;
+    spaId: string;
+    flowName: string;
+    stages: readonly { id: string; project: string }[];
+  }) => void | Promise<void>;
 }
 
 /** Per-run knobs. */
@@ -693,6 +721,14 @@ export interface ExecOptions {
    * true at the command layer (`--no-prereq-from-snapshot` opts out).
    */
   prereqFromSnapshot?: boolean;
+  /**
+   * Exploratory-review capture (`--capture`): inject `PLAYWRIGHT_CAPTURE=all`
+   * into the Playwright child and preserve EVERY spawn's artifacts (not just
+   * red ones). Kept in OPTIONS so the prerequisite recursion (which rebuilds
+   * opts) never inherits it — a prerequisite is a build step, not the thing
+   * under review; its red spawns are still preserved via the deps hook.
+   */
+  capture?: boolean;
 }
 
 /**
@@ -898,7 +934,7 @@ export async function executeResolvedFlow(
         [ENV_TERM_END]: restoredDates.termEnd,
       }
     : undefined;
-  const env = playwrightEnv(resolved, deps.now, opts.lane, deps.ports, dateOverrides);
+  const env = playwrightEnv(resolved, deps.now, opts.lane, deps.ports, dateOverrides, opts.capture);
 
   const spawn = async (stage?: { project: string; noDeps: boolean }): Promise<number> => {
     const argv = playwrightArgv(resolved, opts.passthrough, stage);
@@ -913,12 +949,31 @@ export async function executeResolvedFlow(
     return code;
   };
 
+  // Exploratory-review preservation (docs/e2e-review.md): after EVERY spawn a
+  // --capture run made, and after any RED spawn regardless (the failure
+  // artifacts Playwright would wipe at the next run's start). Must run per
+  // spawn — the per-stage ladder and any later spawn wipe test-results/.
+  const preserveAfter = async (code: number): Promise<void> => {
+    if (deps.preserveTraces === undefined) return;
+    if (opts.capture !== true && code === 0) return;
+    await deps.preserveTraces({
+      appCwd: deps.appCwd,
+      spaId: resolved.spa.id,
+      flowName: resolved.flow.name,
+      stages: resolved.stages.map((s) => ({ id: s.id, project: s.project })),
+    });
+  };
+
   // Default path: ONE spawn with the terminal project — Playwright's config-side
   // dependency chain replays 1..N (byte-identical to pre-M14). The per-stage
   // ladder exists ONLY for M14: baking needs a checkpoint between stages, and a
   // --from window must NOT let the dependency chain replay the restored prefix.
   const perStage = opts.snapshotStages === true || resolved.checkpoint !== undefined;
-  if (!perStage) return spawn();
+  if (!perStage) {
+    const code = await spawn();
+    await preserveAfter(code);
+    return code;
+  }
 
   if (opts.snapshotStages === true && deps.checkpoints === undefined) {
     throw new FlowExecError('--snapshot-stages requires the checkpoint store (internal wiring error)');
@@ -931,6 +986,7 @@ export async function executeResolvedFlow(
     // chain (--no-deps) so earlier stages are never replayed.
     const isFlowFirst = resolved.flow.stages[0]?.id === stage.id;
     const code = await spawn({ project: stage.project, noDeps: !isFlowFirst });
+    await preserveAfter(code);
     if (code !== 0) {
       // No checkpoint for a red stage — and stop the ladder (later checkpoints
       // would capture state the failed stage never produced).

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/trace-preserve.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/trace-preserve.unit.test.ts
@@ -1,0 +1,114 @@
+/**
+ * `runtime/trace-preserve` — copy Playwright artifacts out of the wiped-on-
+ * next-run `test-results/` into the durable `<runsRoot>/<runId>/…` tree, and
+ * scan that tree back for `e2e traces`. All fs through the injected seam —
+ * no disk.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { preserveSpawnArtifacts, listPreservedRuns } from '../trace-preserve.js';
+import type { PreserveFs } from '../trace-preserve.js';
+
+/** An in-memory PreserveFs over a `{dir: files[]}` map + copy log. */
+function fakeFs(tree: Record<string, string[]>): { fs: PreserveFs; copies: Array<[string, string]>; mkdirs: string[] } {
+  const copies: Array<[string, string]> = [];
+  const mkdirs: string[] = [];
+  const dirs = new Set(Object.keys(tree));
+  const fs: PreserveFs = {
+    existsDir: (p) => dirs.has(p) || [...dirs].some((d) => d.startsWith(`${p}/`)),
+    listDirs: (dir) =>
+      [...new Set(
+        [...dirs]
+          .filter((d) => d.startsWith(`${dir}/`))
+          .map((d) => d.slice(dir.length + 1).split('/')[0]),
+      )].sort(),
+    listFiles: (dir) => (tree[dir] ?? []).sort(),
+    mkdirp: (dir) => mkdirs.push(dir),
+    copy: (src, dest) => {
+      if (src.includes('unreadable')) throw new Error('EACCES');
+      copies.push([src, dest]);
+    },
+  };
+  return { fs, copies, mkdirs };
+}
+
+const FRAME = {
+  appCwd: '/repo/apps/web/dash',
+  spaId: 'saga-dash',
+  flowName: 'periods-ordering',
+  stages: [{ id: 'ordering', project: 'periods-ordering' }],
+};
+
+describe('preserveSpawnArtifacts', () => {
+  it('copies artifact files into <runsRoot>/<runId>/<spa>/<flow>/<stage>/<dir>/ and groups by stage', () => {
+    const { fs, copies } = fakeFs({
+      '/repo/apps/web/dash/test-results/spec-ab-title-periods-ordering': ['trace.zip', 'video.webm', 'noise.txt'],
+      '/repo/apps/web/dash/test-results/coherence-cd-x-stage-0-coherence': ['trace.zip'],
+    });
+    const record = preserveSpawnArtifacts(FRAME, { runsRoot: '/state/e2e-runs', runId: 'r1', fs });
+
+    expect(record.root).toBe('/state/e2e-runs/r1/saga-dash/periods-ordering');
+    expect(record.groups.map((g) => g.stageId)).toEqual(['ordering', '_other']);
+    const ordering = record.groups[0];
+    expect(ordering.artifacts.map((a) => a.file).sort()).toEqual(['trace.zip', 'video.webm']);
+    expect(ordering.artifacts[0].absPath).toBe(
+      '/state/e2e-runs/r1/saga-dash/periods-ordering/ordering/spec-ab-title-periods-ordering/trace.zip',
+    );
+    // noise.txt never copied; the coherence gate lands in _other.
+    expect(copies.some(([src]) => src.endsWith('noise.txt'))).toBe(false);
+    expect(copies.some(([, dest]) => dest.includes('/_other/'))).toBe(true);
+  });
+
+  it('returns empty groups when test-results is missing or artifact-free (green non-capture run)', () => {
+    const missing = preserveSpawnArtifacts(FRAME, { runsRoot: '/s', runId: 'r', fs: fakeFs({}).fs });
+    expect(missing.groups).toEqual([]);
+    const empty = preserveSpawnArtifacts(FRAME, {
+      runsRoot: '/s',
+      runId: 'r',
+      fs: fakeFs({ '/repo/apps/web/dash/test-results/spec-x-periods-ordering': ['noise.txt'] }).fs,
+    });
+    expect(empty.groups).toEqual([]);
+  });
+
+  it('is best-effort per file: an unreadable file warns and the rest survive', () => {
+    const { fs } = fakeFs({
+      '/repo/apps/web/dash/test-results/unreadable-spec-periods-ordering': ['trace.zip'],
+      '/repo/apps/web/dash/test-results/spec-ok-periods-ordering': ['trace.zip'],
+    });
+    const warnings: string[] = [];
+    const record = preserveSpawnArtifacts(FRAME, {
+      runsRoot: '/s',
+      runId: 'r',
+      fs,
+      warn: (l) => warnings.push(l),
+    });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('could not copy');
+    const all = record.groups.flatMap((g) => g.artifacts);
+    expect(all).toHaveLength(1);
+    expect(all[0].dirName).toBe('spec-ok-periods-ordering');
+  });
+});
+
+describe('listPreservedRuns', () => {
+  it('scans the tree back newest-first and keeps only trace zips', () => {
+    const { fs } = fakeFs({
+      '/state/e2e-runs/2026-07-09_09-00-00/saga-dash/journey/roster/d1': ['trace.zip', 'video.webm'],
+      '/state/e2e-runs/2026-07-09_15-00-00/saga-dash/periods-ordering/ordering/d2': ['trace.zip'],
+    });
+    const runs = listPreservedRuns('/state/e2e-runs', fs);
+    expect(runs.map((r) => r.runId)).toEqual(['2026-07-09_15-00-00', '2026-07-09_09-00-00']);
+    expect(runs[0].stages).toEqual([
+      {
+        stageId: 'ordering',
+        traces: ['/state/e2e-runs/2026-07-09_15-00-00/saga-dash/periods-ordering/ordering/d2/trace.zip'],
+      },
+    ]);
+    expect(runs[1].spaId).toBe('saga-dash');
+    expect(runs[1].stages[0].traces.every((t) => t.endsWith('.zip'))).toBe(true);
+  });
+
+  it('reads an empty/missing root as no runs', () => {
+    expect(listPreservedRuns('/nowhere', fakeFs({}).fs)).toEqual([]);
+  });
+});

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/trace-preserve.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/trace-preserve.unit.test.ts
@@ -10,8 +10,14 @@ import { preserveSpawnArtifacts, listPreservedRuns } from '../trace-preserve.js'
 import type { PreserveFs } from '../trace-preserve.js';
 
 /** An in-memory PreserveFs over a `{dir: files[]}` map + copy log. */
-function fakeFs(tree: Record<string, string[]>): { fs: PreserveFs; copies: Array<[string, string]>; mkdirs: string[] } {
+function fakeFs(tree: Record<string, string[]>): {
+  fs: PreserveFs;
+  copies: Array<[string, string]>;
+  dirCopies: Array<[string, string]>;
+  mkdirs: string[];
+} {
   const copies: Array<[string, string]> = [];
+  const dirCopies: Array<[string, string]> = [];
   const mkdirs: string[] = [];
   const dirs = new Set(Object.keys(tree));
   const fs: PreserveFs = {
@@ -28,8 +34,9 @@ function fakeFs(tree: Record<string, string[]>): { fs: PreserveFs; copies: Array
       if (src.includes('unreadable')) throw new Error('EACCES');
       copies.push([src, dest]);
     },
+    copyDir: (src, dest) => dirCopies.push([src, dest]),
   };
-  return { fs, copies, mkdirs };
+  return { fs, copies, dirCopies, mkdirs };
 }
 
 const FRAME = {
@@ -57,6 +64,22 @@ describe('preserveSpawnArtifacts', () => {
     // noise.txt never copied; the coherence gate lands in _other.
     expect(copies.some(([src]) => src.endsWith('noise.txt'))).toBe(false);
     expect(copies.some(([, dest]) => dest.includes('/_other/'))).toBe(true);
+    // no playwright-report/ in this tree -> no report preserved.
+    expect(record.reports).toEqual([]);
+  });
+
+  it('preserves the whole-run HTML report beside the stage dirs (suffixing on collision)', () => {
+    const { fs, dirCopies } = fakeFs({
+      '/repo/apps/web/dash/playwright-report': ['index.html'],
+      '/repo/apps/web/dash/playwright-report/data': ['a.zip'],
+      // a previous spawn of the same run already preserved one:
+      '/state/e2e-runs/r1/saga-dash/periods-ordering/playwright-report': ['index.html'],
+    });
+    const record = preserveSpawnArtifacts(FRAME, { runsRoot: '/state/e2e-runs', runId: 'r1', fs });
+    expect(record.reports).toEqual(['/state/e2e-runs/r1/saga-dash/periods-ordering/playwright-report-2']);
+    expect(dirCopies).toEqual([
+      ['/repo/apps/web/dash/playwright-report', '/state/e2e-runs/r1/saga-dash/periods-ordering/playwright-report-2'],
+    ]);
   });
 
   it('returns empty groups when test-results is missing or artifact-free (green non-capture run)', () => {
@@ -91,10 +114,11 @@ describe('preserveSpawnArtifacts', () => {
 });
 
 describe('listPreservedRuns', () => {
-  it('scans the tree back newest-first and keeps only trace zips', () => {
+  it('scans the tree back newest-first, keeping trace zips and whole-run reports', () => {
     const { fs } = fakeFs({
       '/state/e2e-runs/2026-07-09_09-00-00/saga-dash/journey/roster/d1': ['trace.zip', 'video.webm'],
       '/state/e2e-runs/2026-07-09_15-00-00/saga-dash/periods-ordering/ordering/d2': ['trace.zip'],
+      '/state/e2e-runs/2026-07-09_15-00-00/saga-dash/periods-ordering/playwright-report': ['index.html'],
     });
     const runs = listPreservedRuns('/state/e2e-runs', fs);
     expect(runs.map((r) => r.runId)).toEqual(['2026-07-09_15-00-00', '2026-07-09_09-00-00']);
@@ -104,7 +128,11 @@ describe('listPreservedRuns', () => {
         traces: ['/state/e2e-runs/2026-07-09_15-00-00/saga-dash/periods-ordering/ordering/d2/trace.zip'],
       },
     ]);
+    expect(runs[0].reports).toEqual([
+      '/state/e2e-runs/2026-07-09_15-00-00/saga-dash/periods-ordering/playwright-report',
+    ]);
     expect(runs[1].spaId).toBe('saga-dash');
+    expect(runs[1].reports).toEqual([]);
     expect(runs[1].stages[0].traces.every((t) => t.endsWith('.zip'))).toBe(true);
   });
 

--- a/packages/node/saga-stack-cli/src/runtime/index.ts
+++ b/packages/node/saga-stack-cli/src/runtime/index.ts
@@ -49,3 +49,4 @@ export * from './slot-active.js';
 export * from './set-check.js';
 export * from './lock.js';
 export * from './checkpoint-store.js';
+export * from './trace-preserve.js';

--- a/packages/node/saga-stack-cli/src/runtime/trace-preserve.ts
+++ b/packages/node/saga-stack-cli/src/runtime/trace-preserve.ts
@@ -12,7 +12,7 @@
  * `DashFs`).
  */
 
-import { copyFileSync, existsSync, mkdirSync, readdirSync } from 'node:fs';
+import { copyFileSync, cpSync, existsSync, mkdirSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import {
   isArtifactFile,
@@ -35,6 +35,8 @@ export interface PreserveFs {
   listFiles(dir: string): string[];
   mkdirp(dir: string): void;
   copy(src: string, dest: string): void;
+  /** Recursive directory copy (the HTML report dir). */
+  copyDir(src: string, dest: string): void;
 }
 
 /** The production fs seam. */
@@ -55,6 +57,7 @@ export function makeRealPreserveFs(): PreserveFs {
     listFiles: (dir) => entries(dir, false),
     mkdirp: (dir) => mkdirSync(dir, { recursive: true }),
     copy: (src, dest) => copyFileSync(src, dest),
+    copyDir: (src, dest) => cpSync(src, dest, { recursive: true }),
   };
 }
 
@@ -82,7 +85,30 @@ export function preserveSpawnArtifacts(
   const warn = ctx.warn ?? ((): void => {});
   const resultsDir = join(frame.appCwd, 'test-results');
   const root = join(ctx.runsRoot, ctx.runId, frame.spaId, frame.flowName);
-  const record: PreservedRunRecord = { spaId: frame.spaId, flowName: frame.flowName, root, groups: [] };
+  const record: PreservedRunRecord = {
+    spaId: frame.spaId,
+    flowName: frame.flowName,
+    root,
+    groups: [],
+    reports: [],
+  };
+
+  // The whole-run HTML report (capture runs emit playwright-report/ — see the
+  // SPA stack config's PLAYWRIGHT_CAPTURE reporter block). ONE per spawn; the
+  // per-stage ladder's later spawns get a numeric suffix instead of clobbering.
+  const reportSrc = join(frame.appCwd, 'playwright-report');
+  if (fs.listFiles(reportSrc).includes('index.html')) {
+    let reportDest = join(root, 'playwright-report');
+    for (let n = 2; fs.existsDir(reportDest); n++) reportDest = join(root, `playwright-report-${n}`);
+    try {
+      fs.mkdirp(root);
+      fs.copyDir(reportSrc, reportDest);
+      record.reports.push(reportDest);
+    } catch (err) {
+      warn(`⚠ trace-preserve: could not copy the HTML report: ${(err as Error).message}`);
+    }
+  }
+
   if (!fs.existsDir(resultsDir)) return record;
 
   const byStage = new Map<string, PreservedStageGroup>();
@@ -125,16 +151,24 @@ export function listPreservedRuns(runsRoot: string, fs: PreserveFs = makeRealPre
       for (const flowName of fs.listDirs(join(runsRoot, runId, spaId))) {
         const flowDir = join(runsRoot, runId, spaId, flowName);
         const stages: PreservedRunListing['stages'] = [];
-        for (const stageId of fs.listDirs(flowDir)) {
+        const reports: string[] = [];
+        for (const entry of fs.listDirs(flowDir)) {
+          // Whole-run HTML reports live beside the stage dirs.
+          if (entry.startsWith('playwright-report')) {
+            if (fs.listFiles(join(flowDir, entry)).includes('index.html')) {
+              reports.push(join(flowDir, entry));
+            }
+            continue;
+          }
           const traces: string[] = [];
-          for (const dirName of fs.listDirs(join(flowDir, stageId))) {
-            for (const file of fs.listFiles(join(flowDir, stageId, dirName))) {
-              if (file.endsWith('.zip')) traces.push(join(flowDir, stageId, dirName, file));
+          for (const dirName of fs.listDirs(join(flowDir, entry))) {
+            for (const file of fs.listFiles(join(flowDir, entry, dirName))) {
+              if (file.endsWith('.zip')) traces.push(join(flowDir, entry, dirName, file));
             }
           }
-          if (traces.length > 0) stages.push({ stageId, traces });
+          if (traces.length > 0) stages.push({ stageId: entry, traces });
         }
-        runs.push({ runId, spaId, flowName, stages });
+        runs.push({ runId, spaId, flowName, stages, reports });
       }
     }
   }

--- a/packages/node/saga-stack-cli/src/runtime/trace-preserve.ts
+++ b/packages/node/saga-stack-cli/src/runtime/trace-preserve.ts
@@ -1,0 +1,142 @@
+/**
+ * `trace-preserve` — the IO side of the exploratory-review capture path
+ * (docs/e2e-review.md): copy a Playwright spawn's artifacts OUT of the SPA's
+ * `test-results/` (which Playwright wipes at the next run's start — the
+ * observed footgun) into the durable per-run tree
+ *
+ *   <runsRoot>/<runId>/<spaId>/<flowName>/<stageId>/<original-dir-name>/<file>
+ *
+ * The pure math (run ids, dir→stage attribution, review-block lines) lives in
+ * `core/e2e-review.ts`; this module only walks + copies through an injectable
+ * fs seam so unit tests never touch the disk (house pattern: dash-defaults'
+ * `DashFs`).
+ */
+
+import { copyFileSync, existsSync, mkdirSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  isArtifactFile,
+  OTHER_STAGE_BUCKET,
+  stageForTraceDir,
+} from '../core/e2e-review.js';
+import type {
+  PreservedRunRecord,
+  PreservedRunListing,
+  PreservedStageGroup,
+  StageRef,
+} from '../core/e2e-review.js';
+
+/** Injectable fs surface (defaulted to real `node:fs`). */
+export interface PreserveFs {
+  existsDir(path: string): boolean;
+  /** Immediate subdirectory NAMES of `dir` ([] when missing/unreadable). */
+  listDirs(dir: string): string[];
+  /** Immediate file NAMES of `dir` ([] when missing/unreadable). */
+  listFiles(dir: string): string[];
+  mkdirp(dir: string): void;
+  copy(src: string, dest: string): void;
+}
+
+/** The production fs seam. */
+export function makeRealPreserveFs(): PreserveFs {
+  const entries = (dir: string, wantDir: boolean): string[] => {
+    try {
+      return readdirSync(dir, { withFileTypes: true })
+        .filter((e) => (wantDir ? e.isDirectory() : e.isFile()))
+        .map((e) => e.name)
+        .sort();
+    } catch {
+      return [];
+    }
+  };
+  return {
+    existsDir: (p) => existsSync(p),
+    listDirs: (dir) => entries(dir, true),
+    listFiles: (dir) => entries(dir, false),
+    mkdirp: (dir) => mkdirSync(dir, { recursive: true }),
+    copy: (src, dest) => copyFileSync(src, dest),
+  };
+}
+
+/** What the executor tells the preserver about a finished Playwright spawn. */
+export interface PreserveFrame {
+  /** The SPA app dir the spawn ran in (test-results lives under it). */
+  appCwd: string;
+  spaId: string;
+  flowName: string;
+  /** The flow's stages (for dir→stage attribution). */
+  stages: readonly StageRef[];
+}
+
+/**
+ * Copy the spawn's artifacts out of `<appCwd>/test-results/` into the run
+ * tree. Returns the preservation record (empty `groups` when nothing was
+ * found — e.g. a green run without --capture and without retries). Copies are
+ * best-effort per file: one unreadable file must not lose the rest.
+ */
+export function preserveSpawnArtifacts(
+  frame: PreserveFrame,
+  ctx: { runsRoot: string; runId: string; fs?: PreserveFs; warn?: (line: string) => void },
+): PreservedRunRecord {
+  const fs = ctx.fs ?? makeRealPreserveFs();
+  const warn = ctx.warn ?? ((): void => {});
+  const resultsDir = join(frame.appCwd, 'test-results');
+  const root = join(ctx.runsRoot, ctx.runId, frame.spaId, frame.flowName);
+  const record: PreservedRunRecord = { spaId: frame.spaId, flowName: frame.flowName, root, groups: [] };
+  if (!fs.existsDir(resultsDir)) return record;
+
+  const byStage = new Map<string, PreservedStageGroup>();
+  for (const dirName of fs.listDirs(resultsDir)) {
+    const files = fs.listFiles(join(resultsDir, dirName)).filter(isArtifactFile);
+    if (files.length === 0) continue;
+    const stageId = stageForTraceDir(dirName, frame.stages) ?? OTHER_STAGE_BUCKET;
+    const group = byStage.get(stageId) ?? { stageId, artifacts: [] };
+    byStage.set(stageId, group);
+    const destDir = join(root, stageId, dirName);
+    fs.mkdirp(destDir);
+    for (const file of files) {
+      const absPath = join(destDir, file);
+      try {
+        fs.copy(join(resultsDir, dirName, file), absPath);
+        group.artifacts.push({ dirName, file, absPath });
+      } catch (err) {
+        warn(`⚠ trace-preserve: could not copy ${dirName}/${file}: ${(err as Error).message}`);
+      }
+    }
+  }
+
+  // Stage order follows the flow's stage order; the _other bucket sorts last.
+  const order = new Map(frame.stages.map((s, i) => [s.id, i]));
+  record.groups = [...byStage.values()].sort(
+    (a, b) => (order.get(a.stageId) ?? Number.MAX_SAFE_INTEGER) - (order.get(b.stageId) ?? Number.MAX_SAFE_INTEGER),
+  );
+  return record;
+}
+
+/**
+ * Scan the preserved-run tree back off disk for `e2e traces`, NEWEST run
+ * first (run ids are lexically chronological). Tolerates foreign files at any
+ * level (they are simply skipped — the tree is user-visible scratch space).
+ */
+export function listPreservedRuns(runsRoot: string, fs: PreserveFs = makeRealPreserveFs()): PreservedRunListing[] {
+  const runs: PreservedRunListing[] = [];
+  for (const runId of [...fs.listDirs(runsRoot)].sort().reverse()) {
+    for (const spaId of fs.listDirs(join(runsRoot, runId))) {
+      for (const flowName of fs.listDirs(join(runsRoot, runId, spaId))) {
+        const flowDir = join(runsRoot, runId, spaId, flowName);
+        const stages: PreservedRunListing['stages'] = [];
+        for (const stageId of fs.listDirs(flowDir)) {
+          const traces: string[] = [];
+          for (const dirName of fs.listDirs(join(flowDir, stageId))) {
+            for (const file of fs.listFiles(join(flowDir, stageId, dirName))) {
+              if (file.endsWith('.zip')) traces.push(join(flowDir, stageId, dirName, file));
+            }
+          }
+          if (traces.length > 0) stages.push({ stageId, traces });
+        }
+        runs.push({ runId, spaId, flowName, stages });
+      }
+    }
+  }
+  return runs;
+}


### PR DESCRIPTION
## Proposal (and what shipped)

> "I want to confirm the flow tests what it claims — run it headed, or walk me through it step by step with something I can look at." — Nathan, reviewing saga-dash#426 (periods-ordering), 2026-07-09

Two beliefs from the exploratory-testing practice: **flows set worlds up; traces explain them** — a reviewer needs the per-action film strip, not the assertion list; and **artifacts must survive the next run** — Playwright wipes `test-results/` at run start, so Nathan's own review runs deleted the traces he meant to open. Full proposal/doc: [`docs/e2e-review.md`](https://github.com/saga-ed/soa/blob/feat/e2e-capture-review/packages/node/saga-stack-cli/docs/e2e-review.md).

### Shipped (v1)

- **`ss e2e run <flow> --capture`** — injects `PLAYWRIGHT_CAPTURE=all` into the Playwright child (the knob SPA stack configs already honour: per-action trace + video per test). Prerequisite builds never inherit it.
- **Artifact preservation** — after every spawn of a `--capture` run, and after any RED spawn regardless, `trace.zip`/videos/failure screenshots/`error-context.md` are copied to `<stateDir>/e2e-runs/<runId>/<spa>/<flow>/<stage>/` (per spawn — the per-stage ladder and prerequisite replays each wipe `test-results/`). Stage attribution by the result-dir's `-<project>` suffix, longest-first, `-retryN` stripped; non-stage projects land in `_other`.
- **End-of-run review block** — paste-ready `cd <appDir> && pnpm exec playwright show-trace <preserved zip>` per trace, printed win or lose (including red prerequisites).
- **Whole-run HTML report (v1.1, per Nathan's review)** — capture runs emit Playwright's html+json reporters locally (SPA config change rides saga-dash#426); the report dir is preserved beside the stage dirs and the review block leads with its paste-ready `show-report` line — ONE browsable page per run: every scenario, its named `test.step` phases, embedded trace links.
- **`ss e2e traces [--flow <spa>/<flow>] [--open]`** — preserved runs newest-first, reports listed first; `--open` PREFERS the newest whole-run report (`show-report`), falling back to `show-trace`. Best-effort (headless-safe warn). Slot-aware.

### Deferred (in the doc)

Milestone capture profile (awaits `test.step` density across flows) · preserving `results.json` · retention/pruning · chasing video-on-green reliability (the trace film strip covers it). (The HTML-report variant moved from deferred to SHIPPED in v1.1.)

### Verification

- `pnpm test` — **92 files, 1114 passed** (+3 new test files: core review math, trace-preserve fs seam, orchestrator capture wiring; report preservation covered in all three layers).
- `pnpm check-types` / `pnpm lint` clean (0 errors); `pnpm build` regenerated the oclif manifest.
- Dogfooded on saga-dash/periods-ordering (saga-dash#426): capture runs green with preserved traces + review block; `test.step()` adopted in that flow so the film strip reads as named narrative steps. v1.1 proof: the preserved whole-run report decoded to all 7 scenarios (`expected`) with 13 named step blocks, and `show-report <preserved dir>` serves it (HTTP 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
