### PR TITLE
fix(saga-stack-cli): align every JWT validator with iam's minted issuer

### DIFF
--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
@@ -127,6 +127,7 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
       JANUS_REQUIRED: 'false',
       CORS_ORIGIN: 'http://localhost:8900',
       JANUS_LOGIN_HOST: 'localhost:3010/demo',
+      JWT_ISSUER: 'https://iam.wootdev.com',
     });
   });
 
@@ -139,6 +140,7 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
       JANUS_REQUIRED: 'false',
       CORS_ORIGIN: 'http://localhost:8900',
       JANUS_LOGIN_HOST: 'localhost:3010/demo',
+      JWT_ISSUER: 'https://iam.wootdev.com',
     });
   });
 
@@ -149,6 +151,7 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
       IAM_API_URL: 'http://localhost:3010',
       RABBITMQ_URL: 'amqp://rabbitmq_admin:password123@localhost:5672',
       CORS_ORIGIN: 'http://localhost:8900',
+      JWT_ISSUER: 'https://iam.wootdev.com',
     });
   });
 
@@ -160,6 +163,7 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
       IAM_API_URL: 'http://localhost:3010',
       RABBITMQ_URL: 'amqp://rabbitmq_admin:password123@localhost:5672',
       CORS_ORIGIN: 'http://localhost:8900',
+      JWT_ISSUER: 'https://iam.wootdev.com',
     });
   });
 
@@ -169,7 +173,7 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
       SESSIONS_API_CLIENT_BASEURL: 'http://localhost:3007',
       IAM_API_CLIENT_BASEURL: 'http://localhost:3010/trpc',
       IAM_API_URL: 'http://localhost:3010',
-      JWT_ISSUER: 'https://iam.saga.org',
+      JWT_ISSUER: 'https://iam.wootdev.com',
       SERVICE_TOKEN_SERVICESLUG: 'ads-adm-api',
       ADS_ADM_DATABASE_URL: 'postgresql://ads_adm:ads_adm@localhost:5432/ads_adm_local',
       DATABASE_URL: 'postgresql://ads_adm:ads_adm@localhost:5432/ads_adm_local',
@@ -196,7 +200,7 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
       AUTH_ENABLED: 'true',
       JANUS_REQUIRED: 'false',
       IAM_API_URL: 'http://localhost:3010',
-      JWT_ISSUER: 'https://iam.saga.org',
+      JWT_ISSUER: 'https://iam.wootdev.com',
       // #222 port: dash joins the CORS allowlist; rtsm wired for private-convos.
       ALLOWED_ORIGINS: 'http://localhost:6210,http://localhost:8900',
       SESSIONS_API_BASE_URL: 'http://localhost:3007',

--- a/packages/node/saga-stack-cli/src/core/launch-plan.ts
+++ b/packages/node/saga-stack-cli/src/core/launch-plan.ts
@@ -106,10 +106,13 @@ export interface LaunchTokens {
   SAGA_API_TARGET_COACH: string;
   /**
    * The `iss` claim: stamped INTO iam's tokens (JWT_ISSUER) and validated by
-   * coach-api (AUTH_ISSUER). One token feeds both ends so they cannot drift —
-   * this was `https://iam.saga.org` (prod) while the local iam-api stamped
+   * every JWT-verifying consumer — coach-api (AUTH_ISSUER) plus programs-api,
+   * scheduling-api, sessions-api, content-api, ads-adm-api, and connect-api
+   * (JWT_ISSUER). One token feeds all ends so they cannot drift — this was
+   * `https://iam.saga.org` (prod) while the local iam-api stamped
    * `https://iam.wootdev.com` (its .env default), so coach-api 401'd every
-   * locally-minted session.
+   * locally-minted session; 58d58e4 aligned coach but left the other
+   * validators on the prod literal (or the verifier's prod default).
    */
   IAM_ISSUER: string;
 

--- a/packages/node/saga-stack-cli/src/core/manifest/services.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/services.ts
@@ -173,6 +173,10 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
         JANUS_REQUIRED: 'false',
         CORS_ORIGIN: '${DASH_URL}',
         JANUS_LOGIN_HOST: 'localhost:${IAM_PORT}/demo',
+        // Validate the SAME issuer iam-api stamps (its JWT_ISSUER). Without this
+        // the rostering-client verifier falls back to the prod issuer and 401s
+        // every locally-minted session on authenticated procedures.
+        JWT_ISSUER: '${IAM_ISSUER}',
       },
     },
     seed: ['programs'],
@@ -202,6 +206,8 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
         JANUS_REQUIRED: 'false',
         CORS_ORIGIN: '${DASH_URL}',
         JANUS_LOGIN_HOST: 'localhost:${IAM_PORT}/demo',
+        // Same iss iam-api stamps — see programs-api's JWT_ISSUER note.
+        JWT_ISSUER: '${IAM_ISSUER}',
       },
     },
     seed: [],
@@ -230,6 +236,8 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
         IAM_API_URL: '${IAM_URL}',
         RABBITMQ_URL: '${MESH_MQ}',
         CORS_ORIGIN: '${DASH_URL}',
+        // Same iss iam-api stamps — see programs-api's JWT_ISSUER note.
+        JWT_ISSUER: '${IAM_ISSUER}',
       },
     },
     // qtf-demo runs `db:seed:qtf-demo` against the sessions DB (up.sh seed_qtf_demo); add-on, online.
@@ -259,6 +267,8 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
         IAM_API_URL: '${IAM_URL}',
         RABBITMQ_URL: '${MESH_MQ}',
         CORS_ORIGIN: '${DASH_URL}',
+        // Same iss iam-api stamps — see programs-api's JWT_ISSUER note.
+        JWT_ISSUER: '${IAM_ISSUER}',
       },
     },
     seed: ['content'],
@@ -294,7 +304,9 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
         SESSIONS_API_CLIENT_BASEURL: 'http://localhost:${SESSIONS_PORT}',
         IAM_API_CLIENT_BASEURL: '${IAM_URL}/trpc',
         IAM_API_URL: '${IAM_URL}',
-        JWT_ISSUER: 'https://iam.saga.org',
+        // Same iss iam-api stamps — see programs-api's JWT_ISSUER note. Was the
+        // prod literal, which 401'd once iam began minting ${IAM_ISSUER} (58d58e4).
+        JWT_ISSUER: '${IAM_ISSUER}',
         SERVICE_TOKEN_SERVICESLUG: 'ads-adm-api',
         ADS_ADM_DATABASE_URL: '${ADS_ADM_DB_URL}',
         DATABASE_URL: '${ADS_ADM_DB_URL}',
@@ -383,7 +395,9 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
         AUTH_ENABLED: 'true',
         JANUS_REQUIRED: 'false',
         IAM_API_URL: '${IAM_URL}',
-        JWT_ISSUER: 'https://iam.saga.org',
+        // Same iss iam-api stamps — see programs-api's JWT_ISSUER note. Was the
+        // prod literal, which 401'd once iam began minting ${IAM_ISSUER} (58d58e4).
+        JWT_ISSUER: '${IAM_ISSUER}',
         // #222 port: dash calls connect-api cross-origin (journey attendance /
         // connect embeds) — without DASH_URL in the allowlist those are CORS-blocked.
         ALLOWED_ORIGINS: '${CONNECT_WEB_URL},${DASH_URL}',


### PR DESCRIPTION
## Problem

58d58e4 (#303/#307) pointed the local iam-api's minted `iss` claim at `https://iam.wootdev.com` (via the `IAM_ISSUER` launch token) and aligned coach-api's `AUTH_ISSUER` — but left every other JWT-verifying consumer mismatched:

- **programs-api, scheduling-api, sessions-api, content-api** had no `JWT_ISSUER` in their manifest launch env at all, so the rostering-client verifier fell back to its prod default `https://iam.saga.org`.
- **ads-adm-api, connect-api** carried the prod literal hardcoded in the manifest.

Every authenticated procedure on those services then 401'd:

```
[iam-auth] iam_session JWT verification failed (issuer=https://iam.saga.org, audience=saga-platform): unexpected "iss" claim value
```

and the dash bounced the browser to iam with `reasons=iam_required`. First surfaced by `saga-dash/journey` stage 2, where `programs.create` is the first hard-authenticated call — earlier stages pass because they only hit public/optional-auth reads.

## Fix

Feed all six validators the same `${IAM_ISSUER}` token that stamps iam's mint, extending 58d58e4's cannot-drift approach to the whole fleet:

- `services.ts`: add `JWT_ISSUER: '${IAM_ISSUER}'` to programs-api, scheduling-api, sessions-api, content-api; replace the hardcoded prod literal in ads-adm-api and connect-api with the token.
- `launch-plan.ts`: update the `IAM_ISSUER` doc comment to list every consumer.
- `launch-plan.unit.test.ts`: update the six byte-identity launch-env expectations.

## Testing

- CLI suite green: 98 files, 1163 tests.
- Verified end-to-end on a local stack: before the fix, `ss e2e run saga-dash/journey --through sessions` failed at stage 2 with the redirect above; after rebuild + `ss stack restart`, the journey runs green through sessions and programs-api logs no further issuer-verification warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)