### PR TITLE
fix(saga-stack-cli): tunnel fail-loud + persona preflight + bake barrier + full-set dumps (#327 tiers 1–2)

### DIFF
--- a/packages/node/saga-stack-cli/examples/flows/saga-dash.flows.json
+++ b/packages/node/saga-stack-cli/examples/flows/saga-dash.flows.json
@@ -18,6 +18,7 @@
       "progressive": true,
       "foreground": true,
       "seed": { "reset": true, "profile": "roster" },
+      "settlePersonas": ["alex.tutor@example.org"],
       "stages": [
         {
           "id": "roster",

--- a/packages/node/saga-stack-cli/src/__tests__/e2e-orchestrate-tunnel-gate.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/__tests__/e2e-orchestrate-tunnel-gate.unit.test.ts
@@ -1,0 +1,48 @@
+/**
+ * soa#327 tunnel fail-loud — unit tests for the PURE message builder the
+ * prerequisite-restore gate raises under `--tunnel` instead of the local lane's
+ * silent warn+full-replay. The message IS the remediation: it must embed the
+ * original violation verbatim plus the docs/tunnel.md concierge recipe and both
+ * checkpoint escape hatches (`--refresh-snapshot` for develop connect, which has
+ * no --from-stale-ok flag; `--from-stale-ok` for e2e run).
+ */
+
+import { describe, expect, it } from 'vitest';
+import { tunnelPrereqFallbackMessage } from '../e2e-orchestrate.js';
+
+describe('tunnelPrereqFallbackMessage', () => {
+  it('embeds the original violation verbatim so the remediation is exact', () => {
+    const msg = tunnelPrereqFallbackMessage("no checkpoint 'flow-saga-dash-journey-s5-schedule'");
+    expect(msg).toContain("no checkpoint 'flow-saga-dash-journey-s5-schedule'");
+  });
+
+  it('carries the full docs/tunnel.md concierge recipe, in order', () => {
+    const msg = tunnelPrereqFallbackMessage('x');
+    const recipe = [
+      'ss stack down && ss stack up --seed full --reset',
+      'ss e2e run journey --through schedule',
+      'ss stack snapshot store --fixture-id tunnel-connect',
+      'ss stack down && ss stack up --tunnel --reset',
+      'ss stack snapshot restore tunnel-connect',
+      'ss develop connect --tunnel --student-login 1 --reuse',
+    ];
+    let cursor = -1;
+    for (const line of recipe) {
+      const at = msg.indexOf(line);
+      expect(at, `recipe line missing or out of order: ${line}`).toBeGreaterThan(cursor);
+      cursor = at;
+    }
+  });
+
+  it('names BOTH escape hatches — --refresh-snapshot (develop connect) and --from-stale-ok (e2e run only)', () => {
+    const msg = tunnelPrereqFallbackMessage('checkpoint is 9 days old');
+    // develop connect has NO --from-stale-ok flag, so the message must offer its
+    // own re-bake (--refresh-snapshot) and scope --from-stale-ok to e2e run.
+    expect(msg).toContain('--refresh-snapshot');
+    expect(msg).toMatch(/--from-stale-ok.*e2e run only/);
+  });
+
+  it('says it is refusing the silent fallback (the WHY)', () => {
+    expect(tunnelPrereqFallbackMessage('x')).toMatch(/refusing to fall back silently/);
+  });
+});

--- a/packages/node/saga-stack-cli/src/__tests__/helpers/seams.ts
+++ b/packages/node/saga-stack-cli/src/__tests__/helpers/seams.ts
@@ -157,6 +157,9 @@ export function installCoreSeams(opts: CoreSeamsOptions): CoreSeams {
   // repo present so no service is skipped. Suites that test the skip-when-absent
   // path re-spy this per test.
   vi.spyOn(proto, 'getRepoDirCheck').mockReturnValue(() => true);
+  // soa#327: retry/poll delays (tunnel preflight, settle barrier) must never
+  // wall-clock-wait in tests — attempt/poll COUNTS carry the semantics.
+  vi.spyOn(proto, 'getSleep').mockReturnValue(async () => {});
 
   return {
     launches,

--- a/packages/node/saga-stack-cli/src/__tests__/helpers/seams.ts
+++ b/packages/node/saga-stack-cli/src/__tests__/helpers/seams.ts
@@ -52,6 +52,7 @@ import type {
   Runner,
   ScriptInvocation,
   ServiceLauncher,
+  SettleBarrierContext,
   StopResult,
 } from '../../runtime/index.js';
 
@@ -84,6 +85,13 @@ export interface CoreSeams {
    * purpose: up-native pre-seeds the playback trio before any test runs.
    */
   provisioned: Set<string>;
+  /**
+   * Every settle-barrier invocation (soa#327 pre-dump quiescence gate), in
+   * call order. The battery's default barrier is a recording NO-OP — its real
+   * poll/cap logic has scripted unit coverage in settle-barrier.unit.test.ts;
+   * suites that need a hanging/rejecting barrier re-spy `getSettleBarrier`.
+   */
+  barrierCalls: SettleBarrierContext[];
   /** Present only when `captureLauncherSpy` was set. */
   launcherSpy?: ReturnType<typeof vi.spyOn>;
 }
@@ -160,11 +168,19 @@ export function installCoreSeams(opts: CoreSeamsOptions): CoreSeams {
   // soa#327: retry/poll delays (tunnel preflight, settle barrier) must never
   // wall-clock-wait in tests — attempt/poll COUNTS carry the semantics.
   vi.spyOn(proto, 'getSleep').mockReturnValue(async () => {});
+  // soa#327: the REAL barrier would poll the (fake, never-settling) pgProbe up
+  // to its cap on every bake — replace it with a recording no-op so bakes stay
+  // instant; the barrier's own logic is unit-tested with scripted probes.
+  const barrierCalls: SettleBarrierContext[] = [];
+  vi.spyOn(proto, 'getSettleBarrier').mockReturnValue(async (ctx: SettleBarrierContext) => {
+    barrierCalls.push(ctx);
+  });
 
   return {
     launches,
     runs,
     provisioned,
+    barrierCalls,
     ...(opts.captureLauncherSpy ? { launcherSpy } : {}),
   };
 }

--- a/packages/node/saga-stack-cli/src/base-command.ts
+++ b/packages/node/saga-stack-cli/src/base-command.ts
@@ -78,6 +78,7 @@ import {
   repoOverridesFromFlags,
   makeRealSnapshotIO,
   makeRealViteClear,
+  realSleep,
   makeRealDockerWipe,
   makeRealBuildCleaner,
   makeRealEnvFs,
@@ -114,6 +115,7 @@ import type {
   SetStore,
   ServiceLauncher,
   ServiceStopper,
+  SleepFn,
   SnapshotIO,
   ViteClear,
   DockerWipe,
@@ -672,6 +674,16 @@ export abstract class BaseCommand extends Command {
    */
   protected getCookiePoster(): CookiePoster {
     return makeRealCookiePoster();
+  }
+
+  /**
+   * The sleep seam (soa#327 — settle barrier polls + tunnel-preflight retries).
+   * Production is the ONLY place real time passes between attempts; the shared
+   * test battery replaces it with an instant no-op so retry/poll LOGIC is
+   * asserted without wall-clock waits.
+   */
+  protected getSleep(): SleepFn {
+    return realSleep;
   }
 
   /**

--- a/packages/node/saga-stack-cli/src/base-command.ts
+++ b/packages/node/saga-stack-cli/src/base-command.ts
@@ -78,6 +78,7 @@ import {
   repoOverridesFromFlags,
   makeRealSnapshotIO,
   makeRealViteClear,
+  makeSettleBarrier,
   realSleep,
   makeRealDockerWipe,
   makeRealBuildCleaner,
@@ -115,6 +116,7 @@ import type {
   SetStore,
   ServiceLauncher,
   ServiceStopper,
+  SettleBarrier,
   SleepFn,
   SnapshotIO,
   ViteClear,
@@ -684,6 +686,24 @@ export abstract class BaseCommand extends Command {
    */
   protected getSleep(): SleepFn {
     return realSleep;
+  }
+
+  /**
+   * The bake quiescence barrier (soa#327) — production composes the real pg
+   * probe + devLogin poster into the pre-dump settle wait; the shared test
+   * battery replaces the WHOLE barrier with a recording no-op (its poll/cap
+   * logic has its own scripted unit coverage). Must be built AFTER
+   * `applyInstanceEnv` has run for the slot — like the checkpoint store, the
+   * barrier resolves the postgres container at CALL time.
+   */
+  protected getSettleBarrier(slot: number, log: (line: string) => void): SettleBarrier {
+    return makeSettleBarrier({
+      probe: this.getPgProbe(),
+      poster: this.getCookiePoster(),
+      log,
+      slot,
+      sleep: this.getSleep(),
+    });
   }
 
   /**

--- a/packages/node/saga-stack-cli/src/commands/develop/__tests__/connect.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/__tests__/connect.int.test.ts
@@ -171,12 +171,50 @@ describe('develop connect — slot awareness (slot > 0)', () => {
     expect(playwrightRuns()).toHaveLength(0);
   });
 
-  it('--tunnel at slot 0 still works (the guard is slot-scoped, not a tunnel ban)', async () => {
+  it('--tunnel --reuse at slot 0 still works (the guard is slot-scoped, not a tunnel ban)', async () => {
     vi.spyOn(BaseCommand.prototype as never, 'getTunnelMoniker' as never).mockReturnValue(
       (async () => 'testmoniker') as never,
     );
-    await DevelopConnect.run(['--tunnel', ...ws()], config);
+    // --reuse: the walkthrough-verified concierge path (docs/tunnel.md step 3). A bare
+    // tunnel run with no baked prerequisite checkpoint now fail-louds by design
+    // (soa#327, covered below); the concierge path must stay byte-identical.
+    await DevelopConnect.run(['--tunnel', '--reuse', ...ws()], config);
     expect(liveRun()?.env?.PLAYWRIGHT_BASE_URL).toMatch(/^https:\/\/dash\.testmoniker\./);
+  });
+});
+
+describe('develop connect — tunnel fail-loud on an unusable prerequisite checkpoint (soa#327)', () => {
+  function fakeMoniker(): void {
+    vi.spyOn(BaseCommand.prototype as never, 'getTunnelMoniker' as never).mockReturnValue(
+      (async () => 'testmoniker') as never,
+    );
+  }
+
+  it('--tunnel with NO baked checkpoint hard-errors with the docs/tunnel.md recipe — no silent WAN replay', async () => {
+    fakeMoniker();
+    // The seams' store fake answers load → null (no checkpoint baked).
+    await expect(DevelopConnect.run(['--tunnel', ...ws()], config)).rejects.toThrow(
+      /ss stack snapshot restore tunnel-connect[\s\S]*--refresh-snapshot/,
+    );
+    // The gate must PREVENT the replay: no Playwright child (journey stages or the
+    // room) was ever spawned, and no reset/seed ran. If the gate is deleted, the
+    // fallback replay runs and these invocations appear — the mutation is caught.
+    expect(playwrightRuns()).toHaveLength(0);
+    expect(runs.some((r) => r.args.includes('db:seed'))).toBe(false);
+  });
+
+  it('the loud error embeds the ORIGINAL violation so the remediation is exact', async () => {
+    fakeMoniker();
+    await expect(DevelopConnect.run(['--tunnel', ...ws()], config)).rejects.toThrow(/no checkpoint 'flow-saga-dash-journey-s5-schedule'/);
+  });
+
+  it('WITHOUT --tunnel the same missing checkpoint still falls back to the full replay (local lane pinned)', async () => {
+    // Regression twin of checkpoint.int.test.ts "falls back … never hard-errors":
+    // the gate is tunnel-scoped, the local lane keeps the silent replay.
+    await DevelopConnect.run([...ws()], config);
+    // Replay signature: the journey prerequisite spawned before the live room.
+    expect(playwrightRuns().length).toBeGreaterThan(1);
+    expect(liveRun()).toBeDefined();
   });
 });
 

--- a/packages/node/saga-stack-cli/src/commands/develop/__tests__/connect.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/__tests__/connect.int.test.ts
@@ -175,11 +175,24 @@ describe('develop connect — slot awareness (slot > 0)', () => {
     vi.spyOn(BaseCommand.prototype as never, 'getTunnelMoniker' as never).mockReturnValue(
       (async () => 'testmoniker') as never,
     );
+    // The concierge path never restores a checkpoint, so the soa#327 preflight
+    // must make ZERO devLogin probes — record every poster call to prove it.
+    const posterCalls: string[] = [];
+    vi.spyOn(
+      BaseCommand.prototype as unknown as { getCookiePoster: () => unknown },
+      'getCookiePoster',
+    ).mockReturnValue({
+      post: async (url: string) => {
+        posterCalls.push(url);
+        return { status: 200, ok: true, setCookies: [] };
+      },
+    });
     // --reuse: the walkthrough-verified concierge path (docs/tunnel.md step 3). A bare
     // tunnel run with no baked prerequisite checkpoint now fail-louds by design
     // (soa#327, covered below); the concierge path must stay byte-identical.
     await DevelopConnect.run(['--tunnel', '--reuse', ...ws()], config);
     expect(liveRun()?.env?.PLAYWRIGHT_BASE_URL).toMatch(/^https:\/\/dash\.testmoniker\./);
+    expect(posterCalls).toHaveLength(0);
   });
 });
 

--- a/packages/node/saga-stack-cli/src/commands/develop/connect.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/connect.ts
@@ -49,7 +49,7 @@ import { resolveFlow } from '../../core/flow/index.js';
 import { manifest as serviceManifest } from '../../core/manifest/index.js';
 import type { ScriptPlan } from '../../core/flag-map.js';
 import { makeStackApi } from '../../stack-api.js';
-import { resolveVendorScript } from '../../runtime/index.js';
+import { makePersonaPreflight, resolveVendorScript } from '../../runtime/index.js';
 import {
   buildStackContext,
   discoverFlowManifest,
@@ -331,6 +331,14 @@ export default class DevelopConnect extends BaseCommand {
           ports: runtime.launchContext.ports,
           checkpoints,
           tunnelDomain,
+          // soa#327: the tunnel post-restore devLogin probe — a --tunnel session
+          // whose journey@schedule checkpoint restored TORN must fail loud here,
+          // before the room's browsers launch and 401 minutes later.
+          preflight: makePersonaPreflight({
+            poster: this.getCookiePoster(),
+            log: (l) => this.log(l),
+            sleep: this.getSleep(),
+          }),
         },
         {
           lane: 'stack',

--- a/packages/node/saga-stack-cli/src/commands/develop/connect.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/connect.ts
@@ -302,6 +302,10 @@ export default class DevelopConnect extends BaseCommand {
             slot: profile.slot,
             ports: runtime.launchContext.ports,
             checkpoints,
+            // soa#327: the fresh bake must wait out the roster-sync pipeline
+            // before each per-stage dump — this bake path exists precisely to
+            // produce the checkpoint the tunnel session will trust.
+            settleBarrier: this.getSettleBarrier(profile.slot, (l) => this.log(l)),
           },
           { lane: 'stack', skipReset: false, passthrough: [], snapshotStages: true, prereqFromSnapshot: false, spaHead },
         );

--- a/packages/node/saga-stack-cli/src/commands/e2e/__tests__/checkpoint.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/__tests__/checkpoint.int.test.ts
@@ -20,7 +20,15 @@ import { installCoreSeams } from '../../../__tests__/helpers/seams.js';
 import { Config } from '@oclif/core';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { BaseCommand } from '../../../base-command.js';
-import type { LaunchSpec, ScriptInvocation, SnapshotIO } from '../../../runtime/index.js';
+import { PREFLIGHT_ATTEMPTS } from '../../../runtime/index.js';
+import type {
+  CookiePoster,
+  LaunchSpec,
+  PostOptions,
+  PostResult,
+  ScriptInvocation,
+  SnapshotIO,
+} from '../../../runtime/index.js';
 import E2eRun from '../run.js';
 import E2eConnect from '../../develop/connect.js';
 
@@ -488,6 +496,129 @@ describe('tunnel fail-loud (soa#327): unusable prerequisite checkpoint under --t
     await E2eConnect.run([...ws()], config);
     expect(logged.join('\n')).toContain('falling back to full replay');
     expect(playwrightRuns().length).toBeGreaterThan(1); // journey replay + the room
+  });
+});
+
+describe('tunnel post-restore persona preflight (soa#327)', () => {
+  let posts: { url: string; opts: PostOptions }[];
+  let savedVmsBase: string | undefined;
+
+  /** Poster answering `statuses` in order (last repeats); records every call. */
+  function installPoster(statuses: number[]): void {
+    posts = [];
+    const poster: CookiePoster = {
+      async post(url: string, opts: PostOptions): Promise<PostResult> {
+        posts.push({ url, opts });
+        const status = statuses[Math.min(posts.length - 1, statuses.length - 1)] ?? 0;
+        return { status, ok: status >= 200 && status < 300, setCookies: [] };
+      },
+    };
+    vi.spyOn(
+      BaseCommand.prototype as unknown as { getCookiePoster: () => CookiePoster },
+      'getCookiePoster',
+    ).mockReturnValue(poster);
+  }
+
+  function fakeMoniker(): void {
+    vi.spyOn(BaseCommand.prototype as never, 'getTunnelMoniker' as never).mockReturnValue(
+      (async () => 'testmoniker') as never,
+    );
+  }
+
+  beforeEach(() => {
+    // Pin the tunnel base domain so the probed URL is exactly assertable.
+    savedVmsBase = process.env.VMS_BASE;
+    process.env.VMS_BASE = 'vms.test';
+  });
+  afterEach(() => {
+    if (savedVmsBase === undefined) delete process.env.VMS_BASE;
+    else process.env.VMS_BASE = savedVmsBase;
+  });
+
+  async function bakeSchedule(): Promise<void> {
+    await E2eRun.run(['journey', '--through', 'schedule', '--snapshot-stages', '--headless', ...ws()], config);
+    runs.length = 0;
+    ioCalls.length = 0;
+    logged.length = 0;
+  }
+
+  it('valid checkpoint + poster 200: the session proceeds; ONE devLogin against the exact tunnel iam host', async () => {
+    await bakeSchedule();
+    installPoster([200]);
+    fakeMoniker();
+    await E2eConnect.run(['--tunnel', ...ws()], config);
+
+    // The probe drove the SAME host the room's browsers will use, with iam's own
+    // origin (the origin-check is load-bearing) and the declared persona.
+    expect(posts).toHaveLength(1);
+    expect(posts[0]!.url).toBe('https://iam.testmoniker.vms.test/trpc/auth.devLogin');
+    expect(posts[0]!.opts.origin).toBe('https://iam.testmoniker.vms.test');
+    expect(posts[0]!.opts.body).toContain('alex.tutor@example.org');
+    expect(playwrightRuns().some((r) => r.args.includes('interactive-connect'))).toBe(true);
+  });
+
+  it('poster 401: TORN checkpoint — loud error naming the persona + the recipe; no browser launches', async () => {
+    await bakeSchedule();
+    installPoster([401]);
+    fakeMoniker();
+    await expect(E2eConnect.run(['--tunnel', ...ws()], config)).rejects.toThrow(
+      /alex\.tutor@example\.org[\s\S]*HTTP 401[\s\S]*ss stack snapshot restore tunnel-connect/,
+    );
+    expect(playwrightRuns()).toHaveLength(0);
+  });
+
+  it('transport blips: status 0 twice then 200 proceeds — poster called 3x', async () => {
+    await bakeSchedule();
+    installPoster([0, 0, 200]);
+    fakeMoniker();
+    await E2eConnect.run(['--tunnel', ...ws()], config);
+    expect(posts).toHaveLength(3);
+    expect(playwrightRuns().some((r) => r.args.includes('interactive-connect'))).toBe(true);
+  });
+
+  it('persistently unreachable iam: capped retries then the loud torn error', async () => {
+    await bakeSchedule();
+    installPoster([0]);
+    fakeMoniker();
+    await expect(E2eConnect.run(['--tunnel', ...ws()], config)).rejects.toThrow(/no response/);
+    expect(posts).toHaveLength(PREFLIGHT_ATTEMPTS);
+    expect(playwrightRuns()).toHaveLength(0);
+  });
+
+  it('poster 403: devLogin-disabled misconfig gets its OWN message, NOT the re-bake recipe', async () => {
+    await bakeSchedule();
+    installPoster([403]);
+    fakeMoniker();
+    let message = '';
+    try {
+      await E2eConnect.run(['--tunnel', ...ws()], config);
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message).toMatch(/devLogin is disabled/);
+    // Re-baking cannot fix an AUTH_ENABLED/origin misconfig — the recipe would
+    // send the user on a wild-goose chase.
+    expect(message).not.toContain('ss stack snapshot restore tunnel-connect');
+    expect(playwrightRuns()).toHaveLength(0);
+  });
+
+  it('e2e run --from --tunnel fires the preflight after the --from restore too', async () => {
+    await bakeThroughProgram();
+    runs.length = 0;
+    installPoster([200]);
+    fakeMoniker();
+    await E2eRun.run(['journey', '--from', 'program', '--through', 'program', '--tunnel', '--headless', ...ws()], config);
+    expect(posts).toHaveLength(1);
+    expect(posts[0]!.url).toBe('https://iam.testmoniker.vms.test/trpc/auth.devLogin');
+    expect(playwrightRuns()).toHaveLength(1);
+  });
+
+  it('a NON-tunnel restore makes ZERO devLogin probes (local lane byte-identical)', async () => {
+    await bakeSchedule();
+    installPoster([200]);
+    await E2eConnect.run([...ws()], config);
+    expect(posts).toHaveLength(0);
+    expect(playwrightRuns().some((r) => r.args.includes('interactive-connect'))).toBe(true);
   });
 });
 

--- a/packages/node/saga-stack-cli/src/commands/e2e/__tests__/checkpoint.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/__tests__/checkpoint.int.test.ts
@@ -454,6 +454,43 @@ describe('e2e connect --refresh-snapshot (bake the prerequisite fresh, then rest
   });
 });
 
+describe('tunnel fail-loud (soa#327): unusable prerequisite checkpoint under --tunnel', () => {
+  function fakeMoniker(): void {
+    vi.spyOn(BaseCommand.prototype as never, 'getTunnelMoniker' as never).mockReturnValue(
+      (async () => 'testmoniker') as never,
+    );
+  }
+
+  it('a STALE journey@schedule checkpoint hard-errors with the violation + the docs/tunnel.md recipe', async () => {
+    await E2eRun.run(['journey', '--through', 'schedule', '--snapshot-stages', '--headless', ...ws()], config);
+    const m = readCkptManifest(CKPT_SCHEDULE);
+    (m.flow as Record<string, unknown>).bakedAt = '2020-01-01T00:00:00.000Z';
+    writeCkptManifest(CKPT_SCHEDULE, m);
+
+    runs.length = 0;
+    fakeMoniker();
+    await expect(E2eConnect.run(['--tunnel', ...ws()], config)).rejects.toThrow(
+      /days old[\s\S]*ss stack snapshot restore tunnel-connect[\s\S]*--refresh-snapshot/,
+    );
+    // The gate refuses BEFORE any replay spawn — deletion of the gate makes the
+    // journey replay run and these appear (the mutation signature).
+    expect(playwrightRuns()).toHaveLength(0);
+  });
+
+  it('the SAME stale checkpoint WITHOUT --tunnel keeps the local warn+replay (regression pin)', async () => {
+    await E2eRun.run(['journey', '--through', 'schedule', '--snapshot-stages', '--headless', ...ws()], config);
+    const m = readCkptManifest(CKPT_SCHEDULE);
+    (m.flow as Record<string, unknown>).bakedAt = '2020-01-01T00:00:00.000Z';
+    writeCkptManifest(CKPT_SCHEDULE, m);
+
+    runs.length = 0;
+    logged.length = 0;
+    await E2eConnect.run([...ws()], config);
+    expect(logged.join('\n')).toContain('falling back to full replay');
+    expect(playwrightRuns().length).toBeGreaterThan(1); // journey replay + the room
+  });
+});
+
 describe('M14-C review fixes', () => {
   it('--no-prereq-from-snapshot --dry-run does NOT advertise a restore the run would never attempt', async () => {
     logged.length = 0;

--- a/packages/node/saga-stack-cli/src/commands/e2e/__tests__/checkpoint.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/__tests__/checkpoint.int.test.ts
@@ -27,6 +27,8 @@ import type {
   PostOptions,
   PostResult,
   ScriptInvocation,
+  SettleBarrier,
+  SettleBarrierContext,
   SnapshotIO,
 } from '../../../runtime/index.js';
 import E2eRun from '../run.js';
@@ -46,6 +48,7 @@ let launches: LaunchSpec[];
 let runs: ScriptInvocation[];
 const ioCalls: SnapshotIOCall[] = [];
 let logged: string[];
+let barrierCalls: SettleBarrierContext[];
 
 // Hermetic per-test checkpoint root (real files land here — manifest + canned
 // dump bytes), never the developer's real ~/.saga-mesh/snapshots.
@@ -62,6 +65,7 @@ function installSeams(playwrightFail?: string): void {
   const seams = installCoreSeams({ pidBase: 3000, prepFresh: true, playwrightFail });
   launches = seams.launches;
   runs = seams.runs;
+  barrierCalls = seams.barrierCalls;
 
   // schemaRev: null ⇒ the snapshot-ahead guard is inert (covered by
   // snapshot.int.test.ts) — this suite owns the FLOW-level compat rules.
@@ -496,6 +500,75 @@ describe('tunnel fail-loud (soa#327): unusable prerequisite checkpoint under --t
     await E2eConnect.run([...ws()], config);
     expect(logged.join('\n')).toContain('falling back to full replay');
     expect(playwrightRuns().length).toBeGreaterThan(1); // journey replay + the room
+  });
+});
+
+describe('bake quiescence barrier (soa#327)', () => {
+  it('fires ONCE per stage BEFORE that stage’s first dump (declared personas ride the context)', async () => {
+    // Recording barrier that snapshots how many pgDumps had happened at call
+    // time — the ordering witness. Deleting the await (or moving it after the
+    // bake) makes the second entry include its own stage's dumps ⇒ red.
+    const pgDumpsAtBarrier: number[] = [];
+    const fixtures: string[] = [];
+    const barrier: SettleBarrier = async (ctx) => {
+      pgDumpsAtBarrier.push(ioCalls.filter((c) => c.op === 'pgDump').length);
+      fixtures.push(ctx.fixtureId);
+      expect(ctx.personas).toEqual(['alex.tutor@example.org']);
+    };
+    vi.spyOn(
+      BaseCommand.prototype as unknown as { getSettleBarrier: () => SettleBarrier },
+      'getSettleBarrier',
+    ).mockReturnValue(barrier);
+
+    await bakeThroughProgram();
+
+    expect(fixtures).toEqual([CKPT_ROSTER, CKPT_PROGRAM]);
+    const perStage = ioCalls.filter((c) => c.op === 'pgDump').length / 2;
+    expect(perStage).toBeGreaterThan(0);
+    // Stage 1's barrier ran before ANY dump; stage 2's before its OWN dumps.
+    expect(pgDumpsAtBarrier).toEqual([0, perStage]);
+  });
+
+  it('a barrier timeout FAILS the bake: no manifest for the stage, ladder stops', async () => {
+    vi.spyOn(
+      BaseCommand.prototype as unknown as { getSettleBarrier: () => SettleBarrier },
+      'getSettleBarrier',
+    ).mockReturnValue(async () => {
+      throw new Error("settle barrier TIMED OUT before baking 'flow-saga-dash-journey-s1-roster'");
+    });
+
+    await expect(bakeThroughProgram()).rejects.toThrow(/settle barrier TIMED OUT/);
+    // NOTHING was dumped or manifested for the unsettled stage — a red bake, not
+    // a torn checkpoint. Stage 2 never spawned (the ladder stopped).
+    expect(ioCalls.filter((c) => c.op === 'pgDump')).toHaveLength(0);
+    expect(() => readCkptManifest(CKPT_ROSTER)).toThrow();
+    expect(playwrightRuns()).toHaveLength(1);
+  });
+
+  it('a flow with NO settlePersonas bakes with ZERO barrier calls (byte-identical bake)', async () => {
+    // Same bundled journey minus the declaration, via the --spa-path override.
+    const manifest = JSON.parse(
+      readFileSync(
+        resolve(PKG_ROOT, 'examples', 'flows', 'saga-dash.flows.json'),
+        'utf8',
+      ),
+    ) as { flows: Record<string, unknown>[] };
+    for (const flow of manifest.flows) delete flow.settlePersonas;
+    const spaPath = join(DASH_ROOT, 'no-personas.flows.json');
+    writeFileSync(spaPath, JSON.stringify(manifest));
+
+    await E2eRun.run(
+      ['journey', '--through', 'program', '--snapshot-stages', '--headless', '--spa-path', spaPath, ...ws()],
+      config,
+    );
+    expect(barrierCalls).toHaveLength(0);
+    expect(() => readCkptManifest(CKPT_ROSTER)).not.toThrow(); // bake unaffected
+  });
+
+  it('the default bake DOES invoke the barrier with the journey personas (gating positive)', async () => {
+    await bakeThroughProgram();
+    expect(barrierCalls.map((c) => c.stageId)).toEqual(['roster', 'program']);
+    expect(barrierCalls[0]?.personas).toEqual(['alex.tutor@example.org']);
   });
 });
 

--- a/packages/node/saga-stack-cli/src/commands/e2e/__tests__/checkpoint.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/__tests__/checkpoint.int.test.ts
@@ -162,6 +162,18 @@ describe('--snapshot-stages (bake)', () => {
     ).rejects.toThrow(/--snapshot-stages.*requires the stack lane/);
   });
 
+  it('bakes the SLOT-PROVISIONED manifest DB set, not the flow closure subset (soa#327 proof C)', async () => {
+    await bakeThroughProgram();
+    // The through-program closure has NO sessions-api, but `sessions` rows are
+    // event-materialized by bake time and load-bearing for checkpoint CONSUMERS
+    // (`develop connect` restores s5 and reads the expanded session rows — a
+    // closure-scoped dump strands it at "No sessions on the term-start Monday").
+    // Same defect class as the legacy mesh-fixture-cli's 6-DB dump that omitted
+    // `sessions` (docs/tunnel.md). So: every manifest DB the slot provisions.
+    const dbs = (readCkptManifest(CKPT_ROSTER).databases as { db: string }[]).map((d) => d.db);
+    expect(dbs).toEqual(expect.arrayContaining(['sessions', 'iam_local', 'iam_pii_local', 'ledger_local', 'coach_api']));
+  });
+
   it('a RED stage bakes no checkpoint and stops the ladder', async () => {
     installSeams('stage-1-roster'); // stage-1's Playwright child exits 1
     await expect(bakeThroughProgram()).rejects.toMatchObject({ oclif: { exit: 1 } });

--- a/packages/node/saga-stack-cli/src/commands/e2e/__tests__/checkpoint.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/__tests__/checkpoint.int.test.ts
@@ -20,7 +20,6 @@ import { installCoreSeams } from '../../../__tests__/helpers/seams.js';
 import { Config } from '@oclif/core';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { BaseCommand } from '../../../base-command.js';
-import { PREFLIGHT_ATTEMPTS } from '../../../runtime/index.js';
 import type {
   CookiePoster,
   LaunchSpec,
@@ -451,6 +450,13 @@ describe('e2e connect --refresh-snapshot (bake the prerequisite fresh, then rest
     // The freshly baked terminal checkpoint is on disk with the right provenance.
     const schedule = readCkptManifest(CKPT_SCHEDULE);
     expect((schedule.flow as Record<string, unknown>).stageId).toBe('schedule');
+
+    // soa#327 wiring pin: THIS bake path (develop connect --refresh-snapshot)
+    // must pass the settle barrier into the bake deps — it exists precisely to
+    // produce the checkpoint the tunnel session will trust. Unwiring
+    // settleBarrier in connect.ts silently bakes torn iam state ⇒ red here.
+    expect(barrierCalls.map((c) => c.stageId)).toEqual(['roster', 'program', 'enrollment', 'pods', 'schedule']);
+    expect(barrierCalls[0]?.personas).toEqual(['alex.tutor@example.org']);
   });
 
   it('--refresh-snapshot --reuse is rejected (reuse strips the prerequisite there is nothing to bake)', async () => {
@@ -486,6 +492,19 @@ describe('tunnel fail-loud (soa#327): unusable prerequisite checkpoint under --t
     );
     // The gate refuses BEFORE any replay spawn — deletion of the gate makes the
     // journey replay run and these appear (the mutation signature).
+    expect(playwrightRuns()).toHaveLength(0);
+  });
+
+  it('--no-prereq-from-snapshot under --tunnel refuses the replay loudly (every road into the replay is guarded)', async () => {
+    // No checkpoint baked at all: the flag skips the restore attempt entirely,
+    // so the ONLY protection is the guard at the replay entry itself — the
+    // restore-block gate never runs (deps.checkpoints is unconstructed).
+    fakeMoniker();
+    await expect(E2eConnect.run(['--tunnel', '--no-prereq-from-snapshot', ...ws()], config)).rejects.toThrow(
+      /refusing to fall back silently[\s\S]*--no-prereq-from-snapshot/,
+    );
+    // Refused BEFORE any spawn — deleting the replay-entry guard makes the
+    // journey replay run over the tunnel (the WAN-starved-polls trap).
     expect(playwrightRuns()).toHaveLength(0);
   });
 
@@ -545,7 +564,7 @@ describe('bake quiescence barrier (soa#327)', () => {
     expect(playwrightRuns()).toHaveLength(1);
   });
 
-  it('a flow with NO settlePersonas bakes with ZERO barrier calls (byte-identical bake)', async () => {
+  it('a flow with NO settlePersonas bakes with ZERO barrier calls — and says so LOUDLY per stage', async () => {
     // Same bundled journey minus the declaration, via the --spa-path override.
     const manifest = JSON.parse(
       readFileSync(
@@ -557,12 +576,19 @@ describe('bake quiescence barrier (soa#327)', () => {
     const spaPath = join(DASH_ROOT, 'no-personas.flows.json');
     writeFileSync(spaPath, JSON.stringify(manifest));
 
+    logged.length = 0;
     await E2eRun.run(
       ['journey', '--through', 'program', '--snapshot-stages', '--headless', '--spa-path', spaPath, ...ws()],
       config,
     );
     expect(barrierCalls).toHaveLength(0);
     expect(() => readCkptManifest(CKPT_ROSTER)).not.toThrow(); // bake unaffected
+    // The skip is VISIBLE: discovery prefers the SPA repo's authored flows.json,
+    // so an undeclared flow baking iam state silently is the soa#327 trap.
+    const warns = logged.filter((l) =>
+      l.includes("bake quiescence barrier skipped: flow 'journey' declares no settlePersonas"),
+    );
+    expect(warns).toHaveLength(2); // once per baked stage (roster, program)
   });
 
   it('the default bake DOES invoke the barrier with the journey personas (gating positive)', async () => {
@@ -654,7 +680,8 @@ describe('tunnel post-restore persona preflight (soa#327)', () => {
     installPoster([0]);
     fakeMoniker();
     await expect(E2eConnect.run(['--tunnel', ...ws()], config)).rejects.toThrow(/no response/);
-    expect(posts).toHaveLength(PREFLIGHT_ATTEMPTS);
+    // Literal, not the imported constant, so the cap's value stays pinned.
+    expect(posts).toHaveLength(3);
     expect(playwrightRuns()).toHaveLength(0);
   });
 

--- a/packages/node/saga-stack-cli/src/commands/e2e/__tests__/e2e.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/__tests__/e2e.int.test.ts
@@ -272,7 +272,11 @@ describe('e2e connect — foreground connect-session entry', () => {
     vi.spyOn(BaseCommand.prototype as never, 'getTunnelMoniker' as never).mockReturnValue(
       (async () => 'testmoniker') as never,
     );
-    await E2eConnect.run(['--tunnel', ...ws()], config);
+    // --reuse: the concierge path (docs/tunnel.md step 3). Without it a tunnel run
+    // with NO baked prerequisite checkpoint now fail-louds (soa#327) instead of
+    // silently replaying over the WAN — that gate has its own coverage in
+    // connect.int.test.ts; this test owns the tunnel-env plumbing.
+    await E2eConnect.run(['--tunnel', '--reuse', ...ws()], config);
     // The live session's env carries the tunnel URLs — proving tunnelDomain reached the
     // executeResolvedFlow deps (and buildStackContext) for the headed interactive run.
     const live = playwrightRuns().find((r) => r.args.includes('interactive-connect'));

--- a/packages/node/saga-stack-cli/src/commands/e2e/run.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/run.ts
@@ -372,6 +372,11 @@ export default class E2eRun extends BaseCommand {
             log: (l) => this.log(l),
             sleep: this.getSleep(),
           }),
+          // soa#327: the pre-dump quiescence barrier for --snapshot-stages bakes
+          // (invoked only per-bake, only when the flow declares settlePersonas).
+          // Built after applyInstanceEnv above — same call-time-env contract as
+          // the checkpoint store.
+          settleBarrier: this.getSettleBarrier(profile.slot, (l) => this.log(l)),
         },
         {
           lane,

--- a/packages/node/saga-stack-cli/src/commands/e2e/run.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/run.ts
@@ -35,7 +35,7 @@ import type { Lane, RepoKey } from '../../core/manifest/index.js';
 import type { ScriptPlan } from '../../core/flag-map.js';
 import { reviewBlockLines, runIdFrom } from '../../core/e2e-review.js';
 import type { PreservedRunRecord } from '../../core/e2e-review.js';
-import { preserveSpawnArtifacts, resolveVendorScript } from '../../runtime/index.js';
+import { makePersonaPreflight, preserveSpawnArtifacts, resolveVendorScript } from '../../runtime/index.js';
 import { makeStackApi } from '../../stack-api.js';
 import {
   buildStackContext,
@@ -365,6 +365,13 @@ export default class E2eRun extends BaseCommand {
           checkpoints,
           preserveTraces,
           tunnelDomain,
+          // soa#327: the tunnel post-restore devLogin probe (only consulted when
+          // tunnelDomain is set and a checkpoint restore succeeded).
+          preflight: makePersonaPreflight({
+            poster: this.getCookiePoster(),
+            log: (l) => this.log(l),
+            sleep: this.getSleep(),
+          }),
         },
         {
           lane,

--- a/packages/node/saga-stack-cli/src/core/flow/__tests__/settle-personas.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/flow/__tests__/settle-personas.unit.test.ts
@@ -1,0 +1,113 @@
+/**
+ * soa#327 `settlePersonas` — the flow-schema declaration feeding BOTH the bake
+ * quiescence barrier and the tunnel post-restore preflight. Pins:
+ *  - zod round-trip (declared array survives parse; absent stays undefined);
+ *  - resolveFlow carry-through (the resolved flow AND a prerequisite's resolved
+ *    flow expose the PRODUCING flow's personas);
+ *  - the bundled saga-dash example declares alex.tutor@example.org on journey —
+ *    the drift pin against saga-dash's spec constant (TUTOR_EMAIL in
+ *    e2e/interactive/connect-session.e2e.test.ts);
+ *  - stagePrefixHash EXCLUDES settlePersonas (declaring a probe persona must
+ *    not invalidate existing checkpoints — the state the stages produce is
+ *    unchanged).
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { parseFlowManifest } from '../load.js';
+import { resolveFlow } from '../resolve.js';
+import { stagePrefixHash } from '../checkpoint.js';
+import type { FlowManifest } from '../types.js';
+
+const BUNDLED_SAGA_DASH = fileURLToPath(
+  new URL('../../../../examples/flows/saga-dash.flows.json', import.meta.url),
+);
+
+function manifestWith(personas?: string[]): FlowManifest {
+  return parseFlowManifest(
+    JSON.stringify({
+      schemaVersion: 1,
+      spa: {
+        id: 'saga-dash',
+        system: 'saga-dash',
+        repoEnvVar: 'SAGA_DASH',
+        defaultRepoSubpath: 'saga-dash',
+        appDir: 'apps/web/dash',
+        e2eDir: 'apps/web/dash/e2e',
+        playwrightConfig: 'playwright.stack.config.ts',
+      },
+      flows: [
+        {
+          name: 'producer',
+          description: 'producing flow',
+          lanes: ['stack'],
+          progressive: true,
+          ...(personas !== undefined ? { settlePersonas: personas } : {}),
+          stages: [
+            {
+              id: 'one',
+              project: 'stage-1',
+              spec: 'one.e2e.test.ts',
+              requiredSystems: ['sis-api'],
+            },
+          ],
+        },
+        {
+          name: 'consumer',
+          description: 'flow with the producer as prerequisite',
+          lanes: ['stack'],
+          progressive: false,
+          prerequisite: { flow: 'producer', throughStage: 'one' },
+          stages: [
+            {
+              id: 'live',
+              project: 'live',
+              spec: 'live.e2e.test.ts',
+              requiredSystems: ['sessions-api'],
+            },
+          ],
+        },
+      ],
+    }),
+  );
+}
+
+describe('settlePersonas schema + carry-through', () => {
+  it('round-trips through zod and reaches the resolved flow', () => {
+    const m = manifestWith(['alex.tutor@example.org']);
+    expect(m.flows[0]?.settlePersonas).toEqual(['alex.tutor@example.org']);
+    const resolved = resolveFlow(m, 'producer');
+    expect(resolved.flow.settlePersonas).toEqual(['alex.tutor@example.org']);
+  });
+
+  it("a prerequisite's resolved flow exposes the PRODUCING flow's personas", () => {
+    const resolved = resolveFlow(manifestWith(['alex.tutor@example.org']), 'consumer');
+    expect(resolved.prerequisite?.flow.settlePersonas).toEqual(['alex.tutor@example.org']);
+    // The consumer itself declares none — the declaration rides the producer.
+    expect(resolved.flow.settlePersonas).toBeUndefined();
+  });
+
+  it('absent field stays undefined (no fabricated default)', () => {
+    const m = manifestWith();
+    expect(m.flows[0]?.settlePersonas).toBeUndefined();
+  });
+
+  it('an empty-string persona is a schema violation', () => {
+    expect(() => manifestWith([''])).toThrow(/settlePersonas/);
+  });
+
+  it('the BUNDLED saga-dash example declares alex.tutor@example.org on journey (spec-constant drift pin)', () => {
+    const m = parseFlowManifest(readFileSync(BUNDLED_SAGA_DASH, 'utf8'), BUNDLED_SAGA_DASH);
+    const journey = m.flows.find((f) => f.name === 'journey');
+    expect(journey?.settlePersonas).toEqual(['alex.tutor@example.org']);
+  });
+
+  it('stagePrefixHash ignores settlePersonas (declaring a probe must not invalidate checkpoints)', () => {
+    const withPersonas = manifestWith(['alex.tutor@example.org']).flows[0]!;
+    const without = manifestWith().flows[0]!;
+    expect(stagePrefixHash(withPersonas, withPersonas.stages)).toBe(
+      stagePrefixHash(without, without.stages),
+    );
+  });
+});

--- a/packages/node/saga-stack-cli/src/core/flow/types.ts
+++ b/packages/node/saga-stack-cli/src/core/flow/types.ts
@@ -143,6 +143,19 @@ export const flowDefSchema = z.object({
   seed: seedSelectionSchema.optional(),
   /** Extra env injected for every stage of this flow. */
   env: z.record(z.string(), z.string()).optional(),
+  /**
+   * soa#327: persona emails whose devLogin-ability DEFINES "settled" for the
+   * state THIS flow produces — declared on the PRODUCING flow (journey), read
+   * by the bake quiescence barrier and the tunnel post-restore preflight.
+   * These personas are created by the flow itself (roster-sync during stage
+   * replay), NOT by `stack seed` — a seed-alias probe (dev@saga.org) would
+   * false-negative because its pii row exists even in a torn dump. Keep in
+   * sync with the SPA's spec constants (saga-dash: TUTOR_EMAIL in
+   * e2e/interactive/connect-session.e2e.test.ts). Deliberately EXCLUDED from
+   * `stagePrefixHash` — declaring a probe persona does not change the state
+   * the stages produce, so it must not invalidate existing checkpoints.
+   */
+  settlePersonas: z.array(z.string().min(1)).optional(),
 });
 
 /** Top-level `flows.json` document (plan §5.1). */

--- a/packages/node/saga-stack-cli/src/e2e-checkpoint-exec.ts
+++ b/packages/node/saga-stack-cli/src/e2e-checkpoint-exec.ts
@@ -110,9 +110,15 @@ export async function bakeStageCheckpoint(
   const position = resolved.flow.stages.findIndex((s) => s.id === stage.id) + 1;
   const fixtureId = checkpointFixtureId(resolved.spa.id, resolved.flow.name, stage, position);
 
-  // The bake scope is the SLOT-FILTERED closure's DB set (post-closure exclusion,
-  // same rule as `snapshot store --slot N`) — never dump DBs the slot never provisioned.
-  const dbs = [...new Set(services.flatMap((id) => m.services[id]?.databases ?? []))];
+  // The bake scope is NOT passed: checkpoint-store falls through to storePlan's
+  // DEFAULT selection — every manifest DB except the playback/authz extras —
+  // giving byte-for-byte PARITY with `stack snapshot store` (docs/tunnel.md's
+  // known-good bridge). A flow-closure subset silently dropped `sessions`
+  // (event-materialized, load-bearing for `develop connect`, which strands at
+  // "No sessions on the term-start Monday" — soa#327 proof C); and "manifest
+  // minus slot-exclusions" over-reaches into DBs the stack never provisioned
+  // (pg_dump: role "transcripts_app" does not exist). The store plan's default
+  // is the one set proven correct in production use.
 
   // soa#327 quiescence barrier — BEFORE the first dump. A green Playwright stage
   // is not proof the DBs are settled: roster-sync's outbox relay (and the
@@ -124,7 +130,10 @@ export async function bakeStageCheckpoint(
   // roster pipeline to settle). A barrier timeout FAILS the bake loudly — the
   // seam contract says it throws rather than let torn state be written.
   const personas = resolved.flow.settlePersonas ?? [];
-  if (dbs.includes('iam_pii_local')) {
+  // The default store set always covers the iam pair, so the barrier is
+  // unconditional (it was previously gated on the closure subset covering
+  // iam_pii_local — a set that no longer exists).
+  {
     if (deps.settleBarrier !== undefined && personas.length > 0) {
       try {
         await deps.settleBarrier({ fixtureId, stageId: stage.id, personas });
@@ -152,7 +161,6 @@ export async function bakeStageCheckpoint(
     // No fabricated default: a seedless flow's checkpoint says so ('unseeded'
     // never false-matches a real profile in the restore-time double guard).
     profile: resolved.seedSelection?.profile ?? 'unseeded',
-    dbs,
     flow: {
       spa: resolved.spa.id,
       flow: resolved.flow.name,

--- a/packages/node/saga-stack-cli/src/e2e-checkpoint-exec.ts
+++ b/packages/node/saga-stack-cli/src/e2e-checkpoint-exec.ts
@@ -124,11 +124,26 @@ export async function bakeStageCheckpoint(
   // roster pipeline to settle). A barrier timeout FAILS the bake loudly — the
   // seam contract says it throws rather than let torn state be written.
   const personas = resolved.flow.settlePersonas ?? [];
-  if (deps.settleBarrier !== undefined && personas.length > 0 && dbs.includes('iam_pii_local')) {
-    try {
-      await deps.settleBarrier({ fixtureId, stageId: stage.id, personas });
-    } catch (err) {
-      throw new FlowExecError((err as Error).message);
+  if (dbs.includes('iam_pii_local')) {
+    if (deps.settleBarrier !== undefined && personas.length > 0) {
+      try {
+        await deps.settleBarrier({ fixtureId, stageId: stage.id, personas });
+      } catch (err) {
+        throw new FlowExecError((err as Error).message);
+      }
+    } else {
+      // The skip must be LOUD: discovery prefers the SPA repo's authored
+      // flows.json over the bundled example, so a flow that never declared
+      // settlePersonas there would otherwise bake iam state with no barrier
+      // and no trace in the run output (the original soa#327 silent tear).
+      const why =
+        personas.length === 0
+          ? `flow '${resolved.flow.name}' declares no settlePersonas`
+          : 'no settle barrier wired (internal wiring gap)';
+      deps.log(
+        `⚠ bake quiescence barrier skipped: ${why} — this dump covers iam_pii_local ` +
+          'and may bake TORN state (personas can 401 after restore)',
+      );
     }
   }
 

--- a/packages/node/saga-stack-cli/src/e2e-checkpoint-exec.ts
+++ b/packages/node/saga-stack-cli/src/e2e-checkpoint-exec.ts
@@ -114,6 +114,24 @@ export async function bakeStageCheckpoint(
   // same rule as `snapshot store --slot N`) — never dump DBs the slot never provisioned.
   const dbs = [...new Set(services.flatMap((id) => m.services[id]?.databases ?? []))];
 
+  // soa#327 quiescence barrier — BEFORE the first dump. A green Playwright stage
+  // is not proof the DBs are settled: roster-sync's outbox relay (and the
+  // in-flight pii-write window) can still be draining when the stage's HTTP
+  // responses return, and a dump taken then bakes a TORN checkpoint whose
+  // personas 401 after restore (the walkthrough failure). Gated on the flow
+  // DECLARING settlePersonas (no personas ⇒ nothing trustworthy to probe) and
+  // on the bake actually covering iam_pii_local (a closure without iam has no
+  // roster pipeline to settle). A barrier timeout FAILS the bake loudly — the
+  // seam contract says it throws rather than let torn state be written.
+  const personas = resolved.flow.settlePersonas ?? [];
+  if (deps.settleBarrier !== undefined && personas.length > 0 && dbs.includes('iam_pii_local')) {
+    try {
+      await deps.settleBarrier({ fixtureId, stageId: stage.id, personas });
+    } catch (err) {
+      throw new FlowExecError((err as Error).message);
+    }
+  }
+
   await checkpoints.bake({
     fixtureId,
     // No fabricated default: a seedless flow's checkpoint says so ('unseeded'

--- a/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
+++ b/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
@@ -46,7 +46,9 @@ import {
   resolveRepoRoot as resolveSpaRepoRoot,
   splitSpaPaths,
 } from './core/flow/index.js';
-import type { ResolvedFlow, SpaDescriptor } from './core/flow/index.js';
+import type { FlowDef, ResolvedFlow, SpaDescriptor } from './core/flow/index.js';
+import { buildDevLoginRequest } from './core/login.js';
+import type { PersonaPreflight } from './runtime/settle-barrier.js';
 import { deriveInstance } from './core/derive-instance.js';
 import type { InstanceProfile } from './core/derive-instance.js';
 import { defaultLaunchContext } from './core/launch-plan.js';
@@ -845,6 +847,72 @@ export function tunnelPrereqFallbackMessage(violation: string): string {
   ].join('\n');
 }
 
+/**
+ * PURE builder for the post-restore preflight's torn-checkpoint error (soa#327):
+ * the restore SUCCEEDED but the flow's own persona cannot devLogin over the
+ * tunnel — the baked state predates the roster work that creates the persona
+ * (the walkthrough's alex.tutor 401). Remediation = the same re-bake recipe.
+ */
+export function tunnelTornCheckpointMessage(email: string, status: number): string {
+  return [
+    `--tunnel: the restored checkpoint looks TORN — devLogin for '${email}' returned ` +
+      `${status === 0 ? 'no response' : `HTTP ${status}`} over the tunnel iam host, so the flow's ` +
+      'personas cannot log in (their roster/pii state is missing from the baked dump).',
+    '',
+    ...TUNNEL_RECIPE_LINES,
+  ].join('\n');
+}
+
+/**
+ * PURE builder for the preflight's 403 verdict: devLogin is DISABLED on the iam
+ * host — an iam-api/tunnel CONFIGURATION problem, so the re-bake recipe would be
+ * a wild-goose chase and is deliberately NOT included.
+ */
+export function tunnelAuthMisconfigMessage(email: string, iamUrl: string): string {
+  return [
+    `--tunnel: devLogin for '${email}' returned HTTP 403 from ${iamUrl} — devLogin is disabled`,
+    'there (AUTH_ENABLED is on, or the Origin is not allowlisted). This is an iam-api/tunnel',
+    'configuration problem, NOT a stale checkpoint — re-baking will not help. Check the iam-api',
+    'env this stack runs with (devLogin needs AUTH_ENABLED off in dev) and the tunnel host config.',
+  ].join('\n');
+}
+
+/**
+ * soa#327 post-restore preflight (tunnel only): one devLogin per flow-declared
+ * settle persona against the tunnel iam host — the DIRECT probe that the
+ * checkpoint just restored is usable by the very login the session will mint.
+ * Callers gate on `deps.tunnelDomain !== undefined`; a flow with no declared
+ * personas skips with a warning (nothing trustworthy to probe — the seed-alias
+ * personas exist even in torn dumps).
+ */
+async function tunnelPersonaPreflight(flow: FlowDef, deps: ExecDeps): Promise<void> {
+  const domain = deps.tunnelDomain as string;
+  const personas = flow.settlePersonas ?? [];
+  if (personas.length === 0) {
+    deps.log(
+      `⚠ tunnel preflight skipped: flow '${flow.name}' declares no settlePersonas — ` +
+        'cannot verify the restored checkpoint is login-ready before the browsers launch',
+    );
+    return;
+  }
+  if (deps.preflight === undefined) {
+    deps.log('⚠ tunnel preflight skipped: no devLogin prober wired (internal wiring gap)');
+    return;
+  }
+  // The SAME host the remote browsers will use (tunnelServiceUrlEnv hands them
+  // `https://<label>.<domain>`), so the probe exercises the room's exact path.
+  const iamUrl = `https://${TUNNEL_SERVICE_LABELS['iam-api']}.${domain}`;
+  for (const email of personas) {
+    const status = await deps.preflight(buildDevLoginRequest(email, iamUrl));
+    if (status === 200) {
+      deps.log(`✓ tunnel preflight: devLogin 200 for ${email}`);
+      continue;
+    }
+    if (status === 403) throw new FlowExecError(tunnelAuthMisconfigMessage(email, iamUrl));
+    throw new FlowExecError(tunnelTornCheckpointMessage(email, status));
+  }
+}
+
 // ── execution ─────────────────────────────────────────────────────────────────
 
 // M15: FlowExecError + the M14 checkpoint restore/bake execution live in
@@ -908,6 +976,14 @@ export interface ExecDeps {
     flowName: string;
     stages: readonly { id: string; project: string }[];
   }) => void | Promise<void>;
+  /**
+   * soa#327 tunnel preflight: POST one devLogin (capped transport-class retries
+   * inside the impl) and return the FINAL HTTP status. Consulted ONLY after a
+   * successful checkpoint restore when `tunnelDomain` is set; absent ⇒ the
+   * probe is skipped with a warning. Real impl: `makePersonaPreflight`
+   * (runtime/settle-barrier.ts), wired by the command from its poster seam.
+   */
+  preflight?: PersonaPreflight;
 }
 
 /** Per-run knobs. */
@@ -1039,6 +1115,14 @@ export async function executeResolvedFlow(
         }
         deps.log(`⚠ prerequisite checkpoint unavailable — falling back to full replay:\n${err.message}`);
       }
+      // soa#327 preflight: the restore SUCCEEDED, but under --tunnel that is not
+      // enough — probe that the prerequisite flow's own personas can devLogin
+      // over the tunnel iam host BEFORE any browser launches. A torn checkpoint
+      // (the walkthrough's alex.tutor 401) fails loud here with the re-bake
+      // recipe instead of minting a session that 401s minutes later.
+      if (restored && deps.tunnelDomain !== undefined) {
+        await tunnelPersonaPreflight(prereq.flow, deps);
+      }
     }
     if (!restored) {
       deps.log(`==> prerequisite: ${prereq.flow.name} (through '${prereq.stages.at(-1)?.id}', headless)`);
@@ -1092,6 +1176,12 @@ export async function executeResolvedFlow(
     // resolved.reset is already false for a --from window by construction).
     if (resolved.checkpoint) {
       restoredDates = await restoreCheckpoint(resolved, deps, opts, services, m);
+      // soa#327 preflight (the --from twin of the prerequisite site above): a
+      // restored mid-flow checkpoint under --tunnel must be login-ready for the
+      // flow's own personas before Playwright spawns.
+      if (deps.tunnelDomain !== undefined) {
+        await tunnelPersonaPreflight(resolved.flow, deps);
+      }
     }
 
     // 2b. reset + seed (coupled; skipped on --skip-reset or when a prerequisite built the state).

--- a/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
+++ b/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
@@ -48,7 +48,7 @@ import {
 } from './core/flow/index.js';
 import type { FlowDef, ResolvedFlow, SpaDescriptor } from './core/flow/index.js';
 import { buildDevLoginRequest } from './core/login.js';
-import type { PersonaPreflight } from './runtime/settle-barrier.js';
+import type { PersonaPreflight, SettleBarrier } from './runtime/settle-barrier.js';
 import { deriveInstance } from './core/derive-instance.js';
 import type { InstanceProfile } from './core/derive-instance.js';
 import { defaultLaunchContext } from './core/launch-plan.js';
@@ -984,6 +984,16 @@ export interface ExecDeps {
    * (runtime/settle-barrier.ts), wired by the command from its poster seam.
    */
   preflight?: PersonaPreflight;
+  /**
+   * soa#327 bake quiescence barrier: awaited at the TOP of `bakeStageCheckpoint`
+   * (before any dump) when the flow declares `settlePersonas` and the bake
+   * covers iam_pii_local — so a per-stage checkpoint is never dumped while the
+   * roster-sync pipeline (outbox relay + the in-flight pii write window) still
+   * has work in flight. Throws on timeout (a red bake beats a torn checkpoint).
+   * Absent ⇒ no barrier (e.g. `e2e connect`, which never bakes). Real impl:
+   * `makeSettleBarrier` (runtime/settle-barrier.ts), command-wired.
+   */
+  settleBarrier?: SettleBarrier;
 }
 
 /** Per-run knobs. */

--- a/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
+++ b/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
@@ -1135,6 +1135,20 @@ export async function executeResolvedFlow(
       }
     }
     if (!restored) {
+      // soa#327: EVERY road into the full prerequisite replay is guarded, not
+      // just the failed-restore path above — --no-prereq-from-snapshot, a
+      // missing checkpoint store, and a nested prerequisite chain all land
+      // here with tunnelDomain still riding down into the replay's Playwright
+      // env (the WAN-starved-polls trap). Cannot double-fire: the restore
+      // branch's own tunnel throw fires before `restored` can stay false.
+      if (deps.tunnelDomain !== undefined) {
+        throw new FlowExecError(
+          tunnelPrereqFallbackMessage(
+            'the full prerequisite replay was selected (checkpoint restore skipped: ' +
+              '--no-prereq-from-snapshot, no checkpoint store, or a nested prerequisite chain)',
+          ),
+        );
+      }
       deps.log(`==> prerequisite: ${prereq.flow.name} (through '${prereq.stages.at(-1)?.id}', headless)`);
       const preCode = await executeResolvedFlow(prereq, deps, {
         lane: opts.lane,

--- a/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
+++ b/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
@@ -805,6 +805,46 @@ export function describeResolved(resolved: ResolvedFlow, opts: DescribeOptions):
 /** Structural alias for the stage arg `checkpointFixtureId` takes (pure projection use). */
 type StageDefLike = ResolvedFlow['stages'][number];
 
+// ── tunnel fail-loud (soa#327) ─────────────────────────────────────────────────
+
+/**
+ * The docs/tunnel.md concierge recipe, verbatim — the remediation every tunnel
+ * fail-loud error embeds. Local state is rebuilt LOCALLY (fast, tested), then the
+ * tunnel comes up and restores the snapshot; the alternative the gate prevents is
+ * a silent full Playwright replay over the WAN, whose 30s polls starve and fail
+ * far slower than this recipe runs.
+ */
+const TUNNEL_RECIPE_LINES: readonly string[] = [
+  'Rebuild the state locally, then bring the tunnel up and restore it (docs/tunnel.md concierge):',
+  '  ss stack down && ss stack up --seed full --reset',
+  '  ss e2e run journey --through schedule',
+  '  ss stack snapshot store --fixture-id tunnel-connect',
+  '  ss stack down && ss stack up --tunnel --reset',
+  '  ss stack snapshot restore tunnel-connect',
+  '  ss develop connect --tunnel --student-login 1 --reuse',
+  '',
+  'Faster escape hatches when only the CHECKPOINT is the problem:',
+  '  ss develop connect --refresh-snapshot   # re-bake the journey prerequisite fresh, then open the room',
+  '  ss e2e run … --from-stale-ok            # accept an over-7-day checkpoint (e2e run only)',
+];
+
+/**
+ * PURE builder for the fail-loud error a `--tunnel` run raises instead of the
+ * local lane's silent warn+full-replay when the prerequisite checkpoint is
+ * unusable (missing / stale / failed validation). The original violation is
+ * embedded verbatim so the remediation is exact. Exported for unit tests.
+ */
+export function tunnelPrereqFallbackMessage(violation: string): string {
+  return [
+    '--tunnel: the prerequisite checkpoint is unusable, and a full replay over the tunnel is',
+    'a trap (its WAN round-trips starve the specs’ 30s polls) — refusing to fall back silently.',
+    '',
+    violation.replace(/^/gm, '  '),
+    '',
+    ...TUNNEL_RECIPE_LINES,
+  ].join('\n');
+}
+
 // ── execution ─────────────────────────────────────────────────────────────────
 
 // M15: FlowExecError + the M14 checkpoint restore/bake execution live in
@@ -990,6 +1030,13 @@ export async function executeResolvedFlow(
         if (!(err instanceof FlowExecError)) throw err;
         // A failed BRING-UP would fail the replay too — don't retry it.
         if (err.message.includes('bring-up failed')) throw err;
+        // soa#327 fail-loud: under --tunnel the silent full replay is a TRAP, not a
+        // fallback — the remote browser's WAN round-trips starve the specs' 30s
+        // polls, so the replay fails slower than the local re-bake recipe runs.
+        // Local lane (tunnelDomain undefined) keeps the warn+replay byte-identical.
+        if (deps.tunnelDomain !== undefined) {
+          throw new FlowExecError(tunnelPrereqFallbackMessage(err.message));
+        }
         deps.log(`⚠ prerequisite checkpoint unavailable — falling back to full replay:\n${err.message}`);
       }
     }

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/settle-barrier.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/settle-barrier.unit.test.ts
@@ -1,0 +1,96 @@
+/**
+ * soa#327 settle probes — unit tests for `makePersonaPreflight` (the tunnel
+ * post-restore devLogin probe) with a scripted poster + recorded sleep: the
+ * retry policy (transport-class only, capped attempts, fixed spacing) is
+ * asserted without any network or wall-clock time.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildDevLoginRequest } from '../../core/login.js';
+import type { PostOptions, PostResult } from '../http-post.js';
+import type { CookiePoster } from '../http-post.js';
+import {
+  makePersonaPreflight,
+  PREFLIGHT_ATTEMPTS,
+  PREFLIGHT_RETRY_DELAY_MS,
+} from '../settle-barrier.js';
+
+const REQ = buildDevLoginRequest('alex.tutor@example.org', 'https://iam.moniker.vms.test');
+
+/** Poster answering `statuses` in order (last repeats); records every call. */
+function scriptedPoster(statuses: number[]): {
+  poster: CookiePoster;
+  posts: { url: string; opts: PostOptions }[];
+} {
+  const posts: { url: string; opts: PostOptions }[] = [];
+  const poster: CookiePoster = {
+    async post(url: string, opts: PostOptions): Promise<PostResult> {
+      posts.push({ url, opts });
+      const status = statuses[Math.min(posts.length - 1, statuses.length - 1)] ?? 0;
+      return { status, ok: status >= 200 && status < 300, setCookies: [] };
+    },
+  };
+  return { poster, posts };
+}
+
+function harness(statuses: number[]): {
+  preflight: ReturnType<typeof makePersonaPreflight>;
+  posts: { url: string; opts: PostOptions }[];
+  sleeps: number[];
+} {
+  const { poster, posts } = scriptedPoster(statuses);
+  const sleeps: number[] = [];
+  const preflight = makePersonaPreflight({
+    poster,
+    log: () => {},
+    sleep: async (ms) => {
+      sleeps.push(ms);
+    },
+  });
+  return { preflight, posts, sleeps };
+}
+
+describe('makePersonaPreflight', () => {
+  it('200 on the first attempt: one POST, zero sleeps, posts the exact devLogin request', async () => {
+    const { preflight, posts, sleeps } = harness([200]);
+    await expect(preflight(REQ)).resolves.toBe(200);
+    expect(posts).toHaveLength(1);
+    expect(sleeps).toHaveLength(0);
+    expect(posts[0]!.url).toBe('https://iam.moniker.vms.test/trpc/auth.devLogin');
+    // iam's origin-check is load-bearing: Origin must be the iam host itself.
+    expect(posts[0]!.opts.origin).toBe('https://iam.moniker.vms.test');
+    expect(posts[0]!.opts.body).toContain('alex.tutor@example.org');
+  });
+
+  it('transport blips (status 0) are retried at the policy spacing, then the recovery status returns', async () => {
+    const { preflight, posts, sleeps } = harness([0, 0, 200]);
+    await expect(preflight(REQ)).resolves.toBe(200);
+    expect(posts).toHaveLength(3);
+    expect(sleeps).toEqual([PREFLIGHT_RETRY_DELAY_MS, PREFLIGHT_RETRY_DELAY_MS]);
+  });
+
+  it('5xx is transport-class too (proxy/service hiccup): retried, recovery wins', async () => {
+    const { preflight, posts } = harness([503, 200]);
+    await expect(preflight(REQ)).resolves.toBe(200);
+    expect(posts).toHaveLength(2);
+  });
+
+  it('persistent status 0 exhausts the cap and returns 0 (the caller raises the verdict)', async () => {
+    const { preflight, posts } = harness([0]);
+    await expect(preflight(REQ)).resolves.toBe(0);
+    expect(posts).toHaveLength(PREFLIGHT_ATTEMPTS);
+  });
+
+  it('401 is an ANSWER, not a blip: returned immediately with no retry (it IS the torn verdict)', async () => {
+    const { preflight, posts, sleeps } = harness([401]);
+    await expect(preflight(REQ)).resolves.toBe(401);
+    expect(posts).toHaveLength(1);
+    expect(sleeps).toHaveLength(0);
+  });
+
+  it('403 (devLogin disabled) is likewise returned immediately', async () => {
+    const { preflight, posts } = harness([403, 200]);
+    await expect(preflight(REQ)).resolves.toBe(403);
+    expect(posts).toHaveLength(1);
+  });
+});

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/settle-barrier.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/settle-barrier.unit.test.ts
@@ -83,7 +83,10 @@ describe('makePersonaPreflight', () => {
   it('persistent status 0 exhausts the cap and returns 0 (the caller raises the verdict)', async () => {
     const { preflight, posts } = harness([0]);
     await expect(preflight(REQ)).resolves.toBe(0);
-    expect(posts).toHaveLength(PREFLIGHT_ATTEMPTS);
+    // Literal, not the imported constant: this test PINS the cap's absolute
+    // value (a constant-relative assertion would pass for any cap).
+    expect(PREFLIGHT_ATTEMPTS).toBe(3);
+    expect(posts).toHaveLength(3);
   });
 
   it('401 is an ANSWER, not a blip: returned immediately with no retry (it IS the torn verdict)', async () => {

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/settle-barrier.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/settle-barrier.unit.test.ts
@@ -1,18 +1,23 @@
 /**
  * soa#327 settle probes — unit tests for `makePersonaPreflight` (the tunnel
- * post-restore devLogin probe) with a scripted poster + recorded sleep: the
- * retry policy (transport-class only, capped attempts, fixed spacing) is
- * asserted without any network or wall-clock time.
+ * post-restore devLogin probe) and `makeSettleBarrier` (the pre-bake quiescence
+ * gate) with scripted poster/pg-probe fakes + a recorded sleep: retry/poll
+ * policy (transport-class only, capped attempts, stability window, poll cap)
+ * is asserted without any network, docker, or wall-clock time.
  */
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { buildDevLoginRequest } from '../../core/login.js';
 import type { PostOptions, PostResult } from '../http-post.js';
 import type { CookiePoster } from '../http-post.js';
+import type { PgProbe } from '../pg-probe.js';
 import {
   makePersonaPreflight,
+  makeSettleBarrier,
   PREFLIGHT_ATTEMPTS,
   PREFLIGHT_RETRY_DELAY_MS,
+  SETTLE_MAX_POLLS,
+  SETTLE_POLL_INTERVAL_MS,
 } from '../settle-barrier.js';
 
 const REQ = buildDevLoginRequest('alex.tutor@example.org', 'https://iam.moniker.vms.test');
@@ -92,5 +97,142 @@ describe('makePersonaPreflight', () => {
     const { preflight, posts } = harness([403, 200]);
     await expect(preflight(REQ)).resolves.toBe(403);
     expect(posts).toHaveLength(1);
+  });
+});
+
+// ── makeSettleBarrier ────────────────────────────────────────────────────────
+
+/** Per-signal scripted sequences (index by sample ordinal; last value repeats). */
+interface BarrierScript {
+  users: string[];
+  pii: string[];
+  outbox: string[];
+  loginStatuses: number[];
+}
+
+interface BarrierHarness {
+  run: () => Promise<void>;
+  scalarCalls: { container: string; db: string; sql: string }[];
+  loginPosts: { url: string; opts: PostOptions }[];
+  sleeps: number[];
+  logged: string[];
+}
+
+function barrierHarness(script: BarrierScript, opts: { slot?: number; personas?: string[] } = {}): BarrierHarness {
+  const scalarCalls: { container: string; db: string; sql: string }[] = [];
+  const at = (seq: string[], i: number): string => seq[Math.min(i, seq.length - 1)] ?? '';
+  let usersN = 0;
+  let piiN = 0;
+  let outboxN = 0;
+  const probe: PgProbe = {
+    async databaseExists() { return true; },
+    async hasMigrationsTable() { return false; },
+    async publicTableCount() { return 0; },
+    async scalar(container, db, sql) {
+      scalarCalls.push({ container, db, sql });
+      if (sql.includes('outbox_event')) return at(script.outbox, outboxN++);
+      if (db === 'iam_pii_local') return at(script.pii, piiN++);
+      return at(script.users, usersN++);
+    },
+  };
+  const loginPosts: { url: string; opts: PostOptions }[] = [];
+  const poster: CookiePoster = {
+    async post(url, popts): Promise<PostResult> {
+      loginPosts.push({ url, opts: popts });
+      const status = script.loginStatuses[Math.min(loginPosts.length - 1, script.loginStatuses.length - 1)] ?? 0;
+      return { status, ok: status === 200, setCookies: [] };
+    },
+  };
+  const sleeps: number[] = [];
+  const logged: string[] = [];
+  const barrier = makeSettleBarrier({
+    probe,
+    poster,
+    log: (l) => logged.push(l),
+    ...(opts.slot !== undefined ? { slot: opts.slot } : {}),
+    sleep: async (ms) => { sleeps.push(ms); },
+  });
+  const run = (): Promise<void> =>
+    barrier({
+      fixtureId: 'flow-saga-dash-journey-s1-roster',
+      stageId: 'roster',
+      personas: opts.personas ?? ['alex.tutor@example.org'],
+    });
+  return { run, scalarCalls, loginPosts, sleeps, logged };
+}
+
+describe('makeSettleBarrier', () => {
+  beforeEach(() => {
+    process.env.SAGA_MESH_POSTGRES_CONTAINER = 'test-postgres';
+  });
+  afterEach(() => {
+    delete process.env.SAGA_MESH_POSTGRES_CONTAINER;
+  });
+
+  it('fast path: stable counts + outbox 0 + devLogin 200 settles on the FIRST poll', async () => {
+    const h = barrierHarness({ users: ['259'], pii: ['41'], outbox: ['0'], loginStatuses: [200] });
+    await expect(h.run()).resolves.toBeUndefined();
+    // Two samples (baseline + poll 1), one poll interval slept, one devLogin.
+    expect(h.sleeps).toEqual([SETTLE_POLL_INTERVAL_MS]);
+    expect(h.loginPosts).toHaveLength(1);
+    // The probes hit the CALL-TIME container (env contract) and the iam DBs.
+    expect(h.scalarCalls.every((c) => c.container === 'test-postgres')).toBe(true);
+    expect(h.scalarCalls.some((c) => c.db === 'iam_pii_local' && c.sql.includes('user_pii'))).toBe(true);
+    expect(h.scalarCalls.some((c) => c.db === 'iam_local' && c.sql.includes('outbox_event'))).toBe(true);
+  });
+
+  it('moving pii counts RESET the stability window; settles once two consecutive samples agree', async () => {
+    // Samples: baseline 41 → 80 (moved) → 121 (moved) → 121 (stable ⇒ settle).
+    const h = barrierHarness({ users: ['339'], pii: ['41', '80', '121', '121'], outbox: ['0'], loginStatuses: [200] });
+    await expect(h.run()).resolves.toBeUndefined();
+    expect(h.sleeps).toHaveLength(3); // three polls until the pair repeated
+    expect(h.loginPosts).toHaveLength(1); // devLogin only probed once counts settled
+  });
+
+  it('an UNDRAINED outbox blocks settling even with stable counts', async () => {
+    // outbox: 200 unpublished on poll 1, drained on poll 2.
+    const h = barrierHarness({ users: ['339'], pii: ['121'], outbox: ['200', '200', '0'], loginStatuses: [200] });
+    await expect(h.run()).resolves.toBeUndefined();
+    expect(h.sleeps).toHaveLength(2);
+  });
+
+  it('devLogin non-200 keeps polling until the persona can actually log in', async () => {
+    const h = barrierHarness({ users: ['339'], pii: ['121'], outbox: ['0'], loginStatuses: [401, 401, 200] });
+    await expect(h.run()).resolves.toBeUndefined();
+    expect(h.loginPosts).toHaveLength(3);
+  });
+
+  it('the devLogin probe is slot-aware (slot 2 ⇒ iam at :5010) with iam’s own origin', async () => {
+    const h = barrierHarness({ users: ['1'], pii: ['1'], outbox: ['0'], loginStatuses: [200] }, { slot: 2 });
+    await h.run();
+    expect(h.loginPosts[0]!.url).toBe('http://localhost:5010/trpc/auth.devLogin');
+    expect(h.loginPosts[0]!.opts.origin).toBe('http://localhost:5010');
+    expect(h.loginPosts[0]!.opts.body).toContain('alex.tutor@example.org');
+  });
+
+  it('never settling THROWS at the poll cap, naming the fixture + last signal (never bakes torn)', async () => {
+    const h = barrierHarness({ users: ['339'], pii: ['121'], outbox: ['7'], loginStatuses: [200] });
+    await expect(h.run()).rejects.toThrow(
+      /settle barrier TIMED OUT[\s\S]*flow-saga-dash-journey-s1-roster[\s\S]*outbox_unpublished=7/,
+    );
+    expect(h.sleeps).toHaveLength(SETTLE_MAX_POLLS); // the cap is a POLL COUNT (fake-sleep safe)
+  });
+
+  it("a probe error ('' scalar) never reads as stable — '' === '' must not pass the bar", async () => {
+    const h = barrierHarness({ users: [''], pii: [''], outbox: ['0'], loginStatuses: [200] });
+    await expect(h.run()).rejects.toThrow(/TIMED OUT/);
+    expect(h.loginPosts).toHaveLength(0); // devLogin never probed while counts are unreadable
+  });
+
+  it('EVERY declared persona must devLogin 200 (one failing blocks settling)', async () => {
+    // Two personas: the first always 200, the second 401 then 200.
+    const h = barrierHarness(
+      { users: ['1'], pii: ['1'], outbox: ['0'], loginStatuses: [200, 401, 200, 200] },
+      { personas: ['alex.tutor@example.org', 'ann.lee@example.org'] },
+    );
+    await expect(h.run()).resolves.toBeUndefined();
+    // Poll 1: alex 200, ann 401 ⇒ not settled. Poll 2: alex 200, ann 200 ⇒ settled.
+    expect(h.loginPosts).toHaveLength(4);
+    expect(h.loginPosts[1]!.opts.body).toContain('ann.lee@example.org');
   });
 });

--- a/packages/node/saga-stack-cli/src/runtime/checkpoint-store.ts
+++ b/packages/node/saga-stack-cli/src/runtime/checkpoint-store.ts
@@ -50,7 +50,8 @@ export interface BakeInput {
   /** The flow's effective seed profile (stamped as the manifest `profile`). */
   profile: string;
   /** The DBs to dump — the slot-filtered flow closure's set. */
-  dbs: DbId[];
+  /** Optional subset; omitted ⇒ storePlan's default set (snapshot-store parity). */
+  dbs?: DbId[];
   /** The M14 provenance block `--from` validates. */
   flow: SnapshotFlowBlock;
 }

--- a/packages/node/saga-stack-cli/src/runtime/index.ts
+++ b/packages/node/saga-stack-cli/src/runtime/index.ts
@@ -43,6 +43,7 @@ export * from './host-reinstall.js';
 export * from './env-ensure.js';
 export * from './http-post.js';
 export * from './login.js';
+export * from './settle-barrier.js';
 export * from './record.js';
 export * from './tunnel-prep.js';
 export * from './set-store.js';

--- a/packages/node/saga-stack-cli/src/runtime/settle-barrier.ts
+++ b/packages/node/saga-stack-cli/src/runtime/settle-barrier.ts
@@ -1,0 +1,73 @@
+/**
+ * Settle probes for flow-produced iam state (soa#327) — the runtime IO half of
+ * two guards that share one truth: "this stack's state is only usable when the
+ * flow's OWN personas can devLogin".
+ *
+ *  - `makePersonaPreflight` — the tunnel post-restore probe: ONE devLogin POST
+ *    (with capped transport-class retries) whose final status the orchestrator
+ *    turns into a verdict (200 = usable, 401/404 = torn checkpoint, 403 =
+ *    devLogin disabled). The RETRY policy lives here; the VERDICT policy stays
+ *    in the orchestrator where the fail-loud messages live.
+ *  - `makeSettleBarrier` (follow-on change in this series) — the pre-bake
+ *    quiescence barrier: poll the iam DBs + devLogin until the roster-sync
+ *    pipeline is drained, so a per-stage bake never dumps torn state.
+ *
+ * Both compose EXISTING seams — `PgProbe.scalar` (docker-exec psql) and
+ * `CookiePoster` (the devLogin POST) — plus an injectable `sleep`, so unit
+ * tests script every probe answer and never wait wall-clock time.
+ *
+ * INVARIANT: real IO stays in `src/runtime/**`; the orchestrator consumes these
+ * only via `ExecDeps` (`preflight` / `settleBarrier`), never by importing this
+ * module at runtime from `core/**` or `e2e-checkpoint-exec.ts`.
+ */
+
+import type { DevLoginRequest } from '../core/login.js';
+import type { CookiePoster } from './http-post.js';
+
+/** Injectable wait — tests replace it so retries/polls are instant. */
+export type SleepFn = (ms: number) => Promise<void>;
+
+/** The production sleep: real time passes only here. */
+export const realSleep: SleepFn = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// ── tunnel persona preflight (post-restore) ─────────────────────────────────
+
+/**
+ * Preflight retry policy: transport-class results (status 0 = refused/timeout,
+ * 5xx = proxy/service hiccup) are retried this many times, this far apart —
+ * generous enough to ride out a tunnel blip, capped so a genuinely dead iam
+ * fails in ~15s instead of hanging a session. Exported so tests pin them.
+ */
+export const PREFLIGHT_ATTEMPTS = 3;
+export const PREFLIGHT_RETRY_DELAY_MS = 5000;
+
+/**
+ * POST one devLogin and return the FINAL HTTP status after capped
+ * transport-class retries. Never throws — the orchestrator owns the verdict.
+ */
+export type PersonaPreflight = (req: DevLoginRequest) => Promise<number>;
+
+/** Build the production preflight from the command's poster seam. */
+export function makePersonaPreflight(deps: {
+  poster: CookiePoster;
+  log: (line: string) => void;
+  sleep?: SleepFn;
+}): PersonaPreflight {
+  const sleep = deps.sleep ?? realSleep;
+  return async (req: DevLoginRequest): Promise<number> => {
+    let status = 0;
+    for (let attempt = 1; attempt <= PREFLIGHT_ATTEMPTS; attempt++) {
+      if (attempt > 1) await sleep(PREFLIGHT_RETRY_DELAY_MS);
+      ({ status } = await deps.poster.post(req.url, { origin: req.origin, body: req.body }));
+      // Only transport-class results are retryable. 2xx/3xx/4xx are ANSWERS —
+      // return immediately: a 401 IS the torn-checkpoint verdict; retrying it
+      // would only delay the loud error the caller is about to raise.
+      if (status !== 0 && status < 500) return status;
+      deps.log(
+        `… tunnel preflight: devLogin for ${req.email} → ${status === 0 ? 'no response' : `HTTP ${status}`} ` +
+          `(attempt ${attempt}/${PREFLIGHT_ATTEMPTS})`,
+      );
+    }
+    return status;
+  };
+}

--- a/packages/node/saga-stack-cli/src/runtime/settle-barrier.ts
+++ b/packages/node/saga-stack-cli/src/runtime/settle-barrier.ts
@@ -8,9 +8,11 @@
  *    turns into a verdict (200 = usable, 401/404 = torn checkpoint, 403 =
  *    devLogin disabled). The RETRY policy lives here; the VERDICT policy stays
  *    in the orchestrator where the fail-loud messages live.
- *  - `makeSettleBarrier` (follow-on change in this series) — the pre-bake
- *    quiescence barrier: poll the iam DBs + devLogin until the roster-sync
- *    pipeline is drained, so a per-stage bake never dumps torn state.
+ *  - `makeSettleBarrier` — the pre-bake quiescence barrier: poll the iam DBs +
+ *    devLogin until the roster-sync pipeline is drained, so a per-stage bake
+ *    never dumps torn state (soa#327 walkthrough: per-stage checkpoints whose
+ *    iam_pii dump lacked the personas roster-sync creates ⇒ devLogin 401 after
+ *    restore).
  *
  * Both compose EXISTING seams — `PgProbe.scalar` (docker-exec psql) and
  * `CookiePoster` (the devLogin POST) — plus an injectable `sleep`, so unit
@@ -21,8 +23,11 @@
  * module at runtime from `core/**` or `e2e-checkpoint-exec.ts`.
  */
 
+import { buildDevLoginRequest, resolveIamUrl } from '../core/login.js';
 import type { DevLoginRequest } from '../core/login.js';
 import type { CookiePoster } from './http-post.js';
+import type { PgProbe } from './pg-probe.js';
+import { postgresContainer } from './snapshot-store.js';
 
 /** Injectable wait — tests replace it so retries/polls are instant. */
 export type SleepFn = (ms: number) => Promise<void>;
@@ -69,5 +74,127 @@ export function makePersonaPreflight(deps: {
       );
     }
     return status;
+  };
+}
+
+// ── bake quiescence barrier (pre-dump) ──────────────────────────────────────
+
+/**
+ * Barrier polling policy. The measured settle lag is <1.1s end-to-end (outbox
+ * relay drain; the pii write itself is SYNCHRONOUS in-request — soa#327
+ * ground-truth experiment), so 2.5s polls with a 120s cap is deliberately
+ * generous: a healthy stack settles on the first or second poll; the cap only
+ * fires when something is genuinely wedged, and then a red bake beats a torn
+ * checkpoint. Exported so tests pin them. The cap is enforced as a POLL COUNT
+ * (not wall clock) so a fake sleep keeps the timeout deterministic.
+ */
+export const SETTLE_POLL_INTERVAL_MS = 2500;
+export const SETTLE_TIMEOUT_MS = 120_000;
+export const SETTLE_MAX_POLLS = Math.ceil(SETTLE_TIMEOUT_MS / SETTLE_POLL_INTERVAL_MS);
+
+/** What the orchestrator tells the barrier about the bake it is gating. */
+export interface SettleBarrierContext {
+  /** The checkpoint about to be baked (for the log/error lines). */
+  fixtureId: string;
+  /** The just-green stage. */
+  stageId: string;
+  /** The flow-declared settle personas — devLogin 200 for EACH defines "settled". */
+  personas: string[];
+}
+
+/** Await quiescence before a bake; throws (never bakes torn) on timeout. */
+export type SettleBarrier = (ctx: SettleBarrierContext) => Promise<void>;
+
+/** One sample of the iam settle signal. */
+interface SettleSample {
+  users: string;
+  pii: string;
+  outboxUnpublished: string;
+}
+
+/**
+ * Build the production barrier. "Settled" (soa#327 measured signal) =
+ *  (A) iam_local outbox_event has NO unpublished rows (the relay feeding the
+ *      genuinely-async followers — iam.events → programs-api projections — has
+ *      no pending work), AND
+ *  (C) the (iam_local users, iam_pii_local user_pii) count pair is IDENTICAL
+ *      across two consecutive polls (user_pii's only non-seed writer runs
+ *      synchronously inside the user-creating HTTP request, so pii can trail
+ *      users only within a single in-flight request; stability closes that
+ *      window), AND
+ *  devLogin returns 200 for every flow-declared persona (the DIRECT probe of
+ *  the observed failure: alex.tutor 401 after a torn per-stage restore).
+ * Signal (B) of the hunt (rabbitmq queue depth) is deliberately omitted: it
+ * measured 0 across every experiment (consumers keep pace), and probing it
+ * would need a new rabbitmqctl seam for a term (A) already dominates.
+ *
+ * Count equality between users and pii is NOT required — bootstrap/system
+ * users legitimately have no pii row. A probe error ('' scalar) is treated as
+ * UNSETTLED, never as a stable value ('' === '' must not pass the bar).
+ */
+export function makeSettleBarrier(deps: {
+  probe: PgProbe;
+  poster: CookiePoster;
+  log: (line: string) => void;
+  slot?: number;
+  sleep?: SleepFn;
+}): SettleBarrier {
+  const sleep = deps.sleep ?? realSleep;
+
+  return async (ctx: SettleBarrierContext): Promise<void> => {
+    // Resolved at CALL time: the command ran applyInstanceEnv first, so this is
+    // the slot's own container (same contract as the checkpoint store).
+    const container = postgresContainer();
+    const iamUrl = resolveIamUrl({ slot: deps.slot });
+
+    const sample = async (): Promise<SettleSample> => ({
+      users: await deps.probe.scalar(container, 'iam_local', 'SELECT count(*) FROM users'),
+      pii: await deps.probe.scalar(container, 'iam_pii_local', 'SELECT count(*) FROM user_pii'),
+      outboxUnpublished: await deps.probe.scalar(
+        container,
+        'iam_local',
+        'SELECT count(*) FROM outbox_event WHERE published_at IS NULL',
+      ),
+    });
+
+    const personasLoginOk = async (): Promise<boolean> => {
+      for (const email of ctx.personas) {
+        const req = buildDevLoginRequest(email, iamUrl);
+        const { status } = await deps.poster.post(req.url, { origin: req.origin, body: req.body });
+        if (status !== 200) {
+          deps.log(`… settle barrier: devLogin for ${email} → HTTP ${status} (not settled yet)`);
+          return false;
+        }
+      }
+      return true;
+    };
+
+    let prev = await sample();
+    for (let poll = 1; poll <= SETTLE_MAX_POLLS; poll++) {
+      await sleep(SETTLE_POLL_INTERVAL_MS);
+      const cur = await sample();
+      const countsValid = cur.users !== '' && cur.pii !== '';
+      const stable = countsValid && cur.users === prev.users && cur.pii === prev.pii;
+      const drained = cur.outboxUnpublished === '0';
+      // devLogin is probed only once counts look settled — it mints session
+      // state, so don't hammer it every poll while the roster is still moving.
+      if (stable && drained && (await personasLoginOk())) {
+        deps.log(
+          `==> settle barrier: ${ctx.fixtureId} settled after ${poll} poll(s) ` +
+            `(users=${cur.users} pii=${cur.pii} outbox_unpublished=0, devLogin 200 × ${ctx.personas.length})`,
+        );
+        return;
+      }
+      prev = cur;
+    }
+
+    throw new Error(
+      `settle barrier TIMED OUT after ${SETTLE_MAX_POLLS} polls (~${Math.round(SETTLE_TIMEOUT_MS / 1000)}s) ` +
+        `before baking '${ctx.fixtureId}' (stage '${ctx.stageId}') — refusing to dump possibly-torn state. ` +
+        `Last signal: users=${prev.users || '?'} pii=${prev.pii || '?'} ` +
+        `outbox_unpublished=${prev.outboxUnpublished || '?'}; ` +
+        `personas: ${ctx.personas.join(', ')}. The stage may need a retry (known async-settle flake class), ` +
+        'or iam-api / the outbox relay is wedged.',
+    );
   };
 }


### PR DESCRIPTION
Makes bare `ss develop connect --tunnel` work — and every failure mode LOUD. Live-proven: **two consecutive green runs** (restore → preflight 200 → 3 participants joined over the tunnel), plus each trap state demonstrated. Suite **1266 / 107**, tsc 0, lint 0 errors. Refs #327, #329, #305.

## The three trap states of the bare invocation — before and after

| Checkpoint state | Before | After |
|---|---|---|
| missing | silent full replay over the WAN → 30s polls starve | **loud error whose text IS the docs/tunnel.md recipe** (proof A, verbatim capture, zero playwright output) |
| stale (>7d) | same silent fallback | same loud error + `--from-stale-ok` named (proof B) |
| fresh | **torn**: personas 401 → cryptic `sessions.dayList` 401 | barrier-verified dump + **persona preflight** (one devLogin before any browser) |

## Four changes

1. **Tunnel fail-loud** (`e2e-orchestrate.ts`): unusable prereq checkpoint under `--tunnel` ⇒ error carrying the full concierge recipe. Local lane byte-identical.
2. **Persona preflight**: after any tunnel-lane restore, `devLogin` the flow's `settlePersonas[0]` before launching browsers. Caught a REAL torn checkpoint live during proof B ("restored checkpoint looks TORN — devLogin returned HTTP 404").
3. **Bake quiescence barrier**: pre-dump settle (users/pii stable + outbox drained + devLogin 200); timeout ⇒ bake FAILS rather than writing torn state. Investigation note: the original "async pii projection" theory was **falsified** — `user_pii` is written synchronously in-request (iam-api `PiiDataService.upsertMany`); the barrier's value is the outbox/projection settle + the mint proof at dump time.
4. **Full-set dumps** (the proof-C fix): stage checkpoints now use `storePlan`'s DEFAULT DB selection — byte-for-byte parity with `stack snapshot store` (11 DBs incl. `sessions`). The closure subset silently dropped `sessions` (event-materialized, load-bearing for `develop connect` → "No sessions on the term-start Monday"); "manifest minus slot-exclusions" over-reached into unprovisioned DBs (`role "transcripts_app" does not exist`, live). Same defect class tunnel.md documents in the legacy mesh-fixture-cli.

## Verification

- Adversarial review confirmed 4 findings (1 critical: preflight/barrier inert because `settlePersonas` only existed in the bundled example flows.json — fixed incl. the cross-repo dash declaration) — all addressed.
- Every guard mutation-checked (remove gate/preflight/barrier/subset ⇒ exactly the pinned tests fail).
- Live: proof A (missing→loud), B (stale→loud; bonus: preflight caught a genuinely torn checkpoint), C (fresh bake: barrier settled every stage, s5 = 11 DBs, bare connect **2× green**). Doc bridge (`--reuse`) untouched by construction — reviewed as the sacred path.

## Companion PR

saga-dash `fix/journey-settle-personas` (flows.json `settlePersonas: ["alex.tutor@example.org"]`) — the declaration the preflight/barrier key off. Safe to land in either order (schema tolerates absence; soa warns loudly when undeclared).

🤖 Generated with [Claude Code](https://claude.com/claude-code)