### PR TITLE
fix(saga-stack-cli): land #325 on main — its merge went to an already-merged base branch

### DIFF
--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -156,7 +156,7 @@
           "type": "option"
         },
         "tunnel": {
-          "description": "point THIS run's flow browsers at the vms tunnel hosts (https://<label>.<moniker>.<VMS_BASE>) instead of localhost, so a REMOTE peer can reach the same stack. Resolves the moniker via the vendored tunnel.sh (same machinery as `stack up --tunnel`). NOTE: this ONLY repoints the flow's Playwright browsers — it does NOT relaunch the stack; you must have already run `ss stack up --tunnel`. Slot-0 only.",
+          "description": "point THIS run's flow browsers at the vms tunnel hosts (https://<label>.<moniker>.<VMS_BASE>) instead of localhost, so a REMOTE peer can reach the same stack. Resolves the moniker via the vendored tunnel.sh (same machinery as `stack up --tunnel`). Services ALREADY UP are reused untouched; any service this run must launch itself comes up WITH the tunnel browser-env overlay (soa#322). It does NOT start frpc — run `ss stack up --tunnel` first for the tunnel itself. Slot-0 only.",
           "name": "tunnel",
           "allowNo": false,
           "type": "boolean"
@@ -329,7 +329,7 @@
           "type": "boolean"
         },
         "tunnel": {
-          "description": "point THIS run’s Connect browsers at the vms tunnel hosts (https://<label>.<moniker>.<VMS_BASE>) instead of localhost, so a REMOTE peer can reach the same room. Resolves the moniker via the vendored tunnel.sh (same machinery as `stack up --tunnel`). NOTE: this ONLY repoints these Playwright browsers’ URLs — it does NOT relaunch the stack, flip connect-web/rtsm/cookie env, or start frpc. You must have already run `ss stack up --tunnel` so the stack itself is tunnel-served. Slot-0 only.",
+          "description": "point THIS run’s Connect browsers at the vms tunnel hosts (https://<label>.<moniker>.<VMS_BASE>) instead of localhost, so a REMOTE peer can reach the same room. Resolves the moniker via the vendored tunnel.sh (same machinery as `stack up --tunnel`). Services ALREADY UP are reused untouched; any service this run must launch itself comes up WITH the tunnel browser-env overlay (soa#322). It does NOT start frpc or fetch LiveKit creds — run `ss stack up --tunnel` first for the tunnel itself (and real A/V). Slot-0 only.",
           "name": "tunnel",
           "allowNo": false,
           "type": "boolean"
@@ -880,761 +880,6 @@
         "commands",
         "e2e",
         "traces.js"
-      ]
-    },
-    "set:check": {
-      "aliases": [],
-      "args": {
-        "name": {
-          "description": "set name (see `set list`)",
-          "name": "name",
-          "required": true
-        }
-      },
-      "description": "Validate a worktree set: paths, buildable-vs-prebuilt, branch drift (warn), primary-checkout posture, cross-set build collisions. Exit 1 on violations.",
-      "examples": [
-        "<%= config.bin %> <%= command.id %> journey-fix"
-      ],
-      "flags": {
-        "porcelain": {
-          "description": "machine-readable output; no color, minimal noise",
-          "name": "porcelain",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
-          "name": "slot",
-          "default": 0,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "output-json": {
-          "description": "emit structured JSON on stdout instead of human-readable text",
-          "name": "output-json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "set": {
-          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
-          "name": "set",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dev": {
-          "description": "sibling-repo workspace root (where the saga repos are checked out)",
-          "name": "dev",
-          "noCacheDefault": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
-          "name": "state-dir",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "soa": {
-          "description": "override path to the soa repo checkout",
-          "name": "soa",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rostering": {
-          "description": "override path to the rostering repo checkout",
-          "name": "rostering",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "program-hub": {
-          "description": "override path to the program-hub repo checkout",
-          "name": "program-hub",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "saga-dash": {
-          "description": "override path to the saga-dash repo checkout",
-          "name": "saga-dash",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "coach": {
-          "description": "override path to the coach repo checkout",
-          "name": "coach",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "sds": {
-          "description": "override path to the sds (student-data-system) repo checkout",
-          "name": "sds",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "qboard": {
-          "description": "override path to the qboard repo checkout",
-          "name": "qboard",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rtsm": {
-          "description": "override path to the rtsm repo checkout",
-          "name": "rtsm",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fleek": {
-          "description": "override path to the fleek repo checkout",
-          "name": "fleek",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "set:check",
-      "pluginAlias": "@saga-ed/saga-stack-cli",
-      "pluginName": "@saga-ed/saga-stack-cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "set",
-        "check.js"
-      ]
-    },
-    "set:create": {
-      "aliases": [],
-      "args": {
-        "name": {
-          "description": "set name (must be unused)",
-          "name": "name",
-          "required": true
-        }
-      },
-      "description": "Create a worktree set: git worktree add (new/existing branch) off the primary checkout, pnpm install, and record it in the sets file (createdBy: ss). Single repo per call.",
-      "examples": [
-        "<%= config.bin %> <%= command.id %> sched --slot 1 --repo saga-dash --path ~/dev/worktrees/saga-dash-sched --branch feat/sched",
-        "<%= config.bin %> <%= command.id %> topo --slot 2 --repo saga-dash --path ~/dev/worktrees/saga-dash-topo --branch flow/topology --no-install"
-      ],
-      "flags": {
-        "porcelain": {
-          "description": "machine-readable output; no color, minimal noise",
-          "name": "porcelain",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "slot": {
-          "description": "slot the set binds (1..9; slot 0 is the primary-checkout baseline)",
-          "name": "slot",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "output-json": {
-          "description": "emit structured JSON on stdout instead of human-readable text",
-          "name": "output-json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "set": {
-          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
-          "name": "set",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dev": {
-          "description": "sibling-repo workspace root (where the saga repos are checked out)",
-          "name": "dev",
-          "noCacheDefault": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
-          "name": "state-dir",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "soa": {
-          "description": "override path to the soa repo checkout",
-          "name": "soa",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rostering": {
-          "description": "override path to the rostering repo checkout",
-          "name": "rostering",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "program-hub": {
-          "description": "override path to the program-hub repo checkout",
-          "name": "program-hub",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "saga-dash": {
-          "description": "override path to the saga-dash repo checkout",
-          "name": "saga-dash",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "coach": {
-          "description": "override path to the coach repo checkout",
-          "name": "coach",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "sds": {
-          "description": "override path to the sds (student-data-system) repo checkout",
-          "name": "sds",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "qboard": {
-          "description": "override path to the qboard repo checkout",
-          "name": "qboard",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rtsm": {
-          "description": "override path to the rtsm repo checkout",
-          "name": "rtsm",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fleek": {
-          "description": "override path to the fleek repo checkout",
-          "name": "fleek",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "repo": {
-          "description": "repo to make a worktree for",
-          "name": "repo",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "options": [
-            "soa",
-            "rostering",
-            "program-hub",
-            "saga-dash",
-            "coach",
-            "sds",
-            "qboard",
-            "rtsm",
-            "fleek"
-          ],
-          "type": "option"
-        },
-        "path": {
-          "description": "worktree checkout path (recorded verbatim; `~` stays portable)",
-          "name": "path",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "branch": {
-          "description": "branch to check out — created if new, attached if it exists (default: the set name)",
-          "name": "branch",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "base": {
-          "description": "start point for a NEW branch (default: the primary checkout HEAD, e.g. main)",
-          "name": "base",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "note": {
-          "description": "optional note stored on the set",
-          "name": "note",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "install": {
-          "description": "pnpm install in the new worktree so `--set` up/e2e fresh-skip (use --no-install to skip)",
-          "name": "install",
-          "allowNo": true,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "set:create",
-      "pluginAlias": "@saga-ed/saga-stack-cli",
-      "pluginName": "@saga-ed/saga-stack-cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "set",
-        "create.js"
-      ]
-    },
-    "set:list": {
-      "aliases": [],
-      "args": {},
-      "description": "List the worktree sets (name, slot, live ACTIVE state, repos) from the sets file (read-only).",
-      "examples": [
-        "<%= config.bin %> <%= command.id %>",
-        "<%= config.bin %> <%= command.id %> --output-json"
-      ],
-      "flags": {
-        "porcelain": {
-          "description": "machine-readable output; no color, minimal noise",
-          "name": "porcelain",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
-          "name": "slot",
-          "default": 0,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "output-json": {
-          "description": "emit structured JSON on stdout instead of human-readable text",
-          "name": "output-json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "set": {
-          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
-          "name": "set",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dev": {
-          "description": "sibling-repo workspace root (where the saga repos are checked out)",
-          "name": "dev",
-          "noCacheDefault": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
-          "name": "state-dir",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "soa": {
-          "description": "override path to the soa repo checkout",
-          "name": "soa",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rostering": {
-          "description": "override path to the rostering repo checkout",
-          "name": "rostering",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "program-hub": {
-          "description": "override path to the program-hub repo checkout",
-          "name": "program-hub",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "saga-dash": {
-          "description": "override path to the saga-dash repo checkout",
-          "name": "saga-dash",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "coach": {
-          "description": "override path to the coach repo checkout",
-          "name": "coach",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "sds": {
-          "description": "override path to the sds (student-data-system) repo checkout",
-          "name": "sds",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "qboard": {
-          "description": "override path to the qboard repo checkout",
-          "name": "qboard",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rtsm": {
-          "description": "override path to the rtsm repo checkout",
-          "name": "rtsm",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fleek": {
-          "description": "override path to the fleek repo checkout",
-          "name": "fleek",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "set:list",
-      "pluginAlias": "@saga-ed/saga-stack-cli",
-      "pluginName": "@saga-ed/saga-stack-cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "set",
-        "list.js"
-      ]
-    },
-    "set:rm": {
-      "aliases": [],
-      "args": {
-        "name": {
-          "description": "set name (see `set list`)",
-          "name": "name",
-          "required": true
-        }
-      },
-      "description": "Remove a worktree set from the sets file. --and-worktrees also `git worktree remove`s the ss-created worktrees (createdBy: ss); hand-recorded paths are never touched.",
-      "examples": [
-        "<%= config.bin %> <%= command.id %> sched",
-        "<%= config.bin %> <%= command.id %> sched --and-worktrees --yes"
-      ],
-      "flags": {
-        "porcelain": {
-          "description": "machine-readable output; no color, minimal noise",
-          "name": "porcelain",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
-          "name": "slot",
-          "default": 0,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "output-json": {
-          "description": "emit structured JSON on stdout instead of human-readable text",
-          "name": "output-json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "set": {
-          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
-          "name": "set",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dev": {
-          "description": "sibling-repo workspace root (where the saga repos are checked out)",
-          "name": "dev",
-          "noCacheDefault": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
-          "name": "state-dir",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "soa": {
-          "description": "override path to the soa repo checkout",
-          "name": "soa",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rostering": {
-          "description": "override path to the rostering repo checkout",
-          "name": "rostering",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "program-hub": {
-          "description": "override path to the program-hub repo checkout",
-          "name": "program-hub",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "saga-dash": {
-          "description": "override path to the saga-dash repo checkout",
-          "name": "saga-dash",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "coach": {
-          "description": "override path to the coach repo checkout",
-          "name": "coach",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "sds": {
-          "description": "override path to the sds (student-data-system) repo checkout",
-          "name": "sds",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "qboard": {
-          "description": "override path to the qboard repo checkout",
-          "name": "qboard",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rtsm": {
-          "description": "override path to the rtsm repo checkout",
-          "name": "rtsm",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fleek": {
-          "description": "override path to the fleek repo checkout",
-          "name": "fleek",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "and-worktrees": {
-          "description": "also `git worktree remove` the worktrees ss created (createdBy: ss); requires --yes",
-          "name": "and-worktrees",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "force": {
-          "description": "pass --force to `git worktree remove` (a dirty/locked worktree)",
-          "name": "force",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "yes": {
-          "description": "confirm the destructive --and-worktrees removal (required with it)",
-          "name": "yes",
-          "allowNo": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "set:rm",
-      "pluginAlias": "@saga-ed/saga-stack-cli",
-      "pluginName": "@saga-ed/saga-stack-cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "set",
-        "rm.js"
-      ]
-    },
-    "set:show": {
-      "aliases": [],
-      "args": {
-        "name": {
-          "description": "set name (see `set list`)",
-          "name": "name",
-          "required": true
-        }
-      },
-      "description": "Show one worktree set: slot, repos, and each repo’s live branch + dirty state (read-only).",
-      "examples": [
-        "<%= config.bin %> <%= command.id %> journey-fix"
-      ],
-      "flags": {
-        "porcelain": {
-          "description": "machine-readable output; no color, minimal noise",
-          "name": "porcelain",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
-          "name": "slot",
-          "default": 0,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "output-json": {
-          "description": "emit structured JSON on stdout instead of human-readable text",
-          "name": "output-json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "set": {
-          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
-          "name": "set",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dev": {
-          "description": "sibling-repo workspace root (where the saga repos are checked out)",
-          "name": "dev",
-          "noCacheDefault": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
-          "name": "state-dir",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "soa": {
-          "description": "override path to the soa repo checkout",
-          "name": "soa",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rostering": {
-          "description": "override path to the rostering repo checkout",
-          "name": "rostering",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "program-hub": {
-          "description": "override path to the program-hub repo checkout",
-          "name": "program-hub",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "saga-dash": {
-          "description": "override path to the saga-dash repo checkout",
-          "name": "saga-dash",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "coach": {
-          "description": "override path to the coach repo checkout",
-          "name": "coach",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "sds": {
-          "description": "override path to the sds (student-data-system) repo checkout",
-          "name": "sds",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "qboard": {
-          "description": "override path to the qboard repo checkout",
-          "name": "qboard",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rtsm": {
-          "description": "override path to the rtsm repo checkout",
-          "name": "rtsm",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fleek": {
-          "description": "override path to the fleek repo checkout",
-          "name": "fleek",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fetch": {
-          "description": "git fetch each repo first so the mainline-currency report reflects the REMOTE tip (network); without it, currency is as-of the last fetch",
-          "name": "fetch",
-          "allowNo": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "set:show",
-      "pluginAlias": "@saga-ed/saga-stack-cli",
-      "pluginName": "@saga-ed/saga-stack-cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "set",
-        "show.js"
       ]
     },
     "stack:bootstrap": {
@@ -3614,6 +2859,761 @@
         "commands",
         "stack",
         "verify.js"
+      ]
+    },
+    "set:check": {
+      "aliases": [],
+      "args": {
+        "name": {
+          "description": "set name (see `set list`)",
+          "name": "name",
+          "required": true
+        }
+      },
+      "description": "Validate a worktree set: paths, buildable-vs-prebuilt, branch drift (warn), primary-checkout posture, cross-set build collisions. Exit 1 on violations.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> journey-fix"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "set:check",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "set",
+        "check.js"
+      ]
+    },
+    "set:create": {
+      "aliases": [],
+      "args": {
+        "name": {
+          "description": "set name (must be unused)",
+          "name": "name",
+          "required": true
+        }
+      },
+      "description": "Create a worktree set: git worktree add (new/existing branch) off the primary checkout, pnpm install, and record it in the sets file (createdBy: ss). Single repo per call.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> sched --slot 1 --repo saga-dash --path ~/dev/worktrees/saga-dash-sched --branch feat/sched",
+        "<%= config.bin %> <%= command.id %> topo --slot 2 --repo saga-dash --path ~/dev/worktrees/saga-dash-topo --branch flow/topology --no-install"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "slot the set binds (1..9; slot 0 is the primary-checkout baseline)",
+          "name": "slot",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "repo": {
+          "description": "repo to make a worktree for",
+          "name": "repo",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "soa",
+            "rostering",
+            "program-hub",
+            "saga-dash",
+            "coach",
+            "sds",
+            "qboard",
+            "rtsm",
+            "fleek"
+          ],
+          "type": "option"
+        },
+        "path": {
+          "description": "worktree checkout path (recorded verbatim; `~` stays portable)",
+          "name": "path",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "branch": {
+          "description": "branch to check out — created if new, attached if it exists (default: the set name)",
+          "name": "branch",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "base": {
+          "description": "start point for a NEW branch (default: the primary checkout HEAD, e.g. main)",
+          "name": "base",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "note": {
+          "description": "optional note stored on the set",
+          "name": "note",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "install": {
+          "description": "pnpm install in the new worktree so `--set` up/e2e fresh-skip (use --no-install to skip)",
+          "name": "install",
+          "allowNo": true,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "set:create",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "set",
+        "create.js"
+      ]
+    },
+    "set:list": {
+      "aliases": [],
+      "args": {},
+      "description": "List the worktree sets (name, slot, live ACTIVE state, repos) from the sets file (read-only).",
+      "examples": [
+        "<%= config.bin %> <%= command.id %>",
+        "<%= config.bin %> <%= command.id %> --output-json"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "set:list",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "set",
+        "list.js"
+      ]
+    },
+    "set:rm": {
+      "aliases": [],
+      "args": {
+        "name": {
+          "description": "set name (see `set list`)",
+          "name": "name",
+          "required": true
+        }
+      },
+      "description": "Remove a worktree set from the sets file. --and-worktrees also `git worktree remove`s the ss-created worktrees (createdBy: ss); hand-recorded paths are never touched.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> sched",
+        "<%= config.bin %> <%= command.id %> sched --and-worktrees --yes"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "and-worktrees": {
+          "description": "also `git worktree remove` the worktrees ss created (createdBy: ss); requires --yes",
+          "name": "and-worktrees",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "force": {
+          "description": "pass --force to `git worktree remove` (a dirty/locked worktree)",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "yes": {
+          "description": "confirm the destructive --and-worktrees removal (required with it)",
+          "name": "yes",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "set:rm",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "set",
+        "rm.js"
+      ]
+    },
+    "set:show": {
+      "aliases": [],
+      "args": {
+        "name": {
+          "description": "set name (see `set list`)",
+          "name": "name",
+          "required": true
+        }
+      },
+      "description": "Show one worktree set: slot, repos, and each repo’s live branch + dirty state (read-only).",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> journey-fix"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fetch": {
+          "description": "git fetch each repo first so the mainline-currency report reflects the REMOTE tip (network); without it, currency is as-of the last fetch",
+          "name": "fetch",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "set:show",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "set",
+        "show.js"
       ]
     },
     "stack:bundle:list": {

--- a/packages/node/saga-stack-cli/src/__tests__/e2e-orchestrate-slot.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/__tests__/e2e-orchestrate-slot.unit.test.ts
@@ -115,6 +115,28 @@ describe('buildStackContext — slot threading (parity with stack up buildRuntim
     expect(runtime.pgProbe).toBe(PG_PROBE);
     expect(runtime.launchContext.ports['iam-api']).toBe(3010);
   });
+
+  it('--tunnel: the domain reaches the LAUNCH TOKENS, not just the Runtime (soa#322)', () => {
+    // Without TUNNEL_DOMAIN in the tokens, tunnelOverlay() returns {} for every
+    // service this path auto-launches — `develop … --tunnel` then serves pages over
+    // the public tunnel origin whose inlined VITE_*/PUBLIC_* still say localhost.
+    // Runtime.tunnelDomain alone only drives Playwright URLs + the dash hook.
+    const { runtime } = buildStackContext(
+      FLAGS,
+      seams(),
+      delegate,
+      deriveInstance({ slot: 0 }),
+      'x.vms.wootdev.com',
+    );
+    expect(runtime.tunnel).toBe(true);
+    expect(runtime.tunnelDomain).toBe('x.vms.wootdev.com');
+    expect(runtime.launchContext.tokens.TUNNEL_DOMAIN).toBe('x.vms.wootdev.com');
+  });
+
+  it('no --tunnel: no TUNNEL_DOMAIN token (local launches stay overlay-free)', () => {
+    const { runtime } = buildStackContext(FLAGS, seams(), delegate);
+    expect(runtime.launchContext.tokens.TUNNEL_DOMAIN).toBeUndefined();
+  });
 });
 
 describe('serviceUrlEnv / playwrightEnv — offset Playwright service URLs', () => {

--- a/packages/node/saga-stack-cli/src/commands/develop/coach.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/coach.ts
@@ -192,7 +192,7 @@ export default class DevelopCoach extends BaseCommand {
     tunnel: Flags.boolean({
       default: false,
       description:
-        "point THIS run's flow browsers at the vms tunnel hosts (https://<label>.<moniker>.<VMS_BASE>) instead of localhost, so a REMOTE peer can reach the same stack. Resolves the moniker via the vendored tunnel.sh (same machinery as `stack up --tunnel`). NOTE: this ONLY repoints the flow's Playwright browsers — it does NOT relaunch the stack; you must have already run `ss stack up --tunnel`. Slot-0 only.",
+        "point THIS run's flow browsers at the vms tunnel hosts (https://<label>.<moniker>.<VMS_BASE>) instead of localhost, so a REMOTE peer can reach the same stack. Resolves the moniker via the vendored tunnel.sh (same machinery as `stack up --tunnel`). Services ALREADY UP are reused untouched; any service this run must launch itself comes up WITH the tunnel browser-env overlay (soa#322). It does NOT start frpc — run `ss stack up --tunnel` first for the tunnel itself. Slot-0 only.",
     }),
   };
 

--- a/packages/node/saga-stack-cli/src/commands/develop/connect.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/connect.ts
@@ -111,7 +111,7 @@ export default class DevelopConnect extends BaseCommand {
     tunnel: Flags.boolean({
       default: false,
       description:
-        'point THIS run’s Connect browsers at the vms tunnel hosts (https://<label>.<moniker>.<VMS_BASE>) instead of localhost, so a REMOTE peer can reach the same room. Resolves the moniker via the vendored tunnel.sh (same machinery as `stack up --tunnel`). NOTE: this ONLY repoints these Playwright browsers’ URLs — it does NOT relaunch the stack, flip connect-web/rtsm/cookie env, or start frpc. You must have already run `ss stack up --tunnel` so the stack itself is tunnel-served. Slot-0 only.',
+        'point THIS run’s Connect browsers at the vms tunnel hosts (https://<label>.<moniker>.<VMS_BASE>) instead of localhost, so a REMOTE peer can reach the same room. Resolves the moniker via the vendored tunnel.sh (same machinery as `stack up --tunnel`). Services ALREADY UP are reused untouched; any service this run must launch itself comes up WITH the tunnel browser-env overlay (soa#322). It does NOT start frpc or fetch LiveKit creds — run `ss stack up --tunnel` first for the tunnel itself (and real A/V). Slot-0 only.',
     }),
     'student-login': Flags.integer({
       default: 2,

--- a/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
+++ b/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
@@ -284,6 +284,14 @@ export function buildStackContext(
     pinoLevel: process.env.PINO_LOGGER_LEVEL,
     pinoIsExpressContext: process.env.PINO_LOGGER_ISEXPRESSCONTEXT,
     rtsmFleetPath,
+    // --tunnel: thread the domain into the LAUNCH TOKENS, not just the Runtime.
+    // Without this, tunnelOverlay() returns {} for every service THIS path
+    // auto-launches, so `develop … --tunnel` silently brought services up with
+    // pure-local browser env (VITE_*/PUBLIC_* = localhost) inlined into pages
+    // served over the public tunnel origin (soa#322). Services already up are
+    // still adopted untouched — this only fixes what develop itself launches.
+    // lk creds / the generated rtsm fleet stay `stack up --tunnel` machinery.
+    tunnel: tunnelDomain !== undefined ? { domain: tunnelDomain } : undefined,
   });
 
   const runtime: Runtime = {


### PR DESCRIPTION
Rescue PR, no new code. **#325 never reached `main`**: it merged into `gh305-tunnel-slot-rollup` at 00:34, eight minutes *after* #323 had already carried that branch to main at 00:26 — GitHub does not retarget a PR when its base branch still exists, so `45dfd0d` (the #322 fix) + its merge commit were stranded on the rollup branch.

Verified stranded by string test: main's `e2e-orchestrate.ts` carries only the pre-existing boolean `tunnel: tunnelDomain !== undefined,` (Runtime field, line 304) — not the threaded launch-token line the fix adds.

This branch is `main` + a merge of the rollup tip, which brings exactly the two stranded commits (authorship preserved). Suite on this tip: **1224 passed / 104 files**, tsc 0.

All of #325's verification (mutation-check, live `/proc` proof on a relaunched connect-web) applies to these commits unchanged — see #325.

Closes #322 (for real this time — the keyword in #325 never fired because its merge target was not the default branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)