### PR TITLE
feat(saga-stack-cli): slot-aware `ss stack login --browser`

### DIFF
--- a/docs/superpowers/plans/2026-07-15-slot-aware-browser-login.md
+++ b/docs/superpowers/plans/2026-07-15-slot-aware-browser-login.md
@@ -1,0 +1,316 @@
+# Slot-aware `stack login --browser` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let `ss stack login --browser` open an auto-logged-in Chromium at any slot (not just slot 0) by pointing the browser at the slot's own dash, so two backend stacks on two slots give two fully isolated logged-in browsers.
+
+**Architecture:** The headful-browser seam is already env-parameterised (`browser-login.mjs` reads `IAM_URL`/`DASH_URL`/`PROFILE_DIR`; `openVendoredBrowser` already accepts a `dashUrl` override and already passes a slot-aware `iamUrl` + per-slot `PROFILE_DIR`). The only unwired value is `DASH_URL`. This change removes the `slot > 0` refusal in `stack login` and threads the slot's offset dash URL into the existing `dashUrl` override. Slot 0 stays byte-identical. Isolation between slots comes from the already-per-slot `stateDir` (⇒ distinct persistent browser profiles) — no per-slot profile suffix.
+
+**Tech Stack:** TypeScript (ESM, strict), oclif CLI, Vitest, pnpm. Package: `packages/node/saga-stack-cli` (the `ss` CLI).
+
+## Global Constraints
+
+- **Indentation: 2 spaces.** `saga-stack-cli` is 2-space (enforced by its own `eslint.config.js`). Do NOT apply the soa repo-wide 4-space default inside this package — match the file being edited.
+- **pnpm only** (never npm). ESM only. No Prettier; ESLint.
+- **Slot 0 must stay byte-identical.** At slot 0 the computed dash port is `8900`, so `DASH_URL` resolves exactly as before; the existing slot-0 `--browser` test must pass unchanged.
+- **`LOGIN_DASH_URL` wins** over the computed slot dash URL (tunnel/manual escape hatch).
+- **No `up.ts` change** and **no transcripts warning** (both explicitly out of scope per the spec).
+- Run every command from the package root: `packages/node/saga-stack-cli`.
+- `oclif.manifest.json` is git-tracked; `dist/` is not. Any change to a flag `description:` string requires `pnpm build` (which runs `oclif manifest`) and committing the regenerated manifest.
+
+**Spec:** `docs/superpowers/specs/2026-07-15-slot-aware-browser-login-design.md`
+
+---
+
+### Task 1: Slot-parameterise `stack login --browser`
+
+**Files:**
+- Modify: `packages/node/saga-stack-cli/src/commands/stack/login.ts` (remove the `slot > 0` refusal ~lines 66-75; thread `dashUrl` into the `openVendoredBrowser` call ~lines 118-120)
+- Test: `packages/node/saga-stack-cli/src/commands/stack/__tests__/login-native.int.test.ts` (replace the "refused at slot > 0" test; add a `LOGIN_DASH_URL`-precedence test; clear `LOGIN_DASH_URL` between tests)
+
+**Interfaces:**
+- Consumes (existing, unchanged signatures):
+  - `deriveInstance({ slot }): InstanceProfile` — use `profile.portOverrides['saga-dash']` (`number | undefined`; `'saga-dash'` is the manifest service id, base port `8900`).
+  - `this.openVendoredBrowser(flags, ctx: { email: string; iamUrl: string; stateDir: string; dashUrl?: string }): Promise<void>` — already defined on `BaseCommand`; we now pass `dashUrl`.
+  - `res.iamUrl` from `this.mintNativeLoginJar(...)` — already slot-aware (`http://localhost:${3010 + slot*1000}`).
+- Produces: no new exported symbols (terminal behavior change).
+
+- [ ] **Step 1: Update the test file (write the failing tests)**
+
+In `src/commands/stack/__tests__/login-native.int.test.ts`:
+
+(1a) Clear `LOGIN_DASH_URL` alongside `LOGIN_IAM_URL`. In `beforeEach` (currently line 75) add the second delete, and in `afterEach` (currently line 86) add it too:
+
+```ts
+// in beforeEach, replace the single delete with both:
+  delete process.env.LOGIN_IAM_URL;
+  delete process.env.LOGIN_DASH_URL;
+```
+
+```ts
+// in afterEach, replace the single delete with both:
+  vi.restoreAllMocks();
+  delete process.env.LOGIN_IAM_URL;
+  delete process.env.LOGIN_DASH_URL;
+```
+
+(1b) Replace the entire existing `it('--browser at slot > 0 is refused ...')` block (currently lines 193-202) with these two tests:
+
+```ts
+  it('--browser at slot > 0 opens the browser against the SLOT\'s dash + iam (not slot 0)', async () => {
+    installPoster(OK_COOKIES);
+    installJar();
+    // the spawn guard checks the saga-dash dash dir exists; report it present.
+    vi.spyOn(
+      BaseCommand.prototype as unknown as { getRepoDirCheck: () => (dir: string) => boolean },
+      'getRepoDirCheck',
+    ).mockReturnValue(() => true);
+
+    await StackLogin.run(['--browser', '--slot', '1', ...WS], config);
+
+    // native jar minted against the slot-1 iam (:4010) at the slot-1 state dir.
+    expect(posts).toHaveLength(1);
+    expect(posts[0]?.url).toBe('http://localhost:4010/trpc/auth.devLogin');
+    expect(jarWrites).toHaveLength(1);
+    expect(jarWrites[0]?.path).toBe('/tmp/sds-synthetic-s1/cookies.txt');
+
+    // browser opened against the SLOT-1 dash (:9900) with the SLOT-1 persistent profile.
+    expect(runnerCalls).toHaveLength(1);
+    const spawn = runnerCalls[0];
+    expect(spawn?.command).toBe('node');
+    expect((spawn?.args[0] ?? '').endsWith('browser-login.mjs')).toBe(true);
+    expect(spawn?.env).toMatchObject({
+      IAM_URL: 'http://localhost:4010',
+      DASH_URL: 'http://localhost:9900',
+      PROFILE_DIR: '/tmp/sds-synthetic-s1/browser-profile',
+    });
+  });
+
+  it('LOGIN_DASH_URL overrides the computed slot dash URL (tunnel escape hatch)', async () => {
+    process.env.LOGIN_DASH_URL = 'https://dash.moniker.wootdev.com';
+    installPoster(OK_COOKIES);
+    installJar();
+    vi.spyOn(
+      BaseCommand.prototype as unknown as { getRepoDirCheck: () => (dir: string) => boolean },
+      'getRepoDirCheck',
+    ).mockReturnValue(() => true);
+
+    await StackLogin.run(['--browser', '--slot', '1', ...WS], config);
+
+    const spawn = runnerCalls[0];
+    // dash URL is the explicit override; iam stays the slot's (LOGIN_DASH_URL is dash-only).
+    expect(spawn?.env?.DASH_URL).toBe('https://dash.moniker.wootdev.com');
+    expect(spawn?.env?.IAM_URL).toBe('http://localhost:4010');
+  });
+```
+
+- [ ] **Step 2: Run the new tests to verify they FAIL**
+
+Run: `pnpm test -- login-native --run`
+Expected: FAIL — the two new tests error because `stack login --browser --slot 1` still throws the refusal (`this.error(... 'slot 1: --browser opens a Chromium against slot 0's dash' ...)`) before minting the jar or spawning the browser. The unchanged slot-0 tests pass.
+
+- [ ] **Step 3: Remove the `slot > 0` refusal in `login.ts`**
+
+In `src/commands/stack/login.ts`, delete this block (currently lines 66-75, including the trailing blank line) so parsing flows straight into the native-jar section:
+
+```ts
+    // --browser opens a Chromium against slot 0's dash (DASH :8900, PROFILE under
+    // /tmp/sds-synthetic). browser-login.mjs is not slot-parameterised, so refuse
+    // --browser at slot > 0 rather than open a window pointed at slot 0's dash.
+    if (flags.browser && flags.slot > 0) {
+      this.error(
+        `slot ${flags.slot}: --browser opens a Chromium against slot 0's dash (DASH :8900, ` +
+          "PROFILE under /tmp/sds-synthetic). Drop --browser to mint the slot's headless jar natively.",
+      );
+    }
+
+```
+
+Result: line `const { args, flags } = await this.parse(StackLogin);` is now immediately followed by the `// ── NATIVE headless cookie jar ...` comment.
+
+- [ ] **Step 4: Thread the slot's dash URL into `openVendoredBrowser`**
+
+In the same file, replace the final `--browser` block (currently lines 118-120):
+
+```ts
+    if (flags.browser) {
+      await this.openVendoredBrowser(flags, { email, iamUrl, stateDir });
+    }
+```
+
+with:
+
+```ts
+    if (flags.browser) {
+      // Point the browser at the SLOT's own dash (base 8900 + slot*1000, from the
+      // resolved profile). LOGIN_DASH_URL still wins for the tunnel case. iamUrl and
+      // stateDir (⇒ PROFILE_DIR) are already slot-aware; the per-slot stateDir gives a
+      // distinct persistent profile per slot. At slot 0 dashPort is 8900, so this is
+      // byte-identical to the previous slot-0-only behaviour.
+      const dashPort = profile.portOverrides['saga-dash'] ?? 8900;
+      const dashUrl = process.env.LOGIN_DASH_URL || `http://localhost:${dashPort}`;
+      await this.openVendoredBrowser(flags, { email, iamUrl, stateDir, dashUrl });
+    }
+```
+
+(`profile`, `email`, `iamUrl`, `stateDir` are all already in scope from the native-jar section above.)
+
+- [ ] **Step 5: Run the login-native suite to verify it PASSES**
+
+Run: `pnpm test -- login-native --run`
+Expected: PASS — all tests, including:
+- the unchanged slot-0 `--browser` test (`DASH_URL: 'http://localhost:8900'`, `PROFILE_DIR: '/tmp/sds-synthetic/browser-profile'`),
+- the new slot-1 test (`:9900` / `:4010` / `-s1` profile),
+- the `LOGIN_DASH_URL` precedence test.
+
+- [ ] **Step 6: Typecheck**
+
+Run: `pnpm check-types`
+Expected: no errors. (Confirms `profile.portOverrides['saga-dash']` is a valid `ServiceId` index and `dashUrl` matches the `openVendoredBrowser` ctx type.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/commands/stack/login.ts src/commands/stack/__tests__/login-native.int.test.ts
+git commit -m "feat(saga-stack-cli): slot-parameterise stack login --browser
+
+Open the headful Chromium against the slot's own dash (8900+slot*1000) instead
+of refusing at slot > 0. iamUrl + per-slot profile were already slot-aware, so
+two slots give two isolated logged-in browsers. LOGIN_DASH_URL still wins; slot 0
+stays byte-identical.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Correct the stale slot-flag doc + regenerate the manifest
+
+**Files:**
+- Modify: `packages/node/saga-stack-cli/src/shared-flags.ts` (the ceiling comment ~lines 119-123 and the flag `description:` ~lines 125-126)
+- Modify (generated): `packages/node/saga-stack-cli/oclif.manifest.json` (via `pnpm build`)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: nothing new. Doc/help-text only. The `slot` flag's runtime `default`/`min`/`max` are unchanged.
+
+- [ ] **Step 1: Fix the comment block**
+
+In `src/shared-flags.ts`, replace the ceiling comment (currently lines 119-123):
+
+```ts
+    // CEILING 9 (M7 MINOR): the mesh's rabbitmq (:5672) and rabbitmq-mgmt (:15672)
+    // differ by 10000 = 10 * the 1000 stride, so slot 10's rabbitmq (:15672) would
+    // collide with slot 0's rabbitmq-mgmt (:15672). Cap at 9 so every slot's full
+    // resolved port band stays disjoint. Slot > 0 is a BACKEND sub-stack (the
+    // literal-port backends + browser frontends are excluded — see derive-instance).
+```
+
+with:
+
+```ts
+    // CEILING 9 (M7 MINOR): the mesh's rabbitmq (:5672) and rabbitmq-mgmt (:15672)
+    // differ by 10000 = 10 * the 1000 stride, so slot 10's rabbitmq (:15672) would
+    // collide with slot 0's rabbitmq-mgmt (:15672). Cap at 9 so every slot's full
+    // resolved port band stays disjoint. Slot > 0 is a BACKEND + FRONTEND sub-stack:
+    // the saga-dash/coach-web/connect-web frontends run on their OFFSET port; only the
+    // literal-port playback trio stays excluded (soa#271 — see derive-instance).
+```
+
+- [ ] **Step 2: Fix the flag `description:` string**
+
+In the same file, replace the `slot` flag description (currently lines 125-126):
+
+```ts
+    description:
+      'stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.',
+```
+
+with:
+
+```ts
+    description:
+      'stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.',
+```
+
+- [ ] **Step 3: Regenerate the manifest**
+
+Run: `pnpm build`
+Expected: `tsc` succeeds, then `oclif manifest` rewrites `oclif.manifest.json` with the new slot description across every command entry.
+
+Verify the swap took (old string gone, new string present):
+
+Run: `grep -c "frontends stay on slot 0" oclif.manifest.json; grep -c "only the literal-port playback trio stays on slot 0" oclif.manifest.json`
+Expected: first count `0`, second count `> 0`.
+
+- [ ] **Step 4: Full test suite + lint**
+
+Run: `pnpm test`
+Expected: PASS (whole package — confirms the doc change and Task 1 together break nothing).
+
+Run: `pnpm lint`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/shared-flags.ts oclif.manifest.json
+git commit -m "docs(saga-stack-cli): correct stale slot-flag help — frontends are slottable
+
+The slot flag comment + --help description claimed browser frontends stay on /
+are excluded from slot 0; soa#271 made saga-dash/coach-web/connect-web slottable
+(they run on their offset port). Regenerate oclif.manifest.json to match.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: End-to-end verification gate
+
+**Files:** none (verification only).
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Full local gate**
+
+From `packages/node/saga-stack-cli`:
+
+Run: `pnpm test && pnpm check-types && pnpm lint`
+Expected: all pass. (Per the repo's "run the full suite before merge-ready" rule.)
+
+- [ ] **Step 2: (Optional) zero-build manual smoke of the help text**
+
+`bin/dev.js` runs straight from `src/` via `tsx` (no build needed):
+
+Run: `node bin/dev.js stack login --help`
+Expected: the `--slot` help line shows the corrected description (frontends run on their offset port; only the playback trio stays on slot 0), and `--browser` is listed with no slot restriction.
+
+- [ ] **Step 3: (Optional, needs a machine with Docker + two free slots) real two-browser smoke**
+
+This is environmental and not required to land the change; document the result if run:
+
+```bash
+ss stack up --slot 1 && ss stack up --slot 2
+ss stack login --slot 1 --browser   # Chromium → dash :9900, iam :4010, profile /tmp/sds-synthetic-s1
+ss stack login --slot 2 --browser   # Chromium → dash :10900, iam :5010, profile /tmp/sds-synthetic-s2
+```
+
+Expected: two separate Chromium windows, each logged into its own stack, with no shared cookies (distinct persistent profiles). Note: `ss` runs the **main** checkout's CLI, so this reflects the change only after merge; to smoke the worktree build, run the worktree's `bin/run.js` (after `pnpm build`) or `bin/dev.js` in place of `ss`.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Remove `slot > 0` refusal → Task 1, Step 3. ✓
+- Compute slot dash URL from `profile.portOverrides['saga-dash']` and pass as `ctx.dashUrl` → Task 1, Step 4. ✓
+- `LOGIN_DASH_URL` wins; slot 0 byte-identical → Task 1, Step 4 (code) + Step 1/Step 5 (tests). ✓
+- No `up.ts` change, no transcripts warning → not in any task (correctly absent). ✓
+- Decision: no per-slot profile suffix (isolation via per-slot `stateDir`) → reflected in Task 1 Step 4 comment + `PROFILE_DIR: '/tmp/sds-synthetic-s1/browser-profile'` assertion. ✓
+- Housekeeping: fix stale `shared-flags.ts` comment → Task 2. ✓ (Extended to the `--help` description + manifest regen, which the spec's text also covers.)
+- Tests: invert the slot>0 refusal test; assert slot-1 `DASH_URL`/`IAM_URL`/profile; keep `LOGIN_DASH_URL` override → Task 1. ✓ (Corrected the spec's imprecise mention of `slot-guard.unit.test.ts`: the refusal test actually lives in `login-native.int.test.ts`; `slot-guard` needs no change.)
+
+**2. Placeholder scan:** none — every code/test/command step shows the full content.
+
+**3. Type consistency:** `profile.portOverrides['saga-dash']` (`number | undefined`) → `?? 8900` → `number`; `dashUrl: string` matches `openVendoredBrowser`'s `ctx.dashUrl?: string`. Test env keys (`IAM_URL`/`DASH_URL`/`PROFILE_DIR`) match those set in `base-command.ts`'s `openVendoredBrowser`. Consistent.

--- a/docs/superpowers/specs/2026-07-15-slot-aware-browser-login-design.md
+++ b/docs/superpowers/specs/2026-07-15-slot-aware-browser-login-design.md
@@ -1,0 +1,169 @@
+# Slot-aware `stack login --browser` — design
+
+**Date:** 2026-07-15
+**Package:** `packages/node/saga-stack-cli` (the `ss` CLI)
+**Status:** approved design; Phase 1 of a two-phase effort (Phase 2 = multi-frontend-per-stack, specced separately).
+
+## Problem
+
+`ss stack login --browser` (and the `up --login` browser step) is hard-locked to
+slot 0. On any `--slot > 0` the command refuses to open a headful Chromium:
+
+```
+src/commands/stack/login.ts:69   if (flags.browser && flags.slot > 0) this.error(...)
+src/commands/stack/up.ts:582      if (flags.slot === 0) { await this.openVendoredBrowser(...) }
+```
+
+The stated rationale — *"browser-login.mjs opens against slot 0's dash (:8900),
+profile under /tmp/sds-synthetic; it is not slot-parameterised"* — is now largely
+stale. The goal: run two backend stacks on two slots and open two independent,
+logged-in browsers, one per stack, with **no cookie collision** between the two
+logins (they talk to two different iam instances).
+
+## Why this is a small change (current state)
+
+The headful-browser machinery is already almost entirely slot-parameterised:
+
+- **The vendored script is fully env-driven.** `vendor/browser-login.mjs:32-35`
+  reads `IAM_URL`, `DASH_URL`, `LOGIN_EMAIL`, `PROFILE_DIR` from the environment and
+  launches via `chromium.launchPersistentContext(PROFILE, …)`. A distinct
+  `PROFILE_DIR` is a separate on-disk user-data dir = a fully isolated browser
+  (independent cookie store).
+- **`openVendoredBrowser` already passes slot-correct `iamUrl` and `PROFILE_DIR`.**
+  `base-command.ts:1002-1010`: `iamUrl` comes from `resolveIamUrl({ slot })`
+  (`http://localhost:${3010 + slot*1000}`, `core/login.ts:50-55`); `PROFILE_DIR` is
+  `<stateDir>/browser-profile` where `stateDir` is `/tmp/sds-synthetic-s<N>` per slot.
+- **The seam already accepts a `dashUrl` override.** `base-command.ts:979,1006` —
+  `ctx.dashUrl ?? (LOGIN_DASH_URL || 'http://localhost:8900')`. The e2e `--hold`
+  path already uses it to open a slot's own dash.
+- **The slot's dash is actually listening at its offset port.** At `slot > 0`,
+  `stack-api.ts:891-892` appends `--port <base+offset>` for any `isFrontend`
+  service, so `saga-dash` runs on `8900 + slot*1000` (soa#271 made frontends
+  slottable). The `shared-flags.ts:122-126` comment claiming frontends "stay on
+  slot 0 / are excluded" is **stale** and predates soa#271; `derive-instance.ts`
+  is authoritative.
+
+The **only** value not wired for `slot > 0` is `DASH_URL`, which defaults to
+`:8900`. Everything else — including the collision-free per-slot profile — is
+already in place.
+
+### Why cookies (and all other state) don't collide
+
+Each slot's browser is a **separate persistent browser instance**, not a shared
+browser pointed at different URLs. `browser-login.mjs` opens via
+`chromium.launchPersistentContext(PROFILE_DIR, …)` (`vendor/browser-login.mjs:53`),
+which binds the browser to an on-disk user-data dir. Each slot already resolves a
+distinct `PROFILE_DIR` — `/tmp/sds-synthetic-s1/browser-profile` vs `-s2`
+(`base-command.ts:1008`, `<stateDir>/browser-profile` with a per-slot `stateDir`).
+
+Two slots therefore launch **two separate browser processes with two separate
+on-disk profiles**: no shared cookies, localStorage, IndexedDB, cache, or service
+workers. The isolation is structural (separate user-data dirs), independent of the
+URLs differing; two different dirs also avoid Chrome's singleton-lock conflict, so
+they run fully in parallel. This already exists — the change only lets `slot > 0`
+reach the browser-open path that uses it.
+
+(Aside, not the mechanism: browser cookies key on **domain, not port**, so two
+localhost dashes on different ports would share a cookie store *within one
+profile*. That is precisely why isolation relies on separate profiles, not on the
+ports being different.)
+
+## Design (Phase 1)
+
+Single production file changed: `src/commands/stack/login.ts`.
+
+1. **Remove the guard.** Delete the `flags.browser && flags.slot > 0` refusal
+   (`login.ts:66-74`).
+2. **Compute the slot's dash URL** from the already-derived `profile`:
+   `profile.portOverrides['saga-dash']` → `http://localhost:<8900 + slot*1000>`.
+   (`'saga-dash'` is the manifest service id, base port 8900.)
+3. **Pass it as `ctx.dashUrl`** into the existing call
+   `this.openVendoredBrowser(flags, { email, iamUrl, stateDir, dashUrl })`
+   (`login.ts:119`).
+
+`iamUrl` (from `res.iamUrl`, already offset) and `PROFILE_DIR` (slot `stateDir`)
+need no change.
+
+### Precedence
+
+The computed slot URL is what we pass as `ctx.dashUrl`. `LOGIN_DASH_URL` remains
+the explicit override for the tunnel/manual case. To keep the tunnel path
+byte-identical, ordering is: **`LOGIN_DASH_URL` (when set) wins**, else the
+computed slot dash URL, else `:8900`. Concretely, `login.ts` passes
+`dashUrl = process.env.LOGIN_DASH_URL || slotDashUrl`, and `openVendoredBrowser`'s
+existing `ctx.dashUrl ?? …` fallback is preserved.
+
+### Decision: profile isolation relies on the per-slot state dir
+
+The browser profile stays `<stateDir>/browser-profile` (no per-slot suffix).
+Isolation between slots comes from `stateDir` itself being per-slot
+(`/tmp/sds-synthetic-s<N>`) — the *same* mechanism that already isolates each
+stack's pid ledger (`<id>.pid`) and cookie jar (`cookies.txt`). `--state-dir` is
+the whole-stack bookkeeping/identity root, not a browser-only knob, so two slots
+sharing one `stateDir` is already an unsupported "don't do that" that breaks
+loudly elsewhere (a shared pid ledger means `down` on one slot reaps the other;
+a shared jar means the two `cookies.txt` writes clobber). Suffixing only the
+browser profile would band-aid one symptom of that deeper rule while implying the
+profile needs protection the jar/pids don't get. So we do **not** special-case the
+profile; distinct default `stateDir`s already guarantee two fully separate
+persistent browser instances (considered and rejected: a `browser-profile-s<N>`
+suffix; a stateDir-collision guard — the latter is a possible future hardening,
+out of scope here).
+
+### Explicitly out of scope (Phase 1)
+
+- **No `up.ts` change.** Browser-opening stays exclusive to the explicit
+  `stack login --browser`. `up --login` keeps today's behavior (opens at slot 0,
+  skips at slot > 0).
+- **No transcripts warning.** Opening a `slot > 0` browser is silent. (Known
+  property: `transcripts-api` is excluded at `slot > 0`, so the slot's
+  `config.local.json` points transcripts at an offset port with nothing
+  listening — an attendance/transcripts **write** fails loud by design,
+  `dash-defaults.ts:61-72`. Understood and accepted; not surfaced.)
+
+### Housekeeping
+
+- Correct the stale `shared-flags.ts:122-126` comment so it no longer claims
+  browser frontends stay on / are excluded from slot 0.
+
+## Testing
+
+Exercised through the existing injectable browser/vendor seams — **no real
+Chromium**:
+
+- `src/commands/stack/__tests__/login-native.int.test.ts`: add a case asserting
+  `stack login --slot 1 --browser` invokes the vendored browser with
+  `DASH_URL=http://localhost:9900`, `IAM_URL=http://localhost:4010`, and a
+  `PROFILE_DIR` under `/tmp/sds-synthetic-s1`.
+- `src/commands/stack/__tests__/slot-guard.unit.test.ts`: invert/remove the case
+  that asserted `--browser --slot > 0` errors.
+- Preserve a case proving `LOGIN_DASH_URL` still overrides the computed slot URL.
+
+## Outcome
+
+```
+ss stack up    --slot 1        ss stack up    --slot 2
+ss stack login --slot 1 --browser   ss stack login --slot 2 --browser
+```
+
+Two Chromiums with profiles `/tmp/sds-synthetic-s1/browser-profile` vs `-s2`,
+logged into iam `:4010` vs `:5010`, pointed at dash `:9900` vs `:10900`. No
+cookie collision (separate persistent profiles).
+
+## Development / testing note
+
+The global `ss` binary runs the **main** `soa` checkout's saga-stack-cli, so
+worktree edits are invisible to `ss` until merged. Develop in the worktree and
+test via the worktree's own `bin/run.js` (and the vitest suite) until merged.
+
+## Phase 2 (separate design pass) — multi-frontend per stack
+
+Not specced here. Summary of the problem for continuity: the current model
+couples `frontend instance ↔ slot ↔ backend` — frontend port is `f(slot)`, and
+frontend→backend wiring is `apps/web/dash/static/config.local.json` written into
+the saga-dash checkout (`dash-defaults.ts`), one file per checkout. Running N
+saga-dash versions against one backend needs a "frontend variant" abstraction
+(repo checkout + port + target backend) decoupled from the slot, plus lifecycle
+handling (`down`/`status`/`restart` assume one frontend per slot; the wrapper
+lifecycle uses broad `pkill -f tsup`/`nuke_vite` that would clobber siblings).
+This gets its own spec → plan → implementation cycle.

--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -18,7 +18,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -194,7 +194,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -334,7 +334,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -573,7 +573,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -722,7 +722,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -1044,7 +1044,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -1181,7 +1181,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -1335,7 +1335,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -1473,7 +1473,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -1630,7 +1630,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -1803,7 +1803,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -1947,7 +1947,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -2098,7 +2098,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -2264,7 +2264,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -2409,7 +2409,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -2550,7 +2550,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -2720,7 +2720,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -2888,7 +2888,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -3027,7 +3027,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -3273,7 +3273,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -3451,7 +3451,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -3588,7 +3588,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -3721,7 +3721,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -3867,7 +3867,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -4019,7 +4019,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -4201,7 +4201,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/login-native.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/login-native.int.test.ts
@@ -232,6 +232,7 @@ describe('stack login — native headless cookie jar', () => {
 
     await StackLogin.run(['--browser', '--slot', '1', ...WS], config);
 
+    expect(runnerCalls).toHaveLength(1);
     const spawn = runnerCalls[0];
     // dash URL is the explicit override; iam stays the slot's (LOGIN_DASH_URL is dash-only).
     expect(spawn?.env?.DASH_URL).toBe('https://dash.moniker.wootdev.com');

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/login-native.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/login-native.int.test.ts
@@ -73,6 +73,7 @@ beforeEach(async () => {
   config = await Config.load(PKG_ROOT);
   logged = [];
   delete process.env.LOGIN_IAM_URL;
+  delete process.env.LOGIN_DASH_URL;
   vi.spyOn(BaseCommand.prototype as unknown as { log: (m?: string) => void }, 'log').mockImplementation(
     (m?: string) => {
       logged.push(m ?? '');
@@ -84,6 +85,7 @@ beforeEach(async () => {
 afterEach(() => {
   vi.restoreAllMocks();
   delete process.env.LOGIN_IAM_URL;
+  delete process.env.LOGIN_DASH_URL;
 });
 
 const out = (): string => logged.join('\n');
@@ -190,14 +192,49 @@ describe('stack login — native headless cookie jar', () => {
     });
   });
 
-  it('--browser at slot > 0 is refused (browser-login targets slot 0 dash)', async () => {
+  it('--browser at slot > 0 opens the browser against the SLOT\'s dash + iam (not slot 0)', async () => {
     installPoster(OK_COOKIES);
     installJar();
-    await expect(StackLogin.run(['--browser', '--slot', '1', ...WS], config)).rejects.toMatchObject({
-      message: expect.stringContaining('slot 1'),
+    // the spawn guard checks the saga-dash dash dir exists; report it present.
+    vi.spyOn(
+      BaseCommand.prototype as unknown as { getRepoDirCheck: () => (dir: string) => boolean },
+      'getRepoDirCheck',
+    ).mockReturnValue(() => true);
+
+    await StackLogin.run(['--browser', '--slot', '1', ...WS], config);
+
+    // native jar minted against the slot-1 iam (:4010) at the slot-1 state dir.
+    expect(posts).toHaveLength(1);
+    expect(posts[0]?.url).toBe('http://localhost:4010/trpc/auth.devLogin');
+    expect(jarWrites).toHaveLength(1);
+    expect(jarWrites[0]?.path).toBe('/tmp/sds-synthetic-s1/cookies.txt');
+
+    // browser opened against the SLOT-1 dash (:9900) with the SLOT-1 persistent profile.
+    expect(runnerCalls).toHaveLength(1);
+    const spawn = runnerCalls[0];
+    expect(spawn?.command).toBe('node');
+    expect((spawn?.args[0] ?? '').endsWith('browser-login.mjs')).toBe(true);
+    expect(spawn?.env).toMatchObject({
+      IAM_URL: 'http://localhost:4010',
+      DASH_URL: 'http://localhost:9900',
+      PROFILE_DIR: '/tmp/sds-synthetic-s1/browser-profile',
     });
-    // refused BEFORE minting a jar or spawning anything.
-    expect(posts ?? []).toHaveLength(0);
-    expect(runnerCalls).toHaveLength(0);
+  });
+
+  it('LOGIN_DASH_URL overrides the computed slot dash URL (tunnel escape hatch)', async () => {
+    process.env.LOGIN_DASH_URL = 'https://dash.moniker.wootdev.com';
+    installPoster(OK_COOKIES);
+    installJar();
+    vi.spyOn(
+      BaseCommand.prototype as unknown as { getRepoDirCheck: () => (dir: string) => boolean },
+      'getRepoDirCheck',
+    ).mockReturnValue(() => true);
+
+    await StackLogin.run(['--browser', '--slot', '1', ...WS], config);
+
+    const spawn = runnerCalls[0];
+    // dash URL is the explicit override; iam stays the slot's (LOGIN_DASH_URL is dash-only).
+    expect(spawn?.env?.DASH_URL).toBe('https://dash.moniker.wootdev.com');
+    expect(spawn?.env?.IAM_URL).toBe('http://localhost:4010');
   });
 });

--- a/packages/node/saga-stack-cli/src/commands/stack/login.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/login.ts
@@ -63,16 +63,6 @@ export default class StackLogin extends BaseCommand {
   async run(): Promise<void> {
     const { args, flags } = await this.parse(StackLogin);
 
-    // --browser opens a Chromium against slot 0's dash (DASH :8900, PROFILE under
-    // /tmp/sds-synthetic). browser-login.mjs is not slot-parameterised, so refuse
-    // --browser at slot > 0 rather than open a window pointed at slot 0's dash.
-    if (flags.browser && flags.slot > 0) {
-      this.error(
-        `slot ${flags.slot}: --browser opens a Chromium against slot 0's dash (DASH :8900, ` +
-          "PROFILE under /tmp/sds-synthetic). Drop --browser to mint the slot's headless jar natively.",
-      );
-    }
-
     // ── NATIVE headless cookie jar (BOTH the default AND the --browser path). ──
     // Shared with `up --login` via the BaseCommand helper — NEITHER touches up.sh.
     const email = args.email ?? DEFAULT_LOGIN_USER;
@@ -116,7 +106,14 @@ export default class StackLogin extends BaseCommand {
     // ── --browser: ALSO open the headful Chromium via the shared VENDORED browser-login.mjs
     // helper (BaseCommand.openVendoredBrowser) — the same one `up --login` uses. ──
     if (flags.browser) {
-      await this.openVendoredBrowser(flags, { email, iamUrl, stateDir });
+      // Point the browser at the SLOT's own dash (base 8900 + slot*1000, from the
+      // resolved profile). LOGIN_DASH_URL still wins for the tunnel case. iamUrl and
+      // stateDir (⇒ PROFILE_DIR) are already slot-aware; the per-slot stateDir gives a
+      // distinct persistent profile per slot. At slot 0 dashPort is 8900, so this is
+      // byte-identical to the previous slot-0-only behaviour.
+      const dashPort = profile.portOverrides['saga-dash'] ?? 8900;
+      const dashUrl = process.env.LOGIN_DASH_URL || `http://localhost:${dashPort}`;
+      await this.openVendoredBrowser(flags, { email, iamUrl, stateDir, dashUrl });
     }
   }
 }

--- a/packages/node/saga-stack-cli/src/shared-flags.ts
+++ b/packages/node/saga-stack-cli/src/shared-flags.ts
@@ -119,11 +119,12 @@ export const baseFlags = {
     // CEILING 9 (M7 MINOR): the mesh's rabbitmq (:5672) and rabbitmq-mgmt (:15672)
     // differ by 10000 = 10 * the 1000 stride, so slot 10's rabbitmq (:15672) would
     // collide with slot 0's rabbitmq-mgmt (:15672). Cap at 9 so every slot's full
-    // resolved port band stays disjoint. Slot > 0 is a BACKEND sub-stack (the
-    // literal-port backends + browser frontends are excluded — see derive-instance).
+    // resolved port band stays disjoint. Slot > 0 is a BACKEND + FRONTEND sub-stack:
+    // the saga-dash/coach-web/connect-web frontends run on their OFFSET port; only the
+    // literal-port playback trio stays excluded (soa#271 — see derive-instance).
     max: 9,
     description:
-      'stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> BACKEND sub-stack — the literal-port backends + browser frontends stay on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.',
+      'stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.',
   }),
   'output-json': Flags.boolean({
     description: 'emit structured JSON on stdout instead of human-readable text',


### PR DESCRIPTION
> Proposed convenience tooling for saga-stack-cli to help exploratory testing by devs who need to do comparisons (either comparing same-behaviors between stacks, or two frontends to show the difference of a style of bug fix on the same stack data). Companion PR: #319.

## What

Makes `ss stack login --browser` work at any slot instead of hard-refusing at `--slot > 0`. The headful Chromium now opens against the **slot's own dash** (`8900 + slot*1000`) via the `dashUrl` override that `openVendoredBrowser` already exposes (the same one `e2e --hold` uses).

Concretely, this enables two isolated logged-in browsers against two backend stacks:

```
ss stack up    --slot 1        ss stack up    --slot 2
ss stack login --slot 1 --browser   ss stack login --slot 2 --browser
```

→ two Chromiums: profiles `/tmp/sds-synthetic-s1/browser-profile` vs `-s2`, iam `:4010` vs `:5010`, dash `:9900` vs `:10900`.

## Why

Running two stacks on two slots and logging into each in a real browser previously wasn't possible — `--browser` refused above slot 0 because `DASH_URL` was the only value in the browser-open seam not already slot-aware (`iamUrl` and the per-slot `PROFILE_DIR` already were). This threads that last value through.

## How it stays safe

- **Slot 0 byte-identical.** `portOverrides['saga-dash']` is `8900` at slot 0, so `DASH_URL` resolves exactly as before; the existing slot-0 `--browser` test passes unchanged.
- **Cookie/state isolation is structural.** Each slot's browser is a separate `launchPersistentContext` bound to a distinct per-slot `stateDir` user-data dir — separate cookies, localStorage, everything. No per-slot profile suffix needed; isolation rides on the same per-slot `stateDir` that already isolates each stack's pid ledger and cookie jar. (See the design decision in the spec.)
- **`LOGIN_DASH_URL` still wins** over the computed slot URL (tunnel/manual escape hatch), with a dedicated test.
- No `up.ts` change; `up --login` browser-opening stays slot-0-only by design.

## Also

Corrects the now-stale `slot` flag comment + `--help` description in `shared-flags.ts` (frontends became slottable in soa#271 — they run on their offset port; only the literal-port playback trio stays on slot 0) and regenerates the tracked `oclif.manifest.json` to match. Runtime `default`/`min`/`max` unchanged.

## Test plan

- `pnpm test` — 1164 pass (added: slot-1 `--browser` opens `:9900`/`:4010`/`-s1` profile; `LOGIN_DASH_URL` precedence).
- `pnpm check-types` — clean. `pnpm lint` — 0 errors.
- Zero-build smoke: `node bin/dev.js stack login --help` shows the corrected `--slot` text and an unrestricted `--browser`.

## Design docs

- Spec: `docs/superpowers/specs/2026-07-15-slot-aware-browser-login-design.md`
- Plan: `docs/superpowers/plans/2026-07-15-slot-aware-browser-login.md`

This is Phase 1 of a two-phase effort; Phase 2 (multiple frontend versions against one stack) is [#319](https://github.com/saga-ed/soa/pull/319), stacked on top of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
