### PR TITLE
fix(saga-stack-cli): --tunnel --login routing + coach tunnel overlay

### DIFF
--- a/packages/node/saga-stack-cli/src/base-command.ts
+++ b/packages/node/saga-stack-cli/src/base-command.ts
@@ -922,9 +922,15 @@ export abstract class BaseCommand extends Command {
     email: string;
     slot: number;
     stateDir: string;
+    /** Explicit iam host (the `--tunnel` public host); else `LOGIN_IAM_URL` else localhost. */
+    loginIamUrl?: string;
   }): Promise<NativeLoginResult> {
-    // LOGIN_IAM_URL wins (tunnel: login goes through the PUBLIC iam host); else slot-offset localhost.
-    const iamUrl = resolveIamUrl({ slot: opts.slot, loginIamUrl: process.env.LOGIN_IAM_URL });
+    // An explicit loginIamUrl (tunnel: login goes through the PUBLIC iam host) wins, then
+    // the LOGIN_IAM_URL env override, else slot-offset localhost.
+    const iamUrl = resolveIamUrl({
+      slot: opts.slot,
+      loginIamUrl: opts.loginIamUrl ?? process.env.LOGIN_IAM_URL,
+    });
     const jarPath = join(opts.stateDir, COOKIE_JAR_FILE);
     return nativeLogin(
       { email: opts.email, iamUrl, jarPath },

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/up-native.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/up-native.int.test.ts
@@ -508,6 +508,41 @@ describe('stack up --slot N — isolated bring-up (M7 Phase 2)', () => {
     // (no write). The key assertion: NO stack-slot write happened at slot 0.
     expect(dashCalls.some((c) => c.startsWith('write:'))).toBe(false);
   });
+
+  // NB: these two --login tests are placed at the END of this describe (not by the
+  // BARE `--tunnel` test above) on purpose — soa#291 adds its LiveKit-creds tests
+  // right after that bare test, so keeping these here avoids an overlay merge
+  // conflict between the two tunnel PRs in this shared file.
+  it('--tunnel --login: login mints against the PUBLIC tunnel iam + opens the tunnel dash, AFTER the tunnels are up', async () => {
+    await StackUp.run(['--tunnel', '--login', ...WS], config);
+    const TD = 'testmoniker.vms.wootdev.com';
+
+    // devLogin POSTed at the PUBLIC tunnel iam (not localhost:3010), so the minted
+    // iam_session is scoped for the tunnel cookie domain instead of mis-scoped.
+    expect(posts).toHaveLength(1);
+    expect(posts[0]?.url).toBe(`https://iam.${TD}/trpc/auth.devLogin`);
+
+    // the best-effort headful browser targets the tunnel dash + iam (not localhost).
+    const browserLogin = runs.find(
+      (r) => r.command === 'node' && r.args.some((a) => a.endsWith('browser-login.mjs')),
+    );
+    expect(browserLogin?.env?.DASH_URL).toBe(`https://dash.${TD}`);
+    expect(browserLogin?.env?.IAM_URL).toBe(`https://iam.${TD}`);
+
+    // ORDERING (up.sh: tunnel.sh up → login_user): the tunnels came up BEFORE the
+    // login browser step. Both go through runVendor, so compare their run indices.
+    const tunIdx = runs.findIndex((r) => r.command.endsWith('tunnel.sh'));
+    const browserIdx = runs.findIndex(
+      (r) => r.command === 'node' && r.args.some((a) => a.endsWith('browser-login.mjs')),
+    );
+    expect(tunIdx).toBeGreaterThanOrEqual(0);
+    expect(browserIdx).toBeGreaterThan(tunIdx);
+  });
+
+  it('--login WITHOUT --tunnel still mints against localhost (tunnel routing is opt-in)', async () => {
+    await StackUp.run(['--only', 'iam-api', '--login', ...WS], config);
+    expect(posts[0]?.url).toBe('http://localhost:3010/trpc/auth.devLogin');
+  });
 });
 
 describe('stack up — native Connect AV (#221, M9)', () => {

--- a/packages/node/saga-stack-cli/src/commands/stack/up.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/up.ts
@@ -543,18 +543,38 @@ export default class StackUp extends BaseCommand {
     );
     const seeded = await api.seed(plan);
 
+    // Phase 2 --tunnel: after a successful native (tunnel-aware) launch, start the
+    // reverse tunnels via the VENDORED tunnel.sh (up.sh drives the frpc tunnels the
+    // same way). stdio-inherited so the frpc progress owns the TTY. Ordered BEFORE
+    // login (up.sh: tunnel.sh up → login_user) so a `--tunnel --login` mints against
+    // the PUBLIC iam host the tunnels now expose; a bare `--tunnel` just runs it a
+    // step earlier. `loginTunnelDomain` (set only when the tunnels actually came up)
+    // is what routes the login below at the tunnel hosts.
+    const loginTunnelDomain = overlays.tunnel && seeded.ok ? overlays.tunnel.domain : undefined;
+    if (overlays.tunnel && seeded.ok) {
+      const script = resolveVendorScript('tunnel.sh');
+      const plan = flagMap.tunnel('up');
+      await this.runVendor({ cwd: dirname(script), command: script, args: plan.args, env: plan.env }, flags);
+      this.log(`tunnel mode: browser plane at https://<svc>.${overlays.tunnel.domain}`);
+    }
+
     // 4. (optional) login — NATIVE (Phase-2 FINISH, saga-ed/soa#214). No up.sh: mint the
     // headless cookie jar (default persona dev@saga.org, slot-aware) via the SHARED
     // BaseCommand helper, then best-effort open the vendored browser-login.mjs — exactly
     // what up.sh's `--login` did (jar + best-effort headful browser). BEST-EFFORT: a
     // devLogin miss (login-before-seed) or a browser failure (no DISPLAY/playwright) is a
     // warning only — it must NOT redden an otherwise-healthy stack, so it never exits `up`.
+    // Under --tunnel, route login through the PUBLIC tunnel hosts (iam.<domain> /
+    // dash.<domain>) so the minted cookie is scoped for the tunnel (iam sets
+    // AUTH_SESSIONCOOKIEDOMAIN=.<domain>, which a localhost mint would mis-scope); else
+    // slot-offset localhost.
     if (flags.login) {
       const loginStateDir = flags['state-dir'] ?? profile.stateDir;
       const res = await this.mintNativeLoginJar({
         email: DEFAULT_LOGIN_USER,
         slot: flags.slot,
         stateDir: loginStateDir,
+        loginIamUrl: loginTunnelDomain ? `https://iam.${loginTunnelDomain}` : undefined,
       });
       if (res.ok) {
         this.log(`✓ login: session minted — cookie jar → ${res.jarPath} (cookies: ${res.captured.join(', ') || '(none)'})`);
@@ -566,6 +586,7 @@ export default class StackUp extends BaseCommand {
             email: DEFAULT_LOGIN_USER,
             iamUrl: res.iamUrl,
             stateDir: loginStateDir,
+            dashUrl: loginTunnelDomain ? `https://dash.${loginTunnelDomain}` : undefined,
           });
         }
       } else {
@@ -580,16 +601,6 @@ export default class StackUp extends BaseCommand {
     // fleek-absent / ⚠ failed). Never fatal — a record hiccup can't redden an
     // otherwise-healthy stack (like the AV bring-up).
     if (up.record) this.log(up.record.message);
-
-    // Phase 2 --tunnel: after a successful native (tunnel-aware) launch, start the
-    // reverse tunnels via the VENDORED tunnel.sh (up.sh drives the frpc tunnels the
-    // same way). stdio-inherited so the frpc progress owns the TTY.
-    if (overlays.tunnel && seeded.ok) {
-      const script = resolveVendorScript('tunnel.sh');
-      const plan = flagMap.tunnel('up');
-      await this.runVendor({ cwd: dirname(script), command: script, args: plan.args, env: plan.env }, flags);
-      this.log(`tunnel mode: browser plane at https://<svc>.${overlays.tunnel.domain}`);
-    }
 
     // MAJOR-C: R1 records non-fatal build/db:generate failures as warnings (up.sh
     // warn+continue) rather than aborting — surface them so they're visible.

--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.overlay.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.overlay.unit.test.ts
@@ -132,6 +132,18 @@ describe('tunnel_env overlay (--tunnel)', () => {
     expect(envFor('saga-dash', TUN).__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS).toBe(`dash.${TD}`);
   });
 
+  it('coach-api: CORS allow-list gains the bare tunnel domain (keeps localhost)', () => {
+    // up.sh coach-api: EXPRESS_SERVER_CORSALLOWEDDOMAINS=$COACH_WEB_HOST,$TUNNEL_DOMAIN
+    // (hostname suffix match ⇒ the bare domain admits coach.<td> and any tunnel label).
+    expect(envFor('coach-api', TUN).EXPRESS_SERVER_CORSALLOWEDDOMAINS).toBe(`localhost,${TD}`);
+  });
+
+  it('coach-web: browser API URL flips to the tunnel host + vite host allow', () => {
+    const e = envFor('coach-web', TUN);
+    expect(e.PUBLIC_COACH_API_URL).toBe(`https://coach-api.${TD}`);
+    expect(e.__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS).toBe(`coach.${TD}`);
+  });
+
   it('rtsm-api: FLEET_CONFIG_PATH override ONLY when a generated tunnel fleet path is supplied', () => {
     // no fleet path ⇒ keeps the base local fleet.
     expect(envFor('rtsm-api', TUN).FLEET_CONFIG_PATH).toBe(

--- a/packages/node/saga-stack-cli/src/core/launch-plan.ts
+++ b/packages/node/saga-stack-cli/src/core/launch-plan.ts
@@ -369,6 +369,23 @@ function tunnelOverlay(service: ServiceId, tokens: LaunchTokens): Record<string,
         : {};
     case 'saga-dash':
       return { __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS: `dash.${td}` };
+    case 'coach-api':
+      // EXPRESS_SERVER_CORSALLOWEDDOMAINS is coach's hostname allow-list (comma-
+      // split; api-core matches origin.hostname === d || endsWith('.d')), so the
+      // BARE tunnel domain admits coach.<td> — and any other tunnel label —
+      // without enumerating them. Keep COACH_WEB_HOST (localhost) so a local
+      // browser still works alongside remote ones. (up.sh coach-api ~1447.)
+      return { EXPRESS_SERVER_CORSALLOWEDDOMAINS: `${tokens.COACH_WEB_HOST},${td}` };
+    case 'coach-web':
+      // PUBLIC_COACH_API_URL is BROWSER-side (SvelteKit PUBLIC_ var read at
+      // vite-dev time): a remote coworker's browser must reach coach-api via its
+      // public tunnel name, not localhost:6105. iam stays behind coach-api (the
+      // cookie composition lives server-side, coach#94), so nothing else flips.
+      // (up.sh coach-web ~1453-1454.)
+      return {
+        PUBLIC_COACH_API_URL: `https://coach-api.${td}`,
+        __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS: `coach.${td}`,
+      };
     default:
       return {}; // everything else: dev CORS wildcard already admits *.wootdev.com
   }

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/dash-defaults.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/dash-defaults.unit.test.ts
@@ -74,6 +74,17 @@ describe('syncDashLocalDefaults', () => {
       type: 'url',
       url: 'https://programs.abc.vms.wootdev.com',
     });
+    // ads-adm MUST route to its tunnel host (the dash Overview page dials it for
+    // real) — not fall back to config.json's localhost:5005 (a mixed-content
+    // block from the HTTPS tunnel page).
+    expect(parsed.localDefaults['ads-adm']).toEqual({
+      type: 'url',
+      url: 'https://ads-adm.abc.vms.wootdev.com',
+    });
+    // transcripts-api/ledger-api are NOT forwarded by the tunnel, so they must
+    // stay out of the tunnel map (a label would point at a dead host).
+    expect(parsed.localDefaults['transcripts-api']).toBeUndefined();
+    expect(parsed.localDefaults['ledger-api']).toBeUndefined();
     // every label key present, trailing newline preserved.
     expect(Object.keys(parsed.localDefaults).sort()).toEqual(Object.keys(DASH_TUNNEL_LABELS).sort());
     expect(written[0].contents.endsWith('\n')).toBe(true);

--- a/packages/node/saga-stack-cli/src/runtime/dash-defaults.ts
+++ b/packages/node/saga-stack-cli/src/runtime/dash-defaults.ts
@@ -29,7 +29,13 @@ import type { ServiceId } from '../core/manifest/index.js';
 /**
  * The dash service-key → tunnel host-label map (verbatim from up.sh's inline
  * node script). Note `program-hub` and `enrollment-api` BOTH map to `programs`,
- * preserved exactly.
+ * preserved exactly. `ads-adm` is included because the tunnel forwards it
+ * (`ads-adm:5005` in tools/synthetic-dev/tunnel.sh) and the dash's Overview page
+ * dials it for real (`adm.getOverviewSummary`) — without this entry the dash
+ * falls back to `config.json`'s `ads-adm: localhost:5005`, a mixed-content block
+ * from the HTTPS tunnel page. `transcripts-api`/`ledger-api` are intentionally
+ * absent: the tunnel does not forward them, so a label here would point at a
+ * dead host.
  */
 export const DASH_TUNNEL_LABELS: Readonly<Record<string, string>> = {
   iam: 'iam',
@@ -40,6 +46,7 @@ export const DASH_TUNNEL_LABELS: Readonly<Record<string, string>> = {
   'sis-api': 'sis',
   'content-api': 'content',
   connect: 'connect',
+  'ads-adm': 'ads-adm',
 };
 
 /**


### PR DESCRIPTION
Two fidelity gaps between the legacy `up.sh --tunnel` and the native `ss` port (found while debugging a stuck-tunnel e2e). Both left `--tunnel` partially broken.

## (b) `--tunnel --login` minted against localhost, not the public tunnel iam

The native path ran **`login` before `tunnel.sh up`** and never set `LOGIN_IAM_URL`/`LOGIN_DASH_URL`, so `devLogin` POSTed to `http://localhost:3010` **while iam-api had `AUTH_SESSIONCOOKIEDOMAIN=.<domain>` set** — mis-scoping the minted `iam_session` for the tunnel hosts (the same failure class `up.sh`'s `login_user` ordering was written to avoid, and the same class as the stuck-tunnel incident that motivated this).

Fix (matches `up.sh`: `tunnel.sh up` → `login_user`):
- Bring the reverse tunnels up **before** the login step (a bare `--tunnel` just runs it a step earlier).
- Under `--tunnel`, route login at the **public** hosts: `https://iam.<domain>` for the `devLogin` mint and `https://dash.<domain>` for the best-effort headful browser.

The login helpers already accepted these overrides (`LOGIN_IAM_URL` / `ctx.dashUrl`) — they were just never wired on the native path. `mintNativeLoginJar` now takes an explicit `loginIamUrl` (falls back to `LOGIN_IAM_URL` env, then localhost). **A bare `--login` (no `--tunnel`) is unchanged** (localhost).

## (c) coach had no tunnel overlay at all

`tunnelOverlay()` had no `coach-api`/`coach-web` case, so `ss stack up --with coach --tunnel` left:
- coach-web dialing its own `localhost:6105` (browser-side `PUBLIC_COACH_API_URL`),
- coach-api CORS-rejecting the `coach.<domain>` origin,
- vite DNS-rebind **403**ing the tunnel `Host` header.

→ coach was **non-functional over the tunnel**. Ported `up.sh`'s three vars faithfully:
- `coach-api`: `EXPRESS_SERVER_CORSALLOWEDDOMAINS=<COACH_WEB_HOST>,<domain>` (hostname-suffix match ⇒ the bare domain admits `coach.<domain>`).
- `coach-web`: `PUBLIC_COACH_API_URL=https://coach-api.<domain>` + `__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS=coach.<domain>`.

## Out of scope (noted, not fixed here)

The tunnel-mode fidelity audit also flagged (per the plan, left for later): Connect AV LiveKit creds are never fetched from Secrets Manager (`TUNNEL_LK_KEY/SECRET` plumbing exists but nothing populates it), `tunnel.sh up` is gated on seed success (up.sh starts it unconditionally), and the moniker is read from `vendor/.vms-moniker` rather than soa's copy.

## Tests

- `launch-plan.overlay.unit.test.ts` — coach-api CORS allow-list + coach-web `PUBLIC_COACH_API_URL`/vite-host-allow flips.
- `up-native.int.test.ts` — `--tunnel --login`: public-iam `devLogin` mint, tunnel dash/iam in the browser env, and **tunnel-before-login ordering** (both go through `runVendor`, so compared by run index); plus a regression that bare `--login` stays localhost.

Full suite: **1094 passing**, `tsc --noEmit` clean. (Lint runs in CI — the authoring sandbox has an ESLint 8/9 rule-config skew in the reused `node_modules` that reproduces on unchanged files.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)