### PR TITLE
fix(infra): register CloudMap DB records with IMDS private IP, not `hostname -I`

### DIFF
--- a/infra/src/ec2/ec2-router.js
+++ b/infra/src/ec2/ec2-router.js
@@ -246,8 +246,8 @@ export function create_ec2_router(config = {}) {
                 // Register in CloudMap
                 if (namespace_id) {
                     try {
-                        const ip = get_instance_metadata().private_ip;
-                        register({ name, ip, port, namespace_id, region: region || get_instance_metadata().region });
+                        const meta = get_instance_metadata();
+                        register({ name, ip: meta.private_ip, port, namespace_id, region: region || meta.region });
                     } catch (err) {
                         synced.push({
                             ok: true,
@@ -494,8 +494,8 @@ export function create_ec2_router(config = {}) {
                 const ports = get_allocated_ports({ registry_path });
                 const port_entry = ports[name];
                 if (port_entry) {
-                    const ip = get_instance_metadata().private_ip;
-                    register({ name, ip, port: port_entry.port, namespace_id, region: region || get_instance_metadata().region });
+                    const meta = get_instance_metadata();
+                    register({ name, ip: meta.private_ip, port: port_entry.port, namespace_id, region: region || meta.region });
                 }
             }
 
@@ -582,13 +582,13 @@ export function create_ec2_router(config = {}) {
             }
 
             if (namespace_id) {
-                const ip = get_instance_metadata().private_ip;
+                const meta = get_instance_metadata();
                 register({
                     name,
-                    ip,
+                    ip: meta.private_ip,
                     port,
                     namespace_id,
-                    region: region || get_instance_metadata().region,
+                    region: region || meta.region,
                 });
             }
 

--- a/infra/src/ec2/ec2-router.js
+++ b/infra/src/ec2/ec2-router.js
@@ -246,7 +246,7 @@ export function create_ec2_router(config = {}) {
                 // Register in CloudMap
                 if (namespace_id) {
                     try {
-                        const ip = spawnSync('hostname', ['-I'], { encoding: 'utf8' }).stdout.trim().split(/\s+/)[0];
+                        const ip = get_instance_metadata().private_ip;
                         register({ name, ip, port, namespace_id, region: region || get_instance_metadata().region });
                     } catch (err) {
                         synced.push({
@@ -412,7 +412,7 @@ export function create_ec2_router(config = {}) {
 
                 // Register with CloudMap
                 if (namespace_id) {
-                    const ip = spawnSync('hostname', ['-I'], { encoding: 'utf8' }).stdout.trim().split(/\s+/)[0];
+                    const ip = get_instance_metadata().private_ip;
                     register({
                         name,
                         ip,
@@ -494,7 +494,7 @@ export function create_ec2_router(config = {}) {
                 const ports = get_allocated_ports({ registry_path });
                 const port_entry = ports[name];
                 if (port_entry) {
-                    const ip = spawnSync('hostname', ['-I'], { encoding: 'utf8' }).stdout.trim().split(/\s+/)[0];
+                    const ip = get_instance_metadata().private_ip;
                     register({ name, ip, port: port_entry.port, namespace_id, region: region || get_instance_metadata().region });
                 }
             }
@@ -582,7 +582,7 @@ export function create_ec2_router(config = {}) {
             }
 
             if (namespace_id) {
-                const ip = spawnSync('hostname', ['-I'], { encoding: 'utf8' }).stdout.trim().split(/\s+/)[0];
+                const ip = get_instance_metadata().private_ip;
                 register({
                     name,
                     ip,

--- a/infra/src/ec2/volumes.js
+++ b/infra/src/ec2/volumes.js
@@ -16,7 +16,7 @@ function run(cmd, args, options = {}) {
 
 /**
  * Get EC2 instance metadata via IMDSv2.
- * @returns {{ instance_id: string, az: string, region: string }}
+ * @returns {{ instance_id: string, az: string, region: string, private_ip: string }}
  */
 export function get_instance_metadata() {
     const token = run('curl', [

--- a/infra/src/ec2/volumes.js
+++ b/infra/src/ec2/volumes.js
@@ -36,6 +36,13 @@ export function get_instance_metadata() {
         instance_id: identity.instanceId,
         az: identity.availabilityZone,
         region: identity.region,
+        // The node's eth0 private IP, straight from the instance-identity
+        // document. This is the authoritative fleet-network address to register
+        // in CloudMap — unlike `hostname -I`, it is never a docker-compose
+        // bridge gateway (192.168.x/172.x), which on a busy db-host node with
+        // many compose networks would otherwise get picked up and registered as
+        // an unreachable A-record.
+        private_ip: identity.privateIp,
     };
 }
 

--- a/infra/test/unit/ec2-router-provision.unit.test.js
+++ b/infra/test/unit/ec2-router-provision.unit.test.js
@@ -100,6 +100,9 @@ describe('POST /dbs provision race + rollback', () => {
         // document (eth0 private IP), never from `hostname -I`, whose first entry
         // can be a docker-compose bridge gateway (192.168.x/172.x) on a busy
         // db-host node → an unreachable A-record. See volumes.js private_ip.
+        // The create route stands in for all four register sites (create/sync/
+        // start/hydrate), which share the identical `get_instance_metadata().
+        // private_ip` expression — a reverted site would break them together.
         const ns_server = await create_test_server({
             projects_dir, data_dir,
             registry_path: join(data_dir, 'ports.json'),
@@ -113,7 +116,10 @@ describe('POST /dbs provision race + rollback', () => {
             expect(register).toHaveBeenCalledWith(
                 expect.objectContaining({ name: 'svc-pr-ns', ip: '10.3.142.176' }),
             );
-            // And never registers a bridge/loopback address.
+            // And never registers a bridge/loopback address. NB: this rejects
+            // all of 172.16/12 — fine for the fleet's 10/8 VPC, but a default
+            // AWS VPC (172.31/16) would carry a legitimate eth0 IP in that range,
+            // so tighten this guard if the fleet ever moves off 10/8 addressing.
             for (const [{ ip }] of register.mock.calls) {
                 expect(ip).not.toMatch(/^(192\.168\.|172\.(1[6-9]|2\d|3[01])\.|127\.)/);
             }

--- a/infra/test/unit/ec2-router-provision.unit.test.js
+++ b/infra/test/unit/ec2-router-provision.unit.test.js
@@ -12,6 +12,7 @@ vi.mock('../../src/ec2/volumes.js', () => ({
     cleanup_volume: vi.fn(() => true),
     get_instance_metadata: vi.fn(() => ({
         instance_id: 'i-test', az: 'us-west-2a', region: 'us-west-2',
+        private_ip: '10.3.142.176',
     })),
 }));
 vi.mock('../../src/ec2/ports.js', () => ({
@@ -40,6 +41,7 @@ vi.mock('child_process', () => ({
 import { spawnSync } from 'child_process';
 import { create_volume, cleanup_volume } from '../../src/ec2/volumes.js';
 import { release_port } from '../../src/ec2/ports.js';
+import { register } from '../../src/ec2/cloudmap.js';
 import { create_ec2_router } from '../../src/ec2/ec2-router.js';
 
 function create_test_server(router_options) {
@@ -91,6 +93,33 @@ describe('POST /dbs provision race + rollback', () => {
         expect(status).toBe(200);
         expect(data).toMatchObject({ ok: true, name: 'svc-pr-1', volumeId: 'vol-test123' });
         expect(existsSync(join(projects_dir, 'svc-pr-1'))).toBe(true);
+    });
+
+    it('registers the CloudMap A-record with the IMDS private IP, not `hostname -I`', async () => {
+        // Regression guard: the register IP must come from the instance-identity
+        // document (eth0 private IP), never from `hostname -I`, whose first entry
+        // can be a docker-compose bridge gateway (192.168.x/172.x) on a busy
+        // db-host node → an unreachable A-record. See volumes.js private_ip.
+        const ns_server = await create_test_server({
+            projects_dir, data_dir,
+            registry_path: join(data_dir, 'ports.json'),
+            namespace_id: 'ns-test',
+        });
+        try {
+            const { status } = await api(ns_server.base_url, 'POST', '/dbs', {
+                name: 'svc-pr-ns', engine: 'postgres',
+            });
+            expect(status).toBe(200);
+            expect(register).toHaveBeenCalledWith(
+                expect.objectContaining({ name: 'svc-pr-ns', ip: '10.3.142.176' }),
+            );
+            // And never registers a bridge/loopback address.
+            for (const [{ ip }] of register.mock.calls) {
+                expect(ip).not.toMatch(/^(192\.168\.|172\.(1[6-9]|2\d|3[01])\.|127\.)/);
+            }
+        } finally {
+            await ns_server.close();
+        }
     });
 
     it('409s a duplicate provision without touching AWS (name reserved before create)', async () => {


### PR DESCRIPTION
## Summary

The db-host-v2 host agent (`@saga-ed/infra-compose`) registered each container's CloudMap A-record using `hostname -I | split[0]`. That lists **every** interface IP — eth0 (the `10.3.x` fleet ENI) plus one gateway per docker-compose bridge network. On a busy db-host node, `[0]` can land on a **bridge gateway (`192.168.x.1` / `172.(16-31).x.1`)**, registering an **unreachable A-record**.

**Observed impact:** `coach-api-postgres.dbs-v2.local` resolved to `192.168.176.1` (a compose bridge gateway) instead of the fleet node `10.3.142.176`, failing coach-api's deploy `Migrate` step with `P1001: Can't reach database server` for days. Sibling records on the same node resolve correctly only because eth0 happened to sort first at their registration time — a latent race that bites any service on a loaded node and re-poisons on each lifecycle event.

## Fix

Use the eth0 private IP from the IMDS instance-identity document — already fetched (and previously discarded) in `get_instance_metadata()` (`infra/src/ec2/volumes.js`). It's authoritative and never a bridge/loopback address. Applied at all **four** register sites: create (`POST /dbs`), `sync`, `start`, `hydrate`.

## Test

Added a regression test to `ec2-router-provision.unit.test.js` asserting the register call uses the IMDS private IP (`10.3.142.176`) and never a `192.168.x`/`172.16-31.x`/`127.x` address. Full infra suite: **107 passed**; lint clean.

## ⚠ Rollout (for infra owners — not self-merging)

This is the host agent that runs **on each db-host-v2 fleet node**, so the fix only takes effect once the agent is **redeployed to the fleet**. Existing poisoned records need a one-off `servicediscovery register-instance` correction (or a container re-home) to pick up the right IP. Flagging for review + fleet rollout ownership — this is a shared, high-blast-radius path.

Found while resolving coach-api's dev Postgres connectivity (P1001 on Migrate). Coach was independently unblocked by bootstrapping its dev DB + repointing its secrets at the fleet node IP; this PR fixes the underlying fleet-wide registration bug so it stops recurring.

Closes #293

https://claude.ai/code/session_01AHuqxt2xQugmUny4WGb36R