### PR TITLE
feat(saga-stack-cli): flag/reap foreign processes on stack ports

### DIFF
--- a/packages/node/saga-stack-cli/src/base-command.ts
+++ b/packages/node/saga-stack-cli/src/base-command.ts
@@ -80,6 +80,7 @@ import {
   makeRealDockerWipe,
   makeRealBuildCleaner,
   makeRealEnvFs,
+  makeRealForeignProcs,
   generateTunnelFleetConfig,
   generateSlotFleetConfig,
   resolveRepoRoot,
@@ -115,6 +116,7 @@ import type {
   DockerWipe,
   BuildCleaner,
   EnvFs,
+  ForeignProcs,
 } from './runtime/index.js';
 
 /**
@@ -420,6 +422,17 @@ export abstract class BaseCommand extends Command {
    */
   protected getPortProbe(): PortProbe {
     return makeRealPortProbe();
+  }
+
+  /**
+   * The foreign-process seam (saga-ed/soa#foreign-guardrail) — production is the
+   * only place `lsof`/`ss`/`ps` run to answer "is this stack port held by a
+   * process ss did NOT launch?" (ownership by pgid vs the slot's pidfiles), plus
+   * the group-SIGKILL to reap one. `stack verify` uses `find` (warn-only); `stack
+   * cold-start` uses `find` + `reap`. See `runtime/foreign-procs`.
+   */
+  protected getForeignProcs(): ForeignProcs {
+    return makeRealForeignProcs();
   }
 
   /**

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/status-verify.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/status-verify.int.test.ts
@@ -22,6 +22,7 @@ import { deriveInstance } from '../../../core/derive-instance.js';
 import { manifest } from '../../../core/manifest/index.js';
 import type { HealthProber, ProbeResult } from '../../../runtime/health.js';
 import type {
+  ForeignProcs,
   GhRunner,
   GitRunner,
   MeshExec,
@@ -31,6 +32,7 @@ import type {
   ScriptInvocation,
   SlotActiveProbe,
 } from '../../../runtime/index.js';
+import type { ForeignProc } from '../../../core/foreign-procs.js';
 import StackStatus from '../status.js';
 import StackVerify from '../verify.js';
 
@@ -61,6 +63,26 @@ function installProber(downUrls: string[] = []): void {
   vi.spyOn(
     BaseCommand.prototype as unknown as { getProber: () => HealthProber },
     'getProber',
+  ).mockReturnValue(fake);
+}
+
+/**
+ * Fake the foreign-process seam. `find` returns the canned findings; `reap` is
+ * never expected on the verify path (warn-only). Defaults to none, so the real
+ * lsof/ss/ps never run in a unit test.
+ */
+function installForeign(findings: ForeignProc[] = []): void {
+  const fake: ForeignProcs = {
+    async find() {
+      return findings;
+    },
+    async reap(f) {
+      return f.map((x) => ({ ...x, killed: true }));
+    },
+  };
+  vi.spyOn(
+    BaseCommand.prototype as unknown as { getForeignProcs: () => ForeignProcs },
+    'getForeignProcs',
   ).mockReturnValue(fake);
 }
 
@@ -149,6 +171,7 @@ beforeEach(async () => {
   config = await Config.load(PKG_ROOT);
   installProber();
   installRunner(0);
+  installForeign(); // default: no foreign processes (real lsof/ps never runs in tests)
   // The fake workspace paths (--dev /fixed/dev) don't exist on disk; default the
   // repo-dir check to "present" so every service is probed. The not-cloned path is
   // covered explicitly below.
@@ -290,6 +313,50 @@ describe('stack verify — native health gate', () => {
   it('--with coach: a service outside the bundle closure being down does NOT fail', async () => {
     installProber([DASH_URL, CONTENT_URL]); // both outside the coach closure
     await expect(StackVerify.run(['--with', 'coach', ...WS], config)).resolves.toBeUndefined();
+  });
+});
+
+describe('stack verify — FOREIGN process flag (warn-only, never flips the gate)', () => {
+  const FOREIGN_IAM: ForeignProc = {
+    id: 'iam-api',
+    port: 3010,
+    pid: 3537029,
+    pgid: 576078,
+    command: 'node dist/main.js',
+  };
+
+  it('all services up + a foreign holder → still PASSES, with a ⚠ FOREIGN line', async () => {
+    installForeign([FOREIGN_IAM]); // iam-api :3010 held by a non-ss process
+    await expect(StackVerify.run([...WS], config)).resolves.toBeUndefined(); // warn-only ⇒ no exit(1)
+    const text = out.join('\n');
+    expect(text).toContain('FOREIGN');
+    expect(text).toContain('iam-api');
+    expect(text).toContain('cold-start'); // the remediation hint
+  });
+
+  it('porcelain emits `<id>=foreign` and keeps passed=true', async () => {
+    installForeign([FOREIGN_IAM]);
+    await StackVerify.run(['--porcelain', ...WS], config);
+    const lines = out.join('\n');
+    expect(lines).toContain('iam-api=foreign');
+    expect(lines).toContain('passed=true');
+  });
+
+  it('--output-json carries the foreign list + count', async () => {
+    installForeign([FOREIGN_IAM]);
+    await expect(StackVerify.run(['--output-json', ...WS], config)).resolves.toBeUndefined();
+    const json = JSON.parse(out.join(''));
+    expect(json.passed).toBe(true);
+    expect(json.summary.foreign).toBe(1);
+    expect(json.foreign).toEqual([
+      { id: 'iam-api', port: 3010, pid: 3537029, command: 'node dist/main.js' },
+    ]);
+  });
+
+  it('a DOWN service still fails the gate even though a foreign flag is warn-only', async () => {
+    installProber([SIS_URL]); // sis genuinely down
+    installForeign([FOREIGN_IAM]); // foreign flag present but must not change the verdict
+    await expect(StackVerify.run([...WS], config)).rejects.toMatchObject({ oclif: { exit: 1 } });
   });
 });
 

--- a/packages/node/saga-stack-cli/src/commands/stack/cold-start.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/cold-start.ts
@@ -57,8 +57,14 @@ import {
   systemPruneArgs,
 } from '../../runtime/index.js';
 import { deriveInstance } from '../../core/derive-instance.js';
+import { manifest } from '../../core/manifest/index.js';
 import StackUp from './up.js';
 import StackVerify from './verify.js';
+
+/** Clip a command string for a single-line reap note. */
+function clipCmd(s: string): string {
+  return s.length > 60 ? `${s.slice(0, 57)}…` : s;
+}
 
 export default class StackColdStart extends BaseCommand {
   static description =
@@ -117,6 +123,7 @@ export default class StackColdStart extends BaseCommand {
     // ── plan header + single destructive confirm ──
     this.log(dry ? '▶ cold-start DRY RUN — nothing will be changed:' : '▶ cold-start plan:');
     this.log(`    docker: down -v the '${profile.project}' mesh (containers + volumes)${flags['all-docker'] ? ' + system prune -af --volumes' : ''}`);
+    this.log(`    reap:   foreign listeners on stack ports (processes ss didn't launch) — killed before up`);
     this.log(`    repos:  ${repos.length} siblings → clone-if-missing, switch to main, ff to origin`);
     this.log(`    build:  rm -rf dist${flags.reinstall ? ' + node_modules' : ''}${flags['skip-clean'] ? ' (SKIPPED)' : ''} → rebuilt by up (soa CLI restored inline)`);
     this.log(`    env:    scaffold missing .env from .env.example`);
@@ -136,16 +143,42 @@ export default class StackColdStart extends BaseCommand {
 
     // ── STEP 1: docker wipe ──
     await this.step('1/6 docker wipe — down -v the mesh (drop containers + data volumes)', async () => {
+      const stateDir = flags['state-dir'] ?? profile.stateDir;
+      // FOREIGN listeners: a process ss did NOT launch that holds a stack port
+      // (classically a stale `up.sh`/`--tunnel` `tsup --watch` supervisor that
+      // outlived its shell). `stopServices` below reaps only ss's OWN pidfiles, so
+      // a foreign holder survives it and would keep its stale env (e.g. a tunnel
+      // AUTH_SESSIONCOOKIEDOMAIN) alive across the `up` in step 6. cold-start is
+      // the sledgehammer, so blow them away here — under the single up-front
+      // confirm, with a loud per-process note (killing an out-of-band process is a
+      // surprise otherwise). Scanned BEFORE stopServices so the ownership read
+      // (pidfiles) is intact.
+      const foreign = await this.getForeignProcs().find({ manifest, stateDir });
+
       if (dry) {
+        for (const f of foreign) {
+          this.log(`    would REAP foreign ${f.id.padEnd(16)} :${f.port} pid ${f.pid} (pgid ${f.pgid})  ${clipCmd(f.command)}`);
+        }
         this.log(`    would run (in ${soaRoot}/infra): docker ${composeDownVArgs(profile.project).join(' ')}`);
         if (flags['all-docker']) this.log(`    would run: docker ${systemPruneArgs().join(' ')}`);
         return;
       }
       // Stop this slot's own dev-server pids first (best-effort) so no watch child keeps a port.
       try {
-        await this.getServiceStopper()(flags['state-dir'] ?? profile.stateDir);
+        await this.getServiceStopper()(stateDir);
       } catch {
         // best-effort — the compose down + orphan removal is what actually frees the mesh.
+      }
+      if (foreign.length > 0) {
+        this.log(`⚠ reaping ${foreign.length} FOREIGN process(es) on stack ports — NOT launched by ss (a stale up.sh/--tunnel leftover?):`);
+        for (const f of foreign) {
+          this.log(`    ${f.id.padEnd(16)} :${f.port} pid ${f.pid} (pgid ${f.pgid})  ${clipCmd(f.command)}`);
+        }
+        const reaped = await this.getForeignProcs().reap(foreign);
+        const survived = reaped.filter((r) => !r.killed);
+        if (survived.length > 0) {
+          this.log(`⚠ ${survived.length} could not be killed (gone already, or not permitted): ${survived.map((s) => `${s.id}(pid ${s.pid})`).join(', ')}`);
+        }
       }
       const wipe = this.getDockerWipe();
       const down = await wipe.composeDownVolumes({ soaRoot, project: profile.project });

--- a/packages/node/saga-stack-cli/src/commands/stack/verify.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/verify.ts
@@ -38,6 +38,7 @@ import { SYNTH_DEV_DIR } from '../../core/flag-map.js';
 import { healthProbes } from '../../core/probe-plan.js';
 import { getMesh, manifest } from '../../core/manifest/index.js';
 import type { ServiceId } from '../../core/manifest/index.js';
+import type { ForeignProc } from '../../core/foreign-procs.js';
 import { DATA_SQL, assessData } from '../../core/verify-data.js';
 import type { DataAssessment, DataReadings } from '../../core/verify-data.js';
 import { parseOverlayTsv } from '../../core/overlay-tsv.js';
@@ -166,6 +167,12 @@ export default class StackVerify extends BaseCommand {
     const up = rows.filter((r) => r.ok).length;
     const passed = failures.length === 0;
 
+    // WARN-ONLY foreign scan: a required port held by a process ss didn't launch
+    // is why a health probe can go misleadingly green (a `✓ 200` served by a
+    // stale up.sh/--tunnel leftover ss can neither manage nor restart). Surface
+    // it; NEVER let it flip the exit code — `stack cold-start` is what reaps them.
+    const foreign = await this.findForeign(probe, profile);
+
     if (flags['output-json']) {
       this.log(
         JSON.stringify(
@@ -178,7 +185,14 @@ export default class StackVerify extends BaseCommand {
               tolerated: r.tolerated,
             })),
             notCloned: notCloned.map((n) => ({ id: n.id, repo: n.repo, repoDir: n.repoDir })),
-            summary: { total: rows.length, up, failed: failures.length, notCloned: notCloned.length },
+            foreign: foreign.map((f) => ({ id: f.id, port: f.port, pid: f.pid, command: f.command })),
+            summary: {
+              total: rows.length,
+              up,
+              failed: failures.length,
+              notCloned: notCloned.length,
+              foreign: foreign.length,
+            },
             passed,
           },
           null,
@@ -190,23 +204,40 @@ export default class StackVerify extends BaseCommand {
         this.log(`${r.id}=${r.ok ? 'up' : r.tolerated ? 'down-tolerated' : 'down'}`);
       }
       for (const n of notCloned) this.log(`${n.id}=not-cloned`);
+      for (const f of foreign) this.log(`${f.id}=foreign`);
       this.log(`passed=${passed}`);
     } else {
       for (const r of rows) this.log(formatRow(r));
       for (const n of notCloned) {
         this.log(`⚠ ${n.id.padEnd(16)} ${n.repoDir}  (not cloned: ${n.repo} repo not present)`);
       }
+      for (const f of foreign) this.log(formatForeign(f));
       this.log(
         passed
           ? `verify: PASS — ${up}/${rows.length} required services up` +
-              (notCloned.length ? ` (${notCloned.length} not cloned)` : '')
+              (notCloned.length ? ` (${notCloned.length} not cloned)` : '') +
+              (foreign.length ? yellow(` — ⚠ ${foreign.length} FOREIGN (not ss-managed)`) : '')
           : `verify: FAIL — ${failures.length} required service(s) down: ${failures.map((f) => f.id).join(', ')}`,
       );
     }
 
     // Native health gate is the exit code: non-zero iff a non-tolerated required
-    // service is down. (--full runs the DATA gate + delegates posture above.)
+    // service is down. FOREIGN findings are warn-only and never flip this.
     if (!passed) this.exit(1);
+  }
+
+  /**
+   * Resolve which of `ids` have a stack port held by a process ss did NOT launch
+   * (ownership by pgid vs the slot's pidfiles — see `core/foreign-procs`). Pure
+   * data; the caller renders it. Warn-only everywhere it's used.
+   */
+  private findForeign(ids: ServiceId[], profile: InstanceProfile): Promise<ForeignProc[]> {
+    return this.getForeignProcs().find({
+      manifest,
+      services: ids,
+      stateDir: profile.stateDir,
+      portOverrides: profile.portOverrides,
+    });
   }
 
   /**
@@ -255,6 +286,10 @@ export default class StackVerify extends BaseCommand {
       this.log(
         `${r.ok ? green('✓') : red('✗')} ${r.id.padEnd(16)} ${dim(r.url)}  (${r.ok ? green(String(r.status ?? '')) : red('down')})`,
       );
+    }
+    // WARN-ONLY foreign scan (never flips --full's health+data verdict). Slot-0 only.
+    for (const f of await this.findForeign(ids, deriveInstance({ slot: flags.slot }))) {
+      this.log(formatForeign(f));
     }
 
     // 2. native DATA checks (D1–D5). Reads as postgres_admin against the base mesh
@@ -591,6 +626,14 @@ function formatRow(r: VerifyRow): string {
   const mark = r.ok ? '✓' : r.tolerated ? '⚠' : '✗';
   const code = r.status !== undefined ? `(${r.status})` : r.tolerated ? '(down, tolerated)' : '(down)';
   return `${mark} ${r.id.padEnd(16)} ${r.url}  ${code}`;
+}
+
+/** Warn line for a stack port held by a process ss did not launch. */
+function formatForeign(f: ForeignProc): string {
+  return yellow(
+    `⚠ ${f.id.padEnd(16)} :${f.port} held by a FOREIGN process (pid ${f.pid}) — not ss-managed; ` +
+      'a stale up.sh/--tunnel leftover? `ss stack cold-start` reaps it',
+  );
 }
 
 /**

--- a/packages/node/saga-stack-cli/src/core/__tests__/foreign-procs.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/foreign-procs.unit.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Foreign-process classification — PURE ownership logic (no /proc, no lsof, no
+ * spawn). The ownership rule under test: a stack port is FOREIGN iff its
+ * listener's pgid is NOT one of the current `ss` pidfile pids (which, because
+ * services are spawned `detached:true`, ARE the pgid leaders). A port with
+ * nothing listening is "down", not foreign; an ss-owned pgid is skipped.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { classifyForeign, foreignCheckTargets } from '../foreign-procs.js';
+import type { PortListener } from '../foreign-procs.js';
+import { manifest } from '../manifest/index.js';
+import type { ServiceId } from '../manifest/index.js';
+
+function listener(port: number, pid: number, pgid: number, command = 'node dist/main.js'): PortListener {
+  return { port, pid, pgid, command };
+}
+
+describe('foreignCheckTargets — which (id, port) pairs to check', () => {
+  it('defaults to every NON-optional service, at base ports', () => {
+    const targets = foreignCheckTargets(manifest);
+    const byId = Object.fromEntries(targets.map((t) => [t.id, t.port]));
+    // Non-optional services are covered (api + web)…
+    expect(byId['iam-api']).toBe(3010);
+    expect(byId['saga-dash']).toBe(8900);
+    expect(byId['connect-web']).toBe(6210);
+    expect(byId['coach-web']).toBe(8800);
+    // …optional playback/authz services are NOT.
+    expect(byId['transcripts-api']).toBeUndefined();
+    expect(byId['authz-sync']).toBeUndefined();
+  });
+
+  it('restricts to a given subset, preserving order', () => {
+    const ids: ServiceId[] = ['sis-api', 'iam-api'];
+    expect(foreignCheckTargets(manifest, ids)).toEqual([
+      { id: 'sis-api', port: 3100 },
+      { id: 'iam-api', port: 3010 },
+    ]);
+  });
+
+  it('applies slot portOverrides to the checked port', () => {
+    const targets = foreignCheckTargets(manifest, ['iam-api'], { 'iam-api': 4010 });
+    expect(targets).toEqual([{ id: 'iam-api', port: 4010 }]);
+  });
+
+  it('throws on an unknown service id', () => {
+    expect(() => foreignCheckTargets(manifest, ['nope' as ServiceId])).toThrow(/unknown service id/);
+  });
+});
+
+describe('classifyForeign — owned-pgid vs foreign', () => {
+  const targets = [
+    { id: 'iam-api' as ServiceId, port: 3010 },
+    { id: 'sis-api' as ServiceId, port: 3100 },
+  ];
+
+  it('flags a port whose listener pgid is NOT an ss pidfile pid', () => {
+    const listeners = new Map([[3010, listener(3010, 999, 576078, 'node dist/main.js')]]);
+    const foreign = classifyForeign(targets, listeners, new Set([12345]));
+    expect(foreign).toEqual([
+      { id: 'iam-api', port: 3010, pid: 999, pgid: 576078, command: 'node dist/main.js' },
+    ]);
+  });
+
+  it('skips an ss-OWNED listener (pgid == a pidfile pid, even as a grandchild)', () => {
+    // detached:true ⇒ the grandchild listener (pid 3537029) inherits the leader's
+    // pgid (3537000), which is the recorded pidfile pid ⇒ owned, not foreign.
+    const listeners = new Map([[3010, listener(3010, 3537029, 3537000)]]);
+    expect(classifyForeign(targets, listeners, new Set([3537000]))).toEqual([]);
+  });
+
+  it('skips a port with nothing listening (down, not foreign)', () => {
+    expect(classifyForeign(targets, new Map(), new Set([1]))).toEqual([]);
+  });
+
+  it('classifies each target independently and preserves order', () => {
+    const listeners = new Map([
+      [3010, listener(3010, 111, 700)], // foreign
+      [3100, listener(3100, 222, 800)], // owned
+    ]);
+    const foreign = classifyForeign(targets, listeners, new Set([800]));
+    expect(foreign.map((f) => f.id)).toEqual(['iam-api']);
+  });
+});

--- a/packages/node/saga-stack-cli/src/core/foreign-procs.ts
+++ b/packages/node/saga-stack-cli/src/core/foreign-procs.ts
@@ -1,0 +1,90 @@
+/**
+ * Foreign-process classification (PURE) — the "is this stack port held by a
+ * process `ss` did NOT launch?" decision, split out so the command layer + tests
+ * reason about it with zero IO.
+ *
+ * WHY THIS EXISTS: `ss` health-checks a service by PORT, not by ownership — a 200
+ * on `:3010` means "something is serving", not "ss launched it". A stale process
+ * from a previous `up.sh` run (classically a `--tunnel` launch whose `tsup
+ * --watch` supervisor outlived the shell) keeps answering the health probe, so
+ * `up` adopts it ("already up" — launcher.ts) and never writes a pidfile for it;
+ * `restart`/`down`, which reap by PIDFILE, then can't see it, so it survives
+ * every bounce and re-injects its stale env (e.g. a tunnel `AUTH_SESSIONCOOKIE
+ * DOMAIN`). `stack verify` flags this state; `stack cold-start` reaps it.
+ *
+ * OWNERSHIP TEST (exact, not heuristic): `makeRealLauncher` spawns every service
+ * `detached: true`, so the recorded `<stateDir>/<id>.pid` IS the process-group
+ * leader and the port-holding `node dist/main.js` grandchild inherits that pgid.
+ * A listener is therefore ss-OWNED iff its pgid is one of the current pidfile
+ * pids; anything else on a stack port is FOREIGN.
+ *
+ * INVARIANT (plan hard constraint): this lives in `core/` and stays PURE — no
+ * `/proc`, no `lsof`, no spawn. The host IO lives only in `runtime/foreign-procs`.
+ */
+
+import type { Manifest, ServiceId } from './manifest/index.js';
+
+/** A live listener on a stack service port, as resolved by the IO layer. */
+export interface PortListener {
+  /** The stack service port it is listening on. */
+  port: number;
+  /** The listening process's pid. */
+  pid: number;
+  /** Its process-group id — the ownership key (see module docstring). */
+  pgid: number;
+  /** A short command label for display (e.g. `node dist/main.js`), best-effort. */
+  command: string;
+}
+
+/** A stack service port held by a process `ss` did not launch. */
+export interface ForeignProc {
+  /** The manifest service whose port is foreign-held. */
+  id: ServiceId;
+  port: number;
+  pid: number;
+  pgid: number;
+  command: string;
+}
+
+/**
+ * The `(id, port)` pairs to check — every NON-optional service (the same default
+ * surface `healthProbes` uses), or a given subset. `portOverrides` (a slot's
+ * `InstanceProfile.portOverrides`) shifts each port to the slot's offset; absent
+ * (slot 0) ⇒ the manifest base port. Throws on an unknown id.
+ */
+export function foreignCheckTargets(
+  m: Manifest,
+  services?: ServiceId[],
+  portOverrides?: Partial<Record<ServiceId, number>>,
+): { id: ServiceId; port: number }[] {
+  const ids =
+    services ??
+    (Object.keys(m.services) as ServiceId[]).filter((id) => !m.services[id].optional);
+  return ids.map((id) => {
+    const svc = m.services[id];
+    if (!svc) throw new Error(`unknown service id: ${id}`);
+    return { id, port: portOverrides?.[id] ?? svc.port };
+  });
+}
+
+/**
+ * Classify which of `targets` are held by a foreign process. `listeners` maps a
+ * port → its live listener (absent ⇒ nothing on that port ⇒ NOT foreign, just
+ * down). `ownedPgids` is the set of `ss` pidfile pids (== pgid leaders). A port
+ * whose listener's pgid is not owned is foreign. Deterministic and
+ * order-preserving (targets order in, foreign subset out).
+ */
+export function classifyForeign(
+  targets: { id: ServiceId; port: number }[],
+  listeners: Map<number, PortListener>,
+  ownedPgids: Set<number>,
+): ForeignProc[] {
+  const foreign: ForeignProc[] = [];
+  for (const { id, port } of targets) {
+    const l = listeners.get(port);
+    if (!l) continue; // nothing listening ⇒ the service is down, not foreign
+    if (ownedPgids.has(l.pgid)) continue; // ss-launched (pgid is a pidfile leader) ⇒ owned
+    foreign.push({ id, port, pid: l.pid, pgid: l.pgid, command: l.command });
+  }
+  return foreign;
+}

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/foreign-procs.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/foreign-procs.unit.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Foreign-process IO wiring — `makeRealForeignProcs` over a FAKE `ForeignIo`, so
+ * `find`/`reap` are asserted with no sockets, no `ps`, and no real `kill`. The
+ * production `ForeignIo` (lsof/ss/ps/kill) is the thin shell it delegates to; the
+ * logic worth testing is: find = (port→pid) ∘ (pid→pgid) ∘ pidfiles ∘ classify,
+ * and reap = group-kill each finding, reporting per-pid liveness.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { makeRealForeignProcs } from '../foreign-procs.js';
+import type { ForeignIo } from '../foreign-procs.js';
+import { manifest } from '../../core/manifest/index.js';
+
+/** A fake ForeignIo: port→pid, pid→(pgid,command), owned pgids, and a kill spy. */
+function fakeIo(over: Partial<ForeignIo> = {}): ForeignIo {
+  return {
+    async pidOnPort() {
+      return null;
+    },
+    async procInfo() {
+      return null;
+    },
+    ownedPgids() {
+      return [];
+    },
+    killGroup() {
+      return true;
+    },
+    ...over,
+  };
+}
+
+describe('makeRealForeignProcs.find — wiring', () => {
+  it('reports a foreign listener (pgid not in the pidfiles)', async () => {
+    const io = fakeIo({
+      pidOnPort: async (port) => (port === 3010 ? 3537029 : null),
+      procInfo: async (pid) => (pid === 3537029 ? { pgid: 576078, command: 'node dist/main.js' } : null),
+      ownedPgids: () => [12345], // ss owns some OTHER pgid
+    });
+    const found = await makeRealForeignProcs(io).find({
+      manifest,
+      services: ['iam-api'],
+      stateDir: '/tmp/sds-synthetic',
+    });
+    expect(found).toEqual([
+      { id: 'iam-api', port: 3010, pid: 3537029, pgid: 576078, command: 'node dist/main.js' },
+    ]);
+  });
+
+  it('does NOT report an ss-owned listener (its pgid is a pidfile pid)', async () => {
+    const io = fakeIo({
+      pidOnPort: async (port) => (port === 3010 ? 3537029 : null),
+      procInfo: async () => ({ pgid: 3537000, command: 'node dist/main.js' }),
+      ownedPgids: () => [3537000], // recorded pidfile == the pgid leader
+    });
+    const found = await makeRealForeignProcs(io).find({ manifest, services: ['iam-api'], stateDir: '/x' });
+    expect(found).toEqual([]);
+  });
+
+  it('treats a port with no listener as down (not foreign)', async () => {
+    const io = fakeIo({ pidOnPort: async () => null, ownedPgids: () => [] });
+    const found = await makeRealForeignProcs(io).find({ manifest, services: ['iam-api'], stateDir: '/x' });
+    expect(found).toEqual([]);
+  });
+
+  it('drops a pid that vanishes between the port and proc probes', async () => {
+    const io = fakeIo({
+      pidOnPort: async () => 4242,
+      procInfo: async () => null, // gone before we could read its pgid
+      ownedPgids: () => [],
+    });
+    const found = await makeRealForeignProcs(io).find({ manifest, services: ['iam-api'], stateDir: '/x' });
+    expect(found).toEqual([]);
+  });
+});
+
+describe('makeRealForeignProcs.reap — group-kill + report', () => {
+  it('group-kills each finding and reports the killed flag', async () => {
+    const killGroup = vi.fn((_pgid: number, _pid: number) => true);
+    const procs = makeRealForeignProcs(fakeIo({ killGroup }));
+    const reaped = await procs.reap([
+      { id: 'iam-api', port: 3010, pid: 3537029, pgid: 576078, command: 'node dist/main.js' },
+    ]);
+    expect(killGroup).toHaveBeenCalledWith(576078, 3537029);
+    expect(reaped).toEqual([
+      { id: 'iam-api', port: 3010, pid: 3537029, pgid: 576078, command: 'node dist/main.js', killed: true },
+    ]);
+  });
+
+  it('marks a survivor killed:false (e.g. EPERM) without throwing', async () => {
+    const procs = makeRealForeignProcs(fakeIo({ killGroup: () => false }));
+    const reaped = await procs.reap([
+      { id: 'sis-api', port: 3100, pid: 5, pgid: 5, command: 'node dist/main.js' },
+    ]);
+    expect(reaped[0]?.killed).toBe(false);
+  });
+
+  it('signals once per finding even when two share a pgid', async () => {
+    const killGroup = vi.fn(() => true);
+    const procs = makeRealForeignProcs(fakeIo({ killGroup }));
+    await procs.reap([
+      { id: 'iam-api', port: 3010, pid: 100, pgid: 900, command: 'x' },
+      { id: 'sis-api', port: 3100, pid: 101, pgid: 900, command: 'y' },
+    ]);
+    expect(killGroup).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/node/saga-stack-cli/src/runtime/foreign-procs.ts
+++ b/packages/node/saga-stack-cli/src/runtime/foreign-procs.ts
@@ -1,0 +1,185 @@
+/**
+ * Foreign-process IO — the host side of `core/foreign-procs`. Resolves which pid
+ * listens on each stack port, reads the slot's `ss` pidfiles, and reaps a foreign
+ * process group. Host/process IO lives ONLY here; `core/foreign-procs` stays pure.
+ *
+ * Cross-platform by design: port→pid + pid→pgid go through `lsof`/`ss`/`ps` (all
+ * present on a Linux OR macOS dev box) — `/proc` is NOT required. Every shell-out
+ * folds errors into a safe answer (a missing `lsof`/`ss` ⇒ "nothing found"), so
+ * the guardrail DEGRADES OPEN: worst case it reports no foreign process rather
+ * than a false positive. All IO is behind the injectable `ForeignIo` so tests
+ * assert the wiring with no sockets, no `ps`, and no `kill`.
+ */
+
+import { execFile } from 'node:child_process';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  classifyForeign,
+  foreignCheckTargets,
+  type ForeignProc,
+  type PortListener,
+} from '../core/foreign-procs.js';
+import type { Manifest, ServiceId } from '../core/manifest/index.js';
+
+/** A foreign process after a reap attempt. */
+export interface ReapedProc extends ForeignProc {
+  /** True once the pid is confirmed gone (signal delivered or already dead). */
+  killed: boolean;
+}
+
+/** Options for {@link ForeignProcs.find}. */
+export interface FindForeignOptions {
+  manifest: Manifest;
+  /** Service subset to check; omitted ⇒ every non-optional service. */
+  services?: ServiceId[];
+  /** The slot's pidfile dir (`<stateDir>/<id>.pid`) — the ownership source. */
+  stateDir: string;
+  /** A slot's offset ports (`InstanceProfile.portOverrides`); absent ⇒ base ports. */
+  portOverrides?: Partial<Record<ServiceId, number>>;
+}
+
+/**
+ * The command-facing seam: find foreign processes on stack ports, and reap them.
+ * `stack verify` calls `find` (warn-only); `stack cold-start` calls `find` then
+ * `reap`. Injected via `BaseCommand.getForeignProcs()` so command tests fake it.
+ */
+export interface ForeignProcs {
+  find(opts: FindForeignOptions): Promise<ForeignProc[]>;
+  reap(foreign: ForeignProc[]): Promise<ReapedProc[]>;
+}
+
+/**
+ * The low-level host IO, injectable so `makeRealForeignProcs` is unit-testable.
+ * A real impl shells out (`lsof`/`ss`/`ps`) + touches the fs + signals; a fake
+ * answers from maps.
+ */
+export interface ForeignIo {
+  /** The first LISTENING pid on host `port`, or null if nothing listens. */
+  pidOnPort(port: number): Promise<number | null>;
+  /** The pgid + short command for `pid`, or null if it has already vanished. */
+  procInfo(pid: number): Promise<{ pgid: number; command: string } | null>;
+  /** The pids recorded in `<stateDir>/*.pid` (== ss pgid leaders); [] if none. */
+  ownedPgids(stateDir: string): number[];
+  /** SIGKILL a process group (negative pid), then confirm the pid is gone. */
+  killGroup(pgid: number, pid: number): boolean;
+}
+
+/** Run a command, resolving its trimmed stdout (or '' on any error). NEVER throws. */
+function runCapture(command: string, args: string[]): Promise<string> {
+  return new Promise((resolve) => {
+    execFile(command, args, { encoding: 'utf8' }, (err, stdout) => {
+      resolve(err ? '' : (stdout ?? '').toString());
+    });
+  });
+}
+
+function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // EPERM ⇒ alive but not ours to signal; anything else (ESRCH) ⇒ gone.
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+/**
+ * The production `ForeignIo`. `pidOnPort` prefers `lsof -t` (terse pid list,
+ * works on Linux + macOS), falling back to `ss -ltnHp` for a Linux box without
+ * lsof; `procInfo` uses POSIX `ps -o pgid=,args=`; `killGroup` SIGKILLs the
+ * negative pid (the whole detached tree) with a bare-pid fallback.
+ */
+export function makeRealForeignIo(): ForeignIo {
+  return {
+    async pidOnPort(port: number): Promise<number | null> {
+      // lsof -t: newline-separated pids that hold the port; a process with both
+      // an IPv4 and IPv6 listener shows twice, so take the first.
+      const lsof = await runCapture('lsof', ['-t', '-nP', `-iTCP:${port}`, '-sTCP:LISTEN']);
+      const fromLsof = lsof.split('\n').map((s) => Number.parseInt(s.trim(), 10)).find(Number.isInteger);
+      if (fromLsof !== undefined) return fromLsof;
+      // Fallback (Linux, no lsof): ss prints `users:(("node",pid=1234,fd=27))`.
+      const ss = await runCapture('ss', ['-ltnHp', `sport = :${port}`]);
+      const matched = ss.match(/pid=(\d+)/)?.[1];
+      return matched ? Number.parseInt(matched, 10) : null;
+    },
+
+    async procInfo(pid: number): Promise<{ pgid: number; command: string } | null> {
+      // POSIX `ps -o pgid=,args=` → "  <pgid> <full command…>"; headers suppressed
+      // by the trailing `=`. `args` (not `comm`) so the label carries dist/main.js.
+      const out = (await runCapture('ps', ['-o', 'pgid=,args=', '-p', String(pid)])).trim();
+      if (!out) return null;
+      const sp = out.indexOf(' ');
+      if (sp < 0) return null;
+      const pgid = Number.parseInt(out.slice(0, sp).trim(), 10);
+      const command = out.slice(sp + 1).trim();
+      if (!Number.isInteger(pgid)) return null;
+      return { pgid, command };
+    },
+
+    ownedPgids(stateDir: string): number[] {
+      let files: string[];
+      try {
+        files = readdirSync(stateDir);
+      } catch {
+        return []; // no state dir yet ⇒ ss has launched nothing here
+      }
+      const pids: number[] = [];
+      for (const file of files) {
+        if (!file.endsWith('.pid')) continue;
+        try {
+          const pid = Number.parseInt(readFileSync(join(stateDir, file), 'utf8').trim(), 10);
+          if (Number.isInteger(pid) && pid > 0) pids.push(pid);
+        } catch {
+          /* unreadable/stale pidfile ⇒ skip */
+        }
+      }
+      return pids;
+    },
+
+    killGroup(pgid: number, pid: number): boolean {
+      try {
+        process.kill(-pgid, 'SIGKILL');
+      } catch {
+        try {
+          process.kill(pid, 'SIGKILL');
+        } catch {
+          /* already gone — treat as reaped below */
+        }
+      }
+      return !pidAlive(pid);
+    },
+  };
+}
+
+/**
+ * Build the command-facing seam over a `ForeignIo` (production IO by default).
+ * `find` resolves each target port's listener + the slot's owned pgids and runs
+ * the pure `classifyForeign`; `reap` group-kills each foreign pgid and reports
+ * which are confirmed gone.
+ */
+export function makeRealForeignProcs(io: ForeignIo = makeRealForeignIo()): ForeignProcs {
+  return {
+    async find(opts: FindForeignOptions): Promise<ForeignProc[]> {
+      const targets = foreignCheckTargets(opts.manifest, opts.services, opts.portOverrides);
+      const listeners = new Map<number, PortListener>();
+      for (const { port } of targets) {
+        const pid = await io.pidOnPort(port);
+        if (pid === null) continue;
+        const info = await io.procInfo(pid);
+        if (info === null) continue; // vanished between the two probes ⇒ treat as down
+        listeners.set(port, { port, pid, pgid: info.pgid, command: info.command });
+      }
+      const ownedPgids = new Set(io.ownedPgids(opts.stateDir));
+      return classifyForeign(targets, listeners, ownedPgids);
+    },
+
+    async reap(foreign: ForeignProc[]): Promise<ReapedProc[]> {
+      // Group-kill each foreign process. When two services share one supervisor
+      // pgid, the second SIGKILL to the now-dead group is a harmless ESRCH no-op
+      // (folded inside killGroup), and `killed` is still checked per-pid — so no
+      // dedupe is needed and every finding reports its own liveness accurately.
+      return foreign.map((f) => ({ ...f, killed: io.killGroup(f.pgid, f.pid) }));
+    },
+  };
+}

--- a/packages/node/saga-stack-cli/src/runtime/index.ts
+++ b/packages/node/saga-stack-cli/src/runtime/index.ts
@@ -49,3 +49,4 @@ export * from './slot-active.js';
 export * from './set-check.js';
 export * from './lock.js';
 export * from './checkpoint-store.js';
+export * from './foreign-procs.js';


### PR DESCRIPTION
## Why

`ss` health-checks a service by **port, not ownership** — a `200` on `:3010` means "something is serving", not "ss launched it". A stale process from a previous `up.sh` run (classically a `--tunnel` `tsup --watch` supervisor that outlived its shell) keeps answering the health probe, so:

- `stack up` adopts it (`launcher.ts` "already up") and writes **no pidfile** for it, and
- `restart`/`down` — which reap **by pidfile** — can't see it, so it survives every bounce and keeps re-injecting its stale env (e.g. a tunnel `AUTH_SESSIONCOOKIEDOMAIN` that scopes `iam_session` to `.<moniker>.vms.wootdev.com`, breaking localhost e2e).

This is a real incident: a `journey -p 6` e2e run redirected to `https://localhost:3010/demo` (`ERR_SSL_PROTOCOL_ERROR`) because an orphaned `up.sh --tunnel` iam-api kept minting tunnel-domain cookies that a `localhost` browser never sends. `ss stack status` reported it `✓ 200` the whole time.

## Ownership test (exact, not heuristic)

`makeRealLauncher` spawns each service `detached: true`, so the recorded `<stateDir>/<id>.pid` **is** the process-group leader and the port-holding `node dist/main.js` grandchild inherits that pgid. A listener is **ss-owned iff its pgid is a current pidfile pid**; anything else on a stack port is **foreign**.

## What

- **`core/foreign-procs`** (pure): `classifyForeign` + `foreignCheckTargets` — zero IO.
- **`runtime/foreign-procs`** (IO): `lsof`/`ss` (port→pid), `ps` (pid→pgid), pidfile reads, group-SIGKILL reap. Every shell-out **degrades open** (missing `lsof`/`ss` ⇒ "nothing found", never a false positive).
- **`stack cold-start`**: reaps foreign listeners on stack ports **before `up`**, under the command's existing single destructive confirm, with a loud per-process note. `--dry-run` reports what it *would* reap.
- **`stack verify`**: **warn-only** foreign flag over the same service set (a `⚠` line in the human view; `foreign`/`summary.foreign` in `--output-json`; `<id>=foreign` in `--porcelain`). **Never flips the exit code.**

Scope (per request): **all non-optional services** — backend APIs *and* the vite web apps (dash / connect-web / coach-web). `up`/`restart` intentionally left unchanged (minimal surface: cold-start reaps, verify flags).

## Tests

- `core/__tests__/foreign-procs.unit.test.ts` — classification + target derivation (owned pgid skipped, foreign flagged, down≠foreign, slot overrides, unknown id).
- `runtime/__tests__/foreign-procs.unit.test.ts` — `find`/`reap` wiring over a fake `ForeignIo`.
- `status-verify.int.test.ts` — verify's warn-only contract (foreign flagged but still PASS; a genuinely-down service still FAILs; json/porcelain shape).

Full suite: **1109 passing**, `tsc --noEmit` clean.

## Live validation

Ran the real `find()` against a live stack: iam-api (freshly `ss`-launched) and the 8 other pidfile'd services classified **owned**; **4 stale July-7 `up.sh` leftovers** (ads-adm / connect-web / rtsm / coach-web, sharing one dead-leader pgid, no pidfile) correctly flagged **foreign** — 0 false positives on managed services.

> Note: `ss stack lint` couldn't be run in the authoring sandbox (an ESLint 8/9 rule-config skew in the reused `node_modules`, reproduces on unchanged files); CI lints against a fresh install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)