### PR TITLE
feat(saga-stack-cli): inject DASH_CONFIG_LOCAL_JSON into saga-dash's launch env (#328)

### DIFF
--- a/packages/node/saga-stack-cli/docs/tunnel.md
+++ b/packages/node/saga-stack-cli/docs/tunnel.md
@@ -104,6 +104,13 @@ moniker via the vendored `tunnel.sh`, builds the tunnel-aware browser-plane env 
 (incl. coach), writes the dash's tunnel routing (`config.local.json`), fetches the fleek A/V creds,
 launches the stack, and starts the frpc reverse tunnels.
 
+The dash's tunnel routing rides **two channels** (soa#328): the same JSON is also injected into
+saga-dash's launch env as `DASH_CONFIG_LOCAL_JSON`, which a new-enough saga-dash dev server serves
+back for `GET /config.local.json` — per-instance routing that doesn't depend on the shared static
+file. The `config.local.json` file write remains as transitional back-compat for older saga-dash
+checkouts (the env injection also covers non-tunnel `--slot N` lanes; slot-0 non-tunnel injects
+nothing).
+
 The leading `ss stack down` is **part of the instruction**: `up --tunnel` skips any service whose
 port is already healthy, so a stack already up in localhost mode would keep its non-tunnel env —
 most visibly iam would set a **host-only** `iam_session` cookie and the dash couldn't hold the

--- a/packages/node/saga-stack-cli/docs/tunnel.md
+++ b/packages/node/saga-stack-cli/docs/tunnel.md
@@ -111,6 +111,14 @@ file. The `config.local.json` file write remains as transitional back-compat for
 checkouts (the env injection also covers non-tunnel `--slot N` lanes; slot-0 non-tunnel injects
 nothing).
 
+Because the env **shadows** the file in a new-enough dash, a still-running dash from a different
+mode can no longer self-heal by re-reading (or missing) the file — so `DASH_CONFIG_LOCAL_JSON` is
+an `adoptEnv` guard key (the soa#305 mechanism): `up` refuses to adopt an already-healthy dash
+whose stamped routing env doesn't match the current mode (tunnel → plain `up`, a changed moniker,
+a different mode in the same slot) and asks you to stop it and re-run, instead of silently leaving
+it dialing dead tunnel hosts. One-time cost: the first new-CLI `up` over a dash launched by an
+older build (no stamp) is refused the same way — stop the dash (or `ss stack down`) and re-run.
+
 The leading `ss stack down` is **part of the instruction**: `up --tunnel` skips any service whose
 port is already healthy, so a stack already up in localhost mode would keep its non-tunnel env —
 most visibly iam would set a **host-only** `iam_session` cookie and the dash couldn't hold the

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/up-native.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/up-native.int.test.ts
@@ -407,6 +407,14 @@ describe('stack up --slot N — isolated bring-up (M7 Phase 2)', () => {
     expect(launches.map((s) => s.id)).toContain('iam-api'); // backend dep up too
     // dash prelaunch hook ran and WROTE the offset-port slot config (not removed).
     expect(dashCalls.some((c) => c.startsWith('write:'))).toBe(true);
+    // soa#328: the SAME routing JSON also rides saga-dash's OWN launch env, so the
+    // slot's dash serves its own /config.local.json without the shared static file.
+    const cfg = JSON.parse(dash?.env.DASH_CONFIG_LOCAL_JSON ?? 'null');
+    expect(cfg.localDefaults.iam).toEqual({ type: 'url', url: 'http://localhost:4010' }); // 3010 + slot 1 offset
+    expect(cfg.localDefaults['ads-adm'].url).not.toContain(':5005'); // never slot 0's ads-adm
+    // no other service gets the dash-only var.
+    const iam = launches.find((s) => s.id === 'iam-api');
+    expect(iam?.env.DASH_CONFIG_LOCAL_JSON).toBeUndefined();
   });
 
   it('BARE full-stack --slot 1 routes through the NATIVE path (never the up.sh wrapper)', async () => {
@@ -492,6 +500,14 @@ describe('stack up --slot N — isolated bring-up (M7 Phase 2)', () => {
     const tun = runs.find((r) => r.command.endsWith('tunnel.sh'));
     expect(tun?.args).toEqual(['up']);
     expect(tun?.command).toContain('vendor');
+    // soa#328: saga-dash's launch env carries its own tunnel routing JSON (the same
+    // map the file hook writes), so the dash serves per-instance /config.local.json.
+    const dash = launches.find((s) => s.id === 'saga-dash');
+    const cfg = JSON.parse(dash?.env.DASH_CONFIG_LOCAL_JSON ?? 'null');
+    expect(cfg.localDefaults.iam).toEqual({
+      type: 'url',
+      url: 'https://iam.testmoniker.vms.wootdev.com',
+    });
   });
 
   it('--slot 10 is rejected at the flag layer (rabbitmq-mgmt collision ceiling)', async () => {
@@ -509,6 +525,9 @@ describe('stack up --slot N — isolated bring-up (M7 Phase 2)', () => {
     // dash existsFile()=false in the fake ⇒ non-tunnel slot-0 path is a noop-absent
     // (no write). The key assertion: NO stack-slot write happened at slot 0.
     expect(dashCalls.some((c) => c.startsWith('write:'))).toBe(false);
+    // soa#328: slot-0 non-tunnel injects NO dash config env — launch env byte-identical.
+    const dash = launches.find((s) => s.id === 'saga-dash');
+    expect(dash?.env.DASH_CONFIG_LOCAL_JSON).toBeUndefined();
   });
 
   // NB: these two --login tests are placed at the END of this describe (not by the

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/up-native.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/up-native.int.test.ts
@@ -508,6 +508,11 @@ describe('stack up --slot N — isolated bring-up (M7 Phase 2)', () => {
       type: 'url',
       url: 'https://iam.testmoniker.vms.wootdev.com',
     });
+    // … and the launch spec carries the adoptEnv guard on that key: the env now
+    // SHADOWS the static file in a new-enough dash, so a mode-drifted already-up
+    // dash (e.g. tunnel → plain `up` without a `stack down`) must be refused and
+    // relaunched, not adopted with frozen tunnel routing (soa#305 pattern).
+    expect(dash?.adoptEnv).toContain('DASH_CONFIG_LOCAL_JSON');
   });
 
   it('--slot 10 is rejected at the flag layer (rabbitmq-mgmt collision ceiling)', async () => {

--- a/packages/node/saga-stack-cli/src/commands/stack/up.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/up.ts
@@ -646,6 +646,7 @@ export default class StackUp extends BaseCommand {
         skipped: up.skipped.map((s) => ({ id: s.id, repo: s.repo, repoDir: s.repoDir })),
         mesh: { ok: up.mesh.ok, units: up.mesh.units.map((u) => ({ id: u.id, ok: u.ok })) },
         dash: up.dash?.action ?? null,
+        dashConfigEnv: up.dashConfigEnv ?? null,
         seed: {
           ok: seeded.ok,
           offline: seeded.ran.offline,
@@ -660,6 +661,10 @@ export default class StackUp extends BaseCommand {
         ...(up.skipped.length ? [`skipped (repo not cloned): ${up.skipped.map((s) => s.id).join(', ')}`] : []),
         `mesh: ${up.mesh.units.map((u) => `${u.id}=${u.ok ? 'ready' : 'DOWN'}`).join(', ') || '(none)'}`,
         ...(up.dash ? [`dash defaults: ${up.dash.action}`] : []),
+        // soa#328: the per-instance dash routing env (same JSON as the file write).
+        ...(up.dashConfigEnv
+          ? [`dash config env: DASH_CONFIG_LOCAL_JSON injected (${up.dashConfigEnv.mode}, slot ${up.dashConfigEnv.slot})`]
+          : []),
         `seed offline: ${seeded.ran.offline.join(', ') || '(none)'}`,
         `seed online:  ${seeded.ran.online.join(', ') || '(none)'}`,
         seeded.ok ? 'seed: OK' : `seed: FAILED at ${seeded.failed}`,

--- a/packages/node/saga-stack-cli/src/core/manifest/services.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/services.ts
@@ -381,6 +381,19 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
     isFrontend: true,
     optional: false,
     prelaunchHook: 'sync-dash-local-defaults',
+    // soa#328: the dash's routing JSON rides its OWN launch env now
+    // (DASH_CONFIG_LOCAL_JSON — dash-defaults.ts's DASH_CONFIG_ENV_VAR, stamped
+    // by stack-api's launch loop in tunnel / slot > 0 modes), and a new-enough
+    // dash dev server serves that env verbatim for /config.local.json —
+    // SHADOWING the static file. Without this guard an already-up dash from a
+    // different mode gets adopted with its frozen routing (e.g. `up --tunnel`
+    // then plain `up`: the file hook removes config.local.json, but the adopted
+    // dash keeps serving the dead tunnel hosts from its stale env — the
+    // file-only self-heal the dash used to have is gone). Fingerprint the key so
+    // a mode-drifted dash is REFUSED loudly and relaunched with the current
+    // mode's env (soa#305 pattern, like iam-api's JWT_ISSUER; same one-time
+    // "stop and re-run" cost for a dash launched by an older CLI with no stamp).
+    adoptEnv: ['DASH_CONFIG_LOCAL_JSON'],
   },
   'connect-api': {
     id: 'connect-api',

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/dash-defaults.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/dash-defaults.unit.test.ts
@@ -17,6 +17,7 @@ import {
   tunnelConfigContents,
 } from '../dash-defaults.js';
 import type { DashFs } from '../dash-defaults.js';
+import { getService } from '../../core/manifest/index.js';
 import type { ServiceId } from '../../core/manifest/index.js';
 
 const DASH = '/repo/saga-dash';
@@ -184,6 +185,16 @@ describe('buildDashLocalDefaultsJson — soa#328 per-instance env JSON', () => {
     // saga-dash's dev-server middleware reads process.env.DASH_CONFIG_LOCAL_JSON —
     // renaming this breaks the cross-repo contract (soa#328).
     expect(DASH_CONFIG_ENV_VAR).toBe('DASH_CONFIG_LOCAL_JSON');
+  });
+
+  it("the env var is a saga-dash adoptEnv guard key (manifest ties to the constant)", () => {
+    // The env now SHADOWS the static file in a new-enough dash, so an already-up
+    // dash carrying a different mode's stamp must be REFUSED, not adopted — else
+    // `up --tunnel` → plain `up` leaves a dash serving dead tunnel hosts from its
+    // frozen env after the file hook removed config.local.json (the file-only
+    // self-heal is gone). services.ts declares the key as a string literal (core
+    // can't import runtime); this pins the two together.
+    expect(getService('saga-dash').adoptEnv).toContain(DASH_CONFIG_ENV_VAR);
   });
 
   it('tunnel mode: returns the EXACT string the tunnel file writer emits', () => {

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/dash-defaults.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/dash-defaults.unit.test.ts
@@ -7,8 +7,10 @@
 
 import { describe, expect, it } from 'vitest';
 import {
+  DASH_CONFIG_ENV_VAR,
   DASH_LOCAL_SERVICES,
   DASH_TUNNEL_LABELS,
+  buildDashLocalDefaultsJson,
   dashLocalConfigPath,
   stackSlotConfigContents,
   syncDashLocalDefaults,
@@ -168,5 +170,52 @@ describe('syncDashLocalDefaults — M7 stack-lane slot config', () => {
     const parsed = JSON.parse(stackSlotConfigContents({ 'iam-api': 4010 }));
     expect(parsed.localDefaults.iam).toEqual({ type: 'url', url: 'http://localhost:4010' });
     expect(parsed.localDefaults.connect).toBeUndefined(); // connect-api port absent → dropped
+  });
+});
+
+describe('buildDashLocalDefaultsJson — soa#328 per-instance env JSON', () => {
+  const PORTS: Partial<Record<ServiceId, number>> = {
+    'iam-api': 4010,
+    'programs-api': 4006,
+    'ads-adm-api': 6005,
+  };
+
+  it('the env var name is the locked cross-repo contract', () => {
+    // saga-dash's dev-server middleware reads process.env.DASH_CONFIG_LOCAL_JSON —
+    // renaming this breaks the cross-repo contract (soa#328).
+    expect(DASH_CONFIG_ENV_VAR).toBe('DASH_CONFIG_LOCAL_JSON');
+  });
+
+  it('tunnel mode: returns the EXACT string the tunnel file writer emits', () => {
+    expect(buildDashLocalDefaultsJson({ tunnel: true, tunnelDomain: 'abc.vms.wootdev.com' })).toBe(
+      tunnelConfigContents('abc.vms.wootdev.com'),
+    );
+  });
+
+  it('tunnel without a domain: null (never an https://<label>.undefined config)', () => {
+    expect(buildDashLocalDefaultsJson({ tunnel: true })).toBeNull();
+  });
+
+  it('non-tunnel slot > 0: returns the EXACT string the slot file writer emits', () => {
+    expect(buildDashLocalDefaultsJson({ slot: 1, stackPorts: PORTS })).toBe(
+      stackSlotConfigContents(PORTS),
+    );
+  });
+
+  it('non-tunnel slot 0: null even with stackPorts present (nothing to inject)', () => {
+    expect(buildDashLocalDefaultsJson({ slot: 0, stackPorts: PORTS })).toBeNull();
+    expect(buildDashLocalDefaultsJson({ stackPorts: PORTS })).toBeNull();
+  });
+
+  it('non-tunnel slot > 0 WITHOUT stackPorts: null (no ports to point at)', () => {
+    expect(buildDashLocalDefaultsJson({ slot: 1 })).toBeNull();
+  });
+
+  it('output satisfies the reader contract: JSON.parse yields a localDefaults url map', () => {
+    // The dash middleware serves the string VERBATIM after a JSON.parse gate.
+    const out = buildDashLocalDefaultsJson({ slot: 1, stackPorts: PORTS });
+    const parsed = JSON.parse(out ?? 'null');
+    expect(parsed.localDefaults.iam).toEqual({ type: 'url', url: 'http://localhost:4010' });
+    expect(parsed.localDefaults['ads-adm']).toEqual({ type: 'url', url: 'http://localhost:6005' });
   });
 });

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/launcher.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/launcher.unit.test.ts
@@ -282,6 +282,54 @@ describe('makeRealLauncher.launch adopt-contract guard (soa#305)', () => {
     expect(writeContract).toHaveBeenCalledWith(contractFilePath(STATE, 'iam-api'), FINGERPRINT);
   });
 
+  // saga-dash's guard (soa#328): DASH_CONFIG_LOCAL_JSON is injected only in
+  // tunnel / slot > 0 modes, so a MODE SWITCH shows up as the key present in one
+  // fingerprint and ABSENT (omitted, not '') from the other. The stale env
+  // SHADOWS the corrected static file in a new-enough dash, so adoption across
+  // the switch must be refused.
+  it('refuses to adopt across a mode switch: guarded key now ABSENT, stamp has it (tunnel → slot-0 dash)', async () => {
+    const { prober } = seqProber([true]); // old tunnel dash still healthy on :8900
+    const { spawn, calls } = fakeSpawn(1);
+    const launcher = makeRealLauncher({
+      stateDir: STATE,
+      prober,
+      spawn,
+      // stamped by the earlier `up --tunnel`.
+      readContract: () =>
+        JSON.stringify({ DASH_CONFIG_LOCAL_JSON: '{"localDefaults":{"iam":{"type":"url","url":"https://iam.m.vms.wootdev.com"}}}' }),
+    });
+
+    const res = await launcher.launch({
+      ...SPEC,
+      id: 'saga-dash',
+      // plain slot-0 `up`: no injection ⇒ expected fingerprint omits the key ({}).
+      env: { PORT: '8900' },
+      adoptEnv: ['DASH_CONFIG_LOCAL_JSON'],
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.reason).toMatch(/contract/);
+    expect(calls).toHaveLength(0); // loud fail, never a silent stale adoption
+  });
+
+  it('adopts a same-mode re-run when the guarded key is absent on BOTH sides (slot-0 → slot-0 dash)', async () => {
+    const { prober } = seqProber([true]);
+    const launcher = makeRealLauncher({
+      stateDir: STATE,
+      prober,
+      readContract: () => JSON.stringify({}), // stamped by a slot-0 non-tunnel spawn
+    });
+
+    const res = await launcher.launch({
+      ...SPEC,
+      id: 'saga-dash',
+      env: { PORT: '8900' },
+      adoptEnv: ['DASH_CONFIG_LOCAL_JSON'],
+    });
+
+    expect(res).toEqual({ id: 'saga-dash', ok: true, alreadyUp: true });
+  });
+
   it('leaves an UNguarded service (no adoptEnv) adopted unconditionally', async () => {
     const { prober } = seqProber([true]);
     const readContract = vi.fn(() => null);

--- a/packages/node/saga-stack-cli/src/runtime/dash-defaults.ts
+++ b/packages/node/saga-stack-cli/src/runtime/dash-defaults.ts
@@ -18,6 +18,12 @@
  * `DashFs` so the hook is unit-tested with NO real filesystem; production wires
  * `makeRealDashFs()`. This is runtime (fs IO), not core.
  *
+ * soa#328: the SAME JSON (via the pure `buildDashLocalDefaultsJson`) is also
+ * injected into saga-dash's launch env as `DASH_CONFIG_LOCAL_JSON` (see
+ * stack-api's launch loop), so each dash instance can serve its own routing
+ * without the shared static file. The file write/remove here is kept EXACTLY
+ * as before — transitional back-compat for older saga-dash checkouts.
+ *
  * INVARIANT (plan hard constraint): fs IO lives only in `src/runtime/**`;
  * `src/core/**` never imports this and stays pure.
  */
@@ -150,6 +156,34 @@ export function stackSlotConfigContents(stackPorts: Partial<Record<ServiceId, nu
   return `${JSON.stringify({ localDefaults }, null, 2)}\n`;
 }
 
+/** The env var name of the per-instance dash routing contract (soa#328). */
+export const DASH_CONFIG_ENV_VAR = 'DASH_CONFIG_LOCAL_JSON';
+
+/**
+ * PURE builder for a dash instance's `config.local.json` JSON (soa#328) — the
+ * EXACT string the file writers below emit for the same mode, or `null` when
+ * the mode writes no config:
+ *   - tunnel mode (with a domain)            ⇒ the `https://<label>.<domain>` map;
+ *   - tunnel mode WITHOUT a domain           ⇒ `null` (never `https://x.undefined`);
+ *   - non-tunnel slot > 0 (with `stackPorts`)⇒ the offset-localhost map;
+ *   - non-tunnel slot 0                      ⇒ `null` (dash's built-in defaults).
+ *
+ * Used by BOTH the file-write hook (`syncDashLocalDefaults`, transitional
+ * back-compat for older saga-dash checkouts) AND stack-api's launch-env
+ * injection (`DASH_CONFIG_ENV_VAR` = `DASH_CONFIG_LOCAL_JSON`, read by a new
+ * saga-dash dev-server middleware serving GET /config.local.json), so the two
+ * channels can never drift.
+ */
+export function buildDashLocalDefaultsJson(
+  ctx: Omit<DashDefaultsContext, 'sagaDashRoot'>,
+): string | null {
+  if (ctx.tunnel) {
+    return ctx.tunnelDomain ? tunnelConfigContents(ctx.tunnelDomain) : null;
+  }
+  if ((ctx.slot ?? 0) > 0 && ctx.stackPorts) return stackSlotConfigContents(ctx.stackPorts);
+  return null;
+}
+
 /**
  * Run the prelaunch hook. Pure-decision over the injectable `DashFs`, so it's
  * fully testable; returns what it did. In tunnel mode without a `tunnelDomain`
@@ -164,27 +198,22 @@ export function syncDashLocalDefaults(
   if (!fs.existsDir(staticDir)) return { action: 'noop-no-static' };
 
   const cfgPath = dashLocalConfigPath(ctx.sagaDashRoot);
+  const contents = buildDashLocalDefaultsJson(ctx);
 
-  // Non-tunnel (stack lane):
-  if (!ctx.tunnel) {
-    // M7 slot > 0: WRITE the offset-localhost config so the slot's dash dials its
-    // own ports (removing the file would fall back to the base-port = slot-0 iam).
-    if ((ctx.slot ?? 0) > 0 && ctx.stackPorts) {
-      fs.write(cfgPath, stackSlotConfigContents(ctx.stackPorts));
-      return { action: 'wrote-stack-slot', path: cfgPath };
-    }
-    // Slot 0: localhost defaults — remove any stale tunnel config (byte-identical).
-    if (fs.existsFile(cfgPath)) {
-      fs.remove(cfgPath);
-      return { action: 'removed', path: cfgPath };
-    }
-    return { action: 'noop-absent', path: cfgPath };
+  // A mode with config WRITES it (tunnel map, or M7 slot > 0's offset-localhost
+  // map so the slot's dash dials its own ports rather than slot 0's base ports).
+  if (contents !== null) {
+    fs.write(cfgPath, contents);
+    return { action: ctx.tunnel ? 'wrote' : 'wrote-stack-slot', path: cfgPath };
   }
 
-  // Tunnel: write the <svc>→https://<label>.<domain> map.
-  if (!ctx.tunnelDomain) return { action: 'noop-absent', path: cfgPath };
-  fs.write(cfgPath, tunnelConfigContents(ctx.tunnelDomain));
-  return { action: 'wrote', path: cfgPath };
+  // Non-tunnel slot 0: localhost defaults — remove any stale config (byte-identical
+  // to the pre-builder behaviour). Tunnel-without-domain skips the remove too.
+  if (!ctx.tunnel && fs.existsFile(cfgPath)) {
+    fs.remove(cfgPath);
+    return { action: 'removed', path: cfgPath };
+  }
+  return { action: 'noop-absent', path: cfgPath };
 }
 
 /** The production fs surface for the hook. */

--- a/packages/node/saga-stack-cli/src/stack-api.ts
+++ b/packages/node/saga-stack-cli/src/stack-api.ts
@@ -48,8 +48,10 @@ import { buildSeedRegistry } from './core/seed/profiles.js';
 import type { SeedPlan, SeedStep, SkipNote } from './core/seed/types.js';
 import type { PullMode } from './core/auto-pull.js';
 import {
+  DASH_CONFIG_ENV_VAR,
   REPO_DEFAULT_DIR,
   autoPullRepos,
+  buildDashLocalDefaultsJson,
   meshContainer,
   meshUp,
   migrateClosure,
@@ -332,6 +334,13 @@ export interface UpResult {
   migrate?: MigrateResult;
   /** What the dash prelaunch hook did (only when saga-dash was in the closure). */
   dash?: DashSyncResult;
+  /**
+   * The per-instance dash routing env injection (soa#328) — set only when
+   * `DASH_CONFIG_LOCAL_JSON` was injected into saga-dash's launch env (tunnel
+   * mode, or non-tunnel slot > 0). Absent ⇒ nothing injected (slot-0 non-tunnel,
+   * or saga-dash not launchable).
+   */
+  dashConfigEnv?: { mode: 'tunnel' | 'stack-slot'; slot: number };
   /** What the coach-web `.env.local` prelaunch hook did (only when coach-web was launchable + the seam wired). */
   coachWeb?: CoachWebSyncResult;
   /** Per-service launch results, in the order launched (topo waves flattened). */
@@ -879,6 +888,27 @@ export function makeStackApi(m: Manifest, runtime: Runtime): StackApi {
         );
       }
 
+      // 4a. per-instance dash routing env (soa#328) — the SAME JSON the file hook
+      // writes/would write, carried in saga-dash's OWN launch env as
+      // DASH_CONFIG_LOCAL_JSON. A new saga-dash's dev server serves it back for
+      // GET /config.local.json, so each dash instance gets ITS OWN routing from
+      // its own process env instead of the shared static file (which stays, via
+      // the hook above, as transitional back-compat for older saga-dash
+      // checkouts). Null (slot-0 non-tunnel) ⇒ nothing injected — the launch env
+      // stays byte-identical to today.
+      const dashConfigJson = launchable.includes('saga-dash')
+        ? buildDashLocalDefaultsJson({
+            tunnel: runtime.tunnel,
+            tunnelDomain: runtime.tunnelDomain,
+            slot: runtime.slot,
+            stackPorts: launchContext.ports,
+          })
+        : null;
+      const dashConfigEnv: UpResult['dashConfigEnv'] =
+        dashConfigJson !== null
+          ? { mode: runtime.tunnel ? 'tunnel' : 'stack-slot', slot: runtime.slot ?? 0 }
+          : undefined;
+
       // 4b. coach-web prelaunch hook (soa#300) — ONLY when coach-web is launchable AND
       // the seam is wired. coach-web is a SvelteKit adapter-static SPA that INLINES its
       // PUBLIC_* URLs from `.env` at vite-dev start; the checked-in `.env` points at
@@ -938,7 +968,12 @@ export function makeStackApi(m: Manifest, runtime: Runtime): StackApi {
               cwd: spec.cwd,
               command,
               args,
-              env: spec.env,
+              // soa#328: saga-dash carries its own routing JSON in its launch env
+              // (tunnel / slot > 0 only — dashConfigJson is null otherwise).
+              env:
+                id === 'saga-dash' && dashConfigJson !== null
+                  ? { ...spec.env, [DASH_CONFIG_ENV_VAR]: dashConfigJson }
+                  : spec.env,
               healthUrl: spec.healthUrl,
               // Guard the `alreadyUp` adoption on the service's contract keys (iam-api's
               // JWT_ISSUER) so a drifted/foreign already-up process is refused, not adopted
@@ -950,7 +985,7 @@ export function makeStackApi(m: Manifest, runtime: Runtime): StackApi {
         launched.push(...results);
         const failed = results.find((r) => !r.ok);
         if (failed) {
-          return { ok: false, autoPull, av, mesh, prep, provision, migrate, dash, coachWeb, launched, skipped, failedAt: failed.id as ServiceId, failedReason: failed.reason };
+          return { ok: false, autoPull, av, mesh, prep, provision, migrate, dash, dashConfigEnv, coachWeb, launched, skipped, failedAt: failed.id as ServiceId, failedReason: failed.reason };
         }
       }
 
@@ -995,7 +1030,7 @@ export function makeStackApi(m: Manifest, runtime: Runtime): StackApi {
         }
       }
 
-      return { ok: true, autoPull, av, mesh, prep, provision, migrate, dash, coachWeb, launched, skipped, record };
+      return { ok: true, autoPull, av, mesh, prep, provision, migrate, dash, dashConfigEnv, coachWeb, launched, skipped, record };
     },
 
     async down(services: ServiceId[]): Promise<DownResult> {


### PR DESCRIPTION
## Why

Every dash instance ss launches today reads its backend routing from ONE shared file — `<saga-dash>/apps/web/dash/static/config.local.json`, written/removed by the `sync-dash-local-defaults` prelaunch hook. With multiple dash instances live from the same checkout (slot-0 tunnel + slot-1 stack lane), the last writer wins and the other instance silently routes at the wrong backends — the split-brain class the hook's own comments warn about.

## What (writer side of the locked soa#328 cross-repo contract)

Each saga-dash launch now carries **its own routing in its own launch env**: `DASH_CONFIG_LOCAL_JSON` = the exact JSON the hook writes/would write into `config.local.json` for that mode (`{"localDefaults": {"<serviceKey>": {"type": "url", "url": "<...>"}}}`, 2-space JSON + trailing newline). A new-enough saga-dash dev server serves it back verbatim for `GET /config.local.json` (paired saga-dash PR — dev-server-only middleware; cross-link to follow).

- `src/runtime/dash-defaults.ts` — extracted the PURE `buildDashLocalDefaultsJson(ctx) → string | null`: tunnel (with domain) ⇒ tunnel-URL JSON; non-tunnel slot > 0 (with stackPorts) ⇒ offset-localhost JSON; else `null`. `syncDashLocalDefaults` now delegates to it — **file behaviour byte-identical** (same JSON, same modes, same `DashSyncResult` actions, incl. the tunnel-without-domain skip and the slot-0 remove). New `DASH_CONFIG_ENV_VAR` constant names the contract.
- `src/stack-api.ts` — the launch loop injects the builder output into saga-dash's `LaunchSpec.env` (single spawn seam; `launcher.launch` spawns with `{ ...process.env, ...spec.env }` so the var lands in the vite dev-server's `process.env`). Slot-0 non-tunnel ⇒ `null` ⇒ **launch env byte-identical to today**. Surfaced as `UpResult.dashConfigEnv`.
- `src/commands/stack/up.ts` — log line when injected: `dash config env: DASH_CONFIG_LOCAL_JSON injected (<tunnel|stack-slot>, slot <N>)` (+ machine field in the emit payload).
- `docs/tunnel.md` — notes the two channels and the transitional file fallback.

## Back-compat matrix

| dash \ ss | old ss | new ss |
|---|---|---|
| **old dash** | today | today (file still written/removed exactly as before) |
| **new dash** | today (no env ⇒ static fallback) | per-instance env routing; file kept as fallback |

The env injection is **additive** — no file behaviour changed, no manifest/env template changed, slot-0 non-tunnel launches are byte-identical.

## Tests

- `dash-defaults.unit.test.ts` — builder mode matrix (tunnel / tunnel-no-domain / slot > 0 / slot 0 / slot > 0-no-ports), builder output `.toBe()` the exact file-writer strings, JSON.parse reader-contract check, and an env-var-name contract guard.
- `up-native.int.test.ts` — through the REAL `StackUp` command with fake seams: slot-1 dash env carries the offset-port JSON (`iam → localhost:4010`, ads-adm never `:5005`, no leak onto iam-api's env); `--tunnel` dash env carries the tunnel map; slot-0 non-tunnel dash env has **no** `DASH_CONFIG_LOCAL_JSON`.
- Full package suite: **1231 passed / 14 todo, 104 files** (vitest). `tsc --noEmit`: **0 errors**. `eslint src/`: **0 errors** (99 pre-existing `turbo/no-undeclared-env-vars` warnings).

## Pairing

Pairs with the saga-dash reader PR (dev-server middleware serving `GET /config.local.json` from `process.env.DASH_CONFIG_LOCAL_JSON`) — **saga-ed/saga-dash#572**.

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)
