### PR TITLE
fix(saga-stack-cli): snapshot restore must fail loudly and refuse a migrated-ahead DB

### DIFF
--- a/packages/node/saga-stack-cli/src/commands/stack/snapshot/__tests__/snapshot.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/snapshot/__tests__/snapshot.int.test.ts
@@ -242,6 +242,38 @@ describe('stack snapshot restore — restore-as-owner + guards', () => {
     await expect(SnapshotRestore.run(['demo', '--force'], config)).rejects.toThrow(/ahead|stack up --pull/i);
   });
 
+  it('DB-AHEAD guard is HARD: a live head past the snapshot rev refuses, even with --force', async () => {
+    await store(); // manifest captured at CANNED_REV
+    // The live DBs answer with a NEWER head; the checkout knows both, in order.
+    const LIVE_REV = 'mig_002';
+    vi.spyOn(
+      BaseCommand.prototype as unknown as { getSnapshotIO: () => SnapshotIO },
+      'getSnapshotIO',
+    ).mockReturnValue(fakeSnapshotIO({ ioCalls, schemaRev: LIVE_REV }));
+    vi.spyOn(
+      SnapshotRestore.prototype as unknown as {
+        localMigrationsFor: (s: SnapshotManifest) => LocalMigrations;
+      },
+      'localMigrationsFor',
+    ).mockImplementation((s: SnapshotManifest) => {
+      const m: Record<string, readonly string[]> = {};
+      for (const d of s.databases) m[d.db] = [CANNED_REV, LIVE_REV];
+      return m as LocalMigrations;
+    });
+    await expect(SnapshotRestore.run(['demo', '--force'], config)).rejects.toThrow(/AHEAD/);
+    // Guard fires BEFORE any dump is applied — nothing restored.
+    expect(dbsCalled('pgRestore')).toHaveLength(0);
+    expect(ioCalls.some((c) => c.op === 'redisFlushdb')).toBe(false);
+  });
+
+  it('DB-AHEAD guard probes only migrate-deploy pg DBs (skips db-push + mongo)', async () => {
+    await store();
+    await SnapshotRestore.run(['demo'], config);
+    expect(dbsCalled('readSchemaRev')).toContain('iam_local');
+    expect(dbsCalled('readSchemaRev')).not.toContain('iam_pii_local');
+    expect(dbsCalled('readSchemaRev')).not.toContain('connectv3');
+  });
+
   it('errors clearly when the snapshot does not exist', async () => {
     await expect(SnapshotRestore.run(['nope'], config)).rejects.toThrow(/no valid snapshot manifest/);
   });

--- a/packages/node/saga-stack-cli/src/commands/stack/snapshot/restore.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/snapshot/restore.ts
@@ -5,11 +5,15 @@
  * RESTORES a named snapshot over the running stack: `pg_restore --clean
  * --if-exists` (AS each DB's OWNER role — snapshot invariant: ledger_local → the
  * `ledger` role) and `mongorestore --archive --drop`, then optionally flushes
- * redis (rostering cache invalidation, PR #82). Two pure guards (in
- * `restorePlan`) gate the restore BEFORE any IO:
+ * redis (rostering cache invalidation, PR #82). Three guards (evaluated purely
+ * in `restorePlan`) gate the restore before any dump is applied:
  *   - PROFILE mismatch (snapshot vs live SEED_PROFILE) — bypassable with --force.
  *   - SNAPSHOT-AHEAD (a pg DB's recorded `schemaRev` is unknown in the local
  *     checkout) — HARD; the snapshot is newer than your code, run `stack up --pull`.
+ *   - DB-AHEAD (a live pg DB's `_prisma_migrations` head — probed via
+ *     `readSchemaRev` before planning — is ahead of the snapshot's recorded
+ *     rev) — HARD; `--clean` would half-apply and rewind migration history.
+ *     Re-store the fixture on the current schema instead.
  *
  * THIN: the pure `restorePlan` orders the actions + evaluates the guards; the
  * injectable `SnapshotIO` (`this.getSnapshotIO()`) does the `docker exec`. Local
@@ -62,7 +66,8 @@ export default class SnapshotRestore extends BaseCommand {
         'restore only the DBs in the dependency closure of these services (comma-list)',
     }),
     force: Flags.boolean({
-      description: 'bypass the profile-mismatch guard (does NOT bypass the snapshot-ahead guard)',
+      description:
+        'bypass the profile-mismatch guard (does NOT bypass the snapshot-ahead / db-ahead guards)',
       default: false,
     }),
     'flush-redis': Flags.boolean({
@@ -117,20 +122,29 @@ export default class SnapshotRestore extends BaseCommand {
     const ctx = this.scriptContextFromFlags(flags);
     const localMigrations = this.localMigrationsFor(snapshot, ctx);
 
+    const io = this.getSnapshotIO();
+    const pgC = postgresContainer();
+    const mongoC = mongoContainer();
+
+    // The DB-AHEAD guard input needs the live pg heads, so assert + probe BEFORE
+    // planning (pure guards still all evaluate inside restorePlan).
+    await io.assertPgRunning(pgC);
+    const liveSchemaRevs: Partial<Record<DbId, string | null>> = {};
+    for (const entry of snapshot.databases) {
+      if (entry.schemaRev === null) continue; // db-push / mongo — nothing to compare
+      liveSchemaRevs[entry.db] = await io.readSchemaRev(entry.db, pgC);
+    }
+
     const plan = restorePlan(snapshot, manifest, localMigrations, {
       force: flags.force,
       currentProfile: process.env.SEED_PROFILE,
+      liveSchemaRevs,
     });
 
     if (!plan.ok) {
       this.error(plan.guardFailures.map((g) => g.message).join('\n'));
     }
 
-    const io = this.getSnapshotIO();
-    const pgC = postgresContainer();
-    const mongoC = mongoContainer();
-
-    await io.assertPgRunning(pgC);
     if (plan.actions.some((a) => a.engine === 'mongo')) {
       await io.assertMongoRunning(mongoC);
     }

--- a/packages/node/saga-stack-cli/src/core/snapshot/__tests__/plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/snapshot/__tests__/plan.unit.test.ts
@@ -213,6 +213,65 @@ describe('restorePlan — SNAPSHOT-AHEAD guard (HARD, not bypassable)', () => {
   });
 });
 
+describe('restorePlan — DB-AHEAD guard (HARD, not bypassable)', () => {
+  // buildSnapshot captures `iam_local_mig_001`; the checkout knows one newer.
+  const REV = 'iam_local_mig_001';
+  const NEWER = 'iam_local_mig_002';
+  const snap = buildSnapshot(['iam_local']);
+  const ordered: LocalMigrations = { iam_local: [REV, NEWER] };
+
+  it('refuses when the live head is AHEAD of the snapshot rev', () => {
+    const plan = restorePlan(snap, manifest, ordered, {
+      liveSchemaRevs: { iam_local: NEWER },
+    });
+    expect(plan.ok).toBe(false);
+    const g = plan.guardFailures.find((f) => f.kind === 'db-ahead');
+    expect(g?.db).toBe('iam_local');
+    expect(g?.bypassableByForce).toBe(false);
+    expect(g?.message).toMatch(/AHEAD/);
+    expect(g?.message).toMatch(/rewind _prisma_migrations/);
+  });
+
+  it('is HARD: --force does NOT bypass a migrated-ahead DB', () => {
+    const plan = restorePlan(snap, manifest, ordered, {
+      liveSchemaRevs: { iam_local: NEWER },
+      force: true,
+    });
+    expect(plan.ok).toBe(false);
+  });
+
+  it('refuses when the live head is unknown to the local checkout', () => {
+    const plan = restorePlan(snap, manifest, ordered, {
+      liveSchemaRevs: { iam_local: 'not_a_known_migration' },
+    });
+    expect(plan.ok).toBe(false);
+    expect(plan.guardFailures.some((f) => f.kind === 'db-ahead')).toBe(true);
+  });
+
+  it('allows an in-sync DB (live head equals the snapshot rev)', () => {
+    const plan = restorePlan(snap, manifest, ordered, {
+      liveSchemaRevs: { iam_local: REV },
+    });
+    expect(plan.ok).toBe(true);
+    expect(plan.guardFailures).toHaveLength(0);
+  });
+
+  it('allows a live head strictly BEHIND the snapshot rev (dump carries the newer schema)', () => {
+    const newerSnap = buildSnapshot(['iam_local'], { revFor: () => NEWER });
+    const plan = restorePlan(newerSnap, manifest, ordered, {
+      liveSchemaRevs: { iam_local: REV },
+    });
+    expect(plan.ok).toBe(true);
+  });
+
+  it('skips the guard when no live head was observed (absent or null)', () => {
+    expect(restorePlan(snap, manifest, ordered, {}).ok).toBe(true);
+    expect(
+      restorePlan(snap, manifest, ordered, { liveSchemaRevs: { iam_local: null } }).ok,
+    ).toBe(true);
+  });
+});
+
 describe('restorePlan — restore-as-owner + fully-restored services', () => {
   const full = buildSnapshot([...PG_APP_DBS, 'connectv3']);
   const known = knownMigrations(full);

--- a/packages/node/saga-stack-cli/src/core/snapshot/plan.ts
+++ b/packages/node/saga-stack-cli/src/core/snapshot/plan.ts
@@ -187,10 +187,10 @@ export interface RestoreDbAction {
 
 /** A guard that blocks (or warns about) a restore. */
 export interface RestoreGuardFailure {
-  kind: 'profile-mismatch' | 'snapshot-ahead';
-  /** The offending db (snapshot-ahead only). */
+  kind: 'profile-mismatch' | 'snapshot-ahead' | 'db-ahead';
+  /** The offending db (snapshot-ahead / db-ahead only). */
   db?: DbId;
-  /** Whether `--force` bypasses this guard (profile only; snapshot-ahead is hard). */
+  /** Whether `--force` bypasses this guard (profile only; snapshot-ahead and db-ahead are hard). */
   bypassableByForce: boolean;
   message: string;
 }
@@ -207,6 +207,16 @@ export interface RestorePlanOptions {
    * guard fires unless `force`. Omit to skip the profile guard (can't compare).
    */
   currentProfile?: string;
+  /**
+   * The LIVE DB's `_prisma_migrations` head per pg DB (the command reads each
+   * via `SnapshotIO.readSchemaRev` — the same probe store-time capture uses).
+   * Feeds the DB-AHEAD guard: `pg_restore --clean` only drops objects the dump
+   * knows about, so restoring an older snapshot over a migrated-ahead DB
+   * half-applies (FK-blocked drop chains) AND rewinds `_prisma_migrations`,
+   * leaving an applied-but-unrecorded migration that fails the next migrate.
+   * A missing/`null` entry skips the check for that DB (can't compare).
+   */
+  liveSchemaRevs?: Partial<Record<DbId, string | null>>;
 }
 
 export interface RestorePlan {
@@ -236,6 +246,12 @@ export interface RestorePlan {
  *    Skipped for `iam_pii_local` (db push, `schemaRev:null`) and `connectv3`
  *    (mongo, `schemaRev:null`) — both carry a `null` rev, so the predicate
  *    short-circuits without needing the engine.
+ *  - DB-AHEAD GUARD (HARD, not bypassable): per pg DB with a captured rev AND
+ *    an observed live head (`opts.liveSchemaRevs`), refuse if the live head is
+ *    ahead of (or unknown relative to) the snapshot's rev — the DB has been
+ *    migrated past the dump, so `--clean` would half-apply and rewind
+ *    `_prisma_migrations`. A live head strictly BEHIND the snapshot's rev is
+ *    allowed: the dump carries the newer schema wholesale.
  */
 export function restorePlan(
   snapshot: SnapshotManifest,
@@ -275,6 +291,32 @@ export function restorePlan(
           `Run \`stack up --pull\` to update migrations, then retry.`,
       });
     }
+  }
+
+  // DB-AHEAD GUARD (per pg DB with a captured rev + an observed live head).
+  for (const entry of snapshot.databases) {
+    if (entry.schemaRev === null) continue; // db-push / mongo — no history to compare
+    const live = opts.liveSchemaRevs?.[entry.db];
+    if (live == null || live === entry.schemaRev) continue; // unobservable / in sync
+    // Migration ids are timestamp-prefixed, so the local list is chronological:
+    // a live head strictly EARLIER than the snapshot's rev is a behind-DB
+    // (restore carries it forward — fine); later, or unknown to the checkout,
+    // means the live DB is ahead of the dump.
+    const known = localMigrations[entry.db] ?? [];
+    const liveIdx = known.indexOf(live);
+    const snapIdx = known.indexOf(entry.schemaRev);
+    if (liveIdx !== -1 && snapIdx !== -1 && liveIdx < snapIdx) continue;
+    guardFailures.push({
+      kind: 'db-ahead',
+      db: entry.db,
+      bypassableByForce: false,
+      message:
+        `live '${entry.db}' is at migration '${live}', AHEAD of the snapshot's ` +
+        `'${entry.schemaRev}' — pg_restore --clean cannot drop objects the dump does ` +
+        `not know about, so restoring would half-apply and rewind _prisma_migrations. ` +
+        `Re-store the fixture on the current schema, or reset '${entry.db}' to the ` +
+        `snapshot's schema first.`,
+    });
   }
 
   // Order restore actions by manifest declaration order, restricted to the

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/snapshot-pg-restore-failed.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/snapshot-pg-restore-failed.unit.test.ts
@@ -1,0 +1,58 @@
+/**
+ * `pgRestoreFailed` — the pure pg_restore exit classifier (runtime/snapshot.ts).
+ *
+ * The regression this pins: pg_restore prefixes client-side failures as
+ * `pg_restore: error: …` (with the server's `ERROR:` embedded MID-line), and
+ * the original bare-`ERROR:`-only detector never matched that shape — a
+ * schema-drifted restore printed 7 errors, half-applied, and still reported
+ * success. The stderr fixtures below are verbatim shapes from that incident
+ * (a Cohort FK, unknown to the dump, blocked the TutoringPeriod --clean drop chain).
+ */
+import { describe, expect, it } from 'vitest';
+import { pgRestoreFailed } from '../snapshot.js';
+
+/** Verbatim shape of the incident stderr (pg_restore-prefixed errors only). */
+const DRIFTED_RESTORE_STDERR = [
+  'pg_restore: error: could not execute query: ERROR:  cannot drop constraint TutoringPeriod_pkey on table public."TutoringPeriod" because other objects depend on it',
+  'DETAIL:  constraint Cohort_periodId_fkey on table public."Cohort" depends on index public."TutoringPeriod_pkey"',
+  'HINT:  Use DROP ... CASCADE to drop the dependent objects too.',
+  'Command was: ALTER TABLE IF EXISTS ONLY public."TutoringPeriod" DROP CONSTRAINT IF EXISTS "TutoringPeriod_pkey";',
+  'pg_restore: error: COPY failed for table "TutoringPeriod": ERROR:  duplicate key value violates unique constraint "TutoringPeriod_pkey"',
+  'pg_restore: warning: errors ignored on restore: 7',
+].join('\n');
+
+/** Benign --if-exists noise: objects missing on a fresh DB ⇒ non-zero exit, no error. */
+const BENIGN_IF_EXISTS_STDERR = [
+  'pg_restore: warning: errors ignored on restore: 0',
+  'pg_restore: table "TutoringPeriod" does not exist, skipping',
+].join('\n');
+
+describe('pgRestoreFailed', () => {
+  it('FAILS on pg_restore-prefixed errors (the swallowed-incident shape)', () => {
+    expect(pgRestoreFailed(1, DRIFTED_RESTORE_STDERR)).toBe(true);
+  });
+
+  it('FAILS on bare server ERROR:/FATAL: lines (the shape the old regex caught)', () => {
+    expect(pgRestoreFailed(1, 'ERROR:  relation "TutoringPeriod" already exists')).toBe(true);
+    expect(pgRestoreFailed(1, '  FATAL:  terminating connection')).toBe(true);
+  });
+
+  it('tolerates a non-zero exit with only benign warnings (--if-exists skips)', () => {
+    expect(pgRestoreFailed(1, BENIGN_IF_EXISTS_STDERR)).toBe(false);
+  });
+
+  it('never fails a clean exit, whatever stderr says', () => {
+    expect(pgRestoreFailed(0, DRIFTED_RESTORE_STDERR)).toBe(false);
+    expect(pgRestoreFailed(0, '')).toBe(false);
+  });
+
+  it('does not false-positive on an embedded mid-line ERROR: alone', () => {
+    // DETAIL/context lines quote the server error mid-line; only a LINE-LEADING
+    // marker (either shape) is a failure.
+    expect(pgRestoreFailed(1, 'DETAIL: the previous ERROR: was quoted here')).toBe(false);
+  });
+
+  it('treats a null exit (killed) with error output as failure', () => {
+    expect(pgRestoreFailed(null, DRIFTED_RESTORE_STDERR)).toBe(true);
+  });
+});

--- a/packages/node/saga-stack-cli/src/runtime/snapshot.ts
+++ b/packages/node/saga-stack-cli/src/runtime/snapshot.ts
@@ -58,8 +58,10 @@ export interface SnapshotIO {
    * `docker exec -i <container> pg_restore -U <ownerRole> -d <db> --clean
    * --if-exists` with `inPath` streamed via stdin (no shared host↔container
    * volume needed). Connects AS THE DB OWNER (snapshot invariant — ledger_local
-   * → `ledger`). pg_restore exits non-zero on benign warnings too, so a non-zero
-   * exit is only treated as failure when stderr carries a real `ERROR:`/`FATAL:`.
+   * → `ledger`). pg_restore exits non-zero on benign warnings too, so a
+   * non-zero exit is only treated as failure when stderr carries a real error
+   * (`pgRestoreFailed`: `pg_restore: error:`-prefixed or bare `ERROR:`/`FATAL:`
+   * lines) — then it REJECTS so the restore command exits non-zero.
    */
   pgRestore(db: string, container: string, ownerRole: string, inPath: string): Promise<void>;
 
@@ -187,6 +189,22 @@ async function isContainerRunning(container: string): Promise<boolean> {
 }
 
 /**
+ * Classify a pg_restore exit — PURE, exported for unit tests. pg_restore exits
+ * non-zero for benign `--if-exists` "does not exist, skipping" warnings too, so
+ * a non-zero exit alone is not failure; but real errors arrive in TWO shapes
+ * depending on phase: client-side lines prefixed `pg_restore: error:` (which
+ * embed the server's `ERROR:` mid-line) and bare server `ERROR:`/`FATAL:`
+ * lines. The original bare-`ERROR:`-only regex missed the prefixed shape, so a
+ * restore over a schema-drifted DB (FK-blocked `--clean` drop chains, failed
+ * COPYs) printed 7 errors and still reported success — a half-applied restore
+ * must FAIL the command instead.
+ */
+export function pgRestoreFailed(exitCode: number | null, stderr: string): boolean {
+  if (exitCode === 0) return false;
+  return /^pg_restore: (error|fatal):/im.test(stderr) || /^\s*(ERROR|FATAL):/m.test(stderr);
+}
+
+/**
  * The production SnapshotIO: every method shells out via `docker exec`. This is
  * the one place real container/DB processes are launched. Tests never call this
  * — they inject a fake through `BaseCommand.getSnapshotIO()`.
@@ -208,10 +226,7 @@ export function makeRealSnapshotIO(): SnapshotIO {
         ['exec', '-i', container, 'pg_restore', '-U', ownerRole, '-d', db, '--clean', '--if-exists'],
         { stdinFromFile: inPath },
       );
-      // pg_restore returns non-zero on benign warnings too (e.g. "object didn't
-      // exist, skipping" under --if-exists). Only a real ERROR:/FATAL: in stderr
-      // is a failure; otherwise surface warnings and continue.
-      if (exitCode !== 0 && /^\s*(ERROR|FATAL):/m.test(stderr)) {
+      if (pgRestoreFailed(exitCode, stderr)) {
         throw new Error(`pg_restore ${db} failed (exit=${exitCode}).\n${stderr}`);
       }
       if (stderr) process.stderr.write(stderr);


### PR DESCRIPTION
## Problem

`ss stack snapshot restore` over a DB that had been migrated **past** the dump half-applies and still reports success. Real incident (yesterday's `20260714120000_cohorts` migration in program-hub, restoring a fixture stored before it):

```
pg_restore: error: cannot drop constraint TutoringPeriod_pkey ... because other objects depend on it
DETAIL:  constraint Cohort_periodId_fkey on table public."Cohort" depends on ...
pg_restore: error: COPY failed for table "TutoringPeriod": ERROR: duplicate key value ...
pg_restore: warning: errors ignored on restore: 7
restored snapshot 'sessions-active' (11 database(s))     ← exit 0, green summary
```

`pg_restore --clean` can't drop objects the dump doesn't know about, so the new `Cohort` FK blocked the `TutoringPeriod` drop chain: that table kept its live rows while every other table went back to snapshot state — **and** `_prisma_migrations` was still overwritten, rewinding history so the cohorts migration became applied-but-unrecorded, which fails the next `migrate` with "relation already exists".

Two defects compounded:

1. **Swallowed errors** — the pgRestore failure detector matched only bare `^ERROR:`/`^FATAL:` lines, but pg_restore emits client-side failures as `pg_restore: error: …` (server `ERROR:` embedded mid-line). 7 real errors were classified as benign `--if-exists` noise → exit 0.
2. **One-directional guard** — SNAPSHOT-AHEAD (dump newer than checkout) is hard-refused, but DB-ahead-of-dump (the direction produced by the everyday "up --pull, then restore yesterday's fixture" flow) had no guard at all.

## Fix

- **`runtime/snapshot.ts`** — extract the exit classification into pure `pgRestoreFailed(exitCode, stderr)` matching both stderr shapes (`pg_restore: error:`-prefixed and bare `ERROR:`/`FATAL:`). A real error now rejects, so the restore command exits non-zero instead of printing a green summary over a half-applied restore. Benign `--if-exists` warnings still pass.
- **`core/snapshot/plan.ts`** — new hard `db-ahead` guard in `restorePlan`: refuses when a live pg DB's `_prisma_migrations` head is ahead of — or unknown relative to — the snapshot's captured rev (direction decided by position in the local, timestamp-ordered migration list). Live-behind restores stay allowed (the dump carries the newer schema wholesale). `--force` does not bypass, matching snapshot-ahead.
- **`commands/stack/snapshot/restore.ts`** — probe each migrate-deploy pg DB's live head via the existing `readSchemaRev` seam before planning and feed it to the guard; db-push (`schemaRev: null`) and mongo DBs are skipped.

## Testing

- 6 new `restorePlan` unit cases (ahead / unknown / in-sync / behind / unobserved / `--force`-is-hard).
- New pure-predicate suite pinning the incident's verbatim stderr shapes, including the no-false-positive case for mid-line `ERROR:` quotes.
- 2 new command-path integration tests: the guard refuses before any dump is applied (no `pgRestore`/`redisFlushdb` calls), and the live-head probe skips db-push/mongo DBs.
- Full CLI suite green: 104 files, 1215 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)