### PR TITLE
fix(saga-stack-cli): foreign-adoption warning + tunnel.md --force note (#329 papercuts 1–2)

### DIFF
--- a/packages/node/saga-stack-cli/docs/snapshots.md
+++ b/packages/node/saga-stack-cli/docs/snapshots.md
@@ -14,7 +14,7 @@ Bring your stack to the state you want, then:
 ss stack snapshot store --fixture-id my-baseline
 ```
 
-<details><summary>✓ dumps every closure DB (pg) + connectv3 (mongo) into a named fixture</summary>
+<details><summary>✓ dumps every stack DB (pg, storePlan's default set) + connectv3 (mongo) into a named fixture</summary>
 
 ```
 snapshot 'my-baseline' — storing …
@@ -72,7 +72,7 @@ Recovery is one command — relaunch the dead service:
 ss stack up --only programs-api --skip-prep
 ```
 
-The coverage guard, by contrast, behaves well: restoring beyond the baked closure fails
+The coverage guard, by contrast, behaves well: restoring beyond the baked set fails
 fast with a `re-bake with a wider --through` error instead of half-restoring.
 
 ## When to use which

--- a/packages/node/saga-stack-cli/docs/tunnel.md
+++ b/packages/node/saga-stack-cli/docs/tunnel.md
@@ -21,7 +21,7 @@ export AWS_PROFILE=dev_admin      # dev account (moniker registration + fleek A/
 # 1 — Build the Empty Org + a schedule locally (fast, tested), then snapshot it:
 ss stack down && ss stack up --seed full --reset
 ss e2e run journey --through schedule
-ss stack snapshot store --fixture-id tunnel-connect
+ss stack snapshot store --fixture-id tunnel-connect   # add --force on a re-run (the fixture persists)
 
 # 2 — Bring the stack up in TUNNEL mode (fetches fleek A/V creds), then restore the org:
 ss stack down && ss stack up --tunnel --reset

--- a/packages/node/saga-stack-cli/src/commands/stack/up.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/up.ts
@@ -627,7 +627,17 @@ export default class StackUp extends BaseCommand {
     }
 
     // Report.
-    const launchedIds = up.launched.map((r) => `${r.id}${r.alreadyUp ? ' (already up)' : ''}`);
+    const launchedIds = up.launched.map(
+      (r) => `${r.id}${r.adoptedForeign ? ' (already up, FOREIGN)' : r.alreadyUp ? ' (already up)' : ''}`,
+    );
+    const foreign = up.launched.filter((r) => r.adoptedForeign).map((r) => r.id);
+    if (foreign.length > 0) {
+      this.warn(
+        `adopted ${foreign.length} process(es) NOT launched by this CLI (no pidfile): ${foreign.join(', ')} — ` +
+          'their env is unverifiable (a lane/tunnel transition may not have applied). ' +
+          'If behavior looks wrong, stop them and re-run so this CLI relaunches them.',
+      );
+    }
     this.emit(
       flags,
       {

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/launcher.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/launcher.unit.test.ts
@@ -91,7 +91,7 @@ describe('makeRealLauncher.launch', () => {
 
     const res = await launcher.launch(SPEC);
 
-    expect(res).toEqual({ id: 'iam-api', ok: true, alreadyUp: true });
+    expect(res).toEqual({ id: 'iam-api', ok: true, alreadyUp: true, adoptedForeign: true });
     expect(calls).toHaveLength(0); // never spawned
     expect(ensureDir).not.toHaveBeenCalled();
   });
@@ -219,6 +219,34 @@ describe('makeRealLauncher.launch adopt-contract guard (soa#305)', () => {
   };
   const FINGERPRINT = JSON.stringify({ JWT_ISSUER: 'https://iam.wootdev.com' });
 
+  it('flags an UNGUARDED already-up process as adoptedForeign when it has no pidfile (soa#329)', async () => {
+    // A foreign process (another CLI/terminal launched it) 200s on /health and gets
+    // adopted — but its env is unverifiable, which silently voids `down`'s relaunch
+    // guarantee across lane/tunnel transitions. The flag is the caller's cue to WARN.
+    const { prober } = seqProber([true]);
+    const launcher = makeRealLauncher({
+      stateDir: STATE,
+      prober,
+      spawn: fakeSpawn(1).spawn,
+      readPid: () => null, // no pidfile in this slot's state dir ⇒ foreign
+    });
+    const res = await launcher.launch(SPEC); // no adoptEnv — unguarded service
+    expect(res).toMatchObject({ ok: true, alreadyUp: true, adoptedForeign: true });
+  });
+
+  it('does NOT flag adoption when OUR pidfile exists (a normal idempotent re-run)', async () => {
+    const { prober } = seqProber([true]);
+    const launcher = makeRealLauncher({
+      stateDir: STATE,
+      prober,
+      spawn: fakeSpawn(1).spawn,
+      readPid: () => '4242', // this CLI's own pidfile
+    });
+    const res = await launcher.launch(SPEC);
+    expect(res.alreadyUp).toBe(true);
+    expect(res.adoptedForeign).toBeUndefined();
+  });
+
   it('refuses to adopt an already-up process with NO recorded contract fingerprint', async () => {
     const { prober } = seqProber([true]); // already up
     const { spawn, calls } = fakeSpawn(1);
@@ -337,7 +365,7 @@ describe('makeRealLauncher.launch adopt-contract guard (soa#305)', () => {
 
     const res = await launcher.launch(SPEC); // no adoptEnv
 
-    expect(res).toEqual({ id: 'iam-api', ok: true, alreadyUp: true });
+    expect(res).toEqual({ id: 'iam-api', ok: true, alreadyUp: true, adoptedForeign: true });
     expect(readContract).not.toHaveBeenCalled(); // guard never consulted
   });
 });

--- a/packages/node/saga-stack-cli/src/runtime/launcher.ts
+++ b/packages/node/saga-stack-cli/src/runtime/launcher.ts
@@ -90,6 +90,12 @@ export interface LaunchResult {
   /** True iff a 200 came back BEFORE we launched — up.sh's "already up :$port" path. */
   alreadyUp?: boolean;
   /**
+   * alreadyUp AND no pidfile in this slot's state dir — the process answers its
+   * health URL but was NOT launched by this CLI (docs/tunnel.md's "down guarantees
+   * every service (re)launches" is silently void for it: its env may be any lane's).
+   */
+  adoptedForeign?: boolean;
+  /**
    * Set only on a NON-ok result that needs an explanation the caller can't infer from
    * `id` alone — today the `adoptEnv` drift refusal (an already-up process whose launch
    * contract can't be verified), so `up` reports the real cause instead of the generic
@@ -290,7 +296,17 @@ export function makeRealLauncher(deps: RealLauncherDeps = {}): ServiceLauncher {
             };
           }
         }
-        return { id: spec.id, ok: true, alreadyUp: true };
+        // Unguarded services still deserve a trace when the adoptee is FOREIGN
+        // (no pidfile here ⇒ some other CLI/terminal launched it): its env is
+        // unverifiable, which silently voids `down`'s relaunch guarantee — the
+        // walkthrough watched a foreign programs-api ride through a localhost→
+        // tunnel transition this way (soa#329).
+        // Guarded specs that reach here PROVED provenance (fingerprint matched),
+        // pidfile or not. Only an UNGUARDED adoptee with no pidfile is unknowable.
+        const foreign = guardKeys.length === 0 && readPid(pidFilePath(stateDir, spec.id)) === null;
+        return foreign
+          ? { id: spec.id, ok: true, alreadyUp: true, adoptedForeign: true }
+          : { id: spec.id, ok: true, alreadyUp: true };
       }
 
       ensureDir(stateDir);


### PR DESCRIPTION
First two of #329's papercuts (the `--bootstrap` design and the saga-dash timeout papercut remain on #329).

1. **Foreign-adoption warning.** `up` adopting a health-200 process that has **no pidfile and no adopt-contract** now flags it `adoptedForeign` and warns once, naming the processes — the silent version of this is how a foreign `programs-api` rode through a localhost→tunnel transition in the tunnel.md walkthrough, voiding the doc's relaunch guarantee. Guarded services whose fingerprint matched are exempt (provenance proven). Mutation-checked.
2. **tunnel.md**: the concierge's `snapshot store` line now mentions `--force` for re-runs (it refuses on the second top-to-bottom pass).

Suite 1278/107, tsc 0, lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)