### PR TITLE
feat(saga-stack-cli): open ads-adm per-request rosterMode override gate on ss stacks

### DIFF
--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.slot.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.slot.unit.test.ts
@@ -162,6 +162,9 @@ describe('ads-adm-api slottability — tokenized env + EXPRESS_SERVER_PORT injec
     // a slot > 0 ads-adm would dial SLOT 0's programs-api and silently resolve names
     // against the wrong stack (best-effort ⇒ it would no-op, not fail loudly).
     expect(env.PROGRAMS_API_CLIENT_BASEURL).toBe('http://localhost:5006'); // 3006 + 2000
+    // saga-dash#446/#570: the rosterMode override gate is a static literal —
+    // open at every slot, untouched by port/mesh offsets.
+    expect(env.ADM_ALLOW_ROSTER_MODE_OVERRIDE).toBe('true');
     expect(env.IAM_API_CLIENT_BASEURL).toBe('http://localhost:5010/trpc'); // 3010 + 2000
     expect(env.IAM_API_URL).toBe('http://localhost:5010');
     expect(env.CORS_ORIGIN).toBe('http://localhost:10900'); // dash 8900 + 2000
@@ -179,6 +182,10 @@ describe('ads-adm-api slottability — tokenized env + EXPRESS_SERVER_PORT injec
     expect(env.EXPRESS_SERVER_PORT).toBeUndefined(); // no offset ⇒ no injection
     expect(env.SESSIONS_API_CLIENT_BASEURL).toBe('http://localhost:3007');
     expect(env.PROGRAMS_API_CLIENT_BASEURL).toBe('http://localhost:3006');
+    // Deliberate post-up.sh addition (not part of the byte-identity set):
+    // the override gate is open at slot 0 too, so a slot-0 e2e probe can
+    // hard-assert the period path (saga-dash#446/#570).
+    expect(env.ADM_ALLOW_ROSTER_MODE_OVERRIDE).toBe('true');
     expect(env.IAM_API_CLIENT_BASEURL).toBe('http://localhost:3010/trpc');
     expect(env.ADS_ADM_DATABASE_URL).toBe('postgresql://ads_adm:ads_adm@localhost:5432/ads_adm_local');
     expect(env.DATABASE_URL).toBe('postgresql://ads_adm:ads_adm@localhost:5432/ads_adm_local');

--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
@@ -177,6 +177,11 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
       // programId echo). Tokenized so a slot > 0 ads-adm dials ITS slot's
       // programs-api rather than slot 0's.
       PROGRAMS_API_CLIENT_BASEURL: 'http://localhost:3006',
+      // Also NOT an up.sh literal (same precedent): opens the per-request
+      // rosterMode override gate for e2e probes (saga-dash#446/#570). Static
+      // 'true' at every slot; ADM_ROSTER_MODE stays unset so the default mode
+      // is still occurrence — only the override gate opens.
+      ADM_ALLOW_ROSTER_MODE_OVERRIDE: 'true',
       IAM_API_CLIENT_BASEURL: 'http://localhost:3010/trpc',
       IAM_API_URL: 'http://localhost:3010',
       JWT_ISSUER: 'https://iam.wootdev.com',

--- a/packages/node/saga-stack-cli/src/core/manifest/services.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/services.ts
@@ -319,6 +319,14 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
         // prod literal, which 401'd once iam began minting ${IAM_ISSUER} (58d58e4).
         JWT_ISSUER: '${IAM_ISSUER}',
         SERVICE_TOKEN_SERVICESLUG: 'ads-adm-api',
+        // NOT an up.sh literal — a deliberate post-up.sh addition, like
+        // PROGRAMS_API_CLIENT_BASEURL above (soa#320 precedent). Opens ads-adm's
+        // per-request rosterMode override gate so e2e probes (saga-dash#446 /
+        // saga-dash#570 period-path) can hard-assert period-roster derivation in
+        // CI. The DEFAULT mode is untouched (ADM_ROSTER_MODE deliberately not
+        // set — occurrence stays the default); prod is masked by design since
+        // prod is never ss-launched and its deployment omits this flag.
+        ADM_ALLOW_ROSTER_MODE_OVERRIDE: 'true',
         ADS_ADM_DATABASE_URL: '${ADS_ADM_DB_URL}',
         DATABASE_URL: '${ADS_ADM_DB_URL}',
         CORS_ORIGIN: '${DASH_URL}',


### PR DESCRIPTION
## What

Adds `ADM_ALLOW_ROSTER_MODE_OVERRIDE: 'true'` to `ads-adm-api`'s launch env in the ss manifest (`packages/node/saga-stack-cli/src/core/manifest/services.ts`), so ss-launched dev stacks honor the per-request ADS/ADM roster-mode override.

## Why

saga-dash#446's period-path e2e probe (part of the saga-dash#570 Period-Based ADS/ADM attendance effort) needs to hard-assert period-roster derivation in CI. ads-adm-api ignores a client-supplied `rosterMode` unless the deployment opts in via `ADM_ALLOW_ROSTER_MODE_OVERRIDE === 'true'` — without this flag on the stack, the probe can only observe the default occurrence path.

## What this does NOT do

- **`ADM_ROSTER_MODE` is deliberately not set.** The default mode stays `occurrence`; only the per-request override gate opens. Requests that don't send `rosterMode` behave exactly as before.
- **Prod is unaffected by design.** Prod is never ss-launched, and its deployment omits the flag — the gate stays prod-masked (the service's documented default is `false`).

## Precedent

Same shape as the soa#320 `PROGRAMS_API_CLIENT_BASEURL` addition: a deliberate post-up.sh env entry on ads-adm-api, a static literal that rides along unchanged at every slot.

## Tests

- Extended the exact-env pin in `launch-plan.unit.test.ts` (ads-adm-api stack-lane `toEqual`).
- Extended the slot 0 / slot 2 slottability tests in `launch-plan.slot.unit.test.ts` to assert the gate is open at every slot and untouched by port/mesh offsets.
- Full package suite: 107 files / 1276 tests pass; `tsc --noEmit` clean.

Refs saga-dash#446, saga-dash#570

🤖 Generated with [Claude Code](https://claude.com/claude-code)