### PR TITLE
test(saga-stack-cli): stop the bundled-mirror flow list drifting main red

### DIFF
--- a/packages/node/saga-stack-cli/src/core/flow/__tests__/load.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/flow/__tests__/load.unit.test.ts
@@ -25,13 +25,29 @@ const EXAMPLE_PATH = fileURLToPath(
 );
 const EXAMPLE_TEXT = readFileSync(EXAMPLE_PATH, 'utf8');
 
+/**
+ * The flows the bundled example must ALWAYS carry — asserted with
+ * `arrayContaining`, deliberately NOT as an exact list.
+ *
+ * `examples/flows/saga-dash.flows.json` is a MIRROR that legitimately gains flows
+ * over time, and an exact list turns every such addition into an unrelated red
+ * build in a file the author never touched. That has now bitten twice: 6b6571f
+ * (patched reactively by 62977b1) and #308/fc4440c (soa#312, which left main red).
+ * Pinning the literal a third time would just reset the trap.
+ *
+ * This still catches the regression that actually matters — a load-bearing flow
+ * going MISSING from the mirror. Flow CONTENT is asserted below (journey's 8
+ * ordered stages, connect-session's prerequisite), which is the real coverage.
+ */
+const LOAD_BEARING_FLOWS = ['journey', 'connect-session', 'connect-add-student'];
+
 describe('parseFlowManifest — the bundled example validates', () => {
   it('parses against the zod schema and exposes the spa + bundled flows', () => {
     const m = parseFlowManifest(EXAMPLE_TEXT, EXAMPLE_PATH);
     expect(m.schemaVersion).toBe(1);
     expect(m.spa.id).toBe('saga-dash');
     expect(m.spa.system).toBe('saga-dash');
-    expect(m.flows.map((f) => f.name)).toEqual(['journey', 'connect-session', 'connect-add-student']);
+    expect(m.flows.map((f) => f.name)).toEqual(expect.arrayContaining(LOAD_BEARING_FLOWS));
   });
 
   it('strips unknown top-level keys (the example carries a $comment annotation)', () => {
@@ -90,7 +106,9 @@ describe('loadFlowManifest — injectable reader seam (no disk IO)', () => {
       return EXAMPLE_TEXT;
     });
     expect(reads).toEqual(['/virtual/flows.json']);
-    expect(m.flows.map((f) => f.name)).toEqual(['journey', 'connect-session', 'connect-add-student']);
+    // This test's job is the READER SEAM (it parsed exactly what the reader
+    // returned) — the mirror's flow list is incidental here, so same rule as above.
+    expect(m.flows.map((f) => f.name)).toEqual(expect.arrayContaining(LOAD_BEARING_FLOWS));
   });
 
   it('wraps a reader error in a path-tagged message', () => {


### PR DESCRIPTION
Fixes #312. **main is currently red** — this makes it green and stops the same break recurring.

## What's broken

`src/core/flow/__tests__/load.unit.test.ts` fails on `origin/main`:

| | flows |
| --- | --- |
| `examples/flows/saga-dash.flows.json` | `journey, connect-session, session-viewer-observations, connect-add-student` |
| `load.unit.test.ts` (34 + 93) | `['journey', 'connect-session', 'connect-add-student']` |

`fc4440c` (#308, @dmelvin) added `session-viewer-observations` to the bundled **mirror** — a good change — but the test pins the exact list, so it went red in a file that PR never touched. Verified: green at `fc4440c^` (3 flows / expects 3), red at `fc4440c` (4 flows / expects 3).

## Why not just re-pin the literal

Because this is the **second** time. The stale line came from `62977b1` (@nneri): *"load.unit expects connect-add-student in the bundled example (**6b6571f follow-up**)"* — i.e. the identical drift, patched reactively. Re-pinning a third time just resets the trap for the next person who adds a flow.

## The change

Assert `arrayContaining(LOAD_BEARING_FLOWS)` rather than an exact list:

- a flow **added** to the mirror no longer reds an unrelated build (the recurring break), and
- a load-bearing flow going **missing** is still caught (the regression that matters).

Neither test needs the exact list to do its job — one is *"parses against the zod schema / exposes the spa + flows"*, the other is about the **reader seam**. The real coverage is the content assertions right below, which are untouched: journey's 8 ordered stages, connect-session's prerequisite.

## Verification

- Reproduced on a clean `origin/main` checkout: **2 failed**.
- After: **1163 passed / 98 files**, check-types clean.
- **Proved it still catches removals**: temporarily dropped `connect-add-student` from the mirror → the test failed as intended → restored.

Found while merging main into the soa#305 branch (#306), which carries the local expectation fix so it can stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)