### PR TITLE
fix(saga-stack-cli): develop coach hands off against THIS slot's iam (connect-slotting M0)

### DIFF
--- a/packages/node/saga-stack-cli/src/commands/develop/__tests__/coach.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/__tests__/coach.int.test.ts
@@ -280,6 +280,21 @@ describe('develop coach — slot awareness (slot > 0)', () => {
   it('--tunnel --slot 2 hard-errors (tunnel fronts fixed slot-0 ports)', async () => {
     await expect(DevelopCoach.run(['--tunnel', '--slot', '2', ...ws()], config)).rejects.toThrow(/slot 2:.*slot-0 browser ports/);
   });
+
+  it("mints the hand-off jar against THIS SLOT's iam, not slot 0's", async () => {
+    // Regression: handoff() hardcoded `slot: 0` while the coach-web URL it opened
+    // already used the slot-offset port — so `--slot 2` minted a jar against SLOT 0's
+    // iam and opened slot 2's app (a jar for the wrong stack; or, with slot 0 down, a
+    // mint-failure warning on an otherwise healthy slot-2 run).
+    //
+    // Unlike the hand-off PORT (the harness mocks the port probe to fixed values, per
+    // the sibling test above), the iam URL is derived from the slot ALONE
+    // (`resolveIamUrl`: :3010 + slot*1000), so it IS assertable here.
+    await DevelopCoach.run(['--slot', '2', ...ws()], config);
+    expect(posts).toHaveLength(1);
+    expect(posts[0].url).toContain(':5010'); // 3010 + 2*1000
+    expect(posts[0].url).not.toContain(':3010'); // slot 0's iam — the bug
+  });
 });
 
 describe('develop coach — admin (descoped, mock-backed)', () => {

--- a/packages/node/saga-stack-cli/src/commands/develop/coach.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/coach.ts
@@ -367,7 +367,15 @@ export default class DevelopCoach extends BaseCommand {
 
     // Hand off a HEADED, logged-in coach-web at the scenario's route — the slot's
     // OFFSET coach-web port + the per-slot state dir resolved above.
-    await this.handoff(flags, scenario, spec, resolved, runtime.launchContext.ports['coach-web'], stateDir);
+    await this.handoff(
+      flags,
+      scenario,
+      spec,
+      resolved,
+      runtime.launchContext.ports['coach-web'],
+      stateDir,
+      profile.slot,
+    );
   }
 
   /**
@@ -513,12 +521,20 @@ export default class DevelopCoach extends BaseCommand {
   }
 
   /**
-   * Mint the persona cookie jar (slot-0) and open a HEADED, auto-logged-in coach-web
-   * at the scenario's deep-linked route via the generalized `openVendoredBrowser`
-   * ({ repoEnvVar:'COACH', appDir:'apps/web/coach-web', port:8800 }). Mirrors the M2
-   * `holdEpilogue` email-param path but for a first-class command. Best-effort: a
-   * failed jar / browserless host WARNS, never crashes — the stack is up and seeded.
-   * The headed browser holds the terminal until the developer closes it.
+   * Mint the persona cookie jar for THIS SLOT and open a HEADED, auto-logged-in
+   * coach-web at the scenario's deep-linked route via the generalized
+   * `openVendoredBrowser` ({ repoEnvVar:'COACH', appDir:'apps/web/coach-web',
+   * port:8800 }). Mirrors the M2 `holdEpilogue` email-param path but for a
+   * first-class command. Best-effort: a failed jar / browserless host WARNS, never
+   * crashes — the stack is up and seeded. The headed browser holds the terminal
+   * until the developer closes it.
+   *
+   * `slot` MUST be threaded: it selects the iam the jar is minted against
+   * (`mintNativeLoginJar` → `resolveIamUrl({ slot })`, offset :3010 + slot*1000).
+   * It was hardcoded to 0 while the printed `coachWebUrl` already used the
+   * slot-offset `spaPort`, so `--slot N` minted against SLOT 0's iam and opened
+   * slot N's coach-web — a jar for the wrong stack, or (with slot 0 down) a mint
+   * failure warning on an otherwise healthy slot-N run.
    */
   private async handoff(
     flags: WorkspaceFlags & { porcelain: boolean; 'output-json': boolean },
@@ -527,10 +543,11 @@ export default class DevelopCoach extends BaseCommand {
     resolved: ReturnType<typeof resolveFlow>,
     spaPort: number | undefined,
     stateDir: string,
+    slot: number,
   ): Promise<void> {
     const email = spec.email;
 
-    const res = await this.mintNativeLoginJar({ email, slot: 0, stateDir });
+    const res = await this.mintNativeLoginJar({ email, slot, stateDir });
     if (!res.ok) {
       this.warn(
         `hand-off: session mint failed (HTTP ${res.status}) for ${email} — the stack is up + seeded but no ` +


### PR DESCRIPTION
M0 of the `develop connect` slot-awareness plan: fix the residual slot-0 hardcode in **coach**, the reference implementation, *before* connect is built to match it.

## The bug

`handoff()` hardcoded the mint slot:

```ts
const res = await this.mintNativeLoginJar({ email, slot: 0, stateDir });   // ← always slot 0
```

…while the `coachWebUrl` it then opens already uses the slot-offset `spaPort` from `launchContext.ports[coach-web]`. So `ss develop coach --slot 2`:

- minted the persona cookie jar against **slot 0's iam** (`resolveIamUrl` → `:3010`)
- opened **slot 2's coach-web** (`:10800`)

A jar for the wrong stack when slot 0 is up — or, now that slot 0 is typically down, a `session mint failed` warning on an otherwise perfectly healthy slot-2 run.

## Why it survived this long

Neither `slotAware()` (`bf089c5`) nor the profile threading (`c8f96e4`) touched the hand-off path. It's also invisible to the `--real-content` lane, whose Playwright browsers get their iam from `serviceUrlEnv(ports)` independently of this jar — which is why live `--slot 2 --real-content` runs looked fine.

## Fix

Thread `profile.slot` into `handoff()` and mint against it. Two lines plus the signature.

## Verification

- **Mutation-checked, not merely green:** restoring `slot: 0` fails the new test and nothing else.
- The new assertion is possible where the sibling slot test's isn't: the int harness mocks the port probe to fixed values (so it cannot assert the real hand-off *port*), but the iam URL derives from the **slot alone**, so `:5010` vs `:3010` is directly assertable.
- tsc + lint (0 errors) clean; suite **1202 passed / 103 files**.

## Context

Found while inventorying `develop connect` for slot parity. Coach is the template that work will copy, so this needed fixing first. Independent of #314 / #315 — different files, lands in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)