### PR TITLE
ss Tunnel Mode: finish + verify — coach overlay, e2e --tunnel, real A/V, Connect concierge (#298)

### DIFF
--- a/claude/projects/gh_298/research/findings.md
+++ b/claude/projects/gh_298/research/findings.md
@@ -7,9 +7,20 @@ Jeff Ward Slack (G01CQ6UPB0E threads 2026-06-12 and 2026-07-10 `tunnel_info.md`)
 
 Tunnel mode is **already ported to `ss` and merged on `main`**. The original up.sh feature
 (soa#156, merged 2026-06-15) was carried into `saga-stack-cli` by the soa#214/#221 "decouple"
-work (Phase 1 = vendor the scripts, Phase 2 = native overlays). What remains is (a) a small
-**drift fix** and (b) the **one genuinely-missing capability** Jeff called out for the Connect
-use case: `ss e2e … --tunnel`.
+work (Phase 1 = vendor the scripts, Phase 2 = native overlays). What remains are **three** gaps
+(count corrected by the ultracode validation pass — see `validation-report.md`):
+
+1. **Vendored `tunnel.sh` drift** — coach missing from the vendored SERVICES table.
+2. **coach browser-plane overlay missing from the TypeScript** — `coach-api`/`coach-web` fall
+   through to `default:{}` in `launch-plan.ts:375`, so ss never sets coach's tunnel CORS /
+   `PUBLIC_COACH_API_URL` / Vite allowed-hosts. **Distinct from #1** — re-vendoring the script
+   fixes frpc plumbing but leaves coach CORS-rejected + Vite-403'd. This is the gap my first
+   pass missed.
+3. **No `ss e2e … --tunnel`** — the capability Jeff called out for the Connect use case.
+
+> ⚠️ The original "exactly two gaps" thesis was **refuted as stated** by validation. Details,
+> per-service parity table, and the e2e implementation surface map are in
+> `research/validation-report.md`.
 
 ## What tunnel mode is (original design, soa#156)
 

--- a/claude/projects/gh_298/research/findings.md
+++ b/claude/projects/gh_298/research/findings.md
@@ -1,0 +1,97 @@
+# gh_298 — ss Tunnel Mode: research findings
+
+_Research date: 2026-07-13. Sources: soa#156 (original), soa#214/#221/#271/#224 (ss port),
+Jeff Ward Slack (G01CQ6UPB0E threads 2026-06-12 and 2026-07-10 `tunnel_info.md`)._
+
+## TL;DR — this is a *finish + verify*, not a *port from scratch*
+
+Tunnel mode is **already ported to `ss` and merged on `main`**. The original up.sh feature
+(soa#156, merged 2026-06-15) was carried into `saga-stack-cli` by the soa#214/#221 "decouple"
+work (Phase 1 = vendor the scripts, Phase 2 = native overlays). What remains is (a) a small
+**drift fix** and (b) the **one genuinely-missing capability** Jeff called out for the Connect
+use case: `ss e2e … --tunnel`.
+
+## What tunnel mode is (original design, soa#156)
+
+- Reverse-tunnels the browser-facing local services out to
+  `https://<svc>.<moniker>.vms.wootdev.com` via **frp → a small EC2 rendezvous box**
+  (`vms.wootdev.com`, ~$16/mo, `vms/template.yaml`). "Dev VMs are back."
+- **Moniker** = per-dev DNS namespace (initials), stored in gitignored `.vms-moniker`,
+  **never taken on the CLI** (a placeholder in a shared command cross-contaminates stacks).
+  First use prompts + registers it in SSM `/vms/monikers`; the box mints a wildcard cert
+  `*.<moniker>.vms.wootdev.com` within ~1 min.
+- **Two planes.** Only the browser plane is tunnelled; postgres/redis/rabbitmq/mongo get no
+  tunnel by construction. `tunnel_env()` flips ONLY browser-plane env (cookie domain, CORS,
+  `VITE_*` URLs); service-to-service URLs stay `localhost`.
+- **LiveKit/AV stays on the fleek dev cluster** (`*.fleek.wootdev.com`) — LiveKit is UDP and
+  can't ride the HTTP tunnels. This is deliberate and is why remote guests get CRDT/chat
+  (rtsm = websockets) locally but AV via the real cluster.
+- **Companion deps (all MERGED):** soa-api-util CORS allowlist in rostering#533,
+  program-hub#198, student-data-system#162, qboard#183; saga-dash#194 `url`-type override +
+  `config.local.json` local-override seam. ✅ verified merged 2026-07-13.
+
+## Current state of the `ss` port (what already works)
+
+| Capability | Status | Where |
+|---|---|---|
+| `ss stack tunnel <up\|down\|status\|moniker\|urls\|aws-profile>` | ✅ done | `src/commands/stack/tunnel.ts` — thin wrapper over the **vendored** `tunnel.sh` |
+| `ss stack up --tunnel` (native, no up.sh) | ✅ done | `src/commands/stack/up.ts` — resolves moniker, builds `tunnel_env` browser-plane overlay, generates `rtsm-fleet-tunnel.json`, then runs vendored `tunnel.sh up` after a healthy launch |
+| moniker resolve + rtsm fleet gen | ✅ done | `src/runtime/tunnel-prep.ts` (`resolveTunnelMoniker`, `generateTunnelFleetConfig`) |
+| slot-0-only guard for `--tunnel` | ✅ done | up.ts:209 — `--tunnel` fronts FIXED slot-0 browser ports; refuses slot>0 |
+| dash `config.local.json` tunnel routing | ✅ (in up.sh; verify native parity) | up.sh `sync_dash_local_defaults`; confirm ss `dash-defaults.ts` writes the url-type file under `--tunnel` |
+
+Merged commits: `4327971` (Phase 1 vendor), `519b720` (Phase 2 native `--tunnel`),
+`105bc04` (per-slot rtsm, soa#271), `80a2d0e`/#224 (wire coach into tunnel mode).
+
+## Gap 1 — vendored `tunnel.sh` drift (small, mechanical)
+
+`tools/synthetic-dev/tunnel.sh` (source) has coach wired in (soa#224, commit `80a2d0e`) but the
+CLI's **vendored copy is stale**:
+
+```
+diff tools/synthetic-dev/tunnel.sh vendor/tunnel.sh
+< "coach:8800"          # missing from vendored SERVICES table
+< "coach-api:6105"      # missing from vendored SERVICES table
+< …|| coach …           # missing coach branch in the status health-probe
+```
+
+Effect: `ss stack tunnel` / `ss stack up --tunnel` will **not tunnel coach**. Fix = re-vendor
+(there is a vendor sync path in `src/runtime/vendor.ts`). Verify no other drift crept in.
+
+## Gap 2 — no `ss e2e … --tunnel` (the real Connect blocker)
+
+This is the crux of Jeff's 2026-07-10 `tunnel_info.md`. `ss stack up --tunnel --seed full --reset`
+brings the stack up logged in as `demo-dadmin@saga.org`, **but with no launchable sessions** — so
+the invite-a-coworker-to-Connect use case has nothing to launch.
+
+- Sessions are produced by running the **journey e2e** (`ss e2e run journey --through sessions`).
+- That fails in tunnel mode because the journey's Playwright browsers hit **localhost https URLs**
+  that aren't served. The specs already read every URL from `PLAYWRIGHT_*_URL` env
+  (`e2e/fixtures/lane.ts`), so **no test-code change is needed** — the only missing piece is a
+  `--tunnel` flag on `ss e2e run` that resolves the moniker and sets the ~12 `PLAYWRIGHT_*_URL`
+  keys to `https://<svc>.<moniker>.vms.wootdev.com`.
+- Hook point in the ss code: `e2e-orchestrate.ts` → `PLAYWRIGHT_SERVICE_URL_ENV` map +
+  `serviceUrlEnv(ports)` (currently `http://localhost:<port>`) consumed by `playwrightEnv()`.
+  A tunnel variant returns `https://<label>.<domain>` for the same keys.
+
+### The hard constraints (why this isn't free) — from Jeff, verified against the code
+
+1. **One iam, one cookie domain.** `iam_session` has exactly one `Domain` — host-only `localhost`
+   OR `.<moniker>.vms.wootdev.com`, never both. A single running iam serves the localhost journey
+   **or** the tunnel dash, not both at once. This is *why the snapshot bridge exists* (build under
+   one cookie domain, use under the other) — not a patchable plumbing bug.
+2. **WAN hairpin ⇒ slow + flaky.** A tunnel journey routes localhost Playwright → DNS → vms EIP →
+   frp → back to localhost. Hundreds of requests ⇒ much slower; 120s timeouts need bumping. You
+   can't shortcut with `/etc/hosts → 127.0.0.1` (cert is for `*.vms…`, local services speak plain
+   HTTP). So the **non-tunnel-build → snapshot → restore-under-tunnel path stays the fast one.**
+3. Jeff tried the snapshot bridge manually and Demo District sessions **did not** populate — worth
+   reproducing to find whether that's a fixture-domain issue vs a snapshot-scope issue.
+
+## Recommended shape (informs the plan)
+
+- **Slot 0 first** (prompt's guidance + `--tunnel` is already slot-0-only by design — fixed
+  browser ports). Slot 1..N is a later, separate problem (needs per-slot monikers/hostnames or a
+  port-mux on the box; out of scope for v1).
+- Add `--tunnel` to `ss e2e run` (and thread it into `ss e2e connect`, the concierge flow) so the
+  whole invite-a-coworker flow is one command. Accept the slow-journey tradeoff, OR prefer the
+  snapshot bridge and only tunnel the *live* connect room. Decide in the plan.

--- a/claude/projects/gh_298/research/validation-report.md
+++ b/claude/projects/gh_298/research/validation-report.md
@@ -1,0 +1,101 @@
+# gh_298 — ss Tunnel Mode: plan validation (ultracode pass)
+
+## 1. Verdict on the thesis
+
+**Refuted as stated.** The plan's thesis — "already ported + exactly TWO gaps (vendored `tunnel.sh` drift; no `ss e2e --tunnel`)" — is directionally right on "already ported" (native bring-up, `stack tunnel` wrapper, dash `config.local.json` writer, and 10/12 browser-plane env overlays are all confirmed against `up.sh`) but **wrong on the gap count**. There is a **third, independent gap**: coach's browser-plane `tunnel_env` is missing from `launch-plan.ts` (`coach-api`/`coach-web` fall through to `default: return {}` at `launch-plan.ts:375`). This is a code gap in the TS overlay, not vendored-script drift, so re-vendoring `tunnel.sh` (the plan's Phase 1) fixes the frpc reverse-tunnel plumbing but leaves coach CORS-rejected and its Vite host-check 403'd — meaning **Phase 1's own exit criterion ("coach reachable through the tunnel") is unachievable as scoped.** Correct count: (1a) `tunnel.sh` drift, (1b) coach overlay, (2) `ss e2e --tunnel`.
+
+## 2. Claim verification table
+
+| # | Claim | Verdict | One-line evidence |
+|---|-------|---------|-------------------|
+| 1 | `ss stack up --tunnel` is fully native (no `up.sh` shell-out for bring-up) | **SUPPORTED** | `up.ts:492-495` native `api.up(services)`; moniker via vendored `tunnel.sh` (`up.ts:301`, `base-command.ts:528-530`); overlay `launch-plan.ts:314-375`; frpc only at `up.ts:587-592` |
+| 2 | `ss stack tunnel <verb>` runs the VENDORED `tunnel.sh`, not `tools/synthetic-dev/tunnel.sh` | **SUPPORTED** | `tunnel.ts:71` `resolveVendorScript('tunnel.sh')` → `vendor.ts:37-51` walks to `<pkg>/vendor/tunnel.sh`; file exists (12951 B, exec) |
+| 3 | Drift source↔vendored `tunnel.sh` is EXACTLY coach:8800/coach-api:6105 SERVICES entries + coach status-probe branch | **SUPPORTED** | Full `diff` = 3 hunks, all coach: `67,68d66` + `255c253` (`\|\| coach` dropped); 271 vs 269 lines |
+| 4 | NO `--tunnel` flag on ANY `ss e2e` command (run/connect/list/traces) | **SUPPORTED** | Exhaustive grep `/tunnel/i` over `commands/e2e/` = 0 matches; flag sets enumerated `run.ts:68-141` etc.; `baseFlags` (`shared-flags.ts:111-160`) has none |
+| 5 | `serviceUrlEnv`/`playwrightEnv` is the e2e `--tunnel` hook; tunnel variant emits `https://label.domain` on same `PLAYWRIGHT_*_URL` keys, no spec change | **PARTIAL** | Producer side supported (`e2e-orchestrate.ts:400-407`,`453-458`); but labels≠ServiceIds (needs new map), only dash/iam/connect/connect-api/rtsm have hosts, `buildStackContext` hardcodes `tunnel:false` (`:284`), `run.ts` lacks flag; "no spec change" depends on saga-dash `lane.ts` (not in repo) |
+| 6 | Native `--tunnel` writes dash `config.local.json` url-type localDefaults matching `up.sh sync_dash_local_defaults` | **SUPPORTED** | `dash-defaults.ts:122-128` byte-equiv to `up.sh:1486-1487`; identical `DASH_TUNNEL_LABELS` (`:34-43` vs `up.sh:1482-1487`); wired `stack-api.ts:851-863` |
+| 7 | `--tunnel` guarded slot-0-only for `up`; e2e would need same guard | **SUPPORTED** | Guard `up.ts:209-214`; e2e has no flag so needs none today, but shares fixed slot-0 browser ports → would need identical guard if flag added |
+| 8 | OTHER vendored artifacts NOT drifted; `tunnel.sh` is the only stale one | **PARTIAL** | `tunnel.sh` is the only *stale* one (correct practical conclusion); but `refresh-suite.sh` + `.gitignore` are *intentionally forked* from source (not textually identical), and the named `compose-rest` file **does not exist** under `vendor/` |
+
+## 3. Parity risks (up.sh `tunnel_env` vs ss `tunnelOverlay`) — most severe first
+
+Source: `up.sh:1367-1457` vs `launch-plan.ts:314-377`. 10/12 match exactly; the two breaks are both coach and both live (launched, non-optional/browser-facing services).
+
+1. **coach-web `PUBLIC_COACH_API_URL` (SEV: highest, browser cannot reach API).** `up.sh:1453` sets `https://coach-api.$TUNNEL_DOMAIN`; ss drops it (`launch-plan.ts:375` default). Base stays `http://localhost:6105` (`services.ts:531`) — a SvelteKit `PUBLIC_` (compile/serve-time) var, so a remote browser is pointed at localhost and cannot dial coach-api at all.
+2. **coach-web `__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS` (SEV: page won't load).** `up.sh:1454` sets `coach.$TUNNEL_DOMAIN`; ss drops it → Vite dev-server DNS-rebind host check 403s the tunnel `Host` header, so the coach-web page itself fails to load.
+3. **coach-api `EXPRESS_SERVER_CORSALLOWEDDOMAINS` (SEV: API CORS-rejected).** `up.sh:1447` appends bare `$TUNNEL_DOMAIN` to the allow-list; ss keeps base `${COACH_WEB_HOST}` only (`services.ts:505`) → remote browser from `coach.<moniker>.vms…` is CORS-rejected.
+4. **rtsm-api `FLEET_CONFIG_PATH` shape (SEV: low, note only).** `up.sh` always sets it in tunnel mode (`up.sh:2321-2330`); ss emits only if `TUNNEL_RTSM_FLEET_PATH` token present (`launch-plan.ts:367-369`). Functionally equivalent on the native path (token wired from fleet-gen), but ss silently drops the key if fleet-gen is ever skipped.
+
+**Fix trap (record in plan):** do NOT derive coach hosts from manifest `tunnelSlug` (which is `coach-web`, `services.ts:536`). `up.sh` uses label `coach` for coach-web's allowed-host, `coach-api` for the API URL, and the **bare** `$TUNNEL_DOMAIN` for coach-api CORS. A slug-driven impl re-diverges to `coach-web.$TUNNEL_DOMAIN`. The overlay unit test `launch-plan.overlay.unit.test.ts` has **no coach assertions** — nothing guards this regression.
+
+## 4. e2e `--tunnel` implementation surface
+
+All paths under `packages/node/saga-stack-cli/`. Reuses the existing `up --tunnel` machinery (`getTunnelMoniker` seam, `resolveVendorScript('tunnel.sh')`, `<moniker>.<VMS_BASE>`, and the `runtime.tunnel`/`runtime.tunnelDomain` fields the facade already consumes). Genuinely new code = tunnel-domain variant of `serviceUrlEnv` + the WAN timeout env.
+
+- **Flag decl:** `commands/e2e/run.ts` `E2eRun.flags` (~L141, boolean `default:false`); mirror on `commands/e2e/connect.ts` `E2eConnect.flags` (~L98).
+- **Moniker→domain resolution (already exists verbatim):** `commands/stack/up.ts:297-303` (`vmsBase = VMS_BASE ?? 'vms.wootdev.com'`; `getTunnelMoniker()(resolveVendorScript('tunnel.sh'))`; `domain = \`${moniker}.${vmsBase}\``). Seam at `base-command.ts:528` → `runtime/tunnel-prep.ts:34`, available since both e2e commands extend `BaseCommand`. Thread in `run.ts` after `deriveInstance` (~L218) before `buildStackContext` (~L265); `connect.ts` before its `buildStackContext` at L148.
+- **`buildStackContext` (`e2e-orchestrate.ts:227-232` sig, literal `273-309`):** currently hardcodes `tunnel:false` at **:284**, never sets `tunnelDomain`. Add optional `tunnelDomain?` param; set `tunnel: tunnelDomain!==undefined, tunnelDomain`. Facade `stack-api.ts:850-863` already reads these → `syncDashLocalDefaults` → `dash-defaults.ts:122`; **no facade change needed.**
+- **New producer:** add `TUNNEL_SERVICE_LABELS` frozen `ServiceId→label` map after `e2e-orchestrate.ts:390` (keyed to `vendor/tunnel.sh` SERVICES L55-66) + `tunnelServiceUrlEnv(domain)`. Wire into `playwrightEnv` (`:423-461`, overlay line **:456**): prefer tunnel URLs when domain present (must beat `flow.env`). Thread `tunnelDomain` via `ExecDeps.tunnelDomain?` (`:645-694`) from `executeResolvedFlow`'s `playwrightEnv` call (`:937`), and into `describeResolved`/`DescribeOptions` (`:494-537`) so `--dry-run` prints `https://` URLs.
+- **Label↔ServiceId is NOT string-derivable:** `saga-dash→dash`, `connect-web→connect`, `ads-adm-api→ads-adm` are renames; `iam-api/sis-api/programs-api/scheduling-api/sessions-api` drop `-api`; but `connect-api→connect-api` keeps `-api`. All 9 `PLAYWRIGHT_SERVICE_URL_ENV` ServiceIds have a SERVICES entry — no stranded service today.
+- **Slot-0 guard:** `E2eRun` is `slotAware()`/`setAware()` (`run.ts:144,149`) → add hard-error alongside `run.ts:156-167` (before `runSetPreflight`), identical to `up.ts:209-214`; the single `flags.slot>0` check covers `--set` too. `E2eConnect` is neither slot- nor set-aware → already slot-0-only, no guard.
+- **Timeout:** prober does NOT need a bump — services still bind localhost under tunnel (`probe-plan.ts:62-82`, `health.ts:45-55` probe `http://localhost:<port>`). Only the Playwright browser hairpins to `https://<label>.<domain>`. Inject net-new `PLAYWRIGHT_TUNNEL_TIMEOUT_MS` in `playwrightEnv` (`:453-458`) when `tunnelDomain` set. **Cross-repo:** saga-dash `playwright.config.ts` must read it into `use.navigationTimeout`/`actionTimeout`/`timeout` — confirm the exact env name in that repo.
+- **Optional all-in-one:** after green run, start reverse tunnels (parity `up.ts:587-591`: `resolveVendorScript('tunnel.sh')` + `flagMap.tunnel('up')`).
+- **Tests to add:** tunnel cases in `__tests__/e2e-orchestrate-slot.unit.test.ts` (describe L117); new `__tests__/tunnel-service-labels.unit.test.ts` (every `PLAYWRIGHT_SERVICE_URL_ENV` ServiceId has a label, each label a real `tunnel.sh` SERVICES entry); `commands/e2e/__tests__/run.int.test.ts` (`--tunnel --dry-run` prints `https://`; `--tunnel --slot 1` hard-errors) — copy `getTunnelMoniker` stub from `commands/stack/__tests__/up.unit.test.ts`.
+
+## 5. Snapshot-bridge root-cause hypotheses
+
+**Primary (HIGH confidence): the bridge used legacy `mesh-fixture-cli`, whose hardcoded 6-DB list omits `sessions`.** `mesh-fixture-cli/src/lib/postgres.ts:25-32` `SAGA_MESH_DATABASES = {iam_local, iam_pii_local, programs, scheduling, ads_adm_local, ledger_local}` — no `sessions`, no `content`/`coach_api`/`sis_db`, and zero mongo handling (`store.ts` calls `pgDump` only). Demo District sessions live in the `sessions` postgres projection DB (`up.sh:19-22`, seeded by `seed_sessions`/`SEED_DEMO_ONLY=1` at `up.sh:1852-1885`); users live in `iam_local`/`iam_pii_local`. So `iam_local` restores → users repopulate; `sessions` is never dumped → Demo District sessions stay empty. This asymmetry is the exact fingerprint. The gap is called out in-repo (`core/snapshot/plan.ts:13-17`); the NEW `ss stack snapshot` default set covers all 10 pg DBs + `connectv3` mongo (`plan.ts:144-171`).
+
+**Ruled out / secondary:**
+- **Profile guard** (`restore.ts:120-127`) and **snapshot-ahead guard** (`plan.ts:240-278`) are all-or-nothing → would NOT produce the users-yes/sessions-no split. Inconsistent with symptom.
+- **Per-org restore?** No — whole-DB `pg_restore --clean --if-exists` (`restore.ts:138-148`). Ruled out.
+- **Cookie/URL domain baking** (`up.sh:1382-1433`): applied at launch, not baked into rows; `sessions` projection data is domain-independent → would break *joining a live Connect room*, not the list populating. Separate risk.
+
+**Confirm on a live box (UNVERIFIABLE_HERE):**
+```
+# SOURCE box — prove data existed at snapshot time:
+docker exec soa-postgres-1 psql -U postgres_admin -d sessions -tAc \
+  "SELECT count(*) FROM program_projection WHERE id LIKE 'a1b2c3d4-0001-4000-8000-%'"   # >0
+docker exec soa-postgres-1 psql -U postgres_admin -d sessions -tAc \
+  "SELECT count(*) FROM projection_readiness"                                            # >=1
+# Decisive — which tool/DB set:
+ls -la ~/.saga-mesh/snapshots/<fixture-id>/
+cat  ~/.saga-mesh/snapshots/<fixture-id>/manifest.json 2>/dev/null
+#   only the 6 *.dump + no sessions.dump/connectv3.archive/manifest → legacy tool → CONFIRMED
+# TARGET box after restore — prove asymmetry:
+docker exec soa-postgres-1 psql -U postgres_admin -d sessions -tAc \
+  "SELECT count(*) FROM program_projection WHERE id LIKE 'a1b2c3d4-0001-4000-8000-%'"   # 0
+docker exec soa-postgres-1 psql -U postgres_admin -d iam_local -tAc 'SELECT count(*) FROM "User"'  # >0
+```
+Also: hit sessions-api `/my-sessions` on the tunnel box — a 408 "projection … is warming" ⇒ `projection_readiness` row also missing, consistent with the whole `sessions` DB not restored.
+
+**Fix:** bridge must use `ss stack snapshot store/restore`, never `mesh-fixture-cli`; keep `SEED_PROFILE` identical between build and restore (or `--force`) so the profile guard doesn't silently abort.
+
+## 6. Corrections to the plan (prioritized)
+
+**P0 — thesis-breaking:**
+1. **Add GAP 3: coach browser-plane overlay in `launch-plan.ts`.** `coach-api`/`coach-web` fall through to `default:{}` at `launch-plan.ts:375` (vs `up.sh:1440-1454`). Separate from the `tunnel.sh` drift.
+2. **Split Phase 1 → 1a (re-vendor `tunnel.sh`: frpc plumbing) + 1b (add coach cases to `tunnelOverlay()` + overlay unit-test assertions).** Tie Phase 1 Exit ("coach reachable") to **1b, not 1a**. Record the slug trap (§3).
+3. **Re-sequence Phase 0.** Phase 0 step 3 (diff emitted `tunnel_env` per service) already surfaces this divergence, but step 4 pre-labels coach-red as "known (Phase 1)" and waves it through — that pre-label hides Gap 3. Treat any coach env divergence as an open finding routed to 1b.
+
+**P1 — refuted/PARTIAL claims to edit:**
+4. **"No test-code change needed" (Phase 2) is only partial.** Needs explicit `TUNNEL_SERVICE_LABELS` table (labels not string-derivable); `buildStackContext` hardcodes `tunnel:false` (`e2e-orchestrate.ts:284`) → thread `tunnelDomain` through `buildStackContext`→`ExecDeps`→`playwrightEnv`+`describeResolved`; "no spec change" is an **assumption to confirm in saga-dash `lane.ts`** (not in repo), not a fact.
+5. **Phase 2 "bump Playwright timeouts" conflates two timeouts.** Prober needs no bump (localhost). The real one is the browser WAN hairpin, consumed cross-repo in saga-dash `playwright.config.ts`; CLI only exports the env. Add the cross-repo dep and confirm the env name.
+6. **Drift guard must be scoped to `tunnel.sh` only.** A directory-wide "vendor≠source" guard false-positives on the intentionally-forked `refresh-suite.sh` and `.gitignore`. Also drop the nonexistent `compose-rest` reference from findings.
+7. **Add `tunnel-service-labels.unit.test.ts`** to catch label↔SERVICES drift.
+
+**P2 — missed entirely:**
+8. **`seeded.ok`-after-restore interaction.** Reverse tunnels fire at `up.ts:587` only under `if (overlays.tunnel && seeded.ok)` — stricter than findings state (requires a healthy seed). Under the snapshot-bridge decision the happy path *restores* rather than journey-seeds; confirm `seeded.ok` is true post-restore or frpc silently won't come up.
+9. **De-risk & pull Phase 3 forward.** Root cause is now known (§5) → rewrite Phase 3's open question to "confirm bridge uses `ss stack snapshot`, never `mesh-fixture-cli`"; add the profile guard + snapshot-ahead guard as must-satisfy; run the reproduction in parallel with Phase 1/2, not last.
+10. **Separate "list populates" from "room joins" in Phase 3.** Bridge fixes the *list* (domain-independent projection data); room-join relies on Phase 1's launch-time overlay (cookie domain, connect-web `VITE_*`). connect-web overlay is present and matches (parity #8), but a coach-style omission would strand room-join → tie Phase 3 "room reachable" exit to Phase 1b.
+11. **Record rtsm-api `FLEET_CONFIG_PATH` shape note** (low risk, §3 item 4).
+
+**Net:** phases become 0, 1a, **1b (new)**, 2, 3, 4; thesis "exactly TWO gaps" → **THREE**; ~+½ day for 1b, roughly net-neutral since Phase 3 shrinks (~3-4 days total).
+
+## 7. What still needs a running stack to verify (UNVERIFIABLE_HERE)
+
+- **Snapshot root cause** — all live-box checks in §5 (source data existed; snapshot-dir tool/DB-set fingerprint; target-box users>0 while sessions=0; sessions-api 408 warming probe).
+- **coach parity breaks at runtime** — that a remote browser from `coach.<moniker>.vms…` is actually CORS-rejected / Vite-403'd / pointed at localhost:6105 (static comparison only; token values `DASH_URL`/`CONNECT_WEB_URL`/`IAM_PORT` assumed equal across both sides).
+- **saga-dash cross-repo consumers (not in this worktree):** (a) `lane.ts` reads every service URL from env — the load-bearing assumption behind "no e2e spec change"; (b) `playwright.config.ts` reads the WAN-timeout env into `navigationTimeout`/`actionTimeout`/`timeout` — confirm exact env name before finalizing; (c) the saga-dash#194 seam (`lib/api/config.ts mergeLocalTopology` consuming the `url` type) — ss writes a matching config (verified), but consumption is unverifiable here.
+- **`flagMap.tunnel` argv/env** for the final `tunnel.sh up` invocation (`flag-map.ts` not opened; outside claim scope).
+- **`seeded.ok` after a snapshot-restore** (§6 item 8) — whether the frpc gate at `up.ts:587` is satisfied on the restore path.

--- a/claude/projects/gh_298/source/plan.md
+++ b/claude/projects/gh_298/source/plan.md
@@ -97,12 +97,18 @@ capture as a follow-up issue once slot-0 lands.
 
 ## Effort: ~3–4 focused days, sequenced so each phase ships independently.
 
-## Open questions for Sean/Jeff before Phase 3
+## Decisions (resolved with Sean, 2026-07-13)
 
-1. **Seeding strategy:** snapshot-bridge (fast build, tunnel only the live room) vs full
-   `e2e run --tunnel` (one command, slow journey)? Recommend bridge-as-default, `--tunnel` as
-   escape hatch.
-2. **Guest auth for Connect:** how do invited coworkers authenticate — the tunnelled iam demo
-   login page, or pre-minted jars? Affects what the concierge flow hands them.
-3. **Security posture:** Jeff deliberately made it non-VPN. Keep as-is for v1, or add a shared
-   secret / basic-auth at the box for the public URLs?
+1. **Seeding strategy → snapshot bridge (default).** Build under localhost (fast journey),
+   snapshot, restore under the tunnel cookie domain, tunnel only the live room. `ss e2e run
+   --tunnel` (Phase 2) still ships as the slow all-in-one escape hatch. **Consequence:** Phase 3
+   MUST root-cause Jeff's "Demo District sessions didn't populate after snapshot-restore" — the
+   bridge is the happy path, so that bug is now on the critical path, not a nice-to-have.
+2. **Guest auth → tunnelled iam demo login.** Invited coworkers hit
+   `https://iam.<moniker>.vms.wootdev.com/demo` and log in as a seeded persona. No per-guest jar
+   distribution. The concierge flow just hands out the `connect.<moniker>.vms…` URL; the demo
+   login page is the gate. (Confirms the existing `tunnel_env` `MAIL_FRONTEND_BASE_URL` /
+   `JANUS_LOGIN_HOST` → tunnelled iam demo wiring is the right target.)
+3. **Security posture → keep open (v1).** No VPN, no box-level auth — matches what Jeff
+   deliberately shipped. App-layer iam demo login is the only gate. Hardening (shared
+   secret / basic-auth at the box) is a deliberate follow-up, not v1 scope.

--- a/claude/projects/gh_298/source/plan.md
+++ b/claude/projects/gh_298/source/plan.md
@@ -1,0 +1,108 @@
+# gh_298 — ss Tunnel Mode: plan
+
+_See `../research/findings.md` for the evidence behind every claim here._
+
+## Goal
+
+Bring tunnel mode to the `ss` synthetic-dev CLI and verify it functions identically to up.sh's
+`--tunnel`, driven by the real use case: **Jeff invites coworkers to test Connect via a
+publicly-reachable URL against his local stack.** Slot 0 first; slot 1..N deferred.
+
+## Reframing (important)
+
+Tunnel mode is **already ported and merged** (soa#214/#221). `ss stack up --tunnel` and
+`ss stack tunnel <verb>` exist and are native. So this is **not** a from-scratch port — it's
+**close a drift, close one capability gap, then verify parity end-to-end**. That materially
+shrinks the work.
+
+---
+
+## Phase 0 — Verify the existing port actually works (½ day)
+
+Before building anything, confirm the merged `ss` tunnel path reaches the same state up.sh did.
+
+1. Bring up the reference (up.sh) once for the golden baseline (Jeff's command):
+   `./up.sh up --tunnel --seed full --reset --login demo-dadmin@saga.org` → note `dash.<moniker>.vms…`
+   loads, logged in, sessions launchable.
+2. Bring up the `ss` path: `ss stack up --tunnel --seed full --reset` (slot 0).
+3. Compare, per browser-facing service: the emitted `tunnel_env` (cookie domain, CORS, `VITE_*`),
+   the generated `rtsm-fleet-tunnel.json`, and the dash `config.local.json`. A diff harness
+   (dump both env sets, normalize, compare) makes "functions identically" a checkable claim.
+4. Confirm `ss stack tunnel status` shows all services green **except** the known coach gap
+   (Phase 1) and AV (by-design fleek).
+
+**Exit:** documented parity table; any env divergence filed as its own fix.
+
+## Phase 1 — Fix vendored `tunnel.sh` drift (½ day)
+
+- Re-vendor `tools/synthetic-dev/tunnel.sh` → `packages/node/saga-stack-cli/vendor/tunnel.sh`
+  (adds `coach:8800`, `coach-api:6105`, and the coach status-probe branch — soa#224 that never
+  got re-vendored). Use the existing `src/runtime/vendor.ts` sync path, not a hand-edit.
+- Add a **drift guard**: a unit/CI check that fails when `vendor/tunnel.sh` ≠ source (so this
+  can't silently rot again). This is the root cause of Gap 1, worth preventing structurally.
+- Verify coach tunnels: `ss stack up --with coach --tunnel` → `coach.<moniker>.vms…` serves.
+
+**Exit:** vendored copy matches source; drift guard green; coach reachable through the tunnel.
+
+## Phase 2 — `ss e2e run --tunnel` (the Connect enabler) (1–1.5 days)
+
+The missing capability. No test-code change — the specs already read `PLAYWRIGHT_*_URL`.
+
+- Add `--tunnel` boolean to `src/commands/e2e/run.ts`. Guard slot-0-only (same rationale as
+  `up --tunnel`: fixed browser ports front the box).
+- In `e2e-orchestrate.ts`, add a tunnel variant of `serviceUrlEnv(ports)` that, given the
+  resolved moniker domain, returns `https://<label>.<domain>` for each `PLAYWRIGHT_*_URL` key
+  instead of `http://localhost:<port>`. Reuse `resolveTunnelMoniker` from `runtime/tunnel-prep.ts`.
+  Thread it through `playwrightEnv()` (the tunnel URLs overlay where `serviceUrlEnv` does today).
+- Bump Playwright timeouts under `--tunnel` (WAN hairpin — findings §hard-constraint-2). Gate the
+  bump on the flag so localhost runs are unchanged.
+- Unit tests: `--tunnel` emits `https://<svc>.<domain>` for all keys; absent → byte-identical to
+  today; slot>0 + `--tunnel` errors.
+
+**Exit:** `ss stack up --tunnel …` then `ss e2e run journey --through sessions --tunnel` yields
+launchable sessions on `dash.<moniker>.vms…` in one path (slow but correct).
+
+## Phase 3 — Wire tunnel into the Connect concierge flow (0.5–1 day)
+
+Last week's `ss e2e connect` is the natural front door for the use case.
+
+- Add `--tunnel` to `src/commands/e2e/connect.ts`, threading into the same moniker-resolve +
+  URL-overlay from Phase 2, so `ss e2e connect --tunnel` opens the live room **and** the room is
+  reachable at `connect.<moniker>.vms…` for invited guests.
+- **Decide the seeding strategy (open question — see below).** Recommended default: keep the
+  *build* under localhost (fast journey), then **snapshot → restore under the tunnel cookie
+  domain**, and only run the *live* room over the tunnel. `--tunnel` on `e2e run` stays available
+  as the slow all-in-one for when the bridge misbehaves.
+- Reproduce Jeff's "Demo District sessions didn't populate after snapshot-restore" (findings
+  §hard-constraint-3) and root-cause: is it snapshot scope, or fixtures that bake the localhost
+  cookie/URL domain? Fix whichever it is — this is what actually unblocks Jeff.
+
+**Exit:** `ss e2e connect --tunnel` gives Jeff a `connect.<moniker>.vms…` URL to share, backed by
+launchable Demo District sessions, with a documented one-command recipe.
+
+## Phase 4 — Docs + verification (0.5 day)
+
+- Update the `saga-iac:ss` skill reference + `docs/` e2e ladder to cover `--tunnel` on
+  `up` / `e2e run` / `e2e connect`, the AV-on-fleek caveat, and the snapshot-bridge recipe.
+- Run `/code-review` and `/verify` on the diff before the PR.
+
+## Slot 1..N (explicitly deferred)
+
+`--tunnel` is slot-0-only by construction (fixed browser ports front the box). Slotted tunneling
+needs either per-slot monikers/hostnames (`<svc>-s<N>.<moniker>.vms…` + box-side cert/routing) or
+a port-mux, plus per-slot `iam_session` cookie-domain handling. Real scope, separate effort —
+capture as a follow-up issue once slot-0 lands.
+
+---
+
+## Effort: ~3–4 focused days, sequenced so each phase ships independently.
+
+## Open questions for Sean/Jeff before Phase 3
+
+1. **Seeding strategy:** snapshot-bridge (fast build, tunnel only the live room) vs full
+   `e2e run --tunnel` (one command, slow journey)? Recommend bridge-as-default, `--tunnel` as
+   escape hatch.
+2. **Guest auth for Connect:** how do invited coworkers authenticate — the tunnelled iam demo
+   login page, or pre-minted jars? Affects what the concierge flow hands them.
+3. **Security posture:** Jeff deliberately made it non-VPN. Keep as-is for v1, or add a shared
+   secret / basic-auth at the box for the public URLs?

--- a/claude/projects/gh_298/source/plan.md
+++ b/claude/projects/gh_298/source/plan.md
@@ -12,8 +12,13 @@ publicly-reachable URL against his local stack.** Slot 0 first; slot 1..N deferr
 
 Tunnel mode is **already ported and merged** (soa#214/#221). `ss stack up --tunnel` and
 `ss stack tunnel <verb>` exist and are native. So this is **not** a from-scratch port — it's
-**close a drift, close one capability gap, then verify parity end-to-end**. That materially
-shrinks the work.
+**close the gaps, then verify parity end-to-end**. That materially shrinks the work.
+
+The ultracode validation pass (`research/validation-report.md`) **refuted the original "exactly
+two gaps" thesis**: there are **three** — (1a) vendored `tunnel.sh` drift, (1b) coach missing from
+the TypeScript browser-plane overlay (`launch-plan.ts:375`), (2) no `ss e2e --tunnel`. The
+snapshot-bridge failure Jeff hit is also root-caused below (legacy `mesh-fixture-cli` omits the
+`sessions` DB). Phases and exit criteria below reflect those corrections.
 
 ---
 
@@ -33,31 +38,71 @@ Before building anything, confirm the merged `ss` tunnel path reaches the same s
 
 **Exit:** documented parity table; any env divergence filed as its own fix.
 
-## Phase 1 — Fix vendored `tunnel.sh` drift (½ day)
+## Phase 1a — Fix vendored `tunnel.sh` drift (½ day)
 
 - Re-vendor `tools/synthetic-dev/tunnel.sh` → `packages/node/saga-stack-cli/vendor/tunnel.sh`
   (adds `coach:8800`, `coach-api:6105`, and the coach status-probe branch — soa#224 that never
   got re-vendored). Use the existing `src/runtime/vendor.ts` sync path, not a hand-edit.
-- Add a **drift guard**: a unit/CI check that fails when `vendor/tunnel.sh` ≠ source (so this
-  can't silently rot again). This is the root cause of Gap 1, worth preventing structurally.
-- Verify coach tunnels: `ss stack up --with coach --tunnel` → `coach.<moniker>.vms…` serves.
+- Add a **drift guard SCOPED TO `tunnel.sh` ONLY**: a unit/CI check that fails when
+  `vendor/tunnel.sh` ≠ source. Do NOT make it directory-wide — `refresh-suite.sh` and
+  `.gitignore` under `vendor/` are **intentionally forked** from source and would false-positive.
+- This fixes the **frpc reverse-tunnel plumbing** for coach, but NOT coach's browser-plane env
+  (see 1b) — so on its own it does not make coach reachable.
 
-**Exit:** vendored copy matches source; drift guard green; coach reachable through the tunnel.
+**Exit:** vendored copy matches source; tunnel.sh-scoped drift guard green.
+
+## Phase 1b — Add coach to the TypeScript browser-plane overlay (½ day) — NEW, thesis-breaking
+
+Validation found a **third gap the "two gaps" thesis missed**: `coach-api`/`coach-web` fall through
+to `default: return {}` at `launch-plan.ts:375`, so the ss native `--tunnel` overlay never sets
+coach's browser-plane env. Three live parity breaks vs `up.sh tunnel_env` (`up.sh:1440-1454`):
+
+1. `coach-web PUBLIC_COACH_API_URL=https://coach-api.<domain>` (SvelteKit `PUBLIC_`, compile/serve
+   -time) — without it a remote browser dials `localhost:6105` and can't reach coach-api at all.
+2. `coach-web __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS=coach.<domain>` — without it Vite's dev-server
+   host check 403s the tunnel `Host` and the page won't load.
+3. `coach-api EXPRESS_SERVER_CORSALLOWEDDOMAINS += <bare domain>` — without it the remote origin is
+   CORS-rejected.
+
+- **Fix trap:** do NOT derive coach hosts from manifest `tunnelSlug` (which is `coach-web`).
+  up.sh uses label `coach` for coach-web's allowed-host, `coach-api` for the API URL, and the
+  **bare** `$TUNNEL_DOMAIN` for coach-api CORS. A slug-driven impl re-diverges to
+  `coach-web.<domain>`.
+- Add explicit coach cases to `tunnelOverlay()` (`launch-plan.ts`) + **coach assertions** to
+  `launch-plan.overlay.unit.test.ts` (today it has none — nothing guards this regression).
+
+**Exit (moved here from old Phase 1):** `ss stack up --with coach --tunnel` → `coach.<moniker>.vms…`
+serves and its API is reachable/CORS-clean.
 
 ## Phase 2 — `ss e2e run --tunnel` (the Connect enabler) (1–1.5 days)
 
-The missing capability. No test-code change — the specs already read `PLAYWRIGHT_*_URL`.
+The missing capability. **Mostly** no test-code change — the specs read `PLAYWRIGHT_*_URL` — but
+this is an assumption to **confirm in saga-dash `lane.ts`** (not in this repo), not a fact. Surface
+map is exact: see `research/validation-report.md §4`.
 
-- Add `--tunnel` boolean to `src/commands/e2e/run.ts`. Guard slot-0-only (same rationale as
-  `up --tunnel`: fixed browser ports front the box).
-- In `e2e-orchestrate.ts`, add a tunnel variant of `serviceUrlEnv(ports)` that, given the
-  resolved moniker domain, returns `https://<label>.<domain>` for each `PLAYWRIGHT_*_URL` key
-  instead of `http://localhost:<port>`. Reuse `resolveTunnelMoniker` from `runtime/tunnel-prep.ts`.
-  Thread it through `playwrightEnv()` (the tunnel URLs overlay where `serviceUrlEnv` does today).
-- Bump Playwright timeouts under `--tunnel` (WAN hairpin — findings §hard-constraint-2). Gate the
-  bump on the flag so localhost runs are unchanged.
-- Unit tests: `--tunnel` emits `https://<svc>.<domain>` for all keys; absent → byte-identical to
-  today; slot>0 + `--tunnel` errors.
+- Add `--tunnel` boolean to `src/commands/e2e/run.ts` (mirror on `connect.ts`). Guard slot-0-only
+  (same rationale as `up --tunnel`; the single `flags.slot>0` check also covers `--set`).
+- Resolve moniker→domain by **reusing the existing `up --tunnel` machinery** verbatim:
+  `getTunnelMoniker()(resolveVendorScript('tunnel.sh'))` → `<moniker>.<VMS_BASE>` (seam at
+  `base-command.ts:528` → `runtime/tunnel-prep.ts:34`). Thread it after `deriveInstance`, before
+  `buildStackContext`.
+- **`buildStackContext` hardcodes `tunnel:false` (`e2e-orchestrate.ts:284`)** — add an optional
+  `tunnelDomain?` param and set `tunnel: tunnelDomain!==undefined, tunnelDomain`. The facade
+  (`stack-api.ts:850-863`) already reads these → dash `config.local.json`; **no facade change**.
+- **Labels are NOT string-derivable from ServiceIds** (`saga-dash→dash`, `connect-web→connect`,
+  `ads-adm-api→ads-adm`, most drop `-api` but `connect-api` keeps it). Add an explicit frozen
+  `TUNNEL_SERVICE_LABELS` map keyed to `vendor/tunnel.sh` SERVICES, plus `tunnelServiceUrlEnv(domain)`;
+  wire into `playwrightEnv` (overlay line ~:456, must beat `flow.env`) and `describeResolved` so
+  `--dry-run` prints the `https://` URLs.
+- **Timeout — the prober needs NO bump** (services still bind localhost under tunnel; only the
+  Playwright *browser* hairpins). Export a net-new env (e.g. `PLAYWRIGHT_TUNNEL_TIMEOUT_MS`) from
+  `playwrightEnv` when `tunnelDomain` set; the actual timeout is consumed **cross-repo in saga-dash
+  `playwright.config.ts`** (`navigationTimeout`/`actionTimeout`/`timeout`) — confirm the exact env
+  name there before finalizing.
+- Unit tests: `--tunnel` emits `https://<label>.<domain>` for all keys; absent → byte-identical to
+  today; slot>0 + `--tunnel` hard-errors; **new `tunnel-service-labels.unit.test.ts`** asserting
+  every `PLAYWRIGHT_SERVICE_URL_ENV` ServiceId has a label and each label is a real `tunnel.sh`
+  SERVICES entry (catches label↔SERVICES drift).
 
 **Exit:** `ss stack up --tunnel …` then `ss e2e run journey --through sessions --tunnel` yields
 launchable sessions on `dash.<moniker>.vms…` in one path (slow but correct).
@@ -69,16 +114,35 @@ Last week's `ss e2e connect` is the natural front door for the use case.
 - Add `--tunnel` to `src/commands/e2e/connect.ts`, threading into the same moniker-resolve +
   URL-overlay from Phase 2, so `ss e2e connect --tunnel` opens the live room **and** the room is
   reachable at `connect.<moniker>.vms…` for invited guests.
-- **Decide the seeding strategy (open question — see below).** Recommended default: keep the
-  *build* under localhost (fast journey), then **snapshot → restore under the tunnel cookie
-  domain**, and only run the *live* room over the tunnel. `--tunnel` on `e2e run` stays available
-  as the slow all-in-one for when the bridge misbehaves.
-- Reproduce Jeff's "Demo District sessions didn't populate after snapshot-restore" (findings
-  §hard-constraint-3) and root-cause: is it snapshot scope, or fixtures that bake the localhost
-  cookie/URL domain? Fix whichever it is — this is what actually unblocks Jeff.
+- Seeding strategy = **snapshot bridge** (decided): build under localhost (fast journey), snapshot,
+  restore under the tunnel cookie domain, tunnel only the live room. `--tunnel` on `e2e run` stays
+  available as the slow all-in-one escape hatch.
+- **Root cause of Jeff's "Demo District sessions didn't populate" is now KNOWN (HIGH confidence),
+  so this phase is confirm-and-fix, not investigate** (`validation-report.md §5`): the manual
+  bridge used the legacy `mesh-fixture-cli`, whose hardcoded DB list dumps only 6 postgres DBs and
+  **omits `sessions`** (+ no mongo). Demo District sessions live in the `sessions` projection DB →
+  never dumped → never restored, while `iam_local` users repopulate. Exactly Jeff's symptom.
+  - **Fix:** the bridge MUST use `ss stack snapshot store/restore` (new default set covers all 10
+    pg DBs + `connectv3` mongo, `core/snapshot/plan.ts:144-171`), **never** `mesh-fixture-cli`.
+  - Keep `SEED_PROFILE` identical between build and restore (or `--force`) so the all-or-nothing
+    profile guard (`restore.ts:120-127`) doesn't silently abort.
+  - Confirm on a live box with the exact psql/manifest checks in `validation-report.md §5`.
+- **Separate "list populates" from "room joins".** The bridge fixes the session *list*
+  (domain-independent projection data); *joining* a live room relies on Phase 1's launch-time
+  overlay (cookie domain, connect-web `VITE_*`). connect-web's overlay is present and matches
+  (parity ✓), but tie this exit to **Phase 1b** so a coach-style omission can't strand room-join.
+- Guest auth = **tunnelled iam demo login** (decided): the flow hands out the
+  `connect.<moniker>.vms…` URL; guests log in at `iam.<moniker>.vms…/demo` as a seeded persona.
 
 **Exit:** `ss e2e connect --tunnel` gives Jeff a `connect.<moniker>.vms…` URL to share, backed by
-launchable Demo District sessions, with a documented one-command recipe.
+launchable Demo District sessions (via `ss stack snapshot` bridge), with a documented one-command
+recipe.
+
+> **Re-sequencing:** because the root cause is known, run the Phase 3 reproduction **in parallel
+> with Phases 1–2**, not last. Also note (`§6 item 8`): the frpc reverse tunnels fire at
+> `up.ts:587` only under `if (overlays.tunnel && seeded.ok)` — stricter than first stated (needs a
+> healthy seed). On the restore path, confirm `seeded.ok` is true post-restore or frpc silently
+> won't come up.
 
 ## Phase 4 — Docs + verification (0.5 day)
 
@@ -95,7 +159,11 @@ capture as a follow-up issue once slot-0 lands.
 
 ---
 
-## Effort: ~3–4 focused days, sequenced so each phase ships independently.
+## Effort: ~3–4 focused days (phases 0, 1a, 1b, 2, 3, 4).
+
+The new Phase 1b adds ~½ day, but Phase 3 shrinks (root cause already known), so the total is
+roughly net-neutral. Each phase still ships independently; run the Phase 3 reproduction in
+parallel with 1–2.
 
 ## Decisions (resolved with Sean, 2026-07-13)
 

--- a/claude/projects/gh_298/source/plan.md
+++ b/claude/projects/gh_298/source/plan.md
@@ -8,6 +8,23 @@ Bring tunnel mode to the `ss` synthetic-dev CLI and verify it functions identica
 `--tunnel`, driven by the real use case: **Jeff invites coworkers to test Connect via a
 publicly-reachable URL against his local stack.** Slot 0 first; slot 1..N deferred.
 
+## Status (updated 2026-07-13)
+
+- ✅ **Phase 1a / 1b / 2 — implemented** (commit `0c8b50e`): re-vendored `tunnel.sh` + drift guard;
+  coach browser-plane overlay; `ss e2e run/connect --tunnel`. Typecheck clean, full suite 1150/0.
+- ✅ **Phase 4 — docs** (this commit): `docs/tunnel.md` + pointers from README / e2e.md / snapshots.md.
+- ✅ **Static + real-binary verification done here** (no dev creds needed): `ss e2e run --tunnel
+  --dry-run` emits the correct `https://<label>.<moniker>.vms…` for all 9 services + timeout;
+  non-tunnel stays localhost; slot-1 and lane-sandbox guards hard-error; snapshot set confirmed to
+  include `sessions` (Phase 3 root-cause fix). Coach overlay + drift guard pass as unit tests.
+- ⏳ **Phase 0 / 3 — live-stack verification PENDING (needs dev-account AWS creds).** This box's
+  creds resolve to account `531314149529`, not dev `396913734878`, so the frpc bring-up, moniker
+  registration, coach runtime reachability, and the real snapshot-bridge round-trip can't be run
+  here. The exact command sequence to run is in `docs/tunnel.md`; see the checklist at the bottom
+  of this plan.
+- ⏳ **Cross-repo confirmations** (saga-dash `lane.ts` reads the URLs; `playwright.config.ts` reads
+  `PLAYWRIGHT_TUNNEL_TIMEOUT_MS`).
+
 ## Reframing (important)
 
 Tunnel mode is **already ported and merged** (soa#214/#221). `ss stack up --tunnel` and

--- a/packages/node/saga-stack-cli/README.md
+++ b/packages/node/saga-stack-cli/README.md
@@ -14,7 +14,7 @@ you have to reverse-engineer.
 > path (up → status → verify → e2e → down) with the real output of each command, linking out
 > to per-feature docs ([sub-stacks](./docs/sub-stacks-and-bundles.md) · [slots](./docs/slots.md) ·
 > [verify](./docs/verify.md) · [snapshots](./docs/snapshots.md) · [e2e](./docs/e2e.md) ·
-> [integration](./docs/integration.md)).
+> [tunnel](./docs/tunnel.md) · [integration](./docs/integration.md)).
 
 ```bash
 ss stack up --only scheduling-api,sessions-api   # boot just those + their deps

--- a/packages/node/saga-stack-cli/docs/e2e.md
+++ b/packages/node/saga-stack-cli/docs/e2e.md
@@ -132,6 +132,14 @@ Brings up the Connect closure (iam / sessions / content / connect-api / connect-
 and opens a real interactive session — for hands-on Connect development, not an assertion run.
 </details>
 
+## Share the session — `--tunnel`
+
+`ss e2e run` and `ss e2e connect` take `--tunnel`, which points the Playwright browser at the
+`https://<svc>.<moniker>.vms.wootdev.com` tunnel hosts so a **remote** person can reach your
+slot-0 stack (e.g. invite a coworker to a Connect room). `run --tunnel` WAN-hairpins and is slow —
+for seeding launchable sessions prefer the localhost-build → snapshot → restore-under-tunnel bridge.
+Both are slot-0-only. → [tunnel.md](./tunnel.md)
+
 ## Point at a specific flows.json
 
 `--spa-path <file-or-dir>` overrides discovery (handy for a bundled example or a WIP flow):

--- a/packages/node/saga-stack-cli/docs/snapshots.md
+++ b/packages/node/saga-stack-cli/docs/snapshots.md
@@ -83,8 +83,12 @@ fast with a `re-bake with a wider --through` error instead of half-restoring.
 - **e2e stage checkpoints** — mid-flow e2e state (`flow-<spa>-<flow>-s<N>-<stage>` fixtures,
   baked by `e2e run --snapshot-stages`, restored by `--from`); `snapshot list` shows their
   flow provenance as a sub-line. See [e2e → Stage checkpoints](./e2e.md#stage-checkpoints--skip-the-replay-m14).
+- **tunnel-mode bridge** — build launchable state under localhost, snapshot, then restore it under
+  the tunnel cookie domain (`ss stack snapshot` covers all 10 pg DBs + `connectv3` mongo, so
+  sessions survive the bridge; the legacy `mesh-fixture-cli` omitted `sessions`). See
+  [tunnel.md → the snapshot bridge](./tunnel.md#seed-launchable-connect-sessions--the-snapshot-bridge).
 
-← [verify](./verify.md) · [e2e →](./e2e.md)
+← [verify](./verify.md) · [e2e →](./e2e.md) · [tunnel →](./tunnel.md)
 
 ## Porting legacy mesh-fixture fixtures (e.g. `iam-small`, soa#194)
 

--- a/packages/node/saga-stack-cli/docs/tunnel.md
+++ b/packages/node/saga-stack-cli/docs/tunnel.md
@@ -45,6 +45,17 @@ tunnel-aware browser-plane env for every service (incl. coach), writes the dash'
 (`config.local.json`), brings the stack up, and — after a healthy launch+seed — starts the frpc
 reverse tunnels. When it's up, `https://dash.<moniker>.vms.wootdev.com` loads, logged in.
 
+> **Services must (re)launch to pick up the tunnel env.** `up --tunnel` skips any service whose
+> port is already healthy, so if the stack was already running in localhost mode those services keep
+> their non-tunnel env — most visibly, iam then sets a **host-only** `iam_session` cookie (no
+> `Domain=.<moniker>.vms…`), so the dash's calls to the other API subdomains are unauthenticated
+> (you're "logged in" at iam but the dash doesn't hold the session). If in doubt, bring the stack
+> down first so everything launches fresh under the tunnel env:
+> ```bash
+> ss stack down && ss stack up --tunnel --seed full --reset
+> ```
+> Verify with: the `iam_session` `Set-Cookie` should carry `Domain=.<moniker>.vms.wootdev.com`.
+
 Manage the tunnels directly (rarely needed — `up --tunnel` drives them for you):
 
 ```bash

--- a/packages/node/saga-stack-cli/docs/tunnel.md
+++ b/packages/node/saga-stack-cli/docs/tunnel.md
@@ -146,14 +146,15 @@ Empty Org personas (from the journey — the tested `session e2e` roster):
 
 | Role | Email | Does | Login |
 |------|-------|------|-------|
-| **Org admin** | `empty@saga.org` | Sees the org's sessions on `/sessions/list/today`; can **start/launch** a session (via grant) | devLogin or `password123` |
-| Tutor | `alex.tutor@example.org` | Section tutor (Math 101 / Reading 201) — hosts the session | devLogin |
-| Student | `ann.lee@example.org` | Enrolled student — joins | devLogin |
-| Student | `ben.kim@example.org` | Enrolled student — joins | devLogin |
+| **Tutor / host** | `alex.tutor@example.org` | Hosts the Connect room (`interactive-connect` uses this account) | devLogin |
+| Student | `ann.lee@example.org` | Joins the room | devLogin |
+| Student | `cara.diaz@example.org` | Joins the room | devLogin |
+| Org admin (opt.) | `empty@saga.org` | Org admin / in-room observer (`IN_ROOM_OBSERVER=1`) | devLogin or `password123` |
 
-`empty@saga.org` is the simplest login to **see and launch** the journey sessions. (`dev@saga.org` is
-the *seed*-district admin — a different, pre-journey org.) The full roster (2 tutors, 8 students)
-lives in `saga-dash` `e2e/data/fixtures/example-roster.csv`.
+These three (`alex.tutor`, `ann.lee`, `cara.diaz`) are the accounts `ss e2e connect` seats in the
+live room — all enrolled in the same pod (Math 101 + Reading 201). `empty@saga.org` is the Empty Org
+admin (opt-in observer). `dev@saga.org` is the *seed*-district admin — a different, pre-journey org.
+Full roster (2 tutors, 8 students): `saga-dash` `e2e/data/fixtures/example-roster.csv`.
 
 ## Guest security
 

--- a/packages/node/saga-stack-cli/docs/tunnel.md
+++ b/packages/node/saga-stack-cli/docs/tunnel.md
@@ -28,7 +28,8 @@ ss stack down && ss stack up --tunnel --reset
 ss stack snapshot restore tunnel-connect
 
 # 3 — Open the live Connect room over the tunnel. The tutor auto-hosts + STARTS the session.
-ss e2e connect --tunnel --student-login 1        # tutor + 1 local student; 1 seat left OPEN
+#     --reuse: run against the org you just restored (don't rebuild the prerequisite).
+ss e2e connect --tunnel --student-login 1 --reuse   # tutor + 1 local student; 1 seat left OPEN
 ```
 
 `--student-login N` = how many of the 2 students **this machine** logs in and joins locally

--- a/packages/node/saga-stack-cli/docs/tunnel.md
+++ b/packages/node/saga-stack-cli/docs/tunnel.md
@@ -37,24 +37,24 @@ The canonical use case: **invite someone to test Connect with you** via a public
 ## Bring the stack up in tunnel mode
 
 ```bash
-ss stack up --tunnel --seed full --reset
+ss stack down && ss stack up --tunnel --seed full --reset
 ```
 
-This is fully native (no `up.sh`): it resolves your moniker via the vendored `tunnel.sh`, builds the
-tunnel-aware browser-plane env for every service (incl. coach), writes the dash's tunnel routing
-(`config.local.json`), brings the stack up, and — after a healthy launch+seed — starts the frpc
-reverse tunnels. When it's up, `https://dash.<moniker>.vms.wootdev.com` loads, logged in.
+The leading `ss stack down` is part of the instruction, not an afterthought: `up --tunnel` skips any
+service whose port is already healthy, so a stack already running in localhost mode would keep its
+non-tunnel env — most visibly iam would set a **host-only** `iam_session` cookie (no
+`Domain=.<moniker>.vms…`) and the dash couldn't hold the session across the API subdomains. Bringing
+it down first guarantees every service (re)launches under the tunnel env. On a cold machine the
+`down` is a harmless no-op, so this one command is always the right way in.
 
-> **Services must (re)launch to pick up the tunnel env.** `up --tunnel` skips any service whose
-> port is already healthy, so if the stack was already running in localhost mode those services keep
-> their non-tunnel env — most visibly, iam then sets a **host-only** `iam_session` cookie (no
-> `Domain=.<moniker>.vms…`), so the dash's calls to the other API subdomains are unauthenticated
-> (you're "logged in" at iam but the dash doesn't hold the session). If in doubt, bring the stack
-> down first so everything launches fresh under the tunnel env:
-> ```bash
-> ss stack down && ss stack up --tunnel --seed full --reset
-> ```
-> Verify with: the `iam_session` `Set-Cookie` should carry `Domain=.<moniker>.vms.wootdev.com`.
+`up --tunnel` is fully native (no `up.sh`): it resolves your moniker via the vendored `tunnel.sh`,
+builds the tunnel-aware browser-plane env for every service (incl. coach), writes the dash's tunnel
+routing (`config.local.json`), launches the stack, and — after a healthy launch+seed — starts the
+frpc reverse tunnels. When it's up, `https://dash.<moniker>.vms.wootdev.com` loads, logged in.
+
+_Verify the relaunch took:_ the `iam_session` `Set-Cookie` should carry
+`Domain=.<moniker>.vms.wootdev.com` (that's what lets the session span the subdomains). A host-only
+cookie means some service didn't relaunch — run `ss stack down` again and re-up.
 
 Manage the tunnels directly (rarely needed — `up --tunnel` drives them for you):
 

--- a/packages/node/saga-stack-cli/docs/tunnel.md
+++ b/packages/node/saga-stack-cli/docs/tunnel.md
@@ -77,17 +77,22 @@ The fast, reliable path is the **snapshot bridge**: build the state under localh
 across the cookie-domain boundary with a snapshot.
 
 ```bash
-# 1. Build launchable sessions the fast way (localhost, no tunnel):
-ss stack up --seed full --reset
-ss e2e run journey --through sessions
+# 1. Build the Empty Org with a scheduled (launchable) session — localhost, fast, tested:
+#    Stop at `schedule`, NOT `sessions`: the `sessions` stage runs a start+end test that
+#    leaves today's occurrence in `Ended` state, so nothing is left to launch.
+ss stack down && ss stack up --seed full --reset
+ss e2e run journey --through schedule
 
 # 2. Snapshot the built state:
-ss stack snapshot store --fixture-id tunnel-demo
+ss stack snapshot store --fixture-id tunnel-journey
 
 # 3. Bring the stack up in tunnel mode and restore:
-ss stack up --tunnel --reset
-ss stack snapshot restore tunnel-demo
+ss stack down && ss stack up --tunnel --reset
+ss stack snapshot restore tunnel-journey
 ```
+
+Then log in at `https://dash.<moniker>.vms.wootdev.com` as `empty@saga.org` (see
+[Login credentials](#login-credentials)); today's session shows on `/sessions/list/today`, launchable.
 
 > **Use `ss stack snapshot`, never the legacy `mesh-fixture-cli`.** The legacy tool dumped only 6
 > postgres DBs and **omitted `sessions`** — which is exactly why a manual bridge repopulated users
@@ -136,14 +141,14 @@ Empty Org personas (from the journey — the tested `session e2e` roster):
 
 | Role | Email | Does | Login |
 |------|-------|------|-------|
-| **Org admin** | `empty@saga.org` | Sees the org's sessions on `/sessions/list/today`; can **start/end** a session (via grant) | devLogin or `password123` |
-| Tutor | `alex.tutor@example.org` | Section tutor (Math 101 / Reading 201) — hosts sessions | devLogin |
-| Tutor | `morgan.tutor@example.org` | Section tutor (Reading 201) | devLogin |
+| **Org admin** | `empty@saga.org` | Sees the org's sessions on `/sessions/list/today`; can **start/launch** a session (via grant) | devLogin or `password123` |
+| Tutor | `alex.tutor@example.org` | Section tutor (Math 101 / Reading 201) — hosts the session | devLogin |
 | Student | `ann.lee@example.org` | Enrolled student — joins | devLogin |
+| Student | `ben.kim@example.org` | Enrolled student — joins | devLogin |
 
 `empty@saga.org` is the simplest login to **see and launch** the journey sessions. (`dev@saga.org` is
-the *seed*-district admin — a different, pre-journey org.) The full student roster lives in
-`saga-dash` `e2e/data/fixtures/example-roster.csv`.
+the *seed*-district admin — a different, pre-journey org.) The full roster (2 tutors, 8 students)
+lives in `saga-dash` `e2e/data/fixtures/example-roster.csv`.
 
 ## Guest security
 

--- a/packages/node/saga-stack-cli/docs/tunnel.md
+++ b/packages/node/saga-stack-cli/docs/tunnel.md
@@ -77,11 +77,9 @@ The fast, reliable path is the **snapshot bridge**: build the state under localh
 across the cookie-domain boundary with a snapshot.
 
 ```bash
-# 1. Build the Empty Org with a scheduled (launchable) session — localhost, fast, tested:
-#    Stop at `schedule`, NOT `sessions`: the `sessions` stage runs a start+end test that
-#    leaves today's occurrence in `Ended` state, so nothing is left to launch.
+# 1. Build the Empty Org sessions — localhost, fast, tested:
 ss stack down && ss stack up --seed full --reset
-ss e2e run journey --through schedule
+ss e2e run journey --through sessions
 
 # 2. Snapshot the built state:
 ss stack snapshot store --fixture-id tunnel-journey
@@ -92,7 +90,14 @@ ss stack snapshot restore tunnel-journey
 ```
 
 Then log in at `https://dash.<moniker>.vms.wootdev.com` as `empty@saga.org` (see
-[Login credentials](#login-credentials)); today's session shows on `/sessions/list/today`, launchable.
+[Login credentials](#login-credentials)); the org's sessions show on `/sessions/list/today`.
+
+> **Open item — a *launchable* (not-yet-started) session.** The journey materializes today's
+> occurrence already-completed under its clamped test date (`actualStart`≈`actualEnd`, `status=Ended`),
+> so `/sessions/list/today` shows an **Ended** session, not one you can launch. Neither `--through
+> schedule` nor `--through sessions` changes this. Producing a launchable "today" session for the
+> tunnel demo needs a seed/date tweak (same class as up.sh's `SEED_DEMO_ONLY` demo lane) — tracked
+> for follow-up.
 
 > **Use `ss stack snapshot`, never the legacy `mesh-fixture-cli`.** The legacy tool dumped only 6
 > postgres DBs and **omitted `sessions`** — which is exactly why a manual bridge repopulated users

--- a/packages/node/saga-stack-cli/docs/tunnel.md
+++ b/packages/node/saga-stack-cli/docs/tunnel.md
@@ -121,30 +121,29 @@ ss e2e run journey --tunnel    # drive a whole flow over the tunnel (see the cav
 
 ## Login credentials
 
-Guests log in at `https://iam.<moniker>.vms.wootdev.com/demo#auth` — either via **devLogin**
-(enter the email, no password) or with the shared dev password **`password123`**. Every launchable
-demo session belongs to the **`demo` district** (not the roster/`example.org` personas), so the
-stack must have been brought up with **`--seed full`**, and the dash `/sessions` page only shows
-them once programs are seeded (another reason for `--seed full`).
+Log in at `https://iam.<moniker>.vms.wootdev.com/demo#auth` via **devLogin** (enter the email, no
+password). The `@saga.org` seed aliases below also accept the shared dev password **`password123`**;
+the `@example.org` roster users are provisioned by the journey, so use **devLogin** for them.
 
-The personas for the **live, launchable** Connect demo session — Demo North Summer Program, Pod A,
-the one seeded with a renderable board + published content:
+> **Which personas have launchable sessions?** The ones the **journey / Empty Org** creates — NOT the
+> `demo-*` district personas. `ss … --seed full` runs the *canonical projection bake*, which does
+> **not** seed the demo-district sessions (that was up.sh's separate `SEED_DEMO_ONLY` lane). So the
+> `demo-dadmin` / `demo-lead-north` / `demo-student-*` accounts exist and can log in, but under `ss`
+> they have **no sessions to launch**. Launchable sessions come from the [snapshot bridge](#seed-launchable-connect-sessions--the-snapshot-bridge)
+> (`ss e2e run journey --through sessions`), which builds the **Empty Org**.
 
-| Role | Email | Does |
-|------|-------|------|
-| District admin | `demo-dadmin@saga.org` | Sees every demo session on the dash `/sessions` page |
-| **Tutor (session host)** | `demo-lead-north@saga.org` | Hosts Pod A — **launches** the Connect board |
-| Student | `demo-student-1@saga.org` | Joins the session |
-| Student | `demo-student-2@saga.org` | Joins the session |
+Empty Org personas (from the journey — the tested `session e2e` roster):
 
-All log in with **`password123`** (or devLogin, no password).
+| Role | Email | Does | Login |
+|------|-------|------|-------|
+| **Org admin** | `empty@saga.org` | Sees the org's sessions on `/sessions/list/today`; can **start/end** a session (via grant) | devLogin or `password123` |
+| Tutor | `alex.tutor@example.org` | Section tutor (Math 101 / Reading 201) — hosts sessions | devLogin |
+| Tutor | `morgan.tutor@example.org` | Section tutor (Reading 201) | devLogin |
+| Student | `ann.lee@example.org` | Enrolled student — joins | devLogin |
 
-> **The launch host is `demo-lead-north`, not `demo-tutor-1`.** `demo-tutor-1` / `demo-tutor-2` host
-> other demo pods, but those are seeded only in `ended` / `edited` / `cancelled` states — no live
-> board. Only `demo-lead-north`'s Pod A session has a renderable, launchable board. (The full demo
-> roster also includes `demo-student-3..6`, `demo-admin-north`, and `demo-dadmin-ro` (read-only
-> observer). The "session-based attendance demo" and the "Connect launchable" demo are the **same**
-> Demo North/South Summer Program fixture — not separate accounts.)
+`empty@saga.org` is the simplest login to **see and launch** the journey sessions. (`dev@saga.org` is
+the *seed*-district admin — a different, pre-journey org.) The full student roster lives in
+`saga-dash` `e2e/data/fixtures/example-roster.csv`.
 
 ## Guest security
 

--- a/packages/node/saga-stack-cli/docs/tunnel.md
+++ b/packages/node/saga-stack-cli/docs/tunnel.md
@@ -108,6 +108,33 @@ ss e2e run journey --tunnel    # drive a whole flow over the tunnel (see the cav
 - Both are slot-0-only, and `run --tunnel` also requires the local `stack` lane (a deployed lane
   resolves its own hostnames, so `--tunnel --lane sandbox` is rejected).
 
+## Login credentials
+
+Guests log in at `https://iam.<moniker>.vms.wootdev.com/demo#auth` — either via **devLogin**
+(enter the email, no password) or with the shared dev password **`password123`**. Every launchable
+demo session belongs to the **`demo` district** (not the roster/`example.org` personas), so the
+stack must have been brought up with **`--seed full`**, and the dash `/sessions` page only shows
+them once programs are seeded (another reason for `--seed full`).
+
+The personas for the **live, launchable** Connect demo session — Demo North Summer Program, Pod A,
+the one seeded with a renderable board + published content:
+
+| Role | Email | Does |
+|------|-------|------|
+| District admin | `demo-dadmin@saga.org` | Sees every demo session on the dash `/sessions` page |
+| **Tutor (session host)** | `demo-lead-north@saga.org` | Hosts Pod A — **launches** the Connect board |
+| Student | `demo-student-1@saga.org` | Joins the session |
+| Student | `demo-student-2@saga.org` | Joins the session |
+
+All log in with **`password123`** (or devLogin, no password).
+
+> **The launch host is `demo-lead-north`, not `demo-tutor-1`.** `demo-tutor-1` / `demo-tutor-2` host
+> other demo pods, but those are seeded only in `ended` / `edited` / `cancelled` states — no live
+> board. Only `demo-lead-north`'s Pod A session has a renderable, launchable board. (The full demo
+> roster also includes `demo-student-3..6`, `demo-admin-north`, and `demo-dadmin-ro` (read-only
+> observer). The "session-based attendance demo" and the "Connect launchable" demo are the **same**
+> Demo North/South Summer Program fixture — not separate accounts.)
+
 ## Guest security
 
 By design there is **no VPN and no box-level auth** in front of the wildcard hosts — the app-layer

--- a/packages/node/saga-stack-cli/docs/tunnel.md
+++ b/packages/node/saga-stack-cli/docs/tunnel.md
@@ -5,8 +5,56 @@ Tunnel mode exposes the browser-facing services of your **local** stack at
 profile) can reach the stack running on **your** machine — "dev VMs are back." The services keep
 running locally under `pnpm dev` with HMR; the tunnel is a front door, not a deploy.
 
-The canonical use case: **invite someone to test Connect with you** via a publicly-reachable URL
-(`https://connect.<moniker>.vms.wootdev.com`).
+The canonical use case: **run a live Connect session and invite coworkers to join it** over a
+publicly-reachable URL. That whole flow is the concierge below.
+
+---
+
+## Concierge: a live Connect session over the tunnel
+
+From a clean machine to a running tutor + student + student Connect room that a remote coworker can
+join. Run it top to bottom.
+
+```bash
+export AWS_PROFILE=dev_admin      # dev account (moniker registration + fleek A/V creds)
+
+# 1 — Build the Empty Org + a schedule locally (fast, tested), then snapshot it:
+ss stack down && ss stack up --seed full --reset
+ss e2e run journey --through schedule
+ss stack snapshot store --fixture-id tunnel-connect
+
+# 2 — Bring the stack up in TUNNEL mode (fetches fleek A/V creds), then restore the org:
+ss stack down && ss stack up --tunnel --reset
+ss stack snapshot restore tunnel-connect
+
+# 3 — Open the live Connect room over the tunnel. The tutor auto-hosts + STARTS the session.
+ss e2e connect --tunnel --student-login 1        # tutor + 1 local student; 1 seat left OPEN
+```
+
+`--student-login N` = how many of the 2 students **this machine** logs in and joins locally
+(`0`, `1`, or `2`; default `2` = both local). Any seat you don't fill locally stays **open** for a
+remote coworker. Drop `--fake-media` (it's not on by default) — real camera/mic works via the fleek
+cluster once step 2 fetched the creds.
+
+Step 3 prints **login URLs for every participant** — share any with a coworker:
+
+```
+[interactive] ── participant logins (share any to add a remote) ──
+[interactive]   TUTOR   alex.tutor@example.org  (seated locally)
+[interactive]       login: https://iam.<moniker>.vms.wootdev.com/demo#auth  (devLogin as alex.tutor@example.org)  →  join: https://connect.<moniker>.vms.wootdev.com/?slsid=<id>
+[interactive]   STUDENT ann.lee@example.org  (seated locally)
+[interactive]       login: …
+[interactive]   STUDENT cara.diaz@example.org  (OPEN — a remote can take this seat)
+[interactive]       login: …  →  join: https://connect.<moniker>.vms.wootdev.com/?slsid=<id>
+```
+
+**A coworker joins** the open seat: open the `login:` URL, **devLogin** as that email (no password),
+then open the `join:` URL. They land in the same room. The browsers the concierge opened stay up
+until you hit Resume (▶) in the Playwright Inspector.
+
+> Everything below is detail — how each step works and why. You don't need it to run the concierge.
+
+---
 
 ## How it works (one minute)
 
@@ -19,148 +67,109 @@ The canonical use case: **invite someone to test Connect with you** via a public
 - **Moniker** = your per-dev DNS namespace (standard = your initials). It lives in the gitignored
   `vendor/.vms-moniker` and is **never taken on the command line** (a placeholder in a shared
   command cross-contaminates stacks). First use prompts for it and registers it in SSM; the box
-  then mints your wildcard cert `*.<moniker>.vms.wootdev.com` within ~1 minute.
-- **AV (LiveKit) stays on the fleek dev cluster** (`*.fleek.wootdev.com`), NOT the tunnel. LiveKit
-  is UDP and can't ride the HTTP tunnels, so a remote guest gets CRDT/chat locally (rtsm is
-  websockets) but their audio/video goes through the real fleek cluster. This is deliberate.
+  then mints your wildcard cert `*.<moniker>.vms.wootdev.com` within ~1-2 minutes.
+- **A/V rides the fleek dev cluster** (`wss://*.fleek.wootdev.com`), not the tunnel (LiveKit is UDP
+  and can't ride the HTTP tunnels). `up --tunnel` best-effort-fetches the cluster's LiveKit creds
+  from Secrets Manager (`qboard/fleek/livekit-creds`) so connect-api signs tokens the cluster
+  accepts — that's what makes **real** A/V work. CRDT/chat (rtsm, websockets) rides the tunnel.
 
 ## Prerequisites
 
-- **AWS dev-account creds.** tunnel.sh reads `/vms/frp-token` and registers your moniker in
-  `/vms/monikers`, both in the **dev** account (`396913734878`). It resolves the profile by account
-  number and hard-fails if your creds land elsewhere. If you see an account-mismatch error:
-  `aws sso login --profile <your-dev-profile>` (or set `AWS_PROFILE`).
+- **AWS dev-account creds.** tunnel.sh reads `/vms/frp-token` + registers your moniker in
+  `/vms/monikers`, and `up --tunnel` fetches the fleek A/V creds — all in the **dev** account
+  (`396913734878`). It resolves the profile by account number and hard-fails elsewhere. If you see
+  an account mismatch: `aws sso login --profile <your-dev-profile>` (or `export AWS_PROFILE=…`).
 - **Slot 0 only.** `--tunnel` fronts the FIXED slot-0 browser ports (dash :8900 / connect :6210 /
-  iam :3010), so every `--tunnel` command hard-errors at `--slot > 0` / `--set`. Slotted tunneling
-  is a separate, deferred effort.
+  iam :3010), so every `--tunnel` command hard-errors at `--slot > 0` / `--set`.
 
-## Bring the stack up in tunnel mode
+## Why the two-phase build (step 1 + 2)
 
-```bash
-ss stack down && ss stack up --tunnel --seed full --reset
-```
+`iam_session` has exactly one cookie `Domain` — host-only `localhost` **or** `.<moniker>.vms…`,
+never both — so one running iam serves the localhost journey **or** the tunnel dash, not both. The
+concierge therefore **builds the org under localhost** (where the tested journey is fast and
+reliable), snapshots it, then **restores it under the tunnel** cookie domain. The Connect room
+itself doesn't need a pre-launched dash session: `ss e2e connect` reads the schedule, **starts the
+occurrence via `sessions.start`**, and everyone joins — so `--through schedule` is enough (no need
+for the `sessions`/`attendance` stages, which would leave today's occurrence `Ended`).
 
-The leading `ss stack down` is part of the instruction, not an afterthought: `up --tunnel` skips any
-service whose port is already healthy, so a stack already running in localhost mode would keep its
-non-tunnel env — most visibly iam would set a **host-only** `iam_session` cookie (no
-`Domain=.<moniker>.vms…`) and the dash couldn't hold the session across the API subdomains. Bringing
-it down first guarantees every service (re)launches under the tunnel env. On a cold machine the
-`down` is a harmless no-op, so this one command is always the right way in.
+> **Use `ss stack snapshot`, never the legacy `mesh-fixture-cli`.** The legacy tool dumped only 6
+> postgres DBs and **omitted `sessions`**. `ss stack snapshot` is manifest-driven and covers all 10
+> pg DBs + the `connectv3` mongo DB (see [snapshots.md](./snapshots.md)).
 
-`up --tunnel` is fully native (no `up.sh`): it resolves your moniker via the vendored `tunnel.sh`,
-builds the tunnel-aware browser-plane env for every service (incl. coach), writes the dash's tunnel
-routing (`config.local.json`), launches the stack, and — after a healthy launch+seed — starts the
-frpc reverse tunnels. When it's up, `https://dash.<moniker>.vms.wootdev.com` loads, logged in.
+## Bringing the stack up in tunnel mode (`up --tunnel`)
+
+`ss stack down && ss stack up --tunnel --reset` is fully native (no `up.sh`): it resolves your
+moniker via the vendored `tunnel.sh`, builds the tunnel-aware browser-plane env for every service
+(incl. coach), writes the dash's tunnel routing (`config.local.json`), fetches the fleek A/V creds,
+launches the stack, and starts the frpc reverse tunnels.
+
+The leading `ss stack down` is **part of the instruction**: `up --tunnel` skips any service whose
+port is already healthy, so a stack already up in localhost mode would keep its non-tunnel env —
+most visibly iam would set a **host-only** `iam_session` cookie and the dash couldn't hold the
+session across the API subdomains. `down` guarantees every service (re)launches under the tunnel
+env; on a cold machine it's a harmless no-op.
 
 _Verify the relaunch took:_ the `iam_session` `Set-Cookie` should carry
-`Domain=.<moniker>.vms.wootdev.com` (that's what lets the session span the subdomains). A host-only
-cookie means some service didn't relaunch — run `ss stack down` again and re-up.
+`Domain=.<moniker>.vms.wootdev.com`. A host-only cookie means a service didn't relaunch — `down`
+again and re-up.
 
-Manage the tunnels directly (rarely needed — `up --tunnel` drives them for you):
+Manage the tunnels directly (rarely needed — `up --tunnel` drives them):
 
 ```bash
 ss stack tunnel status     # frpc process + per-URL health probes
-ss stack tunnel up         # (re)attach tunnels to an already-tunnel-launched stack
-ss stack tunnel down       # stop the tunnels
+ss stack tunnel up|down    # (re)attach / stop the tunnels
 ss stack tunnel urls       # print the public URL table
 ```
 
-## Seed launchable Connect sessions — the snapshot bridge
-
-`ss stack up --tunnel --seed full --reset` brings the stack up **but with no launchable sessions**:
-those are produced by the journey e2e, whose Playwright browsers can't be pointed at the tunnel
-without a WAN hairpin (slow) and — more fundamentally — because `iam_session` has exactly one cookie
-`Domain` (host-only `localhost` **or** `.<moniker>.vms.wootdev.com`, never both), so one running iam
-serves the localhost journey **or** the tunnel dash, not both at once.
-
-The fast, reliable path is the **snapshot bridge**: build the state under localhost, then carry it
-across the cookie-domain boundary with a snapshot.
-
-```bash
-# 1. Build the Empty Org sessions — localhost, fast, tested:
-ss stack down && ss stack up --seed full --reset
-ss e2e run journey --through sessions
-
-# 2. Snapshot the built state:
-ss stack snapshot store --fixture-id tunnel-journey
-
-# 3. Bring the stack up in tunnel mode and restore:
-ss stack down && ss stack up --tunnel --reset
-ss stack snapshot restore tunnel-journey
-```
-
-Then log in at `https://dash.<moniker>.vms.wootdev.com` as `empty@saga.org` (see
-[Login credentials](#login-credentials)); the org's sessions show on `/sessions/list/today`.
-
-> **Open item — a *launchable* (not-yet-started) session.** The journey materializes today's
-> occurrence already-completed under its clamped test date (`actualStart`≈`actualEnd`, `status=Ended`),
-> so `/sessions/list/today` shows an **Ended** session, not one you can launch. Neither `--through
-> schedule` nor `--through sessions` changes this. Producing a launchable "today" session for the
-> tunnel demo needs a seed/date tweak (same class as up.sh's `SEED_DEMO_ONLY` demo lane) — tracked
-> for follow-up.
-
-> **Use `ss stack snapshot`, never the legacy `mesh-fixture-cli`.** The legacy tool dumped only 6
-> postgres DBs and **omitted `sessions`** — which is exactly why a manual bridge repopulated users
-> but left Demo District sessions empty. `ss stack snapshot` is manifest-driven and covers all 10
-> pg DBs + the `connectv3` mongo DB (see [snapshots.md](./snapshots.md)). Keep the seed profile the
-> same between build and restore (or pass `--force`) so the restore's profile guard doesn't abort.
-
-## e2e in tunnel mode (`--tunnel`)
+## `ss e2e … --tunnel`
 
 `ss e2e run` and `ss e2e connect` accept `--tunnel`, which resolves your moniker and points the
-Playwright browser at `https://<label>.<moniker>.vms.wootdev.com` instead of localhost (the spec
-`lane.ts` already reads every service URL from `PLAYWRIGHT_*_URL`, so no spec change is needed).
+Playwright browser at `https://<label>.<moniker>.vms.wootdev.com` instead of localhost.
 
-```bash
-ss e2e connect --tunnel        # open the live Connect room, reachable at connect.<moniker>.vms…
-ss e2e run journey --tunnel    # drive a whole flow over the tunnel (see the caveat below)
-```
-
-- **`ss e2e connect --tunnel`** is the concierge front door for the invite-a-coworker use case:
-  it opens the live interactive-connect room and the room is reachable at
-  `https://connect.<moniker>.vms.wootdev.com`. Guests authenticate at
-  `https://iam.<moniker>.vms.wootdev.com/demo` as a seeded persona. Pair it with the snapshot bridge
-  above so there are sessions to launch.
-- **`ss e2e run … --tunnel` is the slow all-in-one.** Every request WAN-hairpins (your localhost
-  Playwright → DNS → the vms box → frp → back to your localhost), so a full journey crawls and the
-  timeouts stretch — `--tunnel` exports `PLAYWRIGHT_TUNNEL_TIMEOUT_MS` (consumed by the SPA's
-  `playwright.config.ts`) to compensate. Prefer the snapshot bridge for seeding and reserve
-  `run --tunnel` for when you specifically need the flow to execute against the tunnel.
-- Both are slot-0-only, and `run --tunnel` also requires the local `stack` lane (a deployed lane
-  resolves its own hostnames, so `--tunnel --lane sandbox` is rejected).
+- **`ss e2e connect --tunnel`** — the concierge front door (step 3). `--student-login N` sets how
+  many students join locally; `--fake-media` swaps in a synthetic camera/mic (drop it for real
+  A/V). The tutor always auto-hosts and starts the session. slot-0 only.
+- **`ss e2e run … --tunnel`** is the slow all-in-one: every request WAN-hairpins (localhost →
+  vms box → frp → localhost), so a full journey crawls; it exports `PLAYWRIGHT_TUNNEL_TIMEOUT_MS`
+  for the SPA's `playwright.config.ts`. Prefer the snapshot bridge (step 1) for seeding. slot-0 +
+  local `stack` lane only (`--tunnel --lane sandbox` is rejected).
 
 ## Login credentials
 
 Log in at `https://iam.<moniker>.vms.wootdev.com/demo#auth` via **devLogin** (enter the email, no
-password). The `@saga.org` seed aliases below also accept the shared dev password **`password123`**;
-the `@example.org` roster users are provisioned by the journey, so use **devLogin** for them.
+password). The `@saga.org` seed aliases also accept the shared dev password **`password123`**; the
+`@example.org` roster users are provisioned by the journey, so use **devLogin** for them.
 
-> **Which personas have launchable sessions?** The ones the **journey / Empty Org** creates — NOT the
-> `demo-*` district personas. `ss … --seed full` runs the *canonical projection bake*, which does
-> **not** seed the demo-district sessions (that was up.sh's separate `SEED_DEMO_ONLY` lane). So the
-> `demo-dadmin` / `demo-lead-north` / `demo-student-*` accounts exist and can log in, but under `ss`
-> they have **no sessions to launch**. Launchable sessions come from the [snapshot bridge](#seed-launchable-connect-sessions--the-snapshot-bridge)
-> (`ss e2e run journey --through sessions`), which builds the **Empty Org**.
+The Connect room seats these Empty Org personas (the concierge prints their login URLs):
 
-Empty Org personas (from the journey — the tested `session e2e` roster):
+| Role | Email | Login |
+|------|-------|-------|
+| **Tutor / host** | `alex.tutor@example.org` | devLogin |
+| Student | `ann.lee@example.org` | devLogin |
+| Student | `cara.diaz@example.org` | devLogin |
+| Org admin (opt.) | `empty@saga.org` | devLogin or `password123` |
 
-| Role | Email | Does | Login |
-|------|-------|------|-------|
-| **Tutor / host** | `alex.tutor@example.org` | Hosts the Connect room (`interactive-connect` uses this account) | devLogin |
-| Student | `ann.lee@example.org` | Joins the room | devLogin |
-| Student | `cara.diaz@example.org` | Joins the room | devLogin |
-| Org admin (opt.) | `empty@saga.org` | Org admin / in-room observer (`IN_ROOM_OBSERVER=1`) | devLogin or `password123` |
+All three room personas are in the same pod (Math 101 + Reading 201). `empty@saga.org` is the Empty
+Org admin (opt-in observer via `IN_ROOM_OBSERVER=1`); `dev@saga.org` is the *seed*-district admin, a
+different org. Full roster: `saga-dash` `e2e/data/fixtures/example-roster.csv`.
 
-These three (`alex.tutor`, `ann.lee`, `cara.diaz`) are the accounts `ss e2e connect` seats in the
-live room — all enrolled in the same pod (Math 101 + Reading 201). `empty@saga.org` is the Empty Org
-admin (opt-in observer). `dev@saga.org` is the *seed*-district admin — a different, pre-journey org.
-Full roster (2 tutors, 8 students): `saga-dash` `e2e/data/fixtures/example-roster.csv`.
+> The `demo-dadmin` / `demo-lead-north` / `demo-student-*` accounts exist and can log in, but under
+> `ss` they have **no sessions** — `--seed full` runs the canonical projection bake, not up.sh's
+> `SEED_DEMO_ONLY` demo-session lane. Launchable sessions come from the journey / Empty Org.
+
+## A/V
+
+Real camera/mic works when `up --tunnel` fetched the fleek cluster creds (needs dev creds; it warns
+if it couldn't and connect-api falls back to the dev key, which the cluster rejects → A/V fails but
+CRDT/chat still work). Use `--fake-media` on `ss e2e connect` for a synthetic camera/mic (a machine
+with no camera, or where `v4l2loopback` won't build). A/V always routes through the fleek dev
+cluster, never the tunnel.
 
 ## Guest security
 
 By design there is **no VPN and no box-level auth** in front of the wildcard hosts — the app-layer
 iam demo login is the only gate. Anyone with the URL reaches the login page. (Hardening — a shared
-secret / basic-auth at the box — is a possible future follow-up, not the current posture.)
+secret / basic-auth at the box — is a possible follow-up, not the current posture.)
 
 ## See also
 

--- a/packages/node/saga-stack-cli/docs/tunnel.md
+++ b/packages/node/saga-stack-cli/docs/tunnel.md
@@ -1,0 +1,121 @@
+# Tunnel mode — share your local stack
+
+Tunnel mode exposes the browser-facing services of your **local** stack at
+`https://<svc>.<moniker>.vms.wootdev.com`, so other people (a coworker, QA, a second browser
+profile) can reach the stack running on **your** machine — "dev VMs are back." The services keep
+running locally under `pnpm dev` with HMR; the tunnel is a front door, not a deploy.
+
+The canonical use case: **invite someone to test Connect with you** via a publicly-reachable URL
+(`https://connect.<moniker>.vms.wootdev.com`).
+
+## How it works (one minute)
+
+- A tiny EC2 **rendezvous box** (`vms.wootdev.com`, `tools/synthetic-dev/vms/`) runs `frps` +
+  Caddy. Your machine runs `frpc` (auto-downloaded, pinned) and reverse-tunnels each browser
+  service out to `https://<svc>.<moniker>.vms.wootdev.com`.
+- **Only the browser plane is tunnelled.** postgres/redis/rabbitmq/mongo get no tunnel by
+  construction, so they stay unreachable. Service-to-service URLs stay `localhost`; only the
+  browser-plane env flips (cookie domain, CORS, `VITE_*`/`PUBLIC_*` URLs).
+- **Moniker** = your per-dev DNS namespace (standard = your initials). It lives in the gitignored
+  `vendor/.vms-moniker` and is **never taken on the command line** (a placeholder in a shared
+  command cross-contaminates stacks). First use prompts for it and registers it in SSM; the box
+  then mints your wildcard cert `*.<moniker>.vms.wootdev.com` within ~1 minute.
+- **AV (LiveKit) stays on the fleek dev cluster** (`*.fleek.wootdev.com`), NOT the tunnel. LiveKit
+  is UDP and can't ride the HTTP tunnels, so a remote guest gets CRDT/chat locally (rtsm is
+  websockets) but their audio/video goes through the real fleek cluster. This is deliberate.
+
+## Prerequisites
+
+- **AWS dev-account creds.** tunnel.sh reads `/vms/frp-token` and registers your moniker in
+  `/vms/monikers`, both in the **dev** account (`396913734878`). It resolves the profile by account
+  number and hard-fails if your creds land elsewhere. If you see an account-mismatch error:
+  `aws sso login --profile <your-dev-profile>` (or set `AWS_PROFILE`).
+- **Slot 0 only.** `--tunnel` fronts the FIXED slot-0 browser ports (dash :8900 / connect :6210 /
+  iam :3010), so every `--tunnel` command hard-errors at `--slot > 0` / `--set`. Slotted tunneling
+  is a separate, deferred effort.
+
+## Bring the stack up in tunnel mode
+
+```bash
+ss stack up --tunnel --seed full --reset
+```
+
+This is fully native (no `up.sh`): it resolves your moniker via the vendored `tunnel.sh`, builds the
+tunnel-aware browser-plane env for every service (incl. coach), writes the dash's tunnel routing
+(`config.local.json`), brings the stack up, and — after a healthy launch+seed — starts the frpc
+reverse tunnels. When it's up, `https://dash.<moniker>.vms.wootdev.com` loads, logged in.
+
+Manage the tunnels directly (rarely needed — `up --tunnel` drives them for you):
+
+```bash
+ss stack tunnel status     # frpc process + per-URL health probes
+ss stack tunnel up         # (re)attach tunnels to an already-tunnel-launched stack
+ss stack tunnel down       # stop the tunnels
+ss stack tunnel urls       # print the public URL table
+```
+
+## Seed launchable Connect sessions — the snapshot bridge
+
+`ss stack up --tunnel --seed full --reset` brings the stack up **but with no launchable sessions**:
+those are produced by the journey e2e, whose Playwright browsers can't be pointed at the tunnel
+without a WAN hairpin (slow) and — more fundamentally — because `iam_session` has exactly one cookie
+`Domain` (host-only `localhost` **or** `.<moniker>.vms.wootdev.com`, never both), so one running iam
+serves the localhost journey **or** the tunnel dash, not both at once.
+
+The fast, reliable path is the **snapshot bridge**: build the state under localhost, then carry it
+across the cookie-domain boundary with a snapshot.
+
+```bash
+# 1. Build launchable sessions the fast way (localhost, no tunnel):
+ss stack up --seed full --reset
+ss e2e run journey --through sessions
+
+# 2. Snapshot the built state:
+ss stack snapshot store --fixture-id tunnel-demo
+
+# 3. Bring the stack up in tunnel mode and restore:
+ss stack up --tunnel --reset
+ss stack snapshot restore tunnel-demo
+```
+
+> **Use `ss stack snapshot`, never the legacy `mesh-fixture-cli`.** The legacy tool dumped only 6
+> postgres DBs and **omitted `sessions`** — which is exactly why a manual bridge repopulated users
+> but left Demo District sessions empty. `ss stack snapshot` is manifest-driven and covers all 10
+> pg DBs + the `connectv3` mongo DB (see [snapshots.md](./snapshots.md)). Keep the seed profile the
+> same between build and restore (or pass `--force`) so the restore's profile guard doesn't abort.
+
+## e2e in tunnel mode (`--tunnel`)
+
+`ss e2e run` and `ss e2e connect` accept `--tunnel`, which resolves your moniker and points the
+Playwright browser at `https://<label>.<moniker>.vms.wootdev.com` instead of localhost (the spec
+`lane.ts` already reads every service URL from `PLAYWRIGHT_*_URL`, so no spec change is needed).
+
+```bash
+ss e2e connect --tunnel        # open the live Connect room, reachable at connect.<moniker>.vms…
+ss e2e run journey --tunnel    # drive a whole flow over the tunnel (see the caveat below)
+```
+
+- **`ss e2e connect --tunnel`** is the concierge front door for the invite-a-coworker use case:
+  it opens the live interactive-connect room and the room is reachable at
+  `https://connect.<moniker>.vms.wootdev.com`. Guests authenticate at
+  `https://iam.<moniker>.vms.wootdev.com/demo` as a seeded persona. Pair it with the snapshot bridge
+  above so there are sessions to launch.
+- **`ss e2e run … --tunnel` is the slow all-in-one.** Every request WAN-hairpins (your localhost
+  Playwright → DNS → the vms box → frp → back to your localhost), so a full journey crawls and the
+  timeouts stretch — `--tunnel` exports `PLAYWRIGHT_TUNNEL_TIMEOUT_MS` (consumed by the SPA's
+  `playwright.config.ts`) to compensate. Prefer the snapshot bridge for seeding and reserve
+  `run --tunnel` for when you specifically need the flow to execute against the tunnel.
+- Both are slot-0-only, and `run --tunnel` also requires the local `stack` lane (a deployed lane
+  resolves its own hostnames, so `--tunnel --lane sandbox` is rejected).
+
+## Guest security
+
+By design there is **no VPN and no box-level auth** in front of the wildcard hosts — the app-layer
+iam demo login is the only gate. Anyone with the URL reaches the login page. (Hardening — a shared
+secret / basic-auth at the box — is a possible future follow-up, not the current posture.)
+
+## See also
+
+- [snapshots.md](./snapshots.md) — the store/restore mechanics the bridge relies on.
+- [e2e.md](./e2e.md) — flows, stages, and the live Connect session.
+- `tools/synthetic-dev/vms/README.md` — provisioning the rendezvous box.

--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -146,6 +146,12 @@
           "name": "fake-media",
           "allowNo": false,
           "type": "boolean"
+        },
+        "tunnel": {
+          "description": "point the headed Connect room at the vms tunnel hosts (https://<label>.<moniker>.<VMS_BASE>) instead of localhost, so a REMOTE peer can drive the session. Resolves the moniker via the vendored tunnel.sh (same machinery as `stack up --tunnel`) and writes the dash tunnel config. Connect is slot-0 only, so no slot guard is needed.",
+          "name": "tunnel",
+          "allowNo": false,
+          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
@@ -510,6 +516,12 @@
         "dry-run": {
           "description": "plan only: print the resolved flow + closure + seed plan + playwright argv + occurrence date; touch nothing",
           "name": "dry-run",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "tunnel": {
+          "description": "point the Playwright browser at the vms tunnel hosts (https://<label>.<moniker>.<VMS_BASE>) instead of localhost, so a REMOTE peer can drive this slot-0 stack. Resolves the moniker via the vendored tunnel.sh (same machinery as `stack up --tunnel`); writes the dash tunnel config; exports PLAYWRIGHT_TUNNEL_TIMEOUT_MS for the SPA config. Slot-0 only (hard-errors at --slot > 0 / --set).",
+          "name": "tunnel",
           "allowNo": false,
           "type": "boolean"
         },

--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -153,11 +153,13 @@
           "allowNo": false,
           "type": "boolean"
         },
-        "open-slot": {
-          "description": "leave ONE student seat OPEN (seat only the first student locally) so a REMOTE peer can join as the second student — pair with --tunnel to invite a coworker. The run prints the open persona + the join URL. Sets CONNECT_OPEN_STUDENT_SLOTS=1 on the headed interactive-connect run.",
-          "name": "open-slot",
-          "allowNo": false,
-          "type": "boolean"
+        "student-login": {
+          "description": "how many of the 2 students THIS run logs in + joins locally (0, 1, or 2; default 2). The rest stay OPEN for a REMOTE peer to take — pair with --tunnel to invite coworkers. The tutor always auto-hosts and starts the session; login URLs for EVERY participant are printed regardless. Sets CONNECT_LOCAL_STUDENTS on the headed interactive-connect run.",
+          "name": "student-login",
+          "default": 2,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         }
       },
       "hasDynamicHelp": false,

--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -152,6 +152,12 @@
           "name": "tunnel",
           "allowNo": false,
           "type": "boolean"
+        },
+        "open-slot": {
+          "description": "leave ONE student seat OPEN (seat only the first student locally) so a REMOTE peer can join as the second student — pair with --tunnel to invite a coworker. The run prints the open persona + the join URL. Sets CONNECT_OPEN_STUDENT_SLOTS=1 on the headed interactive-connect run.",
+          "name": "open-slot",
+          "allowNo": false,
+          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,

--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -148,7 +148,7 @@
           "type": "boolean"
         },
         "tunnel": {
-          "description": "point the headed Connect room at the vms tunnel hosts (https://<label>.<moniker>.<VMS_BASE>) instead of localhost, so a REMOTE peer can drive the session. Resolves the moniker via the vendored tunnel.sh (same machinery as `stack up --tunnel`) and writes the dash tunnel config. Connect is slot-0 only, so no slot guard is needed.",
+          "description": "point THIS run’s Connect browsers at the vms tunnel hosts (https://<label>.<moniker>.<VMS_BASE>) instead of localhost, so a REMOTE peer can reach the same room. Resolves the moniker via the vendored tunnel.sh (same machinery as `stack up --tunnel`). NOTE: this ONLY repoints these Playwright browsers’ URLs — it does NOT relaunch the stack, flip connect-web/rtsm/cookie env, or start frpc. You must have already run `ss stack up --tunnel` so the stack itself is tunnel-served. Connect is slot-0 only, so no slot guard is needed.",
           "name": "tunnel",
           "allowNo": false,
           "type": "boolean"

--- a/packages/node/saga-stack-cli/src/__tests__/e2e-orchestrate-slot.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/__tests__/e2e-orchestrate-slot.unit.test.ts
@@ -21,6 +21,8 @@ import {
   buildStackContext,
   playwrightEnv,
   serviceUrlEnv,
+  tunnelServiceUrlEnv,
+  TUNNEL_PLAYWRIGHT_TIMEOUT_MS,
   type StackSeams,
 } from '../e2e-orchestrate.js';
 import type {
@@ -190,5 +192,71 @@ describe('serviceUrlEnv / playwrightEnv — offset Playwright service URLs', () 
     expect(env.PLAYWRIGHT_IAM_URL).toBe('http://localhost:4010');
     // ...while flow.env keeps winning for the date env.
     expect(env.PLAYWRIGHT_OCCURRENCE_DATE).toBe('2026-01-05');
+  });
+});
+
+describe('tunnelServiceUrlEnv / playwrightEnv --tunnel (soa#298)', () => {
+  const DOMAIN = 'testmoniker.vms.wootdev.com';
+  const p0 = deriveInstance({ slot: 0 }).portOverrides;
+  const flow = { name: 'journey', env: undefined } as unknown as ResolvedFlow['flow'];
+  const resolved = { flow } as ResolvedFlow;
+  const now = new Date('2026-06-30T12:00:00'); // a Tuesday — deterministic clamp
+
+  it('tunnelServiceUrlEnv maps every URL key to https://<label>.<domain>', () => {
+    const env = tunnelServiceUrlEnv(DOMAIN);
+    // renames + suffix quirks (the non-derivable labels).
+    expect(env.PLAYWRIGHT_BASE_URL).toBe(`https://dash.${DOMAIN}`); // saga-dash → dash
+    expect(env.PLAYWRIGHT_CONNECT_URL).toBe(`https://connect.${DOMAIN}`); // connect-web → connect
+    expect(env.PLAYWRIGHT_ADS_ADM_URL).toBe(`https://ads-adm.${DOMAIN}`);
+    expect(env.PLAYWRIGHT_CONNECT_API_URL).toBe(`https://connect-api.${DOMAIN}`); // KEEPS -api
+    // suffix-dropping ids.
+    expect(env.PLAYWRIGHT_IAM_URL).toBe(`https://iam.${DOMAIN}`);
+    expect(env.PLAYWRIGHT_SIS_URL).toBe(`https://sis.${DOMAIN}`);
+    expect(env.PLAYWRIGHT_PROGRAMS_URL).toBe(`https://programs.${DOMAIN}`);
+    expect(env.PLAYWRIGHT_SCHEDULING_URL).toBe(`https://scheduling.${DOMAIN}`);
+    expect(env.PLAYWRIGHT_SESSIONS_URL).toBe(`https://sessions.${DOMAIN}`);
+  });
+
+  it('playwrightEnv (stack lane, --tunnel): tunnel https URLs BEAT the localhost URLs + exports the WAN timeout', () => {
+    const env = playwrightEnv(resolved, now, 'stack', p0, undefined, undefined, DOMAIN);
+    // every service URL is the tunnel host, not localhost (the tunnel overlay wins).
+    expect(env.PLAYWRIGHT_BASE_URL).toBe(`https://dash.${DOMAIN}`);
+    expect(env.PLAYWRIGHT_IAM_URL).toBe(`https://iam.${DOMAIN}`);
+    expect(env.PLAYWRIGHT_SESSIONS_URL).toBe(`https://sessions.${DOMAIN}`);
+    expect(env.PLAYWRIGHT_BASE_URL).not.toContain('localhost');
+    // the net-new WAN timeout env (consumed cross-repo in saga-dash playwright.config.ts).
+    expect(env.PLAYWRIGHT_TUNNEL_TIMEOUT_MS).toBe(String(TUNNEL_PLAYWRIGHT_TIMEOUT_MS));
+    // the date clamp still rides along.
+    expect(env.PLAYWRIGHT_OCCURRENCE_DATE).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('playwrightEnv WITHOUT a tunnel domain is byte-identical to today (localhost URLs, no timeout key)', () => {
+    const plain = playwrightEnv(resolved, now, 'stack', p0);
+    const explicitUndefined = playwrightEnv(resolved, now, 'stack', p0, undefined, undefined, undefined);
+    // absent domain ⇒ the exact pre-tunnel env (deep-equal), no tunnel keys leak in.
+    expect(explicitUndefined).toEqual(plain);
+    expect(plain.PLAYWRIGHT_BASE_URL).toBe('http://localhost:8900');
+    expect(plain.PLAYWRIGHT_TUNNEL_TIMEOUT_MS).toBeUndefined();
+  });
+
+  it('a DEPLOYED lane never injects tunnel URLs (lane.ts owns the hostnames)', () => {
+    const env = playwrightEnv(resolved, now, 'sandbox', p0, undefined, undefined, DOMAIN);
+    expect(env.PLAYWRIGHT_BASE_URL).toBeUndefined();
+    expect(env.PLAYWRIGHT_LANE).toBe('sandbox');
+    // the timeout export is domain-gated, not lane-gated — a --tunnel run on a deployed
+    // lane is nonsensical (guarded at the command), but the env stays coherent regardless.
+    expect(env.PLAYWRIGHT_TUNNEL_TIMEOUT_MS).toBe(String(TUNNEL_PLAYWRIGHT_TIMEOUT_MS));
+  });
+
+  it('buildStackContext flips tunnel:true + tunnelDomain when a domain is passed (facade reads these)', () => {
+    const { runtime } = buildStackContext(FLAGS, seams(), delegate, deriveInstance({ slot: 0 }), DOMAIN);
+    expect(runtime.tunnel).toBe(true);
+    expect(runtime.tunnelDomain).toBe(DOMAIN);
+  });
+
+  it('buildStackContext WITHOUT a domain keeps tunnel:false (byte-identical default)', () => {
+    const { runtime } = buildStackContext(FLAGS, seams(), delegate, deriveInstance({ slot: 0 }));
+    expect(runtime.tunnel).toBe(false);
+    expect(runtime.tunnelDomain).toBeUndefined();
   });
 });

--- a/packages/node/saga-stack-cli/src/__tests__/tunnel-service-labels.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/__tests__/tunnel-service-labels.unit.test.ts
@@ -1,0 +1,82 @@
+/**
+ * `TUNNEL_SERVICE_LABELS` drift guard (Tunnel Mode, saga-ed/soa#298).
+ *
+ * `e2e run --tunnel` re-points each `PLAYWRIGHT_*_URL` at `https://<label>.<domain>`,
+ * where `<label>` is the vendored `tunnel.sh` SERVICES key. The label is NOT
+ * string-derivable from the ServiceId (`saga-dash→dash`, `connect-web→connect`,
+ * `ads-adm-api→ads-adm` are renames; most `-api` ids drop the suffix but
+ * `connect-api` keeps it), so it lives in an explicit `TUNNEL_SERVICE_LABELS` table.
+ *
+ * Two ways that table can rot, both caught here:
+ *   1. a NEW `PLAYWRIGHT_SERVICE_URL_ENV` ServiceId lands with no label → its tunnel
+ *      URL would be silently dropped (localhost leaks to the remote browser);
+ *   2. a label drifts from the vendored `tunnel.sh` SERVICES table → the frpc host
+ *      never exists and the browser 502s.
+ *
+ * So: every URL-env ServiceId must have a label, and every label must be a REAL
+ * `vendor/tunnel.sh` SERVICES entry (parsed from the vendored script, cwd-independent).
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { PLAYWRIGHT_SERVICE_URL_ENV, TUNNEL_SERVICE_LABELS } from '../e2e-orchestrate.js';
+
+/** Walk UP from `start` to the first ancestor for which `join(dir, ...rel)` exists. */
+function findUp(start: string, rel: string[]): string {
+    let dir = start;
+    for (let i = 0; i < 12; i++) {
+        const candidate = join(dir, ...rel);
+        if (existsSync(candidate)) return candidate;
+        const parent = dirname(dir);
+        if (parent === dir) break;
+        dir = parent;
+    }
+    throw new Error(`tunnel-service-labels: could not locate ${rel.join('/')} walking up from ${start}`);
+}
+
+/** Parse the `SERVICES=( "label:port" … )` array out of the vendored tunnel.sh. */
+function tunnelServiceLabels(): Set<string> {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const script = readFileSync(findUp(here, ['vendor', 'tunnel.sh']), 'utf8');
+    const block = script.match(/SERVICES=\(([\s\S]*?)\)/);
+    if (!block) throw new Error('tunnel-service-labels: could not find SERVICES=( … ) in vendor/tunnel.sh');
+    const labels = new Set<string>();
+    for (const m of block[1].matchAll(/"([^":]+):\d+"/g)) labels.add(m[1]);
+    return labels;
+}
+
+describe('TUNNEL_SERVICE_LABELS ↔ PLAYWRIGHT_SERVICE_URL_ENV ↔ vendor/tunnel.sh', () => {
+    const vendorLabels = tunnelServiceLabels();
+
+    it('sanity: the vendored SERVICES parse yields the known tunnel hosts', () => {
+        // A guard on the parser itself — if this shrinks to 0 the coverage below is vacuous.
+        expect(vendorLabels.size).toBeGreaterThanOrEqual(9);
+        expect(vendorLabels).toContain('dash');
+        expect(vendorLabels).toContain('connect-api');
+    });
+
+    it('every PLAYWRIGHT_SERVICE_URL_ENV ServiceId has a TUNNEL_SERVICE_LABELS entry', () => {
+        for (const svc of Object.values(PLAYWRIGHT_SERVICE_URL_ENV)) {
+            expect(TUNNEL_SERVICE_LABELS[svc], `no tunnel label for ServiceId '${svc}'`).toBeDefined();
+        }
+    });
+
+    it('every mapped label is a REAL vendor/tunnel.sh SERVICES entry (no phantom hosts)', () => {
+        for (const svc of Object.values(PLAYWRIGHT_SERVICE_URL_ENV)) {
+            const label = TUNNEL_SERVICE_LABELS[svc];
+            expect(vendorLabels.has(label), `label '${label}' (for '${svc}') is not a tunnel.sh SERVICES entry`).toBe(true);
+        }
+    });
+
+    it('pins the non-derivable renames (the trap this table exists to prevent)', () => {
+        // saga-dash→dash / connect-web→connect / ads-adm-api→ads-adm are renames, and
+        // connect-api KEEPS its -api suffix while the other -api ids drop it.
+        expect(TUNNEL_SERVICE_LABELS['saga-dash']).toBe('dash');
+        expect(TUNNEL_SERVICE_LABELS['connect-web']).toBe('connect');
+        expect(TUNNEL_SERVICE_LABELS['ads-adm-api']).toBe('ads-adm');
+        expect(TUNNEL_SERVICE_LABELS['connect-api']).toBe('connect-api');
+        expect(TUNNEL_SERVICE_LABELS['iam-api']).toBe('iam');
+    });
+});

--- a/packages/node/saga-stack-cli/src/base-command.ts
+++ b/packages/node/saga-stack-cli/src/base-command.ts
@@ -85,6 +85,7 @@ import {
   generateSlotFleetConfig,
   resolveRepoRoot,
   resolveTunnelMoniker,
+  resolveFleekLivekitCreds,
   resolveScript,
   resolveVendorScript,
   scriptCwd,
@@ -560,6 +561,18 @@ export abstract class BaseCommand extends Command {
    */
   protected getTunnelFleetGen(): typeof generateTunnelFleetConfig {
     return generateTunnelFleetConfig;
+  }
+
+  /**
+   * The `--tunnel` fleek-cluster LiveKit creds seam (real A/V). Production
+   * best-effort-fetches `qboard/fleek/livekit-creds` from Secrets Manager (up.sh's
+   * AV block); the resolved key/secret become connect-api's `LIVEKIT_API_KEY/SECRET`
+   * so it signs tokens the fleek cluster accepts. Returns `null` when unavailable
+   * (no dev creds / secret) ⇒ connect-api signs with the dev key and cluster A/V
+   * fails, but CRDT/chat and the rest of tunnel mode are unaffected.
+   */
+  protected getFleekCreds(): typeof resolveFleekLivekitCreds {
+    return resolveFleekLivekitCreds;
   }
 
   /** The per-slot rtsm-fleet generator seam (soa#271 — endpoint swapped to the slot's

--- a/packages/node/saga-stack-cli/src/commands/e2e/__tests__/e2e.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/__tests__/e2e.int.test.ts
@@ -264,4 +264,19 @@ describe('e2e connect — foreground connect-session entry', () => {
     expect(pw[1].args).toContain('interactive-connect');
     expect(pw[1].env?.FAKE_MEDIA).toBeUndefined();
   });
+
+  it('--tunnel: the headed interactive-connect session drives the https tunnel hosts (soa#298)', async () => {
+    // Never spawn the vendored tunnel.sh — inject a fixed moniker (run.int.test.ts pattern).
+    vi.spyOn(BaseCommand.prototype as never, 'getTunnelMoniker' as never).mockReturnValue(
+      (async () => 'testmoniker') as never,
+    );
+    await E2eConnect.run(['--tunnel', ...ws()], config);
+    // The live session's env carries the tunnel URLs — proving tunnelDomain reached the
+    // executeResolvedFlow deps (and buildStackContext) for the headed interactive run.
+    const live = playwrightRuns().find((r) => r.args.includes('interactive-connect'));
+    // dash is the non-derivable rename for saga-dash; <label>.<moniker>.<VMS_BASE>.
+    expect(live?.env?.PLAYWRIGHT_BASE_URL).toMatch(/^https:\/\/dash\.testmoniker\./);
+    expect(live?.env?.PLAYWRIGHT_BASE_URL).not.toContain('localhost');
+    expect(live?.env?.PLAYWRIGHT_TUNNEL_TIMEOUT_MS).toMatch(/^\d+$/);
+  });
 });

--- a/packages/node/saga-stack-cli/src/commands/e2e/__tests__/run.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/__tests__/run.int.test.ts
@@ -512,3 +512,42 @@ describe('e2e run — --hold manual-testing handoff (Plan 13)', () => {
     expect(warned.some((w) => w.includes('empty window'))).toBe(true);
   });
 });
+
+describe('e2e run — --tunnel (soa#298)', () => {
+  /** Pull the emitted `--output-json` dry-run object out of the logged lines. */
+  function dryRunJson(): Record<string, unknown> {
+    const line = logged.find((l) => l.trim().startsWith('{'));
+    if (!line) throw new Error(`no JSON emitted; logged: ${logged.join('\\n')}`);
+    return JSON.parse(line) as Record<string, unknown>;
+  }
+
+  beforeEach(() => {
+    // Never spawn the vendored tunnel.sh — inject a fixed moniker (up-native.int.test.ts pattern).
+    vi.spyOn(BaseCommand.prototype as never, 'getTunnelMoniker' as never).mockReturnValue(
+      (async () => 'testmoniker') as never,
+    );
+  });
+
+  it('--tunnel --dry-run: the Playwright service URLs point at the https tunnel hosts + the WAN timeout is exported', async () => {
+    await E2eRun.run(['journey', '--through', 'pods', '--tunnel', '--dry-run', '--output-json', ...ws()], config);
+
+    const env = dryRunJson().env as Record<string, string>;
+    // <label>.<moniker>.<VMS_BASE> — dash is the non-derivable rename for saga-dash.
+    expect(env.PLAYWRIGHT_BASE_URL).toMatch(/^https:\/\/dash\.testmoniker\./);
+    expect(env.PLAYWRIGHT_IAM_URL).toMatch(/^https:\/\/iam\.testmoniker\./);
+    expect(env.PLAYWRIGHT_BASE_URL).not.toContain('localhost');
+    expect(env.PLAYWRIGHT_TUNNEL_TIMEOUT_MS).toMatch(/^\d+$/);
+
+    // still a pure projection — no seam touched.
+    expect(launches).toEqual([]);
+    expect(runs).toEqual([]);
+  });
+
+  it('--tunnel --slot 1 hard-errors (slot-0 only; the single check also covers --set)', async () => {
+    await expect(
+      E2eRun.run(['journey', '--tunnel', '--slot', '1', '--dry-run', ...ws()], config),
+    ).rejects.toMatchObject({ message: expect.stringContaining('--tunnel') });
+    // the guard fires before any moniker resolution / seam touch.
+    expect(launches).toEqual([]);
+  });
+});

--- a/packages/node/saga-stack-cli/src/commands/e2e/connect.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/connect.ts
@@ -101,10 +101,12 @@ export default class E2eConnect extends BaseCommand {
       description:
         'point THIS run’s Connect browsers at the vms tunnel hosts (https://<label>.<moniker>.<VMS_BASE>) instead of localhost, so a REMOTE peer can reach the same room. Resolves the moniker via the vendored tunnel.sh (same machinery as `stack up --tunnel`). NOTE: this ONLY repoints these Playwright browsers’ URLs — it does NOT relaunch the stack, flip connect-web/rtsm/cookie env, or start frpc. You must have already run `ss stack up --tunnel` so the stack itself is tunnel-served. Connect is slot-0 only, so no slot guard is needed.',
     }),
-    'open-slot': Flags.boolean({
-      default: false,
+    'student-login': Flags.integer({
+      default: 2,
+      min: 0,
+      max: 2,
       description:
-        'leave ONE student seat OPEN (seat only the first student locally) so a REMOTE peer can join as the second student — pair with --tunnel to invite a coworker. The run prints the open persona + the join URL. Sets CONNECT_OPEN_STUDENT_SLOTS=1 on the headed interactive-connect run.',
+        'how many of the 2 students THIS run logs in + joins locally (0, 1, or 2; default 2). The rest stay OPEN for a REMOTE peer to take — pair with --tunnel to invite coworkers. The tutor always auto-hosts and starts the session; login URLs for EVERY participant are printed regardless. Sets CONNECT_LOCAL_STUDENTS on the headed interactive-connect run.',
     }),
   };
 
@@ -136,13 +138,15 @@ export default class E2eConnect extends BaseCommand {
     // the prerequisite + reset entirely, exactly like connect-session.sh.
     const resolved = resolveFlow(disco.manifest, CONNECT_FLOW, { lane: 'stack' });
     const base = flags.reuse ? { ...resolved, prerequisite: undefined } : resolved;
-    // --fake-media (FAKE_MEDIA=1) and --open-slot (CONNECT_OPEN_STUDENT_SLOTS=1) pin
+    // --fake-media (FAKE_MEDIA=1) and --student-login (CONNECT_LOCAL_STUDENTS=N) pin
     // env into THIS flow's env (merged last by computeEnv), so they reach only the
     // connect-session stage (headed interactive-connect) — not the journey
     // prerequisite, a separate ResolvedFlow.
     const stageEnv: Record<string, string> = {};
     if (flags['fake-media']) stageEnv.FAKE_MEDIA = '1';
-    if (flags['open-slot']) stageEnv.CONNECT_OPEN_STUDENT_SLOTS = '1';
+    // Default (2) leaves the env unset ⇒ the spec's own default (all students local),
+    // so a plain `e2e connect` is byte-identical to before. Only pin it when narrowing.
+    if (flags['student-login'] !== 2) stageEnv.CONNECT_LOCAL_STUDENTS = String(flags['student-login']);
     const toRun =
       Object.keys(stageEnv).length > 0
         ? { ...base, flow: { ...base.flow, env: { ...base.flow.env, ...stageEnv } } }

--- a/packages/node/saga-stack-cli/src/commands/e2e/connect.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/connect.ts
@@ -99,7 +99,7 @@ export default class E2eConnect extends BaseCommand {
     tunnel: Flags.boolean({
       default: false,
       description:
-        'point the headed Connect room at the vms tunnel hosts (https://<label>.<moniker>.<VMS_BASE>) instead of localhost, so a REMOTE peer can drive the session. Resolves the moniker via the vendored tunnel.sh (same machinery as `stack up --tunnel`) and writes the dash tunnel config. Connect is slot-0 only, so no slot guard is needed.',
+        'point THIS run’s Connect browsers at the vms tunnel hosts (https://<label>.<moniker>.<VMS_BASE>) instead of localhost, so a REMOTE peer can reach the same room. Resolves the moniker via the vendored tunnel.sh (same machinery as `stack up --tunnel`). NOTE: this ONLY repoints these Playwright browsers’ URLs — it does NOT relaunch the stack, flip connect-web/rtsm/cookie env, or start frpc. You must have already run `ss stack up --tunnel` so the stack itself is tunnel-served. Connect is slot-0 only, so no slot guard is needed.',
     }),
   };
 

--- a/packages/node/saga-stack-cli/src/commands/e2e/connect.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/connect.ts
@@ -44,6 +44,7 @@ import { resolveFlow } from '../../core/flow/index.js';
 import { manifest as serviceManifest } from '../../core/manifest/index.js';
 import type { ScriptPlan } from '../../core/flag-map.js';
 import { makeStackApi } from '../../stack-api.js';
+import { resolveVendorScript } from '../../runtime/index.js';
 import {
   buildStackContext,
   discoverFlowManifest,
@@ -95,6 +96,11 @@ export default class E2eConnect extends BaseCommand {
       description:
         "swap real mic/cam capture for Chromium's synthetic camera (moving test pattern) + mic (beep) and auto-accept the getUserMedia prompt — for a machine with no camera or where v4l2loopback won't build. Sets FAKE_MEDIA=1 on the headed interactive-connect run (mirrors connect-session.sh --fake-media); the journey prerequisite is unaffected.",
     }),
+    tunnel: Flags.boolean({
+      default: false,
+      description:
+        'point the headed Connect room at the vms tunnel hosts (https://<label>.<moniker>.<VMS_BASE>) instead of localhost, so a REMOTE peer can drive the session. Resolves the moniker via the vendored tunnel.sh (same machinery as `stack up --tunnel`) and writes the dash tunnel config. Connect is slot-0 only, so no slot guard is needed.',
+    }),
   };
 
   async run(): Promise<void> {
@@ -145,7 +151,20 @@ export default class E2eConnect extends BaseCommand {
     };
     const delegate = (plan: ScriptPlan): Promise<number> =>
       this.runScript(plan, flags as WorkspaceFlags, { propagateExit: false });
-    const { runtime } = buildStackContext(flags, seams, delegate);
+
+    // --tunnel: resolve <moniker>.<VMS_BASE> from the VENDORED tunnel.sh (the SAME
+    // machinery as `stack up --tunnel`, up.ts:297-303) so the headed Connect room
+    // drives the tunnel hosts. E2eConnect is neither slot- nor set-aware ⇒ slot-0
+    // only, so no slot guard is needed. The seam lets unit tests inject a fixed
+    // moniker instead of spawning tunnel.sh.
+    let tunnelDomain: string | undefined;
+    if (flags.tunnel) {
+      const vmsBase = process.env.VMS_BASE ?? 'vms.wootdev.com';
+      const moniker = await this.getTunnelMoniker()(resolveVendorScript('tunnel.sh'));
+      tunnelDomain = `${moniker}.${vmsBase}`;
+    }
+
+    const { runtime } = buildStackContext(flags, seams, delegate, undefined, tunnelDomain);
     const api = makeStackApi(serviceManifest, runtime);
 
     // M14-C: the checkpoint store so the journey prerequisite can be RESTORED
@@ -191,7 +210,7 @@ export default class E2eConnect extends BaseCommand {
     try {
       const code = await executeResolvedFlow(
         toRun,
-        { api, runner: seams.runner, appCwd, now, log: (l) => this.log(l), checkpoints },
+        { api, runner: seams.runner, appCwd, now, log: (l) => this.log(l), checkpoints, tunnelDomain },
         {
           lane: 'stack',
           skipReset: flags.reuse,

--- a/packages/node/saga-stack-cli/src/commands/e2e/connect.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/connect.ts
@@ -101,6 +101,11 @@ export default class E2eConnect extends BaseCommand {
       description:
         'point THIS run’s Connect browsers at the vms tunnel hosts (https://<label>.<moniker>.<VMS_BASE>) instead of localhost, so a REMOTE peer can reach the same room. Resolves the moniker via the vendored tunnel.sh (same machinery as `stack up --tunnel`). NOTE: this ONLY repoints these Playwright browsers’ URLs — it does NOT relaunch the stack, flip connect-web/rtsm/cookie env, or start frpc. You must have already run `ss stack up --tunnel` so the stack itself is tunnel-served. Connect is slot-0 only, so no slot guard is needed.',
     }),
+    'open-slot': Flags.boolean({
+      default: false,
+      description:
+        'leave ONE student seat OPEN (seat only the first student locally) so a REMOTE peer can join as the second student — pair with --tunnel to invite a coworker. The run prints the open persona + the join URL. Sets CONNECT_OPEN_STUDENT_SLOTS=1 on the headed interactive-connect run.',
+    }),
   };
 
   async run(): Promise<void> {
@@ -131,12 +136,17 @@ export default class E2eConnect extends BaseCommand {
     // the prerequisite + reset entirely, exactly like connect-session.sh.
     const resolved = resolveFlow(disco.manifest, CONNECT_FLOW, { lane: 'stack' });
     const base = flags.reuse ? { ...resolved, prerequisite: undefined } : resolved;
-    // --fake-media pins FAKE_MEDIA=1 into THIS flow's env (merged last by
-    // computeEnv), so it reaches only the connect-session stage (headed
-    // interactive-connect) — not the journey prerequisite, a separate ResolvedFlow.
-    const toRun = flags['fake-media']
-      ? { ...base, flow: { ...base.flow, env: { ...base.flow.env, FAKE_MEDIA: '1' } } }
-      : base;
+    // --fake-media (FAKE_MEDIA=1) and --open-slot (CONNECT_OPEN_STUDENT_SLOTS=1) pin
+    // env into THIS flow's env (merged last by computeEnv), so they reach only the
+    // connect-session stage (headed interactive-connect) — not the journey
+    // prerequisite, a separate ResolvedFlow.
+    const stageEnv: Record<string, string> = {};
+    if (flags['fake-media']) stageEnv.FAKE_MEDIA = '1';
+    if (flags['open-slot']) stageEnv.CONNECT_OPEN_STUDENT_SLOTS = '1';
+    const toRun =
+      Object.keys(stageEnv).length > 0
+        ? { ...base, flow: { ...base.flow, env: { ...base.flow.env, ...stageEnv } } }
+        : base;
 
     const appCwd = resolveAppCwd(resolved.spa, flags, process.env);
     const now = new Date();

--- a/packages/node/saga-stack-cli/src/commands/e2e/run.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/run.ts
@@ -35,7 +35,7 @@ import type { Lane } from '../../core/manifest/index.js';
 import type { ScriptPlan } from '../../core/flag-map.js';
 import { reviewBlockLines, runIdFrom } from '../../core/e2e-review.js';
 import type { PreservedRunRecord } from '../../core/e2e-review.js';
-import { preserveSpawnArtifacts } from '../../runtime/index.js';
+import { preserveSpawnArtifacts, resolveVendorScript } from '../../runtime/index.js';
 import { makeStackApi } from '../../stack-api.js';
 import {
   buildStackContext,
@@ -131,6 +131,11 @@ export default class E2eRun extends BaseCommand {
       description: 'plan only: print the resolved flow + closure + seed plan + playwright argv + occurrence date; touch nothing',
       default: false,
     }),
+    tunnel: Flags.boolean({
+      default: false,
+      description:
+        'point the Playwright browser at the vms tunnel hosts (https://<label>.<moniker>.<VMS_BASE>) instead of localhost, so a REMOTE peer can drive this slot-0 stack. Resolves the moniker via the vendored tunnel.sh (same machinery as `stack up --tunnel`); writes the dash tunnel config; exports PLAYWRIGHT_TUNNEL_TIMEOUT_MS for the SPA config. Slot-0 only (hard-errors at --slot > 0 / --set).',
+    }),
     capture: Flags.boolean({
       default: false,
       description:
@@ -164,6 +169,26 @@ export default class E2eRun extends BaseCommand {
     // alias is --phase, and oclif would treat a defaulted value as provided (M14 lesson).
     if (flags.to !== undefined && (flags.through !== undefined || flags.phase !== undefined)) {
       this.error('--to and --through are mutually exclusive: --to K stops BEFORE stage K; --through K runs THROUGH it.');
+    }
+    // --tunnel fronts the FIXED slot-0 browser ports (dash :8900 / connect :6210 / iam :3010)
+    // via the vms rendezvous box, so it is slot-0-only — mirroring `stack up --tunnel`
+    // (up.ts:209-214). The single `flags.slot > 0` check covers `--set` too (a set pins a
+    // slot > 0). Checked before runSetPreflight (the set brings its slot up).
+    if (flags.tunnel && flags.slot > 0) {
+      this.error(
+        `slot ${flags.slot}: --tunnel fronts the FIXED slot-0 browser ports (dash :8900 / connect :6210 / iam :3010) ` +
+          'via the vms rendezvous box, so it cannot run against a peer slot/set. Run the e2e flow at slot 0.',
+      );
+    }
+    // --tunnel only makes sense on the local `stack` lane: the tunnel hosts front the
+    // LOCAL stack, and tunnelServiceUrlEnv is `lane === 'stack'`-gated. A deployed lane
+    // (e.g. `sandbox`) resolves its own hostnames, so --tunnel would spawn tunnel.sh and
+    // export the WAN timeout for nothing. Guard it rather than silently no-op.
+    if (flags.tunnel && flags.lane !== 'stack') {
+      this.error(
+        `--tunnel targets the local stack lane (its hosts front YOUR stack), but --lane ${flags.lane} ` +
+          'resolves its own URLs. Drop --tunnel, or drop --lane to use the stack lane.',
+      );
     }
 
     // M13-B: the implicit set preflight (no-op without --set) — e2e run brings
@@ -218,6 +243,18 @@ export default class E2eRun extends BaseCommand {
     const profile = deriveInstance({ slot: flags.slot });
     const excluded = new Set(profile.excludedServices);
 
+    // --tunnel: resolve <moniker>.<VMS_BASE> from the VENDORED tunnel.sh (the SAME
+    // machinery as `stack up --tunnel`, up.ts:297-303) so the Playwright browser
+    // hairpins to the tunnel hosts. Slot-0-only (guarded above). Resolved for BOTH
+    // the dry-run (so it prints the https:// URLs) and the real run; the seam lets
+    // unit tests inject a fixed moniker instead of spawning tunnel.sh.
+    let tunnelDomain: string | undefined;
+    if (flags.tunnel) {
+      const vmsBase = process.env.VMS_BASE ?? 'vms.wootdev.com';
+      const moniker = await this.getTunnelMoniker()(resolveVendorScript('tunnel.sh'));
+      tunnelDomain = `${moniker}.${vmsBase}`;
+    }
+
     // ── --dry-run: pure projection, no IO, no seam. ──
     if (flags['dry-run']) {
       const desc = describeResolved(resolved, {
@@ -233,6 +270,7 @@ export default class E2eRun extends BaseCommand {
         to: flags.to,
         hold: flags.hold,
         capture: flags.capture,
+        tunnelDomain,
       });
       this.emit(flags, { dryRun: true, ...desc } as unknown as Record<string, unknown>, dryRunLines(desc));
       return;
@@ -262,7 +300,7 @@ export default class E2eRun extends BaseCommand {
     };
     const delegate = (plan: ScriptPlan): Promise<number> =>
       this.runScript(plan, flags as WorkspaceFlags, { propagateExit: false });
-    const { runtime } = buildStackContext(flags, seams, delegate, profile);
+    const { runtime } = buildStackContext(flags, seams, delegate, profile, tunnelDomain);
     const api = makeStackApi(serviceManifest, runtime);
 
     // M14: the checkpoint store (bake/--from) — constructed AFTER applyInstanceEnv
@@ -323,6 +361,7 @@ export default class E2eRun extends BaseCommand {
           excluded,
           checkpoints,
           preserveTraces,
+          tunnelDomain,
         },
         {
           lane,

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/up-native.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/up-native.int.test.ts
@@ -149,6 +149,8 @@ function installNativeSeams(launchFail: Set<string> = new Set()): void {
   // Phase 2: a fixed moniker (never spawn tunnel.sh) + a recording seam that records
   // the resolved RecordPlan (never touches docker/aws).
   vi.spyOn(proto, 'getTunnelMoniker').mockReturnValue(async () => 'testmoniker');
+  // Phase: fixed fleek LiveKit creds (never spawn `tunnel.sh aws-profile` / `aws`).
+  vi.spyOn(proto, 'getFleekCreds').mockReturnValue(() => ({ key: 'realkey', secret: 'realsecret' }));
   // Phase 2 (BLOCKER-2): a fake fleet-config generator that records the request and
   // echoes the outPath as the generated fleet path (never touches the fs).
   vi.spyOn(proto, 'getTunnelFleetGen').mockReturnValue((opts) => {
@@ -606,6 +608,18 @@ describe('stack up — Phase 2 native --sandbox / --tunnel / --record / --worksp
     expect(rtsm?.env.FLEET_CONFIG_PATH).toBe(fleetGenCalls[0].outPath);
     expect(rtsm?.env.FLEET_CONFIG_PATH).toMatch(/\/rtsm-fleet-tunnel\.json$/);
     expect(rtsm?.env.FLEET_CONFIG_PATH).not.toMatch(/rtsm-fleet-local\.json$/);
+  });
+
+  it('--tunnel → connect-api signs with the fetched fleek LiveKit creds (real cluster A/V)', async () => {
+    // The fleek-creds seam resolved real cluster creds (up.sh's Secrets Manager fetch);
+    // connect-api must sign LiveKit tokens with them, not the local dev key, or the
+    // fleek cluster rejects the tokens and A/V fails.
+    await StackUp.run(['--tunnel', ...WS], config);
+    const connectApi = launches.find((s) => s.id === 'connect-api');
+    expect(connectApi?.env.LIVEKIT_API_KEY).toBe('realkey');
+    expect(connectApi?.env.LIVEKIT_API_SECRET).toBe('realsecret');
+    // topology always points browsers at the fleek dev cluster in tunnel mode.
+    expect(connectApi?.env.FLEEK_TOPOLOGY_JSON).toContain('fleek.wootdev.com');
   });
 
   it('--only programs-api --sandbox demo → programs-api gets IAM_API_URL flip + originate (sandbox_env)', async () => {

--- a/packages/node/saga-stack-cli/src/commands/stack/up.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/up.ts
@@ -319,6 +319,24 @@ export default class StackUp extends BaseCommand {
         tunnelDomain: domain,
       });
       if (rtsmFleetPath) overlays.tunnel.rtsmFleetPath = rtsmFleetPath;
+
+      // Real-cluster A/V (up.sh's best-effort Secrets Manager fetch, up.sh:2346-2351):
+      // fetch the fleek LiveKit key/secret so connect-api signs tokens the fleek dev
+      // cluster ACCEPTS. Absent (no dev creds / secret) ⇒ connect-api keeps the local
+      // dev key, the cluster rejects the tokens, and only A/V fails — CRDT/chat and the
+      // rest of tunnel mode work. Behind a seam so unit tests inject fixed creds.
+      const lk = this.getFleekCreds()(resolveVendorScript('tunnel.sh'));
+      if (lk) {
+        overlays.tunnel.lkKey = lk.key;
+        overlays.tunnel.lkSecret = lk.secret;
+        this.log('tunnel A/V: fleek dev-cluster LiveKit creds resolved (real camera/mic).');
+      } else {
+        this.warn(
+          'tunnel A/V: could not fetch qboard/fleek/livekit-creds — real A/V will fail ' +
+            '(connect-api signs LiveKit tokens with the dev key, which the fleek cluster ' +
+            'rejects). CRDT/chat still work. `aws sso login` to the dev account + re-up for cluster A/V.',
+        );
+      }
     }
 
     if (flags.record !== undefined) {

--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.overlay.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.overlay.unit.test.ts
@@ -132,6 +132,20 @@ describe('tunnel_env overlay (--tunnel)', () => {
     expect(envFor('saga-dash', TUN).__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS).toBe(`dash.${TD}`);
   });
 
+  it('coach-api: CORS allow-list appends the BARE tunnel domain, keeping the localhost host', () => {
+    const e = envFor('coach-api', TUN);
+    // up.sh: "$COACH_WEB_HOST,$TUNNEL_DOMAIN" — localhost host retained, bare
+    // domain admits coach.${TD} (api-core hostname match), no per-label enum.
+    expect(e.EXPRESS_SERVER_CORSALLOWEDDOMAINS).toBe(`localhost,${TD}`);
+  });
+
+  it('coach-web: browser-side API URL (label coach-api) + vite host allow (label coach)', () => {
+    const e = envFor('coach-web', TUN);
+    // Labels are HARDCODED to up.sh's, NOT the manifest tunnelSlug (coach-web).
+    expect(e.PUBLIC_COACH_API_URL).toBe(`https://coach-api.${TD}`);
+    expect(e.__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS).toBe(`coach.${TD}`);
+  });
+
   it('rtsm-api: FLEET_CONFIG_PATH override ONLY when a generated tunnel fleet path is supplied', () => {
     // no fleet path ⇒ keeps the base local fleet.
     expect(envFor('rtsm-api', TUN).FLEET_CONFIG_PATH).toBe(

--- a/packages/node/saga-stack-cli/src/core/launch-plan.ts
+++ b/packages/node/saga-stack-cli/src/core/launch-plan.ts
@@ -369,6 +369,26 @@ function tunnelOverlay(service: ServiceId, tokens: LaunchTokens): Record<string,
         : {};
     case 'saga-dash':
       return { __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS: `dash.${td}` };
+    case 'coach-api':
+      // EXPRESS_SERVER_CORSALLOWEDDOMAINS is coach's hostname allow-list (comma-
+      // split; api-core matches origin.hostname === d || endsWith(".d")), so the
+      // BARE tunnel domain admits coach.${td} — and any other tunnel label —
+      // without enumerating them. Keep COACH_WEB_HOST (localhost) so a local
+      // browser still works alongside remote ones. Splatted after the launch
+      // env's CORS value, so this wins (env last-wins).
+      return {
+        EXPRESS_SERVER_CORSALLOWEDDOMAINS: `${tokens.COACH_WEB_HOST},${td}`,
+      };
+    case 'coach-web':
+      // PUBLIC_COACH_API_URL is BROWSER-side (SvelteKit PUBLIC_ var read at
+      // vite-dev time): a remote coworker's browser must reach coach-api via its
+      // public tunnel name (label `coach-api`), not localhost:6105. iam stays
+      // behind coach-api (cookie composition is server-side, coach#94), so
+      // nothing else flips. Label `coach` is coach-web's own allowed-host.
+      return {
+        PUBLIC_COACH_API_URL: `https://coach-api.${td}`,
+        __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS: `coach.${td}`,
+      };
     default:
       return {}; // everything else: dev CORS wildcard already admits *.wootdev.com
   }

--- a/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
+++ b/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
@@ -229,6 +229,14 @@ export function buildStackContext(
   seams: StackSeams,
   delegate: (plan: ScriptPlan) => Promise<number>,
   profile: InstanceProfile = deriveInstance({ slot: 0 }),
+  /**
+   * `e2e run --tunnel`: the resolved `<moniker>.<VMS_BASE>` domain. When present the
+   * runtime flips `tunnel:true`+`tunnelDomain`, which the facade already reads to
+   * write dash `config.local.json`'s url-type localDefaults (`stack-api.ts` →
+   * `syncDashLocalDefaults`); no facade change needed. Absent ⇒ `tunnel:false` (the
+   * pre-tunnel default, byte-identical).
+   */
+  tunnelDomain?: string,
 ): { runtime: Runtime; repoRoots: Record<RepoKey, string> } {
   const ctx: ScriptContext = repoContextFromFlags(flags);
 
@@ -281,7 +289,11 @@ export function buildStackContext(
     dashFs: seams.dashFs,
     prober: seams.prober,
     runner: seams.runner,
-    tunnel: false,
+    // --tunnel (Phase 2): a resolved domain flips tunnel mode on so the facade writes
+    // the dash config.local.json url-type localDefaults (up.sh sync_dash_local_defaults
+    // parity). No domain ⇒ the pre-tunnel default (tunnel:false), byte-identical.
+    tunnel: tunnelDomain !== undefined,
+    tunnelDomain,
     delegate,
     // FLIP 3: wire the native-prep seams at EVERY slot (including slot 0) so the e2e's
     // native `StackApi.up` runs R1 build → R2 provision → R3 migrate before launch+seed,
@@ -407,6 +419,61 @@ export function serviceUrlEnv(ports: Partial<Record<ServiceId, number>>): Record
 }
 
 /**
+ * The `ServiceId` → `tunnel.sh` HOSTNAME LABEL map for `e2e run --tunnel`. Under
+ * `--tunnel` the Playwright browser is a REMOTE peer (opened on another box through
+ * the vms rendezvous), so it can't reach `localhost:<port>` — every service URL must
+ * become `https://<label>.<domain>` where `<label>` is the vendored tunnel.sh
+ * SERVICES key (`vendor/tunnel.sh`, the frpc reverse-tunnel table).
+ *
+ * The label is NOT string-derivable from the ServiceId: `saga-dash→dash` /
+ * `connect-web→connect` / `ads-adm-api→ads-adm` are renames; `iam-api`/`sis-api`/
+ * `programs-api`/`scheduling-api`/`sessions-api` drop the `-api` suffix; but
+ * `connect-api→connect-api` KEEPS it. So this is an explicit table keyed 1:1 to the
+ * `PLAYWRIGHT_SERVICE_URL_ENV` ServiceIds (a drift guard test asserts every URL-env
+ * ServiceId has an entry here and each label is a real tunnel.sh SERVICES entry).
+ */
+export const TUNNEL_SERVICE_LABELS: Readonly<Record<ServiceId, string>> = Object.freeze({
+  'saga-dash': 'dash',
+  'iam-api': 'iam',
+  'sis-api': 'sis',
+  'programs-api': 'programs',
+  'scheduling-api': 'scheduling',
+  'sessions-api': 'sessions',
+  'ads-adm-api': 'ads-adm',
+  'connect-web': 'connect',
+  'connect-api': 'connect-api',
+} as Record<ServiceId, string>);
+
+/**
+ * A generous WAN timeout (ms) exported as `PLAYWRIGHT_TUNNEL_TIMEOUT_MS` when
+ * `e2e run --tunnel` is active. The stack services still bind localhost (the prober
+ * needs no bump), but the Playwright BROWSER hairpins over the WAN to
+ * `https://<label>.<domain>` through the frps rendezvous box, so navigation/action
+ * round-trips are far slower than a localhost run. 120s is a deliberately roomy
+ * ceiling for that hop. CROSS-REPO: the value is CONSUMED in saga-dash's
+ * `playwright.config.ts` (read into `use.navigationTimeout`/`actionTimeout`/`timeout`)
+ * — NOT in this package — so the exact env name + ms budget must be confirmed there.
+ */
+export const TUNNEL_PLAYWRIGHT_TIMEOUT_MS = 120_000;
+
+/**
+ * The tunnel-mode variant of `serviceUrlEnv`: every `PLAYWRIGHT_*_URL` key becomes
+ * `https://<label>.<domain>` (the frpc reverse-tunnel host) instead of
+ * `http://localhost:<port>`. Used ONLY on the stack lane when `--tunnel` supplied a
+ * `<moniker>.<VMS_BASE>` domain — a remote browser reaches the local stack through
+ * the vms box. Keyed to the SAME env vars `lane.ts` consumes; the label per ServiceId
+ * comes from `TUNNEL_SERVICE_LABELS`.
+ */
+export function tunnelServiceUrlEnv(domain: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, svc] of Object.entries(PLAYWRIGHT_SERVICE_URL_ENV)) {
+    const label = TUNNEL_SERVICE_LABELS[svc];
+    if (label !== undefined) env[key] = `https://${label}.${domain}`;
+  }
+  return env;
+}
+
+/**
  * The env overlaid on the Playwright child: the centralized clamped date env
  * (`computeEnv` — the Monday-flake fix, with the flow's own `env` merged last so a
  * date-fixed flow's date pins win), THEN the offset-carrying stack-lane service
@@ -441,6 +508,16 @@ export function playwrightEnv(
    * failures). Omitted (default) ⇒ the env is byte-identical to today.
    */
   capture?: boolean,
+  /**
+   * `e2e run --tunnel`: the resolved `<moniker>.<VMS_BASE>` tunnel domain. When
+   * present (stack lane only), the `PLAYWRIGHT_*_URL` keys are re-pointed at the
+   * frpc reverse-tunnel hosts (`https://<label>.<domain>`) so a REMOTE browser can
+   * reach the local stack, and `PLAYWRIGHT_TUNNEL_TIMEOUT_MS` is exported for the
+   * SPA's Playwright config to widen its WAN timeouts. Overlaid AFTER the
+   * localhost/offset service URLs so tunnel always wins for those keys. Absent ⇒ the
+   * env is byte-identical to today.
+   */
+  tunnelDomain?: string,
 ): Record<string, string> {
   // The date env (with `flow.env` merged LAST inside `computeEnv`) comes first, so
   // a flow's own env keeps winning for the occurrence-date clamp. Then, on the
@@ -449,12 +526,16 @@ export function playwrightEnv(
   // service URL can never point slot > 0 back at slot 0's base port (same
   // split-brain class as the dash config.local.json offset). On a deployed lane
   // the service URLs are the lane's own hostnames (resolved in `lane.ts`), so we
-  // do NOT inject/override them.
+  // do NOT inject/override them. Under --tunnel the tunnel HOSTS overlay LAST (over
+  // the localhost URLs) so a remote browser hairpins through the vms box; --tunnel
+  // is slot-0-only, so it never combines with the slot offset.
   const env: Record<string, string> = {
     ...computeEnv(resolved.flow, now),
     ...(dateOverrides ?? {}),
     ...(lane === 'stack' && ports ? serviceUrlEnv(ports) : {}),
+    ...(lane === 'stack' && tunnelDomain ? tunnelServiceUrlEnv(tunnelDomain) : {}),
     ...(capture === true ? { PLAYWRIGHT_CAPTURE: 'all' } : {}),
+    ...(tunnelDomain ? { PLAYWRIGHT_TUNNEL_TIMEOUT_MS: String(TUNNEL_PLAYWRIGHT_TIMEOUT_MS) } : {}),
   };
   if (lane !== 'stack') env.PLAYWRIGHT_LANE = lane;
   return env;
@@ -523,6 +604,12 @@ export interface DescribeOptions {
   excluded?: Set<ServiceId>;
   /** Exploratory-review capture (`--capture`) — surfaces PLAYWRIGHT_CAPTURE in the projected env. */
   capture?: boolean;
+  /**
+   * `e2e run --tunnel`: the resolved `<moniker>.<VMS_BASE>` domain — threaded into the
+   * projected Playwright env so `--tunnel --dry-run` prints the `https://<label>.<domain>`
+   * service URLs (+ `PLAYWRIGHT_TUNNEL_TIMEOUT_MS`) instead of the localhost ones.
+   */
+  tunnelDomain?: string;
 }
 
 /**
@@ -534,7 +621,7 @@ export interface DescribeOptions {
 export function describeResolved(resolved: ResolvedFlow, opts: DescribeOptions): ResolvedFlowDescription {
   // Computed ONCE; `env` below carries the same date keys (playwrightEnv wraps
   // computeEnv), so occurrenceDate reads from it instead of recomputing.
-  const env = playwrightEnv(resolved, opts.now, opts.lane, opts.ports, undefined, opts.capture);
+  const env = playwrightEnv(resolved, opts.now, opts.lane, opts.ports, undefined, opts.capture, opts.tunnelDomain);
   const effectiveReset = resolved.reset && !opts.skipReset;
   // Drop the slot's excluded services (literal-port playback-trio backends) from the
   // closure so the dry-run matches what a `--slot N` run actually brings up. Empty
@@ -662,6 +749,13 @@ export interface ExecDeps {
    * injected into the Playwright env so specs drive the slot's OWN service URLs.
    */
   ports?: Partial<Record<ServiceId, number>>;
+  /**
+   * `e2e run --tunnel`: the resolved `<moniker>.<VMS_BASE>` domain — threaded into the
+   * Playwright child env so a REMOTE browser drives the `https://<label>.<domain>`
+   * tunnel hosts (+ `PLAYWRIGHT_TUNNEL_TIMEOUT_MS`) instead of localhost. Slot-0-only
+   * (guarded at the command). Rides the prerequisite recursion via `deps`.
+   */
+  tunnelDomain?: string;
   /**
    * Services excluded from THIS slot's bring-up (`profile.excludedServices`).
    * Filtered out of the closure before up/reset/seed/verify. Empty at slot 0.
@@ -934,7 +1028,7 @@ export async function executeResolvedFlow(
         [ENV_TERM_END]: restoredDates.termEnd,
       }
     : undefined;
-  const env = playwrightEnv(resolved, deps.now, opts.lane, deps.ports, dateOverrides, opts.capture);
+  const env = playwrightEnv(resolved, deps.now, opts.lane, deps.ports, dateOverrides, opts.capture, deps.tunnelDomain);
 
   const spawn = async (stage?: { project: string; noDeps: boolean }): Promise<number> => {
     const argv = playwrightArgv(resolved, opts.passthrough, stage);

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/vendor-tunnel-drift.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/vendor-tunnel-drift.unit.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Vendored `tunnel.sh` drift guard (Tunnel Mode, saga-ed/soa#298; re-vendor debt from #224).
+ *
+ * The CLI ships its OWN copy of `tunnel.sh` under the package's `vendor/` dir (see
+ * `vendor.ts`), so `ss tunnel` / `up --tunnel` no longer reach into a resolved soa
+ * checkout's `tools/synthetic-dev`. But a vendored copy silently ROTS when the source
+ * changes and the copy is not refreshed — exactly what happened in #224 (coach:8800 /
+ * coach-api:6105 + the `|| coach` status-probe branch landed in the source but the
+ * vendored copy was never re-vendored). This asserts the two files are byte-identical.
+ *
+ * SCOPED TO tunnel.sh ONLY — the other files under `vendor/` (`refresh-suite.sh`,
+ * `.gitignore`) are INTENTIONALLY forked from the source tree and must NOT be asserted.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/** Walk UP from `start` to the first ancestor for which `join(dir, ...rel)` exists. */
+function findUp(start: string, rel: string[]): string {
+    let dir = start;
+    for (let i = 0; i < 12; i++) {
+        const candidate = join(dir, ...rel);
+        if (existsSync(candidate)) return candidate;
+        const parent = dirname(dir);
+        if (parent === dir) break;
+        dir = parent;
+    }
+    throw new Error(`vendor-tunnel-drift: could not locate ${rel.join('/')} walking up from ${start}`);
+}
+
+describe('vendored tunnel.sh drift guard', () => {
+    it('is byte-identical to tools/synthetic-dev/tunnel.sh', () => {
+        const here = dirname(fileURLToPath(import.meta.url));
+        // Resolve both relative to the package (walk up), so cwd is irrelevant.
+        const vendorPath = findUp(here, ['vendor', 'tunnel.sh']);
+        const sourcePath = findUp(here, ['tools', 'synthetic-dev', 'tunnel.sh']);
+
+        const source = readFileSync(sourcePath);
+        const vendored = readFileSync(vendorPath);
+
+        expect(vendored.equals(source)).toBe(true);
+    });
+});

--- a/packages/node/saga-stack-cli/src/runtime/tunnel-prep.ts
+++ b/packages/node/saga-stack-cli/src/runtime/tunnel-prep.ts
@@ -20,9 +20,61 @@
  * the unit tests inject fakes and never spawn tunnel.sh or read the fleet file.
  */
 
-import { spawn } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
+
+/**
+ * Best-effort fetch of the fleek dev-cluster LiveKit creds from Secrets Manager
+ * (`qboard/fleek/livekit-creds`), mirroring up.sh's `--tunnel` AV block
+ * (up.sh:2346-2351). Real cluster A/V needs connect-api to sign LiveKit tokens
+ * with the CLUSTER key — absent creds ⇒ the caller leaves `LIVEKIT_API_KEY` at the
+ * local dev default and the fleek cluster rejects the tokens (A/V fails; CRDT/chat
+ * and everything else still work). The dev-account AWS profile is resolved the same
+ * way tunnel.sh does (by account number) via `tunnel.sh aws-profile`. Returns null
+ * on ANY failure (no creds / wrong account / aws missing / bad JSON) — never throws,
+ * so it can't break the bring-up.
+ */
+export function resolveFleekLivekitCreds(
+  vendorTunnelSh: string,
+): { key: string; secret: string } | null {
+  try {
+    // The dev-account profile tunnel.sh resolves by account number (empty = default chain).
+    let profile = '';
+    try {
+      profile = execFileSync(vendorTunnelSh, ['aws-profile'], {
+        cwd: dirname(vendorTunnelSh),
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim();
+    } catch {
+      profile = '';
+    }
+    const raw = execFileSync(
+      'aws',
+      [
+        'secretsmanager',
+        'get-secret-value',
+        '--secret-id',
+        'qboard/fleek/livekit-creds',
+        '--query',
+        'SecretString',
+        '--output',
+        'text',
+        '--region',
+        'us-west-2',
+        ...(profile ? ['--profile', profile] : []),
+      ],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+    ).trim();
+    const parsed = JSON.parse(raw) as { api_key?: unknown; api_secret?: unknown };
+    const key = typeof parsed.api_key === 'string' ? parsed.api_key : '';
+    const secret = typeof parsed.api_secret === 'string' ? parsed.api_secret : '';
+    return key && secret ? { key, secret } : null;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Run `<vendorTunnelSh> moniker`, capturing trimmed stdout (the moniker). stdin +

--- a/packages/node/saga-stack-cli/vendor/tunnel.sh
+++ b/packages/node/saga-stack-cli/vendor/tunnel.sh
@@ -64,6 +64,8 @@ SERVICES=(
     "connect:6210"
     "connect-api:6106"
     "rtsm:6110"
+    "coach:8800"
+    "coach-api:6105"
 )
 
 say(){  printf "\033[34m→\033[0m %s\n" "$*" >&2; }
@@ -250,7 +252,7 @@ tunnel_status(){
     for entry in "${SERVICES[@]}"; do
         name=${entry%:*}; port=${entry#*:}
         code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 \
-            "https://$name.$m.$VMS_BASE$( [[ "$name" == dash || "$name" == connect ]] && echo / || { [[ "$name" == connect-api ]] && echo /connectv3/v1/health || echo /health; })" 2>/dev/null)
+            "https://$name.$m.$VMS_BASE$( [[ "$name" == dash || "$name" == connect || "$name" == coach ]] && echo / || { [[ "$name" == connect-api ]] && echo /connectv3/v1/health || echo /health; })" 2>/dev/null)
         printf "  %-12s https://%s.%s.%s → %s\n" "$name" "$name" "$m" "$VMS_BASE" "$code" >&2
     done
 }

--- a/tools/synthetic-dev/vms/template.yaml
+++ b/tools/synthetic-dev/vms/template.yaml
@@ -261,9 +261,15 @@ Resources:
               # routes to the matching laptop tunnel (customDomains).
               # (no shell brace-expansions in this script - it lives inside
               # Fn::Sub, which interprets every dollar-brace sequence)
+              # propagation_delay/timeout + public resolvers make Caddy wait for the
+              # Route53 _acme-challenge TXT to propagate (and self-verify it via
+              # 1.1.1.1/8.8.8.8) BEFORE asking the CA to validate. Without this,
+              # Let's Encrypt PROD's stricter multi-perspective validation runs
+              # before propagation and fails "No TXT record found", so new monikers
+              # never mint a cert (staging, single-perspective, passed). See soa#301.
               for m in $(printf '%s' "$MONIKERS" | tr ',' ' '); do
                   m=$(printf '%s' "$m" | tr -d '[:space:]'); [[ -z "$m" ]] && continue
-                  printf '*.%s.%s {\n    tls {\n        dns route53\n    }\n    reverse_proxy 127.0.0.1:8080\n}\n\n' "$m" "$DOMAIN"
+                  printf '*.%s.%s {\n    tls {\n        dns route53\n        propagation_delay 90s\n        propagation_timeout 5m\n        resolvers 1.1.1.1 8.8.8.8\n    }\n    reverse_proxy 127.0.0.1:8080\n}\n\n' "$m" "$DOMAIN"
               done
           } >"$new_caddy"
 


### PR DESCRIPTION
Finishes + verifies tunnel mode on the `ss` CLI (it was already ~ported by soa#214). Closes the gaps found by an adversarial validation pass and drives the whole invite-a-coworker-to-Connect flow end-to-end over the vms tunnel.

## What's here
- **Coach browser-plane overlay** (`launch-plan.ts`): coach-api/coach-web fell through to `default:{}` — now flip CORS / `PUBLIC_COACH_API_URL` / Vite hosts like up.sh. + re-vendored `tunnel.sh` (coach) with a drift guard.
- **`ss e2e run/connect --tunnel`**: point the Playwright browser at `https://<svc>.<moniker>.vms…` via a `TUNNEL_SERVICE_LABELS` map; slot-0 + stack-lane guards; WAN timeout env.
- **`ss e2e connect --student-login <0|1|2>`**: how many students seat locally; the rest stay OPEN for remote peers. Login URLs printed for every participant.
- **Real A/V**: `up --tunnel` now best-effort-fetches the fleek LiveKit creds (`qboard/fleek/livekit-creds`) → connect-api `LIVEKIT_API_KEY/SECRET`, so tokens the fleek cluster accepts (was signing with `devkey`).
- **docs/tunnel.md**: leads with the concierge (clean-state → live Connect room), details after.

## Verification
Full suite 1155/0; typecheck + lint clean. Validated live end-to-end on the dev account: cert mint, all services incl. coach → 200, tunnel cookie domain, cross-subdomain auth, real-A/V creds on connect-api, and the concierge (`e2e connect --tunnel --student-login 1 --reuse`) opening a tutor+student room with an open remote seat.

Companion: saga-dash#475 (cookie-domain fix + `CONNECT_LOCAL_STUDENTS` + participant logins). Follow-up infra fix for the vms box cert mint: #301.

🤖 Generated with [Claude Code](https://claude.com/claude-code)