### PR TITLE
fix(saga-stack-cli): wire coach-web to iam so the local coach stack authenticates

### DIFF
--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/bootstrap-native.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/bootstrap-native.int.test.ts
@@ -115,8 +115,11 @@ describe('stack bootstrap — native chain', () => {
     expect(clones.some((c) => c.includes('saga-ed/student-data-system.git → /fixed/dev/student-data-system'))).toBe(
       true,
     );
-    expect(clones.some((c) => c.includes('coach'))).toBe(false);
-    expect(clones.some((c) => c.includes('fleek'))).toBe(false);
+    // Match the repo SLUG, not the raw `url → dir` string: `dir` embeds the soa
+    // checkout path, so a bare `includes('coach')` also fires on a worktree or
+    // branch whose name happens to contain "coach".
+    expect(clones.some((c) => c.includes('saga-ed/coach.git'))).toBe(false);
+    expect(clones.some((c) => c.includes('saga-ed/fleek.git'))).toBe(false);
     expect(steps).toEqual(['overlay apply', 'up --reset --seed roster', 'verify']);
   });
 

--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
@@ -77,7 +77,12 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
     expect(env('iam-api')).toEqual({
       PORT: '3010',
       AUTH_DEVUSERID: 'f0000004-0000-4000-8000-00000000beef',
-      CORS_ORIGIN: 'http://localhost:8900,http://localhost:6210',
+      // coach-web (:8800) is in the allowlist because its browser calls
+      // auth.whoami direct; omit it and every coach page 503s on CORS.
+      CORS_ORIGIN: 'http://localhost:8900,http://localhost:6210,http://localhost:8800',
+      // Stamped into the tokens coach-api validates (its AUTH_ISSUER) — one
+      // token feeds both ends so the `iss` claim cannot drift.
+      JWT_ISSUER: 'https://iam.wootdev.com',
       MAIL_FRONTEND_BASE_URL: 'http://localhost:3010/demo',
       REDIS_HOST: 'localhost',
       REDIS_PORT: '6379', // slot 0 base — offset-aware (:7379 at slot 1), see launch-plan.slot test
@@ -245,7 +250,7 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
     });
   });
 
-  it('coach-api (dual-store: coach_api pg + mesh mongo, iss=iam.saga.org)', () => {
+  it('coach-api (dual-store: coach_api pg + mesh mongo, iss=iam.wootdev.com — what local iam mints)', () => {
     expect(env('coach-api')).toEqual({
       NODE_ENV: 'development',
       EXPRESS_SERVER_PORT: '6105',
@@ -257,7 +262,7 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
       AUTH_AUTHENABLED: 'true',
       IAM_API_TARGET: 'http://localhost:3010',
       AUTH_JWKSURL: 'http://localhost:3010/.well-known/jwks.json',
-      AUTH_ISSUER: 'https://iam.saga.org',
+      AUTH_ISSUER: 'https://iam.wootdev.com',
       RABBITMQ_ENABLED: 'false',
       RABBITMQ_URL: 'amqp://rabbitmq_admin:password123@localhost:5672',
       EXPRESS_SERVER_CORSALLOWEDDOMAINS: 'localhost',
@@ -265,9 +270,12 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
     });
   });
 
-  it('coach-web (only needs the coach-api URL)', () => {
+  it('coach-web (client-only SPA: browser calls coach-api AND iam direct)', () => {
     expect(env('coach-web')).toEqual({
       PUBLIC_COACH_API_URL: 'http://localhost:6105',
+      // Without this it falls back to its .env default (https://iam.wootdev.com)
+      // and the local SPA talks to DEPLOYED iam.
+      PUBLIC_IAM_API_URL: 'http://localhost:3010',
     });
   });
 

--- a/packages/node/saga-stack-cli/src/core/launch-plan.ts
+++ b/packages/node/saga-stack-cli/src/core/launch-plan.ts
@@ -88,6 +88,8 @@ export interface LaunchTokens {
   DASH_URL: string;
   /** up.sh `CONNECT_WEB_URL`. */
   CONNECT_WEB_URL: string;
+  /** coach-web (:8800) — its own origin, and the iam URL its browser calls. */
+  COACH_WEB_URL: string;
   /** up.sh `CONNECT_API_URL`. */
   CONNECT_API_URL: string;
   /** up.sh `CONTENT_API_URL`. */
@@ -102,7 +104,13 @@ export interface LaunchTokens {
   COACH_WEB_HOST: string;
   /** up.sh `SAGA_API_TARGET_COACH` — coach's frontend upstream-saga config (default https://staging.wootmath.com). */
   SAGA_API_TARGET_COACH: string;
-  /** up.sh `IAM_ISSUER` — the `iss` claim coach-api/ads-adm-api validate (`https://iam.saga.org`). */
+  /**
+   * The `iss` claim: stamped INTO iam's tokens (JWT_ISSUER) and validated by
+   * coach-api (AUTH_ISSUER). One token feeds both ends so they cannot drift —
+   * this was `https://iam.saga.org` (prod) while the local iam-api stamped
+   * `https://iam.wootdev.com` (its .env default), so coach-api 401'd every
+   * locally-minted session.
+   */
   IAM_ISSUER: string;
 
   // ── mesh broker + DB / mongo connection strings ──
@@ -622,6 +630,7 @@ export function defaultLaunchContext(inputs: LaunchContextInputs, m: Manifest = 
     IAM_URL: `http://localhost:${ports['iam-api']}`,
     DASH_URL: `http://localhost:${ports['saga-dash']}`,
     CONNECT_WEB_URL: `http://localhost:${ports['connect-web']}`,
+    COACH_WEB_URL: `http://localhost:${ports['coach-web']}`,
     CONNECT_API_URL: `http://localhost:${ports['connect-api']}`,
     CONTENT_API_URL: `http://localhost:${ports['content-api']}`,
     RTSM_URL: `http://localhost:${ports['rtsm-api']}`,
@@ -629,7 +638,7 @@ export function defaultLaunchContext(inputs: LaunchContextInputs, m: Manifest = 
     COACH_API_URL: `http://localhost:${ports['coach-api']}`,
     COACH_WEB_HOST: 'localhost',
     SAGA_API_TARGET_COACH: 'https://staging.wootmath.com',
-    IAM_ISSUER: 'https://iam.saga.org',
+    IAM_ISSUER: 'https://iam.wootdev.com',
 
     // mesh broker + connection strings
     MESH_MQ: `amqp://rabbitmq_admin:password123@localhost:${mqPort}`,

--- a/packages/node/saga-stack-cli/src/core/manifest/__tests__/consistency.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/__tests__/consistency.unit.test.ts
@@ -65,7 +65,8 @@ describe('manifest consistency — every edge resolves', () => {
     expect(manifest.services['coach-api'].repo).toBe('COACH');
     expect(manifest.services['coach-api'].databases).toEqual(['coach_api']);
     expect(manifest.services['coach-web'].repo).toBe('COACH');
-    expect(manifest.services['coach-web'].dependsOn).toEqual(['coach-api']);
+    // iam-api too: coach-web's browser calls auth.whoami direct (session.ts).
+    expect(manifest.services['coach-web'].dependsOn).toEqual(['coach-api', 'iam-api']);
     expect(manifest.databases['coach_api'].ownerRole).toBe('coach_api_app');
   });
 

--- a/packages/node/saga-stack-cli/src/core/manifest/services.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/services.ts
@@ -60,7 +60,12 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
       env: {
         PORT: '${IAM_PORT}',
         AUTH_DEVUSERID: '${DEV_USER_UUID}',
-        CORS_ORIGIN: '${DASH_URL},${CONNECT_WEB_URL}',
+        // Stamp the SAME issuer coach-api validates (its AUTH_ISSUER). Injected
+        // rather than left to iam-api/.env so the two ends can never drift.
+        JWT_ISSUER: '${IAM_ISSUER}',
+        // coach-web is here because its browser calls iam's auth.whoami direct
+        // (coach-web session.ts) — omit it and every coach page 503s on CORS.
+        CORS_ORIGIN: '${DASH_URL},${CONNECT_WEB_URL},${COACH_WEB_URL}',
         MAIL_FRONTEND_BASE_URL: 'http://localhost:${IAM_PORT}/demo',
         // iam-api assembles its redis URL from REDIS_HOST+REDIS_PORT (localhost ⇒
         // non-TLS redis://). Slot-offset-aware: :6379 at slot 0, :7379 at slot 1.
@@ -521,14 +526,19 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
     // SvelteKit SPA — probed on the root path like saga-dash / connect-web.
     healthPath: '/',
     databases: [],
-    // Reaches iam server-side THROUGH coach-api, so it only needs the coach-api URL.
-    dependsOn: ['coach-api'],
-    depKinds: { 'coach-api': 'browser' },
+    // Client-only SPA (ssr = false): the BROWSER calls coach-api for data and
+    // iam's auth.whoami direct for identity — so it needs both URLs, and iam
+    // must allow its origin (see iam-api's CORS_ORIGIN).
+    dependsOn: ['coach-api', 'iam-api'],
+    depKinds: { 'coach-api': 'browser', 'iam-api': 'browser' },
     mesh: [],
     launch: {
       cmd: 'pnpm dev',
       env: {
         PUBLIC_COACH_API_URL: '${COACH_API_URL}',
+        // Without this, coach-web falls back to its .env default
+        // (https://iam.wootdev.com) and the local SPA talks to deployed iam.
+        PUBLIC_IAM_API_URL: '${IAM_URL}',
       },
     },
     seed: [],


### PR DESCRIPTION
## Problem

`coach-web` is a client-only SPA (`ssr = false`) — its **browser** calls iam's `auth.whoami` directly for identity. The manifest still assumed it reached iam server-side *through* coach-api:

> `// Reaches iam server-side THROUGH coach-api, so it only needs the coach-api URL.`

That assumption is stale, and three things followed from it. Together they meant the local coach stack could not authenticate at all.

1. **coach-web was given no iam URL.** It fell back to its `.env` default, so the local SPA called a *deployed* iam rather than the one in the stack.
2. **iam's `CORS_ORIGIN` never listed coach-web's origin** — there was no `COACH_WEB_URL` token to list. The browser's `whoami` was blocked, and the SPA rendered a 503 on every route.
3. **The issuer coach-api validates didn't match the one local iam-api stamps**, so coach-api rejected every locally-minted session.

## Fix

- Add a `COACH_WEB_URL` token and put coach-web's origin in iam's `CORS_ORIGIN`.
- Inject the iam URL into coach-web, and declare `iam-api` as a `browser` dep so the closure is honest.
- Make the issuer **one token feeding both ends** — iam's `JWT_ISSUER` and coach-api's `AUTH_ISSUER` — so it cannot drift again. This is the same approach the manifest already uses for `DATABASE_URL`.

## Verification

Against a local stack:

- `auth.whoami` returns `200` with coach-web's origin allowed (was blocked).
- The issuer now matches on both ends (was mismatched).
- coach's authenticated dashboard e2e goes from **failing to passing**, and the SPA renders the authenticated shell.
- CLI suite: **98 files, 1163 tests passing**; `tsc --noEmit` clean.

## Also

Tightens a `bootstrap-native` assertion that matched a bare `'coach'` against the whole `url -> dir` clone string — it fired on any worktree or branch whose *name* contained "coach". It now matches the repo slug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KL4Sp7dWetH8oXLRLVa3RU
