### PR TITLE
feat(saga-stack-cli): additive seed (no reset) for prerequisite flows (#295, saga-ed/qboard#226)

### DIFF
--- a/packages/node/saga-stack-cli/docs/e2e-flows.md
+++ b/packages/node/saga-stack-cli/docs/e2e-flows.md
@@ -35,6 +35,11 @@ ss e2e list          # every SPA, flow, and stage — plus checkpoint freshness
   know when they're stale (`ss e2e list` shows `[checkpoint: re-bake]`).
 - A **prerequisite** flow (ads-adm, connect) needs journey state first — it
   restores journey's checkpoint automatically instead of replaying it.
+- An **additive seed** lets a prerequisite flow (`reset: false`) that *also*
+  declares a `seed` run that seed ON TOP of the restored journey state — e.g.
+  `connect-content` / `connect-nav-lock` publishing their poll into content-api,
+  which journey itself never seeds. Skipped under `--skip-reset`, and never on a
+  `--from` checkpoint (the restore is the state source).
 - A **slot** is an isolated stack instance (`--slot 1..9`, offset ports).
   Slot 0 is your default stack. You never need a slot for a first run.
 

--- a/packages/node/saga-stack-cli/src/__tests__/e2e-orchestrate-additive-seed.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/__tests__/e2e-orchestrate-additive-seed.unit.test.ts
@@ -1,0 +1,148 @@
+/**
+ * `executeResolvedFlow` — additive seed (no reset).
+ *
+ * A flow whose end-state is built by a prerequisite (so `reset` is false) but
+ * which declares a `seed` still runs THAT seed on top of the built state — e.g.
+ * connect-content publishes its legacy poll into content-api, which the journey
+ * prerequisite never seeds (content-api isn't in journey's closure). `--skip-reset`
+ * suppresses it (the caller then wants pure state reuse).
+ *
+ * Offline + deterministic: fake StackApi + Runner. The bundled example flows.json
+ * supplies `connect-session` (prerequisite journey@schedule ⇒ reset:false), into
+ * which we inject a content-only `seedSelection`. Its journey prerequisite replays
+ * and seeds too, so assertions look for the content-ONLY plan among the seeds.
+ */
+
+// eslint-disable-next-line no-restricted-imports -- test fixture read; production core stays fs-free
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { parseFlowManifest } from '../core/flow/load.js';
+import type { ResolvedFlow } from '../core/flow/index.js';
+import { resolveFlow } from '../core/flow/resolve.js';
+import type { SeedPlan } from '../core/seed/index.js';
+import type { SeedSelection } from '../core/seed/types.js';
+import { executeResolvedFlow, isAdditiveSeed } from '../e2e-orchestrate.js';
+import type { RunResult, ScriptInvocation } from '../runtime/index.js';
+import type { HealthProbe, StackApi, UpResult } from '../stack-api.js';
+
+const EXAMPLE = fileURLToPath(new URL('../../examples/flows/saga-dash.flows.json', import.meta.url));
+const flowManifest = parseFlowManifest(readFileSync(EXAMPLE, 'utf8'), EXAMPLE);
+
+// `only:['content-api']` keeps just the content step — it can't clobber the
+// prerequisite-built iam/sessions/programs state.
+const CONTENT_ONLY_SEED: SeedSelection = { profile: 'full', reset: false, only: ['content-api'] };
+
+interface Captured {
+  seedPlans: SeedPlan[];
+  logs: string[];
+}
+
+function makeFakes(): { api: StackApi; cap: Captured } {
+  const cap: Captured = { seedPlans: [], logs: [] };
+  const api: StackApi = {
+    async up(): Promise<UpResult> {
+      return { ok: true, mesh: { ok: true } as UpResult['mesh'], launched: [], skipped: [] };
+    },
+    async down() {
+      return { stopped: [] };
+    },
+    async restart() {
+      throw new Error('unused');
+    },
+    async reset() {
+      return { code: 0 };
+    },
+    async seed(plan: SeedPlan) {
+      cap.seedPlans.push(plan);
+      return { ok: true, ran: { offline: [], online: [] }, skipped: plan.skipped };
+    },
+    async verify(_probes: HealthProbe[]) {
+      return { passed: true, rows: [] };
+    },
+  };
+  return { api, cap };
+}
+
+/** Run connect-session (prerequisite journey@schedule) with an injected seed. */
+async function run(
+  seedSelection: SeedSelection | undefined,
+  skipReset: boolean,
+): Promise<{ code: number; cap: Captured }> {
+  const { api, cap } = makeFakes();
+  const base = resolveFlow(flowManifest, 'connect-session', { headed: false });
+  const resolved = { ...base, seedSelection };
+  const code = await executeResolvedFlow(
+    resolved,
+    {
+      api,
+      runner: {
+        async run(_spec: ScriptInvocation): Promise<RunResult> {
+          return { code: 0 };
+        },
+      },
+      appCwd: '/virtual/saga-dash/apps/web/dash',
+      now: new Date('2026-07-01T12:00:00Z'),
+      log: (line: string) => cap.logs.push(line),
+    },
+    { lane: 'stack', skipReset, passthrough: [] },
+  );
+  return { code, cap };
+}
+
+/** Was a content-ONLY seed plan (the additive one) composed? */
+function seededContentOnly(plans: SeedPlan[]): boolean {
+  return plans.some((p) => {
+    const steps = [...p.offline, ...p.online];
+    return steps.length > 0 && steps.every((s) => s.service === 'content-api');
+  });
+}
+
+describe('executeResolvedFlow — additive seed (no reset) on a prerequisite flow', () => {
+  it('runs the declared seed on top of prerequisite-built state (content-api only)', async () => {
+    const { code, cap } = await run(CONTENT_ONLY_SEED, false);
+    expect(code).toBe(0);
+    expect(seededContentOnly(cap.seedPlans)).toBe(true);
+    expect(cap.logs.some((l) => l.includes('additive seed (no reset)'))).toBe(true);
+  });
+
+  it('does NOT additively seed when the flow declares no seed (baseline)', async () => {
+    const { code, cap } = await run(undefined, false);
+    expect(code).toBe(0);
+    expect(seededContentOnly(cap.seedPlans)).toBe(false);
+    expect(cap.logs.some((l) => l.includes('skip reset/seed'))).toBe(true);
+  });
+
+  it('respects --skip-reset: no additive seed even with a declared seed', async () => {
+    const { code, cap } = await run(CONTENT_ONLY_SEED, true);
+    expect(code).toBe(0);
+    expect(seededContentOnly(cap.seedPlans)).toBe(false);
+  });
+});
+
+describe('isAdditiveSeed (predicate)', () => {
+  const asResolved = (o: Partial<ResolvedFlow>): ResolvedFlow => o as ResolvedFlow;
+  const SEED = CONTENT_ONLY_SEED as ResolvedFlow['seedSelection'];
+  const PREREQ = {} as ResolvedFlow['prerequisite'];
+  const CHECKPOINT = { fixtureId: 'x', predecessor: 'schedule' } as ResolvedFlow['checkpoint'];
+
+  it('true for a prerequisite flow with a seed (reset false, not skipReset)', () => {
+    expect(isAdditiveSeed(asResolved({ reset: false, seedSelection: SEED, prerequisite: PREREQ }), false)).toBe(true);
+  });
+
+  it('false for a --from checkpoint flow — a restore is the state source, NEVER re-seed', () => {
+    expect(isAdditiveSeed(asResolved({ reset: false, seedSelection: SEED, checkpoint: CHECKPOINT }), false)).toBe(false);
+  });
+
+  it('false under --skip-reset (pure state reuse)', () => {
+    expect(isAdditiveSeed(asResolved({ reset: false, seedSelection: SEED, prerequisite: PREREQ }), true)).toBe(false);
+  });
+
+  it('false when the flow declares no seed', () => {
+    expect(isAdditiveSeed(asResolved({ reset: false, prerequisite: PREREQ }), false)).toBe(false);
+  });
+
+  it('false for a normal reset flow (effectiveReset owns the seed)', () => {
+    expect(isAdditiveSeed(asResolved({ reset: true, seedSelection: SEED }), false)).toBe(false);
+  });
+});

--- a/packages/node/saga-stack-cli/src/commands/e2e/run.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/run.ts
@@ -449,7 +449,11 @@ function dryRunLines(d: ReturnType<typeof describeResolved>): string[] {
     `mesh: ${d.closure.mesh.join(', ') || '(none)'}`,
     d.checkpoint
       ? `restore: ${d.checkpoint.fixtureId} (checkpoint after '${d.checkpoint.predecessor}'; validated at run time)`
-      : `reset+seed: ${d.reset ? 'yes' : 'no (reuse state)'}`,
+      : d.reset
+        ? 'reset+seed: yes'
+        : d.seed
+          ? 'seed: additive (no reset)'
+          : 'reset+seed: no (reuse state)',
   ];
   if (d.bakeCheckpoints) {
     lines.push(`bake (per green stage): ${d.bakeCheckpoints.join(', ')}`);

--- a/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
+++ b/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
@@ -526,6 +526,22 @@ export interface DescribeOptions {
 }
 
 /**
+ * Additive seed (no reset): the flow's end-state was built by a PREREQUISITE
+ * (so `reset` is false) yet it declares a `seed` whose steps must run ON TOP —
+ * e.g. connect-content publishes its poll into content-api, which the journey
+ * prerequisite never seeds. Deliberately EXCLUDES the checkpoint (`--from`) case:
+ * there the restore IS the state source, so re-seeding would wipe the DBs the
+ * restore just filled (a `--from` window never seeds). `--from` and a prerequisite
+ * are mutually exclusive (resolve.ts), so keying on `prerequisite` alone is exact.
+ * Also excluded under --skip-reset (the caller then wants pure state reuse).
+ * The single source of truth for both the executor (§2c) and the --dry-run projection.
+ */
+export function isAdditiveSeed(resolved: ResolvedFlow, skipReset: boolean): boolean {
+  const effectiveReset = resolved.reset && !skipReset;
+  return !effectiveReset && !skipReset && !!resolved.seedSelection && !!resolved.prerequisite;
+}
+
+/**
  * Pure projection of a `ResolvedFlow` into the dry-run/JSON shape: the closure,
  * the effective seed plan (composed over the closure, only when this flow resets
  * + seeds), the exact Playwright argv + cwd, and the injected occurrence date.
@@ -542,7 +558,7 @@ export function describeResolved(resolved: ResolvedFlow, opts: DescribeOptions):
   const excluded = opts.excluded ?? new Set<ServiceId>();
   const services = resolved.closure.services.filter((id) => !excluded.has(id));
   const seed =
-    effectiveReset && resolved.seedSelection
+    (effectiveReset || isAdditiveSeed(resolved, opts.skipReset)) && resolved.seedSelection
       ? (() => {
           const plan = composeSeedPlan(resolved.seedSelection, new Set(services), new Set<ServiceId>());
           return {
@@ -891,6 +907,17 @@ export async function executeResolvedFlow(
         const seeded = await deps.api.seed(plan);
         if (!seeded.ok) throw new FlowExecError(`seed failed at ${seeded.failed}`);
       }
+    } else if (resolved.seedSelection && isAdditiveSeed(resolved, opts.skipReset)) {
+      // 2c. Additive seed (no reset): run the flow's declared seed ON TOP of the
+      // prerequisite-built state — e.g. connect-content publishes its legacy poll
+      // into content-api, which the journey prerequisite never seeds (content-api
+      // isn't in journey's closure). Flow authors MUST scope such a seed (`only` /
+      // `perSystem`, as connect-content does with only:['content-api']) so it can't
+      // clobber the prerequisite-built state.
+      deps.log('==> additive seed (no reset)');
+      const plan = composeSeedPlan(resolved.seedSelection, new Set(activeServices), new Set<ServiceId>());
+      const seeded = await deps.api.seed(plan);
+      if (!seeded.ok) throw new FlowExecError(`additive seed failed at ${seeded.failed}`);
     } else if (!resolved.checkpoint) {
       deps.log('==> skip reset/seed (reuse current stack state)');
     }


### PR DESCRIPTION
## What & why

`ss e2e run saga-dash/connect-content` needs to publish its poll into content-api, but the `journey` prerequisite it builds on never seeds content. This adds an **additive seed**: a flow built from a prerequisite (`reset:false`) that also declares a `seed` now runs that seed ON TOP of the prerequisite-built state.

- **`e2e-orchestrate`** — new `isAdditiveSeed(resolved, skipReset)` predicate + a §2c branch in `executeResolvedFlow` that runs the flow's `seed` on top of prerequisite-built state. Keyed on `prerequisite` **only** (never a `--from` checkpoint — that would corrupt `--from` restores); skipped under `--skip-reset`. `describeResolved` uses the same predicate.
- **`run`** — `--dry-run` prints `seed: additive (no reset)`.

## Tests
- New `e2e-orchestrate-additive-seed.unit.test.ts`: 3 executor tests + 5 predicate tests (incl. checkpoint → false). 10 unit tests pass, `tsc` 0 errors, eslint clean.

> Unit-tested but not yet exercised via a full `ss e2e run saga-dash/connect-content` (needs a fresh reseed).

Consumed by saga-ed/saga-dash#453 (the `connect-content` flow).

Closes #295 · Refs saga-ed/qboard#226
