### PR TITLE
fix(saga-stack-cli): refuse to adopt an already-up service with an unverifiable env contract

### DIFF
--- a/packages/node/saga-stack-cli/src/commands/stack/up.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/up.ts
@@ -703,6 +703,7 @@ export interface UpFailureView {
   provision?: { ok: boolean; failed?: string };
   migrate?: { ok: boolean; failed?: string };
   failedAt?: string;
+  failedReason?: string;
 }
 
 /**
@@ -742,7 +743,9 @@ export function describeUpFailure(up: UpFailureView): string[] {
       `migrate FAILED${up.migrate.failed ? ` on ${up.migrate.failed}` : ''} — \`prisma migrate\` exited non-zero; see the streamed output above`,
     ];
   }
-  return [`service launch FAILED at ${up.failedAt ?? '(unknown)'} — it never became healthy`];
+  return [
+    `service launch FAILED at ${up.failedAt ?? '(unknown)'} — ${up.failedReason ?? 'it never became healthy'}`,
+  ];
 }
 
 // Local flag shapes (subset of the parsed StackUp flags each path reads).

--- a/packages/node/saga-stack-cli/src/core/manifest/services.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/services.ts
@@ -123,6 +123,12 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
     tunnelSlug: 'iam',
     isFrontend: false,
     optional: false,
+    // iam MINTS the iss every JWT consumer validates (its JWT_ISSUER, stamped from
+    // ${IAM_ISSUER}). An already-up iam launched by an older CLI without this stamp
+    // falls back to iam-api's saga.org default and mints a token coach-api rejects
+    // (invalid-issuer → 401) — so a drifted/adopted iam is worse than none. Guard
+    // adoption on it (soa#305).
+    adoptEnv: ['JWT_ISSUER'],
   },
   'sis-api': {
     id: 'sis-api',

--- a/packages/node/saga-stack-cli/src/core/manifest/types.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/types.ts
@@ -160,6 +160,18 @@ export interface ServiceDef {
   optional: boolean;
   /** Config-file prep run immediately before this service boots (review minor — §3). */
   prelaunchHook?: 'sync-dash-local-defaults';
+  /**
+   * Launch-env keys whose STAMPED value must match for an already-up process to be
+   * safely ADOPTED (the `alreadyUp` short-circuit). The drift-guarantee this CLI
+   * asserts on these vars (services.ts:63 — "the two ends can never drift") holds
+   * ONLY for processes THIS build launched; a service already 200-ing when `up`
+   * runs may have been launched by an OLDER CLI that stamped a different (or no)
+   * value. For such keys the launcher fingerprints the stamp at spawn and refuses
+   * to adopt on mismatch/absence rather than serve a drifted process. iam-api sets
+   * JWT_ISSUER (a stale iam minting iss=iam.saga.org while coach-api validated
+   * iam.wootdev.com 401'd every GraphQL call for hours — soa#305).
+   */
+  adoptEnv?: readonly string[];
 }
 
 export interface MeshDef {

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/launcher.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/launcher.unit.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
-import { makeRealLauncher, pidFilePath, stopServices } from '../launcher.js';
+import { contractFilePath, makeRealLauncher, pidFilePath, stopServices } from '../launcher.js';
 
 // Mock node:child_process so the DEFAULT SpawnFn's options can be pinned (the
 // injectable `deps.spawn` seam sits ABOVE the `detached: true` flag, so only a
@@ -204,6 +204,93 @@ describe('makeRealLauncher.launch', () => {
     expect(opts.env.AUTH_DEVUSERID).toBe('beef');
     // The pid recorded IS the group leader's pid (pid == pgid under detached).
     expect(writePid).toHaveBeenCalledWith(pidFilePath(STATE, 'iam-api'), 4242);
+  });
+});
+
+describe('makeRealLauncher.launch adopt-contract guard (soa#305)', () => {
+  // iam-api's spec carries adoptEnv:['JWT_ISSUER'] — the key whose stamp coach-api
+  // validates. A stale iam launched by an older CLI (no stamp / a different iss)
+  // still 200s on /health but mints a token every consumer 401s; the guard refuses
+  // to ADOPT such a process instead of silently serving its drifted contract.
+  const GUARDED: LaunchSpec = {
+    ...SPEC,
+    env: { PORT: '3010', JWT_ISSUER: 'https://iam.wootdev.com' },
+    adoptEnv: ['JWT_ISSUER'],
+  };
+  const FINGERPRINT = JSON.stringify({ JWT_ISSUER: 'https://iam.wootdev.com' });
+
+  it('refuses to adopt an already-up process with NO recorded contract fingerprint', async () => {
+    const { prober } = seqProber([true]); // already up
+    const { spawn, calls } = fakeSpawn(1);
+    const launcher = makeRealLauncher({
+      stateDir: STATE,
+      prober,
+      spawn,
+      readContract: () => null, // launched by a build that wrote no fingerprint
+    });
+
+    const res = await launcher.launch(GUARDED);
+
+    expect(res.ok).toBe(false);
+    expect(res.alreadyUp).toBeUndefined(); // NOT adopted
+    expect(res.reason).toMatch(/contract/);
+    expect(calls).toHaveLength(0); // did not spawn (port is held) — a loud fail
+  });
+
+  it('refuses to adopt when the recorded fingerprint DISAGREES (drifted issuer)', async () => {
+    const { prober } = seqProber([true]);
+    const launcher = makeRealLauncher({
+      stateDir: STATE,
+      prober,
+      spawn: fakeSpawn(1).spawn,
+      readContract: () => JSON.stringify({ JWT_ISSUER: 'https://iam.saga.org' }),
+    });
+
+    const res = await launcher.launch(GUARDED);
+
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain('iam.saga.org');
+  });
+
+  it('adopts when the recorded fingerprint MATCHES what we would stamp', async () => {
+    const { prober } = seqProber([true]);
+    const readContract = vi.fn(() => FINGERPRINT);
+    const launcher = makeRealLauncher({ stateDir: STATE, prober, readContract });
+
+    const res = await launcher.launch(GUARDED);
+
+    expect(res).toEqual({ id: 'iam-api', ok: true, alreadyUp: true });
+    expect(readContract).toHaveBeenCalledWith(contractFilePath(STATE, 'iam-api'));
+  });
+
+  it('records the contract fingerprint when it spawns a guarded service', async () => {
+    const { prober } = seqProber([false, true]); // not up ⇒ spawn, then healthy
+    const writeContract = vi.fn();
+    const launcher = makeRealLauncher({
+      stateDir: STATE,
+      prober,
+      spawn: fakeSpawn(4242).spawn,
+      writeContract,
+      writePid: () => {},
+      openLog: () => 'ignore',
+      ensureDir: () => {},
+      sleep: async () => {},
+    });
+
+    await launcher.launch(GUARDED);
+
+    expect(writeContract).toHaveBeenCalledWith(contractFilePath(STATE, 'iam-api'), FINGERPRINT);
+  });
+
+  it('leaves an UNguarded service (no adoptEnv) adopted unconditionally', async () => {
+    const { prober } = seqProber([true]);
+    const readContract = vi.fn(() => null);
+    const launcher = makeRealLauncher({ stateDir: STATE, prober, readContract });
+
+    const res = await launcher.launch(SPEC); // no adoptEnv
+
+    expect(res).toEqual({ id: 'iam-api', ok: true, alreadyUp: true });
+    expect(readContract).not.toHaveBeenCalled(); // guard never consulted
   });
 });
 

--- a/packages/node/saga-stack-cli/src/runtime/launcher.ts
+++ b/packages/node/saga-stack-cli/src/runtime/launcher.ts
@@ -67,6 +67,16 @@ export interface LaunchSpec {
   env: Record<string, string>;
   /** Health URL polled for a 200, e.g. `http://localhost:3010/health`. */
   healthUrl: string;
+  /**
+   * Launch-env keys whose stamped value must match for the `alreadyUp` adoption to
+   * be safe (`ServiceDef.adoptEnv`). When set, the launcher fingerprints these keys'
+   * values from `env` at spawn and, on a pre-launch 200, refuses to adopt a process
+   * whose recorded fingerprint is absent or disagrees — the process was launched by
+   * a build that stamped a different contract and may be drifted (soa#305). Absent/
+   * empty ⇒ the adoption short-circuit is unconditional (unchanged for every other
+   * service).
+   */
+  adoptEnv?: readonly string[];
 }
 
 /** The outcome of launching one service. */
@@ -79,6 +89,13 @@ export interface LaunchResult {
   pid?: number;
   /** True iff a 200 came back BEFORE we launched — up.sh's "already up :$port" path. */
   alreadyUp?: boolean;
+  /**
+   * Set only on a NON-ok result that needs an explanation the caller can't infer from
+   * `id` alone — today the `adoptEnv` drift refusal (an already-up process whose launch
+   * contract can't be verified), so `up` reports the real cause instead of the generic
+   * "never became healthy".
+   */
+  reason?: string;
 }
 
 /** The outcome of stopping one service (the down path). */
@@ -134,6 +151,10 @@ export interface RealLauncherDeps {
   writePid?: (path: string, pid: number) => void;
   /** Read a pid file's contents (for stopServices). Default `fs.readFileSync`; returns null when absent. */
   readPid?: (path: string) => string | null;
+  /** Persist a service's adopt-contract fingerprint file. Default `fs.writeFileSync`. */
+  writeContract?: (path: string, body: string) => void;
+  /** Read a service's adopt-contract fingerprint file. Default `fs.readFileSync`; null when absent. */
+  readContract?: (path: string) => string | null;
   /** Deliver a kill signal. Default `process.kill`. */
   kill?: (pid: number, signal?: NodeJS.Signals) => void;
 }
@@ -160,6 +181,25 @@ export function pidFilePath(stateDir: string, id: string): string {
 /** Path to a service's log file under the state dir. */
 export function logFilePath(stateDir: string, id: string): string {
   return join(stateDir, `${id}.log`);
+}
+
+/** Path to a service's adopt-contract fingerprint under the state dir (soa#305). */
+export function contractFilePath(stateDir: string, id: string): string {
+  return join(stateDir, `${id}.env-contract`);
+}
+
+/**
+ * The subset of `env` the adoption guard fingerprints, in `adoptEnv` order so the
+ * serialization is stable (a key absent from `env` is omitted). Used both to WRITE
+ * the fingerprint at spawn and to compute the EXPECTED value on an adoption check.
+ */
+function contractFingerprint(env: Record<string, string>, adoptEnv: readonly string[]): string {
+  const picked: Record<string, string> = {};
+  for (const k of adoptEnv) {
+    const v = env[k];
+    if (v !== undefined) picked[k] = v;
+  }
+  return JSON.stringify(picked);
 }
 
 /** Read a positive integer from an env var, or undefined if unset/invalid. */
@@ -204,6 +244,17 @@ export function makeRealLauncher(deps: RealLauncherDeps = {}): ServiceLauncher {
         return null;
       }
     });
+  const writeContract =
+    deps.writeContract ?? ((path: string, body: string) => writeFileSync(path, body));
+  const readContract =
+    deps.readContract ??
+    ((path: string): string | null => {
+      try {
+        return readFileSync(path, 'utf8');
+      } catch {
+        return null;
+      }
+    });
   const kill = deps.kill ?? ((pid: number, signal?: NodeJS.Signals) => process.kill(pid, signal));
   const doSpawn: SpawnFn =
     deps.spawn ??
@@ -219,8 +270,26 @@ export function makeRealLauncher(deps: RealLauncherDeps = {}): ServiceLauncher {
 
   return {
     async launch(spec: LaunchSpec): Promise<LaunchResult> {
+      const guardKeys = spec.adoptEnv ?? [];
       // Idempotent re-run: a 200 before we touch anything ⇒ "already up".
       if ((await prober.probe(spec.healthUrl)).ok) {
+        // But the drift guarantee this CLI stamps (services.ts:63) only holds for a
+        // process THIS build launched. For guarded keys, adopt ONLY when the recorded
+        // fingerprint matches what we'd stamp now; a missing/mismatched fingerprint
+        // means the live process was launched by another build (or an older CLI with
+        // no stamp) and may serve a drifted contract — refuse loudly rather than
+        // silently adopt it (soa#305: a stale iam minting the wrong iss 401'd for hours).
+        if (guardKeys.length > 0) {
+          const expected = contractFingerprint(spec.env, guardKeys);
+          const recorded = readContract(contractFilePath(stateDir, spec.id));
+          if (recorded !== expected) {
+            return {
+              id: spec.id,
+              ok: false,
+              reason: `already up but its launch-env contract can't be verified — refusing to adopt a possibly-drifted process. Expected ${expected}, recorded ${recorded ?? '(none)'}. Stop the foreign process and re-run so this CLI relaunches it with the stamp.`,
+            };
+          }
+        }
         return { id: spec.id, ok: true, alreadyUp: true };
       }
 
@@ -237,6 +306,11 @@ export function makeRealLauncher(deps: RealLauncherDeps = {}): ServiceLauncher {
       child.on('error', () => {});
       const pid = child.pid;
       if (typeof pid === 'number') writePid(pidFilePath(stateDir, spec.id), pid);
+      // Record the launch-env contract this build stamped so a later `up` can prove a
+      // still-200-ing process is ours (matching stamp) before adopting it (soa#305).
+      if (guardKeys.length > 0) {
+        writeContract(contractFilePath(stateDir, spec.id), contractFingerprint(spec.env, guardKeys));
+      }
       // Don't keep the parent event loop alive for the detached child.
       child.unref();
 

--- a/packages/node/saga-stack-cli/src/stack-api.ts
+++ b/packages/node/saga-stack-cli/src/stack-api.ts
@@ -340,6 +340,8 @@ export interface UpResult {
   skipped: UpSkip[];
   /** The first service that failed health (set only when `ok` is false at the service stage). */
   failedAt?: ServiceId;
+  /** Why `failedAt` failed, when it's not a plain health timeout (e.g. the adopt-contract drift refusal). */
+  failedReason?: string;
 }
 
 /** The outcome of a native `seed`. */
@@ -938,13 +940,17 @@ export function makeStackApi(m: Manifest, runtime: Runtime): StackApi {
               args,
               env: spec.env,
               healthUrl: spec.healthUrl,
+              // Guard the `alreadyUp` adoption on the service's contract keys (iam-api's
+              // JWT_ISSUER) so a drifted/foreign already-up process is refused, not adopted
+              // with a stale env the CLI's stamp never reached (soa#305).
+              adoptEnv: getService(id, manifest).adoptEnv,
             });
           }),
         );
         launched.push(...results);
         const failed = results.find((r) => !r.ok);
         if (failed) {
-          return { ok: false, autoPull, av, mesh, prep, provision, migrate, dash, coachWeb, launched, skipped, failedAt: failed.id as ServiceId };
+          return { ok: false, autoPull, av, mesh, prep, provision, migrate, dash, coachWeb, launched, skipped, failedAt: failed.id as ServiceId, failedReason: failed.reason };
         }
       }
 


### PR DESCRIPTION
Closes the `alreadyUp` adoption hole that burned today's soa#305 live testing. Suite **1206 passed / 103 files**, tsc 0, lint 0 errors.

## The incident

A stale slot-2 iam-api — launched by an older CLI build predating `70737df` — carried no `JWT_ISSUER` and minted `iss=https://iam.saga.org` (iam's schema default), while the freshly-launched coach-api was stamped `AUTH_ISSUER=https://iam.wootdev.com`. jose rejected every session as invalid-issuer → coach-api 401 → coach-web rendered "Failed to load module data" → the real-content flow died at the module heading.

**It presented as a content regression and was chased as one.** coach#239 was wrongly suspected (it merged the same hour); the exonerating control: kill the stale iam by pid, re-run the identical command on unchanged coach code → **green**. The failure moved with the process, not the code. (#239 was doubly exonerated — the merge's tree hash is byte-identical to its parent; it introduced zero code.)

## The hole

`up()` adopts any service already answering its health URL, but the drift guarantee the manifest asserts — `services.ts:63`: JWT_ISSUER is *"injected rather than left to iam-api/.env so the two ends can never drift"* — **only holds for processes this CLI build launched**. Adoption silently voids it, and the resulting 401 is indistinguishable from "no cookie" (coach-api logs the rejection at debug).

## The fix

- `ServiceDef.adoptEnv?: readonly string[]` — env keys whose stamped values are load-bearing for cross-service agreement. iam-api declares `['JWT_ISSUER']`.
- On spawn, the launcher records a fingerprint of those keys beside the pidfile (`<id>.env-contract`).
- On the `alreadyUp` path, adopt **only** when the recorded fingerprint matches what this build would stamp now. Missing/mismatched ⇒ **fail loud** with both values — not relaunch, because the incident's stale process was foreign (no pidfile in the slot state dir), so a relaunch couldn't free the port; the loud failure names the exact remediation.
- `describeUpFailure` surfaces the reason — "never became healthy" becomes a one-glance diagnosis.

## Verification

- **Live, during the incident rerun** (slot 3): fresh iam-api stamps `iam-api.env-contract = {"JWT_ISSUER":"https://iam.wootdev.com"}`; the un-stamped slot-0 iam is exactly the shape the guard refuses.
- **Mutation-checked twice** (by the implementing agent, then independently re-run before this PR): disabling the fingerprint comparison fails 2 tests.

## Follow-up (separate, coach repo)

coach-api logs session rejections at `logger.debug` while the runtime sits at level 30 — an invalid-issuer 401 is invisible. One line (warn, or reason-on-401 in development) turns this class from a multi-hour hunt into a one-glance read. Filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)