### PR TITLE
fix(saga-stack-cli): retire mongo from coach-api (single-store)

### DIFF
--- a/packages/node/saga-stack-cli/src/__tests__/stack-api.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/__tests__/stack-api.unit.test.ts
@@ -751,11 +751,14 @@ describe('StackApi.reset — native (M8 R4)', () => {
   });
 });
 
-describe('StackApi.seed — R5 stdinFile steps (coach curriculum + playback bootstrap)', () => {
-  it('coach curriculum: mongoimport with the resolved mongo container + stdinFile piped', async () => {
+// Coach's curriculum mongoimport used to be the other stdinFile step here. Mongo is
+// retired (coach is single-store; curriculum reads come from Postgres content_release),
+// so playback's psql-from-stdin now carries the stdinFile + container-token contract.
+describe('StackApi.seed — R5 stdinFile steps (playback bootstrap)', () => {
+  it('coach seeds from Postgres alone — no mongoimport survives the retirement', async () => {
     const { runtime, fakes } = makeRuntime();
     const api = makeStackApi(manifest, runtime);
-    // full profile, narrowed to coach-api ⇒ coach-pg + coach-mongo (offline).
+    // full profile, narrowed to coach-api ⇒ coach-pg ONLY (offline).
     const plan = composeSeedPlan(
       { profile: 'full', only: ['coach-api'] },
       new Set(['coach-api'] as ServiceId[]),
@@ -764,19 +767,10 @@ describe('StackApi.seed — R5 stdinFile steps (coach curriculum + playback boot
     const res = await api.seed(plan);
     expect(res.ok).toBe(true);
 
-    const mongoimports = fakes.runs.filter((r) => r.command === 'docker' && r.args.includes('mongoimport'));
-    // both upserts ran: content_coach (main) + content (optional tail).
-    expect(mongoimports).toHaveLength(2);
-    const [contentCoach, content] = mongoimports;
-    // container token expanded to the resolved slot-0 mongo container.
-    expect(contentCoach.args.slice(0, 4)).toEqual(['exec', '-i', 'soa-connect-mongo-1', 'mongoimport']);
-    // NO dangling ${TOKEN} survives in the argv.
-    for (const a of contentCoach.args) expect(a).not.toMatch(/\$\{/);
-    // stdinFile resolved to the coach-api fixtures under the COACH repo root.
-    expect(contentCoach.stdinFile).toBe('/dev/coach/apps/node/coach-api/scripts/data/content_coach.json');
-    expect(contentCoach.args).toContain('content_coach');
-    expect(content.stdinFile).toBe('/dev/coach/apps/node/coach-api/scripts/data/content.json');
-    expect(content.args).toContain('--jsonArray');
+    expect(fakes.runs.filter((r) => r.args.includes('mongoimport'))).toHaveLength(0);
+    // coach-db's db:seed is the whole coach seed (content + the three projections).
+    const seed = fakes.runs.find((r) => r.command === 'pnpm' && r.args.includes('db:seed'));
+    expect(seed?.env.DATABASE_URL).toContain('coach_api');
   });
 
   it('playback provisioning: psql bootstrap from stdin + the migrate tail, gated behind --with playback', async () => {

--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
@@ -250,15 +250,13 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
     });
   });
 
-  it('coach-api (dual-store: coach_api pg + mesh mongo, iss=iam.wootdev.com — what local iam mints)', () => {
+  // SINGLE-store: mongo is retired (curriculum reads come from Postgres
+  // content_release), so NO MONGO_HOST/MONGO_PORT/MONGO_DATABASE/CONTENT_DATABASE.
+  it('coach-api (single-store: coach_api pg; iss=iam.wootdev.com — what local iam mints)', () => {
     expect(env('coach-api')).toEqual({
       NODE_ENV: 'development',
       EXPRESS_SERVER_PORT: '6105',
       DATABASE_URL: 'postgresql://coach_api_app:dev-password-coach-api-app@localhost:5432/coach_api',
-      MONGO_HOST: 'localhost',
-      MONGO_PORT: '27037',
-      MONGO_DATABASE: 'saga_local',
-      CONTENT_DATABASE: 'wmlms_local',
       AUTH_AUTHENABLED: 'true',
       IAM_API_TARGET: 'http://localhost:3010',
       AUTH_JWKSURL: 'http://localhost:3010/.well-known/jwks.json',

--- a/packages/node/saga-stack-cli/src/core/manifest/services.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/services.ts
@@ -488,19 +488,18 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
     databases: ['coach_api'],
     dependsOn: ['iam-api'],
     depKinds: { 'iam-api': 'url' },
-    // DUAL-STORE: coach_api pg (via `databases`) + the mesh mongo (curriculum read
-    // path). RABBITMQ_ENABLED=false, so rabbitmq is intentionally NOT gated on.
-    mesh: ['connect-mongo'],
+    // SINGLE-STORE: coach_api pg only (via `databases`). Mongo is RETIRED — coach's
+    // curriculum read path is Postgres now (PostgresContentReadStore over
+    // content_release), coach-api carries no mongo dependency and reads no MONGO_*
+    // env, so the mesh mongo is NOT gated on and those vars are not injected.
+    // RABBITMQ_ENABLED=false, so rabbitmq is intentionally NOT gated on either.
+    mesh: [],
     launch: {
       cmd: 'pnpm dev',
       env: {
         NODE_ENV: 'development',
         EXPRESS_SERVER_PORT: '${COACH_API_PORT}',
         DATABASE_URL: '${COACH_DB_URL}',
-        MONGO_HOST: 'localhost',
-        MONGO_PORT: '${CONNECT_MONGO_PORT}',
-        MONGO_DATABASE: 'saga_local',
-        CONTENT_DATABASE: 'wmlms_local',
         AUTH_AUTHENABLED: 'true',
         IAM_API_TARGET: '${IAM_URL}',
         AUTH_JWKSURL: '${IAM_URL}/.well-known/jwks.json',

--- a/packages/node/saga-stack-cli/src/core/seed/__tests__/compose-seed-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/seed/__tests__/compose-seed-plan.unit.test.ts
@@ -65,19 +65,30 @@ describe('composeSeedPlan — gate 2: snapshot-skip (service granularity)', () =
   // whether iam-api ∈ restored; it is not part of composeSeedPlan (M0).
   it.todo('snapshot layer: iam-api ∈ restored only when BOTH iam DBs restored (partial ⇒ kept)');
 
-  it('EXEMPTS a `databases: []` static-fixture step (coach-mongo) even when its service is restored', () => {
-    // A coach-api PG snapshot restore puts coach-api ∈ restored — that skips its
-    // PG-writing step (coach-pg) but MUST NOT skip the coach curriculum mongoimport
-    // (coach-mongo, `databases: []`), whose mongo data is NOT in the PG snapshot.
-    // up.sh's seed_coach_mongo_only always runs (else subjectData 500s post-restore).
-    const sel: SeedSelection = { profile: 'full' };
+  it('EXEMPTS a `databases: []` static-fixture step (fga-bootstrap) even when its service is restored', () => {
+    // A step that writes NO tracked DB is not represented in a PG snapshot, so a
+    // service-restored skip must not swallow it. fga-bootstrap (service iam-api,
+    // `databases: []`) writes the OpenFGA store — restoring iam-api's PG snapshot
+    // says nothing about it, so it MUST still run.
+    //
+    // (This exemption used to be pinned by coach-mongo, the curriculum mongoimport.
+    // Coach is single-store now — mongo is retired — so fga-bootstrap is the
+    // remaining `databases: []` step and carries the case.)
+    const sel: SeedSelection = { profile: 'full', addOns: ['authz'] };
     const active = set('iam-api', 'sessions-api', 'programs-api', 'scheduling-api', 'content-api', 'coach-api');
-    const plan = composeSeedPlan(sel, active, set('coach-api'));
+    const plan = composeSeedPlan(sel, active, set('iam-api', 'coach-api'));
 
-    // coach-mongo (databases: []) survives; coach-pg (databases:['coach_api']) skipped.
-    expect(ids(plan.offline)).toContain('coach-mongo');
+    // fga-bootstrap (databases: []) survives despite iam-api ∈ restored...
+    expect(ids(plan.offline)).toContain('fga-bootstrap');
+    // ...while the DB-writing steps of both restored services are skipped.
     expect(ids(plan.offline)).not.toContain('coach-pg');
-    expect(plan.skipped.filter((s) => s.reason === 'service-restored').map((s) => s.id)).toEqual(['coach-pg']);
+    expect(ids(plan.offline)).not.toContain('iam');
+    expect(plan.skipped.filter((s) => s.reason === 'service-restored').map((s) => s.id)).toEqual([
+      'iam-registry',
+      'iam-dev-user',
+      'iam',
+      'coach-pg',
+    ]);
   });
 });
 
@@ -88,8 +99,9 @@ describe('composeSeedPlan — gate 3: offline / online partition', () => {
     const plan = composeSeedPlan(sel, active, set());
 
     // qtf-demo (requires sessions-api) + content (requires content-api) defer online;
-    // scheduling + coach-pg + coach-mongo (db:seed / docker-exec, no requiresServiceUp)
-    // stay offline. coach-pg + coach-mongo trail content in the canonical run order.
+    // scheduling + coach-pg (db:seed, no requiresServiceUp) stay offline. coach-pg
+    // trails content in the canonical run order, and is now coach's ONLY seed step
+    // (mongo is retired — the former coach-mongo mongoimport is gone).
     expect(ids(plan.offline)).toEqual([
       'iam-registry',
       'iam-dev-user',
@@ -98,7 +110,6 @@ describe('composeSeedPlan — gate 3: offline / online partition', () => {
       'programs',
       'scheduling',
       'coach-pg',
-      'coach-mongo',
     ]);
     expect(ids(plan.online)).toEqual(['qtf-demo', 'content']);
     expect(plan.skipped).toEqual([]);

--- a/packages/node/saga-stack-cli/src/core/seed/profiles.ts
+++ b/packages/node/saga-stack-cli/src/core/seed/profiles.ts
@@ -25,8 +25,7 @@ export type SeedStepId =
   | 'programs'
   | 'scheduling'
   | 'content'
-  | 'coach-pg'
-  | 'coach-mongo' //           M8 R5: coach curriculum mongoimport (stdinFile)
+  | 'coach-pg' //              coach's WHOLE seed — mongo is retired (single-store)
   | 'transcripts-provision' // M8 R5: playback bootstrap SQL + migrate (--with playback)
   | 'insights-provision'
   | 'chat-provision'
@@ -40,9 +39,10 @@ export const PROFILE_STEPS: Readonly<Record<SeedProfile, readonly SeedStepId[]>>
   // soa#253: `iam-registry` FIRST — the Permission/Policy catalog that iam-dev-user's
   // dev-admin grant depends on (registry-gated view_rosters_tab/view_sessions_tab).
   roster: ['iam-registry', 'iam-dev-user', 'iam', 'sessions'],
-  // M8 R5: coach-mongo (curriculum) is now expressible (stdinFile) — un-gated so
-  // native `--seed full` seeds BOTH coach stores (mongo curriculum + pg progress).
-  full: ['iam-registry', 'iam-dev-user', 'iam', 'sessions', 'programs', 'scheduling', 'content', 'coach-pg', 'coach-mongo'],
+  // coach is SINGLE-STORE now: mongo is retired (curriculum reads come from
+  // Postgres content_release), so `coach-mongo` is gone and `coach-pg` — which
+  // also seeds the group_track_map projection — is the whole coach seed.
+  full: ['iam-registry', 'iam-dev-user', 'iam', 'sessions', 'programs', 'scheduling', 'content', 'coach-pg'],
 };
 
 /** Add-on → the seed-step ids it contributes (plan §4.1). */
@@ -87,7 +87,6 @@ export const SEED_RUN_ORDER: readonly SeedStepId[] = [
   'scheduling',
   'content',
   'coach-pg',
-  'coach-mongo',
   // playback provisioning (bootstrap + migrate) precedes the playback fixtures.
   'transcripts-provision',
   'insights-provision',
@@ -121,7 +120,6 @@ const MESH_PG_PORT_TOKEN = '${MESH_PG_PORT}';
  * the resolved `pgContainer`. At slot 0 they expand to `soa-postgres-1` /
  * `soa-connect-mongo-1`.
  */
-const MONGO_CONTAINER_TOKEN = '${SAGA_MESH_CONNECT_MONGO_CONTAINER}';
 const PG_CONTAINER_TOKEN = '${SAGA_MESH_POSTGRES_CONTAINER}';
 
 /** The mesh superuser creds up.sh's playback `*_DB_URL` migrate as. */
@@ -407,13 +405,14 @@ export function buildSeedRegistry(m: Manifest = manifest): Record<SeedStepId, Se
         },
       ],
     },
-    // coach progress store (Postgres) — coach-db `db:seed` (coach#155 local-snapshot),
-    // DATABASE_URL forced to the mesh :5432 coach_api (== $COACH_DB_URL; coach-db's own
-    // default is :5433). main runs it best-effort in seed_stack full after content
-    // (`warn` on failure — coach may be absent / coach#155 unmerged).
+    // coach's WHOLE seed (Postgres) — coach-db `db:seed` (local-snapshot):
+    // content_instance + the THREE iam→coach projections (persona_definition,
+    // persona_assignment, group_track_map) + the content_release the curriculum
+    // read path serves from. DATABASE_URL forced to the mesh :5432 coach_api
+    // (== $COACH_DB_URL; coach-db's own default is :5433).
     //
-    // M8 R5: the curriculum mongoimport is now the 'coach-mongo' step below (was
-    // OMITTED for lack of stdin redirect; `stdinFile` makes it expressible).
+    // There is no mongo companion step any more: coach is single-store, so the
+    // former `coach-mongo` curriculum mongoimport seeded a store nothing reads.
     'coach-pg': {
       id: 'coach-pg',
       service: 'coach-api',
@@ -423,46 +422,6 @@ export function buildSeedRegistry(m: Manifest = manifest): Record<SeedStepId, Se
       env: inlineDatabaseUrl(getDb('coach_api', m)),
       requiresServiceUp: [], // direct pg db:seed — offline
       failureMode: 'warn',
-    },
-    // M8 R5 — coach curriculum mongoimport (up.sh `seed_coach_mongo_only`).
-    // TWO upserts into the mesh mongo: content_coach.json (single object) →
-    // saga_local.content_coach, and content.json (array) → wmlms_local.content —
-    // the dbs coach-api's launch_if points at. Curriculum is static committed
-    // fixtures, so `--mode upsert` makes re-seeds converge. Reads each file from
-    // stdin (`stdinFile`) so no `docker cp` into the container. `--port 27017` is
-    // the CONTAINER-internal port (slot-invariant); the container name is the
-    // slot-resolved token. Best-effort (coach may be absent).
-    'coach-mongo': {
-      id: 'coach-mongo',
-      service: 'coach-api',
-      databases: [], // mongo curriculum (saga_local/wmlms_local) — not a tracked DbId; always seeds
-      cwd: 'apps/node/coach-api',
-      command: [
-        'docker', 'exec', '-i', MONGO_CONTAINER_TOKEN,
-        'mongoimport', '--quiet', '--port', '27017',
-        '-d', 'saga_local', '-c', 'content_coach', '--mode', 'upsert', '--upsertFields', 'name',
-      ],
-      stdinFile: 'scripts/data/content_coach.json',
-      env: { kind: 'inline', vars: {} },
-      requiresServiceUp: [],
-      failureMode: 'warn',
-      optionalSteps: [
-        {
-          id: 'coach-mongo-content',
-          service: 'coach-api',
-          databases: [],
-          cwd: 'apps/node/coach-api',
-          command: [
-            'docker', 'exec', '-i', MONGO_CONTAINER_TOKEN,
-            'mongoimport', '--quiet', '--port', '27017',
-            '-d', 'wmlms_local', '-c', 'content', '--jsonArray', '--mode', 'upsert', '--upsertFields', 'id',
-          ],
-          stdinFile: 'scripts/data/content.json',
-          env: { kind: 'inline', vars: {} },
-          requiresServiceUp: [],
-          failureMode: 'warn',
-        },
-      ],
     },
     // M8 R5 — playback DB provisioning (bootstrap SQL + migrate),
     // gated under `--with playback`. Precede the fixture seed steps below.


### PR DESCRIPTION
Stacked on #303 (same `coach-api` manifest entry — merge that first).

## Problem

Coach is **single-store** now: its curriculum read path is Postgres (`PostgresContentReadStore` over `content_release`), coach-api carries no mongo dependency, and it reads no `MONGO_*` env at all. The stack manifest still treated it as dual-store:

- it **gated coach-api's boot** on the mesh `connect-mongo` container;
- it injected `MONGO_HOST` / `MONGO_PORT` / `MONGO_DATABASE` / `CONTENT_DATABASE`, none of which coach-api reads;
- and `--seed full` ran a `coach-mongo` mongoimport that populated **a store nothing reads**.

## Fix

Drop all three. `coach-pg` (coach-db's `db:seed`) is coach's whole seed now — the content instance, the iam→coach projections, and the content release the curriculum read path serves from.

`connect-mongo` itself **stays**: connect-api still uses it. This only unhooks coach.

## Verification

On a local stack:

- coach-api boots **healthy with zero `MONGO_*` vars** injected;
- a coach-only closure no longer starts `connect-mongo` at all (mesh comes up `postgres` + `redis`);
- the seed plan is `iam-registry, iam-dev-user, iam, coach-pg` — no mongoimport;
- coach's e2e suite is unchanged (no regression);
- CLI suite **98 files / 1163 tests** green; `tsc --noEmit` clean.

## Test note

The `databases: []` snapshot-exemption case that `coach-mongo` used to pin (a static-fixture step must survive a service-restored skip, since its data isn't in the PG snapshot) is now carried by `fga-bootstrap`, the remaining step of that shape — so the behaviour stays covered rather than being deleted with the step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KL4Sp7dWetH8oXLRLVa3RU
