### PR TITLE
feat(saga-stack-cli): inject PROGRAMS_API_CLIENT_BASEURL for ads-adm-api (sds#275)

### DIFF
--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.slot.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.slot.unit.test.ts
@@ -158,6 +158,10 @@ describe('ads-adm-api slottability — tokenized env + EXPRESS_SERVER_PORT injec
     const env = resolveLaunchEnv('ads-adm-api', 'stack', slotCtx(2));
     expect(env.EXPRESS_SERVER_PORT).toBe('7005'); // 5005 + 2000
     expect(env.SESSIONS_API_CLIENT_BASEURL).toBe('http://localhost:5007'); // 3007 + 2000
+    // sds#275: ads-adm resolves program display names from programs-api. Untokenized,
+    // a slot > 0 ads-adm would dial SLOT 0's programs-api and silently resolve names
+    // against the wrong stack (best-effort ⇒ it would no-op, not fail loudly).
+    expect(env.PROGRAMS_API_CLIENT_BASEURL).toBe('http://localhost:5006'); // 3006 + 2000
     expect(env.IAM_API_CLIENT_BASEURL).toBe('http://localhost:5010/trpc'); // 3010 + 2000
     expect(env.IAM_API_URL).toBe('http://localhost:5010');
     expect(env.CORS_ORIGIN).toBe('http://localhost:10900'); // dash 8900 + 2000
@@ -166,7 +170,7 @@ describe('ads-adm-api slottability — tokenized env + EXPRESS_SERVER_PORT injec
     expect(portOf(env.RABBITMQ_URL)).toBe(getMesh('rabbitmq').port + 2000);
     // no base-port literal survives anywhere in the resolved env.
     for (const v of Object.values(env)) {
-      expect(v).not.toMatch(/localhost:(3007|3010|5432|5672|8900)\b/);
+      expect(v).not.toMatch(/localhost:(3006|3007|3010|5432|5672|8900)\b/);
     }
   });
 
@@ -174,6 +178,7 @@ describe('ads-adm-api slottability — tokenized env + EXPRESS_SERVER_PORT injec
     const env = resolveLaunchEnv('ads-adm-api', 'stack', slotCtx(0));
     expect(env.EXPRESS_SERVER_PORT).toBeUndefined(); // no offset ⇒ no injection
     expect(env.SESSIONS_API_CLIENT_BASEURL).toBe('http://localhost:3007');
+    expect(env.PROGRAMS_API_CLIENT_BASEURL).toBe('http://localhost:3006');
     expect(env.IAM_API_CLIENT_BASEURL).toBe('http://localhost:3010/trpc');
     expect(env.ADS_ADM_DATABASE_URL).toBe('postgresql://ads_adm:ads_adm@localhost:5432/ads_adm_local');
     expect(env.DATABASE_URL).toBe('postgresql://ads_adm:ads_adm@localhost:5432/ads_adm_local');

--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
@@ -167,10 +167,16 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
     });
   });
 
-  it('ads-adm-api (tokenized env resolves to exactly up.sh literals at base ports)', () => {
+  it('ads-adm-api (tokenized env resolves to exactly up.sh literals at base ports, + PROGRAMS_API_CLIENT_BASEURL)', () => {
     expect(env('ads-adm-api')).toEqual({
       ADS_ADM_SCHEDULE_PROVIDER: 'program-hub',
       SESSIONS_API_CLIENT_BASEURL: 'http://localhost:3007',
+      // NOT an up.sh literal — a deliberate post-up.sh addition (sds#275). ads-adm
+      // resolves program display names from programs-api because sessions-api
+      // projects no display strings (its occurrence wire's programName is only the
+      // programId echo). Tokenized so a slot > 0 ads-adm dials ITS slot's
+      // programs-api rather than slot 0's.
+      PROGRAMS_API_CLIENT_BASEURL: 'http://localhost:3006',
       IAM_API_CLIENT_BASEURL: 'http://localhost:3010/trpc',
       IAM_API_URL: 'http://localhost:3010',
       JWT_ISSUER: 'https://iam.wootdev.com',

--- a/packages/node/saga-stack-cli/src/core/launch-plan.ts
+++ b/packages/node/saga-stack-cli/src/core/launch-plan.ts
@@ -54,6 +54,12 @@ export interface LaunchTokens {
   /** sessions-api port (3007) — ads-adm-api's SESSIONS_API_CLIENT_BASEURL (was a
    *  literal `:3007` in up.sh; tokenized for M13 ads-adm slottability). */
   SESSIONS_PORT: string;
+  /** programs-api port (3006) — ads-adm-api's PROGRAMS_API_CLIENT_BASEURL. ads-adm
+   *  resolves program display names from programs-api (`programs.get`), because
+   *  sessions-api projects no display strings, so the occurrence wire's programName
+   *  is only the programId echo (sds#275). Without this token a slot > 0 ads-adm-api
+   *  would dial slot 0's programs-api. */
+  PROGRAMS_PORT: string;
   /** content-api port — up.sh `CONTENT_PORT` (3009; default :3010 collides with iam). */
   CONTENT_PORT: string;
   /** connect-api port — up.sh `CONNECT_API_PORT` (6106). */
@@ -618,6 +624,7 @@ export function defaultLaunchContext(inputs: LaunchContextInputs, m: Manifest = 
     IAM_PORT: String(ports['iam-api']),
     SIS_PORT: String(ports['sis-api']),
     SESSIONS_PORT: String(ports['sessions-api']),
+    PROGRAMS_PORT: String(ports['programs-api']),
     CONTENT_PORT: String(ports['content-api']),
     CONNECT_API_PORT: String(ports['connect-api']),
     RTSM_PORT: String(ports['rtsm-api']),

--- a/packages/node/saga-stack-cli/src/core/manifest/services.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/services.ts
@@ -290,8 +290,12 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
     portEnvVar: 'EXPRESS_SERVER_PORT',
     healthPath: '/health',
     databases: ['ads_adm_local', 'ledger_local'],
-    dependsOn: ['iam-api', 'sessions-api'],
-    depKinds: { 'iam-api': 'url', 'sessions-api': 's2s' },
+    // programs-api: ads-adm resolves program display NAMES from it (`programs.get`,
+    // a publicProcedure → 'url', not 's2s' like sessions-api's service-gated reads).
+    // sessions-api projects no display strings, so the occurrence wire's programName
+    // is only the programId echo; ads-adm resolves names itself (sds#275).
+    dependsOn: ['iam-api', 'sessions-api', 'programs-api'],
+    depKinds: { 'iam-api': 'url', 'sessions-api': 's2s', 'programs-api': 'url' },
     mesh: ['postgres', 'rabbitmq'],
     launch: {
       cmd: 'pnpm dev',
@@ -302,6 +306,7 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
       env: {
         ADS_ADM_SCHEDULE_PROVIDER: 'program-hub',
         SESSIONS_API_CLIENT_BASEURL: 'http://localhost:${SESSIONS_PORT}',
+        PROGRAMS_API_CLIENT_BASEURL: 'http://localhost:${PROGRAMS_PORT}',
         IAM_API_CLIENT_BASEURL: '${IAM_URL}/trpc',
         IAM_API_URL: '${IAM_URL}',
         // Same iss iam-api stamps — see programs-api's JWT_ISSUER note. Was the


### PR DESCRIPTION
Wires `ads-adm-api`'s new programs-api dial into the `ss` manifest, for **[student-data-system#275](https://github.com/saga-ed/student-data-system/issues/275)** (period-instance attendance).

## Why

ads-adm-api now resolves program display **names** from programs-api (`programs.get`). It has to, because **sessions-api projects no display strings** — its occurrence wire's `programName` is only the programId echo (`sessions-read.service.ts:691-693` literally does `const programName = programId`).

Without this, the two attendance grains wrote **different `program_name` values for the same program** (`''` vs the UUID), and ADS reporting — which *groups* on that column — split one program into two buckets.

## What (three coupled changes — the env var alone is inert)

- **`launch-plan.ts`** — new **`PROGRAMS_PORT`** token (`LaunchTokens` field + context builder). There was no programs-api port token; the type's own doc requires both halves.
- **`services.ts`** — `PROGRAMS_API_CLIENT_BASEURL: 'http://localhost:${PROGRAMS_PORT}'` on ads-adm-api. **Tokenized** so a slot > 0 ads-adm dials **its** slot's programs-api. Untokenized it would silently resolve names against **slot 0's** stack — and because resolution is best-effort, that's a quiet no-op rather than a loud failure. That's precisely the bug.
- **`services.ts`** — `dependsOn += 'programs-api'`, depKind **`'url'`**.

## ⚠️ Fleet-wide behaviour change — the bit that wants eyes

**Every `ss` closure containing ads-adm-api now also starts programs-api.**

It's required: without the edge, a closure could launch ads-adm-api with no programs-api and name resolution would silently fall back to `''`. But it does change bring-up for everyone, so it shouldn't land without a look.

depKind is **`'url'`, not `'s2s'`** — `programs.get` is a `publicProcedure`, unlike sessions-api's service-gated reads (which are correctly `'s2s'`).

## Tests

- **`launch-plan.unit`** — the ads-adm byte-identity case now includes the new var, **explicitly annotated as a deliberate post-`up.sh` addition** (it is *not* an `up.sh` literal). I'd rather the "faithful to up.sh" framing stay honest than quietly widen the expectation.
- **`launch-plan.slot.unit`** — pins slot 2 → `:5006`, slot 0 → `:3006`, and extends the *no-base-port-literal-survives* guard to include `3006`.
- **Mutation-verified:** hardcoding the `:3006` literal in the manifest makes the slot-2 case **fail** (`every cross-service/mesh URL dials the SLOT (+2000), never slot 0`), then restored green. The test earns its keep.

`check-types` 0 · **1201 tests pass** (103 files).

## Verified live

On `ss` slot 1 with this var injected, both attendance grains now stamp the real name (`Nonrotation Attendance …`), matching programs-api ground truth. The two-bucket split is gone.

Refs saga-ed/student-data-system#275, saga-ed/program-hub#367.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
