### PR TITLE
feat(saga-stack-cli): port up.sh's LiveKit creds fetch to --tunnel

### DIFF
--- a/packages/node/saga-stack-cli/src/base-command.ts
+++ b/packages/node/saga-stack-cli/src/base-command.ts
@@ -81,6 +81,7 @@ import {
   makeRealBuildCleaner,
   makeRealEnvFs,
   makeRealForeignProcs,
+  makeRealLivekitCredsFetch,
   generateTunnelFleetConfig,
   generateSlotFleetConfig,
   resolveRepoRoot,
@@ -117,6 +118,7 @@ import type {
   BuildCleaner,
   EnvFs,
   ForeignProcs,
+  LivekitCredsFetch,
 } from './runtime/index.js';
 
 /**
@@ -527,6 +529,18 @@ export abstract class BaseCommand extends Command {
    */
   protected getTunnelMoniker(): (vendorTunnelSh: string) => Promise<string> {
     return resolveTunnelMoniker;
+  }
+
+  /**
+   * The `--tunnel` LiveKit-creds resolver (fidelity port) — production runs the
+   * VENDORED `tunnel.sh aws-profile` then `aws secretsmanager get-secret-value`
+   * for `qboard/fleek/livekit-creds`, so connect-api signs AV join tokens with the
+   * REAL fleek-cluster key. Best-effort: no aws / no access ⇒ null, and the caller
+   * leaves the creds unset (connect-api falls back to the dev key). See
+   * `runtime/livekit-creds`.
+   */
+  protected getLivekitCredsFetch(): LivekitCredsFetch {
+    return makeRealLivekitCredsFetch();
   }
 
   /**

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/up-native.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/up-native.int.test.ts
@@ -25,6 +25,7 @@ import type {
   GitRunner,
   JarWriter,
   LaunchSpec,
+  LivekitCredsFetch,
   MeshExec,
   PostOptions,
   PostResult,
@@ -142,10 +143,14 @@ function installNativeSeams(launchFail: Set<string> = new Set()): void {
     ) => Promise<{ ok: boolean; message: string }>;
     getCookiePoster: () => CookiePoster;
     getJarWriter: () => JarWriter;
+    getLivekitCredsFetch: () => LivekitCredsFetch;
   };
   // Native `up --login` seams (fake POST + jar capture) — never a real network/fs, never up.sh.
   vi.spyOn(proto, 'getCookiePoster').mockReturnValue(poster);
   vi.spyOn(proto, 'getJarWriter').mockReturnValue(jar);
+  // --tunnel AV creds: default to "unavailable" so no real `aws`/`tunnel.sh` spawns;
+  // the creds-resolved path overrides this per-test.
+  vi.spyOn(proto, 'getLivekitCredsFetch').mockReturnValue(async () => null);
   // Phase 2: a fixed moniker (never spawn tunnel.sh) + a recording seam that records
   // the resolved RecordPlan (never touches docker/aws).
   vi.spyOn(proto, 'getTunnelMoniker').mockReturnValue(async () => 'testmoniker');
@@ -490,6 +495,27 @@ describe('stack up --slot N — isolated bring-up (M7 Phase 2)', () => {
     const tun = runs.find((r) => r.command.endsWith('tunnel.sh'));
     expect(tun?.args).toEqual(['up']);
     expect(tun?.command).toContain('vendor');
+  });
+
+  it('--tunnel with fleek creds resolved → connect-api signs AV with the CLUSTER key', async () => {
+    vi.spyOn(
+      BaseCommand.prototype as unknown as { getLivekitCredsFetch: () => LivekitCredsFetch },
+      'getLivekitCredsFetch',
+    ).mockReturnValue(async () => ({ apiKey: 'fleekKey', apiSecret: 'fleekSecret' }));
+    await StackUp.run(['--tunnel', ...WS], config);
+    const capi = launches.find((s) => s.id === 'connect-api');
+    expect(capi?.env.LIVEKIT_API_KEY).toBe('fleekKey');
+    expect(capi?.env.LIVEKIT_API_SECRET).toBe('fleekSecret');
+  });
+
+  it('--tunnel with NO creds available → connect-api keeps its base dev key (override does not fire)', async () => {
+    // default seam returns null (see installNativeSeams) — the best-effort miss.
+    await StackUp.run(['--tunnel', ...WS], config);
+    const capi = launches.find((s) => s.id === 'connect-api');
+    // The tunnel LiveKit override did NOT fire, so connect-api keeps its base dev
+    // key — which the real fleek cluster rejects, so AV fails (the documented miss).
+    expect(capi?.env.LIVEKIT_API_KEY).toBe('devkey');
+    expect(capi?.env.LIVEKIT_API_KEY).not.toBe('fleekKey');
   });
 
   it('--slot 10 is rejected at the flag layer (rabbitmq-mgmt collision ceiling)', async () => {

--- a/packages/node/saga-stack-cli/src/commands/stack/up.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/up.ts
@@ -319,6 +319,26 @@ export default class StackUp extends BaseCommand {
         tunnelDomain: domain,
       });
       if (rtsmFleetPath) overlays.tunnel.rtsmFleetPath = rtsmFleetPath;
+
+      // AV creds: best-effort fetch the fleek dev-cluster LiveKit key/secret from
+      // Secrets Manager (up.sh's `qboard/fleek/livekit-creds` pull) so connect-api
+      // signs join tokens with the REAL cluster key. Absent (no aws / no SSO / no
+      // access) ⇒ leave them unset: connect-api falls back to the dev key and
+      // cluster AV fails LOUD (the warn below), never a silent unreachable-localhost
+      // fallback. The launch-plan plumbing forwards lkKey/lkSecret →
+      // TUNNEL_LK_KEY/SECRET → connect-api LIVEKIT_API_KEY/SECRET.
+      const lk = await this.getLivekitCredsFetch()(resolveVendorScript('tunnel.sh'));
+      if (lk) {
+        overlays.tunnel.lkKey = lk.apiKey;
+        overlays.tunnel.lkSecret = lk.apiSecret;
+        this.log('✓ tunnel AV: fleek dev-cluster LiveKit creds resolved (qboard/fleek/livekit-creds)');
+      } else {
+        this.warn(
+          'tunnel AV: could not fetch qboard/fleek/livekit-creds — connect-api still points at the fleek ' +
+            'cluster but signs tokens with the dev key, so the cluster rejects them and AV fails. Run `aws sso ' +
+            'login` (with the tunnel AWS profile) and re-up for working cluster AV.',
+        );
+      }
     }
 
     if (flags.record !== undefined) {

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/livekit-creds.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/livekit-creds.unit.test.ts
@@ -1,0 +1,87 @@
+/**
+ * LiveKit fleek-cluster creds fetch — arg construction + JSON parsing, asserted
+ * over a FAKE `LivekitCredsIo` (no real `aws`/`tunnel.sh` spawn). Mirrors up.sh's
+ * `qboard/fleek/livekit-creds` pull: resolve the AWS profile from `tunnel.sh
+ * aws-profile`, then `aws secretsmanager get-secret-value`, then pull
+ * `api_key`/`api_secret`. Best-effort: any miss ⇒ null (dev-key fallback).
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  LIVEKIT_SECRET_ID,
+  LIVEKIT_SECRET_REGION,
+  livekitSecretArgs,
+  makeRealLivekitCredsFetch,
+  parseLivekitSecret,
+} from '../livekit-creds.js';
+import type { LivekitCredsIo } from '../livekit-creds.js';
+
+/** A fake IO: answer `aws-profile` then the `aws` call from canned strings; record calls. */
+function fakeIo(over: { profile?: string; secret?: string } = {}): {
+  io: LivekitCredsIo;
+  calls: { command: string; args: string[] }[];
+} {
+  const calls: { command: string; args: string[] }[] = [];
+  const io: LivekitCredsIo = {
+    async run(command, args) {
+      calls.push({ command, args });
+      if (args[0] === 'aws-profile') return over.profile ?? '';
+      return over.secret ?? '';
+    },
+  };
+  return { io, calls };
+}
+
+describe('parseLivekitSecret', () => {
+  it('extracts api_key/api_secret from the SecretString JSON', () => {
+    expect(parseLivekitSecret('{"api_key":"K1","api_secret":"S1"}')).toEqual({ apiKey: 'K1', apiSecret: 'S1' });
+  });
+  it('returns null on missing api_secret, empty, or malformed JSON', () => {
+    expect(parseLivekitSecret('{"api_key":"K1"}')).toBeNull();
+    expect(parseLivekitSecret('')).toBeNull();
+    expect(parseLivekitSecret('not json')).toBeNull();
+  });
+});
+
+describe('livekitSecretArgs', () => {
+  it('reads the up.sh secret id + region, and adds --profile only when set', () => {
+    expect(LIVEKIT_SECRET_ID).toBe('qboard/fleek/livekit-creds');
+    expect(LIVEKIT_SECRET_REGION).toBe('us-west-2');
+    const withP = livekitSecretArgs('myprofile');
+    expect(withP).toContain('--secret-id');
+    expect(withP).toContain(LIVEKIT_SECRET_ID);
+    expect(withP).toContain('--region');
+    expect(withP).toContain(LIVEKIT_SECRET_REGION);
+    expect(withP.join(' ')).toContain('--profile myprofile');
+    expect(livekitSecretArgs('').join(' ')).not.toContain('--profile');
+  });
+});
+
+describe('makeRealLivekitCredsFetch', () => {
+  it('resolves creds: aws-profile → aws get-secret-value → parsed key/secret', async () => {
+    const { io, calls } = fakeIo({ profile: 'sso-dev', secret: '{"api_key":"realK","api_secret":"realS"}' });
+    const creds = await makeRealLivekitCredsFetch(io)('/w/vendor/tunnel.sh');
+    expect(creds).toEqual({ apiKey: 'realK', apiSecret: 'realS' });
+    // first call resolves the profile via the vendored tunnel.sh …
+    expect(calls[0]).toMatchObject({ command: '/w/vendor/tunnel.sh', args: ['aws-profile'] });
+    // … then the aws call carries the resolved profile.
+    expect(calls[1]?.command).toBe('aws');
+    expect(calls[1]?.args.join(' ')).toContain('--profile sso-dev');
+  });
+
+  it('omits --profile when tunnel.sh aws-profile is empty (default cred chain)', async () => {
+    const { io, calls } = fakeIo({ profile: '', secret: '{"api_key":"K","api_secret":"S"}' });
+    await makeRealLivekitCredsFetch(io)('/w/vendor/tunnel.sh');
+    expect(calls[1]?.args.join(' ')).not.toContain('--profile');
+  });
+
+  it('returns null (dev-key fallback) when the secret is inaccessible', async () => {
+    const { io } = fakeIo({ profile: 'p', secret: '' }); // aws failed / no access
+    expect(await makeRealLivekitCredsFetch(io)('/w/vendor/tunnel.sh')).toBeNull();
+  });
+
+  it('defaults to the real execFile IO when none is injected (smoke — does not throw)', () => {
+    expect(typeof makeRealLivekitCredsFetch()).toBe('function');
+    expect(vi.isMockFunction(makeRealLivekitCredsFetch())).toBe(false);
+  });
+});

--- a/packages/node/saga-stack-cli/src/runtime/index.ts
+++ b/packages/node/saga-stack-cli/src/runtime/index.ts
@@ -51,3 +51,4 @@ export * from './lock.js';
 export * from './checkpoint-store.js';
 export * from './trace-preserve.js';
 export * from './foreign-procs.js';
+export * from './livekit-creds.js';

--- a/packages/node/saga-stack-cli/src/runtime/livekit-creds.ts
+++ b/packages/node/saga-stack-cli/src/runtime/livekit-creds.ts
@@ -1,0 +1,99 @@
+/**
+ * LiveKit fleek-cluster creds fetch — the AWS Secrets Manager pull up.sh does
+ * under `--tunnel` (`qboard/fleek/livekit-creds`), ported to the native `ss` path.
+ *
+ * WHY: tunnel mode points connect-api's AV at the REAL fleek dev LiveKit cluster
+ * (local LiveKit is UDP/WebRTC — it can't ride the frp HTTP tunnels). connect-api
+ * signs each room JOIN TOKEN with a LiveKit API key+secret; the cluster only
+ * honours tokens signed with ITS real creds, not the local `devkey`. So without
+ * these, a remote guest gets CRDT/chat (rtsm, websockets → tunnels fine) but AV
+ * fails to connect. The launch-plan plumbing already forwards `tunnel.lkKey/
+ * lkSecret` → `TUNNEL_LK_KEY/SECRET` → connect-api `LIVEKIT_API_KEY/SECRET`; this
+ * module is the missing piece that RESOLVES them.
+ *
+ * BEST-EFFORT (up.sh parity): no aws CLI, no SSO session, no access to the
+ * secret, or malformed JSON ⇒ `null`. The caller then leaves the creds unset and
+ * connect-api falls back to the dev key (cluster AV fails LOUD) — never a silent
+ * localhost fallback. Every shell-out folds errors into a safe answer; never
+ * throws. The exec is behind the injectable `LivekitCredsIo` so tests assert the
+ * aws-arg construction + JSON parsing with no real `aws`/`tunnel.sh` spawn.
+ */
+
+import { execFile } from 'node:child_process';
+import { dirname } from 'node:path';
+
+/** The fleek dev-cluster LiveKit API creds (from the `qboard/fleek/livekit-creds` secret). */
+export interface LivekitCreds {
+  apiKey: string;
+  apiSecret: string;
+}
+
+/** Resolve the fleek-cluster LiveKit creds, or null when unavailable (best-effort). */
+export type LivekitCredsFetch = (vendorTunnelSh: string) => Promise<LivekitCreds | null>;
+
+/** The Secrets Manager secret id + region up.sh reads (keep in sync with up.sh). */
+export const LIVEKIT_SECRET_ID = 'qboard/fleek/livekit-creds';
+export const LIVEKIT_SECRET_REGION = 'us-west-2';
+
+/** The injectable command runner: resolve trimmed stdout ('' on any error), NEVER throw. */
+export interface LivekitCredsIo {
+  run(command: string, args: string[], cwd?: string): Promise<string>;
+}
+
+/** The production `LivekitCredsIo` — `execFile`, folding every error into ''. */
+export function makeRealLivekitCredsIo(): LivekitCredsIo {
+  return {
+    run(command: string, args: string[], cwd?: string): Promise<string> {
+      return new Promise((resolve) => {
+        execFile(command, args, { encoding: 'utf8', cwd, maxBuffer: 4 * 1024 * 1024 }, (err, stdout) => {
+          resolve(err ? '' : (stdout ?? '').toString().trim());
+        });
+      });
+    },
+  };
+}
+
+/** Build the `aws secretsmanager get-secret-value` argv (profile omitted when empty). */
+export function livekitSecretArgs(profile: string): string[] {
+  return [
+    'secretsmanager',
+    'get-secret-value',
+    '--secret-id',
+    LIVEKIT_SECRET_ID,
+    '--region',
+    LIVEKIT_SECRET_REGION,
+    ...(profile ? ['--profile', profile] : []),
+    '--query',
+    'SecretString',
+    '--output',
+    'text',
+  ];
+}
+
+/** Parse a Secrets Manager `SecretString` into creds, or null (missing keys / bad JSON). */
+export function parseLivekitSecret(raw: string): LivekitCreds | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as { api_key?: string; api_secret?: string };
+    if (parsed.api_key && parsed.api_secret) {
+      return { apiKey: parsed.api_key, apiSecret: parsed.api_secret };
+    }
+  } catch {
+    /* malformed SecretString ⇒ null */
+  }
+  return null;
+}
+
+/**
+ * The production fetch: resolve the AWS profile from the vendored `tunnel.sh
+ * aws-profile` (empty ⇒ the default credential chain, like up.sh's
+ * `${TUNNEL_AWS_PROFILE:+--profile …}`), then `aws secretsmanager get-secret-value`
+ * the JSON secret and pull its `api_key`/`api_secret`. Any miss ⇒ null.
+ */
+export function makeRealLivekitCredsFetch(io: LivekitCredsIo = makeRealLivekitCredsIo()): LivekitCredsFetch {
+  return async (vendorTunnelSh: string): Promise<LivekitCreds | null> => {
+    const profile = await io.run(vendorTunnelSh, ['aws-profile'], dirname(vendorTunnelSh));
+    const raw = await io.run('aws', livekitSecretArgs(profile));
+    return parseLivekitSecret(raw);
+  };
+}


### PR DESCRIPTION
Closes the **MEDIUM** tunnel-fidelity gap flagged in the `--tunnel` audit (the third of the three follow-ups; the other two — seed-gating, moniker source — remain out of scope).

## Why

Native `--tunnel` points connect-api's AV at the **real fleek dev LiveKit cluster** — it has to, because local LiveKit is UDP/WebRTC and can't ride the frp HTTP tunnels. But ss never fetched the cluster's real API creds, so connect-api signed every room **join token with the local `devkey`**. The cluster rejects `devkey`-signed tokens → **AV fails to connect** over an ss tunnel (chat + whiteboard via rtsm/websockets still work). `up.sh` best-effort pulls `qboard/fleek/livekit-creds` from Secrets Manager under `--tunnel`; this ports that.

## What

The launch-plan plumbing was **already** in place — `tunnel.lkKey/lkSecret` → `TUNNEL_LK_KEY/SECRET` → connect-api `LIVEKIT_API_KEY/SECRET`, with a passing overlay test. The only missing piece was **resolving** the creds:

- **`runtime/livekit-creds`** — `makeRealLivekitCredsFetch`: vendored `tunnel.sh aws-profile` → `aws secretsmanager get-secret-value --secret-id qboard/fleek/livekit-creds --region us-west-2 [--profile …]` → parse `api_key`/`api_secret`. The exec is behind an injectable `LivekitCredsIo`, and `parseLivekitSecret` / `livekitSecretArgs` are pure + exported for unit tests.
- **`BaseCommand.getLivekitCredsFetch()`** seam.
- **`up.ts resolveOverlays`** — best-effort fetch under `--tunnel`, populate `overlays.tunnel.lkKey/lkSecret`, and log a `✓`/`⚠` on hit/miss.

**Best-effort (up.sh parity):** no aws / no SSO / no access ⇒ `null` ⇒ connect-api keeps the dev key and AV fails **loud** (the `⚠`), never a silent unreachable-localhost fallback.

## Tests

- `livekit-creds.unit.test.ts` — arg construction (secret id/region match up.sh; `--profile` only when set), JSON parse (valid / missing field / malformed / empty), and the fetch orchestration over a fake IO.
- `up-native.int.test.ts` — `--tunnel` with creds resolved ⇒ connect-api's `LIVEKIT_API_KEY/SECRET` = the cluster key; miss ⇒ connect-api keeps its base `devkey` (override doesn't fire). Default seam returns `null` so no real `aws`/`tunnel.sh` spawns in the suite.

Full suite: **1143 passing**, `tsc --noEmit` clean.

## Live validation

Ran the real fetch against AWS: resolved the live `qboard/fleek/livekit-creds` secret (`api_key`/`api_secret` present, correct lengths — values redacted), ~3.5s, no throw. Confirms profile resolution + the aws call + JSON parse work end-to-end.

> Note: branches off current `main` (which already includes the merged #288 foreign-proc guardrail); the diff is LiveKit-only. Independent of #289. Lint runs in CI (authoring sandbox has an ESLint 8/9 rule-config skew).

🤖 Generated with [Claude Code](https://claude.com/claude-code)