### PR TITLE
feat(saga-stack-cli): make `ss develop connect` slot-aware (M1–M6)

### DIFF
--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -329,7 +329,7 @@
           "type": "boolean"
         },
         "tunnel": {
-          "description": "point THIS run’s Connect browsers at the vms tunnel hosts (https://<label>.<moniker>.<VMS_BASE>) instead of localhost, so a REMOTE peer can reach the same room. Resolves the moniker via the vendored tunnel.sh (same machinery as `stack up --tunnel`). NOTE: this ONLY repoints these Playwright browsers’ URLs — it does NOT relaunch the stack, flip connect-web/rtsm/cookie env, or start frpc. You must have already run `ss stack up --tunnel` so the stack itself is tunnel-served. Connect is slot-0 only, so no slot guard is needed.",
+          "description": "point THIS run’s Connect browsers at the vms tunnel hosts (https://<label>.<moniker>.<VMS_BASE>) instead of localhost, so a REMOTE peer can reach the same room. Resolves the moniker via the vendored tunnel.sh (same machinery as `stack up --tunnel`). NOTE: this ONLY repoints these Playwright browsers’ URLs — it does NOT relaunch the stack, flip connect-web/rtsm/cookie env, or start frpc. You must have already run `ss stack up --tunnel` so the stack itself is tunnel-served. Slot-0 only.",
           "name": "tunnel",
           "allowNo": false,
           "type": "boolean"

--- a/packages/node/saga-stack-cli/src/commands/develop/__tests__/connect.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/__tests__/connect.int.test.ts
@@ -1,0 +1,248 @@
+/**
+ * `develop connect` SLOT-AWARENESS integration tests (gh_305) — the real oclif
+ * command with every BaseCommand IO seam faked (e2e.int.test.ts harness). NOTHING
+ * is spawned; the fake Runner/Launcher record the intended invocations.
+ *
+ * This suite lives beside the command (not in commands/e2e/__tests__ with the rest
+ * of connect's coverage) because it owns a DIFFERENT axis: those suites assert flow
+ * orchestration (prerequisite recursion, --reuse, --fake-media, checkpoint compat)
+ * at slot 0 and are deliberately slot-agnostic; this one owns the slot plumbing —
+ * state dir, snapshot root, offset service URLs — and mirrors coach.int.test.ts's
+ * slot block.
+ *
+ * Every assertion here PROVES the offset (a concrete slot-2 path/port), never
+ * merely that `--slot 2` failed to throw: the bug this suite guards is `--slot N`
+ * silently running against slot 0, which throws nothing at all.
+ */
+
+import { resolve, join } from 'node:path';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir, homedir } from 'node:os';
+import { Config } from '@oclif/core';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BaseCommand } from '../../../base-command.js';
+import type { ScriptInvocation } from '../../../runtime/index.js';
+import type { CheckpointStore } from '../../../runtime/index.js';
+import { useTempSnapshotsDir } from '../../../__tests__/helpers/env.js';
+import { installCoreSeams } from '../../../__tests__/helpers/seams.js';
+import DevelopConnect from '../connect.js';
+
+const PKG_ROOT = process.cwd();
+const SOA_ROOT = resolve(PKG_ROOT, '..', '..', '..');
+const DEV_ROOT = '/fixed/dev';
+
+let DASH_ROOT: string;
+let config: Config;
+let runs: ScriptInvocation[];
+let launcherSpy: ReturnType<typeof vi.spyOn>;
+
+/**
+ * The snapshot root observed AT CHECKPOINT-STORE CONSTRUCTION — the M2 ordering
+ * probe. The store resolves `$SAGA_MESH_SNAPSHOTS_DIR` at CALL time, so the
+ * invariant is that `applyInstanceEnv(profile)` precedes the first bake/restore;
+ * the command satisfies it by building the store in between. Sampling the env in
+ * the spy makes the ordering (not just the end state) assertable at that point.
+ */
+let rootAtStoreBuild: string | undefined;
+
+// Hermetic snapshot root for the slot-0 baseline. At slot > 0 applyInstanceEnv
+// legitimately OVERRIDES this with the profile's `~/.saga-mesh/snapshots-s<N>` —
+// that override is the property under test, and the getCheckpointStore fake below
+// means no real store ever forms, so nothing is read from or written to $HOME.
+const snapDir = useTempSnapshotsDir('saga-connect-slot-');
+
+function installSeams(): void {
+  const seams = installCoreSeams({ pidBase: 2000, prepFresh: false, captureLauncherSpy: true });
+  runs = seams.runs;
+  launcherSpy = seams.launcherSpy as ReturnType<typeof vi.spyOn>;
+
+  // Record the snapshot root as the store is CONSTRUCTED, then hand back a store
+  // whose `load` reports "no checkpoint" so the prerequisite falls back to a normal
+  // headless replay — no snapshot IO, hermetic.
+  rootAtStoreBuild = undefined;
+  const store: CheckpointStore = {
+    load: () => null,
+    bake: async () => {},
+    restore: async () => {},
+  };
+  vi.spyOn(
+    BaseCommand.prototype as unknown as { getCheckpointStore: () => CheckpointStore },
+    'getCheckpointStore',
+  ).mockImplementation(() => {
+    rootAtStoreBuild = process.env.SAGA_MESH_SNAPSHOTS_DIR;
+    return store;
+  });
+}
+
+/** Workspace flags: stub saga-dash (no flows.json → bundled fallback) + real soa. */
+function ws(): string[] {
+  return ['--saga-dash', DASH_ROOT, '--soa', SOA_ROOT, '--dev', DEV_ROOT];
+}
+
+function playwrightRuns(): ScriptInvocation[] {
+  return runs.filter((r) => r.command === 'pnpm' && r.args.includes('playwright'));
+}
+
+/** The headed live-session spawn (the flow's terminal stage). */
+function liveRun(): ScriptInvocation | undefined {
+  return playwrightRuns().find((r) => r.args.includes('interactive-connect'));
+}
+
+/** The state dir the command pointed the launcher at. */
+function launcherStateDir(): unknown {
+  return launcherSpy.mock.calls[0]?.[0];
+}
+
+beforeAll(() => {
+  DASH_ROOT = mkdtempSync(join(tmpdir(), 'saga-dash-connect-slot-'));
+});
+afterAll(() => {
+  rmSync(DASH_ROOT, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  config = await Config.load(PKG_ROOT);
+  installSeams();
+  vi.spyOn(BaseCommand.prototype, 'log').mockImplementation(() => {});
+  vi.spyOn(BaseCommand.prototype, 'warn').mockImplementation(((m: string) => m) as never);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('develop connect — slot awareness (slot > 0)', () => {
+  it('--slot 2 targets slot 2: offset state dir, offset iam/connect URLs on the live session', async () => {
+    await DevelopConnect.run(['--slot', '2', ...ws()], config);
+
+    // The launcher gets the SLOT's pid/log dir — without it every slot collides on
+    // ServiceLauncher's default /tmp/sds-synthetic pidfiles.
+    expect(launcherStateDir()).toBe('/tmp/sds-synthetic-s2');
+
+    // The headed room drives the slot-2 OFFSET services (offset = slot * 1000).
+    // These come from `ports` reaching executeResolvedFlow; without them
+    // playwrightEnv skips serviceUrlEnv and the specs' lane.ts silently falls back
+    // to the base ports below.
+    const live = liveRun();
+    expect(live?.env?.PLAYWRIGHT_IAM_URL).toBe('http://localhost:5010'); // 3010 + 2000
+    expect(live?.env?.PLAYWRIGHT_CONNECT_API_URL).toBe('http://localhost:8106'); // 6106 + 2000
+    expect(live?.env?.PLAYWRIGHT_BASE_URL).toBe('http://localhost:10900'); // saga-dash 8900 + 2000
+    // Explicitly NOT slot 0's iam — the silent-slot-0 bug's signature.
+    expect(live?.env?.PLAYWRIGHT_IAM_URL).not.toBe('http://localhost:3010');
+  });
+
+  it('--slot 2 threads the offset ports into the JOURNEY PREREQUISITE too (deps ride the recursion)', async () => {
+    await DevelopConnect.run(['--slot', '2', ...ws()], config);
+
+    // The prerequisite is a separate ResolvedFlow built through `schedule`; it seeds
+    // the room's data, so a slot-0 prerequisite behind a slot-2 room is a split brain.
+    const prereq = playwrightRuns().find((r) => r.args.includes('stage-5-schedule'));
+    expect(prereq?.env?.PLAYWRIGHT_IAM_URL).toBe('http://localhost:5010');
+  });
+
+  it('--slot 2 PROVISIONS + MIGRATES the slot-2 DBs (a fresh slot has none)', async () => {
+    await DevelopConnect.run(['--slot', '2', ...ws()], config);
+
+    // StackApi gates the whole native-prep pass on `runtime.pgProbe`; without the
+    // prep seams connect silently no-ops provision + migrate. Tolerable at slot 0
+    // (its DBs already exist) — fatal at a FRESH slot N, which has none.
+    const creates = runs.filter((r) => JSON.stringify(r.args).includes('CREATE DATABASE'));
+    expect(creates.length).toBeGreaterThan(0);
+    // …and they run against the SLOT's postgres container, not the base one —
+    // proving applyInstanceEnv's container-env seam reached the runtime.
+    expect(creates.every((r) => r.args.includes('soa-s2-postgres-1'))).toBe(true);
+
+    // R3 migrate targets the slot's OFFSET postgres port (5432 + 2000).
+    const migrate = runs.find((r) => r.args.includes('db:deploy') && r.env?.DATABASE_URL !== undefined);
+    expect(migrate?.env?.DATABASE_URL).toContain('localhost:7432');
+  });
+
+  it('--tunnel --slot 2 hard-errors (tunnel fronts fixed slot-0 ports)', async () => {
+    // Never spawn the vendored tunnel.sh — inject a fixed moniker. If the guard
+    // regresses, the run proceeds through this seam instead of erroring.
+    const moniker = vi.fn(async () => 'testmoniker');
+    vi.spyOn(BaseCommand.prototype as never, 'getTunnelMoniker' as never).mockReturnValue(moniker as never);
+
+    await expect(DevelopConnect.run(['--tunnel', '--slot', '2', ...ws()], config)).rejects.toThrow(
+      /slot 2:.*slot-0 browser ports/,
+    );
+    // The guard must fire BEFORE any tunnel resolution or bring-up.
+    expect(moniker).not.toHaveBeenCalled();
+    expect(playwrightRuns()).toHaveLength(0);
+  });
+
+  it('--tunnel at slot 0 still works (the guard is slot-scoped, not a tunnel ban)', async () => {
+    vi.spyOn(BaseCommand.prototype as never, 'getTunnelMoniker' as never).mockReturnValue(
+      (async () => 'testmoniker') as never,
+    );
+    await DevelopConnect.run(['--tunnel', ...ws()], config);
+    expect(liveRun()?.env?.PLAYWRIGHT_BASE_URL).toMatch(/^https:\/\/dash\.testmoniker\./);
+  });
+});
+
+describe('develop connect — per-slot checkpoint root (the cross-slot corruption guard)', () => {
+  it('builds the checkpoint store in the SLOT-2 snapshot root (applyInstanceEnv must run FIRST)', async () => {
+    await DevelopConnect.run(['--slot', '2', ...ws()], config);
+
+    // The journey@schedule checkpoint --prereq-from-snapshot bakes/restores MUST live
+    // under the slot's own root. Shared, two concurrent slots read/write the SAME
+    // on-disk checkpoint — data corruption, not a port clash. The store resolves that
+    // root at CALL time, so the real invariant is `applyInstanceEnv` before the first
+    // bake/restore. Sampling the env at construction is a PROXY for that (the store is
+    // built between the two), and it is deliberately STRICTER than the invariant: a
+    // hoist above `applyInstanceEnv` fails here without being corrupting on its own.
+    // What it does catch is the mutation that matters — `applyInstanceEnv` dropped or
+    // moved after the flow — since then the env is never the slot's root at all.
+    expect(rootAtStoreBuild).toBe(join(homedir(), '.saga-mesh', 'snapshots-s2'));
+    expect(rootAtStoreBuild).not.toBe(snapDir()); // not the base/shared root
+  });
+
+  it('--refresh-snapshot bakes into the slot-2 root, off the slot-2 stack', async () => {
+    await DevelopConnect.run(['--refresh-snapshot', '--slot', '2', ...ws()], config);
+    expect(rootAtStoreBuild).toBe(join(homedir(), '.saga-mesh', 'snapshots-s2'));
+
+    // The bake is its OWN executeResolvedFlow call (a stage-by-stage headless replay,
+    // so stage-1-roster appears only here — the main run's prerequisite enters at
+    // stage-5). It needs the offset ports independently of the main run: a bake driven
+    // against the base iam would bake slot-0 data INTO the slot-2 checkpoint root.
+    const bake = playwrightRuns().find((r) => r.args.includes('stage-1-roster'));
+    expect(bake).toBeDefined();
+    expect(bake?.env?.PLAYWRIGHT_IAM_URL).toBe('http://localhost:5010');
+  });
+
+  it('two slots resolve DIFFERENT checkpoint roots (the concurrency invariant, stated directly)', async () => {
+    await DevelopConnect.run(['--slot', '2', ...ws()], config);
+    const s2 = rootAtStoreBuild;
+    vi.restoreAllMocks();
+    installSeams();
+    vi.spyOn(BaseCommand.prototype, 'log').mockImplementation(() => {});
+    vi.spyOn(BaseCommand.prototype, 'warn').mockImplementation(((m: string) => m) as never);
+
+    await DevelopConnect.run(['--slot', '3', ...ws()], config);
+    expect(rootAtStoreBuild).toBe(join(homedir(), '.saga-mesh', 'snapshots-s3'));
+    expect(rootAtStoreBuild).not.toBe(s2);
+  });
+});
+
+describe('develop connect — slot 0 is UNCHANGED (regression)', () => {
+  it('uses the base state dir, the base service URLs, and the ambient snapshot root', async () => {
+    await DevelopConnect.run([...ws()], config);
+
+    // deriveInstance({slot:0}) is the no-offset default: same state dir as before.
+    expect(launcherStateDir()).toBe('/tmp/sds-synthetic');
+
+    // Base (un-offset) service URLs.
+    const live = liveRun();
+    expect(live?.env?.PLAYWRIGHT_IAM_URL).toBe('http://localhost:3010');
+    expect(live?.env?.PLAYWRIGHT_BASE_URL).toBe('http://localhost:8900');
+
+    // Slot 0 carries an undefined snapshotsDir ⇒ applyInstanceEnv is a NO-OP and the
+    // ambient $SAGA_MESH_SNAPSHOTS_DIR (here: the temp root) still wins.
+    expect(rootAtStoreBuild).toBe(snapDir());
+  });
+
+  it('--state-dir still overrides the slot default', async () => {
+    await DevelopConnect.run(['--state-dir', '/tmp/pinned', '--slot', '2', ...ws()], config);
+    expect(launcherStateDir()).toBe('/tmp/pinned');
+  });
+});

--- a/packages/node/saga-stack-cli/src/commands/develop/connect.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/connect.ts
@@ -44,6 +44,7 @@
 import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command.js';
 import type { WorkspaceFlags } from '../../base-command.js';
+import { deriveInstance } from '../../core/derive-instance.js';
 import { resolveFlow } from '../../core/flow/index.js';
 import { manifest as serviceManifest } from '../../core/manifest/index.js';
 import type { ScriptPlan } from '../../core/flag-map.js';
@@ -110,7 +111,7 @@ export default class DevelopConnect extends BaseCommand {
     tunnel: Flags.boolean({
       default: false,
       description:
-        'point THIS run’s Connect browsers at the vms tunnel hosts (https://<label>.<moniker>.<VMS_BASE>) instead of localhost, so a REMOTE peer can reach the same room. Resolves the moniker via the vendored tunnel.sh (same machinery as `stack up --tunnel`). NOTE: this ONLY repoints these Playwright browsers’ URLs — it does NOT relaunch the stack, flip connect-web/rtsm/cookie env, or start frpc. You must have already run `ss stack up --tunnel` so the stack itself is tunnel-served. Connect is slot-0 only, so no slot guard is needed.',
+        'point THIS run’s Connect browsers at the vms tunnel hosts (https://<label>.<moniker>.<VMS_BASE>) instead of localhost, so a REMOTE peer can reach the same room. Resolves the moniker via the vendored tunnel.sh (same machinery as `stack up --tunnel`). NOTE: this ONLY repoints these Playwright browsers’ URLs — it does NOT relaunch the stack, flip connect-web/rtsm/cookie env, or start frpc. You must have already run `ss stack up --tunnel` so the stack itself is tunnel-served. Slot-0 only.',
     }),
     'student-login': Flags.integer({
       default: 2,
@@ -121,9 +122,34 @@ export default class DevelopConnect extends BaseCommand {
     }),
   };
 
+  /**
+   * `develop connect` brings up an isolated `soa-s<N>` connect sub-stack at slot > 0
+   * — a live tutoring room is exactly the thing a dev wants off the shared slot 0.
+   * It mirrors `e2e run` / `develop coach`: `deriveInstance` drives the offset
+   * ports/DBs/mesh, the per-slot state dir, and the per-slot checkpoint root, and
+   * the flow's Playwright children get the slot's own service URLs — so nothing is
+   * pinned to slot 0. (See run(): the profile MUST reach buildStackContext and the
+   * env seam MUST precede the checkpoint store, or this flag silently lies.)
+   */
+  protected slotAware(): boolean {
+    return true;
+  }
+
   async run(): Promise<void> {
     const { argv, flags } = await this.parse(DevelopConnect);
     const passthrough = (argv as string[]).filter((a) => a !== CONNECT_FLOW);
+
+    // --tunnel fronts the FIXED slot-0 browser ports via the vms rendezvous box, so
+    // it is slot-0-only — mirroring `develop coach`, `e2e run --tunnel` and `stack up
+    // --tunnel` (docs/tunnel.md). Guard BEFORE resolving the moniker below: without
+    // it, `--tunnel --slot N` falls through and drives slot 0's tunnel hosts while
+    // the rest of the run targets slot N.
+    if (flags.tunnel && flags.slot > 0) {
+      this.error(
+        `slot ${flags.slot}: --tunnel fronts the FIXED slot-0 browser ports via the vms rendezvous box, ` +
+          'so it cannot run against a peer slot. Run develop connect at slot 0, or drop --tunnel.',
+      );
+    }
 
     // --refresh-snapshot bakes the journey prerequisite fresh, then restores it.
     // --reuse strips the prerequisite entirely (nothing to bake); --no-prereq-from-snapshot
@@ -166,8 +192,22 @@ export default class DevelopConnect extends BaseCommand {
     const appCwd = resolveAppCwd(resolved.spa, flags, process.env);
     const now = new Date();
 
+    // M7: resolve the slot profile once — it drives the offset ports/project/
+    // container-env (buildStackContext), the launcher's per-slot state dir, the
+    // checkpoint store's snapshot root, and the DB/mesh targeting so `--slot N`
+    // provisions + migrates + seeds against slot N's OWN offset ports/DBs (mirrors
+    // e2e run.ts). At slot 0 it is the byte-identical no-offset default. WITHOUT
+    // this, `--slot N` would silently target slot 0.
+    const profile = deriveInstance({ slot: flags.slot });
+    // Apply the slot's container-env seam (mesh container names + snapshot dir) and
+    // point the launcher at the slot's state dir (pids/logs) — both no-ops at slot 0.
+    // ORDER-CRITICAL: the checkpoint store's resolvers read $SAGA_MESH_* when INVOKED,
+    // so this call must land before any bake/restore below.
+    this.applyInstanceEnv(profile);
+    const stateDir = flags['state-dir'] ?? profile.stateDir;
+
     const seams = {
-      launcher: this.getLauncher(flags['state-dir']),
+      launcher: this.getLauncher(stateDir),
       meshExec: this.getMeshExec(),
       portProbe: this.getPortProbe(),
       dashFs: this.getDashFs(),
@@ -176,15 +216,26 @@ export default class DevelopConnect extends BaseCommand {
       coachWebFs: this.getCoachWebFs(),
       prober: this.getProber(),
       runner: this.getRunner(),
+      // Native-prep seams: buildStackContext wires them into the runtime at EVERY
+      // slot so StackApi.up runs R2 provision + R3 migrate on the slot's offset DBs
+      // before launch+seed (mirrors e2e run.ts — required for a slot > 0 bring-up,
+      // whose DBs do not exist yet). StackApi gates the whole native-prep pass on
+      // `runtime.pgProbe`, so omitting these silently skips provision + migrate.
+      pgProbe: this.getPgProbe(),
+      prepIsFresh: this.getPrepFreshCheck(),
+      prepWriteStamp: this.getPrepStampWriter(),
+      prepRepairDeps: this.getPrepDepRepairer(),
+      prepDbGenerateScan: this.getDbGenerateScan(),
+      repoDirExists: this.getRepoDirCheck(),
     };
     const delegate = (plan: ScriptPlan): Promise<number> =>
       this.runScript(plan, flags as WorkspaceFlags, { propagateExit: false });
 
     // --tunnel: resolve <moniker>.<VMS_BASE> from the VENDORED tunnel.sh (the SAME
     // machinery as `stack up --tunnel`, up.ts:297-303) so the headed Connect room
-    // drives the tunnel hosts. E2eConnect is neither slot- nor set-aware ⇒ slot-0
-    // only, so no slot guard is needed. The seam lets unit tests inject a fixed
-    // moniker instead of spawning tunnel.sh.
+    // drives the tunnel hosts. Guarded slot-0-only above (the tunnel fronts fixed
+    // slot-0 ports). The seam lets unit tests inject a fixed moniker instead of
+    // spawning tunnel.sh.
     let tunnelDomain: string | undefined;
     if (flags.tunnel) {
       const vmsBase = process.env.VMS_BASE ?? 'vms.wootdev.com';
@@ -192,13 +243,27 @@ export default class DevelopConnect extends BaseCommand {
       tunnelDomain = `${moniker}.${vmsBase}`;
     }
 
-    const { runtime } = buildStackContext(flags, seams, delegate, undefined, tunnelDomain);
+    const { runtime } = buildStackContext(flags, seams, delegate, profile, tunnelDomain);
     const api = makeStackApi(serviceManifest, runtime);
 
     // M14-C: the checkpoint store so the journey prerequisite can be RESTORED
-    // instead of replayed (slot-0 command — no instance env needed; --reuse
-    // strips the prerequisite entirely, so nothing to restore there). Also
-    // needed for --refresh-snapshot's fresh bake of the same prerequisite.
+    // instead of replayed (--reuse strips the prerequisite entirely, so nothing to
+    // restore there). Also needed for --refresh-snapshot's fresh bake.
+    //
+    // ORDER-CRITICAL — `applyInstanceEnv(profile)` MUST precede the first store CALL.
+    // The store's resolvers read `$SAGA_MESH_SNAPSHOTS_DIR` / `$SAGA_MESH_*_CONTAINER`
+    // when INVOKED, not when built (runtime/checkpoint-store.ts "CALL-TIME ENV
+    // CONTRACT", snapshot-store.ts `snapshotsRoot()`); `applyInstanceEnv` is what points
+    // them at the slot's root (`~/.saga-mesh/snapshots-s<N>`). Constructing it here —
+    // after that call, before any bake/restore — keeps the invariant trivially true.
+    // Break it and EVERY slot falls back to the SHARED `~/.saga-mesh/snapshots`: two
+    // concurrent slots bake/restore the SAME journey@schedule checkpoint — on-disk data
+    // corruption, not a port clash. `connect.int.test.ts` pins the ordering.
+    //
+    // The other root input is `scriptContextFromFlags(flags)` — the `--<repo>` path
+    // pins the schema-ahead guard resolves local migrations from. It is flag-derived,
+    // not env-derived, so it is order-independent. (`--set` would pin repo paths AND
+    // a slot ≥ 1, but connect is not `setAware()`, so parse rejects it.)
     const checkpoints =
       toRun.prerequisite !== undefined && (flags['prereq-from-snapshot'] || flags['refresh-snapshot'])
         ? this.getCheckpointStore(this.scriptContextFromFlags(flags))
@@ -225,7 +290,19 @@ export default class DevelopConnect extends BaseCommand {
       try {
         const bakeCode = await executeResolvedFlow(
           prereq,
-          { api, runner: seams.runner, appCwd, now, log: (l) => this.log(l), checkpoints },
+          // The bake is a headless replay against THIS slot's stack, so it needs the
+          // same slot-offset ports as the main run below — otherwise its Playwright
+          // children mint against the base iam and bake a slot-0-shaped checkpoint.
+          {
+            api,
+            runner: seams.runner,
+            appCwd,
+            now,
+            log: (l) => this.log(l),
+            slot: profile.slot,
+            ports: runtime.launchContext.ports,
+            checkpoints,
+          },
           { lane: 'stack', skipReset: false, passthrough: [], snapshotStages: true, prereqFromSnapshot: false, spaHead },
         );
         if (bakeCode !== 0) this.error(`--refresh-snapshot: prerequisite bake failed (exit ${bakeCode}).`);
@@ -238,7 +315,23 @@ export default class DevelopConnect extends BaseCommand {
     try {
       const code = await executeResolvedFlow(
         toRun,
-        { api, runner: seams.runner, appCwd, now, log: (l) => this.log(l), checkpoints, tunnelDomain },
+        // Pass the SLOT-OFFSET ports (mirrors e2e run) so the Playwright spawns get
+        // PLAYWRIGHT_IAM_URL/_CONNECT_URL/_CONNECT_API_URL for THIS slot. Without
+        // `ports`, playwrightEnv skips serviceUrlEnv entirely and the specs' lane.ts
+        // falls back to the hardcoded base ports (iam :3010, connect :6210) — the
+        // room boots against slot 0 (soa#300 tail). Deps ride through the
+        // prerequisite recursion, so the journey prerequisite inherits them.
+        {
+          api,
+          runner: seams.runner,
+          appCwd,
+          now,
+          log: (l) => this.log(l),
+          slot: profile.slot,
+          ports: runtime.launchContext.ports,
+          checkpoints,
+          tunnelDomain,
+        },
         {
           lane: 'stack',
           skipReset: flags.reuse,


### PR DESCRIPTION
Brings `develop connect` to slot parity with `develop coach`, per the plan on soa#305. Depends on nothing; **#316** (coach M0) is a sibling. Suite **1211 passed / 104 files** (baseline 1201/103), tsc 0, lint 0 errors.

## The gate was the easy part

`develop connect` had no `slotAware()` override, so `--slot > 0` hard-errored. But that flag is only the **outer gate** — behind it connect was *structurally* slot-0 in five places. **Flipping it alone would have made every slot silently run against slot 0s resources**, which is precisely the bug that already happened once in coach (`c8f96e4`). So the gate flips **last**:

| Milestone | What |
|---|---|
| M1 | `deriveInstance` + `applyInstanceEnv` + per-slot `stateDir`; `profile` (not `undefined`) into `buildStackContext`, which otherwise defaults to slot 0 |
| M2 | snapshot root — see below |
| M3 | `slot` + `ports` onto `executeResolvedFlow`, **both** call sites |
| M5 | six native-prep seams, so a fresh slots DB is provisioned/migrated |
| M6 | first-ever `develop/__tests__/connect.int.test.ts` (+10) |
| M4 | `slotAware()` **and** the tunnel guard, same edit |

**M3 explains a live symptom.** Without `ports`, `playwrightEnv` skips its `serviceUrlEnv` block, so `PLAYWRIGHT_IAM_URL`/`CONNECT_URL` are never set and the external saga-dash specs fall back to hardcoded `localhost:3010`/`:6210` — exactly what a live run printed. Also applied to `--refresh-snapshot`s bake (**beyond the original brief**): a bake without offset ports writes slot-0 data into the slot-N checkpoint root.

**M4 is one edit for a reason.** The central guard stops covering `--tunnel` the instant `slotAware()` is true, so guard and flip must be atomic. The flag description claiming *"Connect is slot-0 only, so no slot guard is needed"* is now false, and corrected — a stale comment like that is how the next person deletes the guard.

## M2 — the corruption cell, and a correction to my own framing

connect never called `applyInstanceEnv`, so `$SAGA_MESH_SNAPSHOTS_DIR` was unset and **every slot resolved the shared `~/.saga-mesh/snapshots`**. Two concurrent slots with `--prereq-from-snapshot` (**default true**) would bake/restore the *same* `journey@schedule` checkpoint — on-disk corruption, not a port clash.

I framed this as an **ordering** bug. Adversarial review proved that imprecise: the stores resolvers read the env at **call time**, not construction (demonstrated with a throwaway probe — a store built *before* the env was set still resolved the new root). So calling `applyInstanceEnv` **at all** is the fix; constructing the store after it keeps the invariant trivially true. An earlier draft comment asserted construction-time capture — contradicted by both sources it cited *by name*. Now corrected in all three places it had spread to.

## Verification

**Mutation-checked, not observed green.** 9 mutations — and **two tests were initially vacuous**, found only by mutating:

| Mutation | Caught? |
|---|---|
| `profile` → `undefined` | ✅ |
| `getLauncher(flags[state-dir])` | ✅ |
| hoist store above `applyInstanceEnv` | ✅ |
| drop `ports` (main run) | ✅ |
| remove tunnel guard | ✅ |
| **drop `ports` (bake)** | ❌ **survived** → strengthened → ✅ |
| **remove `pgProbe` seam** | ❌ **survived** → strengthened → ✅ |
| remove `applyInstanceEnv` | ✅ |
| `slotAware()` → false | ✅ |

Five parallel reviewers raised 2 findings; 1 survived refutation (the comment falsehood, fixed). The other — "a concurrent writer is mutating the tree" — was refuted: it was the implementers own mutation loop observed mid-flight.

## Not verified live

Mock-backed throughout; offsets assert against `deriveInstance` arithmetic, not a real mesh. **Coachs equivalent bugs (soa#300) only surfaced on a live slot-2 run**, so the two-slot snapshot-isolation property deserves a real check before this leaves draft.

## Related

- **saga-dash #556** — the access card is still one-per-host until that lands; together they make two concurrent slotted connect sessions fully isolated.
- **#316** — coachs residual slot-0 hand-off mint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)