### PR TITLE
feat(authz-model): add staff_org.can_force_clever_sync relation

### DIFF
--- a/packages/core/saga-authz-model/model.fga
+++ b/packages/core/saga-authz-model/model.fga
@@ -158,3 +158,8 @@ type staff_org
     define can_view: staff_admin
     define can_edit: staff_admin
     define can_delete: staff_admin
+    # Staff-only trigger for a district's SIS (Clever) sync. Resolves from
+    # staff_admin (org_admin+ staff), NOT any district persona — sis-api's
+    # forceSync gate checks THIS, replacing the placeholder district-admin
+    # `sis:force_clever_sync` persona permission.
+    define can_force_clever_sync: staff_admin

--- a/packages/core/saga-authz-model/src/__tests__/model-fga.unit.test.ts
+++ b/packages/core/saga-authz-model/src/__tests__/model-fga.unit.test.ts
@@ -94,6 +94,14 @@ describe('staff control-plane namespace (SEC-CRIT-2)', () => {
         expect(rels).not.toContain('admin');
     });
 
+    it('staff_org exposes can_force_clever_sync computed from staff_admin', () => {
+        const rels = byType.staff_org.relations ?? {};
+        expect(rels).toHaveProperty('can_force_clever_sync');
+        // Must resolve THROUGH staff_admin (org_admin+ staff), not a direct
+        // user grant — so it can never be handed to a district persona.
+        expect(JSON.stringify(rels.can_force_clever_sync)).toContain('staff_admin');
+    });
+
     it('staff_org has no `from parent` cascade into the resource tree', () => {
         // No relation on staff_org may resolve through a `parent` edge —
         // the only computed-userset source allowed is `platform`.

--- a/packages/core/saga-authz-model/src/types.ts
+++ b/packages/core/saga-authz-model/src/types.ts
@@ -64,7 +64,8 @@ export interface FgaRelationsByType {
         | 'staff_admin'
         | 'can_view'
         | 'can_edit'
-        | 'can_delete';
+        | 'can_delete'
+        | 'can_force_clever_sync';
 }
 
 export type FgaRelation<T extends FgaType> = FgaRelationsByType[T];


### PR DESCRIPTION
## What

Adds `can_force_clever_sync: staff_admin` to `type staff_org` in the canonical FGA model. A staff-only capability for triggering a district's SIS (Clever) sync, computed from `staff_admin` (org_admin+ staff via `can_admin_personas from platform`).

It replaces the placeholder district-admin `sis:force_clever_sync` persona permission that gates sis-api's `clever.forceSync` today — **staff, not district admins, are the intended force-syncers.**

## Why it's cheap

Rides entirely on wiring that already exists:
- `staff_org:<gid>` objects are projected per district by authz-sync on `iam.group.created` — no sync-worker or tuple changes.
- `staff_admin` already resolves from the platform roles.

So this is a pure model addition: one relation line + the hand-maintained `src/types.ts` union + a regression test.

## Tests

`model-fga.unit.test.ts`: 29 green, including the OpenFGA transformer validity check (proves the model would load into a store) and a new assertion that `can_force_clever_sync` exists and resolves through `staff_admin` (so it can never be granted directly to a district persona).

## ⚠️ This is the HARD PREREQUISITE for the rest of the workstream

**Merge order:**
1. **This PR** merges first.
2. Then dispatch `run-fga-bootstrap` (dev) to publish the model → advances the store's model-id.
3. Only then can the rostering companion PR (iam-api `staffAdmin.canForceCleverSync` + sis-api gate swap) be validated live.

The identical relation is vendored into rostering's `scripts/fga/model.fga` in the companion rostering PR (that's the copy the bootstrap loader currently reads).

## Companion

rostering: iam-api procedure + sis-api gate swap (separate PR, must deploy AFTER this is published).

https://claude.ai/code/session_01MKQTrhedyLFbo32fovNxjf