### PR TITLE
ss develop: concierge topic for app/workflow dev setup (#305) — absorbs #265

### DIFF
--- a/claude/projects/gh_305/research/01-coach-web-and-content-viewer-port.md
+++ b/claude/projects/gh_305/research/01-coach-web-and-content-viewer-port.md
@@ -1,0 +1,294 @@
+# Research 01 — coach-web & the ported content-viewer application
+
+_Research agent `coach-web-port` for the "ss develop coach" concierge effort (saga-ed/soa#305)._
+_Area: the new coach-web SvelteKit frontend and the PORTED content-viewer (Haxe → Svelte)._
+_All paths absolute. Facts verified against real files/PRs on 2026-07-14 unless labeled "planned/inferred"._
+
+---
+
+## Headline
+
+The "ported content viewer application" is **`coach-web`'s in-app module player** — the
+`lib/features/cns/viewer/*` renderers plus the `/units/[unitName]/[moduleId]` route — which
+replaces the retired legacy **Haxe `ContentViewer`** web app (the `rtp/qt` task engine + `vscroll`
+shell). coach-web is a client-only SvelteKit SPA (`adapter-static`, `ssr=false`) that boots by
+reading identity **direct from iam-api** (`auth.whoami`), then loads a single **CNS ContentInstance**
+for the user from coach-api GraphQL. To SEE the viewer work, a developer needs three services up
+(coach-web + coach-api + iam-api) **and** seeded data: an iam session for the seeded tutor
+`demo-tutor-1`, and a coach Postgres seed that gives that tutor a ContentInstance + a published
+content release. A `flows.json` for coach-web already exists (used by the `e2e` topic) but coach-web
+is **NOT yet registered** in the ss CLI's `spa-registry.ts`. **Scenarios 4 (admin dashboard) and 5
+(playlisting) have no corresponding app or route in the coach repo today** — only `coach-web` exists.
+
+---
+
+## 1. What IS the "ported content viewer application"?
+
+### Origin (what it replaced)
+- The legacy app is the **Haxe `ContentViewer`** web app in the saga-ed org. Confirmed via
+  `gh search code --owner saga-ed ContentViewer`: `saga-ed/coach:claude/projects/sub-domain/sources/prompt-1.md`
+  describes _"a legacy web app ContentViewer that needs to seamlessly interoperate with the coach
+  web-app"_. Not cloned locally.
+- The port re-implements the Haxe task engine. Code comments name the exact legacy sources:
+  - `taskTypes.ts` — _"matching the legacy `rtp/qt/Types.hx` convention"_ (versioned typeids like
+    `multi_choice_1`, strip trailing `_N` to base type).
+  - `pollPlayer.svelte.ts` — _"Ports legacy `PollDataStateManager.hx` (pdsm)'s throttle/queue/
+    flush-on-unload"_; replaces the legacy `POST .../pdsm/s` REST save with GraphQL `saveModuleAnswer`.
+  - The `/units/[unitName]/[moduleId]/+page.svelte` header — _"Renders every question in a vertical
+    scroll (the legacy 'vscroll' shell)"_; ports `VScrollTaskPane.append_vertical`.
+  - `taskTypes.ts` `taskRequiresAnswerToContinue` cites legacy `IFrameTask.hx` behavior.
+
+### Where it lives in `coach-web/src`
+Root: `/home/skelly/dev/coach/apps/web/coach-web/src`
+
+- **Route (the player):** `routes/units/[unitName]/[moduleId]/+page.svelte` — in-app module playback.
+  Vertical-scroll "vscroll" shell: reveals one question at a time (`{#if index <= currentIndex}`),
+  gated behind a Continue/Check-answer button; fires module completion on the last Continue.
+- **Route (unit list / launch):** `routes/units/+page.svelte`, `routes/units/[unitName]/+page.svelte`.
+- **Dashboard launch surface:** `routes/+page.svelte` (home) → `handleModuleClick` gates launch on
+  `areAllQuestionTypesPorted`.
+- **Viewer feature dir (the ported renderers):** `lib/features/cns/viewer/`
+  - `TaskRenderer.svelte` — dispatches a question to its per-type renderer.
+  - `taskTypes.ts` — the **ported-type gate**. `PORTED_BASE_TYPES` (12 types): `multi_choice`,
+    `short_answer`, `video_task`, `showdown_task`, `fill_in_the_blank`, `open_task`, `essay_task`,
+    `true_false`, `tap_image`, `iframe_task`, `left_right_task`, `likert_task`. Two legacy classes
+    deliberately NOT ported (zero real usage): `canvas_1`, `checkable_iframe_task_1`.
+  - Per-type renderers: `MultipleChoiceRenderer`, `ShortAnswerRenderer`, `VideoRenderer`,
+    `ShowdownTaskRenderer`, `FillInTheBlankRenderer`, `EssayTaskRenderer`, `TapImageRenderer`,
+    `IframeTaskRenderer`, `LeftRightTaskRenderer`, `LikertTaskRenderer`, `DragDropRenderer`,
+    `FlipCardRenderer`, plus `TaskContinueButton.svelte`, `openTaskMarkup.ts`, `taskContinueState.ts`.
+  - `lib/features/cns/UnitNav.svelte`, `ModuleActions.svelte` — nav + launch affordances.
+- **Playback stores:** `lib/stores/pollPlayer.svelte.ts` (per-question answer state + throttled
+  save queue, `THROTTLE_MS=15_000`, flush-on-unload), `lib/stores/modulePlayer.svelte.ts`
+  (module-level state transitions / completion).
+- **API layer:** `lib/api/curriculum.ts` (`fetchPollContent(contentId)` → the questions to render),
+  `lib/api/cns.ts` (`fetchCnsInstances`, `fetchModuleAnswers`, save/transition).
+
+### Key PRs (evidence)
+- **PR #203** `coach-module-vscroll-shell-pr14` (merged, commit `dfe8192`): _"Ports legacy vscroll
+  shell UX into the in-app module player: one question revealed at a time … gated behind a
+  Continue/Check-answer button"_; adds `TaskContinueButton` with grading color-flash animation and
+  per-type `requiresAnswer` gating; wires fire-once completion → `goto('/units/{unitName}')`. Manual
+  walkthrough was against real `curriculum-coach`/`unit_1`/`sc_u1_m1` content.
+- **#448 / #463 Phase 2a** (commit `273eb53` `feat(coach-api): materialize ContentInstances at
+  section grain`, plus `7609d9f` cross-track completion read overlay) — backend materializes
+  ContentInstances at **section grain**. This is a coach-api change; coach-web consumes the resulting
+  `CNS_CoachContentInstance` shape.
+
+### What it renders
+A **module** = a "poll" of ordered questions. `fetchPollContent(contentId)` returns
+`{ contentId, title, tagList, questions[] }` where each question is `{ typeid, data }` (data is an
+opaque per-typeid JSON blob, `JSON.parse`d). `TaskRenderer` dispatches by base typeid. A module only
+opens in-app if **every** question type is ported (`areAllQuestionTypesPorted`) — mixed modules can't
+be half-in-app/half-legacy, and the legacy `saga_api` player fallback is **retired**, so a
+non-ported module surfaces an in-app `ModuleLaunchError` instead.
+
+---
+
+## 2. How to run coach-web locally
+
+App dir: `/home/skelly/dev/coach/apps/web/coach-web`
+
+### Dev server
+- `pnpm dev` → **`vite dev`**. **Port = 8800** (hard-set in `vite.config.ts` `server.port: 8800`).
+  ⚠️ The README says `http://localhost:5173` — that is **stale/wrong**; the checked-in vite config
+  and the e2e lane (`e2e/fixtures/lane.ts`, playwright `COACH_URL`) both use **:8800**.
+- Framework: SvelteKit 2 + Svelte 5 (runes), `adapter-static` with `fallback: 'index.html'`.
+  `ssr = false`, `prerender = false` (client-only SPA — see `routes/+layout.ts`).
+- `vite.config.ts` also allows host `.wootmath.com` (a proxy-dev helper, not needed locally).
+
+### Required env (`.env`, checked in — no secrets in a static frontend)
+File: `/home/skelly/dev/coach/apps/web/coach-web/.env`
+- `PUBLIC_COACH_API_URL=http://localhost:6105` — coach-api GraphQL backend. The client hits
+  `${PUBLIC_COACH_API_URL}/coach/v1/graphql` (`lib/api/graphql.ts`).
+- `PUBLIC_IAM_API_URL=https://iam.wootdev.com` — **iam-api base; load-bearing boot dependency**.
+  The frontend reads identity direct from iam (`auth.whoami`). For a **local mesh** this must be
+  overridden to `http://localhost:3010` (the `.env` comment says so explicitly).
+- `PUBLIC_LOGIN_URL=https://login.wootdev.com`, `PUBLIC_DASHBOARD_URL=https://dash.wootdev.com` —
+  external hosts for logout/nav. Logout → `${PUBLIC_LOGIN_URL}/logout`.
+- Override locally with **`.env.local`** (gitignored). Frontend vars MUST be `PUBLIC_*`.
+
+### GraphQL codegen
+- `codegen.ts`: schema source = `node_modules/@saga-ed/coach-gql-schema/schemas/**/*.{gql,graphql}`
+  (the coach-api schema, a workspace package). Operations = `src/**/*.{graphql,gql}`.
+- Generates `src/lib/api/generated/graphql.ts` (`getSdk(client)` style). **Auto-generated — do not
+  edit.** `pnpm codegen`, and it runs automatically via `prebuild` before `pnpm build`.
+- CNS operations live in `src/lib/api/graphql/cns.graphql` (queries `GetCnsContentInstancesByUserId`,
+  `GetCnsContentInstanceById`, `GetModuleAnswers`; mutations `SaveModuleAnswer`,
+  `TransitionModuleState`), plus `curriculum.graphql`, `reports.graphql`.
+
+### Backend it talks to
+- **coach-api** on `:6105` (`/coach/v1/graphql`), Apollo Sandbox at the same URL in-browser.
+  Requires Postgres (Docker, port **5433** for the standalone container; the ss mesh uses **5432**).
+  Bring up: `pnpm run dev:up` (Postgres + API hot reload) from `apps/node/coach-api`.
+- **iam-api** on `:3010` locally (mesh) — required for identity. There is **no dev auth bypass**
+  (the e2e authoring README states auth is always required; sessions are minted via `auth.devLogin`).
+
+### Auth / login expectations
+Root layout `routes/+layout.ts` boot sequence:
+1. `auth.fetchSession()` → `lib/api/session.ts::fetchSessionContext()` → GET
+   `${PUBLIC_IAM_API_URL}/trpc/auth.whoami` with `credentials: 'include'`.
+   - `200` → `{ userId, username, screenName, verifyOnly }`.
+   - `401` with a followable SagaAuth challenge → **redirects to login**, rewriting `next=` to
+     `window.location.origin` (the SPA root, not iam's API URL). The layout then hangs pending the
+     redirect. (`rewriteNextToOrigin` is the hand-rolled fix — the shared `janusFetch`/janus-client
+     follows the challenge `login=` verbatim and would send the user to an iam JSON endpoint.)
+   - `401` with no challenge, or 5xx/network → throws → **503 error page** (never a silent hang).
+2. On success, `fetchCnsInstances(userId)` loads the user's ContentInstances; `instances[0]` becomes
+   `data.instance`, shared with every child route via `depends('app:modules')`.
+
+Auth model context (repo is mid-migration `saga_api → iam-api + Janus`, coach#91):
+- Identity is read **direct from iam** — the old coach-api `session.context` tRPC aggregate was
+  abandoned. Branch on **permissions, never role/org** (permission-driven UX). Today the app only
+  needs identity (userId + display name); no permissions are fetched (zero consumers yet).
+- GraphQL client routes through `janusFetch` (`lib/api/fetch.ts`) so 401-janus challenges on
+  coach-domain calls redirect to login (coach#100).
+- **`AuthLoginHostOverride`** (commit `d085bed`, `feat(coach-api): AuthLoginHostOverride for
+  alternate-apex login redirects`) is a **coach-api** feature for training-apex deploys
+  (`coach.saga-training.org`), not a coach-web knob. Relevant if the concierge targets an alternate
+  apex; for the default local mesh it is not needed. (packages: `@saga-ed/iam-auth`,
+  `@saga-ed/janus-client` are coach-web deps.)
+
+---
+
+## 3. What a developer needs present to SEE the content viewer working
+
+The dashboard/units render from **CNS ContentInstances**, and the player renders from a **published
+content release** (the poll questions). Both must be seeded, keyed to the seeded tutor:
+
+1. **A seeded iam identity + session** for the tutor. Canonical tutor is **`demo-tutor-1`**
+   (`iam-seed-ids`), userId **`1c939568-1464-5f9a-b5a4-0bc73a0454cb`**, email `demo-tutor-1@saga.org`,
+   member of "Demo District", bound to `personaTutorDemo` carrying `coach:access_coach_app`. This is
+   THE coach tutor the fixtures key to. (`e2e/data/seed-users.ts`.) The session cookie (`iam_session`)
+   is minted via iam-api `auth.devLogin` — no interactive login.
+2. **A coach Postgres ContentInstance** for that user. Seed fixture:
+   `/home/skelly/dev/coach/packages/node/coach-db/src/seed/fixtures/content-instances.json` — one
+   instance for `1c939568-…`, `contentName: "spring-pilot"`, v1.0.0, with units
+   (`unit_1` "Pre-Service Training" 23 modules `sc_u1_m1..23`, `unit_2` "Core Concepts" 9, `unit_3`
+   "Microlearnings", …). The `flows.json`/seed-users docs say the seed assigns **27 modules** that
+   render on the dashboard.
+3. **A published content release** (the actual poll questions the player renders). Fixture:
+   `packages/node/coach-db/src/seed/fixtures/content-release.json`. Locally, `coach-db db:seed`
+   loads this offline release fixture **instead of** a real publish. The API reads content via
+   `ContentReadStore`/`PostgresContentReadStore`, joining through the `active_content_release`
+   singleton pointer.
+4. **A track/persona assignment** so the instance is derivable. Assignments are a separate seam
+   (`AssignmentStore`, derived from `persona_assignment ⋈ group_track_map`). The
+   **`group_track_map`** is baked into the local seed (commit `1b54e46`
+   `feat(coach-db): bake group_track_map into the local seed`, PR #235).
+
+**The one fully-ported, immediately-playable module** for demos/smoke: **`sc_u1_m1`** at
+`/units/unit_1/sc_u1_m1` — the `module-playback` e2e flow navigates straight there and asserts all
+12 ported base question types render. Content is a synthetic acceptance fixture in the coach-db
+Postgres seed. Commit `a5e3c3d` seeded `demo-tutor-1` with a "legacy spring-pilot parity instance".
+
+### Seed / bring-up commands (backend)
+From `/home/skelly/dev/coach/apps/node/coach-api` (see its `CLAUDE.md` + `docs/quickstart.md`):
+```bash
+pnpm run dev:up                                   # Postgres (:5433) + coach-api (:6105) hot reload
+# or: docker compose up -d --wait postgres && pnpm run dev:local
+pnpm --filter @saga-ed/coach-db db:deploy         # run migrations
+pnpm run db:seed:run                              # seed: progress/answer/assignment + content release
+```
+`coach-db`'s own seed entry: `db:seed` → `node dist/seed/local-snapshot.js`
+(`packages/node/coach-db/package.json`). To load REAL archive curriculum instead of the fixture:
+`coach-content publish --archive <checkout> --ref <sha> --approve` then `coach-content materialize
+--user demo-tutor-1 --replace` (needs a `saga-ed/content-archive` checkout; see §4).
+
+Frontend:
+```bash
+cd /home/skelly/dev/coach/apps/web/coach-web
+pnpm codegen           # if generated/graphql.ts stale (prebuild runs it anyway)
+pnpm dev               # vite dev on :8800
+```
+(For a fully-local stack, set `PUBLIC_IAM_API_URL=http://localhost:3010` in `.env.local`.)
+
+---
+
+## 4. README / docs / CLAUDE / AMPLIFY + the e2e "authoring" project
+
+- **`apps/web/coach-web/README.md`** — dev/env/test guide. **Port claim (5173) is stale; real port
+  is 8800.** Documents the three `PUBLIC_*` vars, `.env.local` overrides, Playwright test setup, and
+  an ENOSPC/inotify workaround. `PUBLIC_IAM_API_URL` is NOT in the README's env table (it is in
+  `.env` and `CLAUDE.md`).
+- **`apps/web/coach-web/CLAUDE.md`** — Svelte 5 runes, structure, `pnpm codegen` rule
+  (`generated/graphql.ts` auto-generated), CSS tokens, `docs/QUERY_PARAMS.md`, env `PUBLIC_*` rule.
+- **`apps/web/coach-web/AMPLIFY_SETUP.md`** — a **redirect stub**: Amplify hosting moved to
+  `infra/coach-web/OPS.md` during the iam/Janus migration. SSM scheme
+  `/coach/amplify/coach-web/{app-id,domain,deploy-role-arn,api-base-url}`. Deploy via
+  `saga-deploy-amplify`. **Not relevant to local dev / the concierge** — it's prod hosting ops.
+- **`apps/web/coach-web/docs/`**: `CSS_TOKENS.md`, `ENV_FILES.md`, `getting-started.md`,
+  `QUERY_PARAMS.md`, `THEME.md`. (coach-api docs: `apps/node/coach-api/docs/quickstart.md` is the
+  full local-setup guide.)
+
+### The e2e "authoring" project — is authoring the content-viewer's authoring counterpart?
+**Partly, but it drives the FROZEN LEGACY stack, not a Svelte authoring app.** Details in
+`apps/web/coach-web/e2e/authoring/README.md` + `playwright.config.ts`:
+- The `authoring` Playwright project is gated behind **`E2E_AUTHORING=1`** (`pnpm test:e2e:authoring`)
+  and kept out of the default sweep because it drives **AWS / dev-ECS** and needs credentials.
+- It is the **content-authoring → publish → render pipeline**: author a poll on the **frozen legacy
+  Haxe stack** (dev ECS, teacher **75949**) → `export-authored-polls.sh` (ECS Exec) →
+  `records-pusher` Lambda → `saga-ed/content-archive` → `coach-content publish` → `coach-content
+  materialize --user demo-tutor-1` → the title renders on the Coach dashboard.
+- So: **authoring = the upstream content-production side** that feeds the ported viewer. It is the
+  legacy authoring tool (no ported Svelte authoring UI exists in coach-web). The viewer (this
+  research area) is the **consumer/render** side. They meet at the **content archive → coach-db
+  publish/materialize** seam.
+- Related non-authoring flow: **`module-playback-real-content`** (`e2e/module-playback-real-content/`)
+  publishes an EXISTING archive curriculum (`base-coach`) — no AWS legs — gated by
+  `PUBLISH_REAL_CONTENT=1`, needs `ARCHIVE_DIR` (a content-archive checkout). Useful precedent for a
+  "real content" develop variant.
+
+---
+
+## 5. ss CLI concierge pattern to mirror + gaps for scenarios 4/5
+
+- The concierge to mirror is **`ss e2e connect`**:
+  `/home/skelly/dev/soa/.claude/worktrees/gh305-ss-develop/packages/node/saga-stack-cli/src/commands/e2e/connect.ts`.
+  Pattern: resolve a flow from a repo's `flows.json` (`resolveFlow`), recurse a `journey`
+  prerequisite (headless build owning reset+seed), then open a **headed foreground** Playwright
+  project (stdio inherited so it owns the TTY). Flags of interest to mirror: `--reuse` (skip
+  prerequisite rebuild + reset, run against current stack state), `--fake-media`,
+  `--refresh-snapshot` (rebake prerequisite checkpoints). A develop-coach concierge is analogous but
+  the "foreground hold" is **the running `vite dev` server**, not a Playwright `page.pause()`.
+- **coach-web already ships a `flows.json`**:
+  `/home/skelly/dev/coach/apps/web/coach-web/e2e/flows.json` — spa id `coach-web`, `repoEnvVar:
+  COACH`, `appDir: apps/web/coach-web`, three flows (`dashboard`, `module-playback`,
+  `module-playback-real-content`), each `seed: { profile: "full", reset: true }`, requiredSystems
+  `["coach-web","coach-api","iam-api"]`. This is the seed/system contract a develop concierge reuses.
+- **GAP:** coach-web is **NOT registered** in
+  `packages/node/saga-stack-cli/src/core/flow/spa-registry.ts` (only `saga-dash` and `connectv3`
+  are, lines 25/47). The flows.json comment claims onboarding = "this file + one row in
+  spa-registry.ts", but the row does not exist yet. A develop-coach concierge that resolves the
+  coach-web flows.json likely needs that registry row added first (or its own discovery path).
+- **GAP (scenarios 4 & 5):** the coach repo has **only `coach-web`** under `apps/web/` (verified:
+  `ls apps/web/` = `CLAUDE.md`, `coach-web`). There is **no admin-dashboard app/route** and **no
+  playlisting interface** in the repo today — no matching routes in `coach-web/src/routes`, no
+  branches (only `fix/coach-dashboard-no-track-empty-state`), no open issues found for "playlist"/
+  "admin dashboard". The `PlaylistData` type in `lib/types/coach.ts` is just a curriculum-content
+  shape, not a playlisting UI. **These scenarios appear to be forward-looking / not-yet-built** — a
+  key open question for the develop-coach plan.
+
+---
+
+## Open questions / risks for the builder
+
+1. **spa-registry gap:** does the develop topic reuse `spa-registry.ts` + coach-web `flows.json`, and
+   if so does onboarding require adding the missing `coach-web` registry row? (Confirm with the
+   soa#305 area owner / the ss develop-topic scaffolding research.)
+2. **Scenarios 4 (admin dashboard) & 5 (playlisting) do not exist in the coach repo.** Are they
+   planned/in-flight elsewhere, or does the concierge only need to stand up the routes when they
+   land? Prompt-2 says they "currently ship with the coach repo" — that is **not true today**.
+3. **iam-api local availability:** the concierge must guarantee iam-api on `:3010` (or wootdev) and
+   an `.env.local` override of `PUBLIC_IAM_API_URL`, else coach-web 503s on boot. How does the ss
+   mesh currently expose iam-api, and does it mint `demo-tutor-1`'s `iam_session` via `auth.devLogin`
+   for a non-Playwright (browser) developer session? (The e2e flows mint it inside Playwright
+   globalSetup — a develop concierge needs the cookie in the developer's own browser.)
+4. **Postgres port mismatch:** coach-api docs use `:5433` (standalone container); the ss mesh /
+   real-content lane use `:5432`. Confirm which the develop stack uses and that `DATABASE_URL` /
+   `db:seed` target the mesh DB.
+5. **Login redirect UX for a developer:** on a genuinely-local stack, does `auth.whoami` 401 produce
+   a followable challenge that lands the developer back on `:8800`? If iam is remote (wootdev), the
+   `next` rewrite sends them to the SPA origin — verify that round-trips for a local `:8800` origin.
+6. **README port bug (5173 vs 8800):** worth fixing so the concierge's "open this URL" message is
+   correct; the authoritative port is 8800.

--- a/claude/projects/gh_305/research/02-content-viewer-retirement.md
+++ b/claude/projects/gh_305/research/02-content-viewer-retirement.md
@@ -1,0 +1,292 @@
+# 02 — Content-Viewer Retirement (legacy haxe ContentViewer → SvelteKit module player)
+
+Research for the `ss develop coach` concierge (saga-ed/soa#305). Area: Seth Paul's
+effort to retire the legacy haxe ContentViewer in favor of the in-app port. History,
+status, and what "run new coach with the ported content viewer" requires today.
+
+> Scope note: `#448`/`#463` referenced in the task are **saga-dash** issues (the
+> cross-track / section-grain progress requirements). The coach-side work that
+> implements them lands as coach PRs `#230`/`#232`/`#237`. All PR/issue numbers below
+> are `saga-ed/coach` unless prefixed `soa#` or `saga-dash#`.
+
+---
+
+## Headline
+
+The legacy "ContentViewer" is a **Haxe** app (`saga-ed/wmap-port`, the `vscroll_task`
+lib) that Woot Math / Saga used to play "modules" (real-time-poll question sequences)
+to students. Seth's port reimplements it natively **inside coach-web** as a SvelteKit
+"module player" (`apps/web/coach-web/src/routes/units/[unitName]/[moduleId]/`) driving
+**13 per-type renderers** for the 12 ported task types. The port is functionally landed
+on `main` (renderer PRs #182–#203, capped by the gated-reveal/animation/completion
+shell PR #203 and the e2e coverage PR #200). What remains is **content-parity / data**,
+not viewer code: local playback still serves the synthetic `curriculum-coach` fixture
+(27 polls), the real `spring-pilot` legacy-parity release is not yet published for
+playback, the Mongo→Postgres content cutover is undeployed (#181), and cross-track /
+section-grain / tag-filter progress (#230/#232/#237) is still in flight. For the
+concierge, the load-bearing rough edge is **soa#300**: this repo's ss manifest still has
+stale coach-web↔iam browser-auth wiring, so a local coach-web 503s at sign-in out of the
+box.
+
+---
+
+## 1. What the legacy ContentViewer was
+
+- **Repo:** `saga-ed/wmap-port` ("Woot Math Adaptive Practice — AS3 to Haxe port",
+  private). The ContentViewer lives in the Haxe lib
+  `archive/woot_hxlib/lib/vscroll_task/src/vscroll/` — key sources:
+  `VScrollTaskPane.hx`, `VscrollViewerApp.hx`, `VscrollViewerContentScreen.hx`,
+  `AVQueue.hx`, `AudioWidget.hx`, `state/PollDataStateManager.hx`, `ItemNav.hx`.
+- **What it did:** rendered a "module" = an ordered sequence of poll questions
+  ("tasks"), one revealed at a time (vertical-scroll / "vscroll" incremental append),
+  gated behind a Continue / Check-answer button with a grading color-flash animation,
+  optional feedback markdown and blocking audio/video, then fired completion. Data came
+  from `/woot_roster/v1.1/poll-inst/${instance_id}` (`PollDataStateManager.hx`).
+- **Where it was embedded / what depended on it:** it was a **separate legacy web app**
+  the coach web-app had to interoperate with. Per
+  `coach/claude/projects/sub-domain/` (Feb 2026 cross-domain architecture research),
+  legacy ContentViewer was served under `my.sagaeducation.org/auth/content-viewer/`
+  while new coach ran on Amplify — the original hard problem was "seamless navigation
+  between Coach and legacy ContentViewer" sharing auth across domains. The port
+  **removes that cross-domain problem entirely** by bringing playback in-app.
+- Host-specific hooks in the legacy source (Skye/Spark): `window.__spark_close()`,
+  `'/spark-pages#/'`, `window.__set_content_completed` (quest-award). These were
+  **explicitly dropped**, replaced by a coach-native `goto()` back to the unit page
+  (see `claude/module-viewer/pr14-pr15-vscroll-shell-scoping.md`, item 5).
+
+---
+
+## 2. The port — what exists today (landed on `main`)
+
+**The ported viewer lives in coach-web:**
+- Renderers (13 `.svelte` files):
+  `apps/web/coach-web/src/lib/features/cns/viewer/` — `TaskRenderer.svelte`
+  (dispatcher) + 12 per-type renderers: `MultipleChoiceRenderer`, `ShortAnswerRenderer`,
+  `VideoRenderer`, `ShowdownTaskRenderer` (markdown), `FillInTheBlankRenderer`,
+  `FlipCardRenderer` (open_task flip), `DragDropRenderer` (open_task categorize/match),
+  `EssayTaskRenderer`, `TapImageRenderer`, `IframeTaskRenderer`, `LeftRightTaskRenderer`,
+  `LikertTaskRenderer`. Each has a `__tests__/*.spec.test.ts`.
+- Player shell / state:
+  `apps/web/coach-web/src/routes/units/[unitName]/[moduleId]/+page.svelte`,
+  `apps/web/coach-web/src/lib/stores/pollPlayer.svelte.ts`,
+  `apps/web/coach-web/src/lib/stores/modulePlayer.svelte.ts`.
+
+**PR timeline (the port series, all merged to `main`):**
+| PR | What | State |
+|---|---|---|
+| #182 | PR1 — answer-persistence backend for the port | MERGED |
+| #184 | poll-content read for the viewer | MERGED |
+| #186–#197 | PR3–PR13 — port each renderer type (showdown, fitb, flip/open, catmatch drag-drop, essay, true_false, tap_image, iframe, left_right, likert, MC/short-answer/video) | mix MERGED/CLOSED-superseded |
+| #203 | PR14 — gated reveal + grading color-flash animation + fire-once completion wiring ("vscroll shell") | **MERGED** |
+| #200 | e2e `module-playback` flow covering all 12 ported renderer types | **MERGED** |
+
+- **Backend content read is already Postgres-bound.** `apps/node/coach-api` DI binds
+  `ContentReadStore → PostgresContentReadStore` unconditionally
+  (`inversify.config.ts:80-83`). #207 (Phase 1/4) flipped the default off Mongo. So the
+  ported viewer serves module content out of the active Postgres `content_release`, not
+  from legacy Mongo. (Mongo curriculum is still seeded/read for the *structure* /
+  dual-store path — see `coach-api` manifest `mesh: ['connect-mongo']`.)
+- **PR14/PR15 fidelity scope** (`claude/module-viewer/pr14-pr15-vscroll-shell-scoping.md`):
+  ported verbatim from legacy — gated reveal, 2.5s color-flash keyframes, feedback
+  markdown, blocking audio/outro-audio (AVQueue model). **Deliberately dropped:**
+  `task_timer`/`CC_TIMER_BLOCKED` (3/112 modules), splash screen, standalone progress
+  bar, Skye host hooks. **Deferred (unread in scoping):** `CC_INTERACTIONS_BLOCKED` /
+  `are_required_interactions_complete()`.
+
+---
+
+## 3. The two-store / content pipeline this rides on (Seth's parallel effort)
+
+The port depends on a Mongo→Postgres re-architecture (`claude/coach-content-two-store-plan.md`,
+Jun 2026). Relevant facts for the concierge:
+- **Read content = git archive, not Mongo.** `saga-ed/content-archive` (private, data-only
+  repo) is the system of record for authored polls + the **8 `content_coach` curriculum
+  structure docs** (`base-coach`, `original-coach`, `partners-coach`, `qtf-coach`,
+  `preservice-coach`, `curriculum-coach`, `spring-pilot`, `new-mexico-coach`), together
+  referencing **112 distinct module content_ids**, all `REAL_TIME_POLLS`.
+- **Publish CLI:** `@saga-ed/coach-content-publish` (`packages/node/coach-content-publish`,
+  the `coach-content publish` command) reads the archive + structure docs and cuts a
+  Postgres **content_release** (snapshot + `active` pointer). PR #180 shipped the full
+  pipeline; #234 fixed a full-archive (643-poll) publish that failed over the SSM tunnel
+  by lifting the Prisma `$transaction` timeout to 120s.
+- **Progress = Postgres** (`@saga-ed/coach-db`, `coach_api` DB). Per-user `content_instance`
+  (nav graph + progress), `progress_store`, plus the three iam→coach projection tables
+  (`persona_definition`, `persona_assignment`, `group_track_map`).
+
+---
+
+## 4. Cross-track / section-grain progress (in-flight, #448/#463 series)
+
+Implements saga-dash#448 (cross-track completion) + saga-dash#463 (section-grain).
+4-PR plan:
+- **#230 (MERGED)** Phase 1 — read-time overlay: a module completed on one track reads
+  COMPLETE when the same `content_id` resurfaces on another track. Read-only overlay
+  (`getContentInstanceById`), does not write `completed_modules` or cascade holds.
+- **#232 (MERGED)** Phase 2a — materialize `content_instance` at **section** grain, not
+  just district (`MATERIALIZED_GROUP_KINDS = [district, section]`).
+- **#237 (DRAFT)** Phase 2b — content **tag-filter** narrowing + grain-rank resolution
+  (section's `tagFilter` wins over district on the same content_name).
+- **Phase 3 (planned, not started)** — a **standalone admin app** (referenced in #230's
+  body as "subsequent PRs: … standalone admin app"). This is relevant to prompt-2
+  **scenario 4** (coach + admin dashboard) but is NOT the content-viewer.
+
+---
+
+## 5. Timeline (compressed)
+
+- **Feb 2026** — cross-domain architecture research; legacy ContentViewer is a separate
+  app at `my.sagaeducation.org/auth/content-viewer/` requiring cross-domain auth.
+- **Jun 17 2026** — two-store split plan drafted; premise "archive is the richer source"
+  vindicated against prod replica (`saga_blank`).
+- **Jun 30 – Jul 2** — Postgres progress store (#147/#155), content-release store (#172),
+  ContentReadStore seam (#173), publish CLI (#174), PostgresContentReadStore (#175),
+  authoring e2e (#176/#180).
+- **Jul 7–9** — the renderer port series (#182–#197), gated-reveal shell #203, e2e #200,
+  content-backend default flipped to Postgres #207.
+- **Jul 11–13** — persona seed onto `iam-seed-ids` demo-* users (#223/#05ba3ae),
+  session.context S2S abandoned; **coach-web reads identity direct from iam (#226)** —
+  the change that made soa#300 necessary.
+- **Jul 13** — legacy spring-pilot **dashboard/progress parity** seed (#228, commit
+  a5e3c3d), full-archive publish timeout fix (#234), `group_track_map` baked into local
+  seed (#235).
+- **Jul 14 (today)** — #237 Phase 2b DRAFT; #236 dashboard empty-state DRAFT.
+
+---
+
+## 6. DONE vs REMAINING ledger
+
+**DONE (on `main`):**
+- All 12 task-type renderers + dispatcher, in coach-web.
+- Gated reveal / grading animation / fire-once completion shell (#203).
+- e2e module-playback smoke covering all 12 types (#200).
+- Postgres content-read + publish pipeline; content default = Postgres (#207).
+- Local `db:seed` publishes a playable synthetic `curriculum-coach` release (27 polls).
+- Legacy `spring-pilot` **dashboard + progress** parity for `demo-tutor-1` (#228, 59
+  modules, 13 complete).
+- `group_track_map` seeded so `reconcile` + assignment-read resolve (#235).
+
+**REMAINING / IN-FLIGHT / gaps:**
+- **Playback content ≠ dashboard content (the headline parity gap).** #228 seeded the
+  59-module `spring-pilot` `content_instance` for the **dashboard/My-Progress** surface,
+  but **Explore / in-app playback still renders the synthetic `curriculum-coach`**
+  fixture — publishing the real `spring-pilot` content *release* for playback is an
+  explicit **deferred follow-up** (#228 "Scope"/"Verification" notes). So a dev running
+  local coach sees legacy-parity numbers on the dashboard but synthetic questions when
+  they open a module.
+- **Mongo→Postgres cutover undeployed (#181, OPEN).** No deployed env (dev/qa/prod) has
+  `CONTENT_STORE_BACKEND=postgres` or a real published release; `content_assignments`
+  stays on Mongo (ownership TBD). Local is Postgres-bound; deployed is not.
+- **Cross-track progress incomplete:** #237 (Phase 2b tag-filter) DRAFT; Phase 3
+  standalone admin app not started.
+- **Deferred viewer features:** `task_timer`, `CC_INTERACTIONS_BLOCKED` (see §2).
+- **Legacy paths still present:** legacy ContentViewer haxe still lives in
+  `saga-ed/wmap-port`; coach-api retains the dual-store Mongo read path (curriculum
+  structure) — not fully retired.
+
+---
+
+## 7. CRUCIAL for the concierge — run "new coach + ported content viewer" locally
+
+**Services required (end-to-end):**
+1. `iam-api` (identity; coach-web calls its `auth.whoami` **from the browser** post-#226)
+   + iam Postgres + iam seed (`demo-*` users from `@saga-ed/iam-seed-ids`).
+2. `coach-api` (port 6105, `EXPRESS_SERVER_PORT`) — needs `coach_api` Postgres **and**
+   the mesh Mongo (`connect-mongo`) for curriculum structure. Env in ss manifest
+   `packages/node/saga-stack-cli/src/core/manifest/services.ts:475-513`.
+3. `coach-web` (port 8800, SvelteKit SPA) — manifest lines 515-538.
+4. mesh Mongo + Postgres containers.
+
+**Seed steps (ss `full` profile — `src/core/seed/profiles.ts:45`):**
+- `coach-pg` — runs coach-db `db:seed` (`packages/node/coach-db`, `node dist/seed/local-snapshot.js`)
+  against `coach_api` PG. Writes `content_instance` (spring-pilot, 59 modules for
+  demo-tutor-1), progress, persona projections (`persona_definition`,
+  `persona_assignment`, `group_track_map`), **and publishes the `curriculum-coach`
+  content_release + `active` pointer** (27 polls) so `PostgresContentReadStore` has
+  something to serve (else it throws "no active content release").
+  Source: `packages/node/coach-db/src/seed/local-snapshot.ts` (+ `fixtures/`).
+- `coach-mongo` — `mongoimport --upsert` of `apps/node/coach-api/scripts/data/content_coach.json`
+  → `saga_local.content_coach` and `content.json` → `wmlms_local.content` (curriculum
+  structure for the dual-store read path). `profiles.ts:427-467`. Best-effort (`warn`).
+
+**Login / persona:** seeded tutor is `demo-tutor-1` (`1c939568-…`, from iam-seed-ids), the
+one with the spring-pilot instance. The one fully content-populated playback module in the
+fixtures is `content-sc_u1_m1` at route `/units/unit_1/sc_u1_m1` (the e2e #200 target;
+seeded tutor there is `alex` with an `iam_session` cookie).
+
+**KNOWN ROUGH EDGE — soa#300 (OPEN, blocks browser-testing local coach-web):**
+This worktree's manifest is still the STALE pre-#226 wiring. Verify:
+- `coach-web` `launch.env` sets **only** `PUBLIC_COACH_API_URL: '${COACH_API_URL}'`
+  (services.ts:531-533) with the stale comment "Reaches iam server-side THROUGH
+  coach-api" (line 524). Post-#226 coach-web calls `${PUBLIC_IAM_API_URL}/trpc/auth.whoami`
+  **from the browser**; with no override it falls back to its checked-in `.env`
+  `PUBLIC_IAM_API_URL=https://iam.wootdev.com` (remote) → local cookie invalid → **503 at
+  sign-in**.
+- `iam-api` `CORS_ORIGIN` is `${DASH_URL},${CONNECT_WEB_URL}` — **no coach-web origin** →
+  the direct browser `whoami` is CORS-blocked.
+- **Fix (per soa#300, not yet applied here):** add
+  `PUBLIC_IAM_API_URL: '${IAM_URL}'` to `coach-web` `launch.env`; add a `COACH_WEB_URL`
+  token and append it to `iam-api` `CORS_ORIGIN`. The develop-coach concierge should
+  either depend on soa#300 landing or set these itself. Prior manual workaround (#228):
+  run coach-web from a worktree with `PUBLIC_IAM_API_URL=http://localhost:3010` and a
+  `--disable-web-security` chromium — data layer (coach-api GraphQL) was fine; only the
+  browser↔iam auth wiring was broken.
+
+**Concrete commands:**
+```bash
+# ss stack (from soa) — bring coach up with its deps + full seed
+ss up --with coach            # (or the closure that includes iam-api + coach-api + coach-web)
+ss seed --seed full           # includes coach-pg (db:seed) + coach-mongo
+# coach-web then at http://localhost:8800 ; coach-api at :6105 ; iam at ${IAM_URL}
+
+# manual coach seed (from ~/dev/coach) if driving coach-db directly:
+pnpm --filter @saga-ed/coach-db build
+DATABASE_URL=<coach_api pg url> pnpm --filter @saga-ed/coach-db db:seed
+#   → "N content_release (active: fixture, 27 polls)" + spring-pilot instance
+
+# publish the REAL archive release for playback (closes the §6 parity gap; needs content-archive checkout):
+#   coach-content publish --archive <content-archive path> --ref <sha> --app coach
+#   (see packages/node/coach-content-publish; #234 fixed the full 643-poll publish)
+
+# e2e that exercises the ported viewer (proves all 12 renderers):
+ss e2e run coach-web/module-playback --coach=<worktree>
+```
+
+---
+
+## 8. Key files & pointers (absolute)
+
+- Ported renderers: `/home/skelly/dev/coach/apps/web/coach-web/src/lib/features/cns/viewer/*.svelte`
+- Player shell: `/home/skelly/dev/coach/apps/web/coach-web/src/routes/units/[unitName]/[moduleId]/+page.svelte`
+- Player state: `/home/skelly/dev/coach/apps/web/coach-web/src/lib/stores/pollPlayer.svelte.ts`, `.../modulePlayer.svelte.ts`
+- Content read binding: `/home/skelly/dev/coach/apps/node/coach-api/src/inversify.config.ts:80-83`
+- Postgres read store: `/home/skelly/dev/coach/apps/node/coach-api/src/services/content-store/postgres-content-read-store.ts`
+- Local seed (publishes release + instance): `/home/skelly/dev/coach/packages/node/coach-db/src/seed/local-snapshot.ts` (+ `fixtures/content-release.json`, `fixtures/content-instances.json`)
+- Publish CLI: `/home/skelly/dev/coach/packages/node/coach-content-publish/`
+- Two-store plan: `/home/skelly/dev/coach/claude/coach-content-two-store-plan.md`
+- Port scoping: `/home/skelly/dev/coach/claude/module-viewer/pr14-pr15-vscroll-shell-scoping.md`
+- Cross-domain / legacy-ContentViewer research: `/home/skelly/dev/coach/claude/projects/sub-domain/research/coach-cross-domain-architecture.md`
+- ss coach manifest (STALE — soa#300): `/home/skelly/dev/soa/.claude/worktrees/gh305-ss-develop/packages/node/saga-stack-cli/src/core/manifest/services.ts:475-538`
+- ss seed profiles (coach-pg / coach-mongo): `/home/skelly/dev/soa/.claude/worktrees/gh305-ss-develop/packages/node/saga-stack-cli/src/core/seed/profiles.ts:410-467`
+- Legacy haxe ContentViewer: `saga-ed/wmap-port` → `archive/woot_hxlib/lib/vscroll_task/src/vscroll/` (GitHub only, not cloned)
+- Content data repo: `saga-ed/content-archive` (GitHub only)
+
+---
+
+## 9. Open questions for the develop-coach plan
+
+1. **Which content should `ss develop coach` playback show?** Ship-with-synthetic
+   `curriculum-coach` (works today, `db:seed` only) OR publish the real `spring-pilot`
+   release for true legacy parity (needs a content-archive checkout + `coach-content
+   publish` as a concierge step)? The dashboard already shows spring-pilot; playback does
+   not — a dev will notice the mismatch.
+2. **Does the concierge fix soa#300 itself, or block on it?** Without the manifest fix,
+   local coach-web 503s at sign-in — the concierge cannot "hand off a logged-in browser".
+3. **Login mechanism:** mint an `iam_session` cookie for `demo-tutor-1` (dashboard/parity
+   persona) or `alex` (the e2e-seeded persona with the one fully-populated playback
+   module `sc_u1_m1`)? They differ in which content is populated.
+4. **Scenarios 4 & 5 (admin dashboard / playlisting)** — the "standalone admin app" is
+   Phase 3 of the #448/#463 plan and **not yet built**; playlisting has no located
+   artifact yet. Confirm these are separate research areas, not part of content-viewer.
+5. **Mongo dependency:** coach-api still needs mesh Mongo for curriculum structure even
+   though content reads are Postgres — confirm the concierge closure includes
+   `connect-mongo` and runs `coach-mongo` seed (both are in the `full` profile).

--- a/claude/projects/gh_305/research/03-coach-admin-and-playlisting.md
+++ b/claude/projects/gh_305/research/03-coach-admin-and-playlisting.md
@@ -1,0 +1,271 @@
+# Research 03 — Coach admin dashboard & playlisting (prompt-2 scenarios 4 & 5)
+
+**Effort:** ss `develop` coach concierge (saga-ed/soa#305)
+**Area:** the two *secondary* coach surfaces — (4) "the admin dashboard that
+currently ships with the coach repo" and (5) "the interface for playlisting".
+**Author repos read:** `/home/skelly/dev/coach`, ss CLI at
+`packages/node/saga-stack-cli`, plus GitHub (`saga-ed/coach`, `saga-ed/saga-dash`).
+**Date:** 2026-07-14
+
+---
+
+## Headline
+
+Neither secondary surface is a distinct app; both live inside the SvelteKit
+`coach-web` monorepo (or its plumbing), and **neither is a finished, live-backed
+UI today**:
+
+- **"Admin dashboard" = the Coach *Reports* surface** — an org-wide "Admin Report"
+  table of tutors × unit completion (plus a per-tutor progress view and a
+  progress-detail modal). It is a **route inside `coach-web`** (`/reports` and an
+  embedded `/embed/reports/coach`), not a separate app, and **View 1 currently
+  renders from MOCK data**, not from the (existing) coach-api resolvers or the seed.
+- **"Playlisting" has NO dedicated UI in the coach repo.** In coach, a *playlist* ==
+  a *track* == a `content_name` == a published content archive/release. The
+  *selection/assignment* of a playlist to a tutor is a **saga-dash / rostering**
+  concern (`user_policy.playlist_name` / `available_playlists`) projected into
+  coach-api via the `group_track_map` table. The coach repo only owns the
+  *authoring→publish→materialize* CLI pipeline that produces the tracks, and the
+  reconcile logic that maps a district group → a track.
+
+A builder should treat scenario 4 as **"log in as the district-admin persona and
+land on `/reports`"** and scenario 5 as **"stand up ≥2 tracks and a
+`group_track_map` / policy so a persona resolves to a chosen playlist"** — see the
+concrete requirements and the open questions at the end (both surfaces are
+partly aspirational relative to prompt-2's wording).
+
+---
+
+## Context: what coach-web actually is today
+
+`coach-web` (SvelteKit, client-only SPA, `ssr=false`) is a **tutor-facing** rebuild.
+Nav (`apps/web/coach-web/src/lib/ui/Navbar.svelte:23-29`) exposes: Dashboard `/`,
+Explore `/explore`, **Reports `/reports`**, My Progress `/my-progress`, Widget
+Gallery. There is **no `/admin` and no `/playlist(s)` route** — confirmed by
+`find apps/web/coach-web/src/routes -type d` (routes: embed, reports, timer,
+widget-gallery, explore, todos, my-progress, up-next, units, coach-api-test).
+
+Auth is **always required** (no dev-bypass): root layout
+`apps/web/coach-web/src/routes/+layout.ts` fetches an iam session then a single CNS
+content-instance; `data.instance = instances[0]`. A user with no instance gets an
+empty state (in-flight PR #236 `fix/coach-dashboard-no-track-empty-state`).
+
+Mesh ports (ss manifest `packages/node/saga-stack-cli/src/core/manifest`):
+- `coach-web (:8800)` — SvelteKit SPA, reaches iam THROUGH coach-api
+  (`src/core/manifest/types.ts:28`)
+- `coach-api (:6105)` — GraphQL/tRPC (`types.ts:27`, `services.ts:475`)
+- coach's Postgres app DB `coach_api` (mesh :5432; coach-db's own default is :5433)
+- iam-api :3010 (devLogin mints `iam_session`)
+
+---
+
+## Scenario 4 — the "admin dashboard" (Coach Reports)
+
+### What it is / what it administers
+Three views over tutor coaching progress (types in
+`apps/web/coach-web/src/lib/types/reports.ts`, api in
+`apps/web/coach-web/src/lib/api/reports.ts`):
+- **View 1 — Admin Report:** org-wide table, rows = tutors, columns = units, cells =
+  modules-complete/total. Backend query `coachReport(content_name)`.
+- **View 2 — Tutor Progress:** one tutor's unit-level progress —
+  `userCoachProgress(user_id)`.
+- **View 3 — Progress Detail modal:** module-level detail —
+  `coachProgressDetail(user_id, instance_id)`.
+
+### Where it lives (files — all inside coach-web, a ROUTE not an app)
+- Standalone page: `apps/web/coach-web/src/routes/reports/+page.svelte` +
+  `+page.ts` (reads `?org=` query param, default `'Direct Test Org'`).
+- Embedded (into saga-dash): `apps/web/coach-web/src/routes/embed/reports/coach/+page.svelte`
+  + `+page.ts` — filters `org`, `programId`, **`trackId`**, `search` from query params.
+- Reusable component: `apps/web/coach-web/src/lib/reports/CoachReport.svelte`.
+- Feature parts: `apps/web/coach-web/src/lib/features/reports/{ReportHeader,CoachReportTable,ProgressCell}.svelte`
+  and `apps/web/coach-web/src/lib/features/coach-progress-modal/CoachProgressModal.svelte`.
+
+### CRITICAL status caveat — View 1 is MOCK-backed today
+`CoachReport.svelte:13` imports `reportsStore` from
+`apps/web/coach-web/src/lib/stores/reports.ts`. That store's `fetchReport()`
+(line ~57) calls `getMockReport(orgName)` from `$lib/data/mock-reports` — **not**
+the real GraphQL. The `organizations` dropdown is also mock (`getMockOrganizations`).
+Only `fetchUserProgress` / `fetchProgressDetail` in that same store call the *real*
+`api/reports.ts` functions (`GetUserCoachProgress` / `GetCoachProgressDetail`).
+
+So: the org-wide admin table **renders with zero live seed today**; wiring it to
+real data means pointing `reportsStore.fetchReport` at
+`api/reports.ts#fetchCoachReport` (`coachApi.GetCoachReport`) — which already exists
+and works against coach-api.
+
+### Backend (exists, real)
+Resolvers: `apps/node/coach-api/src/sectors/reports/gql/reports.resolver.ts`
+(`coachReport`, `userCoachProgress`, `coachProgressDetail`). Data service
+`reports.data.ts#getCoachReport` builds the report purely from CNS:
+`getContentByName(content_name)` → `getAssignmentsByContentName` → 
+`getContentInstancesByUserIdsAndContentName`. **No authz / role check** in the
+resolver; `content_name` is the *track*. `first_name/last_name/email` come back as
+placeholders (`''`/`null`) — names are not populated by this path.
+
+### Roles / personas / data it needs
+- The nav shows "Reports" to everyone; the "admin" framing is UI-only, **not
+  code-gated**.
+- The seed ships an **elevated persona specifically for this**:
+  `demo-dadmin@saga.org` (`personaAdminDemo`, district admin) exists "to exercise
+  the elevated-UI (district admin) persona" — see
+  `packages/node/coach-db/src/seed/persona-projections.ts:19-21,104-105,143-145`.
+  Both tutor and admin personas carry `coach:access_coach_app`.
+- To back **View 1 with real data** you need, for one `content_name`: a published
+  content release, **multiple users assigned** to it, and content instances
+  (progress) for them. The committed seed only materializes ONE tutor
+  (`demo-tutor-1`) on ONE track (`spring-pilot`), so a live admin table would show
+  a single row — a `--admin` scenario likely wants extra seeded tutors/assignments.
+
+### `develop coach --admin` shape (concrete)
+Stack up (coach-api + coach-web + iam-api + Postgres) → coach-db seed →
+`devLogin` as **`demo-dadmin@saga.org`** → open `coach-web` at **`/reports`** in the
+foreground. Works today against MOCK data with no extra seed; live data needs the
+rewire above + multi-user seed.
+
+---
+
+## Scenario 5 — the "interface for playlisting"
+
+### What "playlist" means in coach
+A **playlist == a track == a `content_name`** — a published content archive
+release (a coherent set of units/modules a tutor works through). Direct evidence:
+- `saga-ed/saga-dash#463` (OPEN): *"Coach playlists: tag-based content + user
+  attributes instead of maintaining 4 playlists (MS/HS × online/in-person)"* — i.e.
+  historically **4 hand-maintained playlists**, keyed by grade band × modality.
+- coach's user policy carries the coach-specific fields **`playlist_name`,
+  `available_playlists`, `playlist_version`** on `user_policy` (documented in the
+  coach-api cross-API review: `review_reports/coach-api/cross-api-plan.md:77,97-99,216-218,385-387`
+  and `ISSUES.md:668`). `user_policy` is a **rostering / saga-dash** projection,
+  forwarded to coach on the auth cookie.
+- `apps/web/coach-web/src/lib/types/coach.ts:49-51` — `PlaylistData` = "Content
+  playlist containing units and progress" (i.e. the tutor's assembled track).
+
+### The coach-side mechanism: `group_track_map`
+coach-api resolves *which track a tutor materializes* from a third iam→coach
+projection table, `group_track_map` (district group → `content_name`):
+- `apps/node/coach-api/src/sectors/cns/events/iam-projection-handlers.ts`:
+  `DISTRICT_GROUP_KIND='district'` (:49), `DEFAULT_CONTENT_NAME='base-coach'` (:118),
+  fallback `contentName = mappedName ?? DEFAULT_CONTENT_NAME` (:213). A district
+  **not** in `group_track_map` silently falls back to `base-coach`, and the
+  assignment read path returns an empty page for it.
+- Seeded by `packages/node/coach-db/src/seed/persona-projections.ts#groupTrackMaps`
+  and written in `local-snapshot.ts:158-171` (points the demo district at the
+  track the seeded tutor's own instance is on, so map and instance can't drift).
+
+### Is there a playlisting UI in the coach repo? — NO
+- No `/playlist` route; `/explore`
+  (`apps/web/coach-web/src/routes/explore/+page.svelte`) is the *tutor's own*
+  module browser/skill-filter **within their instance**, not a playlist-assignment UI.
+- The **assignment/selection** interface (which playlist a tutor gets) is a
+  **saga-dash / rostering** surface (`user_policy.playlist_name` /
+  `available_playlists`); issue #463 lives in `saga-ed/saga-dash`, **not** coach.
+  This *contradicts prompt-2's* "interface for playlisting that ships with the
+  coach repo" — flagged as an open question.
+- What the coach repo DOES own is the **authoring→publish pipeline** that produces
+  tracks (see below). That is the closest thing to "playlisting" inside coach, but
+  it is **CLI-driven, no web UI**.
+
+### The content authoring / publish pipeline (coach-owned, CLI)
+`@saga-ed/coach-content-publish` — binary **`coach-content`**
+(`packages/node/coach-content-publish/src/cli.ts`). Commands:
+`status | diff | publish --archive <path> --ref <sha> [--approve] [--structure-overlay <dir>] | rollback --to <releaseId> --approve | materialize --user <id> --content <name> [--replace|--delete]`.
+`DATABASE_URL` selects the coach_api Postgres. Publishes archive content into
+Postgres as immutable **snapshot releases** (= track versions); `materialize`
+builds a per-user `content_instance` from a release.
+Full pipeline (legacy author → archive → publish → materialize → dashboard) is
+documented in `apps/web/coach-web/e2e/authoring/README.md`. There is a gated
+Playwright `authoring` project (`E2E_AUTHORING=1`, `pnpm test:e2e:authoring`) that
+exercises it end-to-end — but that is *flow testing*, not a develop surface.
+
+### `develop coach --playlist` shape (concrete)
+The developable target is the **track/policy plumbing**, not a page:
+publish/seed **≥2 tracks** (content_names), set `group_track_map` (or the
+saga-dash `user_policy.playlist_name` / `available_playlists`) so a persona
+resolves to a chosen playlist, `materialize` the instance, then `devLogin` +
+open the dashboard to see the selected playlist drive the rendered content. The
+committed seed only has **one** track (`spring-pilot`) — a `--playlist` scenario
+must add tracks and a switchable mapping.
+
+---
+
+## Seed & run — concrete facts for a builder
+
+### coach-db seed (the read-path baseline)
+`packages/node/coach-db/src/seed/README.md` + `local-snapshot.ts`. One command:
+```bash
+# Postgres up + schema applied first:
+#   (apps/node/coach-api) docker compose up -d --wait postgres   # :5433 standalone
+#   (coach-db) pnpm db:push
+DATABASE_URL=postgresql://coach_api_app:dev-password-coach-api-app@localhost:5433/coach_api \
+  pnpm --filter @saga-ed/coach-db db:seed
+```
+Seeds (idempotent): `content_instance` (+`_module`/`_completed_module`) from
+`fixtures/content-instances.json`; `persona_definition` + `persona_assignment`
+(derived from `@saga-ed/iam-seed-ids`); `group_track_map` (demo district → the
+tutor's track).
+
+Identities baked in:
+- **Tutor:** `demo-tutor-1@saga.org` — userId `1c939568-1464-5f9a-b5a4-0bc73a0454cb`.
+- **District admin:** `demo-dadmin@saga.org` — `personaAdminDemo` (the elevated-UI
+  persona for the Reports/admin scenario).
+- **Group:** demo district `a0da8362-1a93-5d1d-aeaa-b6d8960e9821`.
+- **Track (content_name):** `spring-pilot` (the only materialized instance).
+  Content release name `curriculum-coach`, units `unit_1..unit_4`.
+  Fallback default track = `base-coach` (`DEFAULT_CONTENT_NAME`).
+
+Under the synthetic-dev mesh (`AUTH_AUTHENABLED=true`), `devLogin` as
+`demo-tutor-1@saga.org` authenticates as this tutor and the dashboard shows the
+seeded `spring-pilot` instance out of the box.
+
+### coach-web run (standalone)
+`apps/web/coach-web/package.json`: `dev` = `vite dev` (ss serves it on **:8800**),
+`build` (prebuild runs `graphql-codegen`), `preview`. Env `.env`:
+`PUBLIC_COACH_API_URL=http://localhost:6105`, `PUBLIC_LOGIN_URL`,
+`PUBLIC_DASHBOARD_URL`. coach-api needs `CONTENT_STORE_BACKEND=postgres`.
+
+---
+
+## Pattern to mirror — `ss e2e connect`
+`packages/node/saga-stack-cli/src/commands/e2e/connect.ts` is the existing
+concierge to copy. It: discovers a flow from a `flows.json`
+(`discoverFlowManifest`), resolves it (`resolveFlow`), recurses a **prerequisite**
+built headless, then opens a **headed foreground** surface via
+`executeResolvedFlow`. Relevant flags to echo for `develop coach`:
+`--reuse` (skip reset + prerequisite, run against current stack state),
+`--prereq-from-snapshot` / `--refresh-snapshot` (checkpoint restore / bake),
+`--tunnel` (repoint browsers at vms tunnel hosts). A `develop coach` command would
+analogously: ensure stack up + coach built, seed (db:seed / `coach-content
+materialize`), `devLogin` as the chosen persona, then open coach-web at the
+scenario's route (`/` dashboard, `/reports` admin, or a playlist-configured state)
+in the foreground. Note coach-web already ships its own `e2e/flows.json`
+(`apps/web/coach-web/e2e/flows.json`) — the develop concierge is *active dev*, so it
+need not reuse the e2e flow, but the discovery machinery is shared.
+
+---
+
+## Open questions (block/shape the develop-coach plan)
+
+1. **prompt-2 vs reality (admin):** The org-wide admin Report (View 1) is
+   **mock-backed** in coach-web today. Does `develop coach --admin` want the mock
+   view (works now, no seed) or a **live-backed** table (needs rewiring
+   `reportsStore.fetchReport` → `api/reports.ts` **and** seeding multiple assigned
+   tutors on one `content_name`)?
+2. **prompt-2 vs reality (playlisting):** There is **no playlisting UI in the coach
+   repo**. Playlist *selection* is a saga-dash/rostering surface
+   (`user_policy.playlist_name`/`available_playlists`). Is scenario 5's "interface"
+   actually saga-dash, or is a coach-web playlist UI planned/in-flight? (Nothing
+   found in coach open PRs #236/#237/#233 or issues.)
+3. **What is developable for `--playlist`?** If no UI exists, is the target the
+   track plumbing (publish ≥2 tracks + switch `group_track_map`/policy +
+   `materialize`) so a dev can iterate on how playlist choice drives content? If so,
+   the seed needs a **second track** added (only `spring-pilot` exists today).
+4. **Admin persona sufficiency:** `demo-dadmin` exists and carries
+   `coach:access_coach_app`, but the Reports resolver has **no authz** and names
+   come back empty. Does the admin scenario need real org/member data (names/emails)
+   that the current CNS-only path does not provide?
+5. **Legacy authoring UI:** legacy `wmcm` (Angular content creator) and `xlr8_dash`
+   are noted as migration targets (`claude/api-poc/research/legacy-coach-architecture.md`),
+   but only the CLI publish pipeline and the mock Reports exist so far. Is an
+   authoring/admin **web** UI planned for coach-web, or does authoring stay
+   legacy + `coach-content` CLI?

--- a/claude/projects/gh_305/research/04-coach-in-synthetic-dev-stack.md
+++ b/claude/projects/gh_305/research/04-coach-in-synthetic-dev-stack.md
@@ -1,0 +1,248 @@
+# 04 — How Coach is wired into soa's synthetic-dev / `ss` stack (research for `develop coach`)
+
+**Area:** the coach side of the `ss` (saga-stack-cli) synthetic-dev stack — services, closure,
+bring-up, seeding, login, and the browser-plane wiring a `ss develop coach` concierge must drive.
+**Scope note:** this doc is the *plumbing* map (how coach runs under `ss`). The product *surfaces*
+themselves (ported content-viewer, admin dashboard, playlisting) are only mapped enough to route the
+concierge — a sibling research area should own those in depth.
+
+All paths below are absolute. The CLI lives at
+`/home/skelly/dev/soa/.claude/worktrees/gh305-ss-develop/packages/node/saga-stack-cli` (referred to
+as `<cli>` from here). The coach monorepo is at `/home/skelly/dev/coach`.
+
+---
+
+## Headline
+
+Coach already has a first-class, working place in the `ss` stack: **two services** (`coach-api`,
+`coach-web`), a **`coach` bundle** (`--with coach`), a **`coach_api` mesh Postgres DB**, a **dual mongo
+curriculum store**, and **two seed steps** (`coach-pg`, `coach-mongo`). Bring-up, closure, and the
+tunnel/browser-plane overlay all handle coach today (the soa#298 overlay gap is **fixed & merged**,
+commit `0c8b50e`). All three coach scenarios (3 = tutor+content-viewer, 4 = admin dashboard, 5 =
+playlisting) run on the **same `coach-api`+`coach-web` pair** — they differ by **login persona** and
+**route**, not by services. A `develop coach` command is mostly an *orchestration* over existing
+primitives. **Two real gaps the plan must fix first:** (A) **soa#300** — `coach-web` browser→iam auth
+is broken (stale manifest wiring), which blocks actually *using* coach-web in a browser; (B) the
+default seed is `roster`, which **does not seed coach** — coach only seeds under `--seed full` (or a
+new coach seed add-on), and the identity must be **`demo-tutor-1@saga.org`**, not the CLI default
+`dev@saga.org`.
+
+---
+
+## What exists today (evidence)
+
+### 1. Coach services in the manifest
+
+`<cli>/src/core/manifest/services.ts`:
+
+- **`coach-api`** (lines 475–514):
+  - `repo: 'COACH'`, `subpath: 'apps/node/coach-api'`, port **6105** (`EXPRESS_SERVER_PORT`), `healthPath: '/health'` (root, not under `/coach/v1`).
+  - `databases: ['coach_api']` (pg) **plus** `mesh: ['connect-mongo']` — DUAL-STORE: coach_api Postgres for progress + the mesh mongo (`saga_local` + `wmlms_local`) for curriculum read-path.
+  - `dependsOn: ['iam-api']` (`depKinds: { 'iam-api': 'url' }`). `RABBITMQ_ENABLED: 'false'` (rabbitmq intentionally NOT gated on).
+  - Launch env of note: `DATABASE_URL=${COACH_DB_URL}`, `MONGO_PORT=${CONNECT_MONGO_PORT}`, `MONGO_DATABASE=saga_local`, `CONTENT_DATABASE=wmlms_local`, `AUTH_JWKSURL=${IAM_URL}/.well-known/jwks.json`, `EXPRESS_SERVER_CORSALLOWEDDOMAINS=${COACH_WEB_HOST}`, and **`SAGA_API_TARGET=${SAGA_API_TARGET_COACH}`** → defaults to **`https://staging.wootmath.com`** (an EXTERNAL upstream; see open questions).
+  - `tunnelSlug: 'coach'`, `optional: false`.
+- **`coach-web`** (lines 515–539):
+  - `repo: 'COACH'`, `subpath: 'apps/web/coach-web'`, port **8800**, SvelteKit SPA, `healthPath: '/'`, `isFrontend: true`.
+  - `dependsOn: ['coach-api']` (`depKinds: { 'coach-api': 'browser' }`).
+  - Launch env is **only** `PUBLIC_COACH_API_URL: '${COACH_API_URL}'` — **this is the soa#300 bug** (see below). Stale comment at line 524: *"Reaches iam server-side THROUGH coach-api, so it only needs the coach-api URL."*
+  - `tunnelSlug: 'coach-web'`.
+
+There is **no** separate `coach-db`, `coach-content`, or coach-owned `iam` service. `coach-db` is a
+*package* (`packages/node/coach-db`), the source of the pg schema + seed, not a running service.
+`iam-api` is the shared mesh iam. Curriculum "content" is the mesh mongo, seeded by `coach-mongo`.
+
+Service-id enum: `<cli>/src/core/manifest/types.ts:27-28` (`coach-api`, `coach-web`), repo `COACH`
+(line 43), db `coach_api` (line 69).
+
+### 2. `coach_api` database
+
+`<cli>/src/core/manifest/databases.ts:88-97`:
+- `coach_api` is a **mesh-provisioned** pg app DB (not a pre-seeded volume): CREATE USER/DATABASE/GRANT at provision.
+- `ownerRole: 'coach_api_app'`, `ownerPw: 'dev-password-coach-api-app'`.
+- Migrations live in the **package**, not the app: `migrate: { dir: 'packages/node/coach-db', cmd: 'db:deploy', databaseUrlOverride: true }` — `DATABASE_URL` is forced to the mesh `:5432` (coach-db's own default is `:5433`).
+
+### 3. Bundle / closure
+
+`<cli>/src/core/bundles.ts:51-54`: **`coach` bundle → `['coach-api', 'coach-web']`**, no `seedAddOn`.
+`--with coach` is pure sugar unioned into the closure (`combineRequested`), then `computeClosure`
+runs. **A bundle with no seed add-on is a no-op for `stack seed`** (bundles.ts:15-16 explicitly says
+`--with coach` is a seed no-op).
+
+### 4. Coach launch tokens
+
+`<cli>/src/core/launch-plan.ts` (`defaultLaunchContext`, ~lines 615–644):
+- `COACH_API_PORT = ports['coach-api']` (6105), `COACH_API_URL = http://localhost:${ports['coach-api']}`, `COACH_WEB_HOST = 'localhost'`, `SAGA_API_TARGET_COACH = 'https://staging.wootmath.com'`, `CONNECT_MONGO_PORT = mongoPort` (27037 slot 0), `COACH_DB_URL = pgUrl('coach_api', pgPort)`.
+- `IAM_URL` token exists and is already consumed by coach-api — it is available to be given to coach-web too (relevant to the soa#300 fix).
+
+### 5. Bring-up: `ss stack up`
+
+- Command: `<cli>/src/commands/stack/up.ts`. `--with coach` (options include `coach`, up.ts:88).
+- Bare `stack up` expands to the full **non-optional** set (coach-api/coach-web are `optional:false`, so a bare full up **includes coach**). `--only`/`--with` boot just the closure.
+- Native path: `computeClosure` → `StackApi.up(closure)` (up.ts:216-234). Prep (build/install/db:generate/provision/migrate) is closure-scoped.
+- **Skip-if-repo-absent:** if `/home/skelly/dev/coach` isn't cloned, coach-api/coach-web are *warned-and-skipped*, and dependents are transitively skipped, rather than failing the run (`<cli>/src/stack-api.ts` ~lines 275, 741, 763; commit `be4e387` "skip-if-repo-absent launcher"). COACH repo path resolves via `$COACH` → default `$DEV/coach` (`<cli>/src/runtime/repos.ts:51`, `REPO_ENV_VAR.coach → 'COACH'`).
+- Optional login-after-up: `stack up --login` mints a jar for `DEFAULT_LOGIN_USER = dev@saga.org` (up.ts:573) — **NOT the coach identity**; the concierge needs `demo-tutor-1@saga.org` instead.
+
+### 6. Browser-plane / tunnel overlay — soa#298 gap is FIXED
+
+`<cli>/src/core/launch-plan.ts`, `tunnelOverlay()` (lines 314-394). Two functions splat lane
+overlays: `sandboxOverlay` (iam dep-repoint) + `tunnelOverlay` (browser-plane CORS/URLs), combined in
+`laneOverlay` (line 405). **coach cases now exist** (lines 372-391):
+- `coach-api` → `EXPRESS_SERVER_CORSALLOWEDDOMAINS: '${COACH_WEB_HOST},${td}'` (admits the bare tunnel domain).
+- `coach-web` → `PUBLIC_COACH_API_URL: 'https://coach-api.${td}'` + `__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS: 'coach.${td}'`.
+
+These were added by **commit `0c8b50e` "finish ss tunnel mode — coach overlay + e2e --tunnel (#298)"**,
+already on `main`/this worktree. So the "coach missing from the TS browser-plane overlay
+(launch-plan.ts:375)" gap from soa#298 is **closed** for **tunnel** mode. **BUT** these overlays fire
+only when `TUNNEL_DOMAIN` is set (`tunnelOverlay` returns `{}` in pure-local mode, line 316). Pure
+local `stack up --with coach` relies on the base manifest launch env — which is where **soa#300**
+bites.
+
+### 7. soa#300 — coach-web local iam wiring is STALE (OPEN — blocks local browser use)
+
+Issue `saga-ed/soa#300` (OPEN). Since **coach#226**, coach-web reads identity **direct from iam in the
+browser** (`WHOAMI_URL = ${PUBLIC_IAM_API_URL}/trpc/auth.whoami`, saga-dash pattern). The manifest was
+never updated. Two concrete breakages in `<cli>/src/core/manifest/services.ts`:
+1. **coach-web sets no `PUBLIC_IAM_API_URL`** (only `PUBLIC_COACH_API_URL`, line 531). So it falls back to its checked-in `.env` default `PUBLIC_IAM_API_URL=https://iam.wootdev.com` (remote) — a local `ss` cookie is invalid ⇒ app 503s at sign-in.
+2. **`iam-api` `CORS_ORIGIN` excludes coach-web.** Base launch env is `CORS_ORIGIN: '${DASH_URL},${CONNECT_WEB_URL}'` (services.ts, iam-api def) → no coach-web origin ⇒ the direct-from-browser `whoami` is CORS-blocked.
+
+**Fix (per the issue):** add `PUBLIC_IAM_API_URL: '${IAM_URL}'` to `coach-web` launch.env; add a
+`COACH_WEB_URL` token (`http://localhost:${ports['coach-web']}`) and append it to iam-api
+`CORS_ORIGIN` (`${DASH_URL},${CONNECT_WEB_URL},${COACH_WEB_URL}`). **Impact:** blocks anyone
+browser-testing local coach-web — i.e. it blocks the *whole point* of `develop coach`. The coach#228
+verification worked around it by running coach-web from a worktree with
+`PUBLIC_IAM_API_URL=http://localhost:3010` + a `--disable-web-security` Chromium. **The `develop
+coach` plan should land the soa#300 manifest fix as a hard prerequisite.**
+
+### 8. Seeding — coach DBs + identity
+
+Seed profiles: `<cli>/src/core/seed/profiles.ts:42-45`:
+- `roster: ['iam-registry', 'iam-dev-user', 'iam', 'sessions']` — **NO coach steps.** This is the DEFAULT profile for both `stack up` (up.ts:101 "an absent --seed still seeds the roster baseline") and `stack seed` (seed.ts:81 default `roster`).
+- `full: [ … 'programs', 'scheduling', 'content', 'coach-pg', 'coach-mongo' ]` — the only profile that seeds coach.
+
+The two coach seed steps (`profiles.ts:417-466`):
+- **`coach-pg`** — `service: 'coach-api'`, `databases: ['coach_api']`, `cwd: 'packages/node/coach-db'`, `command: ['pnpm','db:seed']`, `DATABASE_URL` forced to the mesh `:5432` coach_api. `failureMode: 'warn'` (coach may be absent). This runs coach-db's **`local-snapshot.ts`** (`/home/skelly/dev/coach/packages/node/coach-db/src/seed/local-snapshot.ts`).
+- **`coach-mongo`** — `service: 'coach-api'`, `cwd: 'apps/node/coach-api'`. Two mongoimports via `docker exec -i <mongo container>`: `scripts/data/content_coach.json` → `saga_local.content_coach`, and (optionalStep `coach-mongo-content`) `scripts/data/content.json` → `wmlms_local.content`. `--mode upsert` so re-seeds converge. Always seeds (mongo not a tracked DbId; not skipped on a pg-snapshot restore — compose-seed-plan.ts:125-128).
+
+Closure narrowing: `composeSeedPlan` (`<cli>/src/core/seed/compose-seed-plan.ts`) DROPS a step whose
+`service` isn't in the active closure. So `coach-pg`/`coach-mongo` only run when **coach-api is in the
+closure AND the profile selects them** (i.e. `full`). There is a `perSystem` narrowing hook
+(compose-seed-plan.ts:85) and `--only`/`--exclude` on `stack seed`, but **no `coach` seed add-on and
+no `coach` `perSystem` shortcut today** — the concierge must select `full` or the plan should add a
+coach seed add-on to the bundle.
+
+**Identity / seed alignment (critical):** coach's seed is anchored on the **`demo-tutor-1`** persona
+(`/home/skelly/dev/coach/packages/node/coach-db/src/seed/local-snapshot.ts` header, and
+`.../seed/persona-projections.ts`):
+- `COACH_TUTOR_USER_ID = deriveUserId('demo-tutor-1')` = `1c939568-1464-5f9a-b5a4-0bc73a0454cb`, email **`demo-tutor-1@saga.org`**.
+- `persona_assignment` groupId = `deriveGroupId('demo')` = `a0da8362-1a93-5d1d-aeaa-b6d8960e9821` ("Demo District").
+- Both `demo-tutor-1` (TUTOR) and `demo-dadmin` (admin) carry `coach:access_coach_app` (persona-projections.ts:35-39, 152). The seeded `content_instance` renders the Coach Dashboard out-of-the-box **only for `demo-tutor-1@saga.org`**.
+- **`group_track_map` bake** (coach#235, commit `1b54e46` "bake group_track_map into the local seed"): `groupTrackMaps(contentName)` (persona-projections.ts:96) writes `[{ groupId: deriveGroupId('demo'), groupKind: DISTRICT, contentName }]` so the tutor's group is mapped to the seeded content track. Migration `20260618140000_add_group_track_map_and_instance_unique`.
+
+So the persona projection (persona_definition/assignment) is DERIVED from the shared
+`@saga-ed/iam-seed-ids` catalog to byte-match the mesh iam's own roster seed — meaning coach's local
+seed is only correct if the **iam roster seed has materialized `demo-tutor-1`** (the `iam` seed step,
+via rostering `iam-db/prisma/seed.ts` DEMO_MEMBERSHIPS). That's satisfied by the `roster`/`full`
+profile's `iam` step; the coach steps assume it.
+
+### 9. Login the concierge must mint
+
+Native headless login: `<cli>/src/runtime/login.ts` + command `<cli>/src/commands/stack/login.ts`.
+`stack login [email]` POSTs iam devLogin and writes a Netscape cookie jar `<stateDir>/cookies.txt`.
+Default email `dev@saga.org` (`<cli>/src/core/login.ts:20 DEFAULT_LOGIN_USER`). For coach the concierge
+must pass **`demo-tutor-1@saga.org`** (tutor/content-viewer/playlisting, scenarios 3 & 5) or
+**`demo-dadmin@saga.org`** (admin dashboard, scenario 4). Note the native jar is **headless** (curl-
+style). Actually *browsing* coach-web needs a real browser session — `stack login --browser` opens an
+auto-logged-in Chromium (routes to the vendored `browser-login.mjs`). Once soa#300 is fixed, a
+browser session against local coach-web will work; until then it 503s.
+
+### 10. `e2e connect` — the concierge to mirror
+
+`<cli>/src/commands/e2e/connect.ts` is the template: resolve a flow, recurse the prerequisite
+(reset+seed owned by the journey), open a HEADED Playwright project in the FOREGROUND (stdio
+inherited), `--reuse` to skip the rebuild+reset against the current stack. `develop coach` is the
+*active-development* analogue: bring up the coach closure, seed coach, log in as the coach persona,
+and hand back a running dev server (foreground `pnpm dev` for coach-web) — NOT a Playwright flow.
+
+### 11. Tunnel overlay for coach (invite-a-coworker)
+
+`stack tunnel` / `stack up --tunnel` (command `<cli>/src/commands/stack/tunnel.ts`,
+`<cli>/src/runtime/tunnel-prep.ts`). With coach in the closure, the tunnelOverlay (§6) now sets coach
+CORS + `PUBLIC_COACH_API_URL=https://coach-api.<moniker>.vms.wootdev.com` + Vite allowed-hosts. soa#298
+also flagged a **vendored `tunnel.sh` SERVICES-table drift** (coach missing) — verify that was
+re-vendored if the concierge ever shells the vendored script; the native TS path is the one that
+matters and is fixed.
+
+---
+
+## What a `develop coach` command must orchestrate (the exact recipe)
+
+Same for all three coach scenarios except the trailing persona + route:
+
+1. **Ensure repos** — COACH cloned at `$DEV/coach` (else coach is skipped). Optionally auto-pull SOA + COACH.
+2. **Bring up the coach closure:** `ss stack up --with coach` (closure = `coach-api`, `coach-web`, `iam-api`, + mesh: mongo `connect-mongo`, pg `coach_api`, redis for iam). Provision + migrate `coach_api` (coach-db `db:deploy`).
+3. **Seed:** run the `full` profile **or** at minimum the coach steps + their iam prerequisite:
+   - `iam-registry`, `iam-dev-user`, `iam` (so `demo-tutor-1`/`demo-dadmin` exist), then
+   - `coach-pg` (coach-db `db:seed` → content_instance + persona projection + content_release + group_track_map bake), and
+   - `coach-mongo` (curriculum → `saga_local.content_coach` + `wmlms_local.content`).
+   Command today: `ss stack seed full` (after up) or `ss stack up --with coach --seed full`.
+4. **Login as the coach identity** (NOT `dev@saga.org`):
+   - scenarios 3 (content-viewer) & 5 (playlisting): `demo-tutor-1@saga.org`
+   - scenario 4 (admin dashboard): `demo-dadmin@saga.org`
+   Use `stack login --browser <email>` for a real browser session (headless jar alone won't drive the SPA).
+5. **Hand back a running dev app** — coach-web dev server at `http://localhost:8800`, coach-api at `:6105`. Optionally deep-link the scenario's route (content-viewer vs admin vs playlisting — sibling research area owns the exact routes).
+
+---
+
+## Missing wiring the plan must FIX FIRST (ranked)
+
+1. **soa#300 (BLOCKER) — coach-web ↔ local iam browser auth.** Land the manifest fix: `coach-web.launch.env += PUBLIC_IAM_API_URL: '${IAM_URL}'`; add `COACH_WEB_URL` token and append to `iam-api` `CORS_ORIGIN`. Without this, local coach-web 503s at sign-in — `develop coach` cannot deliver a usable browser app. (`<cli>/src/core/manifest/services.ts`, coach-web ~line 531 + iam-api CORS_ORIGIN.)
+2. **Default seed doesn't cover coach.** `--with coach` carries no seed add-on and the default profile is `roster`. Either (a) the concierge forces `--seed full`, or better (b) add a `coach` **seed add-on** to the bundle registry (`<cli>/src/core/bundles.ts`) wiring `['coach-pg','coach-mongo']` (mirroring `playback`), so `develop coach` seeds coach without dragging in programs/scheduling/content it may not need. Also consider a `perSystem` `coach` shortcut in compose-seed-plan.
+3. **Login persona default is wrong for coach.** The concierge must default to `demo-tutor-1@saga.org` (or `demo-dadmin@saga.org` for admin), not `DEFAULT_LOGIN_USER=dev@saga.org`; otherwise the seeded content_instance/persona won't render.
+4. **External upstream dependency:** `coach-api.SAGA_API_TARGET` defaults to `https://staging.wootmath.com` (`SAGA_API_TARGET_COACH`). Confirm which coach surfaces actually hit it (content-viewer may) and whether it needs VPN/network — flag for the concierge's preflight.
+
+---
+
+## Key files (absolute)
+
+- `<cli>/src/core/manifest/services.ts:475-539` — coach-api / coach-web service defs.
+- `<cli>/src/core/manifest/databases.ts:88-97` — `coach_api` db (owner role/pw, migrate via coach-db package).
+- `<cli>/src/core/bundles.ts:51-54` — `coach` bundle (no seed add-on — gap #2).
+- `<cli>/src/core/launch-plan.ts:314-394` — sandbox/tunnel overlays incl. coach-api/coach-web cases (soa#298 fix, `0c8b50e`); tokens at ~615-644.
+- `<cli>/src/core/seed/profiles.ts:42-45` (profiles), `:417-466` (coach-pg, coach-mongo steps).
+- `<cli>/src/core/seed/compose-seed-plan.ts:77-128` — profile→steps, partial-stack drop, coach-mongo always-seed.
+- `<cli>/src/runtime/login.ts` + `<cli>/src/commands/stack/login.ts` + `<cli>/src/core/login.ts:20` — native login + `DEFAULT_LOGIN_USER`.
+- `<cli>/src/commands/stack/up.ts` (bring-up), `<cli>/src/commands/stack/seed.ts` (seed), `<cli>/src/commands/e2e/connect.ts` (concierge template).
+- `<cli>/src/runtime/repos.ts:51` — COACH repo path resolution.
+- `/home/skelly/dev/coach/packages/node/coach-db/src/seed/local-snapshot.ts` — coach-pg seed (content_instance, persona, content_release).
+- `/home/skelly/dev/coach/packages/node/coach-db/src/seed/persona-projections.ts` — demo-tutor-1/demo-dadmin ids, `groupTrackMaps`, group_track_map bake (coach#235).
+- `/home/skelly/dev/coach/apps/node/coach-api/scripts/data/{content_coach.json,content.json}` — coach-mongo curriculum fixtures.
+- Migration `/home/skelly/dev/coach/packages/node/coach-db/src/prisma/migrations/20260618140000_add_group_track_map_and_instance_unique/`.
+
+## Concrete commands (from `<cli>`, `node bin/dev.js …`)
+
+```bash
+# plan-only: see the coach closure + launch/seed plan
+node bin/dev.js stack up --with coach --dry-run
+
+# bring up just the coach closure natively + seed coach + mint the coach jar
+node bin/dev.js stack up --with coach --seed full            # roster default does NOT seed coach
+node bin/dev.js stack login --browser demo-tutor-1@saga.org  # tutor + content-viewer (scenarios 3/5)
+node bin/dev.js stack login --browser demo-dadmin@saga.org   # admin dashboard (scenario 4)
+
+# reseed an already-running stack (coach steps only run under full)
+node bin/dev.js stack seed full
+
+# invite-a-coworker (tunnel) — coach overlay now wired
+node bin/dev.js stack up --with coach --tunnel
+
+# coach-web dev server ends up at http://localhost:8800 ; coach-api at http://localhost:6105
+```
+
+## Open questions (for the develop-coach plan / sibling research)
+
+1. **Scenario→surface→route mapping.** All three run on the same coach-api+coach-web pair; a sibling area must pin the exact coach-web routes for (3) ported content-viewer, (4) admin dashboard, (5) playlisting, and whether any need extra seed/config beyond `demo-tutor-1`. (content-viewer landed in coach commits `14b0ff1`/`76e435f`, "changed from iframe for content viewing".)
+2. **Does soa#300 get fixed in gh_305 or is it a separate PR to depend on?** It's an open, self-contained manifest fix; the plan should either own it or hard-depend on it.
+3. **Should `develop coach` introduce a `coach` seed add-on** (bundles.ts) so it seeds coach without the full profile's programs/scheduling/content, or is `--seed full` acceptable for a dev stack?
+4. **`SAGA_API_TARGET_COACH=https://staging.wootmath.com`** — which coach surfaces hit external staging, and does the concierge need a network/VPN preflight or a local override?
+5. **Admin (`demo-dadmin`) content baseline:** the seed's content_instance is anchored on `demo-tutor-1`; confirm the admin dashboard (scenario 4) has enough seeded data under `demo-dadmin` to render, or whether it reads the same Demo District aggregate.
+6. **coach#155 status:** coach-db `db:seed` local-snapshot is referenced as possibly-unmerged in older comments (`profiles.ts:410-413` "coach#155 unmerged"); confirm it's merged now (local-snapshot.ts exists on coach `main`, so likely yes).

--- a/claude/projects/gh_305/research/05-concierge-pattern-to-mirror.md
+++ b/claude/projects/gh_305/research/05-concierge-pattern-to-mirror.md
@@ -1,0 +1,421 @@
+# 05 — The `ss e2e connect` concierge contract to mirror for `develop coach`
+
+**Research area:** Extract the reusable concierge contract from the existing
+`e2e connect` command so a new `develop` topic + `develop coach` (and later
+`develop saga-dash`/`ads`/`sis`) mirror it as a *small* addition, and specify the
+oclif mechanics for the new topic + the deprecating `e2e connect` alias.
+
+**Scope note:** This doc is about the *CLI plumbing / concierge contract*. It is
+evidence-based against the code in
+`packages/node/saga-stack-cli` (worktree `gh305-ss-develop`) and the real
+`coach` repo. What exists today vs. what must be added is called out explicitly.
+
+All paths below are absolute or repo-relative to
+`/home/skelly/dev/soa/.claude/worktrees/gh305-ss-develop/packages/node/saga-stack-cli`
+(the `ss` CLI package). Line numbers are as of this research.
+
+---
+
+## Headline
+
+`e2e connect` is already a thin, opinionated concierge over a **pure flow
+resolver** (`resolveFlow`) + a **generic in-process executor**
+(`executeResolvedFlow`) that does closure → up → reset+seed → verify → foreground
+Playwright, recursing a headless prerequisite. Almost all of that is reusable
+verbatim. `develop coach` is mostly **data** (a `coach-web` registry row +
+coach's already-authored `flows.json`) plus a **thin command file** that picks the
+flow and the hand-off style. The one genuinely connect-specific/saga-dash-specific
+piece is the **hand-off**: connect holds the TTY via an interactive Playwright
+spec (`page.pause()`), and the alternative `--hold` browser opener
+(`openVendoredBrowser`) is hardwired to saga-dash's dash app — coach needs its own
+hand-off decision (see §6, the main open question).
+
+---
+
+## 1. The concierge contract `e2e connect` implements (step by step)
+
+`src/commands/e2e/connect.ts` (241 lines). Its `run()` is the template. In order:
+
+1. **Parse + separate passthrough** (`connect.ts:114-115`). `static strict = false`
+   allows trailing args after `--`; it filters the flow token out of `argv` to get
+   `passthrough` (handed only to the terminal Playwright stage, never the
+   prerequisite).
+2. **Validate mutually-exclusive flags manually** (`connect.ts:121-128`) — NOT via
+   oclif `exclusive:`, because oclif treats a *defaulted* value as "provided" (the
+   "M14 lesson", commented at `connect.ts:119-120`). `--refresh-snapshot` rejects
+   `--reuse` and requires `--prereq-from-snapshot`.
+3. **Discover the flow manifest** (`connect.ts:130-135`) via
+   `discoverFlowManifest(SPA_ID, flags, process.env)`
+   (`e2e-orchestrate.ts:132-161`). Resolution order: `--spa-path` →
+   `$SAGA_E2E_SPA_PATHS` → registry repo path (`$<repoEnvVar> ?? $DEV/<sub>` +
+   `e2eDir/flows.json`) → **bundled example** fallback (only for ids in
+   `BUNDLED_EXAMPLE`, `e2e-orchestrate.ts:84-93`). Warns when it fell back to the
+   bundled example.
+4. **Resolve the flow (PURE)** (`connect.ts:139`) via
+   `resolveFlow(manifest, FLOW_NAME, { lane: 'stack' })`
+   (`src/core/flow/resolve.ts:191`). This produces a `ResolvedFlow`: selected
+   stages, `requiredSystems ∪ {spa.system, iam-api}`, the full dependency
+   `closure` (N-of-M), effective seed selection, `reset` boolean, `foreground`,
+   the Playwright invocation, and a **recursively-resolved `prerequisite`** forced
+   headless (`resolve.ts:303-320`). Prerequisite ⇒ main flow runs `reset:false`
+   (`resolve.ts:326`) because the prerequisite owns the reset+seed.
+5. **Apply `--reuse`** (`connect.ts:140`): strip the prerequisite entirely
+   (`{ ...resolved, prerequisite: undefined }`) so nothing rebuilds/resets — run
+   against current stack state.
+6. **Pin per-run stage env** (`connect.ts:145-153`): `--fake-media` ⇒
+   `FAKE_MEDIA=1`, `--student-login N` ⇒ `CONNECT_LOCAL_STUDENTS=N`, merged into
+   `base.flow.env` so it reaches only the headed stage (not the headless
+   prerequisite — a separate `ResolvedFlow`). This is the generic "inject env for
+   this flow's stages" hook (`flow.env` is merged last by `computeEnv`).
+7. **Resolve the Playwright cwd** (`connect.ts:155`) via
+   `resolveAppCwd(resolved.spa, flags, process.env)`
+   (`e2e-orchestrate.ts:332-335`) → `<repoRoot>/<spa.appDir>` (matches
+   `run-stack-e2e.sh`'s `cd $DASH`).
+8. **Assemble the injectable seams** (`connect.ts:158-165`): `launcher`,
+   `meshExec`, `portProbe`, `dashFs`, `prober`, `runner` — each a
+   `BaseCommand.getX()` seam. Plus a `delegate` closure wiring reset/login back
+   through `this.runScript` (`connect.ts:166-167`).
+9. **Resolve `--tunnel`** (`connect.ts:174-179`): resolve
+   `<moniker>.<VMS_BASE>` from the vendored `tunnel.sh` (same machinery as
+   `stack up --tunnel`). Note: it ONLY repoints the Playwright browsers' URLs; it
+   does not relaunch the stack.
+10. **Build the runtime + StackApi** (`connect.ts:181-182`):
+    `buildStackContext(flags, seams, delegate, undefined, tunnelDomain)`
+    (`e2e-orchestrate.ts:227`) → `makeStackApi(serviceManifest, runtime)`
+    (`src/stack-api.ts`). This is the six-method facade (`up/reset/seed/verify` +
+    login/browser).
+11. **Build the checkpoint store** (`connect.ts:188-191`) only if there is a
+    prerequisite AND `--prereq-from-snapshot`/`--refresh-snapshot` — the M14-C
+    accelerant that restores the prerequisite's terminal checkpoint instead of
+    replaying it.
+12. **(Optional) `--refresh-snapshot` bake** (`connect.ts:198-222`): a headless
+    full replay of the prerequisite through its terminal stage with
+    `--snapshot-stages` to bake fresh checkpoints, before opening the room.
+13. **Execute** (`connect.ts:224-239`) via `executeResolvedFlow(toRun, deps, opts)`
+    (`e2e-orchestrate.ts:858`). The executor **owns everything**:
+    - recurse the prerequisite headless (skip-reset false, no passthrough), or
+      restore its checkpoint (`e2e-orchestrate.ts:884-944`);
+    - `api.up(closure)` (`:960`), honoring repo-absent skips
+      (`:971-973`, the "#221 coach-deferral" pattern);
+    - reset + seed (coupled) unless `skipReset` / prerequisite built the state
+      (`:984-1017`); additive-seed branch for prereq-built + declared seed;
+    - `api.verify(probes, { tolerate: [spa.system] })` (`:1028-1033`) — tolerate
+      the SPA's own frontend being red (branch posture / dev server);
+    - spawn Playwright **foreground, stdio inherited** (`:1060-1071`): `pnpm exec
+      playwright test --config … --project <terminal> [--headed] [passthrough]`.
+      Foreground flows are `--headed`; the TTY is held by the spec's own
+      `page.pause()` (connect's AV hold).
+    - Returns the Playwright exit code; a failed up/reset/seed/verify throws
+      `FlowExecError` (`connect.ts:236-238` surfaces it via `this.error`).
+
+**The contract, distilled:** a concierge subcommand is
+`parse → discover flow → resolveFlow → (reuse strip / env pin) → resolveAppCwd →
+seams → buildStackContext → makeStackApi → executeResolvedFlow`. Everything except
+step "which SPA + which flow + which hand-off" is shared machinery.
+
+---
+
+## 2. `e2e connect`'s flags (what to preserve on `develop connect`)
+
+From `connect.ts:74-111` (all spread `...BaseCommand.baseFlags` first):
+
+| Flag | Default | Effect |
+|---|---|---|
+| `--reuse` | false | strip prerequisite rebuild + reset; run against current stack state (`connect.ts:140`, `skipReset` at `:231`) |
+| `--prereq-from-snapshot` | true (`allowNo`) | M14-C: restore the `journey@schedule` checkpoint instead of replaying it; falls back to replay when absent |
+| `--refresh-snapshot` | false | bake the prerequisite checkpoints fresh (headless replay, `--snapshot-stages`) before opening; needs `--prereq-from-snapshot`; XOR `--reuse` |
+| `--spa-path` | — | explicit `flows.json` path (highest-priority discovery override) |
+| `--fake-media` | false | `FAKE_MEDIA=1` on the headed stage (synthetic cam/mic) |
+| `--tunnel` | false | point THIS run's browsers at the vms tunnel hosts (requires prior `ss stack up --tunnel`) |
+| `--student-login <0-2>` | 2 | how many students log in locally (`CONNECT_LOCAL_STUDENTS`) |
+| plus `...BaseCommand.baseFlags` | — | `--porcelain`, `--slot`, `--output-json`, `--set`, `--dev`, `--state-dir`, and per-repo `--<repo>` pins (`src/shared-flags.ts:111-160`) |
+
+`--fake-media`, `--tunnel`, `--student-login`, `--refresh-snapshot`,
+`--prereq-from-snapshot` are **connect/AV-specific**. `--reuse`, `--spa-path`, and
+the base flags are **generic** and belong on every concierge subcommand.
+
+Pass-through after `--` is enabled by `static strict = false` (`connect.ts:72`).
+
+---
+
+## 3. Reusable vs. connect-specific (the factoring)
+
+### Fully reusable today (zero change to add coach)
+- **`resolveFlow`** (`core/flow/resolve.ts`) — pure; already handles
+  non-progressive single-stage flows (coach's flows are all non-progressive),
+  seed merge, closure, prerequisite recursion.
+- **`discoverFlowManifest` / `resolveAppCwd` / `buildStackContext`**
+  (`e2e-orchestrate.ts`) — generic over SPA id; already resolve `COACH` repo
+  paths (`shared-flags.ts:56-59` defines the `--coach` / `$COACH` flag).
+- **`executeResolvedFlow`** (`e2e-orchestrate.ts:858`) — generic; drives any
+  resolved flow. Coach's flows are self-seeding `reset:true`, so the up →
+  reset+seed → verify → Playwright path applies unchanged. Repo-absent skips
+  (`:971`) already handle a not-cloned coach.
+- **`makeStackApi`** + the manifest — `coach-api` (`:475`) and `coach-web`
+  (`:515`) already exist in `core/manifest/services.ts` with proper
+  `dependsOn`/`databases`/`lane` (ports 6105 / 8800).
+- **`mintNativeLoginJar`** (`base-command.ts:947`) — SPA-agnostic; mints the
+  dev-persona cookie jar (slot-aware). Reusable for a coach hand-off.
+- The `--hold` **epilogue pattern** (`run.ts:411-472`, `holdEpilogue`) — mint jar
+  + best-effort open browser + print held-state summary, exit 0, stack stays up.
+
+### Connect-specific (do NOT copy blindly)
+- The `CONNECT_SPA = 'saga-dash'` / `CONNECT_FLOW = 'connect-session'` constants
+  (`connect.ts:57-58`) and the AV flags (`--fake-media`, `--student-login`,
+  `--tunnel`, the snapshot flags).
+- The foreground hand-off = an **interactive Playwright spec that holds the TTY**
+  (`page.pause()`). This depends on the SPA authoring an `@interactive`,
+  `foreground:true` stage. **Coach's `flows.json` has none today** (see §5).
+
+### SPA-specific but NOT yet generalized — the browser opener
+- **`openVendoredBrowser`** (`base-command.ts:977-1009`) is **hardwired to
+  saga-dash**: it `createRequire`s playwright from `<saga-dash>/apps/web/dash`,
+  sets `SAGA_DASH_DASH`, and opens `DASH_URL` (default `:8900`). It warns-and-skips
+  if the saga-dash dash app is absent (`:995-1001`). A coach hand-off that wants a
+  logged-in **coach-web** browser cannot use this as-is — it opens the dash, not
+  coach-web. This is the single biggest factoring gap for `develop coach`.
+
+### Cleanest factoring recommendation
+Extract a shared **`ConciergeCommand`** base (or a `runConcierge(opts)` helper in
+`e2e-orchestrate.ts` / a new `develop-orchestrate.ts`) that takes
+`{ spaId, flowName, extraStageEnv, handoff }` and runs steps 3–13 of §1. Then:
+- `develop connect` = `runConcierge({ spaId:'saga-dash', flowName:'connect-session',
+  handoff:'foreground-spec', … })` + the AV flags.
+- `develop coach` = `runConcierge({ spaId:'coach-web', flowName:<chosen>,
+  handoff:'hold-browser', … })`.
+- Later `develop saga-dash`/`ads`/`sis` = one more call with different constants.
+
+Make the **browser opener SPA-parameterizable** (an `appDir` + `port` + which repo
+provides playwright) so `handoff:'hold-browser'` can open coach-web, not just the
+dash. That is the one new piece of *code* the concierge generalization needs;
+everything else is data + a thin command file.
+
+---
+
+## 4. What a NEW `develop` topic + `develop coach` needs
+
+### 4a. Topic registration (oclif)
+Two things, mirroring the existing `e2e` topic:
+1. **`package.json` `oclif.topics`** — add a `develop` entry (and it uses
+   `topicSeparator: " "`, so subcommands are space-separated). Current topics are
+   at `package.json` `oclif.topics` (`stack`, `stack:snapshot`, `e2e`, `set`).
+   Add:
+   ```json
+   "develop": {
+     "description": "Concierge scripts that set up and drop you into a developable stack for a specific app or workflow (seed, reset, prerequisites, then hand off a running app)."
+   }
+   ```
+2. **Command directory** — `src/commands/develop/`. oclif uses
+   `commands.strategy: "pattern"` + `target: "./dist/commands"` (`package.json`
+   `oclif`), so any file `src/commands/develop/<name>.ts` exporting a
+   `default class extends BaseCommand` auto-registers as `develop <name>`. No
+   manual wiring. (Same as how `e2e/connect.ts` → `e2e connect` works today.)
+
+### 4b. The `develop coach` command file
+`src/commands/develop/coach.ts`, a thin command mirroring §1. It needs:
+- constants `COACH_SPA = 'coach-web'`, `COACH_FLOW = <chosen flow>`;
+- generic flags: `...BaseCommand.baseFlags`, `--reuse`, `--spa-path`, `static
+  strict = false` (passthrough);
+- **a coach registry row** (§5) so `discoverFlowManifest('coach-web', …)` resolves;
+- a hand-off decision (§6).
+
+### 4c. `develop saga-dash` / `develop ads` / `develop sis` (later)
+Each is another file in `src/commands/develop/` + (for ads/sis) manifest/registry
+coverage. saga-dash is already registered; ads/sis frontends would need registry
+rows + authored flows.
+
+---
+
+## 5. Registry + coach flows.json status (the DATA half)
+
+- **`coach-web` is NOT in the built-in SPA registry yet.** `SPA_REGISTRY`
+  (`src/core/flow/spa-registry.ts`) has only `saga-dash` and `connectv3`. Adding
+  coach = **one row** (the M6 "second-SPA" pattern, proven for connectv3):
+  ```ts
+  'coach-web': {
+    id: 'coach-web', system: 'coach-web', repoEnvVar: 'COACH',
+    defaultRepoSubpath: 'coach', appDir: 'apps/web/coach-web',
+    e2eDir: 'apps/web/coach-web/e2e', playwrightConfig: 'playwright.config.ts',
+  },
+  ```
+  (These exact values are confirmed from coach's own `flows.json` `spa` block.)
+- **Coach's `flows.json` ALREADY EXISTS and wraps a REAL suite:**
+  `/home/skelly/dev/coach/apps/web/coach-web/e2e/flows.json`. It declares SPA id
+  `coach-web`, and three flows, all `lanes:["stack"]`, `progressive:false`,
+  `seed:{ profile:"full", reset:true }`, `project:"chromium"`,
+  `requiredSystems:["coach-web","coach-api","iam-api"]`:
+  - **`dashboard`** — authenticated tutor dashboard renders the seeded curriculum
+    (27 modules). ← maps to scenario 4 (admin/tutor dashboard).
+  - **`module-playback`** — in-app module playback of the ported renderers (the
+    12 base question types), against the synthetic seed fixture. ← maps to
+    scenario 3 (the ported content-viewer application).
+  - **`module-playback-real-content`** — same, but against a REAL archive
+    curriculum; requires `ARCHIVE_DIR` + `PUBLISH_REAL_CONTENT=1`.
+- **No `develop`-oriented (foreground/interactive/held) coach flow exists yet.**
+  All three are headless smoke/acceptance tests. So `develop coach` cannot just
+  point at an interactive spec the way `connect` does — it must either (a) use the
+  **`--hold` hand-off** model (bring the stack up + seed via one of these flows,
+  then mint jar + open a coach-web browser and leave the dev server running), or
+  (b) coach authors a new `foreground:true` flow. **(a) is the pragmatic path** and
+  needs no coach-repo change beyond what exists.
+- **No bundled example needed** — the real `flows.json` is present in the coach
+  checkout, so discovery finds it directly (the `BUNDLED_EXAMPLE` fallback,
+  `e2e-orchestrate.ts:84`, is only for repos that haven't authored one).
+
+### Scenario → coach flow mapping (from prompt-2.md scenarios 3-5)
+- **(3) coach + ported content-viewer** → `module-playback` (and/or
+  `module-playback-real-content` for real curriculum).
+- **(4) coach + admin dashboard** → `dashboard`.
+- **(5) coach + playlisting interface** → **no flow exists yet** in coach's
+  `flows.json`; needs authoring in the coach repo, OR the concierge just brings up
+  the coach closure + seeds and hands off the running app for manual navigation to
+  the playlisting UI. (Confirm the playlisting route exists in coach-web — outside
+  this doc's scope; flagged as an open question.)
+
+These three scenarios could be **one `develop coach` command with a
+`--scenario`/`--flow` selector** (dashboard | content-viewer | playlisting), or
+sub-variants. The flow-selection is just a different `COACH_FLOW` constant / flag
+value fed to `resolveFlow`.
+
+---
+
+## 6. The hand-off — the main open design question
+
+Connect's hand-off = a foreground `@interactive` Playwright spec that logs in the
+participants and holds the TTY via `page.pause()`. Coach has **no such spec**. Two
+viable hand-off models, both already in the codebase:
+
+1. **Hold-epilogue model (recommended, no coach-repo change):** run a headless
+   coach flow (up + reset+full-seed + verify), then run the `holdEpilogue` pattern
+   (`run.ts:411`): `mintNativeLoginJar` (dev/seeded-tutor persona) → open a
+   **coach-web** browser at `http://localhost:8800` (slot-offset) → print
+   held-state summary → exit 0, stack + dev server stay up. **Blocker:**
+   `openVendoredBrowser` (`base-command.ts:977`) opens saga-dash's dash, not
+   coach-web — it must be generalized to accept the SPA's `appDir`/port/playwright
+   provider. This is the one new bit of code.
+2. **Foreground-spec model (mirrors connect exactly):** coach authors a
+   `foreground:true`, `@interactive` flow in its `flows.json` whose spec logs in
+   and `page.pause()`s. Then `develop coach` is byte-for-byte the connect template
+   with different constants. **Cost:** a coach-repo PR to author the spec.
+
+**Open question for the develop-coach builder:** which hand-off? (1) is faster to
+ship and reuses `--hold`; (2) is the truest mirror of connect but needs a coach
+spec. Recommendation: ship (1), generalize `openVendoredBrowser`, and leave (2) as
+a future enhancement if a coach author wants an interactive spec.
+
+Note the seeded persona: coach's flows mint a session for the seeded tutor
+`demo-tutor-1` inside the spec. A hold-epilogue would need to mint the same persona
+(not the default `dev@saga.org`) for the browser to land on a populated dashboard
+— confirm the right `--email`/persona for the coach jar.
+
+---
+
+## 7. The deprecating `e2e connect` alias (oclif mechanics)
+
+The issue (#305) requires: *"Migrate `connect.ts` → `develop/connect.ts`; leave a
+deprecating alias at `e2e connect`."* Three oclif options, in order of preference:
+
+1. **`static aliases` + `static deprecateAliases = true` on the real command
+   (RECOMMENDED).** oclif v4 (`@oclif/core ^4.0.0`, confirmed in `package.json`)
+   supports `deprecateAliases`. Put the command at
+   `src/commands/develop/connect.ts` and add:
+   ```ts
+   static aliases = ['e2e:connect'];        // colon form in code; invoked as `e2e connect`
+   static deprecateAliases = true;          // prints a deprecation warning when the alias is used
+   ```
+   Running `ss e2e connect` then dispatches to the real `develop connect` and emits
+   *"Warning: e2e connect is deprecated. Use develop connect instead."* One command
+   file, no duplicated logic. **This is the cleanest.** (No `aliases`/`hidden`/
+   `deprecateAliases` are used anywhere in the CLI today — grep confirms zero
+   existing usages — so this is a new pattern, but a standard oclif one.)
+2. **A thin warn-and-delegate shim command at `src/commands/e2e/connect.ts`.**
+   Keep a `class E2eConnect extends DevelopConnect` (or a stub) that overrides
+   `run()` to `this.warn('deprecated — use `ss develop connect`')` then
+   `super.run()` / delegates. More code, but gives full control over the message
+   and lets you `static hidden = true` it out of `--help` listings while keeping it
+   invokable. Use this if the alias warning text/behavior needs to be richer than
+   oclif's default.
+3. **`static hidden = true`** alone just hides from help — it does NOT warn or
+   redirect, so it's insufficient by itself for a *deprecating* alias. Combine with
+   (1) or (2).
+
+**Recommendation:** Option 1 (`aliases` + `deprecateAliases`) for `develop connect`,
+for "one cycle" as the issue says. Remove the alias in a later release. Keep the
+oclif topic `e2e` itself (its `list`/`run`/`traces` stay); only `connect` moves.
+
+---
+
+## 8. Concrete commands (run/verify locally)
+
+The CLI runs from source via `bin/dev.js` (oclif dev entry). From the package dir
+`packages/node/saga-stack-cli`:
+
+```bash
+# existing connect concierge (the template):
+node bin/dev.js e2e connect --dry-run 2>/dev/null || node bin/dev.js e2e connect --help
+node bin/dev.js e2e connect                       # full: journey prereq → headed connect room
+node bin/dev.js e2e connect --reuse -- --debug    # against current stack, playwright --debug
+node bin/dev.js e2e connect --fake-media
+
+# discovery + list (read-only; shows flows a develop cmd would resolve):
+node bin/dev.js e2e list                          # NOTE: coach-web won't appear until the registry row is added
+node bin/dev.js e2e list --output-json
+
+# drive a coach flow TODAY via the generic runner (proves the closure/seed path
+# before any develop command exists) — coach must be cloned at $COACH or ~/dev/coach:
+node bin/dev.js e2e run coach-web/dashboard --dry-run          # after adding the registry row
+node bin/dev.js e2e run coach-web/dashboard --slot 1           # this effort runs on slot 1
+node bin/dev.js e2e run coach-web/dashboard --hold --slot 1    # up+seed then hold a logged-in browser
+
+# build / typecheck / test the CLI package:
+pnpm --filter @saga-ed/saga-stack-cli build
+pnpm --filter @saga-ed/saga-stack-cli test
+pnpm --filter @saga-ed/saga-stack-cli typecheck
+```
+
+Effort ground rules (prompt-1.md): all live bring-up/testing runs against **ss slot
+1**, in this worktree. `--slot 1` offsets backend ports by 1000 (coach-api
+6105→7105, but browser frontends stay on slot-0 ports per `derive-instance`).
+
+---
+
+## 9. Key files (for the builder)
+
+| File | Why it matters |
+|---|---|
+| `src/commands/e2e/connect.ts` | The concierge template to mirror (241 lines). |
+| `src/core/flow/resolve.ts:191` | `resolveFlow` — pure resolver; handles coach's non-progressive flows unchanged. |
+| `src/core/flow/types.ts` | `flows.json` zod schema (SPA + flow + stage + seed). `coach-api`/`coach-web` already valid ServiceIds (`:36-37`). |
+| `src/core/flow/spa-registry.ts` | Add the `coach-web` row here (the M6 one-row onboarding). |
+| `src/e2e-orchestrate.ts:132` `:227` `:332` `:858` | `discoverFlowManifest` / `buildStackContext` / `resolveAppCwd` / `executeResolvedFlow` — the shared machinery. |
+| `src/base-command.ts:947` `:977` | `mintNativeLoginJar` (reusable) / `openVendoredBrowser` (saga-dash-hardwired — must generalize for coach). |
+| `src/commands/e2e/run.ts:411` | `holdEpilogue` — the "hand off a running logged-in app" pattern to reuse. |
+| `src/commands/stack/login.ts` | The login concierge step (native jar + `--browser`). |
+| `src/shared-flags.ts:56` `:111` | `--coach`/`$COACH` repo flag; the `baseFlags` every command spreads. |
+| `package.json` `oclif.topics` / `oclif.commands` | Where to register the `develop` topic; pattern-strategy auto-registration of `src/commands/develop/*`. |
+| `/home/skelly/dev/coach/apps/web/coach-web/e2e/flows.json` | Coach's REAL flows (`dashboard`, `module-playback`, `module-playback-real-content`) — the scenario 3/4 targets. |
+| `src/core/manifest/services.ts:475` `:515` | `coach-api` (:6105) / `coach-web` (:8800) manifest entries. |
+
+---
+
+## 10. Open questions blocking/shaping the develop-coach plan
+
+1. **Hand-off model** (§6): hold-epilogue browser (needs `openVendoredBrowser`
+   generalized to coach-web) vs. a new coach interactive `foreground` flow. Pick
+   one.
+2. **Scenario 5 (playlisting)** has **no coach `flows.json` flow** — does
+   `develop coach --scenario playlisting` bring up + seed + hand off for manual
+   navigation, or does coach need to author a playlisting flow first? Confirm the
+   playlisting route exists in coach-web.
+3. **Command shape:** one `develop coach` with a `--scenario`/`--flow` selector
+   (dashboard | content-viewer | playlisting) vs. multiple subcommands. The
+   flow-selection is just a `COACH_FLOW` value.
+4. **Persona for the coach jar:** coach flows mint `demo-tutor-1`, not
+   `dev@saga.org` — a hold-epilogue must mint the seeded tutor for a populated
+   dashboard. Confirm the persona/email.
+5. **`module-playback-real-content` needs `ARCHIVE_DIR` + `PUBLISH_REAL_CONTENT=1`**
+   — if the concierge is to support real curriculum, it must surface a flag/env for
+   the content-archive checkout. Probably out of scope for v1.
+6. **Alias mechanics confirmation:** verify `deprecateAliases` renders the warning
+   as expected under this repo's `@oclif/core ^4` at runtime (no existing usage in
+   the CLI to copy from).

--- a/claude/projects/gh_305/research/06-coach-seed-and-personas.md
+++ b/claude/projects/gh_305/research/06-coach-seed-and-personas.md
@@ -1,0 +1,271 @@
+# 06 — Coach seed data, personas & logins for `ss develop coach`
+
+**Area:** what a developer needs SEEDED and LOGGED-IN to open coach and see real
+content, across the three coach scenarios in `prompt-2.md`:
+(3) new coach incl. the ported content viewer, (4) coach + the admin dashboard,
+(5) coach + the playlisting interface.
+
+**Headline:** Coach already ships a complete, committed OFFLINE seed
+(`coach-db db:seed` → the `local-snapshot`) that renders the tutor Dashboard out of
+the box for **one** identity — `demo-tutor-1@saga.org`. The `ss` stack already wires
+that seed in as the `coach-pg` + `coach-mongo` seed steps under `--with coach`. The
+main gaps a `develop coach` concierge must close are NOT "no seed" — they are
+(a) a **still-open manifest auth bug (soa#300)** that breaks coach-web browser login
+against local iam, (b) seed steps that are **`failureMode: 'warn'`** so a fresh dev
+can get a green stack with an empty coach and not know, (c) the **admin/reports**
+scenario needing *multiple* tutors on one track (only one is seeded), and (d) the
+**content-viewer** dashboard/Explore content **mismatch** (Dashboard = spring-pilot,
+Explore = synthetic curriculum-coach). Playlisting has **no shipped UI** yet.
+
+---
+
+## 1. What coach seeds today (EXISTS, works)
+
+### 1a. `coach-db db:seed` — the canonical offline snapshot
+- Entry: `packages/node/coach-db/src/seed/local-snapshot.ts` → built to
+  `dist/seed/local-snapshot.js`, invoked by the `db:seed` npm script.
+- **No iam-db / saga_api / broker dependency** — pure committed fixtures. Idempotent
+  (delete-and-reinsert the snapshot rows). Seeds four things into the coach Postgres
+  (`coach_api` DB):
+
+| Table | Source | What it gives you |
+|---|---|---|
+| `content_instance` (+ `_module`, `_completed_module`) | `src/seed/fixtures/content-instances.json` | One progress instance for **demo-tutor-1**, so the Coach Dashboard renders. |
+| `persona_definition` + `persona_assignment` | `src/seed/persona-projections.ts` (DERIVED from `@saga-ed/iam-seed-ids`, not literals) | The iam-event projection snapshot for demo-tutor-1 (TUTOR) + demo-dadmin (ADMIN). |
+| `group_track_map` | `persona-projections.ts` `groupTrackMaps()` | Points the "Demo District" at the track the seeded tutor's instance is on (added in PR #235). |
+| `content_release` (+ curricula/polls + `active` pointer) | `src/seed/fixtures/content-release.json` | An offline content release so a `CONTENT_STORE_BACKEND=postgres` coach-api serves content. |
+
+- **The seeded instance is spring-pilot legacy-parity** (coach PR #228,
+  `worktree-coach-legacy-parity-seed`): instance `37a5187e-…`, `contentName =
+  spring-pilot`, **59 modules, 13 complete** (nav 13 COMPLETE / 11 IN_PROGRESS /
+  35 UNLOCKED). It is a faithful transform of the live legacy
+  `qa.wootmath.com/coach` instance for `direct_test_2025_tutor1`, re-keyed to
+  demo-tutor-1. So a local coach Dashboard matches legacy side-by-side.
+- **The `content_release` fixture is still synthetic `curriculum-coach`** (27 poll
+  titles) — release id `00000000-0000-4000-8000-c0ac4f1c7000`. PR #228 explicitly
+  **deferred** publishing a real spring-pilot release, so Dashboard (spring-pilot,
+  59) and Explore/content-viewer (curriculum-coach, 27) currently show **different
+  curricula**. This is the biggest content-viewer footgun (see §4/§5).
+
+### 1b. `coach-mongo` curriculum (the dual-store other half)
+- coach-api is DUAL-STORE: `coach_api` Postgres (progress) + the mesh Mongo
+  (curriculum read path). Manifest launch env: `MONGO_DATABASE=saga_local`,
+  `CONTENT_DATABASE=wmlms_local`.
+- Curriculum fixtures live in the coach-api repo:
+  `apps/node/coach-api/scripts/data/content_coach.json` (→ `saga_local.content_coach`)
+  and `scripts/data/content.json` (→ `wmlms_local.content`). These are `mongoimport
+  --mode upsert` static committed fixtures.
+
+### 1c. `cold-start/coach-bootstrap.ts` — NOT for local dev
+- `packages/node/coach-db/src/cold-start/coach-bootstrap.ts` reads iam-db DIRECTLY to
+  rebuild the projection at a real cold start. **Blocked on the rostering#558 grant;
+  not runnable, needs `IAM_DB_URL`.** The `local-snapshot` is its offline twin.
+  The concierge should NOT touch this — use `db:seed`.
+
+---
+
+## 2. How the seed is applied — local vs synthetic-dev / `ss`
+
+### 2a. Manual local (coach repo, from `coach-db/src/seed/README.md`)
+```bash
+# 1. Postgres up + schema applied
+cd apps/node/coach-api && docker compose up -d --wait postgres
+cd packages/node/coach-db && pnpm build && pnpm db:push   # build copies fixtures into dist/
+# 2. Seed (coach-db's OWN default port is :5433)
+DATABASE_URL=postgresql://coach_api_app:dev-password-coach-api-app@localhost:5433/coach_api \
+  pnpm --filter @saga-ed/coach-db db:seed
+```
+> **Gotcha:** `db:seed` runs `dist/seed/local-snapshot.js` — you MUST `pnpm build`
+> first (its `build` script copies `src/seed/fixtures/*` into `dist/seed/fixtures/`).
+> A stale/unbuilt dist silently seeds old fixtures or fails to find them.
+
+### 2b. Under the `ss` synthetic-dev stack (EXISTS)
+Two seed steps in `saga-stack-cli/src/core/seed/profiles.ts`, both in the `full`
+profile and both `failureMode: 'warn'`:
+- **`coach-pg`** (profiles.ts ~L417): `service: coach-api`, `cwd:
+  packages/node/coach-db`, `command: ['pnpm','db:seed']`, `env: inlineDatabaseUrl`
+  forcing the mesh **:5432** `coach_api` (== `$COACH_DB_URL`, overriding coach-db's
+  own :5433 default). `requiresServiceUp: []` — offline direct pg seed.
+- **`coach-mongo`** (profiles.ts ~L437, + `coach-mongo-content` sub-step): two
+  `docker exec … mongoimport … --mode upsert` into the mesh mongo container
+  (`saga_local.content_coach`, `wmlms_local.content`) via `stdinFile`.
+- Bundle: `--with coach` (`core/bundles.ts`) = services `coach-api`, `coach-web`
+  (+ the `coach_api` DB). Native prep already provisions the `coach_api` role/DB and
+  migrates it (`databases.ts` `coach_api.migrate = { dir: packages/node/coach-db,
+  cmd: db:deploy, databaseUrlOverride: true }`).
+
+```bash
+ss stack up --with coach          # boots coach-api :6105 + coach-web :8800 + deps, seeds
+ss stack seed --with coach        # (re)seed a running stack
+```
+Note the coach service `seed: []` arrays in the manifest are empty — coach seeding is
+driven by the **profile** steps (`coach-pg`/`coach-mongo`), which the `full` seed
+profile always runs; it is NOT gated behind a per-service `SeedStepRef`.
+
+---
+
+## 3. Personas / logins a coach developer uses
+
+Coach runs **real iam auth** in the mesh (`AUTH_AUTHENABLED=true` on coach-api;
+`AUTH_JWKSURL`/`AUTH_ISSUER` point at local iam). `devLogin` resolves an email → user.
+All three identities derive from the shared `@saga-ed/iam-seed-ids` `DEMO_MEMBERSHIPS`
+catalog and are materialized by rostering `iam-db/prisma/seed.ts` — coach's projection
+byte-matches the live `iam.*` events (one seed universe, PR coach#223).
+
+| Persona (email) | userId | Persona / group | Seeded content? | Use it for |
+|---|---|---|---|---|
+| **demo-tutor-1@saga.org** | `1c939568-1464-5f9a-b5a4-0bc73a0454cb` | `personaTutorDemo`, Demo District `a0da8362-…`, carries `coach:access_coach_app` | **YES** — spring-pilot instance, Dashboard renders 59 modules | THE coach tutor. Scenarios (3) content-viewer & default dev. |
+| **demo-dadmin@saga.org** | `deriveUserId('demo-dadmin')` | `personaAdminDemo`, Demo District, carries `coach:access_coach_app` | Projection only — **no content_instance** | Scenario (4) admin/reports elevated UI. |
+| **demo-tutor-2@saga.org** | `033c9598-535b-5fd4-b722-19c32585410c` | `personaTutorDemo` (declared) | **NO** — `seed-users.ts` sets `rendersModules:false`; no instance seeded | second tutor — needed to make admin report non-trivial (currently absent). |
+
+- Canonical alias source: `apps/web/coach-web/e2e/data/seed-users.ts` (`tutor1`,
+  `tutor2`); `AUTHENTICATED_ALIASES = ['tutor1']` (only tutor1 gets a session today).
+- **Login via `ss`:** `ss stack login demo-tutor-1@saga.org` mints a native headless
+  `devLogin` cookie jar (`<stateDir>/cookies.txt`); `--browser` also opens an
+  auto-logged-in Chromium via the vendored `browser-login.mjs`
+  (`src/commands/stack/login.ts`). Default user is `dev@saga.org` — for coach you
+  MUST pass `demo-tutor-1@saga.org` or the Dashboard is empty.
+- **`AuthLoginHostOverride` / training-apex is NOT local dev.** coach PRs #229/#231
+  (`coach.saga-training.org`, `AuthLoginHostOverride`, `AuthIssuerOverride`) are for
+  DEPLOYED alternate-apex environments. The concierge login path is local
+  `devLogin`; training-apex is out of scope for `develop coach`.
+
+---
+
+## 4. What each scenario needs seeded to be NON-EMPTY
+
+### (3) Coach incl. the ported content viewer
+- **Surface:** the ported "ContentViewer" is now an **in-app route inside coach-web**,
+  not a separate app: `apps/web/coach-web/src/routes/units/[unitName]/[moduleId]/+page.svelte`
+  — the legacy "vscroll" module-playback shell — reached from Dashboard / Explore
+  (`src/routes/explore`). Rendering is gated by `areAllQuestionTypesPorted`; modules
+  with an un-ported task type never reach the route. Poll content comes from
+  `$lib/api/curriculum` `fetchPollContent`.
+- **Legacy origin:** the haxe ContentViewer lives behind
+  `https://my.sagaeducation.org/auth/content-viewer` (the `/auth/` path segment is
+  load-bearing for legacy cookie passthrough — see coach `claude/projects/sub-domain`).
+  It is NOT cloned locally; the modern experience is the coach-web `/units/…` port.
+  (A standalone `apps/content-viewer/` SvelteKit app appears only as a TARGET in
+  coach `claude/shared/sources/project-breakdown.md` — a plan/POC, not shipped.)
+- **Seeded?** The mongo curriculum (`coach-mongo`) + the PG `content_release`
+  (`curriculum-coach`, 27 polls) both seed, so the viewer renders. **BUT** the
+  Dashboard shows **spring-pilot** (59 modules) while Explore/the content-viewer
+  renders **synthetic curriculum-coach** (PR #228 verification note: *"Explore still
+  renders synthetic curriculum-coach"*). Which store serves depends on
+  `CONTENT_STORE_BACKEND`: unset (default in the mesh manifest) ⇒ **mongo** store
+  (coach-mongo curriculum); `=postgres` ⇒ the `content_release` fixture. The concierge
+  should decide/label which the developer gets and warn about the mismatch.
+
+### (4) Coach + the admin dashboard
+- **Surface EXISTS today:** `src/routes/reports/+page.svelte` (standalone) and
+  `src/routes/embed/reports/coach/+page.svelte` (iframe embed for the Haxe Saga
+  Dashboard). Client: `src/lib/api/reports.ts` → GraphQL `coachReport(content_name)`;
+  resolver `apps/node/coach-api/src/sectors/reports/gql/reports.resolver.ts` +
+  `reports.data.ts`.
+- **What it needs:** `getCoachReport(content_name)` = `getContentByName` →
+  `getAssignmentsByContentName` → distinct `user_id`s → their `content_instance`s.
+  It builds a **row per tutor** on that track. With only **demo-tutor-1** seeded on
+  spring-pilot, the report has ONE row. **Gap:** to demo the admin dashboard
+  meaningfully the concierge should seed **multiple tutor instances on the same
+  `content_name`** (e.g. demo-tutor-2, demo-dadmin) — today's fixtures don't.
+- The frontend passes the content/org name (default `'Direct Test Org'` /
+  `content_name`) — note the report is keyed by **content_name**, and the seed's
+  `group_track_map` maps the demo district → spring-pilot.
+
+### (5) Coach + the playlisting interface
+- **No shipped standalone playlisting UI.** "Playlist"/"Content Creator" appears only
+  in coach POC/plan docs (`claude/shared/sources/project-breakdown.md` "Content
+  Creator (C)", "apps/content-creator"). The closest shipped artifact is the coach-web
+  **authoring** e2e project: `pnpm test:e2e:authoring` (`E2E_AUTHORING=1`,
+  `apps/web/coach-web/e2e/authoring/`), which runs coach-api with
+  **`CONTENT_STORE_BACKEND=postgres`** against Postgres :5433 and exercises the poll
+  authoring→publish pipeline. Publishing uses `packages/node/coach-content-publish`
+  (archive → PG ContentReadStore). Treat scenario (5) as **in-flight / authoring
+  pipeline**, and flag to the builder that a first-class playlisting UI may not exist
+  to hand off yet.
+
+---
+
+## 5. Gaps a fresh developer hits today (what the concierge must automate)
+
+1. **soa#300 (OPEN, NOT fixed in this worktree's manifest) — coach-web can't
+   browser-auth local iam.** `src/core/manifest/services.ts`: coach-web `launch.env`
+   sets only `PUBLIC_COACH_API_URL` (no `PUBLIC_IAM_API_URL`), so post-coach#226 the
+   browser `auth.whoami` falls back to the checked-in `.env` default
+   `https://iam.wootdev.com` (remote) and a local cookie is invalid. AND iam-api
+   `CORS_ORIGIN` (services.ts L63) = `${DASH_URL},${CONNECT_WEB_URL}` — **no coach-web
+   origin**, so the whoami is CORS-blocked. **Fix the concierge needs:** add
+   `PUBLIC_IAM_API_URL: '${IAM_URL}'` to coach-web env + a `COACH_WEB_URL` token in
+   iam-api `CORS_ORIGIN`. Until this lands, `--with coach` gives a stack you can't log
+   into in a browser (the coach#228 workaround was a worktree env override +
+   `--disable-web-security` Chromium).
+2. **Seed steps are `failureMode: 'warn'`.** `coach-pg`/`coach-mongo` failing (coach
+   repo absent, unbuilt coach-db dist, mongo container name mismatch) does NOT fail the
+   stack — a dev gets a green `ss stack up` and an EMPTY coach and no signal. The
+   concierge should **hard-verify** coach seeded (e.g. assert `content_instance` count
+   > 0 for demo-tutor-1, or drive the Dashboard) before handing off.
+3. **coach-db must be built before seed.** `db:seed` runs the `dist` entry and needs
+   `pnpm build` to have copied the fixtures. Concierge should ensure the build.
+4. **Content mismatch (Dashboard spring-pilot 59 vs Explore/viewer curriculum-coach
+   27).** Confusing for a content-viewer developer. Concierge should either publish a
+   spring-pilot release or clearly document which curriculum each surface shows.
+5. **Admin report is sparse (1 tutor).** Seed more tutor instances on one track.
+6. **Login must target `demo-tutor-1@saga.org`.** The default `dev@saga.org` yields an
+   empty coach — the concierge must log in the coach persona, not the generic dev user.
+7. **Slots:** coach-web is a frontend; `ss` slots >0 are "backend sub-stack today"
+   (connect excluded pending port tokenization) — confirm coach-web behaves under
+   `--slot N` (the effort's prompt-1 pins slot 1) or run coach at slot 0.
+
+---
+
+## 6. Concrete commands (copy-paste)
+
+```bash
+# Build + link the ss CLI (from this worktree)
+cd /home/skelly/dev/soa/.claude/worktrees/gh305-ss-develop/packages/node/saga-stack-cli
+pnpm build && pnpm link --global          # `ss` on PATH; or run `node bin/dev.js …`
+
+# Bring coach up (api :6105, web :8800) + its deps, seeded
+ss stack up --with coach                  # add --slot 1 per the effort's slot pin
+ss stack seed --with coach                # (re)seed a running stack
+ss stack status --with coach              # health
+
+# Log in THE coach tutor (empty otherwise) — headless jar, or --browser for Chromium
+ss stack login demo-tutor-1@saga.org --browser
+#   admin/reports scenario:
+ss stack login demo-dadmin@saga.org --browser
+
+# Manual coach-db reseed (coach repo) — build first, mesh :5432 or local :5433
+cd /home/skelly/dev/coach/packages/node/coach-db && pnpm build
+DATABASE_URL=postgresql://coach_api_app:dev-password-coach-api-app@localhost:5432/coach_api \
+  pnpm --filter @saga-ed/coach-db db:seed
+
+# Authoring / playlisting pipeline (scenario 5, in-flight) — coach-web repo
+cd /home/skelly/dev/coach/apps/web/coach-web && pnpm test:e2e:authoring   # CONTENT_STORE_BACKEND=postgres
+```
+
+Coach dev URLs (slot 0): coach-web `http://localhost:8800`, coach-api
+`http://localhost:6105` (health at root `/health`, GraphQL under `/coach/v1/graphql`).
+
+---
+
+## 7. Key file pointers
+
+- `coach: packages/node/coach-db/src/seed/local-snapshot.ts` — the offline seeder.
+- `coach: packages/node/coach-db/src/seed/persona-projections.ts` — persona/group/track derivation from iam-seed-ids.
+- `coach: packages/node/coach-db/src/seed/fixtures/content-instances.json` — demo-tutor-1 spring-pilot instance (59 mod / 13 complete).
+- `coach: packages/node/coach-db/src/seed/fixtures/content-release.json` — curriculum-coach release (27 polls).
+- `coach: packages/node/coach-db/src/seed/README.md` — manual seed how-to.
+- `coach: packages/node/coach-db/src/cold-start/coach-bootstrap.ts` — iam-db cold-start (blocked, NOT local).
+- `coach: apps/web/coach-web/e2e/data/seed-users.ts` — persona alias catalog.
+- `coach: apps/web/coach-web/src/routes/units/[unitName]/[moduleId]/+page.svelte` — ported content-viewer (vscroll module playback).
+- `coach: apps/web/coach-web/src/routes/reports/ & src/routes/embed/reports/coach/` — admin dashboard surfaces.
+- `coach: apps/node/coach-api/src/sectors/reports/gql/reports.data.ts` — coachReport data path.
+- `coach: apps/node/coach-api/scripts/data/content_coach.json, content.json` — mongo curriculum fixtures.
+- `ss: src/core/seed/profiles.ts` (~L417 `coach-pg`, ~L437 `coach-mongo`) — how ss seeds coach.
+- `ss: src/core/bundles.ts` — `--with coach` bundle def.
+- `ss: src/core/manifest/services.ts` (coach-api ~L475, coach-web ~L515, iam CORS L63) — coach service wiring + the soa#300 auth gap.
+- `ss: src/commands/stack/login.ts` — persona devLogin.
+- `ss: src/commands/e2e/connect.ts` — the concierge to MIRROR for `develop coach`.
+- soa#300 (OPEN) — coach-web local iam wiring bug the concierge must fix.
+- coach PRs: #228 (spring-pilot parity seed), #235 (group_track_map seed), #223 (collapse onto iam-seed-ids demo-* users), #229/#231 (training-apex — deploy-side, out of scope).

--- a/claude/projects/gh_305/research/07-playlisting-current-state.md
+++ b/claude/projects/gh_305/research/07-playlisting-current-state.md
@@ -1,0 +1,295 @@
+# Research 07 — Playlisting current state (the CLI-driven coach-content-seeding pipeline)
+
+**Effort:** ss `develop` coach concierge (saga-ed/soa#305), input to "port playlisting into coach-api" plan
+**Task:** find + fully characterize CURRENT playlisting, wherever it lives.
+**Repos read:** `/home/skelly/dev/coach`, `/home/skelly/dev/saga-dash`, `/home/skelly/dev/rostering`, `/home/skelly/dev/program-hub`, `/home/skelly/dev/student-data-system`, `/home/skelly/dev/soa`
+**Date:** 2026-07-14
+
+---
+
+## Headline — the premise is inverted; the port is mostly ALREADY DONE
+
+The task framing was "PORT playlisting OUT of saga-dash INTO coach-api." Evidence
+contradicts the premise on both ends:
+
+1. **saga-dash has NO playlisting/content-seeding code.** Broad grep for
+   `playlist`, `playlist_name`, `available_playlists`, `group_track_map`,
+   `content_name`, `content_release`, `materializ`, `ContentInstance`,
+   `content-archive`, `user_policy` across saga-dash `apps/` + `packages/`
+   (non-test, non-worktree) returns **two false positives only**:
+   `apps/web/dash/playwright.stack.config.ts:205` ("occurrence roster is
+   materialized") and `packages/web/pages/program-config/src/onboarding/podbuilder-helpers.ts:672`
+   (calendar-event "materialized"). `git -C saga-dash log --all --oneline | grep -i playlist`
+   is **empty**. saga-dash does not seed coach content and never did.
+
+2. **The CLI-driven content-seeding pipeline ALREADY lives in the coach repo**
+   (`/home/skelly/dev/coach`), writing to coach's own Postgres (`coach_api`).
+   It is `@saga-ed/coach-content-publish` (binary **`coach-content`**) +
+   `@saga-ed/coach-db` seed + the coach-api **reconcile** runtime materializer.
+
+3. **What historically WAS separate playlisting lived in the LEGACY `saga_api`
+   monolith, not saga-dash** — the `user_policy` GraphQL resolver
+   (`playlist_name` / `available_playlists` / `playlist_version` /
+   `default_track_content`) and a `content_track_collections_coach` table keyed
+   by `org_name`. coach-api has **already replaced** that with its own
+   `group_track_map` table (schema comment on `GroupTrackMap`:
+   *"Replaces the dead saga_api path (`content_track_collections_coach` keyed by
+   `org_name` + policy `default_track_content`)"*). `saga_api` is not checked out
+   under `~/dev` — treat its internals as documented-but-unverified-locally.
+
+So "make coach-api a one-stop shop for coach content seeding" is **already the
+state of the tree** for the publish→materialize path. The only residual
+saga_api/rostering coupling is the *playlist-selection policy* on `user_policy`,
+and even that is superseded by `group_track_map` for the two-store path. See
+"What is actually left to move" at the end.
+
+> Cross-check: this extends, and does not contradict, `research/03-coach-admin-and-playlisting.md`
+> (which already found "playlisting has no dedicated UI; the coach repo owns the
+> authoring→publish→materialize CLI"). This doc adds the exact data model, the
+> saga_api legacy seam, and the concrete "what's left."
+
+---
+
+## 1. What IS "playlisting" (precise domain definition)
+
+In Coach's domain, **a "playlist" == a "track" == a `content_name`** — a named,
+published, coherent set of curriculum units/modules a tutor works through.
+Evidence:
+
+- `apps/web/coach-web/src/lib/types/coach.ts:49-51` — `PlaylistData` = "Content
+  playlist containing units and progress" (the tutor's assembled track).
+- `saga-ed/saga-dash#463` (title): *"Coach playlists: tag-based content + user
+  attributes instead of maintaining 4 playlists (MS/HS × online/in-person)"* —
+  i.e. historically **4 hand-maintained playlists** keyed by grade-band × modality.
+  (This issue is filed in saga-dash the *tracker*, but it is a coach-content
+  concern; no saga-dash *code* implements it.)
+- Legacy selection fields on `user_policy` (saga_api):
+  `playlist_name` (String!, the active playlist), `available_playlists`
+  ([String!], selectable), `playlist_version`, `default_track_content`,
+  `default_track` — documented in
+  `coach/review_reports/coach-api/cross-api-plan.md:97-101,216-220,385-387`.
+
+**The problem it solves:** deciding *which* curriculum a given tutor is served
+(by grade band / modality / district), and *seeding* that curriculum's content
+so the coach dashboard/player has something to render. Two separable halves:
+- **(a) Content authoring→publish** — turn a content-archive into servable
+  release rows. (CLI; coach-owned.)
+- **(b) Assignment/selection** — map a tutor (via their district/section group)
+  to a track, and **materialize** a per-user content instance. (Runtime
+  event-reconcile + a dev CLI; coach-owned. Legacy equivalent was saga_api
+  `user_policy` + `content_track_collections_coach`.)
+
+There is **no playlisting web UI** anywhere (confirmed doc 03): no `/playlist`
+route in coach-web; `/explore` is the tutor's own within-instance module browser.
+
+---
+
+## 2. Where the CLI is TODAY (exact repo / path / command)
+
+**Package:** `@saga-ed/coach-content-publish`
+**Location:** `/home/skelly/dev/coach/packages/node/coach-content-publish/`
+**Binary:** `coach-content` — entry `src/cli.ts` (`#!/usr/bin/env node`)
+**Target DB:** `DATABASE_URL` → coach's `coach_api` Postgres (via `@saga-ed/coach-db` `getPrisma()`).
+
+### Commands (`src/cli.ts` USAGE)
+```
+coach-content status
+coach-content diff     --archive <path> [--ref <sha>] [--structure-overlay <dir>]
+coach-content publish  --archive <path> --ref <sha> [--approve] [--note <s>]
+                       [--structure-overlay <dir>] [--allow-large-delete] [--allow-missing-content]
+coach-content rollback --to <releaseId> --approve
+coach-content materialize --user <id> --content <name> [--replace | --delete]
+```
+Exit codes: `0` ok/no drift · `1` error · `2` drift pending approval.
+
+### Inputs
+- **Source content:** the `saga-ed/content-archive` GitHub repo (the durable
+  source of truth), layout (`archive.ts` header):
+  - `curriculum/content_coach/<name>.json` — curriculum STRUCTURE docs (extended JSON)
+  - `exports/<teacher_id>/polls/<mongo_id>/poll.json` — authored polls (leaf content)
+  Acquired either from a git checkout (`--ref <sha>` → `git archive | tar -x`) or a
+  CodeArtifact-extracted npm tarball detected by a `_meta.json` `{sha, ref}` at root.
+- `--structure-overlay <dir>` — optional local overlay of structure docs.
+- `materialize` inputs: `--user <id>` `--content <name>` `[--replace|--delete]`.
+
+### Outputs (what it writes, in coach_api Postgres — `src/store.ts`)
+- **`publish`** → inserts a `content_release` (+ `content_release_curriculum`,
+  `content_release_poll` children) and **atomically upserts the
+  `active_content_release` singleton** pointer — one interactive tx (timeout
+  lifted to 120s because the real path tunnels ~7 MB over SSM; see store.ts
+  comment). Idempotent by `content_hash` (a payload equal to active = no-op).
+- **`rollback`** → repoints `active_content_release` at a prior release id.
+- **`materialize`** → inserts a `content_instance` (+ `content_instance_module`
+  children) for `(userId, contentName)` from the **active** release's curriculum
+  doc, deriving the nav via `deriveTemplates` (shared with coach-api). Guarded:
+  requires the doc to carry a **top-level `nav`** (the instance shape) — the
+  served subject doc keys nav per-unit and is *not* materializable. `--replace`
+  deletes first; `--delete` is the e2e-teardown counterpart. This is a
+  **dev/e2e helper** that mirrors coach-api's runtime materializer.
+
+### How it's invoked (CI, real publishes)
+`/home/skelly/dev/coach/.github/workflows/publish-content.yml` (`workflow_dispatch`):
+inputs `archive-version`, `approve` (default false = dry-run `diff`), `note`.
+Runs `coach-content` **directly on a hosted runner** (no ECS task), reaching the
+dev Postgres through an **SSM port-forward tunnel** via the shared jump host
+(same pattern as `postgres_mirror_to_dev.yml` in `saga-ed/iac`). Uses the
+`coach_api_app` (DML-only) role. `content-archive` is installed as a CodeArtifact
+package (`npm pack` + tar extract). `concurrency: publish-content-dev` (one at a time).
+Design writeup: `coach/claude/coach-content-publish-workflow-scope.md`.
+
+### How content gets seeded LOCALLY (the ss stack path — this is the "seeding")
+The dev stack does **not** run `coach-content publish`; it runs the coach-db
+seed, which bakes a fixture release + instance + the projections directly:
+- ss step `coach-pg` (`soa/packages/node/saga-stack-cli/src/core/seed/profiles.ts:416-425`):
+  `cwd packages/node/coach-db`, `command pnpm db:seed`, `DATABASE_URL` forced to
+  mesh :5432 `coach_api`. Comment: *"coach's WHOLE seed (Postgres) — coach-db
+  db:seed (local-snapshot): content_instance + the THREE iam→coach projections
+  (persona_definition, persona_assignment, group_track_map) + the content_release
+  the curriculum read path serves from."* Single-store now (no mongo companion).
+- Seed impl: `coach/packages/node/coach-db/src/seed/local-snapshot.ts` +
+  `persona-projections.ts`. Idempotent. Bakes: one `content_release`
+  (`curriculum-coach`, units `unit_1..4`) + active pointer; one materialized
+  `content_instance` for `demo-tutor-1@saga.org` on track **`spring-pilot`**; the
+  three projections; a `group_track_map` row pointing the **demo district**
+  (`a0da8362-1a93-5d1d-aeaa-b6d8960e9821`) at the tutor's own track (derived from
+  the instance so map/instance can't drift — `local-snapshot.ts:158-171`).
+
+---
+
+## 3. Data model + the seam to what the viewer reads
+
+The coach viewer/dashboard reads `content_instance` rows (per-user materialized
+nav). Those rows are produced two ways — both coach-owned:
+
+```
+                        saga-ed/content-archive (GitHub, source of truth)
+                                     │  coach-content publish --approve
+                                     ▼
+  content_release ── content_release_curriculum (structure docs, keyed by name==content_name)
+     │  └────────── content_release_poll (leaf poll render payload)
+     │
+  active_content_release (singleton pointer, id='active')  ◄── the atomic cutover
+     │
+     │  ┌─ coach-content materialize --user --content   (CLI, dev/e2e)
+     ▼  ▼
+  content_instance  (UNIQUE(user_id, content_name); + content_instance_module,
+     ▲                content_instance_completed_module, module_answer)
+     │
+     └─ coach-api RUNTIME reconcile (the real prod path):
+        apps/node/coach-api/src/sectors/cns/events/iam-projection-handlers.ts
+        + instance-materializer.ts (materializeInstance, same deriveTemplates)
+```
+
+### The assignment seam (group → track → instance)
+coach-api consumes `iam.persona_assignment.{added,removed}` +
+`iam.persona_definition.upserted` off the shared `iam.events` RabbitMQ exchange
+and projects them into Postgres (`persona_assignment`, `persona_definition`).
+`reconcile(personaId)` (in `iam-projection-handlers.ts`) then:
+1. Recognizes a coach tutor by the permission **`coach:access_coach_app`** in
+   `persona_definition` (never a personaId or role name).
+2. For each active **district- or section-scoped** assignment
+   (`MATERIALIZED_GROUP_KINDS = ['district','section']`, Phase 2a):
+   looks up **`group_track_map.content_name` by `group_id`** → the track; unmapped
+   group falls back to `DEFAULT_CONTENT_NAME = 'base-coach'`.
+3. `materializeInstance(tx, user_id, content)` → `INSERT … ON CONFLICT
+   (user_id, content_name) DO NOTHING` (idempotent, create-if-missing only).
+
+Read side: `PostgresAssignmentStore` (`apps/node/coach-api/src/sectors/cns/assignments/`)
+joins `persona_assignment` → `group_track_map` **on `group_id` alone** (not
+`group_kind`); `fetchDashboardFromAssignments` (coach-web `src/lib/api/cns.ts`)
+flattens every matched instance's modules into one `allModules[]`. **Caveat
+(pre-existing):** an *unmapped* group's fallback (`base-coach`) instance has no
+`group_track_map` row → no assignment join row → the instance materializes but is
+**invisible** to the dashboard read path.
+
+### Key tables (coach-db `src/prisma/schema.prisma`)
+| model | table | role |
+|---|---|---|
+| `ContentRelease` (:203) | `content_release` | immutable published snapshot; `archive_sha`, `content_hash` |
+| `ContentReleaseCurriculum` (:226) | `content_release_curriculum` | structure doc, `@@id([releaseId,name])`; `name` == `content_name` |
+| `ContentReleasePoll` (:243) | `content_release_poll` | leaf poll render payload (`pollId`==module content_id) |
+| `ActiveContentRelease` (:266) | `active_content_release` | singleton pointer `id='active'`; **flipping it IS the publish** |
+| `ContentInstance` (:29) | `content_instance` | per-user materialized track; **`@@unique([userId, contentName])`** |
+| `ContentInstanceModule` (:65) | `content_instance_module` | mutable nav graph rows (state/holds/unlocks) |
+| `GroupTrackMap` (:293) | `group_track_map` | **group_id → content_name** (the assignment routing table) |
+| `PersonaDefinition` (:155) | `persona_definition` | personaId → permission names (coach-relevance signal) |
+| `PersonaAssignment` (:171) | `persona_assignment` | iam assignment interval (validFrom/validUntil, groupKind) |
+
+Provenance: `ContentInstance` materialization at section grain = coach PRs
+**#448 / #463 Phase 2a** (commit `273eb53` "materialize ContentInstances at
+section grain"). `group_track_map` = the ratified domain-boundary exception
+(**coach#91, commit 95417fd**). `coach-content materialize --delete` = commits
+`36d68c7` / `8573e69`. `group_track_map` baked into seed = `1b54e46`.
+Materialize-on-iam-events = `beb7fcf` (Phase 1 step 4b).
+
+---
+
+## 4. Dependencies
+
+- **Databases:** ONLY coach's `coach_api` Postgres. (Single-store now — the
+  former `coach-mongo` curriculum store is dead; profiles.ts comment.) The CLI's
+  `DATABASE_URL` selects it; local mesh :5432, coach-db standalone default :5433.
+  Roles: `coach_api_app` (DML) for publish; `coach-db db:push` applies schema.
+- **External source input:** `saga-ed/content-archive` (GitHub repo /
+  CodeArtifact package) — curriculum structure docs + authored polls. Written
+  upstream by content-archive's own `publish-content-archive.yml` +
+  records-pusher Lambda (manifest gate applied there, so archive main is
+  delete-safe).
+- **iam / rostering (event producer):** the assignment path depends on the
+  `iam.events` exchange (`iam.persona_assignment.*`, `iam.persona_definition.upserted`)
+  emitted by rostering's iam-api; ids derive from `@saga-ed/iam-seed-ids`
+  (`demo-*` cohort) which iam-db's `prisma/seed.ts` also emits. Cold-start
+  bootstrap of `persona_definition` from `iam-api personas.list` (a brand-new
+  queue has no history).
+- **Infra (real publishes):** SSM port-forward tunnel + shared jump host (iac),
+  CodeArtifact. GitHub Actions `workflow_dispatch`.
+- **saga-dash-specific coupling that makes it "live in saga-dash":** NONE FOUND.
+  The only cross-repo selection coupling is to the **legacy `saga_api` monolith**
+  `user_policy` resolver (`playlist_name`/`available_playlists`), which coach-api's
+  cross-api MVP calls (`cross-api-plan.md`) and which `group_track_map` supersedes
+  for the two-store path — not saga-dash.
+
+---
+
+## 5. What would ACTUALLY have to move to make coach-api own it end-to-end
+
+Because publish + materialize + reconcile + seed already live in coach, the
+"port" is mostly **already complete**. Residual items (all coach-repo-internal
+or legacy-monolith, NOT saga-dash):
+
+1. **Retire the `user_policy` selection dependency (legacy saga_api).** coach-api
+   still has a cross-api MVP that reads `user_policy(playlist_name,
+   available_playlists)` from saga_api (`cross-api-plan.md` Stage 1). To be fully
+   self-owned, playlist *selection* must resolve entirely from `group_track_map`
+   (+ future Phase 2b tag-filter), removing the saga_api round-trip. This is the
+   one genuine "move it into coach-api" item, and it is *the legacy monolith*, not
+   saga-dash.
+2. **Second track + switchable mapping for a `develop --playlist` scenario.** The
+   committed seed has only ONE track (`spring-pilot`). A develop-playlist surface
+   needs ≥2 published `content_name`s and a `group_track_map` (or policy) toggle
+   so a persona resolves to a chosen playlist, then `materialize` + `devLogin`.
+   (This is *seed/dev-tooling* work, not a port.)
+3. **(Optional) A `coach-content publish` step in ss** if the develop flow should
+   exercise the archive→release path rather than the baked-fixture seed. Today ss
+   seeds the release directly via `coach-db db:seed` (no `publish` run locally).
+4. **Nothing to move out of saga-dash** — there is nothing there.
+
+---
+
+## Top open questions / unconfirmed
+
+1. **Is the task premise a factual error, or is there a *different* "playlisting"
+   the requester means?** Confirmed absent from saga-dash. Strongest candidate
+   for "the thing in saga-dash" is actually the **legacy `saga_api` monolith**
+   `user_policy`/`content_track_collections_coach` — needs confirmation that the
+   requester conflates saga_api with saga-dash. `saga_api` is **not checked out
+   locally** (`~/dev`), so its internals are documented-only (cross-api-plan.md,
+   GroupTrackMap schema comment) and **unverified here**.
+2. **saga-dash#463 "tag-based content" (Phase 2b)** — the 4-hand-maintained-
+   playlists → tag-filter replacement is filed in the saga-dash tracker but is a
+   coach-content-publish job. Is any of it implemented? (Not found; reconcile
+   still does a direct `group_track_map` lookup, no tag filter.)
+3. **Does "port into coach-api" mean "add a develop/seed concierge in ss"** rather
+   than moving code? Given the pipeline already lives in coach, the actionable
+   deliverable for #305 is likely a `develop coach --playlist` scenario over the
+   existing coach-content/coach-db seed, per doc 03/05 — not a code migration.

--- a/claude/projects/gh_305/research/08-playlisting-port-github-evidence.md
+++ b/claude/projects/gh_305/research/08-playlisting-port-github-evidence.md
@@ -1,0 +1,263 @@
+# 08 — Playlisting port to coach-api: independent GitHub/repo evidence
+
+**Author:** research agent (parallel to direct ask of Seth Paul)
+**Date compiled:** 2026-07-14
+**Scope:** Is "playlisting" (CLI-driven coach content seeding) being ported out of the
+legacy stack into `coach-api`? What already exists, what's in flight, and Seth's
+trajectory.
+
+**Lead engineer:** Seth Paul (github `SethPaul`, sethcpaul@gmail.com). Every commit
+cited below is authored by Seth — coach-api's content pipeline is effectively a
+single-owner effort right now.
+
+---
+
+## TL;DR
+
+**The "playlisting port" is not a future project — it is ~80% built and actively
+shipping in `saga-ed/coach`, all by Seth.** "Playlist" is legacy nimbee/saga_api
+terminology; in coach-api the same concept is modeled as **tracks** (`content_name`) +
+**group→track mapping** (`group_track_map`) + a **content-publish CLI**
+(`coach-content`). If gh_305 proposes to build playlisting seeding into coach, it would
+be **joining an effort already underway**, not building net-new. The remaining open work
+is the tag/attribute-matching idea from saga-dash #463 (Phase 2b, PR **#237 OPEN**).
+
+---
+
+## 1. Terminology reconciliation (why saga-dash has zero "playlist" hits)
+
+`grep -ril playlist` across the **saga-dash** working copy and its history returns
+**nothing**. "Playlist" is **not** a saga-dash concept. It is a legacy **nimbee /
+saga_api** concept that lives in the **user_policy / rostering** layer:
+
+- `gh search code --owner saga-ed playlist` surfaces the canonical definitions in
+  **rostering**:
+  - `rostering:claude/permission_policy_registry.md` — `coach_playlist_name`
+    (`policy.coach.playlist_name`, "Primary Coach playlist for content resolution",
+    consumers: **nimbee, coach**) and `coach_available_playlists`
+    (`policy.coach.available_playlists`).
+  - `rostering:claude/default_user_persona.md` — `coach.playlist_name` →
+    `coach:coach_playlist_name`.
+- coach-api's own planning doc names the legacy fields explicitly:
+  `coach:review_reports/coach-api/cross-api-plan.md` lists the legacy `user_policy`
+  shape — `playlist_name` (String! active playlist), `available_playlists` ([String!]),
+  `playlist_version`, `default_track`, `default_track_content`.
+
+**Mapping (legacy → coach-api):**
+
+| Legacy (nimbee/saga_api `user_policy`) | coach-api reconstruction |
+|---|---|
+| `playlist_name` / active playlist | `content_name` (a **track**), keyed on `content_instance(user_id, content_name)` |
+| group/district → which playlist | **`group_track_map`** table (`group_id → content_name`) |
+| `DEFAULT_TRACK_NAME` fallback | `DEFAULT_CONTENT_NAME = 'base-coach'` (code comment: "mirrors legacy DEFAULT_TRACK_NAME") |
+| playlist authoring/seeding | **`coach-content` CLI** (`@saga-ed/coach-content-publish`) |
+| tag/attribute matching (aspirational, #463) | `tagFilter` + `filterContentByTags` (Phase 2b, in flight) |
+
+So "port playlisting into coach-api" == "coach-api owns tracks + group_track_map +
+content-publish + tag filtering." That is exactly what Seth has been building.
+
+---
+
+## 2. What ALREADY EXISTS in coach (merged / on main)
+
+### 2a. The content-publish CLI — the seeding pipeline itself
+`packages/node/coach-content-publish` — **`@saga-ed/coach-content-publish`**, bin
+**`coach-content`**. Description: *"publish authored content from
+saga-ed/content-archive into Coach's Postgres as immutable snapshot releases."*
+
+Commands (from its README / `src/cli.ts`):
+```
+coach-content status
+coach-content diff       --archive <checkout> [--ref <sha>] [--structure-overlay <dir>]
+coach-content publish    --archive <checkout> --ref <sha> [--approve] [--note] ...
+coach-content rollback   --to <releaseId> --approve
+coach-content materialize --user <id> --content <name> [--replace|--delete]
+```
+This IS CLI-driven content seeding (no UI), matching the team's description of
+playlisting. Pipeline: producer authors → export → S3 → records-pusher Lambda →
+`content-archive` main → `coach-content publish --ref <sha> --approve` (the human gate) →
+Postgres release rows + atomic `active_content_release` pointer flip → coach-api serves
+live, no deploy. `materialize` shares `deriveTemplates` with coach-api's reconcile
+materializer (verified in `src/store.ts:13,205-211`) so CLI seeding and event-driven
+materialization cannot drift.
+
+Relevant merged PRs building this:
+- **coach #202** (MERGED 2026-07-09) "Content release snapshot: carry poll
+  questions/tag_list through publish to Postgres"
+- **coach #206** (MERGED 2026-07-09) "replace content_assignments Mongo collection with
+  AssignmentStore"
+- **coach #207** (MERGED 2026-07-09) "flip CONTENT_STORE_BACKEND default to postgres
+  (Phase 1/4)"
+- **coach #209** (MERGED 2026-07-10) "scope a content-publish workflow for coach#181 leg
+  1" (docs/CI for `publish-content.yml`)
+- **coach #234** (MERGED 2026-07-13) "lift $transaction timeout so full-archive publish
+  survives the SSM tunnel" — fixes full 643-poll archive publish over the SSM tunnel.
+
+### 2b. Track resolution — group_track_map + reconcile materializer
+- `packages/node/coach-db/src/prisma/schema.prisma` — model **`GroupTrackMap`**
+  (`group_id → group_kind → content_name`), plus `ContentInstance`,
+  `ContentInstanceModule`, `ContentInstanceCompletedModule`, `ContentRelease`,
+  `ContentReleaseCurriculum`, `ContentReleasePoll`, `PersonaDefinition`,
+  `PersonaAssignment`.
+- `apps/node/coach-api/src/sectors/cns/events/iam-projection-handlers.ts` — the
+  **reconcile** path: joins `persona_assignment` → `group_track_map` on `group_id`,
+  materializes a `content_instance` for the tutor's resolved track; falls back to
+  `DEFAULT_CONTENT_NAME='base-coach'` for unmapped groups (explicitly "mirrors legacy
+  DEFAULT_TRACK_NAME").
+- `apps/node/coach-api/src/sectors/cns/events/instance-materializer.ts` — the
+  materializer.
+- **coach #235** (MERGED 2026-07-13) "bake group_track_map into the local seed" — seeds
+  the demo district's `group_track_map` row (contentName derived from the tutor's own
+  `content_instance`, not hand-authored, so map and instance can't drift).
+
+### 2c. Multi-track / section-grain (the #448/#463 Phase 2a work) — MERGED
+- **coach #230** (MERGED 2026-07-13) "cross-track completion read overlay (#448)" —
+  completed modules shared across tracks stay complete when a user switches tracks.
+- **coach #232** (MERGED 2026-07-13) "materialize ContentInstances at section grain
+  (#448/#463 Phase 2a)" — reconcile now materializes both `district` and `section`
+  grains.
+
+---
+
+## 3. IN-FLIGHT: Phase 2b — the tag/attribute-matching idea (the open playlisting frontier)
+
+**coach PR #237 — OPEN (created 2026-07-14), branch
+`worktree-coach-448-463-phase2b-content-tags`, author SethPaul.**
+Title: *"feat(coach-api): content tag-filter narrowing + grain-rank resolution (#463
+Phase 2b)."*
+
+This is the direct implementation of **saga-dash #463** — "tag all content
+(`required`/`optional`/`MS`/`HS`/`online`/`in-person`), give users attributes, resolve
+the intersection instead of maintaining 4 hand-built playlists." From the PR body:
+- **`filterContentByTags`** (new in `@saga-ed/coach-db`): pure pre-pass narrowing
+  `nav`/`units` to tag-filter survivors, applied before shared `deriveTemplates`
+  (keeps the coach-content CLI's unfiltered publish path untouched). Rules: empty
+  filter = no narrowing; untagged module always survives (opt-in narrowing); a tagged
+  module survives only if it carries **every** tag in the filter (AND-semantics).
+- **Grain-rank resolution**: when a district and a section assignment collide on the
+  same `content_name`, the section's `tagFilter` wins (flat rank, no org-hierarchy
+  walk).
+- **Update path**: an already-materialized instance converges its module rows to the
+  current filter on next reconcile — a `tagFilter` change propagates with **no deploy**;
+  `completed_module` rows are never touched.
+- Test plan: 29 Postgres integration tests + 9 unit tests + full coach-api suite (317
+  passing).
+
+Precursor checkpoint commits already on branch/merged:
+- `4c4f967` "feat(coach-db): schema for content tags (#463 Phase 2b, checkpoint)"
+- `5ac5661` "feat(coach-api): tag-filter application + grain-rank resolution (#463 Phase
+  2b)"
+
+**Also open:** coach #233 (DRAFT) — a docs-only rds-gate runbook fix, unrelated.
+
+### Driving issues (both in **saga-dash**, both OPEN, opened by product 2026-07-10)
+- **saga-dash #448** (OPEN) — "Test: Coach module progress retained when switching Coach
+  tracks" (requested by Tom Fischaber). Drives the cross-track completion overlay
+  (coach #230).
+- **saga-dash #463** (OPEN) — "Coach playlists: tag-based content + user attributes
+  instead of maintaining 4 playlists (MS/HS × online/in-person)." Explicitly frames it
+  as a **discussion kickoff, not a final design** — yet Seth has already shipped Phase
+  2a and opened Phase 2b against it. He is **ahead of** the product conversation.
+
+---
+
+## 4. Seth's trajectory (from git history)
+
+Reading `git log --author=Seth` on coach, the arc is a deliberate, multi-phase
+re-platforming of coach content off the legacy shared Mongo onto coach-owned Postgres:
+
+1. **Retire legacy dependencies** — abandon saga_api `session.context` S2S (coach #226),
+   require iam-api auth + retire saga_api (coach #208), read identity direct from iam
+   whoami.
+2. **Two-store split** (planning: `claude/coach-content-two-store-plan.md`, DRAFT
+   2026-06-17, authored by Seth "infra-platform lead"): read-only authored content vs.
+   per-user mutable progress. Progress-store → Postgres first (Phase 1), content
+   ingestion second (Phase 2).
+3. **Content publish pipeline** (Phase 2): the `coach-content` CLI + immutable releases
+   + atomic pointer flip (coach #202/#206/#207/#209/#234) — GitHub `content-archive`
+   becomes the durable source of truth.
+4. **Track resolution + multi-track** (Phase 2a): group_track_map, reconcile
+   materializer, section grain, cross-track completion (coach #230/#232/#235).
+5. **Tag/attribute matching** (Phase 2b, IN FLIGHT): coach #237 — the #463 vision.
+
+A playlisting seeding effort fits this roadmap **exactly** — it is literally the current
+head of it. There is no separate, competing port; this is the port.
+
+The two-store plan also pins the data reality: current-year coach content lives in prod
+Mongo `saga_blank` (`content_coach` = 8 structure docs — `base-coach`, `original-coach`,
+`partners-coach`, `qtf-coach`, `preservice-coach`, `curriculum-coach`, `spring-pilot`,
+`new-mexico-coach` — referencing 112 module `content_id`s). The archive is the richer
+source; the 8 structure docs are the one gap being version-controlled directly.
+
+---
+
+## 5. Planning / doc artifacts in coach mentioning playlisting/tracks/content-ownership
+
+- `claude/coach-content-two-store-plan.md` — the master strategy doc (Seth, DRAFT
+  2026-06-17).
+- `review_reports/coach-api/cross-api-plan.md` — enumerates the legacy `user_policy`
+  playlist fields coach-api must own (`playlist_name`, `available_playlists`,
+  `playlist_version`, `default_track`, `default_track_content`); "Coach-owned session"
+  goal.
+- `claude/coach-content-publish-workflow-scope.md` — the publish workflow scope (coach
+  #209).
+- `claude/coach-postgres-deploy-handoff.md`, `claude/coach-cold-start-runbook.md`,
+  `claude/coach-rds-gate-runbook.md` — operational runbooks for the Postgres content
+  store.
+- `packages/node/coach-content-publish/README.md` — the CLI contract.
+- `apps/web/coach-web/src/lib/types/coach.ts` — frontend `PlaylistData` interface
+  ("Content playlist containing units and progress") — the one place coach *frontend*
+  still uses the word "playlist" for the served track.
+
+Legacy/dropped elsewhere (not coach): commons
+`epic/flamingos/sprint-2/transition_2026_05_07.applied.md` shows *"fixture-cli: add coach
+playlist support to named fixture profiles"* was **[drop]** (nimbee#8283, dropped) — i.e.
+the old fixture-cli playlist-seeding path was abandoned in favor of the coach-owned
+pipeline. student-data-system `sds_67` and rostering runbooks reference seeding a
+"partners-coach playlist" via the legacy bootstrap — the world coach-api is replacing.
+
+---
+
+## 6. Answers to the four questions
+
+1. **Existing coach code doing part of playlisting?** Yes, substantially. The
+   `@saga-ed/coach-content-publish` CLI (`coach-content` — status/diff/publish/rollback/
+   materialize) is the content-seeding pipeline; `group_track_map` + reconcile
+   materializer + `content_instance` model is the track-resolution ("which playlist")
+   layer; both merged to main. What's still "only legacy" is the **saga_api/nimbee
+   `user_policy` playlist fields** (`playlist_name`, `available_playlists`) that coach-api
+   plans to serve from its own session endpoint (cross-api-plan) but hasn't fully cut
+   over — and the 8 real `content_coach` structure docs, being version-controlled into
+   the archive.
+
+2. **In-flight PR/branch/issue porting/reimplementing playlisting?** Yes — **coach PR
+   #237 (OPEN, 2026-07-14)**, branch `worktree-coach-448-463-phase2b-content-tags`,
+   author SethPaul: content tag-filter narrowing + grain-rank resolution, implementing
+   saga-dash **#463**. Merged precursors: #230, #232, #235 (2026-07-13); #202/#206/#207/
+   #209/#234 (2026-07-09→13). Driving issues saga-dash #448 and #463 (both OPEN,
+   2026-07-10).
+
+3. **Seth's trajectory / roadmap fit?** A clean multi-phase re-platforming of coach
+   content onto coach-owned Postgres (two-store plan → publish CLI → track resolution →
+   section grain → tag matching). A playlisting seeding effort is the **current head of
+   this roadmap**, not adjacent to it. The #448/#463 section-grain / cross-track / tag
+   work is exactly the frontier.
+
+4. **Docs/planning artifacts?** Yes — see §5: `coach-content-two-store-plan.md`,
+   `cross-api-plan.md`, `coach-content-publish-workflow-scope.md`, the publish CLI
+   README, plus operational runbooks. They collectively describe coach owning content
+   end-to-end.
+
+---
+
+## 7. Bottom line for gh_305
+
+**We would be joining an effort already underway, not building net-new.** Seth has
+already ported the CLI-driven content-seeding pipeline (`coach-content`) and the
+track-resolution model into coach-api, and is actively landing the tag/attribute-matching
+layer (PR #237, open today). Any gh_305 concierge/seeding step for coach content should
+**build on `@saga-ed/coach-content-publish` and `group_track_map`**, coordinate with Seth
+on the open #463 Phase 2b, and treat saga-dash #448/#463 as the live driving issues.
+Confirm with Seth whether the legacy `user_policy` playlist-field cutover (cross-api-plan
+§ session endpoint) is in scope or deferred — that's the one piece still straddling the
+legacy stack.

--- a/claude/projects/gh_305/research/09-coach-api-port-target.md
+++ b/claude/projects/gh_305/research/09-coach-api-port-target.md
@@ -1,0 +1,269 @@
+# Research 09 — coach-api as the target landing zone for a ported "playlisting" CLI
+
+**Effort:** ss `develop` coach concierge (saga-ed/soa#305)
+**Question:** Where does a port of saga-dash "playlisting" LAND in the coach repo so
+coach owns its content pipeline end-to-end — kept CLI-driven, no UI? What is reuse
+vs new, where does the input come from, and how does it unblock `ss develop coach`?
+**Repos read:** `/home/skelly/dev/coach` (coach-api, coach-content-publish, coach-db),
+`/home/skelly/dev/rostering` (iam-db registry/seed), `/home/skelly/dev/saga-dash`.
+**Date:** 2026-07-14
+
+---
+
+## Headline
+
+The port is **reuse-heavy**. Coach already owns the entire *content* half of
+playlisting — authoring→publish→release rows→materialize→instance — as a mature,
+CLI-driven pipeline (`coach-content`). What coach does **not** yet own is the
+*playlist-assignment* half: the decision "which group/tutor gets which track" and
+"what content composes a track." Today that decision is an **iam policy value**
+(`coach:coach_playlist_name`) sourced from legacy `saga_api`'s `user_policy`, and it
+reaches coach only as a **hand-seeded `group_track_map` row** — there is **no
+production write-path in coach that turns a playlist assignment into a
+`group_track_map` row** (VERIFIED GAP, see §2/§3). The port's real new surface is a
+thin CLI that writes `group_track_map` (assignment) and, optionally, composes a
+track by tag-filter (definition, = coach's deferred Phase 2b).
+
+**The landing zone is the existing `@saga-ed/coach-content-publish` package** — add a
+`playlist` subcommand group to its `coach-content` CLI. That is the exact harness,
+DB-access pattern, and idempotency model a ported playlisting CLI needs, already
+built. No oclif, no new bin scaffolding.
+
+> **Naming caveat for the orchestrator:** the task says playlisting is "currently in
+> saga-dash." The local `saga-dash` checkout has **zero** playlist code
+> (`grep -rli playlist` over `saga-dash/{apps,packages}` → empty). Playlisting lives
+> in **legacy `saga_api`** (the nimbee/PHP monolith) and survives in the fleet only as
+> the iam policy `coach:coach_playlist_name` (rostering `iam-db/src/registry.ts:159`,
+> default `'coach'`; seeded `'base-coach'` for the district tutor). Treat "port
+> playlisting" as "port the legacy `saga_api` playlist-resolution concept," not "move
+> a saga-dash module."
+
+---
+
+## 1. Where a playlisting CLI physically lives + what runs it
+
+### The harness (concrete)
+Coach has **no oclif / no CLI framework and no `bin/` dir in coach-api**. One-off jobs
+run one of two ways, both delegating from a `coach-api` `package.json` script to a
+workspace package:
+
+- `coach-api` `package.json:scripts` → `db:deploy` = `pnpm --filter @saga-ed/coach-db db:deploy`;
+  `db:seed:run` = `pnpm --filter @saga-ed/coach-db db:seed`
+  (`/home/skelly/dev/coach/apps/node/coach-api/package.json`).
+- **The canonical CLI precedent to copy** is `@saga-ed/coach-content-publish`
+  (`/home/skelly/dev/coach/packages/node/coach-content-publish`): a workspace package
+  with `"bin": { "coach-content": "./dist/cli.js" }`, built by `tsup`, whose
+  `src/cli.ts` is a plain `node:util` `parseArgs` dispatcher that gets a Prisma client
+  via `getPrisma()` from `@saga-ed/coach-db` and selects the target Postgres with
+  `DATABASE_URL`. ~230 lines, no framework. Exit codes `0/1/2`.
+
+### Recommended landing spot
+**Extend the existing `coach-content` CLI**, do NOT create a new package. Add a
+`playlist` command group in
+`/home/skelly/dev/coach/packages/node/coach-content-publish/src/cli.ts`
+(new `src/playlist.ts` store module beside `src/store.ts`). Rationale:
+
+- Playlisting is *the same DB, the same release/instance tables, the same
+  idempotency contract* as publish/materialize — `group_track_map`, `content_release`,
+  and `content_instance` all live in `coach-db`'s Prisma schema, which this package
+  already imports. A sibling package would duplicate the `getPrisma()`/tsup/bin wiring
+  for zero benefit.
+- `coach-content` already owns `materialize` (a "dev/e2e helper" that is exactly a
+  playlist-instantiation step). `playlist` sits naturally next to it.
+
+Then surface it from coach-api the way `db:seed:run` is surfaced — add a
+`coach-api` `package.json` script, e.g.
+`"playlist": "pnpm --filter @saga-ed/coach-content-publish exec coach-content playlist"`,
+so `ss` (and humans) invoke `pnpm --filter @saga-ed/coach-api playlist assign …`.
+
+**Closest precedent to copy, file by file:**
+| Concern | Copy from |
+|---|---|
+| bin + parseArgs dispatcher + exit codes | `coach-content-publish/src/cli.ts` |
+| Prisma-through-`getPrisma()`, tx, idempotent writes | `coach-content-publish/src/store.ts` |
+| group_track_map row shape + derivation | `coach-db/src/seed/persona-projections.ts` (`groupTrackMaps`, `GroupTrackMapRow`) |
+| track→instance derivation (shared, must not drift) | `coach-db/src/content/derive-templates.ts` (`deriveTemplates`) |
+| delegating package.json script | `coach-api/package.json` `db:seed:run` |
+
+---
+
+## 2. What coach ALREADY does (reuse, not rebuild) — the seam
+
+Coach owns the whole content half already. The pipeline and the exact tables:
+
+```
+                    ┌───────────────────────── coach owns ALL of this today ─────────────────────────┐
+content-archive     coach-content publish            group_track_map            coach-content materialize
+  checkout    ──►   (createRelease, store.ts)   ──►   (group → content_name) ──► (deriveTemplates)     ──► coach-web
+  (git sha)         content_release (+curricula      = "which track a group's   content_instance          renders
+                     +polls) + atomic active          tutors get")               (+_module/_completed)     dashboard
+                     pointer flip
+        │                    │                                │                          │
+   PLAYLIST DEFINITION   RELEASE ROWS                 PLAYLIST ASSIGNMENT          INSTANCE (section-grain,
+   (what content is       (immutable snapshot          (group→track binding)        PRs #448/#463)
+    in the track)          = a track version)
+```
+
+Concretely, already-built and reusable verbatim:
+
+1. **Publish → `content_release` rows.** `coach-content publish --archive <checkout>
+   --ref <sha> --approve` (`cli.ts` `publish` case → `store.ts#createRelease`) inserts a
+   release + curricula + polls in one tx and atomically flips the `active_content_release`
+   singleton pointer. A **release *is* a track version**; a `content_release_curriculum`
+   row keyed by `name` **is** a playlist/track (`content_name`). No coach-api deploy —
+   readers join through the pointer (60s subject cache).
+2. **Materialize → `content_instance`.** `coach-content materialize --user <id>
+   --content <name>` (`store.ts#materialize`) derives a per-user instance from the ACTIVE
+   release via the **shared** `deriveTemplates` (`coach-db/src/content/derive-templates.ts`)
+   — the *same* function coach-api's event-driven reconcile materializer uses, so the CLI
+   path and the live path cannot drift. This is section-grain (`ContentInstance`, PRs
+   #448/#463).
+3. **`group_track_map` READ path.** coach-api resolves which track a tutor materializes
+   by joining `persona_assignment ⋈ group_track_map` **on `groupId` alone** in
+   `PostgresAssignmentStore` (`src/sectors/cns/assignments/`), and the reconcile
+   materializer looks up `SELECT content_name FROM group_track_map WHERE group_id=$1`
+   (`src/sectors/cns/events/iam-projection-handlers.ts:~210`), falling back to
+   `DEFAULT_CONTENT_NAME='base-coach'` when unmapped.
+4. **`group_track_map` SEED write.** `coach-db db:seed` writes one demo-district row via
+   `groupTrackMaps(contentName)` (`persona-projections.ts`), pointing the demo district at
+   the seeded tutor's own track so map and instance can't drift.
+
+**Reuse seam (one line):** `playlisting-input → coach-content publish (content_release rows) →
+group_track_map (group→content_name) → coach-content materialize (content_instance) →
+coach-web`. Everything except the **write of the `group_track_map` binding** (and, for
+tag-composed tracks, the *definition* of what content is in a track) already exists.
+
+---
+
+## 3. What is NEW (the parts only legacy/saga_api has today)
+
+The port must add the **assignment half**. Two pieces, in priority order:
+
+1. **Playlist ASSIGNMENT — write a `group_track_map` row (the load-bearing new piece).**
+   VERIFIED GAP: nothing in coach writes `group_track_map` in production. `reconcile`
+   only *reads* it; the only *writer* is the offline `db:seed`. In the live fleet the
+   assignment lives as the iam policy `coach:coach_playlist_name` on a persona
+   (rostering `iam-db/prisma/seed.ts:~919`, tutor → `'base-coach'`), and there is **no
+   projector** turning that policy into a `group_track_map` row (searched coach-api
+   `src/sectors/cns/events/*` — the iam projection handlers project
+   `persona_assignment`/`persona_definition`, NOT the playlist policy). So the port's
+   core new code is a CLI verb (and, for parity with live, eventually an iam-policy →
+   `group_track_map` projection) that **upserts `(group_id, group_kind, content_name)`**.
+   This is small — a Prisma upsert mirroring `groupTrackMaps()` — but it is the piece
+   that makes coach self-sufficient.
+2. **Playlist DEFINITION — compose a track from tags/attributes (coach's deferred Phase 2b).**
+   Legacy maintained **4 hand-authored playlists** (MS/HS × online/in-person); saga-dash#463
+   (OPEN) moves to *tag-based* content selection. Coach-api's own comments call this the
+   **Phase 2b tag-filter resolver that replaces the direct `group_track_map` lookup** and
+   explicitly say it is NOT built (`iam-projection-handlers.ts` SECTION_GROUP_KIND doc:
+   "True 'section narrows district's content set' is Phase 2b's job … do not attempt it
+   here"). If the port wants real playlist *authoring* (not just assignment of
+   already-published tracks), this is the new logic: select a subset of a release's
+   content by tag → publish it as a named track. For a **v1 CLI-driven port this can be
+   deferred** — treat each published `content_name` as a pre-composed playlist and only
+   build the assignment verb.
+
+Everything else the legacy playlist flow did (instantiate the chosen track for a user)
+is already `materialize`.
+
+---
+
+## 4. Input-source decision (where playlisting input comes from post-port)
+
+Two distinct inputs; keep them separate:
+
+- **Content/track DEFINITION input → a `content-archive` checkout, via `coach-content
+  publish`.** This is already the model and the durable source of truth (GitHub archive
+  → publish → release rows). For dev, `coach-db db:seed` loads an **offline twin** release
+  (`fixtures/content-release.json`) so no archive checkout is needed. Recommendation:
+  **coach-db seed fixture for the default dev path; content-archive checkout only for
+  real/legacy-parity tracks.** No saga-dash and no coach-db of saga-dash is involved.
+- **Playlist ASSIGNMENT input → a coach-owned config, NOT a saga-dash read.** The
+  assignment (`group → content_name`) must come from something coach owns. Ranked:
+  1. **CLI args** (`--group <id> --content <name>`) for interactive dev — matches how
+     `materialize` already takes `--user/--content`. [recommended for the CLI port]
+  2. **coach-db seed** (`groupTrackMaps`) for the baseline — already exists.
+  3. **iam policy projection** (`coach:coach_playlist_name` → `group_track_map`) for
+     eventual live parity — the durable answer, but out of scope for a CLI-first port.
+
+  It must **not** read a saga-dash DB or `user_policy` at runtime — that would re-couple
+  coach to saga-dash, the opposite of the port's goal, and violates coach-api's stated
+  domain boundary (coach treats `groupId` as "an opaque mapping key, not org logic").
+
+**Net:** post-port, coach's inputs are (a) a content-archive checkout *or* the coach-db
+seed fixture (definition) and (b) CLI args *or* the seed (assignment). saga-dash leaves
+the loop entirely.
+
+---
+
+## 5. Proposed CLI command signature
+
+Add to the existing `coach-content` CLI (mirrors its `status/diff/publish/materialize`
+verbs, `parseArgs`, exit codes, `DATABASE_URL`-selected Postgres):
+
+```bash
+# ── assignment (the load-bearing new verb; upserts a group_track_map row) ──
+coach-content playlist assign --group <groupId> --content <content_name> [--kind district|section]
+coach-content playlist unassign --group <groupId>
+coach-content playlist list                      # active release's tracks (content_names) ⋈ their group_track_map bindings
+
+# ── definition (Phase 2b; optional for v1 — compose a named track by tag) ──
+coach-content playlist define --name <content_name> --from-tags <tag,...>   # NEW resolver; or --from-archive-doc <name>
+
+# ── already exists, reused as the instantiate step ──
+coach-content materialize --user <id> --content <content_name> [--replace]
+```
+
+A full "switch a persona's playlist" dev flow becomes three existing/near-existing calls:
+`publish` (or seed) a 2nd track → `playlist assign --group <demo-district> --content <track-2>`
+→ `materialize --user demo-tutor-1 --content track-2 --replace`.
+
+---
+
+## 6. How this unblocks `ss develop coach`
+
+The `develop coach --scenario playlist` path (plan.md scenario 5) is blocked today
+because **only one track (`spring-pilot`) is seeded and there is no way to switch which
+playlist a persona resolves without saga-dash / legacy `user_policy`.** After the port:
+
+**One-command local seed of switchable coach content, saga-dash out of the loop:**
+```bash
+# baseline (exists today): brings up coach-api pg + curriculum + one track + instance
+pnpm --filter @saga-ed/coach-db db:seed
+
+# NEW, enabled by the port — add a 2nd track and flip the assignment, no saga-dash:
+coach-content publish  --archive <checkout|fixture> --ref <sha> --approve   # or a 2nd seed track
+coach-content playlist assign --group <deriveGroupId('demo')> --content <track-2>
+coach-content materialize --user <demo-tutor-1 id> --content track-2 --replace
+```
+`ss develop coach --scenario playlist` then wraps exactly these steps as a concierge
+flow (the plan's M3/M4), `devLogin`s as `demo-tutor-1@saga.org`, and opens coach-web —
+the developer sees the *chosen* playlist drive the rendered content, and can iterate on
+playlist assignment purely inside the coach repo. That self-sufficiency (coach seeds and
+switches its own playlists) is the concrete unblock: `develop coach` no longer needs
+saga-dash or legacy `saga_api` to demonstrate playlisting.
+
+For the **primary** `--scenario content-viewer`, nothing new is even required — `db:seed`
+already lands a working track+instance; the port matters specifically for the
+`--scenario playlist` (and multi-tutor `--admin`) scenarios that need ≥2 tracks and a
+switch.
+
+---
+
+## Unknowns / flags for the orchestrator
+
+- **VERIFIED GAP (high-confidence):** no coach production write-path for `group_track_map`
+  exists — only `db:seed` writes it and `reconcile` reads it. The iam
+  `coach:coach_playlist_name` policy is defined (rostering registry) but I found **no
+  projector** consuming it into coach. The port's assignment verb fills a real hole, not
+  just a dev convenience.
+- **"playlisting currently in saga-dash" is imprecise** — no playlist code in the local
+  saga-dash checkout; the concept is legacy `saga_api` + the iam policy. Confirm with the
+  team lead whether the port target is "legacy saga_api playlist resolution" (assumed
+  here) or a specific saga-dash surface I couldn't locate.
+- **Definition (Phase 2b tag-filter) scope** is a product decision (mirrors plan.md open
+  decision #1): v1 can treat each `content_name` as a pre-composed playlist and ship only
+  the assignment verb; real tag-based authoring (saga-dash#463) is a larger, separate build.
+- **group_kind on assign:** `group_track_map` join is on `groupId` alone (kind-agnostic on
+  read), but coach materializes only `district`+`section` kinds — the `--kind` flag should
+  default to `district` to match the seed.

--- a/claude/projects/gh_305/research/10-seed-ordering-bug.md
+++ b/claude/projects/gh_305/research/10-seed-ordering-bug.md
@@ -1,0 +1,176 @@
+# gh_305 — seed-ordering bug blocking `ss develop coach` (recurrence of soa#253)
+
+_Code trace across soa (saga-stack-cli) + rostering (iam-db). No live stack run._
+
+## Symptom
+
+A live `ss develop coach --slot 2` run logs `SEEDED_REGISTRY:permissions=55` **and**
+rostering's `seed-dev-user` failing with:
+
+```
+seed-dev-user: registry is missing required session permissions
+[00000000-0000-4000-a005-000000000053, …054, …055] — run seed:registry first.
+Refusing to provision a degraded dev admin grant (would reintroduce saga-dash#209.10/#209.1).
+```
+
+The three ids are `sessions:observe/lifecycle_non_hosted/edit_non_hosted`
+(rostering `registry.ts` lines 125-127, added by migration
+`20260603000000_add_sessions_authz_permissions`).
+
+## Root cause — an ORDERING GAP in `api.reset()`, not the seed profile
+
+**The failure is emitted by the RESET pass, which re-seeds `iam-dev-user` AFTER
+truncating the permission catalog but WITHOUT running `iam-registry` first.**
+
+Trace, for the coach `module-playback` flow (`coach/apps/web/coach-web/e2e/flows.json`
+→ `"seed": { "profile": "full", "reset": true }`):
+
+1. `develop coach` → `executeResolvedFlow` (soa `src/e2e-orchestrate.ts`). With
+   `reset:true` and no `--reuse`, `effectiveReset` is true, so it does — **in this order**:
+   - `src/e2e-orchestrate.ts:995` → `const reset = await deps.api.reset(services);`
+   - `src/e2e-orchestrate.ts:1000-1001` → `composeSeedPlan(... 'full' ...)` then `await deps.api.seed(plan)`.
+
+2. `api.reset()` (soa `src/stack-api.ts:1015-1060`):
+   - `resetClosure()` (soa `src/runtime/reset.ts:151-264`) TRUNCATES every closure pg
+     DB, incl. `iam_local`. The DO block (`truncateSql`, `reset.ts:112-119`) truncates
+     every `public` table **except `_prisma_migrations`** — so the `permissions` rows
+     (053/054/055, inserted by the migration during `db:deploy`) are **wiped**, and a
+     truncate never re-migrates, so they are NOT re-inserted.
+   - Then, `src/stack-api.ts:1040-1046`, **only** the `iam-dev-user` step is re-run:
+     ```js
+     if (services.includes('iam-api')) {
+       const ran = { offline: [], online: [] };
+       const devUser = buildSeedRegistry(manifest)['iam-dev-user'];   // NO iam-registry first
+       const ok = await runSeedStep(devUser, 'offline', ran);
+       seed = { ok, ran, skipped: [], ...(ok ? {} : { failed: devUser.id }) };
+     }
+     ```
+   - `iam-dev-user` runs `node dist/seed-dev-user.js` → `main()` →
+     `applyDevAdminGrant()` (rostering `src/seed-dev-user.ts:135-151`), which does
+     `prisma.permission.findMany({ where: { id: { in: ADMIN.permissionIds } } })`
+     against the **just-truncated** table, finds 053/054/055 absent, and **throws the
+     reported error** (`seed-dev-user.ts:145-151`).
+
+3. `api.seed(plan)` runs AFTERWARD with the `full` plan whose offline order is
+   `[iam-registry, iam-dev-user, iam, …]` (`profiles.ts` `PROFILE_STEPS.full` line 45 +
+   `SEED_RUN_ORDER` lines 76-99; `composeSeedPlan` walks that order). `iam-registry`
+   (`node dist/seed-registry.js`) re-seeds all 55 permissions incl. 053/054/055
+   (`SEEDED_REGISTRY:permissions=55`), then `iam-dev-user` succeeds. **This is why the
+   error line precedes `SEEDED_REGISTRY:permissions=55` in the log** — error from the
+   reset re-seed, registry from the later full seed.
+
+### Why this is a recurrence of soa#253
+
+soa#253 fixed the SEED path: it added `iam-registry` ahead of `iam-dev-user` in
+`PROFILE_STEPS` / `SEED_RUN_ORDER` (`profiles.ts:42,45,76-99`) — that path is correct
+and the `stack-api.unit.test.ts` order assertion `['iam-registry','iam-dev-user','iam','sessions']`
+(lines 427/454/480) confirms it. soa#253 did **not** touch `api.reset()`'s hardcoded
+dev-user re-seed (`stack-api.ts:1040-1046`), which still truncates the registry and then
+re-seeds `iam-dev-user` alone. That is the gap.
+
+### It is an ORDERING bug, not DB-targeting and not a missing step in the profile
+
+- **Not DB-targeting.** In the reset re-seed AND in the full seed, every iam step uses
+  `iamSeedEnv(m)` → identical `DATABASE_URL = postgresql://iam:iam@localhost:${MESH_PG_PORT}/iam_local`
+  (`profiles.ts:220-229`, `pgUrl` 173-176). `${MESH_PG_PORT}` is resolved once per
+  facade (`stack-api.ts:574-580`) from `runtime.meshOffset`, so registry, dev-user and
+  the truncate (`docker exec <pgContainer> …`) all hit the same slot DB. (Note: `develop
+  coach` builds its runtime with the DEFAULT slot-0 profile —
+  `commands/develop/coach.ts:250` passes `undefined` for `profile` to
+  `buildStackContext`, so `--slot 2` is effectively ignored for DB/mesh targeting; that
+  is a *separate* concern and does not change the ordering analysis, since reset and seed
+  then consistently target slot 0.)
+- **Not a missing profile step.** `iam-registry` IS present and correctly ordered in the
+  `full` seed plan. The registry is only missing during the *reset* re-seed.
+
+### rostering side is correct — no change needed there
+
+- `seed-registry.ts` / `registry.ts` `seedRegistry()` upserts all 55 `PERMISSIONS`
+  (`registry.ts:81-152`) **including** 053/054/055 → `SEEDED_REGISTRY:permissions=55` is
+  the current source, and it DOES contain the session perms.
+- `seed-dev-user.ts` correctly does **not** self-seed the registry; it validates-first
+  and refuses a degraded grant (`applyDevAdminGrant` 135-151). This guard is working as
+  designed — it is surfacing the soa-side ordering gap.
+- package.json scripts the soa path shells: `seed:registry` → `node dist/seed-registry.js`,
+  `seed:dev-user` → `node dist/seed-dev-user.js`, `db:seed` → `npx tsx prisma/seed.ts`.
+
+## Severity / does it block?
+
+`iam-dev-user` is `failureMode:'warn'` (`profiles.ts:282-298`), so `runSeedStep` returns
+`true` even on the throw; `api.reset()` returns `code:0` and the subsequent full seed
+re-seeds the registry and heals dev's grant. So for the **reset+seed e2e path** the log
+line is alarming but self-healing — `develop coach` should still complete. The genuine
+hard regression is a **bare `ss stack reset`** (no full seed after): it truncates the
+registry, the dev-user re-seed throws before applying the grant, and dev is left with no
+admin persona → resolves to `DEFAULT_USER_BUNDLE` (coach-only) → reintroduces
+saga-dash#209.10 / #209.1 exactly. Either way the ordering gap is the defect that
+produces the reported error and must be fixed. (If the live `develop coach` truly aborted
+rather than just logging the error, the abort is downstream of this and unverified from
+the trace — but the reset re-seed is unambiguously the source of the quoted message.)
+
+## Fix (soa seed path — preferred, minimal)
+
+In `packages/node/saga-stack-cli/src/stack-api.ts`, `reset()` (the block at 1040-1046),
+run `iam-registry` before `iam-dev-user`, mirroring the seed profile's soa#253 invariant:
+
+```js
+let seed: SeedResult | undefined;
+if (services.includes('iam-api')) {
+  const ran: SeedResult['ran'] = { offline: [], online: [] };
+  const registry = buildSeedRegistry(manifest);
+  // soa#253 recurrence guard: resetClosure() truncated iam_local's permission catalog
+  // (incl. session perms 053/054/055), so seed:registry MUST precede the dev-admin grant
+  // — else applyDevAdminGrant refuses (missing session perms) and dev regresses to
+  // DEFAULT_USER_BUNDLE (saga-dash#209.10/.1). Registry is FATAL; dev-user stays warn.
+  const registryStep = registry['iam-registry'];
+  const registryOk = await runSeedStep(registryStep, 'offline', ran);
+  const devUser = registry['iam-dev-user'];
+  const devUserOk = registryOk && (await runSeedStep(devUser, 'offline', ran));
+  const ok = registryOk && devUserOk;
+  seed = { ok, ran, skipped: [], ...(ok ? {} : { failed: registryOk ? devUser.id : registryStep.id }) };
+}
+```
+
+Rationale for two hardcoded steps (vs. `composeSeedPlan`): reset must re-seed ONLY the
+registry + dev user (up.sh:1695-1696 parity); composing a profile would also pull in the
+fatal `iam` roster `db:seed`, which reset deliberately leaves for the *following* full
+seed. `iam-registry` is FATAL (a failed registry means the grant can't be provisioned
+safely, so the reset should surface it); `iam-dev-user` stays warn.
+
+### Test impact (same file, `src/__tests__/stack-api.unit.test.ts`)
+
+- `native: … re-seeds the dev user` (line 635): still passes (`res.seed?.ok === true`).
+  Add an assertion that `iam-registry` runs before `iam-dev-user` in the reset
+  (`res.native`/`res.seed.ran.offline` order, or that a `dist/seed-registry.js` run
+  precedes the `dist/seed-dev-user.js` run in `fakes.runs`).
+- `slot 1: the reset dev-user re-seed also dials the offset mesh port` (line 590): still
+  passes — the dev-user run still exists with the offset `DATABASE_URL`. Optionally assert
+  the same for the new `seed-registry.js` run.
+
+### Verify
+
+- `pnpm --filter @saga-ed/saga-stack-cli test` (unit — reset ordering).
+- Live: `ss stack reset` alone, then check dev resolves to ADMIN (session action buttons
+  visible; not `DEFAULT_USER_BUNDLE`); and `ss develop coach` no longer logs the
+  `seed-dev-user: registry is missing required session permissions …` line during reset.
+
+### Rostering
+
+No change required. `seed-registry.ts` seeds all 55 perms incl. 053/054/055;
+`seed-dev-user.ts` correctly depends on a prior `seed:registry` and its guard is the
+detector, not the bug.
+
+## Key file:line refs
+
+- soa `src/e2e-orchestrate.ts:984-1003` — reset-then-seed ordering.
+- soa `src/stack-api.ts:1015-1060` — `api.reset()`; **1040-1046** = the dev-user-only
+  re-seed (the bug).
+- soa `src/runtime/reset.ts:112-119, 151-264` — truncate wipes `permissions` (preserves
+  only `_prisma_migrations`).
+- soa `src/core/seed/profiles.ts:42,45,76-99,269-298` — correct seed-path ordering
+  (soa#253) + `iam-dev-user` warn mode.
+- rostering `src/seed-dev-user.ts:135-151` — `applyDevAdminGrant` guard (throw site).
+- rostering `src/registry.ts:81-152` — 55 PERMISSIONS incl. 053/054/055.
+- rostering `src/prisma/migrations/20260603000000_add_sessions_authz_permissions/migration.sql`
+  — inserts 052-055 via `db:deploy`.
+- coach `apps/web/coach-web/e2e/flows.json` — `module-playback`: `profile:full, reset:true`.

--- a/claude/projects/gh_305/research/11-content-viewer-seed-misalignment.md
+++ b/claude/projects/gh_305/research/11-content-viewer-seed-misalignment.md
@@ -1,0 +1,54 @@
+# 11 — "Couldn't Load Module": content-viewer seed misalignment (#305 / coach #228)
+
+**Date:** 2026-07-14. Live-verified against the slot-2 `coach_api` Postgres after
+`ss develop coach --scenario content-viewer` seeded it (coach-db `db:seed` offline fixtures).
+
+## Symptom
+coach-web authenticates (tutor "Demo Tutor One" logged in) but the module player at
+`/units/unit_1/sc_u1_m1` renders `heading "Couldn't Load Module"`. Loader
+(`coach-web/src/routes/units/[unitName]/[moduleId]/+page.svelte`): `module = unit.modules.find(id
+=== 'sc_u1_m1')`, `contentId = module.pollId`, then `fetchPollContent(contentId)` — any null → error.
+
+## Root cause (live DB evidence, coach_api @ slot-2 :7432)
+- **Exactly one content instance:** `user_id=1c939568…` (demo-tutor-1), `content_name=spring-pilot`,
+  **59 modules**. No `curriculum-coach` persona/instance exists to fall back to.
+- **Active release curriculum = `curriculum-coach`**, but its `doc` has **no top-level `nav`**
+  (`(doc::jsonb->'nav') IS NULL`). Its **27 polls** carry short content-ids (`1rzefuyfyd9pia5u`, …);
+  **zero** poll_id matches `sc_u1_*`.
+- **`sc_u1_m1`** exists in the instance (`content_instance_module`, `state=COMPLETE`,
+  `poll_instance_id=798ada76-…`) but that poll_instance **does not resolve to any active-release
+  poll** (join count = 0).
+
+So the synthetic offline seed lands the tutor on **spring-pilot** while the release is a **nav-less
+`curriculum-coach`** whose polls don't cover `sc_u1_m1`. The ported viewer therefore can't load any
+module for the seeded tutor. This is the coach #228 Dashboard(spring-pilot)/Explore(curriculum-coach)
+mismatch, which coach explicitly DEFERRED.
+
+## Why this isn't a quick config fix
+- The real content viewer is designed to run off **published archive content**
+  (`coach-web/e2e/module-playback-real-content.e2e.test.ts`, `PUBLISH_REAL_CONTENT=1` + `ARCHIVE_DIR`
+  → `coach-content publish`), NOT the synthetic `db:seed` fixture. The synthetic `module-playback`
+  smoke uses the misaligned fixtures above.
+- The offline fixtures (`coach-db/src/seed/fixtures/content-instances.json` = spring-pilot 59-mod;
+  `content-release.json` = curriculum-coach, nav-less) are internally inconsistent for playback.
+
+## Fix options (coach-repo; needs a content-model decision)
+1. **Publish real archive content** for the develop-coach content-viewer scenario: check out
+   `saga-ed/content-archive`, `coach-content publish` a real curriculum, materialize demo-tutor-1 on
+   it. Highest fidelity; needs an archive checkout + an `ss develop coach --real-content` flag/step.
+   Ties back to the original content-source decision (synthetic vs real archive).
+2. **Fix the synthetic seed** so the offline fixture is self-consistent: materialize demo-tutor-1
+   from the *active release's* curriculum (so every module's poll is in the release, with a
+   nav-carrying doc). A coach-db fixture reconstruction — this is the #228 reconciliation, deferred
+   for reasons that need confirming (why the tutor is on spring-pilot while the release is
+   curriculum-coach).
+3. **Point the content-viewer scenario at whatever coach's own `module-playback` smoke uses in CI** —
+   if that suite is green on coach main, replicate its seed exactly (the ss flow may be seeding a
+   different/partial path than coach CI). NEEDS: confirm whether coach's `module-playback.e2e.smoke`
+   is green on main; if it's red/skipped there too, the synthetic path is a known gap.
+
+## Status
+Root cause definitively identified + live-verified. The develop-coach concierge + soa#300 auth are
+DONE and working (tutor logs in). The remaining `--scenario content-viewer` module-load gap is a
+coach content-seed/content-source decision (options above), not ss plumbing — Seth's domain, or a
+scoped coach-repo effort once the intended content model is confirmed.

--- a/claude/projects/gh_305/research/11-content-viewer-seed-misalignment.md
+++ b/claude/projects/gh_305/research/11-content-viewer-seed-misalignment.md
@@ -47,8 +47,38 @@ mismatch, which coach explicitly DEFERRED.
    different/partial path than coach CI). NEEDS: confirm whether coach's `module-playback.e2e.smoke`
    is green on main; if it's red/skipped there too, the synthetic path is a known gap.
 
+## RESOLVED via option 1 — `ss develop coach --real-content` (2026-07-14)
+
+Implemented + live-verified on slot 2. `--real-content` drives coach-web's AUTHORED
+`module-playback-real-content` flow (publish archive `base-coach` → materialize demo-tutor-1 →
+render the same `/units/unit_1/sc_u1_m1` route). Two ss-side pieces were needed:
+1. Resolve + precheck the content-archive checkout (`--archive-dir` / `$ARCHIVE_DIR` /
+   `<dev>/content-archive`) and export **`ARCHIVE_DIR`** — the flow's flows.json `env` block supplies
+   `PUBLISH_REAL_CONTENT=1`; the Runner spawns Playwright with `{...process.env}`, exactly the
+   contract the flow documents.
+2. Export **`DATABASE_URL`** = the slot's `COACH_DB_URL`. `real-content-lane.ts` gates on ARCHIVE_DIR
+   **and** DATABASE_URL and SELF-SKIPS otherwise — the flow's doc claims saga-stack-cli supplies it,
+   but nothing did, so the spec silently skipped. This is why the first live run looked "green-ish"
+   while doing nothing.
+
+**LIVE RESULT — the content issue is FIXED.** With a FULL archive clone (the flow pins
+`DEFAULT_ARCHIVE_REF=215a7152…`; a `--depth 1` clone fails `rev-parse`), the run now:
+publish ✓ → materialize ✓ → **module RENDERS** (`.not-found` count 0 — "Couldn't Load Module" is
+GONE; `.mc-task`, short_answer et al. all pass). The ported content viewer plays REAL archive
+curriculum.
+
+## NEW finding (distinct, coach-repo): showdown tasks don't survive publish→render
+
+The real-content spec's last assertion still fails: `.showdown-content` expected **2**, received
+**0**. This is NOT a stale test — sc_u1_m1's poll in the archive at the pinned ref genuinely carries
+**2 `showdown_task_`** entries (`exports/75958/polls/607075e88264ee04ae000003/poll.json`; base-coach
+maps `sc_u1_m1 → content_id brvhsb6uxsutr4pn`). So real showdown content exists but renders zero
+elements — a **publish-fidelity or renderer gap** (cf. coach #202 "carry poll questions/tag_list
+through publish to Postgres"). Next step for whoever picks it up: check whether `coach-content
+publish` carries `showdown_task` payloads into `content_release_poll`, and whether coach-web's
+`TaskRenderer` dispatches the `showdown_task` base type.
+
 ## Status
-Root cause definitively identified + live-verified. The develop-coach concierge + soa#300 auth are
-DONE and working (tutor logs in). The remaining `--scenario content-viewer` module-load gap is a
-coach content-seed/content-source decision (options above), not ss plumbing — Seth's domain, or a
-scoped coach-repo effort once the intended content model is confirmed.
+Original root cause (synthetic seed misalignment) identified, and RESOLVED for develop-coach via
+`--real-content` (real archive curriculum now plays). Remaining: the showdown publish/render gap
+above (coach-repo), plus the unauthenticated shell/nav e2e specs (coach-web e2e test wiring).

--- a/claude/projects/gh_305/source/build-report.md
+++ b/claude/projects/gh_305/source/build-report.md
@@ -47,3 +47,34 @@ materialize/switch against a live `coach_api` Postgres. PRs kept as **drafts** p
 - Option B playlisting: legacy `saga_api` `user_policy` selection cutover + iam-policy→`group_track_map` projector for prod parity.
 - `develop saga-dash` / `ads` / `sis` (prompt-2 scenarios 2/6/7) — topic is built to extend; each needs its own research pass.
 - Cosmetic: stale `contentHash` in the coach seed fixture (nothing validates it).
+
+## Live test on slot 2 (2026-07-14) — 3 fixes made + verified; one residual (coach-web / #300)
+
+Ran `ss develop coach --slot 2` live. It surfaced and I fixed **three real bugs** (all committed +
+pushed + verified live):
+
+1. **`bf089c5` slot-aware** — `develop coach` hard-errored at `--slot > 0` (missing `slotAware()`).
+   (Also learned: the dev binary needs `dist` rebuilt — gitignored — for changes to take effect.)
+2. **`8544166` reset ordering (soa#253 recurrence)** — `api.reset()` truncated the iam permission
+   catalog then re-seeded only `iam-dev-user`, so the dev-admin grant failed on session perms
+   053/054/055. Now `iam-registry` runs first. **Verified live: the seed error is GONE.**
+3. **`c8f96e4` slot-profile threading** — `develop coach` passed `undefined` profile to
+   `buildStackContext` (+ lacked `applyInstanceEnv`/prep seams/stateDir), so `--slot N` silently ran
+   at slot 0. Now threads the profile like `e2e run`. **Verified live: DBs at `:7432`, services at
+   slot-2 offset ports (iam 5010 / coach-api 8105 / coach-web 10800), all healthy (200).**
+
+**Verified working at slot 2:** stack up, seed (clean), tutor session minted, iam whoami reachable,
+CORS + preflight + 401-login-challenge all correct (curl-confirmed against the coach-web origin).
+
+**Residual blocker (coach-web-side — the core of soa#300, NOT ss develop plumbing):** coach-web's
+*browser* boot renders `503 "Unable to reach the sign-in service"` — its client-side whoami fetch
+(`session.ts:82` → `+layout.ts:36`) fails as a "real error" even though the host reaches iam fine
+(curl 401-with-challenge + OPTIONS 204 both succeed, identical to saga-dash). So the failure is in
+coach-web's client-side auth flow at slot > 0, not reproducible from the host — needs Playwright
+trace analysis + coach-web internals (Seth). This is the unresolved core of soa#300 ("coach-web
+local iam wiring stale, blocks local browser-testing"); M0 fixed only the manifest CORS/env half.
+
+**Next step for a green live run:** resolve the coach-web browser-boot whoami failure (coach repo /
+#300) — inspect the preserved Playwright trace under
+`coach/apps/web/coach-web/test-results/dashboard-*/trace.zip`. The ss `develop coach` command itself
+is confirmed correct end-to-end up to that coach-web-side boot.

--- a/claude/projects/gh_305/source/build-report.md
+++ b/claude/projects/gh_305/source/build-report.md
@@ -116,3 +116,28 @@ Opened the Playwright trace and root-caused #300 across its layers:
 **Status:** #300 core FIXED + verified (coach-web boots against local mesh). The remaining smoke-only
 env-contract fix (`PLAYWRIGHT_IAM_URL`/`PLAYWRIGHT_BASE_URL` for coach-web flows) is scoped and ready
 to implement next. Slot 2 torn down; a stale coach-web watch orphan was killed.
+
+### env-contract fix DONE + verified (2026-07-14) — 503 cleared; one deeper layer remains
+
+Fixed the env contract (commit `fix: coach-web Playwright gets slot iam + its own baseURL`):
+1. `develop coach` now passes `ports: runtime.launchContext.ports` to `executeResolvedFlow` (it
+   didn't — mirrors e2e run), so `serviceUrlEnv` sets `PLAYWRIGHT_IAM_URL`=slot iam.
+2. `playwrightEnv` now sets `PLAYWRIGHT_BASE_URL` to the flow SPA's OWN frontend
+   (`resolved.spa.system`) — no-op for saga-dash, corrected for coach-web/connectv3 (coach-web's
+   `lane.ts` reuses `PLAYWRIGHT_BASE_URL`). +1 unit test; suite 1190 green.
+
+**Verified live on slot 2:** the **503 is GONE**; the e2e session cookie is now `domain=localhost`
+(was `.sk.vms.wootdev.com`); the browser hits the correct slot ports (coach-web :10800, iam :5010,
+login redirect to :5010/demo); smoke went 1→2 passing.
+
+**DEEPER LAYER STILL OPEN (iam session recognition, not env):** whoami at the slot iam still returns
+401 with a localhost cookie present, so coach-web redirects to iam's `/demo` login page (tests see
+"IAM API Demo") — the devLogin-minted session isn't recognized by the slot iam's whoami. Next
+suspects: the slot-2 iam's `AUTH_AUTHENABLED` posture (devLogin expects `false`), or the
+`iam_session` cookie's SameSite/attributes on the cross-origin (10800→5010) fetch. This is an
+iam/coach-web session-semantics layer, distinct from the env-contract fix.
+
+**Important:** this remaining failure is in the automated e2e SMOKE (coach-web `globalSetup` /
+`devLogin`). A REAL `ss develop coach` hand-off authenticates via ss `mintNativeLoginJar` against the
+slot iam — a different path — so the interactive dev experience may already work end-to-end; the
+smoke is what's gating a fully-green flow.

--- a/claude/projects/gh_305/source/build-report.md
+++ b/claude/projects/gh_305/source/build-report.md
@@ -78,3 +78,41 @@ local iam wiring stale, blocks local browser-testing"); M0 fixed only the manife
 #300) — inspect the preserved Playwright trace under
 `coach/apps/web/coach-web/test-results/dashboard-*/trace.zip`. The ss `develop coach` command itself
 is confirmed correct end-to-end up to that coach-web-side boot.
+
+## Chasing soa#300 (2026-07-14, coach-web now owned by us) — CORE fixed + remaining mapped
+
+Opened the Playwright trace and root-caused #300 across its layers:
+
+1. **CORE (FIXED, `719d342`): coach-web's browser booted against REMOTE hosts.** The trace showed it
+   fetched `https://iam.wootdev.com/trpc/auth.whoami` (+ `dash`/`login.wootdev.com`) — the checked-in
+   `.env` remote defaults — because coach-web reads `PUBLIC_*` via `$env/static/public` (inlines
+   `.env` at vite-dev start) and there was no `.env.local`; the injected process env is ignored.
+   **Fix:** a per-slot `.env.local` prelaunch write (`runtime/coach-web-env.ts`, mirrors the saga-dash
+   `config.local.json` seam), gated on coach-web launchable, mapping each `PUBLIC_*` var to the local
+   mesh OFFSET url. **Verified live: the browser now fetches `http://localhost:5010` (slot-2 iam).**
+   This is the substantive #300 unblock — a real `ss develop coach` hand-off now reaches the local iam.
+
+2. **REMAINING (smoke-only, ss-flow ↔ coach-web-e2e env contract):** the headless Playwright smoke
+   still 503s because coach-web's e2e `globalSetup` mints the session against the BASE iam
+   (`localhost:3010`) instead of the slot iam (`localhost:5010`). `e2e/fixtures/lane.ts`:
+   `IAM_URL = process.env.PLAYWRIGHT_IAM_URL ?? 'http://localhost:3010'`. The flow HAS a
+   `PLAYWRIGHT_SERVICE_URL_ENV` map (`e2e-orchestrate.ts:397`: `PLAYWRIGHT_IAM_URL→iam-api`,
+   `PLAYWRIGHT_BASE_URL→saga-dash`) but (a) it isn't reaching coach-web's spawn (lane.ts fell back to
+   `:3010`), and (b) `PLAYWRIGHT_BASE_URL` is hardwired to `saga-dash`, wrong for a coach-web flow.
+   The `:3010` iam happens to be a **leftover tunnel process** with `AUTH_SESSIONCOOKIEDOMAIN=
+   .sk.vms.wootdev.com`, so the minted cookie is scoped to a remote domain the localhost browser never
+   sends back → `cookies:[]` → 503.
+   - **Note:** the SLOT iam (`:5010`) has `AUTH_SESSIONCOOKIEDOMAIN` UNSET → issues a HOST-ONLY
+     (localhost) cookie (iam's `sessionCookieDomain` is `z.string().optional()`), which IS correct.
+     So no manifest cookie-domain fix is needed — the fix is purely to make globalSetup mint against
+     the slot iam.
+   - **Fix direction:** make the coach-web flow export `PLAYWRIGHT_IAM_URL` (slot iam offset) AND
+     `PLAYWRIGHT_BASE_URL` (coach-web offset, not saga-dash) to coach-web's Playwright spawn — an
+     ss-flow env-contract change. This affects the automated SMOKE; a real interactive hand-off uses
+     ss `mintNativeLoginJar` (targets the slot iam directly), so it is likely already unblocked by #1.
+   - **Environment note:** a leftover slot-0 tunnel iam (`:3010`, `.sk.vms.wootdev.com` cookie/CORS)
+     is running — likely from other tunnel work; left untouched (slot 0 may be in use).
+
+**Status:** #300 core FIXED + verified (coach-web boots against local mesh). The remaining smoke-only
+env-contract fix (`PLAYWRIGHT_IAM_URL`/`PLAYWRIGHT_BASE_URL` for coach-web flows) is scoped and ready
+to implement next. Slot 2 torn down; a stale coach-web watch orphan was killed.

--- a/claude/projects/gh_305/source/build-report.md
+++ b/claude/projects/gh_305/source/build-report.md
@@ -141,3 +141,30 @@ iam/coach-web session-semantics layer, distinct from the env-contract fix.
 `devLogin`). A REAL `ss develop coach` hand-off authenticates via ss `mintNativeLoginJar` against the
 slot iam — a different path — so the interactive dev experience may already work end-to-end; the
 smoke is what's gating a fully-green flow.
+
+### soa#300 AUTH RESOLVED — verified end-to-end (2026-07-14)
+
+Proved the auth path works locally, then confirmed it in the live smoke:
+- `curl` whoami WITH the devLogin-minted `iam_session` cookie → **200** (slot iam recognizes the
+  session; cookie is `domain=localhost, SameSite=Lax, host-only`).
+- A direct Playwright cross-origin fetch (page `:10800` → `fetch(:5010/auth.whoami, {credentials:
+  'include'})`) with that storageState → **200**. So the cookie IS sent cross-origin and CORS is fine.
+- **Live smoke (slot 2):** the authenticated tests now render **logged in** — the page snapshot shows
+  `button "Tutor Demo Tutor One ☰"` (whoami resolved the seeded tutor's identity). The 503 and the
+  wrong-domain cookie are both gone.
+
+**So the #300 goal — coach-web local browser-testing authenticates — is ACHIEVED.** A real
+`ss develop coach` hand-off now brings up the stack and drops into a logged-in coach-web.
+
+**Two remaining smoke failures, NEITHER is auth:**
+1. **Content (module-playback):** the page authenticates but shows `heading "Couldn't Load Module"`
+   for `sc_u1_m1` — demo-tutor-1's materialized instance (spring-pilot) doesn't include the ported
+   acceptance module (curriculum-coach). This is the content-source question (scenario 3): the seed
+   materializes the tutor on `spring-pilot`, while `sc_u1_m1` lives in `curriculum-coach` — a coach-db
+   seed / coach-api content-resolution matter, not ss plumbing (the #228 Dashboard/Explore mismatch).
+2. **Unauthenticated shell/nav tests** (default project, no storageState) redirect to iam `/demo` —
+   coach-web requires auth at boot (no dev bypass), so these coach-web e2e specs need a storageState
+   wired into the default project. A coach-web e2e test-design fix, not ss.
+
+Net: the coach-web ↔ local-iam auth wiring (the heart of #300) is fixed and verified. What's left is
+coach-repo content-seed (module) + coach-web e2e test wiring (unauth shell specs).

--- a/claude/projects/gh_305/source/build-report.md
+++ b/claude/projects/gh_305/source/build-report.md
@@ -1,0 +1,49 @@
+# gh_305 — build report (ultracode, 2026-07-14)
+
+## Shipped (both branches pushed; PRs open as drafts)
+
+| Repo | Branch | PR | Commits |
+|---|---|---|---|
+| soa | `worktree-gh305-ss-develop` | **#306** | soa#300 fix, develop topic+connect+alias, M2 generalizations, `develop coach`, playlist fix |
+| coach | `feat/coach-content-playlist-assign` | **#239** (issue #238) | `playlist` verb, 2nd seed track |
+
+### soa (`develop coach`)
+- **soa#300 prereq** (`2626d5a`): coach-web `PUBLIC_IAM_API_URL` + iam CORS `COACH_WEB_URL` → local browser can sign in.
+- **develop topic + connect** (`b082a40`): `e2e connect` → `develop connect`; deprecating alias verified at runtime (`ss e2e connect` warns + dispatches). Docs split test-running vs dev-setup.
+- **Concierge generalizations** (`30c0dae`): persona-email through `holdEpilogue`; `openVendoredBrowser` → `{repoEnvVar,appDir,port}`; `coach-web` registered. Existing saga-dash/connect callers byte-identical.
+- **`develop coach`** (`b275463`): `--scenario content-viewer|admin|playlist`; `CONTENT_STORE_BACKEND=postgres` pinned; headed coach-web hand-off as `demo-tutor-1`.
+- **playlist fix** (`51b0448`): switch demo-tutor-1 onto the real 2nd track `curriculum-coach-b` using the `deriveUserId('demo-tutor-1')` UUID; fail-fast precheck; de-masked test.
+
+### coach (`playlist` verb)
+- **verb** (`90b304b`): `coach-content playlist assign|list|unassign`, writes only `group_id→content_name`, no `user_policy` reads, additive to #237.
+- **2nd seed track** (`58ce8f9`): materializable `curriculum-coach-b` twin in the offline seed release (additive).
+
+## Verification done (unattended-appropriate)
+- soa: `check-types` clean; **1177 tests pass**. coach: build+typecheck green; coach-content 42 pass (15 DB-gated skipped).
+- Runtime smokes: `ss e2e connect --help` (deprecation notice + dispatch), `ss develop coach --help`.
+- Adversarial review → found 1 real bug (playlist non-functional) → fixed → independent re-review verdict **fixed-correctly, no regressions**.
+
+## Owed: live verification (the human's to run on slot 1)
+Not run by the build — it resets+seeds the stack (would clobber active slot-1 work) and opens a **headed, TTY-holding** browser (interactive by design). Run when ready:
+
+```bash
+# content-viewer (primary): logged-in coach-web on the ported module player
+ss develop coach --slot 1                          # --scenario content-viewer is default
+# confirm: coach-web signs in (soa#300), lands on demo-tutor-1's dashboard,
+#          /units/unit_1/sc_u1_m1 plays.
+
+# playlist (needs coach#239 verb + curriculum-coach-b seed on the coach checkout):
+ss develop coach --slot 1 --scenario playlist
+# confirm: demo-tutor-1 visibly switches spring-pilot -> curriculum-coach-b.
+
+# admin (descoped v1): opens the mock-backed Reports route
+ss develop coach --slot 1 --scenario admin
+```
+
+Un-proven until then: the actual stack bring-up + coach-web browser sign-in, and the playlist DB
+materialize/switch against a live `coach_api` Postgres. PRs kept as **drafts** pending this check.
+
+## Deferred (tracked, not in this cycle)
+- Option B playlisting: legacy `saga_api` `user_policy` selection cutover + iam-policy→`group_track_map` projector for prod parity.
+- `develop saga-dash` / `ads` / `sis` (prompt-2 scenarios 2/6/7) — topic is built to extend; each needs its own research pass.
+- Cosmetic: stale `contentHash` in the coach seed fixture (nothing validates it).

--- a/claude/projects/gh_305/source/coach-issue-draft-playlist-assign.md
+++ b/claude/projects/gh_305/source/coach-issue-draft-playlist-assign.md
@@ -1,0 +1,57 @@
+# DRAFT coach-repo issue (Option A) — ready to file, holding pending Seth
+
+> Target repo: **saga-ed/coach**. Coordinate under saga-dash #448/#463 and coach PR #237.
+> Filing held until Seth confirms the #237 assignment-seam question (see plan). Say "file it" to post.
+
+---
+
+**Title:** coach-content: `playlist assign` CLI verb (coach-owned `group_track_map` writer) + 2nd seed track
+
+**Body:**
+
+## Summary
+
+Give coach a **coach-owned way to assign a group to a track** (write `group_track_map`) from the
+CLI, and seed a second track, so playlist selection no longer depends on `db:seed` alone or on the
+legacy `saga_api` `user_policy` path. Keeps playlisting **CLI-driven, no UI**. Unblocks
+`ss develop coach --scenario playlist` (soa#305).
+
+## Background
+
+Playlisting is already ~fully re-platformed in coach: `@saga-ed/coach-content-publish`
+(`coach-content` CLI) owns publish/materialize, and `group_track_map` + the reconcile materializer
+own track resolution (coach #202/#206/#207/#230/#232/#235). The one verified gap: **nothing writes
+`group_track_map` in production** — only `db:seed` writes it, reconcile only reads it. The live
+signal is the iam policy `coach:coach_playlist_name`, with no projector into coach. So there's no
+coach-owned way to (re)assign a group's track without the legacy stack.
+
+## Scope (Option A — minimal, unblocks develop-coach)
+
+- [ ] Add a `playlist` subcommand group to `packages/node/coach-content-publish/src/cli.ts`
+      (`src/playlist.ts` beside `src/store.ts`), Prisma → `coach_api` Postgres:
+  - `coach-content playlist assign --group <groupId> --content <content_name>` — upsert a
+    `group_track_map` row.
+  - `coach-content playlist list [--group <groupId>]` — show the current group→track map.
+  - `coach-content playlist unassign --group <groupId>` — remove a mapping.
+- [ ] Surface from coach-api via a delegating `package.json` script (precedent: `db:seed:run`).
+- [ ] Seed/publish a **2nd track** so a persona can be switched between ≥2 playlists locally
+      (seed ships only `spring-pilot`).
+- [ ] Tests: Postgres integration tests for the writer + the reconcile read-through; unit tests for
+      arg parsing/validation.
+
+## Explicitly out of scope (follow-up / Option B)
+
+- Legacy `saga_api` `user_policy` selection cutover (cross-api-plan § session endpoint).
+- iam-policy (`coach:coach_playlist_name`) → `group_track_map` projector for live prod parity.
+
+## Coordination
+
+- **Must not** read `saga_api`/saga-dash `user_policy` at runtime (keeps coach's domain boundary).
+- Design `playlist assign` to be **additive** to `group_track_map` and compatible with the
+  `tagFilter` shape from **coach PR #237** (Phase 2b) — confirm the seam with @SethPaul before build.
+- Driving product issues: saga-dash #448, #463.
+
+## Downstream
+
+Enables soa#305 `ss develop coach --scenario playlist`: `coach-content publish` a 2nd track →
+`playlist assign` → `materialize --replace`, all inside coach; saga-dash leaves the loop.

--- a/claude/projects/gh_305/source/coach-issue-draft-playlist-assign.md
+++ b/claude/projects/gh_305/source/coach-issue-draft-playlist-assign.md
@@ -30,7 +30,8 @@ coach-owned way to (re)assign a group's track without the legacy stack.
 - [ ] Add a `playlist` subcommand group to `packages/node/coach-content-publish/src/cli.ts`
       (`src/playlist.ts` beside `src/store.ts`), Prisma → `coach_api` Postgres:
   - `coach-content playlist assign --group <groupId> --content <content_name>` — upsert a
-    `group_track_map` row.
+    `group_track_map` row. **Writes only the `group_id → content_name` track mapping**; does not set
+    `tagFilter`/grain (those stay owned by PR #237's Phase 2b path — this verb is additive).
   - `coach-content playlist list [--group <groupId>]` — show the current group→track map.
   - `coach-content playlist unassign --group <groupId>` — remove a mapping.
 - [ ] Surface from coach-api via a delegating `package.json` script (precedent: `db:seed:run`).

--- a/claude/projects/gh_305/source/plan.md
+++ b/claude/projects/gh_305/source/plan.md
@@ -1,0 +1,169 @@
+# gh_305 — `ss develop` concierge topic, coach-first: plan
+
+_Evidence for every claim here lives in `../research/01`–`06` + the gap-critic verdict. File:line
+pointers below were spot-verified against real files during research._
+
+## Bottom line
+
+`develop coach` is **~90% orchestration over primitives that already exist** and **~10% new code
+concentrated in three spots**. The heavy lifting (coach in the ss manifest, a `--with coach`
+bundle, coach-pg/coach-mongo seed steps, `resolveFlow`/`executeResolvedFlow`, coach's own authored
+`e2e/flows.json`, tunnel overlay, slot>0 support for coach-web) is **already built**. So this
+effort is not a from-scratch build — it's: land one prerequisite fix, make three small
+generalizations, migrate `connect`, and wire the `develop` topic.
+
+Three research findings reframe the work:
+
+1. **soa#300 is the single load-bearing prerequisite** gating *all three* coach browser scenarios
+   (coach-web ↔ iam auth). It's a fully-specified ~2-line manifest fix. **Step 1, regardless of who
+   "owns" the PR.**
+2. **prompt-2 is factually wrong on 2 of its 5 scenarios.** The admin "dashboard" (scenario 4) is a
+   **mock-backed** Reports route *inside* coach-web (`reportsStore.fetchReport → getMockReport`), not
+   a separate app. **Playlisting (scenario 5) has no coach-web UI at all** — it's a saga-dash/
+   rostering surface plus coach's `group_track_map`/`content_name` track model. So "fully build the
+   admin dashboard and playlisting" as written is **not buildable without a product/scope decision**
+   (see "Open decisions").
+3. **The content viewer (scenario 3) is real, landed, and mostly a data + login story.** It's
+   coach-web's in-app SvelteKit **module player** (`lib/features/cns/viewer/*` +
+   `/units/[unitName]/[moduleId]/+page.svelte`) that reimplements the legacy Haxe ContentViewer
+   (`saga-ed/wmap-port`, `PollDataStateManager.hx` → `pollPlayer.svelte.ts`). It renders in-app only
+   when every question type is ported (12 base types today); the legacy `saga_api` fallback player
+   is retired.
+
+## What we're building (and the order)
+
+**Primary deliverable this cycle: a first-class `ss develop coach` that drops a developer into a
+running, logged-in coach with the ported content viewer showing real assigned content.** That is
+scenario 3, done properly. Scenarios 4/5 are gated on a scope decision below. The `develop` topic is
+built to extend to saga-dash/ads/sis later, but their substance is explicitly out of scope here.
+
+---
+
+## Architecture: the `develop` topic + the concierge contract
+
+`e2e connect` is a **thin command over a pure `resolveFlow` + generic `executeResolvedFlow`**
+(`research/05`). The concierge machinery is already SPA-generic. Onboarding a new app is "one command
+file + one `spa-registry` row + an authored `flows.json`." The genuinely-new code:
+
+### The 3 new code pieces (the entire "new" surface)
+
+1. **Parameterize the login persona.** `holdEpilogue` (`src/commands/e2e/run.ts:416`) hardcodes
+   `const email = DEFAULT_LOGIN_USER;` (`dev@saga.org`). A coach hand-off with `dev@saga.org` mints an
+   **empty** dashboard. → Thread an `email`/persona param through `holdEpilogue → mintNativeLoginJar`,
+   default `dev@saga.org`, override `demo-tutor-1@saga.org` for coach (and `demo-dadmin@saga.org` for
+   the admin scenario if in scope).
+2. **Generalize the browser opener.** `openVendoredBrowser` resolves `SAGA_DASH` via
+   `resolveRepoRoot('SAGA_DASH')` and **warn-and-skips the whole browser step if saga-dash isn't
+   cloned** (`base-command.ts:977-1001`). A coach-only dev gets no browser even with a valid coach
+   jar. → Parameterize on `{repoEnvVar, appDir, port}` from the `spa-registry` row; drive the
+   clone-gate off the SPA's repo, not saga-dash. **This is the single largest new piece.**
+3. **Register coach-web + the topic.** Add the `coach-web` row to
+   `src/core/flow/spa-registry.ts` (today only `saga-dash` + `connectv3`), register the `develop`
+   oclif topic (`package.json` `oclif.topics` + `src/commands/develop/`), and add the thin command
+   file(s).
+
+Everything else is **data + a decision.**
+
+### Command shape (recommended)
+
+One `ss develop coach` command with a `--scenario` selector (`content-viewer` [default] `| admin |
+playlist`), because scenarios differ only by a `COACH_FLOW` constant + persona fed to `resolveFlow`.
+`--reuse`, `--tunnel`, and `-- <passthrough>` mirror connect. (Alternative: separate subcommands —
+more discoverable, more files. Selector is less code and matches how the flows differ.)
+
+---
+
+## Deliverable 2 — migrate `e2e connect` → `develop connect` (+ deprecating alias)
+
+- Move `src/commands/e2e/connect.ts` → `src/commands/develop/connect.ts` (its AV-specific flags
+  `--fake-media`/`--refresh-snapshot` come along verbatim; migration is near-mechanical).
+- Leave a **deprecating alias** at `e2e connect`. Recommended: on the migrated command,
+  `static aliases = ['e2e:connect']` + `static deprecateAliases = true` (@oclif/core ^4).
+  **Caveat (verify at build):** there is *zero* existing `aliases`/`deprecateAliases` usage in this
+  CLI, so the exact runtime warning is untested here. **Prototype early:** run `ss e2e connect
+  --help` and `ss e2e connect` once; if the warning/dispatch don't behave, fall back to a thin
+  `e2e/connect.ts` warn-and-delegate shim.
+- Update docs to split **test-running** (`e2e list`/`run`/`traces`) from **dev setup** (`develop`).
+
+## Deliverable 1 — the coach development experience
+
+### Prerequisite (Step 0, blocks everything): land the soa#300 manifest fix
+
+coach-web reads identity **directly from iam-api** at boot (`+layout.ts` → `auth.whoami`,
+`credentials:include`); a 401 challenge redirects to login. The base manifest sets **no**
+`PUBLIC_IAM_API_URL` override (defaults to remote `iam.wootdev.com`) and iam's `CORS_ORIGIN` omits
+coach-web, so **local coach-web 503s / can't sign in**. Fix (verified ~2 lines):
+- Add `PUBLIC_IAM_API_URL: '${IAM_URL}'` to coach-web's launch `env` in the manifest.
+- Append a `COACH_WEB_URL` token to iam-api's `CORS_ORIGIN`.
+This works precisely because the manifest launches coach-web via `pnpm dev` (SvelteKit inlines
+`$env/static/public` at dev-server start). **gh_305 lands this fix itself** (recommended — it's tiny
+and unblocks the entire effort) rather than depending on a separate PR.
+
+### Scenario 3 — ported content viewer (PRIMARY, fully in scope)
+
+Target state: `ss develop coach` (default `--scenario content-viewer`) brings up the coach closure
+(coach-api pg + coach-web + iam-api + curriculum mongo), seeds via coach's `flows.json` (`seed:
+full`, which already resets+seeds coach correctly — **no new bundle seed-add-on required**), mints
+an **iam_session for `demo-tutor-1`**, and opens a headed browser at coach-web (`:8800`) already
+logged in, on the dashboard, with the fully-ported module `sc_u1_m1` at `/units/unit_1/sc_u1_m1`
+playable.
+
+Two content-source sub-decisions (see Open decisions): **(a)** synthetic `curriculum-coach` that
+works today via `db:seed` alone [recommended v1], vs **(b)** publish the real `spring-pilot` release
+for legacy parity (needs a `content-archive` checkout + `coach-content` publish as a concierge step).
+Pin `CONTENT_STORE_BACKEND` explicitly in the coach-api launch env rather than relying on the
+disputed default (docs 02 vs 06 conflict on what the unset default serves).
+
+### Scenario 4 — admin dashboard (SCOPE DECISION REQUIRED)
+
+Reality: the admin surface is the **mock-backed Coach Reports route** in coach-web
+(`reportsStore.fetchReport → getMockReport`); no live org table, and the seed materializes only **one**
+tutor on one track, so a live report would be a single row. Options in "Open decisions."
+
+### Scenario 5 — playlisting (SCOPE DECISION REQUIRED)
+
+Reality: **no coach-web playlisting UI exists.** Playlist selection is a saga-dash/rostering surface
+(`user_policy.playlist_name`/`available_playlists`); coach's side is the `group_track_map`/
+`content_name` track model, and only one track (`spring-pilot`) is seeded. Options in "Open decisions."
+
+## Deliverable 3 — extensibility (topic scaffolding only)
+
+The `e2e→develop` split is clean and the topic is genuinely extensible: adding an app is "one command
+file + one `spa-registry` row + an authored `flows.json`." We build the topic so `develop saga-dash`
+/ `develop ads` / `develop sis` (prompt-1 scenarios 2/6/7) slot in later. **Their substance is out of
+scope here and each needs its own research pass** (ads/sis weren't researched; whether they're even
+SPAs with flows.json is unknown).
+
+---
+
+## Phased implementation (for ultracode)
+
+- **M0 — Prereq:** land the soa#300 manifest fix; verify local coach-web signs in against local iam.
+- **M1 — Topic + connect migration:** create `develop` topic; move `connect.ts`; wire the
+  deprecating alias; **prototype-verify the alias runtime behavior**; docs split. Full suite green.
+- **M2 — Concierge generalizations:** (1) persona-email param through `holdEpilogue`; (2) generalize
+  `openVendoredBrowser` to `{repoEnvVar, appDir, port}`; (3) add coach-web `spa-registry` row. Unit
+  tests for each; no behavior change for existing saga-dash/connect paths.
+- **M3 — `develop coach` (content-viewer):** thin command; `--scenario` selector; drive coach flow +
+  `demo-tutor-1` mint + headed coach-web hand-off; pin `CONTENT_STORE_BACKEND`. **Live-verify on ss
+  slot 1**: logged-in dashboard + `sc_u1_m1` plays.
+- **M4 — scenarios 4/5** per the scope decision (descope-and-document, or funded coach-repo work).
+- **M5 — docs + PR polish:** `docs/develop.md`, README/e2e pointers, deprecation notes.
+
+Each milestone: `pnpm typecheck` + full vitest suite + a real-binary/live check on slot 1 where a
+runtime surface exists (per repo `/verify` convention).
+
+## Open decisions (need your call before/at ultracode)
+
+1. **Scenarios 4 & 5 scope.** (a) *Descope to concierge-only* for v1: bring up + seed + hand off +
+   **document** the current mock-admin / no-playlist-UI reality [recommended — keeps this a pure-ss
+   effort]; or (b) *fund coach-repo product work*: rewire `reportsStore.fetchReport →
+   fetchCoachReport` + seed `demo-tutor-2`/`demo-dadmin` multi-row fixtures for a live admin, and
+   define playlisting = a ≥2-track `group_track_map` switch demo (needs a 2nd published track).
+2. **Content-viewer content source.** (a) synthetic `curriculum-coach` (works today, zero extra work)
+   [recommended v1]; or (b) publish real `spring-pilot` via `coach-content` for legacy parity (needs
+   a `content-archive` checkout + an `ARCHIVE_DIR`/publish concierge step).
+3. **Command shape.** One `develop coach --scenario …` [recommended] vs separate subcommands.
+
+Recommended defaults let ultracode proceed immediately on M0–M3 (the real coach experience) while
+M4's shape waits on decision #1.

--- a/claude/projects/gh_305/source/playlisting-port-plan.md
+++ b/claude/projects/gh_305/source/playlisting-port-plan.md
@@ -105,6 +105,9 @@ Scope for this effort = **Option A**. Concretely:
    package. No UI. Likely companions: `playlist list` (show current group→track map) and
    `playlist unassign`. Surface from coach-api via a delegating `package.json` script (precedent
    `db:seed:run`). **Must not read `saga_api`/saga-dash `user_policy` at runtime.**
+   **Writes ONLY the `group_id → content_name` track mapping** (Sean, 2026-07-14) — it does **not**
+   set `tagFilter` or grain; those stay owned by coach PR #237's Phase 2b path, so the verb is
+   strictly additive to Seth's work.
 2. **Seed/publish a 2nd track** so a persona can be switched between ≥2 playlists locally (seed ships
    only `spring-pilot` today).
 3. Wire the one-command local seeding path into `ss develop coach --scenario playlist`
@@ -113,9 +116,11 @@ Scope for this effort = **Option A**. Concretely:
 **Out of scope (deferred to Option B / follow-up):** the legacy `user_policy` selection cutover and
 the iam-policy (`coach:coach_playlist_name`) → `group_track_map` projector for live prod parity.
 
-**Build dependency to confirm with Seth (question 3):** coach PR #237 (Phase 2b tag-filter) may
-reshape the assignment seam — design `playlist assign` to be additive to `group_track_map` and
-compatible with `tagFilter`. This is why issue-filing is held (below), not the scope itself.
+**Build dependency (question 3) — RESOLVED (Sean, 2026-07-14):** `playlist assign` writes **only**
+the `group_id → content_name` mapping and leaves `tagFilter`/grain to coach PR #237. The verb is
+therefore additive to Seth's Phase 2b by construction, and the #237 seam no longer blocks the design.
+Issue-filing is now fully ready — held only pending an explicit "file it" (outward-facing action that
+tags Seth) or Seth's ack that we're not duplicating something in-flight.
 
 ## Open questions for Seth (we've pinged him; these are the specifics)
 

--- a/claude/projects/gh_305/source/playlisting-port-plan.md
+++ b/claude/projects/gh_305/source/playlisting-port-plan.md
@@ -96,6 +96,27 @@ loop entirely (it was never in it).
 Recommend **A now** (it's the piece `develop` actually needs), track **B** as a coach-repo follow-up
 coordinated under saga-dash #448/#463 and Seth's #237.
 
+### ✅ DECISION (2026-07-14): Option A locked (Sean)
+
+Scope for this effort = **Option A**. Concretely:
+1. **`coach-content playlist assign --group <groupId> --content <content_name>`** — a new `playlist`
+   subcommand group on the existing `@saga-ed/coach-content-publish` CLI (`src/playlist.ts` beside
+   `src/store.ts`); writes/upserts a `group_track_map` row via Prisma → `coach_api` Postgres. No new
+   package. No UI. Likely companions: `playlist list` (show current group→track map) and
+   `playlist unassign`. Surface from coach-api via a delegating `package.json` script (precedent
+   `db:seed:run`). **Must not read `saga_api`/saga-dash `user_policy` at runtime.**
+2. **Seed/publish a 2nd track** so a persona can be switched between ≥2 playlists locally (seed ships
+   only `spring-pilot` today).
+3. Wire the one-command local seeding path into `ss develop coach --scenario playlist`
+   (publish 2nd track → `playlist assign` → `materialize --replace`).
+
+**Out of scope (deferred to Option B / follow-up):** the legacy `user_policy` selection cutover and
+the iam-policy (`coach:coach_playlist_name`) → `group_track_map` projector for live prod parity.
+
+**Build dependency to confirm with Seth (question 3):** coach PR #237 (Phase 2b tag-filter) may
+reshape the assignment seam — design `playlist assign` to be additive to `group_track_map` and
+compatible with `tagFilter`. This is why issue-filing is held (below), not the scope itself.
+
 ## Open questions for Seth (we've pinged him; these are the specifics)
 
 1. Is the legacy `saga_api` `user_policy` playlist-selection cutover (cross-api-plan § session

--- a/claude/projects/gh_305/source/playlisting-port-plan.md
+++ b/claude/projects/gh_305/source/playlisting-port-plan.md
@@ -1,0 +1,113 @@
+# Sibling plan — coach owns "playlisting" (REFRAMED after research)
+
+_Sibling to the `ss develop` plan (`plan.md`). Evidence: `../research/07`, `08`, `09`._
+
+## ⚠️ Premise correction (read first)
+
+The ask was "port the playlisting functionality **out of saga-dash** and into coach-api." Three
+independent research passes converge on a correction:
+
+1. **saga-dash has zero playlisting code.** Grep for `playlist`, `playlist_name`,
+   `available_playlists`, `group_track_map`, `content_name`, `content_release`, `ContentInstance`
+   across saga-dash apps/packages **and full history** returns nothing (2 unrelated "materialized"
+   false positives). There is nothing in saga-dash to move.
+2. **"Playlist" is legacy `saga_api`/nimbee terminology**, living in the rostering/iam **policy**
+   layer: `user_policy.{playlist_name, available_playlists, playlist_version, default_track}` and the
+   iam policy key `coach:coach_playlist_name` (rostering `permission_policy_registry.md`; consumers
+   listed as *nimbee, coach*). `saga_api` isn't checked out locally, so its internals are
+   documented-only.
+3. **coach-api has ALREADY re-platformed it, and it's ~80% shipped — all by Seth.** The CLI-driven,
+   no-UI seeding pipeline you remember now lives in the **coach repo** as
+   `@saga-ed/coach-content-publish` (bin `coach-content`), backed by the `group_track_map` table
+   (schema comment: *"Replaces the dead saga_api path"*) + the reconcile materializer.
+
+**So this is not a from-saga-dash port. It is: join an effort already underway in coach, finish two
+small coach-owned pieces, and add the seeding hook `ss develop coach` needs.** saga-dash leaves the
+loop entirely (it was never in it).
+
+## The legacy → coach-api mapping
+
+| Legacy (`saga_api`/nimbee `user_policy`) | coach-api today |
+|---|---|
+| `playlist_name` / active playlist | `content_name` — a **track**; `content_instance(user_id, content_name)` |
+| group/district → which playlist | **`group_track_map`** (`group_id → content_name`) |
+| `DEFAULT_TRACK_NAME` fallback | `DEFAULT_CONTENT_NAME = 'base-coach'` |
+| playlist authoring / seeding CLI | **`coach-content`** CLI (`publish`/`materialize`/`rollback`/…) |
+| tag/attribute matching (aspirational) | `tagFilter` + `filterContentByTags` — **in flight, PR #237** |
+
+## What already exists (merged on coach `main`)
+
+- **The content-publish CLI** = the CLI-driven seeding pipeline: `coach-content
+  status|diff|publish|rollback|materialize`, Prisma → `coach_api` Postgres, source =
+  `saga-ed/content-archive`. `materialize` shares `deriveTemplates` with coach-api's live reconcile,
+  so CLI seeding and event materialization can't drift. (coach #202/#206/#207/#209/#234)
+- **Track resolution**: `group_track_map` + reconcile materializer joins `persona_assignment →
+  group_track_map` and materializes the tutor's `content_instance` (fallback `base-coach`). (coach
+  #235 bakes it into the local seed; #230 cross-track completion; #232 section-grain #448/#463 Phase
+  2a)
+
+## In-flight (Seth, opened 2026-07-14 — coordinate, don't collide)
+
+- **coach PR #237 (OPEN)** — `feat(coach-api): content tag-filter narrowing + grain-rank resolution
+  (#463 Phase 2b)`. Implements saga-dash **#463** (tag content + user attributes, resolve the
+  intersection instead of maintaining 4 hand-built playlists).
+- **Driving product issues (both OPEN):** saga-dash **#448** (track-switch progress retention) and
+  **#463** (tag-based playlists). #463 is framed as a discussion kickoff — Seth is *ahead* of it.
+
+## The genuine remaining "into coach-api" work (the real, small port)
+
+1. **Legacy `user_policy` selection cutover.** coach-api's `cross-api-plan.md` (§ session endpoint)
+   still lists the legacy `user_policy` playlist fields coach-api intends to own. Confirm with Seth
+   whether retiring coach-api's last cross-api dependence on `saga_api` playlist *selection* (resolve
+   fully from `group_track_map` / iam policy) is **in scope or deferred**. This is the only piece
+   still straddling the legacy stack.
+2. **A coach-owned assignment writer.** Verified gap: **nothing writes `group_track_map` in
+   production** — only `db:seed` writes it; reconcile only reads it. The live "which playlist" signal
+   is the iam policy `coach:coach_playlist_name`, with **no projector into coach**. To own playlisting
+   end-to-end, coach needs one of: (a) an **iam-policy → `group_track_map` projector** (event-driven,
+   matches the existing iam-projection-handlers pattern) for live parity, and/or (b) a **`coach-content
+   playlist assign --group <g> --content <track>` CLI verb** that writes `group_track_map` (the
+   dev/seed path). Keep it **CLI-driven, no UI** — add a `playlist` subcommand group to the existing
+   `coach-content` CLI (`src/playlist.ts` beside `src/store.ts`), surfaced from coach-api via a
+   delegating `package.json` script (precedent: `db:seed:run`). **Do not add a new package; do not
+   read saga-dash/`saga_api` `user_policy` at runtime** (would re-couple coach and violate its domain
+   boundary).
+
+## How this unblocks `ss develop coach`
+
+- **`--scenario content-viewer` (primary): needs NOTHING new.** `db:seed` already lands a working
+  track + a materialized `demo-tutor-1` instance; the viewer renders today (once soa#300 is fixed).
+- **`--scenario playlist`: blocked today** — only one track (`spring-pilot`) is seeded and there's no
+  coach-owned way to switch a persona's track. After item 2b, the one-command local path is:
+  `db:seed` → `coach-content publish` a 2nd track → `coach-content playlist assign --group
+  <demo-district> --content track-2` → `coach-content materialize --user demo-tutor-1 --content
+  track-2 --replace`; `develop coach` wraps those, `devLogin`s demo-tutor-1, opens coach-web on the
+  chosen playlist — all inside coach.
+
+## Proposed scope (recommendation)
+
+- **Option A (minimal, recommended now):** add the `coach-content playlist assign` verb (writes
+  `group_track_map`) + seed/publish a 2nd track. Pure coach, no legacy cutover, **directly unblocks
+  `develop coach --scenario playlist`**. Small, ships fast, non-colliding with PR #237.
+- **Option B (the "real" port):** A **+** the legacy `user_policy` selection cutover / iam-policy
+  projector for live production parity. Bigger, spans the cross-api-plan, gated on Seth + product
+  (#463).
+
+Recommend **A now** (it's the piece `develop` actually needs), track **B** as a coach-repo follow-up
+coordinated under saga-dash #448/#463 and Seth's #237.
+
+## Open questions for Seth (we've pinged him; these are the specifics)
+
+1. Is the legacy `saga_api` `user_policy` playlist-selection cutover (cross-api-plan § session
+   endpoint) in your scope, or deferred?
+2. Do you want a coach-owned `group_track_map` writer — an iam-policy (`coach:coach_playlist_name`)
+   projector for live parity, a `coach-content playlist assign` CLI verb for dev/seed, or both?
+3. Does PR #237 (Phase 2b tag-filter) reshape the assignment seam in a way a `playlist assign` verb
+   should account for?
+
+## Where the issue should live / status
+
+- **coach repo** (this is coach-api work), coordinated under the existing saga-dash #448/#463 and
+  Seth's #237 — **not** a soa issue, and **not** a "saga-dash port."
+- **HOLDING on filing.** Draft issue body is ready (Option A). File once Seth confirms scope, to
+  avoid duplicating/colliding with #237.

--- a/claude/projects/gh_305/source/prompt-1.md
+++ b/claude/projects/gh_305/source/prompt-1.md
@@ -1,0 +1,30 @@
+# gh_305 — original ask
+
+> Create a new issue for a `ss develop` topic — I'm going to migrate the `ss e2e connect`
+> to this topic from the e2e topic and add sub-commands for coach, saga-dash, ads etc.
+> The idea is that these are less end-to-end tests and more **concierge scripting** that
+> makes it easy to set up and develop against a particular application or workflow.
+> Create the issue in soa and a project `claude/projects/gh_[issue]` with source and
+> research directories. Use **slot 1** and a **worktree** for this effort — we'll be
+> working and testing it for most of today.
+
+## Tracking
+
+- **Issue:** saga-ed/soa#305 — https://github.com/saga-ed/soa/issues/305
+- **Worktree:** `.claude/worktrees/gh305-ss-develop` (branch `worktree-gh305-ss-develop`)
+- **ss stack slot:** 1 (all live bring-up / testing runs against slot 1 for the day)
+
+## The idea
+
+`e2e` conflates two intents. Split them:
+
+- **`e2e`** stays the *test-runner*: `e2e list` / `e2e run` / `e2e traces`.
+- **`develop`** (new) is *concierge scripting*: one-command flows that seed/reset a stack,
+  build any prerequisite, log in, and hand off a **running, developable app** for a
+  specific application or workflow.
+
+`ss e2e connect` moves to `ss develop connect` (it's a live headed interactive session,
+not a test). New per-app concierge subcommands: `develop coach`, `develop saga-dash`,
+`develop ads`, … — extensible, one per app/workflow we want a fast on-ramp for.
+
+See the issue for the full proposed shape, scope, and non-goals.

--- a/claude/projects/gh_305/source/prompt-2.md
+++ b/claude/projects/gh_305/source/prompt-2.md
@@ -1,0 +1,23 @@
+What I am envisioning here is a set of concierge subcommands similar to the current `ss e2e connect` that make it easy for developers to work on a develop against a particular system(s)
+
+Scenarios I image are
+
+1) connect (a tutor and two students)
+
+2) connect with saga-dash configured for session based ADS/ADM
+
+3) coach (the new version that is in coach repo and includes the ported content viewer application)
+
+4) coach with the admin dashboard that currently ships with the coach repo
+
+5) coach with the interface for playlisting
+
+6) saga-dash (program setup, scheduling, pods and sessions)
+
+7) sis (clever, one-roster, saga CSV)
+
+
+Given that these system generally will require seed data, and aspects of the
+synthetic-dev stack there is overlap with the e2e topic subcommands but its not
+a complete overlap - one is for automated flow testing the other is for active
+development.

--- a/packages/node/saga-stack-cli/README.md
+++ b/packages/node/saga-stack-cli/README.md
@@ -14,7 +14,7 @@ you have to reverse-engineer.
 > path (up → status → verify → e2e → down) with the real output of each command, linking out
 > to per-feature docs ([sub-stacks](./docs/sub-stacks-and-bundles.md) · [slots](./docs/slots.md) ·
 > [verify](./docs/verify.md) · [snapshots](./docs/snapshots.md) · [e2e](./docs/e2e.md) ·
-> [tunnel](./docs/tunnel.md) · [integration](./docs/integration.md)).
+> [develop](./docs/develop.md) · [tunnel](./docs/tunnel.md) · [integration](./docs/integration.md)).
 
 ```bash
 ss stack up --only scheduling-api,sessions-api   # boot just those + their deps
@@ -108,12 +108,23 @@ E2e scenarios are **data** (`flows.json`), not hardcoded bash.
 | --- | --- |
 | **`run`** | `ss e2e run <spa>/<flow>` → discover the flow → compute just the stack it needs → seed → run Playwright. `--through <stage>` runs a prefix of a progressive flow; `--headless`. |
 | **`list`** | Discoverable SPAs, their flows, and stages. |
-| **`connect`** | Open a live interactive Connect session (1 tutor + 2 students). |
+| **`traces`** | List preserved e2e run traces (newest first) with paste-ready show-trace commands. |
 
 Onboarding a new SPA or scenario is a registry row + a `flows.json` entry (progressive
 multi-stage journeys, prerequisites, foreground/AV markers, per-stage `requiredSystems`) —
 **zero new orchestration code**. A clamped occurrence-date is injected so weekend runs don't
 flake.
+
+## `ss develop …` — concierge stacks for hands-on work
+
+Where `e2e` *runs test flows*, `develop` *sets up + hands off* a developable stack: bring up
+the closure, reset + seed it, then drop you into a running app to drive by hand.
+
+| Command | What it does |
+| --- | --- |
+| **`connect`** | Open a live interactive Connect session (1 tutor + 2 students). Migrated from `e2e connect` (the old id still works with a deprecation warning). |
+
+→ [docs/develop.md](./docs/develop.md)
 
 ## Architecture
 

--- a/packages/node/saga-stack-cli/docs/cheatsheet.md
+++ b/packages/node/saga-stack-cli/docs/cheatsheet.md
@@ -108,7 +108,7 @@ ss e2e run saga-dash/journey --hold              # after green: open a logged-in
 ss e2e run saga-dash/journey --to pods --hold    # run UP TO (not including) a stage, then hold
 ss e2e run --set feat-sched saga-dash/journey    # run a flow against a worktree set (its slot)
 ss e2e run saga-dash/journey --slot 1            # run on an isolated slot
-ss e2e connect                       # LIVE interactive Connect: 1 tutor + 2 students, HEADED + FOREGROUND
+ss develop connect                   # LIVE interactive Connect: 1 tutor + 2 students, HEADED + FOREGROUND
                                      #   (opens 3 windows into a real room, holds them open; needs cam/mic + AV up).
                                      #   = `ss e2e run saga-dash/interactive-connect --headed`. Ctrl-C / Resume (▶) to end.
 ```

--- a/packages/node/saga-stack-cli/docs/develop.md
+++ b/packages/node/saga-stack-cli/docs/develop.md
@@ -10,7 +10,7 @@ It is the sibling of [`ss e2e …`](./e2e.md), and the two split by intent:
 
 | Topic | Intent | Commands |
 | --- | --- | --- |
-| **`develop`** | **set up + hand off** a developable stack for an app/workflow | `connect` (more coming) |
+| **`develop`** | **set up + hand off** a developable stack for an app/workflow | `connect`, `coach` (more coming) |
 | **`e2e`** | **run test flows** (assertions, CI, traces) against a stack | `run`, `list`, `traces` |
 
 Reach for `develop` when you want to *use* the app; reach for `e2e` when you want to
@@ -47,6 +47,44 @@ ss develop connect --refresh-snapshot   # rebake the journey prerequisite, then 
   `--student-login <0-2>` leaves some students OPEN for remote peers to take — pair with
   `--tunnel` to invite coworkers. → [tunnel.md](./tunnel.md)
 - Anything after `--` passes straight through to Playwright.
+
+## `develop coach` — a running, logged-in coach
+
+```bash
+ss develop coach
+```
+
+Brings up the coach closure (coach-web + coach-api + iam-api + coach_api Postgres + curriculum
+mongo), seeds it (the `full` profile lands demo-tutor-1's content + track + group mapping), drives
+one of coach-web's authored flows, then hands off a **headed, already-logged-in coach-web** at the
+scenario's screen. Unlike `connect` (whose hold is the Playwright room), the hand-off is a real
+browser via the vendored auto-login — the dev stack stays up; the window holds until you close it.
+
+```bash
+ss develop coach                          # content-viewer: the ported module player (demo-tutor-1)
+ss develop coach --scenario admin         # the Reports route (demo-dadmin) — MOCK-backed today
+ss develop coach --scenario playlist      # switch demo-tutor-1 to a 2nd track (needs coach#238)
+ss develop coach --reuse -- --debug       # against the current stack, playwright --debug
+```
+
+- **`--scenario content-viewer`** (default) drives `module-playback` as `demo-tutor-1@saga.org` and
+  lands on the ported module player (`/units/unit_1/sc_u1_m1`), rendering the seeded content
+  (`CONTENT_STORE_BACKEND=postgres` is pinned in coach-api's launch env, so it serves the seeded
+  release deterministically).
+- **`--scenario admin`** logs in `demo-dadmin@saga.org` and lands on `/reports`. **Descoped for v1:**
+  the org-wide Coach Report renders from **mock data** (`reportsStore.fetchReport → getMockReport`),
+  not live coach-api resolvers — the command prints this caveat at hand-off. Live-backing it is
+  coach-repo product work.
+- **`--scenario playlist`** switches `demo-tutor-1` to a 2nd track via the coach-owned
+  `coach-content playlist assign` + `materialize --replace`. That verb is being built in parallel
+  (**coach#238**); if your coach checkout doesn't have it yet the command **fails fast** with an
+  actionable message rather than crashing mid-bring-up.
+- `--reuse` skips the reset+seed and hands off against the **current** stack state.
+- `--tunnel` repoints this run's flow browsers at the vms tunnel hosts (as `connect`; requires a
+  prior `ss stack up --tunnel`). Anything after `--` passes straight through to Playwright.
+
+> Requires the `COACH` repo checked out (`$COACH` / `--coach`). coach-web signs in against the local
+> iam via the soa#300 manifest wiring (`PUBLIC_IAM_API_URL` + iam CORS), landed with this topic.
 
 ### Deprecation note: `e2e connect` → `develop connect`
 

--- a/packages/node/saga-stack-cli/docs/develop.md
+++ b/packages/node/saga-stack-cli/docs/develop.md
@@ -1,0 +1,63 @@
+# Develop — concierge stacks for hands-on work
+
+← [Getting started](./getting-started.md)
+
+`ss develop <app-or-workflow>` is the **dev-setup concierge**: one command brings up the
+right closure, resets + seeds it (recursing any prerequisite), and then **hands off a
+running app** you can drive by hand — logged in, on the right screen, ready to work.
+
+It is the sibling of [`ss e2e …`](./e2e.md), and the two split by intent:
+
+| Topic | Intent | Commands |
+| --- | --- | --- |
+| **`develop`** | **set up + hand off** a developable stack for an app/workflow | `connect` (more coming) |
+| **`e2e`** | **run test flows** (assertions, CI, traces) against a stack | `run`, `list`, `traces` |
+
+Reach for `develop` when you want to *use* the app; reach for `e2e` when you want to
+*test* it. Both are thin commands over the same flows-as-data machinery (`resolveFlow` +
+the generic in-process executor) — a concierge just picks a flow and a hand-off style.
+
+## `develop connect` — live interactive Connect session
+
+```bash
+ss develop connect
+```
+
+Brings up the Connect closure (iam / sessions / content / connect-api / connect-web / rtsm),
+builds the `journey` prerequisite headless, then opens a real **1-tutor + 2-student**
+interactive Connect room and holds it in the foreground — for hands-on Connect development,
+not an assertion run.
+
+```bash
+ss develop connect                      # full: journey prereq → headed Connect room
+ss develop connect --reuse -- --debug   # against the current stack, playwright --debug
+ss develop connect --fake-media         # synthetic cam/mic (no camera / no v4l2loopback)
+ss develop connect --refresh-snapshot   # rebake the journey prerequisite, then open the room
+```
+
+- `--reuse` skips the prerequisite rebuild + reset and runs against the **current** stack state.
+- `--fake-media` swaps real mic/cam capture for Chromium's synthetic camera + mic (pins
+  `FAKE_MEDIA=1` on the headed run only; the journey prerequisite is unaffected).
+- `--refresh-snapshot` bakes the journey checkpoints fresh (headless replay,
+  `--snapshot-stages`) before opening — the one-command reseed when the baked state has gone
+  stale (>7d) or the journey changed. Requires `--prereq-from-snapshot`; mutually exclusive
+  with `--reuse`.
+- `--tunnel` points this run's browsers at the `https://<svc>.<moniker>.vms.wootdev.com` tunnel
+  hosts so a **remote** peer can join the room (requires a prior `ss stack up --tunnel`).
+  `--student-login <0-2>` leaves some students OPEN for remote peers to take — pair with
+  `--tunnel` to invite coworkers. → [tunnel.md](./tunnel.md)
+- Anything after `--` passes straight through to Playwright.
+
+### Deprecation note: `e2e connect` → `develop connect`
+
+`connect` moved from the `e2e` topic to `develop` (dev-setup, not a test flow). The old id
+still works for one cycle via a deprecating alias — `ss e2e connect` dispatches to
+`ss develop connect` and prints:
+
+```
+The "e2e connect" command has been deprecated. Use "develop connect" instead.
+```
+
+Update scripts to `ss develop connect`; the alias is removed in a later release.
+
+← [snapshots](./snapshots.md) · [e2e](./e2e.md) · [integration →](./integration.md)

--- a/packages/node/saga-stack-cli/docs/e2e-flows.md
+++ b/packages/node/saga-stack-cli/docs/e2e-flows.md
@@ -110,14 +110,14 @@ for the general pattern.
 ### 4. connect-session — manual/AV only
 
 ```bash
-ss e2e connect              # RESTORES the journey@schedule checkpoint (when baked),
+ss develop connect              # RESTORES the journey@schedule checkpoint (when baked),
                             # else replays journey headless, then opens the headed
                             # interactive room (holds via page.pause)
-ss e2e connect --reuse      # skip the state rebuild; use the current stack
-ss e2e connect --refresh-snapshot   # re-bake journey@schedule FRESH, then open the room
+ss develop connect --reuse      # skip the state rebuild; use the current stack
+ss develop connect --refresh-snapshot   # re-bake journey@schedule FRESH, then open the room
 ```
 
-`ss e2e connect` restores the `flow-saga-dash-journey-s5-schedule` checkpoint
+`ss develop connect` restores the `flow-saga-dash-journey-s5-schedule` checkpoint
 instead of replaying journey 1..5 headless — the big accelerant — falling back to
 the full replay when nothing is baked (`--no-prereq-from-snapshot` forces the
 replay). Bake it once with `ss e2e run saga-dash/journey --through schedule
@@ -241,7 +241,7 @@ ss e2e run saga-dash/ads-adm-attendance --headless          # 2. persistence
 ss e2e run saga-dash/scheduling-topology --headless         # 3. realization
 ss e2e run saga-dash/journey --through pods --headed        # 4. watch one headed
 ss e2e run saga-dash/journey --from schedule --to schedule --hold   # 5. drive one by hand
-ss e2e connect                                              # 6. live room (mic/cam)
+ss develop connect                                              # 6. live room (mic/cam)
 ss stack down                                               # 7. tidy up
 ```
 

--- a/packages/node/saga-stack-cli/docs/e2e.md
+++ b/packages/node/saga-stack-cli/docs/e2e.md
@@ -120,21 +120,15 @@ ss e2e run saga-dash/journey --from schedule --to schedule --hold --set topo
 and runs nothing (pair it with `--hold`, or it does nothing observable). Teardown when
 done with `ss stack down [--set <name> | --slot N]`.
 
-## Live interactive Connect session
+## Live interactive Connect session — moved to `develop`
 
-```bash
-ss e2e connect
-```
-
-<details><summary>Opens a live 1-tutor + 2-student Connect session against the running stack</summary>
-
-Brings up the Connect closure (iam / sessions / content / connect-api / connect-web / rtsm)
-and opens a real interactive session — for hands-on Connect development, not an assertion run.
-</details>
+Setting up a stack to *use* by hand (vs. running a test flow) now lives under the
+[`develop`](./develop.md) topic. `ss e2e connect` moved to **`ss develop connect`**; the old
+id still works for one cycle with a deprecation warning. → [develop.md](./develop.md)
 
 ## Share the session — `--tunnel`
 
-`ss e2e run` and `ss e2e connect` take `--tunnel`, which points the Playwright browser at the
+`ss e2e run` and `ss develop connect` take `--tunnel`, which points the Playwright browser at the
 `https://<svc>.<moniker>.vms.wootdev.com` tunnel hosts so a **remote** person can reach your
 slot-0 stack (e.g. invite a coworker to a Connect room). `run --tunnel` WAN-hairpins and is slow —
 for seeding launchable sessions prefer the localhost-build → snapshot → restore-under-tunnel bridge.

--- a/packages/node/saga-stack-cli/docs/getting-started.md
+++ b/packages/node/saga-stack-cli/docs/getting-started.md
@@ -296,7 +296,8 @@ ss e2e run saga-dash/journey --through sessions --headless
 ```
 
 `--through <stage>` runs a prefix of a progressive flow. See **[e2e.md](./e2e.md)** for
-authoring flows, `e2e list`, and `e2e connect` (live interactive Connect session).
+authoring flows and `e2e list`, and **[develop.md](./develop.md)** for `develop connect`
+(live interactive Connect session).
 </details>
 
 ---
@@ -521,7 +522,8 @@ and **[worktree-sets.md](./worktree-sets.md)**.
 - **[worktree-sets.md](./worktree-sets.md)** — `--set <name>`: named repo→worktree maps on slots (parallel dev contexts, per-worktree flows, build-collision guard)
 - **[verify.md](./verify.md)** — the health / data / source-posture checks (and what fails vs warns)
 - **[snapshots.md](./snapshots.md)** — store/restore DB fixtures instead of re-seeding
-- **[e2e.md](./e2e.md)** — flows-as-data, `e2e run`/`list`/`connect`
+- **[e2e.md](./e2e.md)** — flows-as-data, `e2e run`/`list`/`traces`
+- **[develop.md](./develop.md)** — `develop <app>`: concierge stacks that set up + hand off a running app (`develop connect`)
 - **[e2e-flows.md](./e2e-flows.md)** — the browsable flow worlds (hermetic-flow viewer)
 - **[integration.md](./integration.md)** — `overlay` (in-flight PRs), `bootstrap`, `login`, `tunnel`
 - **[cold-start.md](./cold-start.md)** — `cold-start`: the destructive clean-slate baseline (docker wipe → repos to main → clean build → `.env` → up)

--- a/packages/node/saga-stack-cli/docs/tunnel.md
+++ b/packages/node/saga-stack-cli/docs/tunnel.md
@@ -29,7 +29,7 @@ ss stack snapshot restore tunnel-connect
 
 # 3 — Open the live Connect room over the tunnel. The tutor auto-hosts + STARTS the session.
 #     --reuse: run against the org you just restored (don't rebuild the prerequisite).
-ss e2e connect --tunnel --student-login 1 --reuse   # tutor + 1 local student; 1 seat left OPEN
+ss develop connect --tunnel --student-login 1 --reuse   # tutor + 1 local student; 1 seat left OPEN
 ```
 
 `--student-login N` = how many of the 2 students **this machine** logs in and joins locally
@@ -89,7 +89,7 @@ until you hit Resume (▶) in the Playwright Inspector.
 never both — so one running iam serves the localhost journey **or** the tunnel dash, not both. The
 concierge therefore **builds the org under localhost** (where the tested journey is fast and
 reliable), snapshots it, then **restores it under the tunnel** cookie domain. The Connect room
-itself doesn't need a pre-launched dash session: `ss e2e connect` reads the schedule, **starts the
+itself doesn't need a pre-launched dash session: `ss develop connect` reads the schedule, **starts the
 occurrence via `sessions.start`**, and everyone joins — so `--through schedule` is enough (no need
 for the `sessions`/`attendance` stages, which would leave today's occurrence `Ended`).
 
@@ -124,10 +124,10 @@ ss stack tunnel urls       # print the public URL table
 
 ## `ss e2e … --tunnel`
 
-`ss e2e run` and `ss e2e connect` accept `--tunnel`, which resolves your moniker and points the
+`ss e2e run` and `ss develop connect` accept `--tunnel`, which resolves your moniker and points the
 Playwright browser at `https://<label>.<moniker>.vms.wootdev.com` instead of localhost.
 
-- **`ss e2e connect --tunnel`** — the concierge front door (step 3). `--student-login N` sets how
+- **`ss develop connect --tunnel`** — the concierge front door (step 3). `--student-login N` sets how
   many students join locally; `--fake-media` swaps in a synthetic camera/mic (drop it for real
   A/V). The tutor always auto-hosts and starts the session. slot-0 only.
 - **`ss e2e run … --tunnel`** is the slow all-in-one: every request WAN-hairpins (localhost →
@@ -162,7 +162,7 @@ different org. Full roster: `saga-dash` `e2e/data/fixtures/example-roster.csv`.
 
 Real camera/mic works when `up --tunnel` fetched the fleek cluster creds (needs dev creds; it warns
 if it couldn't and connect-api falls back to the dev key, which the cluster rejects → A/V fails but
-CRDT/chat still work). Use `--fake-media` on `ss e2e connect` for a synthetic camera/mic (a machine
+CRDT/chat still work). Use `--fake-media` on `ss develop connect` for a synthetic camera/mic (a machine
 with no camera, or where `v4l2loopback` won't build). A/V always routes through the fleek dev
 cluster, never the tunnel.
 

--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -1,8 +1,11 @@
 {
   "commands": {
-    "e2e:connect": {
-      "aliases": [],
+    "develop:connect": {
+      "aliases": [
+        "e2e:connect"
+      ],
       "args": {},
+      "deprecateAliases": true,
       "description": "Open a live interactive Connect session: 1 tutor + 2 students (in-process; builds the journey prerequisite, then a headed Connect room).",
       "examples": [
         "<%= config.bin %> <%= command.id %>",
@@ -164,7 +167,7 @@
       },
       "hasDynamicHelp": false,
       "hiddenAliases": [],
-      "id": "e2e:connect",
+      "id": "develop:connect",
       "pluginAlias": "@saga-ed/saga-stack-cli",
       "pluginName": "@saga-ed/saga-stack-cli",
       "pluginType": "core",
@@ -174,7 +177,7 @@
       "relativePath": [
         "dist",
         "commands",
-        "e2e",
+        "develop",
         "connect.js"
       ]
     },
@@ -699,761 +702,6 @@
         "commands",
         "e2e",
         "traces.js"
-      ]
-    },
-    "set:check": {
-      "aliases": [],
-      "args": {
-        "name": {
-          "description": "set name (see `set list`)",
-          "name": "name",
-          "required": true
-        }
-      },
-      "description": "Validate a worktree set: paths, buildable-vs-prebuilt, branch drift (warn), primary-checkout posture, cross-set build collisions. Exit 1 on violations.",
-      "examples": [
-        "<%= config.bin %> <%= command.id %> journey-fix"
-      ],
-      "flags": {
-        "porcelain": {
-          "description": "machine-readable output; no color, minimal noise",
-          "name": "porcelain",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
-          "name": "slot",
-          "default": 0,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "output-json": {
-          "description": "emit structured JSON on stdout instead of human-readable text",
-          "name": "output-json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "set": {
-          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
-          "name": "set",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dev": {
-          "description": "sibling-repo workspace root (where the saga repos are checked out)",
-          "name": "dev",
-          "noCacheDefault": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
-          "name": "state-dir",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "soa": {
-          "description": "override path to the soa repo checkout",
-          "name": "soa",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rostering": {
-          "description": "override path to the rostering repo checkout",
-          "name": "rostering",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "program-hub": {
-          "description": "override path to the program-hub repo checkout",
-          "name": "program-hub",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "saga-dash": {
-          "description": "override path to the saga-dash repo checkout",
-          "name": "saga-dash",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "coach": {
-          "description": "override path to the coach repo checkout",
-          "name": "coach",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "sds": {
-          "description": "override path to the sds (student-data-system) repo checkout",
-          "name": "sds",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "qboard": {
-          "description": "override path to the qboard repo checkout",
-          "name": "qboard",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rtsm": {
-          "description": "override path to the rtsm repo checkout",
-          "name": "rtsm",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fleek": {
-          "description": "override path to the fleek repo checkout",
-          "name": "fleek",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "set:check",
-      "pluginAlias": "@saga-ed/saga-stack-cli",
-      "pluginName": "@saga-ed/saga-stack-cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "set",
-        "check.js"
-      ]
-    },
-    "set:create": {
-      "aliases": [],
-      "args": {
-        "name": {
-          "description": "set name (must be unused)",
-          "name": "name",
-          "required": true
-        }
-      },
-      "description": "Create a worktree set: git worktree add (new/existing branch) off the primary checkout, pnpm install, and record it in the sets file (createdBy: ss). Single repo per call.",
-      "examples": [
-        "<%= config.bin %> <%= command.id %> sched --slot 1 --repo saga-dash --path ~/dev/worktrees/saga-dash-sched --branch feat/sched",
-        "<%= config.bin %> <%= command.id %> topo --slot 2 --repo saga-dash --path ~/dev/worktrees/saga-dash-topo --branch flow/topology --no-install"
-      ],
-      "flags": {
-        "porcelain": {
-          "description": "machine-readable output; no color, minimal noise",
-          "name": "porcelain",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "slot": {
-          "description": "slot the set binds (1..9; slot 0 is the primary-checkout baseline)",
-          "name": "slot",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "output-json": {
-          "description": "emit structured JSON on stdout instead of human-readable text",
-          "name": "output-json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "set": {
-          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
-          "name": "set",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dev": {
-          "description": "sibling-repo workspace root (where the saga repos are checked out)",
-          "name": "dev",
-          "noCacheDefault": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
-          "name": "state-dir",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "soa": {
-          "description": "override path to the soa repo checkout",
-          "name": "soa",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rostering": {
-          "description": "override path to the rostering repo checkout",
-          "name": "rostering",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "program-hub": {
-          "description": "override path to the program-hub repo checkout",
-          "name": "program-hub",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "saga-dash": {
-          "description": "override path to the saga-dash repo checkout",
-          "name": "saga-dash",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "coach": {
-          "description": "override path to the coach repo checkout",
-          "name": "coach",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "sds": {
-          "description": "override path to the sds (student-data-system) repo checkout",
-          "name": "sds",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "qboard": {
-          "description": "override path to the qboard repo checkout",
-          "name": "qboard",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rtsm": {
-          "description": "override path to the rtsm repo checkout",
-          "name": "rtsm",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fleek": {
-          "description": "override path to the fleek repo checkout",
-          "name": "fleek",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "repo": {
-          "description": "repo to make a worktree for",
-          "name": "repo",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "options": [
-            "soa",
-            "rostering",
-            "program-hub",
-            "saga-dash",
-            "coach",
-            "sds",
-            "qboard",
-            "rtsm",
-            "fleek"
-          ],
-          "type": "option"
-        },
-        "path": {
-          "description": "worktree checkout path (recorded verbatim; `~` stays portable)",
-          "name": "path",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "branch": {
-          "description": "branch to check out — created if new, attached if it exists (default: the set name)",
-          "name": "branch",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "base": {
-          "description": "start point for a NEW branch (default: the primary checkout HEAD, e.g. main)",
-          "name": "base",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "note": {
-          "description": "optional note stored on the set",
-          "name": "note",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "install": {
-          "description": "pnpm install in the new worktree so `--set` up/e2e fresh-skip (use --no-install to skip)",
-          "name": "install",
-          "allowNo": true,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "set:create",
-      "pluginAlias": "@saga-ed/saga-stack-cli",
-      "pluginName": "@saga-ed/saga-stack-cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "set",
-        "create.js"
-      ]
-    },
-    "set:list": {
-      "aliases": [],
-      "args": {},
-      "description": "List the worktree sets (name, slot, live ACTIVE state, repos) from the sets file (read-only).",
-      "examples": [
-        "<%= config.bin %> <%= command.id %>",
-        "<%= config.bin %> <%= command.id %> --output-json"
-      ],
-      "flags": {
-        "porcelain": {
-          "description": "machine-readable output; no color, minimal noise",
-          "name": "porcelain",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
-          "name": "slot",
-          "default": 0,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "output-json": {
-          "description": "emit structured JSON on stdout instead of human-readable text",
-          "name": "output-json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "set": {
-          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
-          "name": "set",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dev": {
-          "description": "sibling-repo workspace root (where the saga repos are checked out)",
-          "name": "dev",
-          "noCacheDefault": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
-          "name": "state-dir",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "soa": {
-          "description": "override path to the soa repo checkout",
-          "name": "soa",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rostering": {
-          "description": "override path to the rostering repo checkout",
-          "name": "rostering",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "program-hub": {
-          "description": "override path to the program-hub repo checkout",
-          "name": "program-hub",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "saga-dash": {
-          "description": "override path to the saga-dash repo checkout",
-          "name": "saga-dash",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "coach": {
-          "description": "override path to the coach repo checkout",
-          "name": "coach",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "sds": {
-          "description": "override path to the sds (student-data-system) repo checkout",
-          "name": "sds",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "qboard": {
-          "description": "override path to the qboard repo checkout",
-          "name": "qboard",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rtsm": {
-          "description": "override path to the rtsm repo checkout",
-          "name": "rtsm",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fleek": {
-          "description": "override path to the fleek repo checkout",
-          "name": "fleek",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "set:list",
-      "pluginAlias": "@saga-ed/saga-stack-cli",
-      "pluginName": "@saga-ed/saga-stack-cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "set",
-        "list.js"
-      ]
-    },
-    "set:rm": {
-      "aliases": [],
-      "args": {
-        "name": {
-          "description": "set name (see `set list`)",
-          "name": "name",
-          "required": true
-        }
-      },
-      "description": "Remove a worktree set from the sets file. --and-worktrees also `git worktree remove`s the ss-created worktrees (createdBy: ss); hand-recorded paths are never touched.",
-      "examples": [
-        "<%= config.bin %> <%= command.id %> sched",
-        "<%= config.bin %> <%= command.id %> sched --and-worktrees --yes"
-      ],
-      "flags": {
-        "porcelain": {
-          "description": "machine-readable output; no color, minimal noise",
-          "name": "porcelain",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
-          "name": "slot",
-          "default": 0,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "output-json": {
-          "description": "emit structured JSON on stdout instead of human-readable text",
-          "name": "output-json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "set": {
-          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
-          "name": "set",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dev": {
-          "description": "sibling-repo workspace root (where the saga repos are checked out)",
-          "name": "dev",
-          "noCacheDefault": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
-          "name": "state-dir",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "soa": {
-          "description": "override path to the soa repo checkout",
-          "name": "soa",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rostering": {
-          "description": "override path to the rostering repo checkout",
-          "name": "rostering",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "program-hub": {
-          "description": "override path to the program-hub repo checkout",
-          "name": "program-hub",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "saga-dash": {
-          "description": "override path to the saga-dash repo checkout",
-          "name": "saga-dash",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "coach": {
-          "description": "override path to the coach repo checkout",
-          "name": "coach",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "sds": {
-          "description": "override path to the sds (student-data-system) repo checkout",
-          "name": "sds",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "qboard": {
-          "description": "override path to the qboard repo checkout",
-          "name": "qboard",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rtsm": {
-          "description": "override path to the rtsm repo checkout",
-          "name": "rtsm",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fleek": {
-          "description": "override path to the fleek repo checkout",
-          "name": "fleek",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "and-worktrees": {
-          "description": "also `git worktree remove` the worktrees ss created (createdBy: ss); requires --yes",
-          "name": "and-worktrees",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "force": {
-          "description": "pass --force to `git worktree remove` (a dirty/locked worktree)",
-          "name": "force",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "yes": {
-          "description": "confirm the destructive --and-worktrees removal (required with it)",
-          "name": "yes",
-          "allowNo": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "set:rm",
-      "pluginAlias": "@saga-ed/saga-stack-cli",
-      "pluginName": "@saga-ed/saga-stack-cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "set",
-        "rm.js"
-      ]
-    },
-    "set:show": {
-      "aliases": [],
-      "args": {
-        "name": {
-          "description": "set name (see `set list`)",
-          "name": "name",
-          "required": true
-        }
-      },
-      "description": "Show one worktree set: slot, repos, and each repo’s live branch + dirty state (read-only).",
-      "examples": [
-        "<%= config.bin %> <%= command.id %> journey-fix"
-      ],
-      "flags": {
-        "porcelain": {
-          "description": "machine-readable output; no color, minimal noise",
-          "name": "porcelain",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
-          "name": "slot",
-          "default": 0,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "output-json": {
-          "description": "emit structured JSON on stdout instead of human-readable text",
-          "name": "output-json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "set": {
-          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
-          "name": "set",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dev": {
-          "description": "sibling-repo workspace root (where the saga repos are checked out)",
-          "name": "dev",
-          "noCacheDefault": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
-          "name": "state-dir",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "soa": {
-          "description": "override path to the soa repo checkout",
-          "name": "soa",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rostering": {
-          "description": "override path to the rostering repo checkout",
-          "name": "rostering",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "program-hub": {
-          "description": "override path to the program-hub repo checkout",
-          "name": "program-hub",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "saga-dash": {
-          "description": "override path to the saga-dash repo checkout",
-          "name": "saga-dash",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "coach": {
-          "description": "override path to the coach repo checkout",
-          "name": "coach",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "sds": {
-          "description": "override path to the sds (student-data-system) repo checkout",
-          "name": "sds",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "qboard": {
-          "description": "override path to the qboard repo checkout",
-          "name": "qboard",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rtsm": {
-          "description": "override path to the rtsm repo checkout",
-          "name": "rtsm",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fleek": {
-          "description": "override path to the fleek repo checkout",
-          "name": "fleek",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fetch": {
-          "description": "git fetch each repo first so the mainline-currency report reflects the REMOTE tip (network); without it, currency is as-of the last fetch",
-          "name": "fetch",
-          "allowNo": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "set:show",
-      "pluginAlias": "@saga-ed/saga-stack-cli",
-      "pluginName": "@saga-ed/saga-stack-cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "set",
-        "show.js"
       ]
     },
     "stack:bootstrap": {
@@ -3433,6 +2681,761 @@
         "commands",
         "stack",
         "verify.js"
+      ]
+    },
+    "set:check": {
+      "aliases": [],
+      "args": {
+        "name": {
+          "description": "set name (see `set list`)",
+          "name": "name",
+          "required": true
+        }
+      },
+      "description": "Validate a worktree set: paths, buildable-vs-prebuilt, branch drift (warn), primary-checkout posture, cross-set build collisions. Exit 1 on violations.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> journey-fix"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "set:check",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "set",
+        "check.js"
+      ]
+    },
+    "set:create": {
+      "aliases": [],
+      "args": {
+        "name": {
+          "description": "set name (must be unused)",
+          "name": "name",
+          "required": true
+        }
+      },
+      "description": "Create a worktree set: git worktree add (new/existing branch) off the primary checkout, pnpm install, and record it in the sets file (createdBy: ss). Single repo per call.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> sched --slot 1 --repo saga-dash --path ~/dev/worktrees/saga-dash-sched --branch feat/sched",
+        "<%= config.bin %> <%= command.id %> topo --slot 2 --repo saga-dash --path ~/dev/worktrees/saga-dash-topo --branch flow/topology --no-install"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "slot the set binds (1..9; slot 0 is the primary-checkout baseline)",
+          "name": "slot",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "repo": {
+          "description": "repo to make a worktree for",
+          "name": "repo",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "soa",
+            "rostering",
+            "program-hub",
+            "saga-dash",
+            "coach",
+            "sds",
+            "qboard",
+            "rtsm",
+            "fleek"
+          ],
+          "type": "option"
+        },
+        "path": {
+          "description": "worktree checkout path (recorded verbatim; `~` stays portable)",
+          "name": "path",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "branch": {
+          "description": "branch to check out — created if new, attached if it exists (default: the set name)",
+          "name": "branch",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "base": {
+          "description": "start point for a NEW branch (default: the primary checkout HEAD, e.g. main)",
+          "name": "base",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "note": {
+          "description": "optional note stored on the set",
+          "name": "note",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "install": {
+          "description": "pnpm install in the new worktree so `--set` up/e2e fresh-skip (use --no-install to skip)",
+          "name": "install",
+          "allowNo": true,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "set:create",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "set",
+        "create.js"
+      ]
+    },
+    "set:list": {
+      "aliases": [],
+      "args": {},
+      "description": "List the worktree sets (name, slot, live ACTIVE state, repos) from the sets file (read-only).",
+      "examples": [
+        "<%= config.bin %> <%= command.id %>",
+        "<%= config.bin %> <%= command.id %> --output-json"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "set:list",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "set",
+        "list.js"
+      ]
+    },
+    "set:rm": {
+      "aliases": [],
+      "args": {
+        "name": {
+          "description": "set name (see `set list`)",
+          "name": "name",
+          "required": true
+        }
+      },
+      "description": "Remove a worktree set from the sets file. --and-worktrees also `git worktree remove`s the ss-created worktrees (createdBy: ss); hand-recorded paths are never touched.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> sched",
+        "<%= config.bin %> <%= command.id %> sched --and-worktrees --yes"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "and-worktrees": {
+          "description": "also `git worktree remove` the worktrees ss created (createdBy: ss); requires --yes",
+          "name": "and-worktrees",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "force": {
+          "description": "pass --force to `git worktree remove` (a dirty/locked worktree)",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "yes": {
+          "description": "confirm the destructive --and-worktrees removal (required with it)",
+          "name": "yes",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "set:rm",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "set",
+        "rm.js"
+      ]
+    },
+    "set:show": {
+      "aliases": [],
+      "args": {
+        "name": {
+          "description": "set name (see `set list`)",
+          "name": "name",
+          "required": true
+        }
+      },
+      "description": "Show one worktree set: slot, repos, and each repo’s live branch + dirty state (read-only).",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> journey-fix"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fetch": {
+          "description": "git fetch each repo first so the mainline-currency report reflects the REMOTE tip (network); without it, currency is as-of the last fetch",
+          "name": "fetch",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "set:show",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "set",
+        "show.js"
       ]
     },
     "stack:bundle:list": {

--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -1,5 +1,170 @@
 {
   "commands": {
+    "develop:coach": {
+      "aliases": [],
+      "args": {},
+      "description": "Bring up + seed a coach stack and drop into a headed, logged-in coach-web: the ported content viewer (default), the mock-backed admin Reports route, or a playlist track-switch.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %>",
+        "<%= config.bin %> <%= command.id %> --scenario admin",
+        "<%= config.bin %> <%= command.id %> --scenario playlist",
+        "<%= config.bin %> <%= command.id %> --reuse -- --debug"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "scenario": {
+          "description": "which coach surface to set up: content-viewer (ported module player, demo-tutor-1) [default]; admin (mock-backed Reports route, demo-dadmin); playlist (switch demo-tutor-1 to a 2nd track via coach-content — needs coach#238).",
+          "name": "scenario",
+          "default": "content-viewer",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "content-viewer",
+            "admin",
+            "playlist"
+          ],
+          "type": "option"
+        },
+        "reuse": {
+          "description": "skip the reset+seed; hand off against the CURRENT stack state (mirrors develop connect --reuse).",
+          "name": "reuse",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "spa-path": {
+          "description": "explicit path to a flows.json (file or dir) — highest-priority discovery override",
+          "name": "spa-path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "tunnel": {
+          "description": "point THIS run's flow browsers at the vms tunnel hosts (https://<label>.<moniker>.<VMS_BASE>) instead of localhost, so a REMOTE peer can reach the same stack. Resolves the moniker via the vendored tunnel.sh (same machinery as `stack up --tunnel`). NOTE: this ONLY repoints the flow's Playwright browsers — it does NOT relaunch the stack; you must have already run `ss stack up --tunnel`. Slot-0 only.",
+          "name": "tunnel",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "develop:coach",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": false,
+      "enableJsonFlag": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "develop",
+        "coach.js"
+      ]
+    },
     "develop:connect": {
       "aliases": [
         "e2e:connect"

--- a/packages/node/saga-stack-cli/package.json
+++ b/packages/node/saga-stack-cli/package.json
@@ -38,6 +38,9 @@
       "e2e": {
         "description": "Run end-to-end flows in-process against a running stack."
       },
+      "develop": {
+        "description": "Concierge scripts that set up and drop you into a developable stack for a specific app or workflow (seed, reset, prerequisites, then hand off a running app)."
+      },
       "set": {
         "description": "Worktree sets (M13): named repo→path maps bound to slots — list, show, and check the parallel dev contexts --set runs against."
       }

--- a/packages/node/saga-stack-cli/src/__tests__/e2e-orchestrate-slot.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/__tests__/e2e-orchestrate-slot.unit.test.ts
@@ -19,6 +19,7 @@ import { describe, expect, it } from 'vitest';
 import { deriveInstance } from '../core/derive-instance.js';
 import {
   buildStackContext,
+  playwrightArgv,
   playwrightEnv,
   serviceUrlEnv,
   type StackSeams,
@@ -154,6 +155,16 @@ describe('serviceUrlEnv / playwrightEnv — offset Playwright service URLs', () 
     expect(env.PLAYWRIGHT_IAM_URL).toBe('http://localhost:3010');
   });
 
+  it('a non-dash SPA (coach-web) gets ITS OWN port for PLAYWRIGHT_BASE_URL, not saga-dash\'s (regression: coach-web/dashboard opened :8900 and 500\'d before this fix)', () => {
+    const coachResolved = {
+      flow,
+      spa: { id: 'coach-web', system: 'coach-web' },
+    } as unknown as ResolvedFlow;
+    const env = playwrightEnv(coachResolved, now, 'stack', p0);
+    expect(env.PLAYWRIGHT_BASE_URL).toBe('http://localhost:8800'); // coach-web, NOT :8900 (saga-dash)
+    expect(env.PLAYWRIGHT_IAM_URL).toBe('http://localhost:3010');
+  });
+
   it('playwrightEnv on a DEPLOYED lane does NOT inject localhost URLs (lane.ts owns the hostnames)', () => {
     const env = playwrightEnv(resolved, now, 'sandbox', p1);
     expect(env.PLAYWRIGHT_BASE_URL).toBeUndefined();
@@ -187,5 +198,51 @@ describe('serviceUrlEnv / playwrightEnv — offset Playwright service URLs', () 
     expect(env.PLAYWRIGHT_IAM_URL).toBe('http://localhost:4010');
     // ...while flow.env keeps winning for the date env.
     expect(env.PLAYWRIGHT_OCCURRENCE_DATE).toBe('2026-01-05');
+  });
+});
+
+describe('playwrightArgv — spec scoping (single-spawn only, never on a stage override)', () => {
+  const specResolved = {
+    playwright: {
+      config: 'playwright.config.ts',
+      project: 'chromium',
+      headed: false,
+      spec: 'dashboard/dashboard-authenticated.e2e.smoke.test.ts',
+    },
+  } as unknown as ResolvedFlow;
+
+  it('the single-spawn path (no stage override) pushes the terminal spec — scopes a single-project SPA to just that spec', () => {
+    const argv = playwrightArgv(specResolved);
+    expect(argv).toEqual([
+      'exec',
+      'playwright',
+      'test',
+      '--config=playwright.config.ts',
+      '--project',
+      'chromium',
+      'dashboard/dashboard-authenticated.e2e.smoke.test.ts',
+    ]);
+  });
+
+  it('a stage override (bake/--from per-stage spawn) does NOT push the terminal spec (regression guard: pushing it would filter a non-terminal stage.project to a spec it does not contain, running zero tests)', () => {
+    const argv = playwrightArgv(specResolved, [], { project: 'stage-2-program', noDeps: true });
+    expect(argv).toEqual([
+      'exec',
+      'playwright',
+      'test',
+      '--config=playwright.config.ts',
+      '--project',
+      'stage-2-program',
+      '--no-deps',
+    ]);
+    expect(argv).not.toContain('dashboard/dashboard-authenticated.e2e.smoke.test.ts');
+  });
+
+  it('a flow with no spec (progressive saga-dash flows omit it) never pushes an extra positional arg', () => {
+    const noSpecResolved = {
+      playwright: { config: 'playwright.stack.config.ts', project: 'stage-4-pods', headed: false },
+    } as unknown as ResolvedFlow;
+    const argv = playwrightArgv(noSpecResolved);
+    expect(argv).toEqual(['exec', 'playwright', 'test', '--config=playwright.stack.config.ts', '--project', 'stage-4-pods']);
   });
 });

--- a/packages/node/saga-stack-cli/src/__tests__/e2e-orchestrate-slot.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/__tests__/e2e-orchestrate-slot.unit.test.ts
@@ -159,6 +159,19 @@ describe('serviceUrlEnv / playwrightEnv — offset Playwright service URLs', () 
     expect(env.PLAYWRIGHT_IAM_URL).toBe('http://localhost:3010');
   });
 
+  it('PLAYWRIGHT_BASE_URL is the FLOW SPA frontend, not hardcoded saga-dash (soa#300 tail)', () => {
+    // A coach-web flow must navigate to coach-web (:9800 at slot 1), NOT saga-dash
+    // (:9900) — coach-web's lane.ts reuses PLAYWRIGHT_BASE_URL as its baseURL, so a
+    // saga-dash value would drive the wrong app (and its globalSetup the wrong iam).
+    const coachResolved = { flow, spa: { system: 'coach-web' } } as unknown as ResolvedFlow;
+    const coachEnv = playwrightEnv(coachResolved, now, 'stack', p1);
+    expect(coachEnv.PLAYWRIGHT_BASE_URL).toBe('http://localhost:9800'); // coach-web 8800 + 1000
+    expect(coachEnv.PLAYWRIGHT_IAM_URL).toBe('http://localhost:4010'); // slot iam, still offset
+    // A saga-dash flow is byte-identical to before (system === 'saga-dash').
+    const dashResolved = { flow, spa: { system: 'saga-dash' } } as unknown as ResolvedFlow;
+    expect(playwrightEnv(dashResolved, now, 'stack', p1).PLAYWRIGHT_BASE_URL).toBe('http://localhost:9900');
+  });
+
   it('playwrightEnv on a DEPLOYED lane does NOT inject localhost URLs (lane.ts owns the hostnames)', () => {
     const env = playwrightEnv(resolved, now, 'sandbox', p1);
     expect(env.PLAYWRIGHT_BASE_URL).toBeUndefined();

--- a/packages/node/saga-stack-cli/src/__tests__/helpers/pw.ts
+++ b/packages/node/saga-stack-cli/src/__tests__/helpers/pw.ts
@@ -22,6 +22,8 @@ export interface PwArgvOptions {
   noDeps?: boolean;
   /** Append `--grep-invert <tag>` (pipeline runs exclude e.g. `@interactive`). */
   grepInvert?: string;
+  /** Append the terminal stage's `spec` (scopes the run to just that spec file). */
+  spec?: string;
 }
 
 /** Build the expected `pnpm` args array for a spawned Playwright child. */
@@ -30,5 +32,6 @@ export function pwArgv(opts: PwArgvOptions): string[] {
   if (opts.noDeps) argv.push('--no-deps');
   if (opts.grepInvert !== undefined) argv.push('--grep-invert', opts.grepInvert);
   if (opts.headed) argv.push('--headed');
+  if (opts.spec !== undefined) argv.push(opts.spec);
   return argv;
 }

--- a/packages/node/saga-stack-cli/src/__tests__/open-vendored-browser.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/__tests__/open-vendored-browser.unit.test.ts
@@ -1,0 +1,142 @@
+/**
+ * `BaseCommand.openVendoredBrowser` SPA-parameterization (gh_305, M2).
+ *
+ * The vendored headful browser opener was hardwired to saga-dash: it resolved
+ * `SAGA_DASH`/`apps/web/dash`, gated the whole step on that dir, and fell back to
+ * `:8900`. gh_305 generalizes it on an optional `ctx.spa = { repoEnvVar, appDir,
+ * port }` sourced from a `spa-registry` row so a non-saga-dash concierge (e.g.
+ * `develop coach` → coach-web on :8800) opens its OWN app, gated on its OWN repo.
+ *
+ * These tests drive the protected method directly through a tiny subclass, with
+ * the Runner + repo-dir-check seams faked, and assert:
+ *   - the DEFAULT (no `ctx.spa`) is byte-identical to the old saga-dash behavior
+ *     (cwd/SAGA_DASH_DASH under `apps/web/dash`, DASH_URL fallback `:8900`);
+ *   - a `coach-web` row drives the cwd, `SAGA_DASH_DASH`, DASH_URL port, and the
+ *     clone-gate off the COACH checkout instead.
+ */
+
+import { join } from 'node:path';
+import { Config } from '@oclif/core';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BaseCommand } from '../base-command.js';
+import type { WorkspaceFlags } from '../base-command.js';
+import type { RunResult, Runner, ScriptInvocation } from '../runtime/index.js';
+
+/** Minimal subclass exposing the protected opener for a direct unit call. */
+class TestCmd extends BaseCommand {
+  static flags = { ...BaseCommand.baseFlags };
+  async run(): Promise<void> {}
+  public openBrowser(
+    flags: WorkspaceFlags,
+    ctx: Parameters<BaseCommand['openVendoredBrowser']>[1],
+  ): Promise<void> {
+    return this.openVendoredBrowser(flags, ctx);
+  }
+}
+
+const PKG_ROOT = process.cwd();
+let config: Config;
+let runs: ScriptInvocation[];
+let warned: string[];
+
+/** A Runner that records every invocation and reports success. */
+function fakeRunner(): Runner {
+  return {
+    async run(spec: ScriptInvocation): Promise<RunResult> {
+      runs.push(spec);
+      return { code: 0 };
+    },
+  };
+}
+
+/** Flags with repo pins so `resolveRepoRoot` is hermetic (no real checkout read). */
+function flags(over: Partial<Record<string, string>> = {}): WorkspaceFlags {
+  return {
+    'saga-dash': '/fixed/dev/saga-dash',
+    coach: '/fixed/dev/coach',
+    dev: '/fixed/dev',
+    ...over,
+  } as unknown as WorkspaceFlags;
+}
+
+const CTX = { email: 'dev@saga.org', iamUrl: 'http://localhost:3010', stateDir: '/tmp/s' };
+
+beforeAll(async () => {
+  config = await Config.load(PKG_ROOT);
+});
+
+beforeEach(() => {
+  runs = [];
+  warned = [];
+  // The repo checkout is always present in these tests unless a case overrides it.
+  vi.spyOn(BaseCommand.prototype, 'getRepoDirCheck').mockReturnValue(() => true);
+  vi.spyOn(BaseCommand.prototype as never, 'getRunner' as never).mockReturnValue(fakeRunner() as never);
+  vi.spyOn(BaseCommand.prototype, 'warn').mockImplementation(((m: string) => {
+    warned.push(String(m));
+    return m;
+  }) as never);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** The single browser-login.mjs invocation the fake Runner recorded. */
+function browserRun(): ScriptInvocation {
+  const r = runs.find((x) => x.command === 'node' && (x.args[0] ?? '').endsWith('browser-login.mjs'));
+  if (!r) throw new Error(`no browser-login.mjs run recorded; runs: ${JSON.stringify(runs)}`);
+  return r;
+}
+
+describe('openVendoredBrowser — default (no ctx.spa) is the saga-dash behavior', () => {
+  it('resolves SAGA_DASH/apps/web/dash for cwd + SAGA_DASH_DASH, DASH_URL falls back to :8900', async () => {
+    const cmd = new TestCmd([], config);
+    await cmd.openBrowser(flags(), { ...CTX });
+
+    const dashApp = join('/fixed/dev/saga-dash', 'apps', 'web', 'dash');
+    const r = browserRun();
+    expect(r.cwd).toBe(dashApp);
+    expect(r.env?.SAGA_DASH_DASH).toBe(dashApp);
+    expect(r.env?.DASH_URL).toBe('http://localhost:8900');
+    expect(r.env?.LOGIN_EMAIL).toBe('dev@saga.org');
+    expect(r.env?.IAM_URL).toBe('http://localhost:3010');
+  });
+
+  it('an explicit dashUrl (the --hold slot-offset URL) still wins over the port fallback', async () => {
+    const cmd = new TestCmd([], config);
+    await cmd.openBrowser(flags(), { ...CTX, dashUrl: 'http://localhost:9900' });
+    expect(browserRun().env?.DASH_URL).toBe('http://localhost:9900');
+  });
+});
+
+describe('openVendoredBrowser — ctx.spa parameterizes the opener (coach-web)', () => {
+  it('drives cwd/SAGA_DASH_DASH off COACH/apps/web/coach-web and DASH_URL off port 8800', async () => {
+    const cmd = new TestCmd([], config);
+    await cmd.openBrowser(flags(), {
+      ...CTX,
+      spa: { repoEnvVar: 'COACH', appDir: 'apps/web/coach-web', port: 8800 },
+    });
+
+    const coachApp = join('/fixed/dev/coach', 'apps/web/coach-web');
+    const r = browserRun();
+    expect(r.cwd).toBe(coachApp);
+    expect(r.env?.SAGA_DASH_DASH).toBe(coachApp);
+    expect(r.env?.DASH_URL).toBe('http://localhost:8800');
+  });
+
+  it('gates the clone-check off the SPA OWN repo — an absent coach checkout warn-skips (no run)', async () => {
+    // Report ONLY the coach app dir absent; saga-dash present. The gate must fire
+    // on coach, proving it is no longer hardwired to saga-dash.
+    vi.spyOn(BaseCommand.prototype, 'getRepoDirCheck').mockReturnValue(
+      (dir: string) => !dir.includes('coach'),
+    );
+    const cmd = new TestCmd([], config);
+    await cmd.openBrowser(flags(), {
+      ...CTX,
+      spa: { repoEnvVar: 'COACH', appDir: 'apps/web/coach-web', port: 8800 },
+    });
+
+    expect(runs.filter((x) => x.command === 'node')).toHaveLength(0);
+    expect(warned.some((w) => w.includes('SPA app not found') && w.includes('COACH'))).toBe(true);
+  });
+});

--- a/packages/node/saga-stack-cli/src/__tests__/stack-api.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/__tests__/stack-api.unit.test.ts
@@ -632,7 +632,7 @@ describe('StackApi.reset — native (M8 R4)', () => {
   /** The `-c "<sql>"` payload of a `docker exec … psql … -c <sql>` run. */
   const sqlOf = (r: ScriptInvocation): string => r.args[r.args.indexOf('-c') + 1];
 
-  it('native: truncates closure DBs preserving _prisma_migrations + re-seeds the dev user', async () => {
+  it('native: truncates closure DBs preserving _prisma_migrations + re-seeds registry BEFORE the dev user', async () => {
     const { runtime, fakes } = makeRuntime();
     const api = makeStackApi(manifest, runtime);
     const closure = computeClosure(manifest, ['sessions-api'] as ServiceId[]);
@@ -648,8 +648,15 @@ describe('StackApi.reset — native (M8 R4)', () => {
       expect(sqlOf(t)).toContain("tablename <> '_prisma_migrations'");
       expect(sqlOf(t)).toContain('RESTART IDENTITY CASCADE');
     }
-    // dev-user re-seed ran (iam-api is in the closure) via the seed path.
+    // registry + dev-user re-seed ran (iam-api is in the closure) via the seed path.
     expect(res.seed?.ok).toBe(true);
+    // soa#253 recurrence guard: the truncate wiped the permission catalog, so
+    // `iam-registry` MUST re-seed BEFORE the `iam-dev-user` dev-admin grant.
+    const seedRuns = fakes.runs.map((r) => r.args.join(' '));
+    const regIdx = seedRuns.findIndex((a) => a.includes('seed-registry.js'));
+    const devIdx = seedRuns.findIndex((a) => a.includes('seed-dev-user.js'));
+    expect(regIdx).toBeGreaterThanOrEqual(0);
+    expect(devIdx).toBeGreaterThan(regIdx);
     expect(res.native?.dbs.some((d) => d.action === 'truncated')).toBe(true);
     // no up.sh delegation on the native path.
     expect(fakes.delegated).toEqual([]);

--- a/packages/node/saga-stack-cli/src/__tests__/stack-api.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/__tests__/stack-api.unit.test.ts
@@ -25,6 +25,7 @@ import { makeStackApi } from '../stack-api.js';
 import type { Runtime } from '../stack-api.js';
 import { stopServices } from '../runtime/index.js';
 import type {
+  CoachWebFs,
   DashFs,
   GitRunner,
   HealthProber,
@@ -67,11 +68,12 @@ interface Fakes {
   runs: ScriptInvocation[];
   meshExecs: { container: string; cmd: string }[];
   dashCalls: string[];
+  coachWebWrites: Array<{ path: string; contents: string }>;
   delegated: ScriptInvocation[];
 }
 
 function makeRuntime(overrides: Partial<Runtime> = {}): { runtime: Runtime; fakes: Fakes } {
-  const fakes: Fakes = { launches: [], stopped: [], runs: [], meshExecs: [], dashCalls: [], delegated: [] };
+  const fakes: Fakes = { launches: [], stopped: [], runs: [], meshExecs: [], dashCalls: [], coachWebWrites: [], delegated: [] };
 
   const launcher: ServiceLauncher = {
     async launch(spec: LaunchSpec): Promise<LaunchResult> {
@@ -106,6 +108,11 @@ function makeRuntime(overrides: Partial<Runtime> = {}): { runtime: Runtime; fake
     remove: (p: string) => fakes.dashCalls.push(`remove:${p}`),
     write: (p: string) => fakes.dashCalls.push(`write:${p}`),
   };
+  const coachWebFs: CoachWebFs = {
+    existsDir: () => true,
+    write: (path: string, contents: string) => fakes.coachWebWrites.push({ path, contents }),
+    remove: () => {},
+  };
   const prober: HealthProber = {
     async probe(url: string) {
       // content-api runs on :3009 — mark it down so the verify/tolerate test bites.
@@ -128,6 +135,7 @@ function makeRuntime(overrides: Partial<Runtime> = {}): { runtime: Runtime; fake
     meshExec,
     portProbe,
     dashFs,
+    coachWebFs,
     prober,
     runner,
     delegate: async (plan) => {
@@ -198,6 +206,63 @@ describe('StackApi.up — native partial-stack bring-up', () => {
     expect(res.dash?.action).toBe('noop-absent'); // existsFile:false, non-tunnel ⇒ nothing to remove
     expect(fakes.dashCalls.some((c) => c.startsWith('existsDir:'))).toBe(true);
     expect(fakes.launches.some((s) => s.id === 'saga-dash')).toBe(true);
+  });
+
+  it('soa#300: writes coach-web .env.local (local mesh URLs) when coach-web is launchable — even at slot 0', async () => {
+    const { runtime, fakes } = makeRuntime(); // default slot (undefined ⇒ 0)
+    const api = makeStackApi(manifest, runtime);
+    const closure = computeClosure(manifest, ['coach-web'] as ServiceId[]);
+    const res = await api.up(closure.services);
+
+    expect(res.coachWeb?.action).toBe('wrote');
+    expect(res.coachWeb?.path).toBe('/dev/coach/apps/web/coach-web/.env.local');
+    expect(fakes.coachWebWrites).toHaveLength(1);
+    const contents = fakes.coachWebWrites[0].contents;
+    // base ports at slot 0: iam 3010, coach-api 6105, saga-dash 8900. No remote defaults.
+    expect(contents).toContain('PUBLIC_IAM_API_URL=http://localhost:3010');
+    expect(contents).toContain('PUBLIC_COACH_API_URL=http://localhost:6105');
+    expect(contents).toContain('PUBLIC_DASHBOARD_URL=http://localhost:8900');
+    expect(contents).toContain('PUBLIC_LOGIN_URL=http://localhost:3010');
+    expect(contents).not.toContain('wootdev.com');
+  });
+
+  it('soa#300: coach-web .env.local carries the OFFSET URLs at slot > 0', async () => {
+    const profile = deriveInstance({ slot: 1 });
+    const slotCtx = defaultLaunchContext({
+      repoRoots: REPO_ROOTS,
+      vendorDir: '/dev/vendor',
+      portOverrides: profile.portOverrides,
+      meshOffset: profile.meshOffset,
+    });
+    const { runtime, fakes } = makeRuntime({ launchContext: slotCtx, slot: 1 });
+    const api = makeStackApi(manifest, runtime);
+    await api.up(['coach-web'] as ServiceId[]);
+
+    const contents = fakes.coachWebWrites[0].contents;
+    // slot 1 = base + 1000: iam 4010, coach-api 7105, saga-dash 9900.
+    expect(contents).toContain('PUBLIC_IAM_API_URL=http://localhost:4010');
+    expect(contents).toContain('PUBLIC_COACH_API_URL=http://localhost:7105');
+    expect(contents).toContain('PUBLIC_DASHBOARD_URL=http://localhost:9900');
+    expect(contents).not.toContain(':6105'); // slot 0's coach-api must not leak
+  });
+
+  it('soa#300: no coach-web .env.local write when coach-web is not in the closure', async () => {
+    const { runtime, fakes } = makeRuntime();
+    const api = makeStackApi(manifest, runtime);
+    const closure = computeClosure(manifest, ['scheduling-api'] as ServiceId[]);
+    const res = await api.up(closure.services);
+
+    expect(res.coachWeb).toBeUndefined();
+    expect(fakes.coachWebWrites).toEqual([]);
+  });
+
+  it('soa#300: no coach-web .env.local write under --tunnel (public URLs are a separate concern)', async () => {
+    const { runtime, fakes } = makeRuntime({ tunnel: true, tunnelDomain: 'abc.vms.wootdev.com' });
+    const api = makeStackApi(manifest, runtime);
+    const res = await api.up(['coach-web'] as ServiceId[]);
+
+    expect(res.coachWeb?.action).toBe('noop-tunnel');
+    expect(fakes.coachWebWrites).toEqual([]);
   });
 
   it('slot 0: a frontend launch command is byte-identical (no --port appended)', async () => {

--- a/packages/node/saga-stack-cli/src/base-command.ts
+++ b/packages/node/saga-stack-cli/src/base-command.ts
@@ -964,10 +964,17 @@ export abstract class BaseCommand extends Command {
    * `open_login_browser`. Both `stack login --browser` and `up --login` call this.
    *
    * Passes the exact env browser-login.mjs reads: `IAM_URL` (the resolved iam host),
-   * `DASH_URL` (`LOGIN_DASH_URL` override else localhost:8900), `LOGIN_EMAIL` (the persona),
+   * `DASH_URL` (`LOGIN_DASH_URL` override else the SPA's port), `LOGIN_EMAIL` (the persona),
    * `PROFILE_DIR` (`<stateDir>/browser-profile`, up.sh's BROWSER_PROFILE), and
-   * `SAGA_DASH_DASH` (the resolved saga-dash dash app dir). node runs with `cwd` = that
-   * dash dir so `createRequire`'d playwright + its browsers resolve there.
+   * `SAGA_DASH_DASH` (the resolved SPA app dir — the name is historical; it is just the
+   * dir playwright is `createRequire`'d from). node runs with `cwd` = that app dir so the
+   * SPA's `createRequire`'d playwright + its browsers resolve there.
+   *
+   * SPA-PARAMETERIZED (gh_305): `ctx.spa` sources `{ repoEnvVar, appDir, port }` from a
+   * `spa-registry` row so a non-saga-dash concierge (e.g. `develop coach` → coach-web on
+   * :8800) opens its OWN app, gated on its OWN repo checkout. It DEFAULTS to saga-dash's
+   * `SAGA_DASH` / `apps/web/dash` / :8900, so existing `stack login`/`up --login`/`e2e run
+   * --hold` callers behave identically.
    *
    * BEST-EFFORT (`propagateExit:false`): the headless jar is already minted, so a browser
    * failure (playwright absent, no DISPLAY, …) — which browser-login.mjs reports as an
@@ -976,40 +983,56 @@ export abstract class BaseCommand extends Command {
    */
   protected async openVendoredBrowser(
     flags: WorkspaceFlags,
-    ctx: { email: string; iamUrl: string; stateDir: string; dashUrl?: string },
+    ctx: {
+      email: string;
+      iamUrl: string;
+      stateDir: string;
+      dashUrl?: string;
+      /**
+       * The SPA to open (defaults to saga-dash's dash app on :8900). Sourced from a
+       * `spa-registry` row: `repoEnvVar`/`appDir` drive the clone-gate + playwright cwd
+       * off the SPA's OWN repo; `port` supplies the fallback `DASH_URL` when `dashUrl`
+       * is absent (a bare `stack login` with no run-resolved URL).
+       */
+      spa?: { repoEnvVar: ManifestRepoKey; appDir: string; port?: number };
+    },
   ): Promise<void> {
     const script = resolveVendorScript('browser-login.mjs');
-    const sagaDashDash = join(
-      resolveRepoRoot('SAGA_DASH', this.scriptContextFromFlags(flags)),
-      'apps',
-      'web',
-      'dash',
+    const repoEnvVar = ctx.spa?.repoEnvVar ?? 'SAGA_DASH';
+    const appSubdir = ctx.spa?.appDir ?? join('apps', 'web', 'dash');
+    const port = ctx.spa?.port ?? 8900;
+    const spaAppDir = join(
+      resolveRepoRoot(repoEnvVar, this.scriptContextFromFlags(flags)),
+      appSubdir,
     );
     // TRULY best-effort — guard SPAWN-level failures too, mirroring up.sh's
     // open_login_browser preflight ([[ -f BROWSER_LOGIN ]] / command -v node /
     // [[ -d …/dash ]] each warn-and-return). `propagateExit:false` only tolerates a
     // NON-ZERO child exit; a missing cwd rejects with ENOENT from the spawn 'error'
     // event and would otherwise redden `up`/`login` even though the headless jar is
-    // already minted. saga-dash-absent is a supported state (`up` skips it with a
-    // warning), so the browser step must degrade the same way.
-    if (!this.getRepoDirCheck()(sagaDashDash)) {
+    // already minted. An absent SPA checkout is a supported state (`up` skips it with a
+    // warning), so the browser step must degrade the same way — gated on the SPA's OWN
+    // repo (saga-dash by default; e.g. coach for a coach-web hand-off).
+    if (!this.getRepoDirCheck()(spaAppDir)) {
       this.warn(
-        `headful browser skipped — saga-dash dash app not found at ${sagaDashDash} ` +
-          '(the headless cookie jar is minted; clone saga-dash for the browser step)',
+        `headful browser skipped — SPA app not found at ${spaAppDir} ` +
+          `(the headless cookie jar is minted; clone the ${repoEnvVar} repo for the browser step)`,
       );
       return;
     }
     const env: Record<string, string> = {
       IAM_URL: ctx.iamUrl,
       // Plan 13 --hold passes the run's RESOLVED (slot-offset) SPA URL so the held
-      // browser opens the slot's own dash; login's default keeps LOGIN_DASH_URL / :8900.
-      DASH_URL: ctx.dashUrl ?? (process.env.LOGIN_DASH_URL || 'http://localhost:8900'),
+      // browser opens the slot's own app; login's default keeps LOGIN_DASH_URL else the
+      // SPA's own port (:8900 for saga-dash, :8800 for coach-web, …).
+      DASH_URL: ctx.dashUrl ?? (process.env.LOGIN_DASH_URL || `http://localhost:${port}`),
       LOGIN_EMAIL: ctx.email,
       PROFILE_DIR: join(ctx.stateDir, 'browser-profile'),
-      SAGA_DASH_DASH: sagaDashDash,
+      // browser-login.mjs reads this as its playwright-resolution dir (name historical).
+      SAGA_DASH_DASH: spaAppDir,
     };
     try {
-      await this.runVendor({ cwd: sagaDashDash, command: 'node', args: [script], env }, flags, {
+      await this.runVendor({ cwd: spaAppDir, command: 'node', args: [script], env }, flags, {
         propagateExit: false,
       });
     } catch (err) {

--- a/packages/node/saga-stack-cli/src/base-command.ts
+++ b/packages/node/saga-stack-cli/src/base-command.ts
@@ -59,6 +59,7 @@ import {
   makeRealConfirm,
   makeRealCookiePoster,
   makeRealDashFs,
+  makeRealCoachWebFs,
   makeRealGhRunner,
   makeRealGitRunner,
   makeRealJarWriter,
@@ -95,6 +96,7 @@ import {
 import type {
   ConfirmSeam,
   CookiePoster,
+  CoachWebFs,
   DashFs,
   GhRunner,
   GitRunner,
@@ -502,6 +504,16 @@ export abstract class BaseCommand extends Command {
   }
 
   /**
+   * The coach-web env fs seam (soa#300 — the `.env.local` prelaunch hook) —
+   * production is the only place coach-web's `.env.local` is written/removed for the
+   * hook, so its browser boots against the local mesh instead of the checked-in
+   * `.env` remote defaults.
+   */
+  protected getCoachWebFs(): CoachWebFs {
+    return makeRealCoachWebFs();
+  }
+
+  /**
    * The repo-dir existence check (M4 native partial-stack) — production is a real
    * `fs.existsSync` predicate. The native `stack up` path calls it per service to
    * SKIP (warn, not fail) any service whose sibling-repo checkout is absent (e.g.
@@ -821,6 +833,7 @@ export abstract class BaseCommand extends Command {
       meshExec: this.getMeshExec(),
       portProbe: this.getPortProbe(),
       dashFs: this.getDashFs(),
+      coachWebFs: this.getCoachWebFs(),
       prober: this.getProber(),
       runner: this.getRunner(),
       // M8 native prep pass (R1 build → R2 provision → R3 migrate on `up`; harmless

--- a/packages/node/saga-stack-cli/src/base-command.ts
+++ b/packages/node/saga-stack-cli/src/base-command.ts
@@ -513,6 +513,23 @@ export abstract class BaseCommand extends Command {
   }
 
   /**
+   * Read a sibling-repo file as UTF-8 text for prechecks — production is a real
+   * `fs.readFileSync` that returns `undefined` on ANY error (missing / unreadable
+   * / permission) so callers decide how to degrade. `develop coach`'s playlist
+   * precheck uses it to read coach-db's seed fixture and confirm the 2nd track is
+   * present BEFORE bring-up. Seam-mocking tests stub it to supply fixture content.
+   */
+  protected getRepoFileRead(): (path: string) => string | undefined {
+    return (path: string) => {
+      try {
+        return readFileSync(path, 'utf8');
+      } catch {
+        return undefined;
+      }
+    };
+  }
+
+  /**
    * The `--record` bring-up seam (Phase 2) — production is the only place the
    * fleek recording docker-compose stack + CodeArtifact token fetch is shelled.
    */

--- a/packages/node/saga-stack-cli/src/commands/develop/__tests__/coach.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/__tests__/coach.int.test.ts
@@ -239,6 +239,21 @@ describe('develop coach — content-viewer (default scenario)', () => {
   });
 });
 
+describe('develop coach — slot awareness (slot > 0)', () => {
+  it('accepts --slot 2 (slotAware) and still hands off', async () => {
+    // Was a hard-error before slotAware(): a per-slot dev concierge must run at
+    // slot > 0. (The concrete hand-off port at slot > 0 is verified live — the
+    // test harness mocks the port probe to fixed values, so it cannot assert the
+    // real mesh offset here.)
+    await DevelopCoach.run(['--slot', '2', ...ws()], config);
+    expect(browserRuns()).toHaveLength(1);
+  });
+
+  it('--tunnel --slot 2 hard-errors (tunnel fronts fixed slot-0 ports)', async () => {
+    await expect(DevelopCoach.run(['--tunnel', '--slot', '2', ...ws()], config)).rejects.toThrow(/slot 2:.*slot-0 browser ports/);
+  });
+});
+
 describe('develop coach — admin (descoped, mock-backed)', () => {
   it('drives the dashboard flow, logs in demo-dadmin at /reports, and WARNS that the report is mock-backed', async () => {
     await DevelopCoach.run(['--scenario', 'admin', ...ws()], config);

--- a/packages/node/saga-stack-cli/src/commands/develop/__tests__/coach.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/__tests__/coach.int.test.ts
@@ -89,6 +89,24 @@ const COACH_FLOWS = {
         },
       ],
     },
+    {
+      name: 'module-playback-real-content',
+      description: 'Module playback against REAL archive curriculum (base-coach).',
+      lanes: ['stack'],
+      progressive: false,
+      seed: { profile: 'full', reset: true },
+      // The flow itself supplies the gate; the invoker supplies only ARCHIVE_DIR.
+      env: { PUBLISH_REAL_CONTENT: '1' },
+      stages: [
+        {
+          id: 'module-playback-real-content',
+          phase: 1,
+          project: 'chromium',
+          spec: 'module-playback-real-content/module-playback-real-content.e2e.test.ts',
+          requiredSystems: ['coach-web', 'coach-api', 'iam-api'],
+        },
+      ],
+    },
   ],
 };
 
@@ -147,6 +165,14 @@ function installLoginSeams(result: PostResult = OK_COOKIES): void {
  * `coach-content/src/playlist.ts` feature-detect passes; every OTHER path
  * (coach-web appDir for the browser step) reports present so the hand-off runs.
  */
+/** Stub the repo-dir seam so the `--real-content` precheck sees (or misses) an archive checkout. */
+function installArchiveDirCheck(present: boolean): void {
+  vi.spyOn(BaseCommand.prototype as never, 'getRepoDirCheck' as never).mockReturnValue(((dir: string) => {
+    if (dir.endsWith(join('content-archive', '.git'))) return present;
+    return true;
+  }) as never);
+}
+
 function installRepoDirCheck(playlistVerb: boolean): void {
   vi.spyOn(BaseCommand.prototype as never, 'getRepoDirCheck' as never).mockReturnValue(((dir: string) => {
     if (dir.endsWith(join('coach-content-publish', 'src', 'playlist.ts'))) return playlistVerb;
@@ -271,6 +297,41 @@ describe('develop coach — admin (descoped, mock-backed)', () => {
 
     // the mock-backed caveat is surfaced.
     expect(warned.some((w) => w.includes('mock-backed') || w.includes('MOCK data'))).toBe(true);
+  });
+});
+
+describe('develop coach — --real-content (REAL archive curriculum)', () => {
+  afterEach(() => {
+    delete process.env.ARCHIVE_DIR; // the command exports it for the flow; don't leak across tests.
+  });
+
+  it('fails fast with an actionable message when the content-archive checkout is ABSENT — before any bring-up', async () => {
+    installArchiveDirCheck(false); // <archive>/.git not present
+    await expect(DevelopCoach.run(['--real-content', ...ws()], config)).rejects.toMatchObject({
+      message: expect.stringContaining('content-archive'),
+    });
+    // fail-fast: no docker/seed spent on a run the flow would only self-skip.
+    expect(launches).toEqual([]);
+    expect(playwrightRuns()).toHaveLength(0);
+  });
+
+  it('--real-content on a non-content-viewer scenario hard-errors', async () => {
+    await expect(DevelopCoach.run(['--real-content', '--scenario', 'admin', ...ws()], config)).rejects.toThrow(
+      /--real-content applies to --scenario content-viewer/,
+    );
+  });
+
+  it('drives the AUTHORED real-content flow, exports ARCHIVE_DIR, and still hands off the logged-in tutor', async () => {
+    installRepoDirCheck(true);
+    await DevelopCoach.run(['--real-content', '--archive-dir', '/fixed/dev/content-archive', ...ws()], config);
+
+    // the REAL-archive flow (publish base-coach → materialize), not the synthetic fixture.
+    expect(logged.join('\n')).toContain('coach-web/module-playback-real-content');
+    // ARCHIVE_DIR is the one thing the authored flow needs from the invoking env
+    // (its flows.json env block supplies PUBLISH_REAL_CONTENT=1).
+    expect(process.env.ARCHIVE_DIR).toBe('/fixed/dev/content-archive');
+    const br = browserRuns();
+    expect(br[0].env?.LOGIN_EMAIL).toBe('demo-tutor-1@saga.org');
   });
 });
 

--- a/packages/node/saga-stack-cli/src/commands/develop/__tests__/coach.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/__tests__/coach.int.test.ts
@@ -246,6 +246,8 @@ describe('develop coach — content-viewer (default scenario)', () => {
     expect(pw).toHaveLength(1);
     expect(pw[0].cwd).toBe(join(COACH_ROOT, 'apps', 'web', 'coach-web'));
     expect(logged.join('\n')).toContain('coach-web/module-playback');
+    // Non-progressive ⇒ restricted to this flow's OWN spec (not the whole project).
+    expect(pw[0].args).toContain('module-playback/module-playback.e2e.smoke.test.ts');
 
     // hand-off: demo-tutor-1 jar minted, then a headed coach-web at the module route.
     expect(posts).toHaveLength(1);
@@ -329,6 +331,13 @@ describe('develop coach — --real-content (REAL archive curriculum)', () => {
 
     // the REAL-archive flow (publish base-coach → materialize), not the synthetic fixture.
     expect(logged.join('\n')).toContain('coach-web/module-playback-real-content');
+    // Non-progressive ⇒ Playwright is restricted to THIS flow's spec. Without the
+    // filter the spawn runs coach-web's whole chromium project (11 specs, incl.
+    // unauthenticated shell specs that always fail) and the flow could never go
+    // green — so `develop coach` would never reach its hand-off.
+    expect(playwrightRuns()[0].args).toContain(
+      'module-playback-real-content/module-playback-real-content.e2e.test.ts',
+    );
     // The authored flow's lane gates on ARCHIVE_DIR **and** DATABASE_URL and
     // self-skips if either is missing (its flows.json env block supplies
     // PUBLISH_REAL_CONTENT=1). Export both — DATABASE_URL must be THIS slot's

--- a/packages/node/saga-stack-cli/src/commands/develop/__tests__/coach.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/__tests__/coach.int.test.ts
@@ -1,0 +1,273 @@
+/**
+ * `develop coach` integration tests (gh_305 M3) — the coach concierge driven
+ * through the REAL oclif command with every BaseCommand IO seam faked. NOTHING is
+ * spawned: the fake Runner/Launcher/Prober record the intended invocations.
+ *
+ * Coverage: command wiring (`--help` renders; the command resolves), the
+ * scenario→flow/persona/route mapping (content-viewer→module-playback→demo-tutor-1
+ * vs admin→dashboard→demo-dadmin), the mock-backed admin note, --reuse, and the
+ * `--scenario playlist` coach#238 feature-detect (fail-fast when the verb is
+ * absent; orchestrate publish/assign/materialize when present).
+ *
+ * Hermetic: a real coach `flows.json` (copied structure) is written into a temp
+ * COACH checkout that `--coach` points at, so discovery resolves coach-web's
+ * authored flows without touching the developer's real `$COACH`.
+ */
+
+import { join } from 'node:path';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import { Config } from '@oclif/core';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BaseCommand } from '../../../base-command.js';
+import type { ScriptInvocation } from '../../../runtime/index.js';
+import type { CookiePoster, JarWriter, PostOptions, PostResult } from '../../../runtime/index.js';
+import { useTempSnapshotsDir } from '../../../__tests__/helpers/env.js';
+import { installCoreSeams } from '../../../__tests__/helpers/seams.js';
+import DevelopCoach from '../coach.js';
+
+const PKG_ROOT = process.cwd();
+const SOA_ROOT = resolve(PKG_ROOT, '..', '..', '..');
+const DEV_ROOT = '/fixed/dev';
+
+/** coach-web's authored flows.json (the fields the resolver + our command read). */
+const COACH_FLOWS = {
+  schemaVersion: 1,
+  spa: {
+    id: 'coach-web',
+    system: 'coach-web',
+    repoEnvVar: 'COACH',
+    defaultRepoSubpath: 'coach',
+    appDir: 'apps/web/coach-web',
+    e2eDir: 'apps/web/coach-web/e2e',
+    playwrightConfig: 'playwright.config.ts',
+  },
+  flows: [
+    {
+      name: 'dashboard',
+      description: 'Authenticated tutor dashboard.',
+      lanes: ['stack'],
+      progressive: false,
+      seed: { profile: 'full', reset: true },
+      stages: [
+        {
+          id: 'dashboard',
+          phase: 1,
+          project: 'chromium',
+          spec: 'dashboard/dashboard-authenticated.e2e.smoke.test.ts',
+          requiredSystems: ['coach-web', 'coach-api', 'iam-api'],
+        },
+      ],
+    },
+    {
+      name: 'module-playback',
+      description: 'In-app module playback.',
+      lanes: ['stack'],
+      progressive: false,
+      seed: { profile: 'full', reset: true },
+      stages: [
+        {
+          id: 'module-playback',
+          phase: 1,
+          project: 'chromium',
+          spec: 'module-playback/module-playback.e2e.smoke.test.ts',
+          requiredSystems: ['coach-web', 'coach-api', 'iam-api'],
+        },
+      ],
+    },
+  ],
+};
+
+let COACH_ROOT: string;
+let config: Config;
+let launches: ReturnType<typeof installCoreSeams>['launches'];
+let runs: ScriptInvocation[];
+let logged: string[];
+let warned: string[];
+
+useTempSnapshotsDir('saga-coach-snaps-');
+
+/** Workspace flags: temp COACH (with the authored flows.json) + real soa. */
+function ws(): string[] {
+  return ['--coach', COACH_ROOT, '--soa', SOA_ROOT, '--dev', DEV_ROOT];
+}
+
+/** The Playwright child invocations the Runner recorded. */
+function playwrightRuns(): ScriptInvocation[] {
+  return runs.filter((r) => r.command === 'pnpm' && r.args.includes('playwright'));
+}
+/** The vendored browser-login.mjs child invocation (the hand-off). */
+function browserRuns(): ScriptInvocation[] {
+  return runs.filter((r) => r.command === 'node' && (r.args[0] ?? '').endsWith('browser-login.mjs'));
+}
+/** The coach-content CLI invocations the Runner recorded (playlist orchestration). */
+function coachContentRuns(): ScriptInvocation[] {
+  return runs.filter((r) => r.command === 'pnpm' && r.args.includes('coach-content'));
+}
+
+// Native-login seams (cookie poster + jar writer), mirroring run.int.test.ts.
+let posts: { url: string; opts: PostOptions }[];
+let jarWrites: { path: string; contents: string }[];
+const OK_COOKIES: PostResult = {
+  status: 200,
+  ok: true,
+  setCookies: ['iam_session=jwt.tok.sig; Path=/; HttpOnly', 'iam_refresh=refr; Path=/; HttpOnly'],
+};
+
+function installLoginSeams(result: PostResult = OK_COOKIES): void {
+  posts = [];
+  jarWrites = [];
+  const poster: CookiePoster = {
+    async post(url: string, opts: PostOptions): Promise<PostResult> {
+      posts.push({ url, opts });
+      return result;
+    },
+  };
+  const jar: JarWriter = { write: (path, contents) => jarWrites.push({ path, contents }) };
+  vi.spyOn(BaseCommand.prototype as never, 'getCookiePoster' as never).mockReturnValue(poster as never);
+  vi.spyOn(BaseCommand.prototype as never, 'getJarWriter' as never).mockReturnValue(jar as never);
+}
+
+/**
+ * Stub the repo-dir existence seam. `playlistVerb` controls whether the coach#238
+ * `coach-content/src/playlist.ts` feature-detect passes; every OTHER path
+ * (coach-web appDir for the browser step) reports present so the hand-off runs.
+ */
+function installRepoDirCheck(playlistVerb: boolean): void {
+  vi.spyOn(BaseCommand.prototype as never, 'getRepoDirCheck' as never).mockReturnValue(((dir: string) => {
+    if (dir.endsWith(join('coach-content-publish', 'src', 'playlist.ts'))) return playlistVerb;
+    return true;
+  }) as never);
+}
+
+beforeAll(() => {
+  COACH_ROOT = mkdtempSync(join(tmpdir(), 'coach-dev-'));
+  const e2eDir = join(COACH_ROOT, 'apps', 'web', 'coach-web', 'e2e');
+  mkdirSync(e2eDir, { recursive: true });
+  writeFileSync(join(e2eDir, 'flows.json'), JSON.stringify(COACH_FLOWS), 'utf8');
+});
+afterAll(() => {
+  rmSync(COACH_ROOT, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  config = await Config.load(PKG_ROOT);
+  const seams = installCoreSeams({ pidBase: 3000, prepFresh: true });
+  launches = seams.launches;
+  runs = seams.runs;
+  logged = [];
+  warned = [];
+  installLoginSeams();
+  installRepoDirCheck(true);
+  vi.spyOn(BaseCommand.prototype, 'log').mockImplementation((m?: string) => {
+    logged.push(String(m ?? ''));
+  });
+  vi.spyOn(BaseCommand.prototype, 'warn').mockImplementation(((m: string) => {
+    warned.push(String(m));
+    return m;
+  }) as never);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('develop coach — content-viewer (default scenario)', () => {
+  it('brings up the coach closure, seeds full, drives module-playback, hands off demo-tutor-1 at the module player', async () => {
+    await DevelopCoach.run([...ws()], config);
+
+    // the coach closure came up (coach-web + coach-api + iam-api at minimum).
+    const ids = launches.map((s) => s.id);
+    expect(ids).toContain('coach-web');
+    expect(ids).toContain('coach-api');
+    expect(ids).toContain('iam-api');
+
+    // full seed ran the coach pg seed (db:seed) — NOT skipped.
+    expect(runs.some((r) => r.args.includes('db:seed'))).toBe(true);
+
+    // exactly one Playwright child, in coach-web's appDir; the flow mapping shows
+    // in the hand-off summary (both coach flows share the `chromium` project).
+    const pw = playwrightRuns();
+    expect(pw).toHaveLength(1);
+    expect(pw[0].cwd).toBe(join(COACH_ROOT, 'apps', 'web', 'coach-web'));
+    expect(logged.join('\n')).toContain('coach-web/module-playback');
+
+    // hand-off: demo-tutor-1 jar minted, then a headed coach-web at the module route.
+    expect(posts).toHaveLength(1);
+    expect(posts[0]?.opts.body).toContain('demo-tutor-1@saga.org');
+    const br = browserRuns();
+    expect(br).toHaveLength(1);
+    expect(br[0].env?.LOGIN_EMAIL).toBe('demo-tutor-1@saga.org');
+    expect(br[0].env?.DASH_URL).toBe('http://localhost:8800/units/unit_1/sc_u1_m1');
+
+    expect(logged.join('\n')).toContain("coach ready — scenario 'content-viewer'");
+  });
+
+  it('--reuse skips the reset+seed but still hands off', async () => {
+    await DevelopCoach.run(['--reuse', ...ws()], config);
+    expect(runs.some((r) => r.args.includes('db:seed'))).toBe(false);
+    expect(browserRuns()).toHaveLength(1);
+  });
+});
+
+describe('develop coach — admin (descoped, mock-backed)', () => {
+  it('drives the dashboard flow, logs in demo-dadmin at /reports, and WARNS that the report is mock-backed', async () => {
+    await DevelopCoach.run(['--scenario', 'admin', ...ws()], config);
+
+    // admin maps to the dashboard flow (not module-playback).
+    const pw = playwrightRuns();
+    expect(pw).toHaveLength(1);
+    expect(logged.join('\n')).toContain('coach-web/dashboard');
+
+    // logged in as the district-admin persona at /reports.
+    expect(posts[0]?.opts.body).toContain('demo-dadmin@saga.org');
+    const br = browserRuns();
+    expect(br[0].env?.LOGIN_EMAIL).toBe('demo-dadmin@saga.org');
+    expect(br[0].env?.DASH_URL).toBe('http://localhost:8800/reports');
+
+    // the mock-backed caveat is surfaced.
+    expect(warned.some((w) => w.includes('mock-backed') || w.includes('MOCK data'))).toBe(true);
+  });
+});
+
+describe('develop coach — playlist (coach#238 feature-detect)', () => {
+  it('fails fast with an actionable coach#238 message when the playlist verb is ABSENT — before any bring-up', async () => {
+    installRepoDirCheck(false); // coach-content/src/playlist.ts not present
+    await expect(DevelopCoach.run(['--scenario', 'playlist', ...ws()], config)).rejects.toMatchObject({
+      message: expect.stringContaining('coach#238'),
+    });
+    // fail-fast: nothing was launched and no Playwright ran.
+    expect(launches).toEqual([]);
+    expect(playwrightRuns()).toHaveLength(0);
+  });
+
+  it('when the verb IS present: brings up + seeds, runs playlist assign + materialize --replace, then hands off', async () => {
+    installRepoDirCheck(true);
+    await DevelopCoach.run(['--scenario', 'playlist', ...ws()], config);
+
+    // the coach-owned track switch ran against the mesh coach_api pg.
+    const cc = coachContentRuns();
+    const assign = cc.find((r) => r.args.includes('assign'));
+    const materialize = cc.find((r) => r.args.includes('materialize'));
+    expect(assign).toBeDefined();
+    expect(assign?.args).toContain('playlist');
+    expect(assign?.args).toContain('--group');
+    expect(materialize).toBeDefined();
+    expect(materialize?.args).toContain('--replace');
+    expect(materialize?.args).toContain('demo-tutor-1');
+    // both carry the coach_api DATABASE_URL so they hit the mesh pg.
+    expect(assign?.env?.DATABASE_URL).toContain('coach_api');
+
+    // and it still handed off a logged-in coach-web.
+    expect(browserRuns()).toHaveLength(1);
+  });
+});
+
+describe('develop coach — command wiring', () => {
+  it('rejects an unknown --scenario value (oclif options)', async () => {
+    await expect(DevelopCoach.run(['--scenario', 'bogus', ...ws()], config)).rejects.toMatchObject({
+      message: expect.stringContaining('bogus'),
+    });
+  });
+});

--- a/packages/node/saga-stack-cli/src/commands/develop/__tests__/coach.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/__tests__/coach.int.test.ts
@@ -31,6 +31,19 @@ const PKG_ROOT = process.cwd();
 const SOA_ROOT = resolve(PKG_ROOT, '..', '..', '..');
 const DEV_ROOT = '/fixed/dev';
 
+/**
+ * The 2nd track `--scenario playlist` switches onto — the MATERIALIZABLE curriculum
+ * coach-db's seed ships (fixtures/content-release.json → curriculum-coach-b). MUST
+ * stay in lock-step with coach.ts's `PLAYLIST_TRACK_2`.
+ */
+const PLAYLIST_TRACK_2 = 'curriculum-coach-b';
+/**
+ * demo-tutor-1's DERIVED coach user id (`deriveUserId('demo-tutor-1')`) — the id
+ * coach-web's whoami reads by and the seed keys the tutor's instance to. materialize
+ * MUST use this, not the `demo-tutor-1` handle. Mirrors coach.ts's COACH_TUTOR_USER_ID.
+ */
+const COACH_TUTOR_UUID = '1c939568-1464-5f9a-b5a4-0bc73a0454cb';
+
 /** coach-web's authored flows.json (the fields the resolver + our command read). */
 const COACH_FLOWS = {
   schemaVersion: 1,
@@ -141,6 +154,20 @@ function installRepoDirCheck(playlistVerb: boolean): void {
   }) as never);
 }
 
+/**
+ * Stub the repo-file-read seam so the playlist precheck reads a coach-db seed
+ * fixture carrying exactly `tracks` as its curricula names. Any other path reads
+ * as absent (undefined), mirroring the real seam's error → undefined contract.
+ */
+function installRepoFileRead(tracks: string[]): void {
+  vi.spyOn(BaseCommand.prototype as never, 'getRepoFileRead' as never).mockReturnValue(((path: string) => {
+    if (path.endsWith(join('coach-db', 'src', 'seed', 'fixtures', 'content-release.json'))) {
+      return JSON.stringify({ curricula: tracks.map((name) => ({ name })) });
+    }
+    return undefined;
+  }) as never);
+}
+
 beforeAll(() => {
   COACH_ROOT = mkdtempSync(join(tmpdir(), 'coach-dev-'));
   const e2eDir = join(COACH_ROOT, 'apps', 'web', 'coach-web', 'e2e');
@@ -160,6 +187,7 @@ beforeEach(async () => {
   warned = [];
   installLoginSeams();
   installRepoDirCheck(true);
+  installRepoFileRead([PLAYLIST_TRACK_2]);
   vi.spyOn(BaseCommand.prototype, 'log').mockImplementation((m?: string) => {
     logged.push(String(m ?? ''));
   });
@@ -242,8 +270,20 @@ describe('develop coach — playlist (coach#238 feature-detect)', () => {
     expect(playwrightRuns()).toHaveLength(0);
   });
 
-  it('when the verb IS present: brings up + seeds, runs playlist assign + materialize --replace, then hands off', async () => {
+  it('fails fast when the coach seed does NOT ship the materializable 2nd track — before any bring-up', async () => {
+    installRepoDirCheck(true); // verb present…
+    installRepoFileRead(['curriculum-coach']); // …but the seed lacks curriculum-coach-b
+    await expect(DevelopCoach.run(['--scenario', 'playlist', ...ws()], config)).rejects.toMatchObject({
+      message: expect.stringContaining(PLAYLIST_TRACK_2),
+    });
+    // fail-fast: nothing was launched and no Playwright ran.
+    expect(launches).toEqual([]);
+    expect(playwrightRuns()).toHaveLength(0);
+  });
+
+  it('when the verb + seeded track are present: brings up + seeds, assigns + materializes the SEEDED 2nd track keyed by the derived user id, then hands off', async () => {
     installRepoDirCheck(true);
+    installRepoFileRead([PLAYLIST_TRACK_2]);
     await DevelopCoach.run(['--scenario', 'playlist', ...ws()], config);
 
     // the coach-owned track switch ran against the mesh coach_api pg.
@@ -253,9 +293,22 @@ describe('develop coach — playlist (coach#238 feature-detect)', () => {
     expect(assign).toBeDefined();
     expect(assign?.args).toContain('playlist');
     expect(assign?.args).toContain('--group');
+
+    // The materialize target is the SAME track the assign uses AND the one the
+    // precheck confirmed the seed ships — not a name nothing ensures exists.
+    const assignContent = assign?.args[(assign?.args.indexOf('--content') ?? -1) + 1];
+    const materializeContent = materialize?.args[(materialize?.args.indexOf('--content') ?? -1) + 1];
+    expect(assignContent).toBe(PLAYLIST_TRACK_2);
+    expect(materializeContent).toBe(PLAYLIST_TRACK_2);
+
     expect(materialize).toBeDefined();
     expect(materialize?.args).toContain('--replace');
-    expect(materialize?.args).toContain('demo-tutor-1');
+    // Keyed by the tutor's DERIVED user id (what coach-web reads by), NOT the
+    // 'demo-tutor-1' handle — the switched instance is invisible in-app otherwise.
+    const materializeUser = materialize?.args[(materialize?.args.indexOf('--user') ?? -1) + 1];
+    expect(materializeUser).toBe(COACH_TUTOR_UUID);
+    expect(materialize?.args).not.toContain('demo-tutor-1');
+
     // both carry the coach_api DATABASE_URL so they hit the mesh pg.
     expect(assign?.env?.DATABASE_URL).toContain('coach_api');
 

--- a/packages/node/saga-stack-cli/src/commands/develop/__tests__/coach.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/__tests__/coach.int.test.ts
@@ -302,7 +302,9 @@ describe('develop coach — admin (descoped, mock-backed)', () => {
 
 describe('develop coach — --real-content (REAL archive curriculum)', () => {
   afterEach(() => {
-    delete process.env.ARCHIVE_DIR; // the command exports it for the flow; don't leak across tests.
+    // the command exports these for the authored flow; don't leak across tests.
+    delete process.env.ARCHIVE_DIR;
+    delete process.env.DATABASE_URL;
   });
 
   it('fails fast with an actionable message when the content-archive checkout is ABSENT — before any bring-up', async () => {
@@ -327,9 +329,12 @@ describe('develop coach — --real-content (REAL archive curriculum)', () => {
 
     // the REAL-archive flow (publish base-coach → materialize), not the synthetic fixture.
     expect(logged.join('\n')).toContain('coach-web/module-playback-real-content');
-    // ARCHIVE_DIR is the one thing the authored flow needs from the invoking env
-    // (its flows.json env block supplies PUBLISH_REAL_CONTENT=1).
+    // The authored flow's lane gates on ARCHIVE_DIR **and** DATABASE_URL and
+    // self-skips if either is missing (its flows.json env block supplies
+    // PUBLISH_REAL_CONTENT=1). Export both — DATABASE_URL must be THIS slot's
+    // coach_api so the publish lands in the slot's own Postgres.
     expect(process.env.ARCHIVE_DIR).toBe('/fixed/dev/content-archive');
+    expect(process.env.DATABASE_URL).toContain('coach_api');
     const br = browserRuns();
     expect(br[0].env?.LOGIN_EMAIL).toBe('demo-tutor-1@saga.org');
   });

--- a/packages/node/saga-stack-cli/src/commands/develop/coach.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/coach.ts
@@ -124,6 +124,19 @@ const SCENARIOS: Readonly<Record<Scenario, ScenarioSpec>> = Object.freeze({
 const PLAYLIST_TRACK_2 = 'curriculum-coach-b';
 
 /**
+ * `--real-content`: coach-web's AUTHORED flow that plays REAL archive curriculum
+ * instead of the synthetic seed. It publishes the archive's `base-coach` into the
+ * slot's coach_api Postgres (`coach-content publish`), materializes demo-tutor-1
+ * onto it, then renders the SAME route the synthetic flow uses
+ * (`/units/unit_1/sc_u1_m1` — real base-coach carries that module; coach-db's
+ * synthetic `curriculum-coach` release does NOT, which is why the default flow
+ * shows "Couldn't Load Module" — coach#228 seed misalignment, research/11).
+ * The flow's own flows.json `env` block sets `PUBLISH_REAL_CONTENT=1`; the ONLY
+ * thing the invoker must supply is `ARCHIVE_DIR` (a content-archive checkout).
+ */
+const REAL_CONTENT_FLOW = 'module-playback-real-content';
+
+/**
  * demo-tutor-1's canonical coach user id — `deriveUserId('demo-tutor-1')` from
  * `@saga-ed/iam-seed-ids`, the id coach-db's seed keys the tutor's persona +
  * content_instance to (content-instances.json) AND the id coach-web's iam
@@ -163,6 +176,15 @@ export default class DevelopCoach extends BaseCommand {
     reuse: Flags.boolean({
       default: false,
       description: 'skip the reset+seed; hand off against the CURRENT stack state (mirrors develop connect --reuse).',
+    }),
+    'real-content': Flags.boolean({
+      default: false,
+      description:
+        "content-viewer only: play REAL curriculum published from a saga-ed/content-archive checkout (base-coach) instead of coach-db's synthetic acceptance fixture. Drives coach-web's authored `module-playback-real-content` flow, which publishes the archive into the slot's coach_api Postgres and materializes demo-tutor-1 onto it. Needs an archive checkout (--archive-dir / $ARCHIVE_DIR / $DEV/content-archive).",
+    }),
+    'archive-dir': Flags.string({
+      description:
+        'path to a saga-ed/content-archive checkout for --real-content (default: $ARCHIVE_DIR, else <dev>/content-archive).',
     }),
     'spa-path': Flags.string({
       description: 'explicit path to a flows.json (file or dir) — highest-priority discovery override',
@@ -210,7 +232,18 @@ export default class DevelopCoach extends BaseCommand {
       );
     }
 
-    const resolved = resolveFlow(disco.manifest, spec.flow, { lane: 'stack' });
+    // --real-content swaps the content-viewer's synthetic flow for coach-web's
+    // authored REAL-archive flow (publish base-coach → materialize → same route).
+    if (flags['real-content'] && scenario !== 'content-viewer') {
+      this.error(
+        `--real-content applies to --scenario content-viewer (got '${scenario}'). ` +
+          'It swaps the ported module player onto REAL published archive curriculum; ' +
+          'admin/playlist do not read the archive.',
+      );
+    }
+    const flowName = flags['real-content'] ? REAL_CONTENT_FLOW : spec.flow;
+
+    const resolved = resolveFlow(disco.manifest, flowName, { lane: 'stack' });
     const appCwd = resolveAppCwd(resolved.spa, flags, process.env);
     // COACH checkout root: appCwd is `<coachRoot>/apps/web/coach-web`.
     const coachRoot = appCwd.slice(0, appCwd.length - resolved.spa.appDir.length - 1);
@@ -220,6 +253,19 @@ export default class DevelopCoach extends BaseCommand {
     // fails fast with an actionable message instead of crashing halfway through
     // docker + seed (or, worse, materializing against a track that isn't there).
     if (scenario === 'playlist') this.assertPlaylistPrereqs(coachRoot);
+
+    // --real-content: resolve + PRECHECK the content-archive checkout BEFORE any
+    // bring-up, then export it as ARCHIVE_DIR — the ONE thing the authored flow
+    // requires from "the invoking shell's env" (its flows.json env block supplies
+    // PUBLISH_REAL_CONTENT=1; DATABASE_URL comes from our own launch-plan). The
+    // Runner spawns Playwright with `{...process.env, ...spec.env}`, so setting it
+    // here is exactly the contract the flow documents.
+    if (flags['real-content']) {
+      const archiveDir = this.resolveArchiveDir(flags);
+      this.assertRealContentPrereqs(archiveDir);
+      process.env.ARCHIVE_DIR = archiveDir;
+      this.log(`==> real-content: publishing base-coach from ${archiveDir}`);
+    }
 
     // coach flows are non-progressive + prerequisite-free; --reuse just drops the
     // reset+seed (mirrors connect). base === resolved when the flow has no prereq.
@@ -331,6 +377,34 @@ export default class DevelopCoach extends BaseCommand {
    *
    * Reuses the shared repo-dir existence + repo-file-read seams (tests stub them).
    */
+  /**
+   * The content-archive checkout `--real-content` publishes from: an explicit
+   * `--archive-dir`, else `$ARCHIVE_DIR` (the env var the authored flow documents),
+   * else the sibling-repo convention `<dev>/content-archive` — mirroring how every
+   * other repo root resolves (`runtime/scripts.ts` `resolveRepoRoot`).
+   */
+  private resolveArchiveDir(flags: { 'archive-dir'?: string; dev?: string }): string {
+    const dev = flags.dev ?? process.env.DEV ?? join(process.env.HOME ?? '', 'dev');
+    return flags['archive-dir'] ?? process.env.ARCHIVE_DIR ?? join(dev, 'content-archive');
+  }
+
+  /**
+   * `--real-content` PRECHECK: the archive must be a real git checkout before we
+   * spend a docker bring-up + full seed on a run the flow would only self-skip
+   * (`real-content-lane.ts` returns `{skip}` when ARCHIVE_DIR is unset/blank, and
+   * the spec asserts `<archiveDir>/.git` exists). Fail fast + actionable instead.
+   */
+  private assertRealContentPrereqs(archiveDir: string): void {
+    if (!this.getRepoDirCheck()(join(archiveDir, '.git'))) {
+      this.error(
+        `--real-content needs a saga-ed/content-archive checkout, but ${archiveDir} is not a git checkout.\n` +
+          `  clone it:  git clone git@github.com:saga-ed/content-archive.git ${archiveDir}\n` +
+          `  or point at an existing one:  --archive-dir <path>  (or export ARCHIVE_DIR=<path>)\n` +
+          `  Without --real-content, content-viewer plays coach-db's synthetic seed instead.`,
+      );
+    }
+  }
+
   private assertPlaylistPrereqs(coachRoot: string): void {
     const verbFile = join(coachRoot, 'packages', 'node', 'coach-content-publish', 'src', 'playlist.ts');
     if (!this.getRepoDirCheck()(verbFile)) {

--- a/packages/node/saga-stack-cli/src/commands/develop/coach.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/coach.ts
@@ -1,0 +1,372 @@
+/**
+ * `saga-stack develop coach` — bring up a running, seeded coach and drop the
+ * developer into a HEADED, logged-in coach-web (gh_305, soa#305).
+ *
+ * The dev-setup analogue of `develop connect`: it resolves one of coach-web's
+ * authored flows (`apps/web/coach-web/e2e/flows.json` — `dashboard`,
+ * `module-playback`, `module-playback-real-content`) via the SAME
+ * `resolveFlow` + `executeResolvedFlow` path `connect` uses, so the coach
+ * closure (coach-web + coach-api + iam-api + coach_api pg + curriculum mongo)
+ * comes up and the `full` seed profile lands demo-tutor-1's content_instance,
+ * content_release and group_track_map. Then — UNLIKE connect (whose hold IS the
+ * headed Playwright room) — it hands off a headed coach-web via the generalized
+ * `openVendoredBrowser`, logged in as the scenario's persona and deep-linked to
+ * the scenario's route. The dev stack stays up; the browser holds the terminal
+ * until closed.
+ *
+ * `--scenario` (default `content-viewer`) selects persona + flow + route:
+ *   - content-viewer  drive `module-playback` as demo-tutor-1@saga.org, land on
+ *                     the ported module player (/units/unit_1/sc_u1_m1). PRIMARY.
+ *   - admin           bring up + seed + hand off demo-dadmin@saga.org on the
+ *                     Reports route (/reports). DESCOPED v1: the org-wide report
+ *                     is MOCK-backed (coach-web reportsStore.fetchReport →
+ *                     getMockReport) pending coach-repo work — printed as a note.
+ *   - playlist        orchestrate the coach-OWNED track switch: publish a 2nd
+ *                     track, `coach-content playlist assign`, `materialize
+ *                     --replace`, then hand off. The `playlist assign` verb is
+ *                     being built in parallel (coach#238); if it is not present
+ *                     on the developer's coach checkout this fails fast with an
+ *                     actionable message rather than crashing mid-bring-up.
+ *
+ * `--reuse` skips the reset+seed and runs against the CURRENT stack state (mirror
+ * connect). `--tunnel` repoints THIS run's flow browsers at the vms tunnel hosts
+ * (same machinery + same slot-0-only caveat as connect — it does NOT relaunch the
+ * stack). Anything after `--` passes straight through to Playwright.
+ *
+ *   node bin/dev.js develop coach
+ *   node bin/dev.js develop coach --scenario admin
+ *   node bin/dev.js develop coach --scenario playlist
+ *   node bin/dev.js develop coach --reuse -- --debug
+ */
+
+import { join } from 'node:path';
+import { Flags } from '@oclif/core';
+import { BaseCommand } from '../../base-command.js';
+import type { WorkspaceFlags } from '../../base-command.js';
+import { resolveFlow } from '../../core/flow/index.js';
+import { deriveInstance } from '../../core/derive-instance.js';
+import { manifest as serviceManifest } from '../../core/manifest/index.js';
+import type { RepoKey } from '../../core/manifest/index.js';
+import type { ScriptPlan } from '../../core/flag-map.js';
+import { makeStackApi } from '../../stack-api.js';
+import { resolveVendorScript } from '../../runtime/index.js';
+import {
+  buildStackContext,
+  discoverFlowManifest,
+  executeResolvedFlow,
+  FlowExecError,
+  resolveAppCwd,
+} from '../../e2e-orchestrate.js';
+
+/** The concierge target is coach-web (registered in spa-registry.ts, M2). */
+const COACH_SPA = 'coach-web';
+
+/** The scenarios `--scenario` selects. */
+type Scenario = 'content-viewer' | 'admin' | 'playlist';
+
+/** Per-scenario recipe: which authored flow to drive, which persona to log in, where to land. */
+interface ScenarioSpec {
+  /** coach-web flows.json flow name driven via resolveFlow/executeResolvedFlow. */
+  flow: string;
+  /** iam persona the hand-off browser + cookie jar log in as (NOT dev@saga.org). */
+  email: string;
+  /** path appended to coach-web's base URL for the headed hand-off (deep-link). */
+  route: string;
+  /** optional caveat printed at hand-off (e.g. admin is mock-backed). */
+  note?: string;
+}
+
+/**
+ * The scenario table. All three run on the SAME coach-api + coach-web pair and
+ * the SAME `full` seed — they differ only by persona, flow and route (research
+ * 03/04). demo-tutor-1 is the seed's canonical tutor (its content_instance
+ * renders out of the box); demo-dadmin is the seeded elevated district-admin
+ * persona the Reports surface is framed for.
+ */
+const SCENARIOS: Readonly<Record<Scenario, ScenarioSpec>> = Object.freeze({
+  'content-viewer': {
+    flow: 'module-playback',
+    email: 'demo-tutor-1@saga.org',
+    route: '/units/unit_1/sc_u1_m1',
+  },
+  admin: {
+    flow: 'dashboard',
+    email: 'demo-dadmin@saga.org',
+    route: '/reports',
+    note:
+      'admin is DESCOPED for v1: the org-wide Coach Report renders from MOCK data today ' +
+      '(coach-web reportsStore.fetchReport → getMockReport), not live coach-api resolvers. ' +
+      'Live-backing it (rewire fetchReport → fetchCoachReport + seed multiple assigned tutors) ' +
+      'is coach-repo product work outside gh_305.',
+  },
+  playlist: {
+    // Bring up + seed the base track first (module-playback exercises the
+    // renderers), THEN switch demo-tutor-1 to a 2nd track via coach-content and
+    // hand off on the dashboard so the switched playlist drives the content.
+    flow: 'module-playback',
+    email: 'demo-tutor-1@saga.org',
+    route: '/',
+  },
+});
+
+/**
+ * The 2nd track `--scenario playlist` publishes + switches demo-tutor-1 onto
+ * (the committed seed ships only `spring-pilot`). A distinct content_name so the
+ * switch is observable. Kept here so the orchestration + its message agree.
+ */
+const PLAYLIST_TRACK_2 = 'base-coach';
+
+/** demo district group id the seed maps to a track (deriveGroupId('demo'), research 03/04). */
+const DEMO_DISTRICT_GROUP = 'a0da8362-1a93-5d1d-aeaa-b6d8960e9821';
+
+export default class DevelopCoach extends BaseCommand {
+  static description =
+    'Bring up + seed a coach stack and drop into a headed, logged-in coach-web: the ported content viewer (default), the mock-backed admin Reports route, or a playlist track-switch.';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --scenario admin',
+    '<%= config.bin %> <%= command.id %> --scenario playlist',
+    '<%= config.bin %> <%= command.id %> --reuse -- --debug',
+  ];
+
+  // Trailing Playwright passthrough (after `--`).
+  static strict = false;
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    scenario: Flags.string({
+      options: ['content-viewer', 'admin', 'playlist'],
+      default: 'content-viewer',
+      description:
+        'which coach surface to set up: content-viewer (ported module player, demo-tutor-1) [default]; ' +
+        'admin (mock-backed Reports route, demo-dadmin); playlist (switch demo-tutor-1 to a 2nd track via coach-content — needs coach#238).',
+    }),
+    reuse: Flags.boolean({
+      default: false,
+      description: 'skip the reset+seed; hand off against the CURRENT stack state (mirrors develop connect --reuse).',
+    }),
+    'spa-path': Flags.string({
+      description: 'explicit path to a flows.json (file or dir) — highest-priority discovery override',
+    }),
+    tunnel: Flags.boolean({
+      default: false,
+      description:
+        "point THIS run's flow browsers at the vms tunnel hosts (https://<label>.<moniker>.<VMS_BASE>) instead of localhost, so a REMOTE peer can reach the same stack. Resolves the moniker via the vendored tunnel.sh (same machinery as `stack up --tunnel`). NOTE: this ONLY repoints the flow's Playwright browsers — it does NOT relaunch the stack; you must have already run `ss stack up --tunnel`. Slot-0 only.",
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { argv, flags } = await this.parse(DevelopCoach);
+    const scenario = flags.scenario as Scenario;
+    const spec = SCENARIOS[scenario];
+    const passthrough = argv as string[];
+
+    // Discover + load coach-web's authored flows.json (COACH checkout; no bundled
+    // example — coach ships its own, so an absent checkout is a hard, clear error).
+    const disco = discoverFlowManifest(COACH_SPA, flags, process.env);
+    if (disco.usedBundledExample) {
+      this.warn(
+        `no flows.json found for '${COACH_SPA}' in the repo; using the BUNDLED EXAMPLE shipped with @saga-ed/saga-stack-cli (${disco.sourcePath}).`,
+      );
+    }
+
+    const resolved = resolveFlow(disco.manifest, spec.flow, { lane: 'stack' });
+    const appCwd = resolveAppCwd(resolved.spa, flags, process.env);
+    // COACH checkout root: appCwd is `<coachRoot>/apps/web/coach-web`.
+    const coachRoot = appCwd.slice(0, appCwd.length - resolved.spa.appDir.length - 1);
+
+    // --scenario playlist: FEATURE-DETECT coach#238's `coach-content playlist assign`
+    // verb BEFORE any bring-up, so a checkout without it fails fast with an actionable
+    // message instead of crashing halfway through docker + seed.
+    if (scenario === 'playlist') this.assertPlaylistVerb(coachRoot);
+
+    // coach flows are non-progressive + prerequisite-free; --reuse just drops the
+    // reset+seed (mirrors connect). base === resolved when the flow has no prereq.
+    const base = flags.reuse ? { ...resolved, prerequisite: undefined } : resolved;
+
+    const now = new Date();
+    const seams = {
+      launcher: this.getLauncher(flags['state-dir']),
+      meshExec: this.getMeshExec(),
+      portProbe: this.getPortProbe(),
+      dashFs: this.getDashFs(),
+      prober: this.getProber(),
+      runner: this.getRunner(),
+    };
+    const delegate = (plan: ScriptPlan): Promise<number> =>
+      this.runScript(plan, flags as WorkspaceFlags, { propagateExit: false });
+
+    // --tunnel: resolve <moniker>.<VMS_BASE> from the VENDORED tunnel.sh (same
+    // machinery as connect/`stack up --tunnel`). develop coach is slot-0 only, so
+    // no slot guard is needed. The seam lets unit tests inject a fixed moniker.
+    let tunnelDomain: string | undefined;
+    if (flags.tunnel) {
+      const vmsBase = process.env.VMS_BASE ?? 'vms.wootdev.com';
+      const moniker = await this.getTunnelMoniker()(resolveVendorScript('tunnel.sh'));
+      tunnelDomain = `${moniker}.${vmsBase}`;
+    }
+
+    const { runtime } = buildStackContext(flags, seams, delegate, undefined, tunnelDomain);
+    const api = makeStackApi(serviceManifest, runtime);
+
+    // Drive the flow (up → reset+seed → verify → headless Playwright smoke). This
+    // seeds demo-tutor-1's content + mints the tutor session inside Playwright and
+    // asserts the renderers work BEFORE we hand off the real browser.
+    try {
+      const code = await executeResolvedFlow(
+        base,
+        { api, runner: seams.runner, appCwd, now, log: (l) => this.log(l), tunnelDomain },
+        { lane: 'stack', skipReset: flags.reuse, passthrough },
+      );
+      if (code !== 0) this.exit(code);
+    } catch (err) {
+      if (err instanceof FlowExecError) this.error(err.message);
+      throw err;
+    }
+
+    // --scenario playlist: NOW the stack is up + base-seeded, switch demo-tutor-1
+    // onto the 2nd track via the coach-owned CLI (publish → assign → materialize).
+    if (scenario === 'playlist') {
+      await this.orchestratePlaylist(coachRoot, runtime.launchContext.tokens.COACH_DB_URL);
+    }
+
+    // Hand off a HEADED, logged-in coach-web at the scenario's route. develop coach
+    // is slot-0 only; use the slot-0 state dir unless overridden.
+    const stateDir = flags['state-dir'] ?? deriveInstance({ slot: 0 }).stateDir;
+    await this.handoff(flags, scenario, spec, resolved, runtime.launchContext.ports['coach-web'], stateDir);
+  }
+
+  /**
+   * FEATURE-DETECT the coach#238 `coach-content playlist` verb group. The sibling
+   * plan (playlisting-port-plan.md §Decision) places it at
+   * `packages/node/coach-content-publish/src/playlist.ts` (beside `src/store.ts`).
+   * Absent ⇒ fail fast with an actionable message pointing at coach#238, BEFORE any
+   * bring-up. Reuses the shared repo-dir existence seam (tests stub it).
+   */
+  private assertPlaylistVerb(coachRoot: string): void {
+    const verbFile = join(coachRoot, 'packages', 'node', 'coach-content-publish', 'src', 'playlist.ts');
+    if (!this.getRepoDirCheck()(verbFile)) {
+      this.error(
+        `--scenario playlist needs the \`coach-content playlist assign\` verb, which is being built in ` +
+          `coach#238 and is not present in your coach checkout (${coachRoot}).\n` +
+          `  expected: ${verbFile}\n` +
+          `  Update your coach checkout once coach#238 lands, then retry. Meanwhile ` +
+          `\`ss develop coach\` (content-viewer) and \`--scenario admin\` work without it.`,
+      );
+    }
+  }
+
+  /**
+   * The coach-owned track switch for `--scenario playlist` (playlisting-port-plan
+   * Option A). Runs the documented one-command local path against the mesh coach_api
+   * Postgres: publish/ensure a 2nd track, `playlist assign` it to the demo district
+   * (writes ONLY group_id→content_name), then `materialize --replace` demo-tutor-1
+   * onto it. Only reached once `assertPlaylistVerb` has confirmed the verb exists.
+   */
+  private async orchestratePlaylist(coachRoot: string, databaseUrl: string): Promise<void> {
+    const runner = this.getRunner();
+    const coachContent = async (label: string, args: string[]): Promise<void> => {
+      this.log(`==> playlist: ${label} (coach-content ${args.join(' ')})`);
+      const { code } = await runner.run({
+        cwd: coachRoot,
+        command: 'pnpm',
+        args: ['--filter', '@saga-ed/coach-content-publish', 'exec', 'coach-content', ...args],
+        env: { DATABASE_URL: databaseUrl },
+        stdio: 'inherit',
+      });
+      if (code !== 0) this.error(`playlist: \`coach-content ${args[0]}\` failed (exit ${code}).`);
+    };
+
+    // 1. Ensure a 2nd published track exists (the committed seed ships only
+    //    spring-pilot). materialize below points demo-tutor-1 at it.
+    await coachContent('assign the 2nd track to the demo district', [
+      'playlist',
+      'assign',
+      '--group',
+      DEMO_DISTRICT_GROUP,
+      '--content',
+      PLAYLIST_TRACK_2,
+    ]);
+    // 2. Re-materialize demo-tutor-1 onto the newly-assigned track (replace the
+    //    existing instance so the dashboard renders the switched playlist).
+    await coachContent('re-materialize demo-tutor-1 onto the 2nd track', [
+      'materialize',
+      '--user',
+      'demo-tutor-1',
+      '--content',
+      PLAYLIST_TRACK_2,
+      '--replace',
+    ]);
+    this.log(`==> playlist: demo-tutor-1 switched to '${PLAYLIST_TRACK_2}'.`);
+  }
+
+  /**
+   * Mint the persona cookie jar (slot-0) and open a HEADED, auto-logged-in coach-web
+   * at the scenario's deep-linked route via the generalized `openVendoredBrowser`
+   * ({ repoEnvVar:'COACH', appDir:'apps/web/coach-web', port:8800 }). Mirrors the M2
+   * `holdEpilogue` email-param path but for a first-class command. Best-effort: a
+   * failed jar / browserless host WARNS, never crashes — the stack is up and seeded.
+   * The headed browser holds the terminal until the developer closes it.
+   */
+  private async handoff(
+    flags: WorkspaceFlags & { porcelain: boolean; 'output-json': boolean },
+    scenario: Scenario,
+    spec: ScenarioSpec,
+    resolved: ReturnType<typeof resolveFlow>,
+    spaPort: number | undefined,
+    stateDir: string,
+  ): Promise<void> {
+    const email = spec.email;
+
+    const res = await this.mintNativeLoginJar({ email, slot: 0, stateDir });
+    if (!res.ok) {
+      this.warn(
+        `hand-off: session mint failed (HTTP ${res.status}) for ${email} — the stack is up + seeded but no ` +
+          'logged-in jar was written. Confirm the iam roster seed materialized the persona (run with the full seed).',
+      );
+      return;
+    }
+
+    const baseUrl = spaPort !== undefined ? `http://localhost:${spaPort}` : undefined;
+    const landingUrl = baseUrl !== undefined ? `${baseUrl}${spec.route}` : undefined;
+
+    if (spec.note) this.warn(`--scenario ${scenario}: ${spec.note}`);
+
+    this.emit(
+      flags,
+      {
+        handedOff: true,
+        scenario,
+        flow: `${resolved.spa.id}/${resolved.flow.name}`,
+        email,
+        jarPath: res.jarPath,
+        coachWebUrl: landingUrl ?? null,
+        note: spec.note ?? null,
+      },
+      [
+        `✓ coach ready — scenario '${scenario}' (${resolved.spa.id}/${resolved.flow.name})`,
+        `  logged-in as ${email} · cookie jar → ${res.jarPath}`,
+        landingUrl
+          ? `  opening a headed coach-web at ${landingUrl} (best-effort; a headless host warns)…`
+          : '  (no coach-web port resolved — browser open skipped)',
+        '  teardown when done: ss stack down',
+      ],
+    );
+
+    if (landingUrl) {
+      await this.openVendoredBrowser(flags, {
+        email,
+        iamUrl: res.iamUrl,
+        stateDir,
+        // Deep-link the headed browser straight to the scenario's route.
+        dashUrl: landingUrl,
+        spa: {
+          repoEnvVar: resolved.spa.repoEnvVar as RepoKey,
+          appDir: resolved.spa.appDir,
+          port: spaPort,
+        },
+      });
+    }
+  }
+}

--- a/packages/node/saga-stack-cli/src/commands/develop/coach.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/coach.ts
@@ -321,6 +321,15 @@ export default class DevelopCoach extends BaseCommand {
     const { runtime } = buildStackContext(flags, seams, delegate, profile, tunnelDomain);
     const api = makeStackApi(serviceManifest, runtime);
 
+    // --real-content: the authored flow's lane (`real-content-lane.ts`) gates on
+    // ARCHIVE_DIR **and** DATABASE_URL ("the stack lane's own DB" — its flows.json
+    // says saga-stack-cli supplies it), and SELF-SKIPS if either is missing. Export
+    // the SLOT's coach_api URL now that the launch context is resolved, so the spec
+    // publishes into THIS slot's Postgres instead of silently skipping.
+    if (flags['real-content']) {
+      process.env.DATABASE_URL = runtime.launchContext.tokens.COACH_DB_URL;
+    }
+
     // Drive the flow (up → reset+seed → verify → headless Playwright smoke). This
     // seeds demo-tutor-1's content + mints the tutor session inside Playwright and
     // asserts the renderers work BEFORE we hand off the real browser.

--- a/packages/node/saga-stack-cli/src/commands/develop/coach.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/coach.ts
@@ -243,6 +243,10 @@ export default class DevelopCoach extends BaseCommand {
       meshExec: this.getMeshExec(),
       portProbe: this.getPortProbe(),
       dashFs: this.getDashFs(),
+      // soa#300: buildStackContext threads this into the runtime so StackApi.up writes
+      // coach-web's `.env.local` (local mesh offset URLs) before launch — else its
+      // browser inlines the checked-in `.env` remote defaults and 503s at sign-in.
+      coachWebFs: this.getCoachWebFs(),
       prober: this.getProber(),
       runner: this.getRunner(),
       // Native-prep seams: buildStackContext wires them into the runtime at EVERY

--- a/packages/node/saga-stack-cli/src/commands/develop/coach.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/coach.ts
@@ -281,7 +281,21 @@ export default class DevelopCoach extends BaseCommand {
     try {
       const code = await executeResolvedFlow(
         base,
-        { api, runner: seams.runner, appCwd, now, log: (l) => this.log(l), tunnelDomain },
+        // Pass the SLOT-OFFSET ports (mirrors e2e run) so the coach-web Playwright
+        // spawn gets PLAYWRIGHT_IAM_URL = the slot iam and PLAYWRIGHT_BASE_URL = the
+        // slot coach-web. Without this the specs' lane.ts falls back to base ports
+        // (iam :3010, coach-web :8800) — globalSetup then mints the iam_session on
+        // the wrong iam and the browser boots 503 (soa#300 tail).
+        {
+          api,
+          runner: seams.runner,
+          appCwd,
+          now,
+          log: (l) => this.log(l),
+          slot: profile.slot,
+          ports: runtime.launchContext.ports,
+          tunnelDomain,
+        },
         { lane: 'stack', skipReset: flags.reuse, passthrough },
       );
       if (code !== 0) this.exit(code);

--- a/packages/node/saga-stack-cli/src/commands/develop/coach.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/coach.ts
@@ -174,11 +174,32 @@ export default class DevelopCoach extends BaseCommand {
     }),
   };
 
+  /**
+   * `develop coach` brings up an isolated `soa-s<N>` coach sub-stack at slot > 0
+   * — the whole point of a per-slot dev concierge. It mirrors `e2e run` (same
+   * slot-aware `executeResolvedFlow`), derives the slot profile via
+   * `deriveInstance`, and hands off the browser at the SLOT-OFFSET coach-web port
+   * (`launchContext.ports['coach-web']`), so nothing is pinned to slot 0.
+   */
+  protected slotAware(): boolean {
+    return true;
+  }
+
   async run(): Promise<void> {
     const { argv, flags } = await this.parse(DevelopCoach);
     const scenario = flags.scenario as Scenario;
     const spec = SCENARIOS[scenario];
     const passthrough = argv as string[];
+
+    // --tunnel fronts the FIXED slot-0 browser ports via the vms rendezvous box,
+    // so it is slot-0-only — mirroring `e2e run --tunnel` (run.ts) and `stack up
+    // --tunnel`. The `flags.slot > 0` check covers `--set` too (a set pins slot > 0).
+    if (flags.tunnel && flags.slot > 0) {
+      this.error(
+        `slot ${flags.slot}: --tunnel fronts the FIXED slot-0 browser ports via the vms rendezvous box, ` +
+          'so it cannot run against a peer slot/set. Run develop coach at slot 0, or drop --tunnel.',
+      );
+    }
 
     // Discover + load coach-web's authored flows.json (COACH checkout; no bundled
     // example — coach ships its own, so an absent checkout is a hard, clear error).

--- a/packages/node/saga-stack-cli/src/commands/develop/coach.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/coach.ts
@@ -226,20 +226,41 @@ export default class DevelopCoach extends BaseCommand {
     const base = flags.reuse ? { ...resolved, prerequisite: undefined } : resolved;
 
     const now = new Date();
+
+    // M7: resolve the slot profile once — it drives the offset ports/project/
+    // container-env (buildStackContext), the launcher's per-slot state dir, and the
+    // DB/mesh targeting so `--slot N` provisions + migrates + seeds against slot N's
+    // OWN offset ports/DBs (mirrors e2e run.ts). At slot 0 it is the byte-identical
+    // no-offset default. WITHOUT this, `--slot N` would silently target slot 0.
+    const profile = deriveInstance({ slot: flags.slot });
+    // Apply the slot's container-env seam (mesh container names + snapshot dir) and
+    // point the launcher at the slot's state dir (pids/logs) — both no-ops at slot 0.
+    this.applyInstanceEnv(profile);
+    const stateDir = flags['state-dir'] ?? profile.stateDir;
+
     const seams = {
-      launcher: this.getLauncher(flags['state-dir']),
+      launcher: this.getLauncher(stateDir),
       meshExec: this.getMeshExec(),
       portProbe: this.getPortProbe(),
       dashFs: this.getDashFs(),
       prober: this.getProber(),
       runner: this.getRunner(),
+      // Native-prep seams: buildStackContext wires them into the runtime at EVERY
+      // slot so StackApi.up runs R2 provision + R3 migrate on the slot's offset DBs
+      // before launch+seed (mirrors e2e run.ts — required for a slot > 0 bring-up).
+      pgProbe: this.getPgProbe(),
+      prepIsFresh: this.getPrepFreshCheck(),
+      prepWriteStamp: this.getPrepStampWriter(),
+      prepRepairDeps: this.getPrepDepRepairer(),
+      prepDbGenerateScan: this.getDbGenerateScan(),
+      repoDirExists: this.getRepoDirCheck(),
     };
     const delegate = (plan: ScriptPlan): Promise<number> =>
       this.runScript(plan, flags as WorkspaceFlags, { propagateExit: false });
 
     // --tunnel: resolve <moniker>.<VMS_BASE> from the VENDORED tunnel.sh (same
-    // machinery as connect/`stack up --tunnel`). develop coach is slot-0 only, so
-    // no slot guard is needed. The seam lets unit tests inject a fixed moniker.
+    // machinery as connect/`stack up --tunnel`). Guarded slot-0-only above (the
+    // tunnel fronts fixed slot-0 ports). The seam lets unit tests inject a moniker.
     let tunnelDomain: string | undefined;
     if (flags.tunnel) {
       const vmsBase = process.env.VMS_BASE ?? 'vms.wootdev.com';
@@ -247,7 +268,7 @@ export default class DevelopCoach extends BaseCommand {
       tunnelDomain = `${moniker}.${vmsBase}`;
     }
 
-    const { runtime } = buildStackContext(flags, seams, delegate, undefined, tunnelDomain);
+    const { runtime } = buildStackContext(flags, seams, delegate, profile, tunnelDomain);
     const api = makeStackApi(serviceManifest, runtime);
 
     // Drive the flow (up → reset+seed → verify → headless Playwright smoke). This
@@ -271,9 +292,8 @@ export default class DevelopCoach extends BaseCommand {
       await this.orchestratePlaylist(coachRoot, runtime.launchContext.tokens.COACH_DB_URL);
     }
 
-    // Hand off a HEADED, logged-in coach-web at the scenario's route. develop coach
-    // is slot-0 only; use the slot-0 state dir unless overridden.
-    const stateDir = flags['state-dir'] ?? deriveInstance({ slot: 0 }).stateDir;
+    // Hand off a HEADED, logged-in coach-web at the scenario's route — the slot's
+    // OFFSET coach-web port + the per-slot state dir resolved above.
     await this.handoff(flags, scenario, spec, resolved, runtime.launchContext.ports['coach-web'], stateDir);
   }
 

--- a/packages/node/saga-stack-cli/src/commands/develop/coach.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/coach.ts
@@ -21,12 +21,14 @@
  *                     Reports route (/reports). DESCOPED v1: the org-wide report
  *                     is MOCK-backed (coach-web reportsStore.fetchReport →
  *                     getMockReport) pending coach-repo work — printed as a note.
- *   - playlist        orchestrate the coach-OWNED track switch: publish a 2nd
- *                     track, `coach-content playlist assign`, `materialize
- *                     --replace`, then hand off. The `playlist assign` verb is
- *                     being built in parallel (coach#238); if it is not present
- *                     on the developer's coach checkout this fails fast with an
- *                     actionable message rather than crashing mid-bring-up.
+ *   - playlist        orchestrate the coach-OWNED track switch onto the 2nd track
+ *                     coach-db's seed already ships (curriculum-coach-b — no
+ *                     publish step): `coach-content playlist assign` the demo
+ *                     district to it, `materialize --replace` demo-tutor-1's
+ *                     instance (keyed by the tutor's derived user id) onto it, then
+ *                     hand off. Needs the `coach-content playlist` verb (coach#238)
+ *                     AND the seeded 2nd track; a precheck confirms BOTH before any
+ *                     bring-up and fails fast with an actionable message otherwise.
  *
  * `--reuse` skips the reset+seed and runs against the CURRENT stack state (mirror
  * connect). `--tunnel` repoints THIS run's flow browsers at the vms tunnel hosts
@@ -110,11 +112,27 @@ const SCENARIOS: Readonly<Record<Scenario, ScenarioSpec>> = Object.freeze({
 });
 
 /**
- * The 2nd track `--scenario playlist` publishes + switches demo-tutor-1 onto
- * (the committed seed ships only `spring-pilot`). A distinct content_name so the
- * switch is observable. Kept here so the orchestration + its message agree.
+ * The 2nd track `--scenario playlist` switches demo-tutor-1 onto. It is a
+ * MATERIALIZABLE curriculum coach-db's offline seed ALREADY ships in the active
+ * content_release (fixtures/content-release.json → `curriculum-coach-b`: a
+ * top-level-nav + units track twin of `curriculum-coach`, the only doc shape
+ * `coach-content materialize` can instantiate). Distinct from the tutor's seeded
+ * track (`spring-pilot`) so the switch is observable. NOT published at runtime —
+ * the precheck confirms this name is present in the developer's coach seed before
+ * any bring-up, so `materialize --content` always has a real target.
  */
-const PLAYLIST_TRACK_2 = 'base-coach';
+const PLAYLIST_TRACK_2 = 'curriculum-coach-b';
+
+/**
+ * demo-tutor-1's canonical coach user id — `deriveUserId('demo-tutor-1')` from
+ * `@saga-ed/iam-seed-ids`, the id coach-db's seed keys the tutor's persona +
+ * content_instance to (content-instances.json) AND the id coach-web's iam
+ * `whoami` returns. `materialize` MUST write the switched instance under THIS id,
+ * not the `demo-tutor-1` HANDLE, or the new playlist is invisible to coach-web.
+ * Hardcoded with an explicit derivation note (the soa CLI is a separate monorepo
+ * that cannot import iam-seed-ids) — mirrors DEMO_DISTRICT_GROUP below.
+ */
+const COACH_TUTOR_USER_ID = '1c939568-1464-5f9a-b5a4-0bc73a0454cb';
 
 /** demo district group id the seed maps to a track (deriveGroupId('demo'), research 03/04). */
 const DEMO_DISTRICT_GROUP = 'a0da8362-1a93-5d1d-aeaa-b6d8960e9821';
@@ -176,10 +194,11 @@ export default class DevelopCoach extends BaseCommand {
     // COACH checkout root: appCwd is `<coachRoot>/apps/web/coach-web`.
     const coachRoot = appCwd.slice(0, appCwd.length - resolved.spa.appDir.length - 1);
 
-    // --scenario playlist: FEATURE-DETECT coach#238's `coach-content playlist assign`
-    // verb BEFORE any bring-up, so a checkout without it fails fast with an actionable
-    // message instead of crashing halfway through docker + seed.
-    if (scenario === 'playlist') this.assertPlaylistVerb(coachRoot);
+    // --scenario playlist: PRECHECK coach#238's `coach-content playlist` verb AND
+    // coach-db's seeded 2nd track BEFORE any bring-up, so a checkout missing either
+    // fails fast with an actionable message instead of crashing halfway through
+    // docker + seed (or, worse, materializing against a track that isn't there).
+    if (scenario === 'playlist') this.assertPlaylistPrereqs(coachRoot);
 
     // coach flows are non-progressive + prerequisite-free; --reuse just drops the
     // reset+seed (mirrors connect). base === resolved when the flow has no prereq.
@@ -238,13 +257,22 @@ export default class DevelopCoach extends BaseCommand {
   }
 
   /**
-   * FEATURE-DETECT the coach#238 `coach-content playlist` verb group. The sibling
-   * plan (playlisting-port-plan.md §Decision) places it at
-   * `packages/node/coach-content-publish/src/playlist.ts` (beside `src/store.ts`).
-   * Absent ⇒ fail fast with an actionable message pointing at coach#238, BEFORE any
-   * bring-up. Reuses the shared repo-dir existence seam (tests stub it).
+   * PRECHECK both prerequisites the coach-owned playlist switch needs, BEFORE any
+   * bring-up, so a stale coach checkout fails fast with an actionable message
+   * instead of an opaque throw mid-orchestration:
+   *
+   *   1. the coach#238 `coach-content playlist` verb group — placed at
+   *      `packages/node/coach-content-publish/src/playlist.ts` (beside `store.ts`),
+   *      per playlisting-port-plan.md §Decision. Absent ⇒ point at coach#238.
+   *   2. the seeded 2nd track (`PLAYLIST_TRACK_2`) — a MATERIALIZABLE curriculum in
+   *      coach-db's offline seed release (fixtures/content-release.json). Without it
+   *      `materialize --content` throws `active release has no curriculum doc named`
+   *      deep in the run. We read the fixture and confirm the track is present so
+   *      the materialize target the orchestration uses is guaranteed to exist.
+   *
+   * Reuses the shared repo-dir existence + repo-file-read seams (tests stub them).
    */
-  private assertPlaylistVerb(coachRoot: string): void {
+  private assertPlaylistPrereqs(coachRoot: string): void {
     const verbFile = join(coachRoot, 'packages', 'node', 'coach-content-publish', 'src', 'playlist.ts');
     if (!this.getRepoDirCheck()(verbFile)) {
       this.error(
@@ -255,14 +283,51 @@ export default class DevelopCoach extends BaseCommand {
           `\`ss develop coach\` (content-viewer) and \`--scenario admin\` work without it.`,
       );
     }
+
+    // The 2nd track must exist as a materializable curriculum in coach-db's seed
+    // release — otherwise the later `materialize --content ${PLAYLIST_TRACK_2}`
+    // aborts with `active release has no curriculum doc named …`.
+    const seedFixture = join(
+      coachRoot,
+      'packages', 'node', 'coach-db', 'src', 'seed', 'fixtures', 'content-release.json',
+    );
+    const raw = this.getRepoFileRead()(seedFixture);
+    if (raw === undefined) {
+      this.error(
+        `--scenario playlist could not read coach-db's seed fixture to confirm the 2nd track ` +
+          `'${PLAYLIST_TRACK_2}' is present.\n` +
+          `  expected: ${seedFixture}\n` +
+          `  Update your coach checkout (it must ship the additive seed with '${PLAYLIST_TRACK_2}'), then retry.`,
+      );
+    }
+    let tracks: string[];
+    try {
+      const parsed = JSON.parse(raw) as { curricula?: Array<{ name?: unknown }> };
+      tracks = (parsed.curricula ?? []).map((c) => String(c.name));
+    } catch {
+      this.error(
+        `--scenario playlist: coach-db's seed fixture is not valid JSON, cannot confirm the 2nd track.\n` +
+          `  file: ${seedFixture}`,
+      );
+    }
+    if (!tracks.includes(PLAYLIST_TRACK_2)) {
+      this.error(
+        `--scenario playlist needs the materializable 2nd track '${PLAYLIST_TRACK_2}' in coach-db's seed ` +
+          `release, but your coach checkout's fixture does not ship it (found: ${tracks.join(', ') || 'none'}).\n` +
+          `  file: ${seedFixture}\n` +
+          `  Update your coach checkout to the additive seed that adds '${PLAYLIST_TRACK_2}', then retry.`,
+      );
+    }
   }
 
   /**
    * The coach-owned track switch for `--scenario playlist` (playlisting-port-plan
    * Option A). Runs the documented one-command local path against the mesh coach_api
-   * Postgres: publish/ensure a 2nd track, `playlist assign` it to the demo district
-   * (writes ONLY group_id→content_name), then `materialize --replace` demo-tutor-1
-   * onto it. Only reached once `assertPlaylistVerb` has confirmed the verb exists.
+   * Postgres: `playlist assign` the demo district to the seeded 2nd track (writes
+   * ONLY group_id→content_name), then `materialize --replace` demo-tutor-1's
+   * instance — keyed by the tutor's DERIVED user id, the id coach-web reads by —
+   * onto it. No publish step: `PLAYLIST_TRACK_2` is already in coach-db's seed
+   * release, and `assertPlaylistPrereqs` has confirmed both the verb and the track.
    */
   private async orchestratePlaylist(coachRoot: string, databaseUrl: string): Promise<void> {
     const runner = this.getRunner();
@@ -278,8 +343,8 @@ export default class DevelopCoach extends BaseCommand {
       if (code !== 0) this.error(`playlist: \`coach-content ${args[0]}\` failed (exit ${code}).`);
     };
 
-    // 1. Ensure a 2nd published track exists (the committed seed ships only
-    //    spring-pilot). materialize below points demo-tutor-1 at it.
+    // 1. Point the demo district at the seeded 2nd track (curriculum-coach-b —
+    //    already in the active content_release; the precheck confirmed it).
     await coachContent('assign the 2nd track to the demo district', [
       'playlist',
       'assign',
@@ -289,16 +354,20 @@ export default class DevelopCoach extends BaseCommand {
       PLAYLIST_TRACK_2,
     ]);
     // 2. Re-materialize demo-tutor-1 onto the newly-assigned track (replace the
-    //    existing instance so the dashboard renders the switched playlist).
+    //    existing instance so the dashboard renders the switched playlist). Keyed
+    //    by the tutor's DERIVED user id — the id coach-web's whoami returns — NOT
+    //    the `demo-tutor-1` handle, or the switched instance is invisible in-app.
     await coachContent('re-materialize demo-tutor-1 onto the 2nd track', [
       'materialize',
       '--user',
-      'demo-tutor-1',
+      COACH_TUTOR_USER_ID,
       '--content',
       PLAYLIST_TRACK_2,
       '--replace',
     ]);
-    this.log(`==> playlist: demo-tutor-1 switched to '${PLAYLIST_TRACK_2}'.`);
+    this.log(
+      `==> playlist: demo-tutor-1 (${COACH_TUTOR_USER_ID}) switched to '${PLAYLIST_TRACK_2}'.`,
+    );
   }
 
   /**

--- a/packages/node/saga-stack-cli/src/commands/develop/connect.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/connect.ts
@@ -1,5 +1,9 @@
 /**
- * `saga-stack e2e connect` — open a LIVE interactive Connect tutoring session (M5).
+ * `saga-stack develop connect` — open a LIVE interactive Connect tutoring session (M5).
+ *
+ * Migrated from `e2e connect` (gh_305): dev-setup concierge commands live under the
+ * `develop` topic; the old `e2e connect` id keeps working via a deprecating alias
+ * (`static aliases`/`deprecateAliases` below).
  *
  * Replaces the M2 thin shell over connect-session.sh. It resolves the
  * `connect-session` flow from saga-dash's `flows.json` (bundled example until the
@@ -31,10 +35,10 @@
  * or the journey stages changed. Requires the default `--prereq-from-snapshot` (it
  * bakes so that path can restore); mutually exclusive with `--reuse`.
  *
- *   node bin/dev.js e2e connect
- *   node bin/dev.js e2e connect --reuse -- --debug
- *   node bin/dev.js e2e connect --fake-media
- *   node bin/dev.js e2e connect --refresh-snapshot
+ *   node bin/dev.js develop connect
+ *   node bin/dev.js develop connect --reuse -- --debug
+ *   node bin/dev.js develop connect --fake-media
+ *   node bin/dev.js develop connect --refresh-snapshot
  */
 
 import { Flags } from '@oclif/core';
@@ -57,9 +61,16 @@ import {
 const CONNECT_SPA = 'saga-dash';
 const CONNECT_FLOW = 'connect-session';
 
-export default class E2eConnect extends BaseCommand {
+export default class DevelopConnect extends BaseCommand {
   static description =
     'Open a live interactive Connect session: 1 tutor + 2 students (in-process; builds the journey prerequisite, then a headed Connect room).';
+
+  // gh_305: `connect` migrated from the `e2e` topic to `develop`. Keep the old id
+  // working for one cycle with a deprecation warning (@oclif/core ^4). Aliases use
+  // the colon form in code; the topicSeparator (" ") means it is invoked as
+  // `ss e2e connect`.
+  static aliases = ['e2e:connect'];
+  static deprecateAliases = true;
 
   static examples = [
     '<%= config.bin %> <%= command.id %>',
@@ -111,7 +122,7 @@ export default class E2eConnect extends BaseCommand {
   };
 
   async run(): Promise<void> {
-    const { argv, flags } = await this.parse(E2eConnect);
+    const { argv, flags } = await this.parse(DevelopConnect);
     const passthrough = (argv as string[]).filter((a) => a !== CONNECT_FLOW);
 
     // --refresh-snapshot bakes the journey prerequisite fresh, then restores it.

--- a/packages/node/saga-stack-cli/src/commands/develop/connect.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/connect.ts
@@ -171,6 +171,9 @@ export default class DevelopConnect extends BaseCommand {
       meshExec: this.getMeshExec(),
       portProbe: this.getPortProbe(),
       dashFs: this.getDashFs(),
+      // soa#300: coach-web `.env.local` prelaunch seam — harmless here (coach-web is not
+      // in the connect closure), wired for parity with the other bring-up paths.
+      coachWebFs: this.getCoachWebFs(),
       prober: this.getProber(),
       runner: this.getRunner(),
     };

--- a/packages/node/saga-stack-cli/src/commands/e2e/__tests__/checkpoint.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/__tests__/checkpoint.int.test.ts
@@ -22,7 +22,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import { BaseCommand } from '../../../base-command.js';
 import type { LaunchSpec, ScriptInvocation, SnapshotIO } from '../../../runtime/index.js';
 import E2eRun from '../run.js';
-import E2eConnect from '../connect.js';
+import E2eConnect from '../../develop/connect.js';
 
 const PKG_ROOT = process.cwd();
 const SOA_ROOT = resolve(PKG_ROOT, '..', '..', '..');

--- a/packages/node/saga-stack-cli/src/commands/e2e/__tests__/e2e.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/__tests__/e2e.int.test.ts
@@ -28,7 +28,7 @@ import { pwArgv } from '../../../__tests__/helpers/pw.js';
 import { installCoreSeams } from '../../../__tests__/helpers/seams.js';
 import E2eRun from '../run.js';
 import E2eList from '../list.js';
-import E2eConnect from '../connect.js';
+import E2eConnect from '../../develop/connect.js';
 
 const PKG_ROOT = process.cwd();
 const SOA_ROOT = resolve(PKG_ROOT, '..', '..', '..');

--- a/packages/node/saga-stack-cli/src/commands/e2e/__tests__/e2e.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/__tests__/e2e.int.test.ts
@@ -169,7 +169,9 @@ describe('e2e run — native orchestration (stack lane)', () => {
     // VARIANT argv (T5): differs from run.int's golden literal pin only in the
     // project — built with the shared pwArgv (the literal shape protection
     // lives in run.int.test.ts's happy-path anchor).
-    expect(pw[0].args).toEqual(pwArgv({ project: 'stage-1-roster', grepInvert: '@interactive' }));
+    expect(pw[0].args).toEqual(
+      pwArgv({ project: 'stage-1-roster', grepInvert: '@interactive', spec: 'roster/csv-upload-view.e2e.test.ts' }),
+    );
     expect(pw[0].env?.PLAYWRIGHT_OCCURRENCE_DATE).toMatch(/^\d{4}-\d{2}-\d{2}$/);
     expect(pw[0].stdio).toBe('inherit');
   });

--- a/packages/node/saga-stack-cli/src/commands/e2e/__tests__/run.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/__tests__/run.int.test.ts
@@ -209,6 +209,7 @@ describe('e2e run — native orchestration (stack lane)', () => {
       'stage-4-pods',
       '--grep-invert',
       '@interactive',
+      'journey/pods.e2e.test.ts',
     ]);
     expect(pw[0].args).not.toContain('--headed');
     expect(pw[0].env?.PLAYWRIGHT_OCCURRENCE_DATE).toMatch(/^\d{4}-\d{2}-\d{2}$/);

--- a/packages/node/saga-stack-cli/src/commands/e2e/run.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/run.ts
@@ -286,6 +286,9 @@ export default class E2eRun extends BaseCommand {
       meshExec: this.getMeshExec(),
       portProbe: this.getPortProbe(),
       dashFs: this.getDashFs(),
+      // soa#300: coach-web `.env.local` prelaunch seam — buildStackContext threads it so
+      // a coach-web-in-closure e2e run boots the SPA against the LOCAL mesh, not remote.
+      coachWebFs: this.getCoachWebFs(),
       prober: this.getProber(),
       runner: this.getRunner(),
       // Native-prep seams (built always; since FLIP 3 buildStackContext wires them

--- a/packages/node/saga-stack-cli/src/commands/e2e/run.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/run.ts
@@ -31,7 +31,7 @@ import { parseFlowRef, resolveFlow } from '../../core/flow/index.js';
 import { DEFAULT_LOGIN_USER } from '../../core/login.js';
 import { deriveInstance } from '../../core/derive-instance.js';
 import { manifest as serviceManifest } from '../../core/manifest/index.js';
-import type { Lane } from '../../core/manifest/index.js';
+import type { Lane, RepoKey } from '../../core/manifest/index.js';
 import type { ScriptPlan } from '../../core/flag-map.js';
 import { reviewBlockLines, runIdFrom } from '../../core/e2e-review.js';
 import type { PreservedRunRecord } from '../../core/e2e-review.js';
@@ -411,9 +411,21 @@ export default class E2eRun extends BaseCommand {
   private async holdEpilogue(
     resolved: ReturnType<typeof resolveFlow>,
     flags: WorkspaceFlags & { set?: string; to?: string; porcelain: boolean; 'output-json': boolean },
-    ctx: { slot: number; stateDir: string; spaPort?: number; services: string[]; boundary?: string },
+    ctx: {
+      slot: number;
+      stateDir: string;
+      spaPort?: number;
+      services: string[];
+      boundary?: string;
+      // gh_305: the login persona for the held jar + browser. Defaults to
+      // DEFAULT_LOGIN_USER (dev@saga.org — the seeded Seed District admin), so
+      // existing `e2e run --hold` callers are unchanged. A concierge that seeds a
+      // different persona (e.g. `develop coach` → demo-tutor-1) overrides it so the
+      // held browser lands on that persona's populated app instead of an empty one.
+      email?: string;
+    },
   ): Promise<void> {
-    const email = DEFAULT_LOGIN_USER;
+    const email = ctx.email ?? DEFAULT_LOGIN_USER;
     const res = await this.mintNativeLoginJar({ email, slot: ctx.slot, stateDir: ctx.stateDir });
     if (!res.ok) {
       // A failed jar (no roster seed yet, iam down) is a WARN, not a crash — the run
@@ -467,6 +479,16 @@ export default class E2eRun extends BaseCommand {
         iamUrl: res.iamUrl,
         stateDir: ctx.stateDir,
         dashUrl: spaUrl,
+        // gh_305: gate the clone-check + playwright cwd off THIS flow's SPA (from the
+        // resolved `spa` block / registry row), not hardwired saga-dash — so `e2e run
+        // coach-web/… --hold` opens coach-web from the coach checkout. For a saga-dash
+        // flow this is byte-identical to the old SAGA_DASH / apps/web/dash default.
+        // The registry-sourced `repoEnvVar` is always a real manifest RepoKey.
+        spa: {
+          repoEnvVar: resolved.spa.repoEnvVar as RepoKey,
+          appDir: resolved.spa.appDir,
+          port: ctx.spaPort,
+        },
       });
     }
   }

--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
@@ -77,7 +77,8 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
     expect(env('iam-api')).toEqual({
       PORT: '3010',
       AUTH_DEVUSERID: 'f0000004-0000-4000-8000-00000000beef',
-      CORS_ORIGIN: 'http://localhost:8900,http://localhost:6210',
+      // soa#300: coach-web (8800) appended so browser-direct iam whoami isn't CORS-blocked.
+      CORS_ORIGIN: 'http://localhost:8900,http://localhost:6210,http://localhost:8800',
       MAIL_FRONTEND_BASE_URL: 'http://localhost:3010/demo',
       REDIS_HOST: 'localhost',
       REDIS_PORT: '6379', // slot 0 base — offset-aware (:7379 at slot 1), see launch-plan.slot test
@@ -265,9 +266,11 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
     });
   });
 
-  it('coach-web (only needs the coach-api URL)', () => {
+  it('coach-web (coach-api URL + soa#300 direct-iam URL)', () => {
     expect(env('coach-web')).toEqual({
       PUBLIC_COACH_API_URL: 'http://localhost:6105',
+      // soa#300: coach-web reads identity direct from iam in the browser.
+      PUBLIC_IAM_API_URL: 'http://localhost:3010',
     });
   });
 

--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
@@ -255,6 +255,8 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
       MONGO_PORT: '27037',
       MONGO_DATABASE: 'saga_local',
       CONTENT_DATABASE: 'wmlms_local',
+      // gh_305: content read-store pinned to Postgres (serves the seeded release).
+      CONTENT_STORE_BACKEND: 'postgres',
       AUTH_AUTHENABLED: 'true',
       IAM_API_TARGET: 'http://localhost:3010',
       AUTH_JWKSURL: 'http://localhost:3010/.well-known/jwks.json',

--- a/packages/node/saga-stack-cli/src/core/flow/__tests__/coach-web-registry.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/flow/__tests__/coach-web-registry.unit.test.ts
@@ -1,0 +1,42 @@
+/**
+ * coach-web registry row (gh_305, M2 — the THIRD-SPA onboarding proof).
+ *
+ * Onboarding coach-web for `develop coach` is the same M6 pattern proven for
+ * connectv3: ONE `spa-registry` row + coach's already-authored `flows.json` —
+ * zero new resolver/command/core logic. This pins the row's shape (it must agree
+ * with `core/manifest/services.ts` coach-web · COACH · `apps/web/coach-web`) so
+ * `discoverFlowManifest('coach-web', …)` resolves the coach checkout, and so a
+ * `--hold` hand-off opens coach-web (not the dash) from the right repo.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { knownSpaIds, lookupSpa } from '../spa-registry.js';
+
+describe('coach-web — first-class registry row (onboarding = 1 row + 1 json)', () => {
+  it('is registered and appears in knownSpaIds', () => {
+    expect(knownSpaIds()).toContain('coach-web');
+    expect(lookupSpa('coach-web')).toBeDefined();
+  });
+
+  it('the descriptor matches the coach-web service + coach repo layout', () => {
+    // repoEnvVar/defaultRepoSubpath mirror up.sh's COACH path resolution; appDir is
+    // the coach-web SvelteKit app (port 8800 lives in the manifest, not the row);
+    // e2eDir holds coach's authored flows.json; Playwright runs in appDir.
+    expect(lookupSpa('coach-web')).toEqual({
+      id: 'coach-web',
+      system: 'coach-web',
+      repoEnvVar: 'COACH',
+      defaultRepoSubpath: 'coach',
+      appDir: 'apps/web/coach-web',
+      e2eDir: 'apps/web/coach-web/e2e',
+      playwrightConfig: 'playwright.config.ts',
+    });
+  });
+
+  it('leaves the existing saga-dash + connectv3 rows intact', () => {
+    // The generalization must not disturb the first two SPAs.
+    expect(lookupSpa('saga-dash')?.repoEnvVar).toBe('SAGA_DASH');
+    expect(lookupSpa('connectv3')?.repoEnvVar).toBe('QBOARD');
+    expect(knownSpaIds()).toEqual(expect.arrayContaining(['saga-dash', 'connectv3', 'coach-web']));
+  });
+});

--- a/packages/node/saga-stack-cli/src/core/flow/__tests__/coach-web.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/flow/__tests__/coach-web.unit.test.ts
@@ -1,0 +1,112 @@
+/**
+ * coach-web THIRD-SPA onboarding proof (plan §5.3, saga-ed/soa#214; coach e2e/
+ * saga-stack-cli parity task). Unlike connectv3's bundled placeholder, coach-web
+ * already has a REAL Playwright suite, so its `flows.json` is authored directly
+ * in the coach repo (`apps/web/coach-web/e2e/flows.json`) rather than bundled
+ * under `examples/flows/` — this test reads it from the sibling checkout the
+ * same way a real `ss e2e run coach-web/dashboard` discovery would (repo root
+ * derived via `$COACH` / `$DEV/coach`, mirroring `discover.ts`).
+ *
+ * Skips (not fails) when the coach checkout isn't present, since saga-stack-cli
+ * doesn't require every mesh repo to be checked out to run its own unit suite.
+ * `it.skipIf` (not a top-level conditional `describe`) keeps this file a valid
+ * suite either way — vitest errors a file with zero registered tests.
+ *
+ * Path resolution goes through the REAL `flowsCandidatePaths`/`resolveRepoRoot`
+ * (discover.ts) with an EXPLICIT env bag — not live `process.env` — so this test
+ * dogfoods the actual discovery logic without being at the mercy of a stray
+ * ambient `$DEV` (observed in this sandbox: some tool in the pnpm/vitest chain
+ * sets `DEV=1`, which `discover.ts`'s real `$DEV`-as-tree-root convention would
+ * misinterpret).
+ */
+
+// TEST-only fixture read (excluded from the lib build via tsconfig); production
+// core code stays fs-free, guarded by the no-restricted-imports eslint rule.
+// eslint-disable-next-line no-restricted-imports
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { describe, expect, it } from 'vitest';
+import { flowsCandidatePaths } from '../discover.js';
+import { parseFlowManifest } from '../load.js';
+import { resolveFlow } from '../resolve.js';
+import { lookupSpa } from '../spa-registry.js';
+import type { FlowManifest } from '../types.js';
+
+const spa = lookupSpa('coach-web');
+if (!spa) throw new Error('coach-web must be registered in SPA_REGISTRY for this test to run');
+
+// Real HOME + an explicit $COACH passthrough (for a worktree checkout), but a
+// clean env bag otherwise — isolates discovery from ambient vars like the
+// stray `DEV=1` seen in this sandbox's pnpm/vitest chain.
+const CLEAN_ENV = { HOME: homedir(), COACH: process.env.COACH };
+const FLOWS_PATH = flowsCandidatePaths({ spa, env: CLEAN_ENV }).at(-1)!;
+const present = existsSync(FLOWS_PATH);
+
+// Loaded once, lazily, only when present — avoids a top-level readFileSync that
+// would throw even under `it.skipIf`.
+const manifest: FlowManifest | undefined = present
+  ? parseFlowManifest(readFileSync(FLOWS_PATH, 'utf8'), FLOWS_PATH)
+  : undefined;
+
+describe('coach-web flows.json — validates against the one external contract (schema)', () => {
+  it.skipIf(!present)(`parses + zod-validates as a FlowManifest (checkout: ${FLOWS_PATH})`, () => {
+    expect(manifest!.schemaVersion).toBe(1);
+    expect(manifest!.spa.id).toBe('coach-web');
+    expect(manifest!.flows.map((f) => f.name)).toContain('dashboard');
+  });
+
+  it.skipIf(!present)('the authored spa block matches the coach-web service + coach repo layout', () => {
+    expect(manifest!.spa).toMatchObject({
+      id: 'coach-web',
+      system: 'coach-web',
+      repoEnvVar: 'COACH',
+      defaultRepoSubpath: 'coach',
+      appDir: 'apps/web/coach-web',
+      e2eDir: 'apps/web/coach-web/e2e',
+      playwrightConfig: 'playwright.config.ts',
+    });
+  });
+
+  it.skipIf(!present)('coach-web is registered and its descriptor agrees with the authored file', () => {
+    const reg = lookupSpa('coach-web');
+    expect(reg).toBeDefined();
+    expect(reg).toMatchObject(manifest!.spa);
+  });
+
+  describe('dashboard flow — resolves through the SAME resolveFlow/closure engine', () => {
+    it.skipIf(!present)('selects the single non-progressive dashboard stage + its Playwright target', () => {
+      const r = resolveFlow(manifest!, 'dashboard');
+      expect(r.stages.map((s) => s.id)).toEqual(['dashboard']);
+      expect(r.playwright.project).toBe('chromium');
+      expect(r.playwright.config).toBe('playwright.config.ts');
+    });
+
+    it.skipIf(!present)('requiredSystems = the stage systems (coach-web ∪ coach-api ∪ iam-api)', () => {
+      const r = resolveFlow(manifest!, 'dashboard');
+      expect(r.requiredSystems).toEqual(['coach-web', 'coach-api', 'iam-api']);
+    });
+
+    it.skipIf(!present)('closure is exactly {coach-web, coach-api, iam-api} — no unrelated services leak in', () => {
+      const r = resolveFlow(manifest!, 'dashboard');
+      expect([...r.closure.services].sort()).toEqual(['coach-api', 'coach-web', 'iam-api']);
+    });
+
+    it.skipIf(!present)('closure pulls the coach_api pg db + connect-mongo mesh (coach-api dual-store)', () => {
+      const r = resolveFlow(manifest!, 'dashboard');
+      expect(r.closure.databases).toContain('coach_api');
+      expect(r.closure.mesh).toContain('connect-mongo');
+    });
+
+    it.skipIf(!present)('seeds with the full profile (needed for the coach-pg alex fixture) + reset', () => {
+      const r = resolveFlow(manifest!, 'dashboard');
+      expect(r.seedSelection).toMatchObject({ profile: 'full', reset: true });
+      expect(r.reset).toBe(true);
+      expect(r.prerequisite).toBeUndefined();
+    });
+
+    it.skipIf(!present)('supports only the stack lane it declares', () => {
+      expect(() => resolveFlow(manifest!, 'dashboard', { lane: 'stack' })).not.toThrow();
+      expect(() => resolveFlow(manifest!, 'dashboard', { lane: 'sandbox' })).toThrow();
+    });
+  });
+});

--- a/packages/node/saga-stack-cli/src/core/flow/__tests__/resolve.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/flow/__tests__/resolve.unit.test.ts
@@ -97,6 +97,10 @@ describe('resolveFlow — journey --through pods (progressive prefix)', () => {
     expect(r.playwright.grepInvert).toBe('@interactive'); // pipeline default-excludes the AV stage
   });
 
+  it('carries the terminal stage’s spec, scoping the run to just that file (not the whole testMatch)', () => {
+    expect(r.playwright.spec).toBe('journey/pods.e2e.test.ts'); // the --through stage's own spec
+  });
+
   it('carries the flow-level roster seed and resets itself (no prerequisite)', () => {
     expect(r.seedSelection).toMatchObject({ profile: 'roster', reset: true });
     expect(r.reset).toBe(true);

--- a/packages/node/saga-stack-cli/src/core/flow/resolve.ts
+++ b/packages/node/saga-stack-cli/src/core/flow/resolve.ts
@@ -37,6 +37,8 @@ export interface ResolvedPlaywright {
   config: string;
   /** The TERMINAL stage's Playwright `project`; deps chain 1..N (matches check-e2e.sh). */
   project: string;
+  /** The TERMINAL stage's `spec` file, scoping the Playwright invocation to just that spec. */
+  spec?: string;
   /** Playwright `--grep-invert` tag for pipeline runs (e.g. `@interactive`); omitted when the run IS the tagged stage. */
   grepInvert?: string;
   /** Run headed (foreground flows default headed; `--headless` flips it). */
@@ -345,6 +347,7 @@ export function resolveFlow(
       config: manifest.spa.playwrightConfig,
       // Empty window ⇒ no terminal stage ⇒ no project (the executor skips Playwright).
       project: terminal?.project ?? '',
+      spec: terminal?.spec,
       grepInvert,
       headed,
     },

--- a/packages/node/saga-stack-cli/src/core/flow/spa-registry.ts
+++ b/packages/node/saga-stack-cli/src/core/flow/spa-registry.ts
@@ -53,6 +53,24 @@ export const SPA_REGISTRY: Readonly<Record<string, SpaDescriptor>> = Object.free
     // repo-relative to `appDir` (Playwright runs in `appDir`).
     playwrightConfig: 'playwright.config.ts',
   },
+
+  // ── coach-web (the THIRD-SPA proof, coach e2e/saga-stack-cli parity task) ──
+  // `repoEnvVar: 'COACH'` matches `runtime/repos.ts`'s existing `coach: 'COACH'`
+  // mapping; `system: 'coach-web'` and `defaultRepoSubpath: 'coach'` match the
+  // manifest's `coach-web` service (repo `'COACH'`, `core/manifest/services.ts`).
+  // The real `flows.json` is authored in the coach repo at
+  // `apps/web/coach-web/e2e/flows.json` (not bundled here — coach-web already
+  // has a real Playwright suite, unlike connectv3's placeholder).
+  'coach-web': {
+    id: 'coach-web',
+    system: 'coach-web',
+    repoEnvVar: 'COACH',
+    defaultRepoSubpath: 'coach',
+    appDir: 'apps/web/coach-web',
+    e2eDir: 'apps/web/coach-web/e2e',
+    // repo-relative to `appDir` (Playwright runs in `appDir`).
+    playwrightConfig: 'playwright.config.ts',
+  },
 });
 
 /** Look up a known SPA descriptor by id (undefined if not registered). */

--- a/packages/node/saga-stack-cli/src/core/flow/spa-registry.ts
+++ b/packages/node/saga-stack-cli/src/core/flow/spa-registry.ts
@@ -53,6 +53,29 @@ export const SPA_REGISTRY: Readonly<Record<string, SpaDescriptor>> = Object.free
     // repo-relative to `appDir` (Playwright runs in `appDir`).
     playwrightConfig: 'playwright.config.ts',
   },
+
+  // ── coach-web (gh_305 — the `develop coach` concierge target) ──────────────
+  // The THIRD-SPA onboarding (same M6 pattern as connectv3): this row + coach's
+  // already-authored `apps/web/coach-web/e2e/flows.json` are ALL it takes — zero
+  // new resolver/command/core logic. Unlike saga-dash/connectv3 there is NO
+  // bundled example fallback; discovery finds coach's real `flows.json` directly
+  // in the `$COACH` checkout (BUNDLED_EXAMPLE, `e2e-orchestrate.ts`, only covers
+  // repos that haven't authored one).
+  //
+  // Paths confirmed against `core/manifest/services.ts` `coach-web` (COACH ·
+  // `apps/web/coach-web`, port 8800 hard-set in coach-web's vite.config.ts) and
+  // coach's own `flows.json` `spa` block. The authored `flows.json`'s own `spa`
+  // block remains authoritative once loaded; this row only locates it.
+  'coach-web': {
+    id: 'coach-web',
+    system: 'coach-web',
+    repoEnvVar: 'COACH',
+    defaultRepoSubpath: 'coach',
+    appDir: 'apps/web/coach-web',
+    e2eDir: 'apps/web/coach-web/e2e',
+    // repo-relative to `appDir` (Playwright runs in `appDir`).
+    playwrightConfig: 'playwright.config.ts',
+  },
 });
 
 /** Look up a known SPA descriptor by id (undefined if not registered). */

--- a/packages/node/saga-stack-cli/src/core/launch-plan.ts
+++ b/packages/node/saga-stack-cli/src/core/launch-plan.ts
@@ -98,6 +98,8 @@ export interface LaunchTokens {
   SAGA_API_TARGET: string;
   /** up.sh `COACH_API_URL` — `http://localhost:$COACH_API_PORT` (coach-web PUBLIC_COACH_API_URL). */
   COACH_API_URL: string;
+  /** coach-web lane URL — `http://localhost:$COACH_WEB_PORT` (soa#300: iam-api CORS_ORIGIN entry). */
+  COACH_WEB_URL: string;
   /** up.sh `COACH_WEB_HOST` — bare hostname for coach-api's CORS allow-list (`localhost`). */
   COACH_WEB_HOST: string;
   /** up.sh `SAGA_API_TARGET_COACH` — coach's frontend upstream-saga config (default https://staging.wootmath.com). */
@@ -627,6 +629,7 @@ export function defaultLaunchContext(inputs: LaunchContextInputs, m: Manifest = 
     RTSM_URL: `http://localhost:${ports['rtsm-api']}`,
     SAGA_API_TARGET: inputs.sagaApiTarget ?? 'https://wootmath.com',
     COACH_API_URL: `http://localhost:${ports['coach-api']}`,
+    COACH_WEB_URL: `http://localhost:${ports['coach-web']}`,
     COACH_WEB_HOST: 'localhost',
     SAGA_API_TARGET_COACH: 'https://staging.wootmath.com',
     IAM_ISSUER: 'https://iam.saga.org',

--- a/packages/node/saga-stack-cli/src/core/manifest/services.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/services.ts
@@ -499,6 +499,13 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
         MONGO_PORT: '${CONNECT_MONGO_PORT}',
         MONGO_DATABASE: 'saga_local',
         CONTENT_DATABASE: 'wmlms_local',
+        // gh_305: pin the content read-store to Postgres explicitly. coach-db's
+        // db:seed lands the offline `content_release` fixture in coach_api pg, and
+        // both the module-playback e2e flow and `ss develop coach --scenario
+        // content-viewer` render from it. The UNSET default is disputed (docs 02 vs
+        // 06 disagree on whether it serves mongo or pg), so don't rely on it — the
+        // dev stack always serves the seeded pg release.
+        CONTENT_STORE_BACKEND: 'postgres',
         AUTH_AUTHENABLED: 'true',
         IAM_API_TARGET: '${IAM_URL}',
         AUTH_JWKSURL: '${IAM_URL}/.well-known/jwks.json',

--- a/packages/node/saga-stack-cli/src/core/manifest/services.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/services.ts
@@ -60,7 +60,10 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
       env: {
         PORT: '${IAM_PORT}',
         AUTH_DEVUSERID: '${DEV_USER_UUID}',
-        CORS_ORIGIN: '${DASH_URL},${CONNECT_WEB_URL}',
+        // soa#300: coach-web (post-coach#226) reads identity DIRECT from iam in
+        // the browser (`${PUBLIC_IAM_API_URL}/trpc/auth.whoami`), so iam must
+        // allow coach-web's origin or the whoami is CORS-blocked and sign-in 503s.
+        CORS_ORIGIN: '${DASH_URL},${CONNECT_WEB_URL},${COACH_WEB_URL}',
         MAIL_FRONTEND_BASE_URL: 'http://localhost:${IAM_PORT}/demo',
         // iam-api assembles its redis URL from REDIS_HOST+REDIS_PORT (localhost ⇒
         // non-TLS redis://). Slot-offset-aware: :6379 at slot 0, :7379 at slot 1.
@@ -529,6 +532,12 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
       cmd: 'pnpm dev',
       env: {
         PUBLIC_COACH_API_URL: '${COACH_API_URL}',
+        // soa#300: post-coach#226 coach-web reads identity DIRECT from iam in the
+        // browser (SvelteKit inlines this PUBLIC_ var at `pnpm dev` start). Without
+        // this override it falls back to its checked-in .env default
+        // (`https://iam.wootdev.com`), where a local `ss` cookie is invalid ⇒ 503
+        // at sign-in. Point it at the slot's local iam so browser login works.
+        PUBLIC_IAM_API_URL: '${IAM_URL}',
       },
     },
     seed: [],

--- a/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
+++ b/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
@@ -379,6 +379,20 @@ export function playwrightArgv(
   if (stage?.noDeps) argv.push('--no-deps');
   if (resolved.playwright.grepInvert) argv.push('--grep-invert', resolved.playwright.grepInvert);
   if (resolved.playwright.headed) argv.push('--headed');
+  // Restrict a NON-PROGRESSIVE flow to its own stage's spec. Such a flow resolves
+  // to exactly ONE stage (resolve.ts §3) whose project carries no dependency chain,
+  // so a file filter is safe — and without it the spawn runs EVERY spec in the
+  // project: coach-web's `chromium` project has 11, including unauthenticated shell
+  // specs that always fail against an auth-required app, so a flow could never go
+  // green (and `develop coach` could never reach its hand-off) no matter how well
+  // its OWN spec did. Progressive flows chain stage deps 1..N through the config's
+  // project graph — a file filter would break that chain — so they stay unfiltered
+  // (byte-identical). Pushed BEFORE passthrough so an explicit `-- <filter>` still
+  // reaches Playwright.
+  if (!stage && !resolved.flow.progressive && resolved.stages.length === 1) {
+    const spec = resolved.stages[0]?.spec;
+    if (spec) argv.push(spec);
+  }
   argv.push(...passthrough);
   return argv;
 }

--- a/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
+++ b/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
@@ -67,6 +67,7 @@ import {
   generateSlotFleetConfig,
 } from './runtime/index.js';
 import type {
+  CoachWebFs,
   DashFs,
   HealthProber,
   MeshExec,
@@ -178,6 +179,13 @@ export interface StackSeams {
   meshExec: MeshExec;
   portProbe: PortProbe;
   dashFs: DashFs;
+  /**
+   * soa#300: the coach-web `.env.local` prelaunch fs seam — when coach-web is in the
+   * closure, `up` writes `<coachWebRoot>/.env.local` so its browser boots against the
+   * LOCAL mesh. Optional so callers that don't wire it stay byte-identical; the
+   * command builds it from `getCoachWebFs()`.
+   */
+  coachWebFs?: CoachWebFs;
   prober: HealthProber;
   runner: Runner;
   /**
@@ -287,6 +295,7 @@ export function buildStackContext(
     meshExec: seams.meshExec,
     portProbe: seams.portProbe,
     dashFs: seams.dashFs,
+    coachWebFs: seams.coachWebFs,
     prober: seams.prober,
     runner: seams.runner,
     // --tunnel (Phase 2): a resolved domain flips tunnel mode on so the facade writes

--- a/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
+++ b/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
@@ -334,6 +334,17 @@ export function playwrightArgv(
   if (stage?.noDeps) argv.push('--no-deps');
   if (resolved.playwright.grepInvert) argv.push('--grep-invert', resolved.playwright.grepInvert);
   if (resolved.playwright.headed) argv.push('--headed');
+  // Scope the run to the terminal stage's own spec — else Playwright's testMatch
+  // sweeps every spec in the SPA's e2e dir (found running coach-web/dashboard: it
+  // also executed unrelated nav/timer specs). Gated to the single-spawn path only
+  // (no `stage` override): `resolved.playwright.spec` is the TERMINAL stage's spec,
+  // so pushing it during a bake/--from per-stage spawn (`stage.project` overridden
+  // to a non-terminal project) would filter that stage's own project to a spec it
+  // doesn't contain, running zero tests. Progressive flows' per-stage `project`s are
+  // already testMatch-scoped to their own spec by the SPA's Playwright config, so
+  // they don't need this — it's specifically for single-project SPAs like coach-web
+  // where one `chromium` project matches every spec in the dir.
+  if (!stage && resolved.playwright.spec) argv.push(resolved.playwright.spec);
   argv.push(...passthrough);
   return argv;
 }
@@ -345,12 +356,16 @@ export function playwrightArgv(
  * URL as `process.env.PLAYWRIGHT_<X>_URL ?? http://localhost:<base port>`, and the
  * Playwright config's `baseURL` is `PLAYWRIGHT_BASE_URL ?? http://localhost:8900`.
  * By injecting each key from `launchContext.ports[svc]` (= manifest base + slot
- * offset), a slot-1 journey drives saga-dash on :9900 and hits iam :4010 /
- * scheduling :4008 / sessions :4007 / … instead of slot 0's base ports. Keyed to
- * the exact env vars `lane.ts` consumes today (nothing invented).
+ * offset), a slot-1 journey drives the SPA frontend on its offset port and hits
+ * iam :4010 / scheduling :4008 / sessions :4007 / … instead of slot 0's base
+ * ports. Keyed to the exact env vars `lane.ts` consumes today (nothing invented).
+ *
+ * `PLAYWRIGHT_BASE_URL` has no fixed `ServiceId` here — it must resolve to
+ * WHICHEVER SPA's flow is running (`resolved.spa.system`), not always saga-dash.
+ * `serviceUrlEnv`/`playwrightEnv` take that id as a param and default to
+ * `'saga-dash'` only when the caller has no spa context (back-compat).
  */
 export const PLAYWRIGHT_SERVICE_URL_ENV: Readonly<Record<string, ServiceId>> = Object.freeze({
-  PLAYWRIGHT_BASE_URL: 'saga-dash', // the dash frontend origin (Playwright `baseURL`)
   PLAYWRIGHT_IAM_URL: 'iam-api',
   PLAYWRIGHT_SIS_URL: 'sis-api',
   PLAYWRIGHT_PROGRAMS_URL: 'programs-api',
@@ -360,6 +375,9 @@ export const PLAYWRIGHT_SERVICE_URL_ENV: Readonly<Record<string, ServiceId>> = O
   PLAYWRIGHT_CONNECT_URL: 'connect-web',
 });
 
+/** `PLAYWRIGHT_BASE_URL`'s `ServiceId` when no SPA context is available (back-compat). */
+const DEFAULT_BASE_URL_SERVICE: ServiceId = 'saga-dash';
+
 /**
  * Build the stack-lane service-URL env from RESOLVED ports (each = manifest base +
  * slot offset). At slot 0 the ports are the base ports, so this yields the SAME
@@ -367,9 +385,18 @@ export const PLAYWRIGHT_SERVICE_URL_ENV: Readonly<Record<string, ServiceId>> = O
  * carries the `N * 1000` offset. Derived from `launchContext.ports` — never a
  * hardcoded port — so a re-banded/remapped service slots for free. A service with
  * no resolved port is omitted rather than emitting `localhost:undefined`.
+ *
+ * `baseUrlService` picks WHICH service backs `PLAYWRIGHT_BASE_URL` — the running
+ * flow's own SPA frontend (`resolved.spa.system`), defaulting to saga-dash when
+ * the caller has none.
  */
-export function serviceUrlEnv(ports: Partial<Record<ServiceId, number>>): Record<string, string> {
+export function serviceUrlEnv(
+  ports: Partial<Record<ServiceId, number>>,
+  baseUrlService: ServiceId = DEFAULT_BASE_URL_SERVICE,
+): Record<string, string> {
   const env: Record<string, string> = {};
+  const basePort = ports[baseUrlService];
+  if (basePort !== undefined) env.PLAYWRIGHT_BASE_URL = `http://localhost:${basePort}`;
   for (const [key, svc] of Object.entries(PLAYWRIGHT_SERVICE_URL_ENV)) {
     const port = ports[svc];
     if (port !== undefined) env[key] = `http://localhost:${port}`;
@@ -390,6 +417,11 @@ export function serviceUrlEnv(ports: Partial<Record<ServiceId, number>>): Record
  * service URLs are the lane's own hostnames (resolved in `lane.ts`), NOT localhost,
  * so we do NOT inject them. `now` is supplied by the command (`new Date()`); this
  * never reads the clock.
+ *
+ * `PLAYWRIGHT_BASE_URL` is derived from `resolved.spa.system` — the flow's OWN
+ * SPA frontend — not hardcoded to saga-dash, else a non-dash flow's Playwright
+ * run navigates to saga-dash's port and 500s (found running coach-web's
+ * `dashboard` flow: it opened `:8900`, saga-dash's port, instead of coach-web's).
  */
 export function playwrightEnv(
   resolved: ResolvedFlow,
@@ -417,7 +449,7 @@ export function playwrightEnv(
   const env: Record<string, string> = {
     ...computeEnv(resolved.flow, now),
     ...(dateOverrides ?? {}),
-    ...(lane === 'stack' && ports ? serviceUrlEnv(ports) : {}),
+    ...(lane === 'stack' && ports ? serviceUrlEnv(ports, resolved.spa?.system) : {}),
   };
   if (lane !== 'stack') env.PLAYWRIGHT_LANE = lane;
   return env;

--- a/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
+++ b/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
@@ -542,6 +542,14 @@ export function playwrightEnv(
     ...computeEnv(resolved.flow, now),
     ...(dateOverrides ?? {}),
     ...(lane === 'stack' && ports ? serviceUrlEnv(ports) : {}),
+    // `PLAYWRIGHT_BASE_URL` is the Playwright `baseURL` — THIS flow's OWN frontend
+    // origin. `serviceUrlEnv` hardcodes it to saga-dash (the first SPA), so a
+    // coach-web / connectv3 flow would otherwise navigate to saga-dash. Override it
+    // to the resolved SPA's frontend service port (`resolved.spa.system`): a no-op
+    // for saga-dash flows (system === 'saga-dash'), corrected for the others.
+    ...(lane === 'stack' && !tunnelDomain && resolved.spa?.system && ports?.[resolved.spa.system] !== undefined
+      ? { PLAYWRIGHT_BASE_URL: `http://localhost:${ports[resolved.spa.system]}` }
+      : {}),
     ...(lane === 'stack' && tunnelDomain ? tunnelServiceUrlEnv(tunnelDomain) : {}),
     ...(capture === true ? { PLAYWRIGHT_CAPTURE: 'all' } : {}),
     ...(tunnelDomain ? { PLAYWRIGHT_TUNNEL_TIMEOUT_MS: String(TUNNEL_PLAYWRIGHT_TIMEOUT_MS) } : {}),

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/coach-web-env.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/coach-web-env.unit.test.ts
@@ -1,0 +1,122 @@
+/**
+ * coach-web-env prelaunch hook (soa#300). The fs is injected, so this asserts the
+ * mode-for-mode behaviour with NO real filesystem: the per-slot `.env.local`
+ * contents (offset PUBLIC_* URLs at slot 0 and slot 2), the tunnel no-op, and the
+ * no-app no-op.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  coachWebEnvLocalContents,
+  coachWebEnvLocalPath,
+  syncCoachWebEnvLocal,
+} from '../coach-web-env.js';
+import type { CoachWebFs } from '../coach-web-env.js';
+import type { ServiceId } from '../../core/manifest/index.js';
+
+const COACH_WEB = '/repo/coach/apps/web/coach-web';
+const ENV_LOCAL = coachWebEnvLocalPath(COACH_WEB);
+
+/** A fake fs with controllable existence + recorded mutations. */
+function fakeFs(opts: { hasApp?: boolean } = {}): {
+  fs: CoachWebFs;
+  removed: string[];
+  written: Array<{ path: string; contents: string }>;
+} {
+  const removed: string[] = [];
+  const written: Array<{ path: string; contents: string }> = [];
+  const fs: CoachWebFs = {
+    existsDir: () => opts.hasApp ?? true,
+    write: (path, contents) => written.push({ path, contents }),
+    remove: (path) => removed.push(path),
+  };
+  return { fs, removed, written };
+}
+
+/** slot-N port map for the coach-web-backing services (base ports + offset). */
+const slotPorts = (offset: number): Partial<Record<ServiceId, number>> => ({
+  'iam-api': 3010 + offset,
+  'coach-api': 6105 + offset,
+  'saga-dash': 8900 + offset,
+});
+
+/** Parse a KEY=VALUE `.env` string into a lookup, ignoring `#` comments/blank lines. */
+function parseEnv(contents: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const line of contents.split('\n')) {
+    if (!line || line.startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    out[line.slice(0, eq)] = line.slice(eq + 1);
+  }
+  return out;
+}
+
+describe('syncCoachWebEnvLocal', () => {
+  it('no-ops when the coach-web app dir is absent (coach not checked out here)', () => {
+    const { fs, removed, written } = fakeFs({ hasApp: false });
+    const res = syncCoachWebEnvLocal({ coachWebRoot: COACH_WEB, stackPorts: slotPorts(0) }, fs);
+    expect(res.action).toBe('noop-no-app');
+    expect(removed).toEqual([]);
+    expect(written).toEqual([]);
+  });
+
+  it('no-ops under --tunnel (public coach-web URLs are a separate concern)', () => {
+    const { fs, removed, written } = fakeFs();
+    const res = syncCoachWebEnvLocal(
+      { coachWebRoot: COACH_WEB, tunnel: true, stackPorts: slotPorts(0) },
+      fs,
+    );
+    expect(res.action).toBe('noop-tunnel');
+    expect(removed).toEqual([]);
+    expect(written).toEqual([]);
+  });
+
+  it('slot 0: WRITES .env.local with the LOCAL (base-port) PUBLIC_* URLs', () => {
+    const { fs, written, removed } = fakeFs();
+    const res = syncCoachWebEnvLocal({ coachWebRoot: COACH_WEB, slot: 0, stackPorts: slotPorts(0) }, fs);
+    expect(res).toEqual({ action: 'wrote', path: ENV_LOCAL });
+    expect(removed).toEqual([]);
+    expect(written).toHaveLength(1);
+    const env = parseEnv(written[0].contents);
+    // base ports: iam 3010, coach-api 6105, saga-dash 8900. Remote wootdev defaults gone.
+    expect(env.PUBLIC_IAM_API_URL).toBe('http://localhost:3010');
+    expect(env.PUBLIC_COACH_API_URL).toBe('http://localhost:6105');
+    expect(env.PUBLIC_DASHBOARD_URL).toBe('http://localhost:8900');
+    // PUBLIC_LOGIN_URL → iam (the whoami 401 challenge login lives at iam's /demo).
+    expect(env.PUBLIC_LOGIN_URL).toBe('http://localhost:3010');
+    // never leaks a remote host.
+    expect(written[0].contents).not.toContain('wootdev.com');
+    expect(written[0].contents.endsWith('\n')).toBe(true);
+  });
+
+  it('slot 2: WRITES .env.local with the OFFSET PUBLIC_* URLs (offset 2000)', () => {
+    const { fs, written } = fakeFs();
+    const res = syncCoachWebEnvLocal({ coachWebRoot: COACH_WEB, slot: 2, stackPorts: slotPorts(2000) }, fs);
+    expect(res).toEqual({ action: 'wrote', path: ENV_LOCAL });
+    const env = parseEnv(written[0].contents);
+    // slot 2 = base + 2000: iam 5010, coach-api 8105, saga-dash 10900.
+    expect(env.PUBLIC_IAM_API_URL).toBe('http://localhost:5010');
+    expect(env.PUBLIC_COACH_API_URL).toBe('http://localhost:8105');
+    expect(env.PUBLIC_DASHBOARD_URL).toBe('http://localhost:10900');
+    expect(env.PUBLIC_LOGIN_URL).toBe('http://localhost:5010');
+    // base-port (slot 0) values must NOT leak through at an offset slot.
+    expect(env.PUBLIC_IAM_API_URL).not.toContain(':3010');
+    expect(env.PUBLIC_COACH_API_URL).not.toContain(':6105');
+  });
+
+  it('coachWebEnvLocalContents omits a PUBLIC_ var whose backing service has no resolved port', () => {
+    // no saga-dash port ⇒ PUBLIC_DASHBOARD_URL dropped (coach-web keeps its .env default),
+    // never `localhost:undefined`.
+    const contents = coachWebEnvLocalContents({ 'iam-api': 3010, 'coach-api': 6105 });
+    expect(contents).not.toContain('undefined');
+    const env = parseEnv(contents);
+    expect(env.PUBLIC_DASHBOARD_URL).toBeUndefined();
+    expect(env.PUBLIC_IAM_API_URL).toBe('http://localhost:3010');
+  });
+
+  it('defaults the real fs when none is injected (does not throw on a missing dir)', () => {
+    // /no/such/coach-web has no app dir → noop-no-app via the real fs.
+    const res = syncCoachWebEnvLocal({ coachWebRoot: '/no/such/coach-web-xyz', stackPorts: slotPorts(0) });
+    expect(res.action).toBe('noop-no-app');
+  });
+});

--- a/packages/node/saga-stack-cli/src/runtime/coach-web-env.ts
+++ b/packages/node/saga-stack-cli/src/runtime/coach-web-env.ts
@@ -1,0 +1,152 @@
+/**
+ * The `coach-web-env` prelaunch hook (soa#300) — the coach-web analogue of the
+ * saga-dash `sync-dash-local-defaults` hook (`dash-defaults.ts`), run right after
+ * it in the facade's bring-up sequence, gated on coach-web being launchable.
+ *
+ * WHY: coach-web (a SvelteKit adapter-static SPA at `<coachRoot>/apps/web/coach-web`)
+ * reads its `PUBLIC_*` URLs via `$env/static/public`, which SvelteKit/Vite INLINES
+ * from the CHECKED-IN `.env` at vite-dev start. That `.env` carries REMOTE defaults
+ * (`https://iam.wootdev.com`, `https://dash.wootdev.com`, …) plus the base coach-api
+ * port (wrong at slot > 0). So the browser boots against remote/wrong hosts → the
+ * whoami fetch fails → coach-web renders a 503 "Unable to reach the sign-in service"
+ * and NO route renders. Injecting env into the process does NOT help — SvelteKit
+ * inlines `.env`, not `process.env`.
+ *
+ * THE FIX: write a per-slot `<coachWebRoot>/.env.local` mapping each PUBLIC_ var to
+ * this slot's LOCAL mesh OFFSET url. `.env.local` beats `.env` in Vite/SvelteKit and
+ * is gitignored in coach-web, so this overrides the remote defaults without a
+ * coach-web code change and without dirtying the checkout. Runs at EVERY slot,
+ * including slot 0 — the `.env` remote defaults break local browser-testing at slot 0
+ * too (that is the original soa#300).
+ *
+ * SCOPE: the local `stack` lane only. Under `--tunnel` the coach-web URLs are a
+ * separate concern (public tunnel hosts), so the hook NO-OPS and leaves `.env` /
+ * any tunnel wiring alone — mirroring how the dash hook keeps tunnel routing distinct.
+ *
+ * The fs (dir-exists / write / remove) is behind the injectable `CoachWebFs` so the
+ * hook is unit-tested with NO real filesystem; production wires `makeRealCoachWebFs()`.
+ * This is runtime (fs IO), not core.
+ *
+ * INVARIANT (plan hard constraint): fs IO lives only in `src/runtime/**`;
+ * `src/core/**` never imports this and stays pure.
+ */
+
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import type { ServiceId } from '../core/manifest/index.js';
+
+/** Inputs to the coach-web-env prelaunch hook. */
+export interface CoachWebEnvContext {
+  /** Resolved coach-web app root (`<coachRoot>/apps/web/coach-web`). */
+  coachWebRoot: string;
+  /**
+   * True iff running in `--tunnel` mode. Tunnel coach-web URLs are a separate
+   * concern (public hosts), so the hook no-ops rather than writing localhost URLs.
+   * Default false (the native partial-stack default).
+   */
+  tunnel?: boolean;
+  /**
+   * Stack instance slot (M7). Carried for parity/logging; the hook WRITES at every
+   * slot (including 0) because the checked-in `.env` remote defaults break local
+   * browser-testing at every slot. Default 0 (or absent).
+   */
+  slot?: number;
+  /**
+   * Resolved per-service localhost ports for the slot (the launch context's `ports`,
+   * already OFFSET for the slot — exactly the map the dash hook writes). Each PUBLIC_
+   * var is mapped to `http://localhost:<offset port>`.
+   */
+  stackPorts: Partial<Record<ServiceId, number>>;
+}
+
+/** What the hook did, for `emit()` / logging. */
+export interface CoachWebSyncResult {
+  action: 'wrote' | 'noop-tunnel' | 'noop-no-app';
+  /** The `.env.local` path acted on (when applicable). */
+  path?: string;
+}
+
+/** Injectable fs surface for the hook (defaulted to real `node:fs`). */
+export interface CoachWebFs {
+  existsDir(path: string): boolean;
+  write(path: string, contents: string): void;
+  remove(path: string): void;
+}
+
+/** Relative path of the gitignored env override under the coach-web app root. */
+const ENV_LOCAL_REL = '.env.local';
+
+/** Absolute path to the coach-web `.env.local` under a coach-web app root. */
+export function coachWebEnvLocalPath(coachWebRoot: string): string {
+  return join(coachWebRoot, ENV_LOCAL_REL);
+}
+
+/**
+ * Build the per-slot `.env.local` contents: each coach-web `PUBLIC_*` url → this
+ * slot's LOCAL mesh offset host. A PUBLIC_ line whose backing service has no resolved
+ * port is omitted rather than emitting `localhost:undefined` (coach-web then falls
+ * back to its `.env` default for that one var — never a broken URL). Trailing newline.
+ *
+ *   PUBLIC_IAM_API_URL   ← iam-api    (browser dials iam DIRECT for whoami)
+ *   PUBLIC_COACH_API_URL ← coach-api  (the coach BFF)
+ *   PUBLIC_DASHBOARD_URL ← saga-dash  (the "open dashboard" link)
+ *   PUBLIC_LOGIN_URL     ← iam-api    (the whoami 401 challenge login lives at iam's /demo)
+ *
+ * PUBLIC_EMBED_ALLOWED_ORIGINS is deliberately LEFT ALONE — not needed for boot.
+ */
+export function coachWebEnvLocalContents(stackPorts: Partial<Record<ServiceId, number>>): string {
+  const iam = stackPorts['iam-api'];
+  const coachApi = stackPorts['coach-api'];
+  const dash = stackPorts['saga-dash'];
+
+  const header = [
+    '# Generated per-slot by `ss` at coach-web launch (soa#300) — GITIGNORED, do not commit.',
+    '# Overrides the checked-in `.env` REMOTE defaults so coach-web\'s browser boots',
+    '# against the LOCAL ss mesh: SvelteKit inlines these PUBLIC_* vars at vite-dev',
+    '# start, and `.env.local` wins over `.env`.',
+  ];
+
+  const vars: string[] = [];
+  if (iam !== undefined) vars.push(`PUBLIC_IAM_API_URL=http://localhost:${iam}`);
+  if (coachApi !== undefined) vars.push(`PUBLIC_COACH_API_URL=http://localhost:${coachApi}`);
+  if (dash !== undefined) vars.push(`PUBLIC_DASHBOARD_URL=http://localhost:${dash}`);
+  // PUBLIC_LOGIN_URL → iam locally: the whoami 401 challenge login URL is iam's /demo.
+  if (iam !== undefined) vars.push(`PUBLIC_LOGIN_URL=http://localhost:${iam}`);
+
+  return `${[...header, ...vars].join('\n')}\n`;
+}
+
+/**
+ * Run the prelaunch hook. Pure-decision over the injectable `CoachWebFs`, so it's
+ * fully testable; returns what it did.
+ *   - Tunnel mode ⇒ no-op (public coach-web URLs are a separate concern).
+ *   - No coach-web app dir at the resolved path ⇒ no-op.
+ *   - Otherwise ⇒ WRITE `<coachWebRoot>/.env.local` with the slot's offset localhost URLs.
+ */
+export function syncCoachWebEnvLocal(
+  ctx: CoachWebEnvContext,
+  fs: CoachWebFs = makeRealCoachWebFs(),
+): CoachWebSyncResult {
+  // Tunnel: leave `.env` / any tunnel wiring alone — the public tunnel coach-web URLs
+  // are a separate concern, not this local-mesh override.
+  if (ctx.tunnel) return { action: 'noop-tunnel' };
+
+  // coach-web not checked out at the resolved path ⇒ nothing to write.
+  if (!fs.existsDir(ctx.coachWebRoot)) return { action: 'noop-no-app' };
+
+  const path = coachWebEnvLocalPath(ctx.coachWebRoot);
+  fs.write(path, coachWebEnvLocalContents(ctx.stackPorts));
+  return { action: 'wrote', path };
+}
+
+/** The production fs surface for the hook. */
+export function makeRealCoachWebFs(): CoachWebFs {
+  return {
+    existsDir: (path: string) => existsSync(path),
+    write: (path: string, contents: string) => {
+      mkdirSync(dirname(path), { recursive: true });
+      writeFileSync(path, contents);
+    },
+    remove: (path: string) => rmSync(path, { force: true }),
+  };
+}

--- a/packages/node/saga-stack-cli/src/runtime/index.ts
+++ b/packages/node/saga-stack-cli/src/runtime/index.ts
@@ -21,6 +21,7 @@ export * from './preflight.js';
 export * from './prep-repair.js';
 export * from './orphan-audit.js';
 export * from './dash-defaults.js';
+export * from './coach-web-env.js';
 export * from './flows.js';
 export * from './pg-probe.js';
 export * from './prep.js';

--- a/packages/node/saga-stack-cli/src/stack-api.ts
+++ b/packages/node/saga-stack-cli/src/stack-api.ts
@@ -1040,9 +1040,24 @@ export function makeStackApi(m: Manifest, runtime: Runtime): StackApi {
       let seed: SeedResult | undefined;
       if (services.includes('iam-api')) {
         const ran: SeedResult['ran'] = { offline: [], online: [] };
-        const devUser = buildSeedRegistry(manifest)['iam-dev-user'];
-        const ok = await runSeedStep(devUser, 'offline', ran);
-        seed = { ok, ran, skipped: [], ...(ok ? {} : { failed: devUser.id }) };
+        const registry = buildSeedRegistry(manifest);
+        // soa#253 recurrence guard: resetClosure() truncated iam_local's permission
+        // catalog (incl. session perms 053/054/055), and a truncate never re-migrates.
+        // So `iam-registry` MUST run before the `iam-dev-user` dev-admin grant — else
+        // applyDevAdminGrant refuses (missing session perms) and dev regresses to
+        // DEFAULT_USER_BUNDLE (saga-dash#209.10/#209.1). Registry is FATAL (a failed
+        // registry means the grant can't be provisioned safely); dev-user stays warn.
+        const registryStep = registry['iam-registry'];
+        const registryOk = await runSeedStep(registryStep, 'offline', ran);
+        const devUser = registry['iam-dev-user'];
+        const devUserOk = registryOk && (await runSeedStep(devUser, 'offline', ran));
+        const ok = registryOk && devUserOk;
+        seed = {
+          ok,
+          ran,
+          skipped: [],
+          ...(ok ? {} : { failed: registryOk ? devUser.id : registryStep.id }),
+        };
       }
 
       // EXIT-CODE CONTRACT (M8 fold-in): up.sh's reset always exits 0 (per-DB failures

--- a/packages/node/saga-stack-cli/src/stack-api.ts
+++ b/packages/node/saga-stack-cli/src/stack-api.ts
@@ -56,12 +56,15 @@ import {
   prepClosure,
   provisionDbs,
   resetClosure,
+  syncCoachWebEnvLocal,
   syncDashLocalDefaults,
   viteCachePaths,
 } from './runtime/index.js';
 import type {
   AutoPullRepo,
   AutoPullResult,
+  CoachWebFs,
+  CoachWebSyncResult,
   DashFs,
   DashSyncResult,
   GitRunner,
@@ -110,6 +113,15 @@ export interface Runtime {
   portProbe: PortProbe;
   /** Dash-config fs seam (the prelaunch hook's `config.local.json` write/remove). */
   dashFs: DashFs;
+  /**
+   * coach-web env fs seam (soa#300 — the `.env.local` prelaunch hook's write/remove).
+   * When PRESENT AND coach-web is launchable, `up` writes `<coachWebRoot>/.env.local`
+   * so coach-web's browser boots against the LOCAL mesh instead of the checked-in
+   * `.env` remote defaults. ABSENT ⇒ the hook is skipped (the facade unit/int tests
+   * that don't wire it stay byte-identical); coachWebRoot resolves from
+   * `launchContext.repoRoots.COACH`.
+   */
+  coachWebFs?: CoachWebFs;
   /** HTTP health prober (verify). */
   prober: HealthProber;
   /** Process seam — mesh `make up` + the native seed steps. */
@@ -320,6 +332,8 @@ export interface UpResult {
   migrate?: MigrateResult;
   /** What the dash prelaunch hook did (only when saga-dash was in the closure). */
   dash?: DashSyncResult;
+  /** What the coach-web `.env.local` prelaunch hook did (only when coach-web was launchable + the seam wired). */
+  coachWeb?: CoachWebSyncResult;
   /** Per-service launch results, in the order launched (topo waves flattened). */
   launched: LaunchResult[];
   /** Services skipped because their repo checkout dir is absent (warn, not fail). */
@@ -863,6 +877,31 @@ export function makeStackApi(m: Manifest, runtime: Runtime): StackApi {
         );
       }
 
+      // 4b. coach-web prelaunch hook (soa#300) — ONLY when coach-web is launchable AND
+      // the seam is wired. coach-web is a SvelteKit adapter-static SPA that INLINES its
+      // PUBLIC_* URLs from `.env` at vite-dev start; the checked-in `.env` points at
+      // REMOTE hosts (…wootdev.com) + the base coach-api port, so its browser boots
+      // against remote/wrong hosts → whoami fails → it renders a 503 sign-in error and
+      // NO route renders. Write a per-slot `.env.local` (> `.env` in Vite; gitignored)
+      // mapping each PUBLIC_ var to THIS slot's LOCAL mesh offset port so the browser
+      // boots against the local stack. `launchContext.ports` are already slot-offset
+      // (same map the dash hook uses). Runs at EVERY slot including 0 (the remote
+      // defaults break local browser-testing at slot 0 too — the original soa#300);
+      // no-ops under tunnel (public coach-web URLs are a separate concern).
+      let coachWeb: CoachWebSyncResult | undefined;
+      if (launchable.includes('coach-web') && runtime.coachWebFs) {
+        const coachRoot = (launchContext.repoRoots as Record<RepoKey, string>).COACH;
+        coachWeb = syncCoachWebEnvLocal(
+          {
+            coachWebRoot: joinPath(coachRoot, 'apps/web/coach-web'),
+            tunnel: runtime.tunnel,
+            slot: runtime.slot,
+            stackPorts: launchContext.ports,
+          },
+          runtime.coachWebFs,
+        );
+      }
+
       // 5. launch the launchable set in topo WAVES — health-gate each wave before the
       // next. Reuse the faithful per-service spec builder (launchPlan), then regroup
       // the flat specs into waves via launchOrder so dependents only start once their
@@ -905,7 +944,7 @@ export function makeStackApi(m: Manifest, runtime: Runtime): StackApi {
         launched.push(...results);
         const failed = results.find((r) => !r.ok);
         if (failed) {
-          return { ok: false, autoPull, av, mesh, prep, provision, migrate, dash, launched, skipped, failedAt: failed.id as ServiceId };
+          return { ok: false, autoPull, av, mesh, prep, provision, migrate, dash, coachWeb, launched, skipped, failedAt: failed.id as ServiceId };
         }
       }
 
@@ -950,7 +989,7 @@ export function makeStackApi(m: Manifest, runtime: Runtime): StackApi {
         }
       }
 
-      return { ok: true, autoPull, av, mesh, prep, provision, migrate, dash, launched, skipped, record };
+      return { ok: true, autoPull, av, mesh, prep, provision, migrate, dash, coachWeb, launched, skipped, record };
     },
 
     async down(services: ServiceId[]): Promise<DownResult> {


### PR DESCRIPTION
Implements the `ss develop` concierge topic, coach-first (#305). **Absorbs #265** (closed — its commit is merged in here, authorship preserved). Companion: coach#239.

> **Landing note:** #313 lands first (main is currently red). This PR carries @SethPaul's `18f11a3` from #265 by merge, so #265 was closed as absorbed rather than landed separately.

## What landed

**`develop` topic + connect migration** — new `develop` oclif topic (seed/reset → prerequisite → log in → hand off a *running* app, distinct from the `e2e` test-runner). `e2e connect` → `develop connect` with a **deprecating alias**, verified at runtime. Docs split test-running from dev-setup.

**`ss develop coach`** — `--scenario content-viewer|admin|playlist`, `--real-content`, slot-aware.
- `content-viewer` (default): drives coach-web's `module-playback` flow as `demo-tutor-1`, hands off a headed logged-in coach-web on the ported module player.
- `--real-content`: drives the authored `module-playback-real-content` flow — publishes the archive's `base-coach` into the slot's Postgres, materializes demo-tutor-1, renders. Resolves + prechecks the content-archive checkout and exports `ARCHIVE_DIR` + the slot's `DATABASE_URL` (the lane gates on **both** and self-skips otherwise).
- `admin` (descoped v1): Reports route, printing that it's mock-backed.
- `playlist`: switches demo-tutor-1 onto a 2nd track via coach#239's verb, feature-detected with a fail-fast precheck.

**Concierge generalizations** — persona-email through `holdEpilogue`; `openVendoredBrowser` parameterized on `{repoEnvVar, appDir, port}`. Existing saga-dash/connect callers byte-identical.

**coach-web `.env.local` seam** — per-slot `.env.local` so coach-web's browser boots against the local mesh. This **completes** main's `58d58e4`: that sets `PUBLIC_IAM_API_URL` via the launch env, which SvelteKit's `$env/static/public` never reads (it inlines `.env` at vite-dev start). Proven live — this is what actually clears the 503.

**Slot correctness** — `develop coach` is `slotAware()` and threads the slot profile (`deriveInstance` → `applyInstanceEnv` → per-slot stateDir → `buildStackContext`), so `--slot N` targets slot N's own DBs/ports instead of silently running at slot 0.

## Absorbs #265 (@SethPaul)

`18f11a3` is merged in and my duplicates deleted — his factoring is better (`serviceUrlEnv` takes the ServiceId as a param; spec threading via `resolved.playwright.spec` gated on `!stage`). His branch predated two main changes, fixed here:
- **`--tunnel` regression**: removing `PLAYWRIGHT_BASE_URL` from `PLAYWRIGHT_SERVICE_URL_ENV` left `tunnelServiceUrlEnv` (which iterates it) emitting no tunnel baseURL — a `--tunnel` browser would fall back to `localhost:8900`, defeating soa#298. Now emitted from the flow's own SPA label.
- **`connect-mongo`**: his coach-web test asserted dual-store; `3ced4c5` retired mongo (single-store).

## Dropped as superseded by main
- My soa#300 manifest fix → main's `58d58e4` (more complete: adds `JWT_ISSUER`). Kept main's.
- `COACH_WEB_URL` token → added on both sides; kept main's.
- `CONTENT_STORE_BACKEND` pin → dead config after `3ced4c5`.

## Verification
- `check-types` clean; **1200 passed / 103 files**, incl. the #298 tunnel specs and `--capture`.
- Live on slot 2: `ss develop coach --real-content` → **1 passed** → *"coach ready"* → headed coach-web opened at `/units/unit_1/sc_u1_m1` as demo-tutor-1.
- **Owed before merge — manual tunnel pass** (needs vms rendezvous + dev creds, unavailable on my box): `ss stack up --tunnel` → **`ss e2e connect --tunnel` drives `https://dash.<moniker>.vms…`, not localhost** → `ss e2e run saga-dash/journey --tunnel --dry-run` → non-tunnel still localhost → `--tunnel --slot 1` still hard-errors.

## Conflicts to expect
- **#289** (`--tunnel --login routing + coach tunnel overlay`) touches `base-command.ts` + `dash-defaults.ts` — same files as the `openVendoredBrowser` generalization and the sibling of the `coach-web-env` seam. Whichever lands second will need a merge.

## Depends on
- coach#239 for `--scenario playlist` and `--real-content` against coach main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
