### PR TITLE
ss: advisory slot claims + `ss stack slots` — who is on what slot

### DIFF
--- a/packages/node/saga-stack-cli/docs/slots.md
+++ b/packages/node/saga-stack-cli/docs/slots.md
@@ -60,6 +60,88 @@ stopped: iam-api, scheduling-api, sessions-api
 ```
 </details>
 
+## Who's on what slot — `ss stack slots` and claim files
+
+With several humans and agents multiplexing one box, `ss stack slots` is the one-glance
+answer to "who is on what slot". It always sweeps **all slots 0–9** (`--slot` is accepted
+but never narrows the report) and is strictly read-only:
+
+```bash
+ss stack slots                   # human table
+ss stack slots --porcelain       # one TSV line per row-worthy slot (active, claimed, or set-bound): slot  active  set  actor  live|stale  at
+ss stack slots --output-json     # full claim + per-repo posture detail
+```
+
+<details><summary>Columns SLOT · ACTIVE · SET · ACTOR · SINCE, per-repo posture under active slots, unused slots collapsed</summary>
+
+```
+SLOT  ACTIVE  SET          ACTOR                          SINCE
+──────────────────────────────────────────────────────────────────────────────
+0     ● up    —            skelly@devbox:pts/4            2026-07-16T09:12:31Z
+      soa          @ main  (clean)
+      saga-dash    @ main  (dirty)
+1     ● up    journey-fix  claude:41234                   2026-07-16T10:02:07Z
+      saga-dash    @ feat/journey-weekends  (clean)  ⚠ drifted since launch
+2     —       —            coach-aug3-training (stale)    2026-07-15T18:40:11Z
+slots 3, 4, 5, 6, 7, 8, 9: unused — no live activity, no claim, no set
+```
+
+A slot earns a row when it's **active, claimed, or set-bound**; the rest collapse into one
+dim line. Posture (branch / dirty / behind / drift) is gathered for **active** slots only:
+a set-bound slot reads its set's worktrees, slot 0 reads the shared checkouts, and an
+active slot > 0 without a set just notes `shared checkouts (see slot 0)` — no git spawns.
+</details>
+
+**The claim file.** Every command that *drives* a slot's stack — `up` / `down` / `reset` /
+`restart` / `seed` / `login` / `cold-start` / `bootstrap` / `tunnel` /
+`snapshot store|restore|delete` / `e2e run` / `develop coach|connect` / mutating `overlay`
+verbs — writes `<stateDir>/claim.json` on entry (slot 1: `/tmp/sds-synthetic-s1/claim.json`),
+recording **who last drove this slot**:
+
+```jsonc
+{
+  "version": 1,
+  "actor": "claude:41234",           // resolved identity — see order below
+  "actorSource": "claude",           // "env" | "claude" | "fallback"
+  "pid": 52110,                      // the ss process; liveness is checked at READ time
+  "command": "ss stack:up --slot 1 --only iam-api",
+  "at": "2026-07-16T10:02:07.331Z",  // ISO-8601 write time
+  "cwd": "/home/skelly/dev/soa",
+  "slot": 1,
+  "set": "journey-fix",              // only when the run was --set-driven
+  "sourceAtLaunch": {                // per repo that existed on disk at launch:
+    "saga-dash": { "branch": "feat/journey-weekends", "headSha": "6b1e0c9…", "dirty": false }
+  }
+}
+```
+
+**Actor resolution order** — first match wins:
+
+1. `$SS_ACTOR` (non-empty) → `actorSource: "env"`.
+2. A `claude` process anywhere up the ppid chain → `claude:<pid>`, `actorSource: "claude"`.
+3. `<user>@<host>[:<tty>]` (e.g. `skelly@devbox:pts/4`) → `actorSource: "fallback"`.
+
+Agents: put **`SS_ACTOR=<task-name>`** in your environment *before* running mutating
+commands — the claude-ancestry fallback only identifies *a* Claude; `SS_ACTOR` says which
+task is driving.
+
+**Staleness is read-time, and stale is normal.** A stack deliberately outlives the `ss`
+process that launched it, so the claim's pid is usually dead by the time anyone looks —
+that is exactly what "**last driven by**" means. `stack slots` probes pid-liveness when it
+*reads*: a live pid renders plain, a dead one gets the dim `(stale)` suffix. **Nothing
+ever deletes `claim.json`** — a stale claim on an inactive slot is ordinary history, not
+an error.
+
+**Advisory, not exclusive.** A claim never blocks anything: two actors can drive one slot
+back-to-back and the file simply records the most recent driver. It's a coordination
+courtesy between humans and agents, not a lock (the realpath-keyed prep lock in
+[worktree sets](./worktree-sets.md) is the actual mutual exclusion — and it guards
+*builds*, not slots).
+
+**Drift.** `sourceAtLaunch` freezes each repo's branch + HEAD at claim time; when a repo's
+current HEAD no longer matches, the posture line flags `⚠ drifted since launch` — the
+running stack was built from code its checkout has since moved past.
+
 ## Notes
 
 - `--slot N` works on `up` / `status` / `verify` / `down` / `reset` / `seed` / `snapshot` / `e2e run`.

--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -170,6 +170,7 @@
       "pluginType": "core",
       "strict": false,
       "enableJsonFlag": false,
+      "slotClaimWritten": false,
       "isESM": true,
       "relativePath": [
         "dist",
@@ -351,6 +352,7 @@
       "pluginType": "core",
       "strict": false,
       "enableJsonFlag": false,
+      "slotClaimWritten": false,
       "isESM": true,
       "relativePath": [
         "dist",
@@ -489,6 +491,7 @@
       "pluginType": "core",
       "strict": true,
       "enableJsonFlag": false,
+      "slotClaimWritten": false,
       "isESM": true,
       "relativePath": [
         "dist",
@@ -729,6 +732,7 @@
       "pluginType": "core",
       "strict": false,
       "enableJsonFlag": false,
+      "slotClaimWritten": false,
       "isESM": true,
       "relativePath": [
         "dist",
@@ -874,6 +878,7 @@
       "pluginType": "core",
       "strict": true,
       "enableJsonFlag": false,
+      "slotClaimWritten": false,
       "isESM": true,
       "relativePath": [
         "dist",
@@ -1030,6 +1035,7 @@
       "pluginType": "core",
       "strict": true,
       "enableJsonFlag": false,
+      "slotClaimWritten": false,
       "isESM": true,
       "relativePath": [
         "dist",
@@ -1205,6 +1211,7 @@
       "pluginType": "core",
       "strict": true,
       "enableJsonFlag": false,
+      "slotClaimWritten": false,
       "isESM": true,
       "relativePath": [
         "dist",
@@ -1342,6 +1349,7 @@
       "pluginType": "core",
       "strict": true,
       "enableJsonFlag": false,
+      "slotClaimWritten": false,
       "isESM": true,
       "relativePath": [
         "dist",
@@ -1486,6 +1494,7 @@
       "pluginType": "core",
       "strict": true,
       "enableJsonFlag": false,
+      "slotClaimWritten": false,
       "isESM": true,
       "relativePath": [
         "dist",
@@ -1666,6 +1675,7 @@
       "pluginType": "core",
       "strict": false,
       "enableJsonFlag": false,
+      "slotClaimWritten": false,
       "isESM": true,
       "relativePath": [
         "dist",
@@ -1812,6 +1822,7 @@
       "pluginType": "core",
       "strict": true,
       "enableJsonFlag": false,
+      "slotClaimWritten": false,
       "isESM": true,
       "relativePath": [
         "dist",
@@ -1942,6 +1953,7 @@
       "pluginType": "core",
       "strict": true,
       "enableJsonFlag": false,
+      "slotClaimWritten": false,
       "isESM": true,
       "relativePath": [
         "dist",
@@ -2121,12 +2133,145 @@
       "pluginType": "core",
       "strict": true,
       "enableJsonFlag": false,
+      "slotClaimWritten": false,
       "isESM": true,
       "relativePath": [
         "dist",
         "commands",
         "stack",
         "seed.js"
+      ]
+    },
+    "stack:slots": {
+      "aliases": [],
+      "args": {},
+      "description": "Show who is on what slot: live activity, worktree-set binding, and the last advisory claim per slot — always reports ALL slots 0-9 (read-only).",
+      "examples": [
+        "<%= config.bin %> <%= command.id %>",
+        "<%= config.bin %> <%= command.id %> --output-json"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "stack:slots",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "slotClaimWritten": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "stack",
+        "slots.js"
       ]
     },
     "stack:status": {
@@ -2275,6 +2420,7 @@
       "pluginType": "core",
       "strict": true,
       "enableJsonFlag": false,
+      "slotClaimWritten": false,
       "isESM": true,
       "relativePath": [
         "dist",
@@ -2428,6 +2574,7 @@
       "pluginType": "core",
       "strict": true,
       "enableJsonFlag": false,
+      "slotClaimWritten": false,
       "isESM": true,
       "relativePath": [
         "dist",
@@ -2673,6 +2820,7 @@
       "pluginType": "core",
       "strict": true,
       "enableJsonFlag": false,
+      "slotClaimWritten": false,
       "isESM": true,
       "relativePath": [
         "dist",
@@ -2853,6 +3001,7 @@
       "pluginType": "core",
       "strict": true,
       "enableJsonFlag": false,
+      "slotClaimWritten": false,
       "isESM": true,
       "relativePath": [
         "dist",
@@ -2989,6 +3138,7 @@
       "pluginType": "core",
       "strict": true,
       "enableJsonFlag": false,
+      "slotClaimWritten": false,
       "isESM": true,
       "relativePath": [
         "dist",
@@ -3180,6 +3330,7 @@
       "pluginType": "core",
       "strict": true,
       "enableJsonFlag": false,
+      "slotClaimWritten": false,
       "isESM": true,
       "relativePath": [
         "dist",
@@ -3311,6 +3462,7 @@
       "pluginType": "core",
       "strict": true,
       "enableJsonFlag": false,
+      "slotClaimWritten": false,
       "isESM": true,
       "relativePath": [
         "dist",
@@ -3466,6 +3618,7 @@
       "pluginType": "core",
       "strict": true,
       "enableJsonFlag": false,
+      "slotClaimWritten": false,
       "isESM": true,
       "relativePath": [
         "dist",
@@ -3608,6 +3761,7 @@
       "pluginType": "core",
       "strict": true,
       "enableJsonFlag": false,
+      "slotClaimWritten": false,
       "isESM": true,
       "relativePath": [
         "dist",
@@ -3739,6 +3893,7 @@
       "pluginType": "core",
       "strict": true,
       "enableJsonFlag": false,
+      "slotClaimWritten": false,
       "isESM": true,
       "relativePath": [
         "dist",
@@ -3876,6 +4031,7 @@
       "pluginType": "core",
       "strict": true,
       "enableJsonFlag": false,
+      "slotClaimWritten": false,
       "isESM": true,
       "relativePath": [
         "dist",
@@ -4016,6 +4172,7 @@
       "pluginType": "core",
       "strict": true,
       "enableJsonFlag": false,
+      "slotClaimWritten": false,
       "isESM": true,
       "relativePath": [
         "dist",
@@ -4174,6 +4331,7 @@
       "pluginType": "core",
       "strict": true,
       "enableJsonFlag": false,
+      "slotClaimWritten": false,
       "isESM": true,
       "relativePath": [
         "dist",
@@ -4351,6 +4509,7 @@
       "pluginType": "core",
       "strict": true,
       "enableJsonFlag": false,
+      "slotClaimWritten": false,
       "isESM": true,
       "relativePath": [
         "dist",
@@ -4495,6 +4654,7 @@
       "pluginType": "core",
       "strict": true,
       "enableJsonFlag": false,
+      "slotClaimWritten": false,
       "isESM": true,
       "relativePath": [
         "dist",

--- a/packages/node/saga-stack-cli/src/base-command.ts
+++ b/packages/node/saga-stack-cli/src/base-command.ts
@@ -39,13 +39,14 @@ import { Command } from '@oclif/core';
 import type { Interfaces } from '@oclif/core';
 import { dirname, join } from 'node:path';
 import { SET_UNSUPPORTED_COMMAND_MESSAGE, SLOT_UNSUPPORTED_COMMAND_MESSAGE, baseFlags } from './shared-flags.js';
-import { applySetToFlags, resolveSet } from './core/set/index.js';
-import type { SetInjectableFlags, WorktreeSet } from './core/set/index.js';
+import { SET_REPO_KEYS, applySetToFlags, resolveSet } from './core/set/index.js';
+import type { SetInjectableFlags, SetRepoKey, WorktreeSet } from './core/set/index.js';
 import { checkWorktreeSet, makeCheckpointStore, makeSlotActiveProbe } from './runtime/index.js';
 import { stampMatches, writeStamp } from './runtime/prep-stamp.js';
 import { repairStaleDeps } from './runtime/prep-repair.js';
 import type { CheckpointStore, SlotActiveProbe } from './runtime/index.js';
 import type { PullMode } from './core/auto-pull.js';
+import { deriveInstance } from './core/derive-instance.js';
 import type { InstanceProfile } from './core/derive-instance.js';
 import type { RecordMode, ScriptPlan } from './core/flag-map.js';
 import { defaultLaunchContext } from './core/launch-plan.js';
@@ -56,6 +57,8 @@ import { COOKIE_JAR_FILE, nativeLogin } from './runtime/login.js';
 import type { NativeLoginResult } from './runtime/login.js';
 import {
   buildRepoEnv,
+  makeClaimReader,
+  makeClaimWriter,
   makeRealConfirm,
   makeRealCookiePoster,
   makeRealDashFs,
@@ -94,8 +97,11 @@ import {
   scriptCwd,
   stopServices,
   REPO_DEFAULT_DIR,
+  REPO_ENV_VAR,
 } from './runtime/index.js';
 import type {
+  ClaimReader,
+  ClaimWriter,
   ConfirmSeam,
   CookiePoster,
   CoachWebFs,
@@ -210,6 +216,32 @@ export abstract class BaseCommand extends Command {
   }
 
   /**
+   * Opt-in: does this command DRIVE a slot's stack (⇒ write an advisory claim
+   * on entry)? Default `false` — read-only commands never touch `claim.json`.
+   * The mutating lifecycle set overrides this to `true`; the claim hook in
+   * `parse` runs AFTER set-injection + the slot guard and is suppressed by
+   * `--dry-run` (nothing mutated ⇒ nothing claimed). `positionals` are the
+   * PARSED positional tokens (never flag values), for verb-dispatched commands
+   * (`overlay`) whose mutating-ness depends on the verb.
+   */
+  protected claimsSlot(_positionals?: readonly string[]): boolean {
+    return false;
+  }
+
+  /**
+   * Per-process claim latch: `cold-start`/`bootstrap` re-invoke `StackUp.run()`
+   * (and `StackOverlay.run()`) IN-PROCESS, and the inner command's parse would
+   * overwrite the claim with a synthetic argv the user never typed. One process
+   * is one user command, so only the FIRST claim in a process wins.
+   */
+  private static slotClaimWritten = false;
+
+  /** Test seam — in-process command runs share one process (and this latch). */
+  static resetSlotClaimLatchForTests(): void {
+    BaseCommand.slotClaimWritten = false;
+  }
+
+  /**
    * The worktree-set store seam (M13-A). Production reads
    * `$SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json`.
    */
@@ -224,6 +256,23 @@ export abstract class BaseCommand extends Command {
    */
   protected getSlotActiveProbe(): SlotActiveProbe {
     return makeSlotActiveProbe();
+  }
+
+  /**
+   * The advisory slot-claim writer (slot claims — "who last drove this slot").
+   * Production writes `<stateDir>/claim.json`; it NEVER throws (every error
+   * folds to a silent no-op — advisory state must not break a real run).
+   */
+  protected getClaimWriter(): ClaimWriter {
+    return makeClaimWriter();
+  }
+
+  /**
+   * The advisory slot-claim reader (`stack slots`). Staleness is derived at
+   * READ time from the recorded pid's liveness — no recorded active state.
+   */
+  protected getClaimReader(): ClaimReader {
+    return makeClaimReader();
   }
 
   /**
@@ -299,6 +348,7 @@ export abstract class BaseCommand extends Command {
     // (there are seven independent builders), so rewriting it here threads the
     // set through all of them. Runs BEFORE the slot guard so a set's slot is
     // guarded exactly like a typed `--slot`.
+    let injectedSet: string | undefined; // captured for the claim hook below
     const setName = (result.flags as { set?: unknown }).set;
     if (typeof setName === 'string') {
       if (!this.setAware()) this.error(SET_UNSUPPORTED_COMMAND_MESSAGE);
@@ -331,11 +381,45 @@ export abstract class BaseCommand extends Command {
       }
 
       applySetToFlags(result.flags as SetInjectableFlags, typed, set);
+      injectedSet = set.name;
     }
 
     const slot = (result.flags as { slot?: unknown }).slot;
     if (typeof slot === 'number' && slot > 0 && !this.slotAware()) {
       this.error(SLOT_UNSUPPORTED_COMMAND_MESSAGE);
+    }
+
+    // ── Slot claims (advisory): a DRIVING command (`claimsSlot()` ⇒ true)
+    // records "who last drove this slot" to `<stateDir>/claim.json` on entry.
+    // AFTER the set-injection (the set's slot/pins are what get claimed) and
+    // the slot guard (a rejected slot never claims); `--dry-run` mutates
+    // nothing, so it claims nothing. The writer folds every error to a silent
+    // no-op — advisory state must never break a real run. The per-process
+    // latch keeps nested in-process re-invocations (cold-start/bootstrap →
+    // StackUp.run) from overwriting the user's real command line.
+    if (
+      !BaseCommand.slotClaimWritten &&
+      this.claimsSlot((result.argv ?? []) as string[]) &&
+      (result.flags as { 'dry-run'?: unknown })['dry-run'] !== true
+    ) {
+      BaseCommand.slotClaimWritten = true;
+      const claimSlot = typeof slot === 'number' ? slot : 0;
+      const stateDir =
+        ((result.flags as { 'state-dir'?: unknown })['state-dir'] as string | undefined) ??
+        deriveInstance({ slot: claimSlot }).stateDir;
+      // The same flag-side resolution every command uses (kebab pins → manifest
+      // keys → roots), keyed back by the kebab `SetRepoKey` — the claim's repo
+      // vocabulary. The writer skips roots that don't exist on disk.
+      const ctx = repoContextFromFlags(result.flags as Record<string, unknown>);
+      const repoRoots: Partial<Record<SetRepoKey, string>> = {};
+      for (const repo of SET_REPO_KEYS) repoRoots[repo] = resolveRepoRoot(REPO_ENV_VAR[repo], ctx);
+      await this.getClaimWriter().write({
+        slot: claimSlot,
+        stateDir,
+        command: [this.config.bin, this.id, ...this.argv].join(' '),
+        set: injectedSet,
+        repoRoots,
+      });
     }
     return result;
   }

--- a/packages/node/saga-stack-cli/src/commands/develop/coach.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/coach.ts
@@ -207,6 +207,11 @@ export default class DevelopCoach extends BaseCommand {
     return true;
   }
 
+  /** Slot claims: the concierge brings up + DRIVES the slot's sub-stack — record the advisory claim on entry. */
+  protected claimsSlot(): boolean {
+    return true;
+  }
+
   async run(): Promise<void> {
     const { argv, flags } = await this.parse(DevelopCoach);
     const scenario = flags.scenario as Scenario;

--- a/packages/node/saga-stack-cli/src/commands/develop/connect.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/connect.ts
@@ -135,6 +135,11 @@ export default class DevelopConnect extends BaseCommand {
     return true;
   }
 
+  /** Slot claims: the tutoring room brings up + DRIVES the slot's sub-stack — record the advisory claim on entry. */
+  protected claimsSlot(): boolean {
+    return true;
+  }
+
   async run(): Promise<void> {
     const { argv, flags } = await this.parse(DevelopConnect);
     const passthrough = (argv as string[]).filter((a) => a !== CONNECT_FLOW);

--- a/packages/node/saga-stack-cli/src/commands/e2e/run.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/run.ts
@@ -155,6 +155,11 @@ export default class E2eRun extends BaseCommand {
     return true;
   }
 
+  /** Slot claims: `e2e run` brings up + DRIVES the slot's stack — record the advisory claim on entry. */
+  protected claimsSlot(): boolean {
+    return true;
+  }
+
   async run(): Promise<void> {
     const { argv, flags } = await this.parse(E2eRun);
 

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/claim-hook.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/claim-hook.unit.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Advisory slot-claim hook (slot claims — "who last drove this slot").
+ *
+ * `BaseCommand.parse` writes `<stateDir>/claim.json` for every command that
+ * opts in via `claimsSlot()` — AFTER the set-injection and the central slot
+ * guard, so the claim records the slot the run actually targets. claim.json is
+ * ADVISORY state (the deliberate counterpart to slot-active.ts's "no recorded
+ * active state" stance), so the hook must be invisible on every other axis:
+ * read-only commands never claim, `--dry-run` (mutates nothing) never claims,
+ * and a claim-write failure never breaks the command.
+ *
+ * Like slot-guard.unit.test.ts, the command classes run in-process; the ONE
+ * seam the hook uses (`getClaimWriter`) is spied on the prototype with a
+ * recording fake, so we assert the WRITE PLAN (slot / stateDir / command line /
+ * repo roots) without touching the filesystem.
+ */
+
+import { resolve } from 'node:path';
+import { Config } from '@oclif/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BaseCommand } from '../../../base-command.js';
+import { restoreEnv, saveEnv } from '../../../__tests__/helpers/env.js';
+import { makeClaimWriter } from '../../../runtime/index.js';
+import type { ClaimWriteInput } from '../../../runtime/index.js';
+import StackSeed from '../seed.js';
+import StackStatus from '../status.js';
+import StackUp from '../up.js';
+
+// Direct in-process runs bypass oclif's plugin loader, which is what normally
+// stamps `static id` onto each command class — without it, `Command.run` falls
+// back to the lowercased class name ('stackseed'). Pin the real ids so the
+// claim's recorded command line matches production ('saga-stack stack:seed …').
+StackSeed.id = 'stack:seed';
+StackStatus.id = 'stack:status';
+StackUp.id = 'stack:up';
+
+const PKG_ROOT = process.cwd();
+const SOA_ROOT = resolve(PKG_ROOT, '..', '..', '..');
+const WS = ['--soa', SOA_ROOT, '--dev', '/fixed/dev'];
+
+// Slot-parameterized commands (seed --slot 2 below) apply the slot env seam to
+// process.env — save/restore so no test leaks it (the slot-guard/up-native recipe).
+const SLOT_ENV_KEYS = [
+  'SAGA_MESH_POSTGRES_CONTAINER',
+  'SAGA_MESH_REDIS_CONTAINER',
+  'SAGA_MESH_RABBITMQ_CONTAINER',
+  'SAGA_MESH_MONGO_CONTAINER',
+  'SAGA_MESH_CONNECT_MONGO_CONTAINER',
+  'SAGA_MESH_SNAPSHOTS_DIR',
+];
+
+let config: Config;
+let writes: ClaimWriteInput[];
+let savedEnv: ReturnType<typeof saveEnv>;
+
+beforeEach(async () => {
+  config = await Config.load(PKG_ROOT);
+  writes = [];
+  savedEnv = saveEnv(SLOT_ENV_KEYS);
+  // In-process command runs share one process — and therefore the per-process
+  // nested-claim latch (first claim wins). Each test is its own "process".
+  BaseCommand.resetSlotClaimLatchForTests();
+  vi.spyOn(BaseCommand.prototype, 'log').mockImplementation(() => {});
+  // The recording claim-writer fake on the ONE seam the hook uses.
+  vi.spyOn(
+    BaseCommand.prototype as unknown as { getClaimWriter: () => unknown },
+    'getClaimWriter',
+  ).mockReturnValue({
+    async write(input: ClaimWriteInput) {
+      writes.push(input);
+    },
+  });
+  // Neutralize the delegated child processes so an accepted run never spawns.
+  vi.spyOn(
+    BaseCommand.prototype as unknown as { getRunner: () => unknown },
+    'getRunner',
+  ).mockReturnValue({ async run() { return { code: 0 }; } });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  restoreEnv(savedEnv);
+});
+
+describe('a claiming command writes ONE claim on entry', () => {
+  it('stack seed --slot 2 claims slot 2 with the derived state dir + command line', async () => {
+    await StackSeed.run(['--slot', '2', ...WS], config);
+
+    expect(writes).toHaveLength(1);
+    const claim = writes[0]!;
+    expect(claim.slot).toBe(2);
+    expect(claim.stateDir).toBe('/tmp/sds-synthetic-s2');
+    expect(claim.command).toContain('stack:seed');
+    expect(claim.command).toContain('--slot 2');
+    expect(claim.set).toBeUndefined(); // no --set injected this parse
+    // Repo roots resolve exactly like every command's own resolution: the
+    // typed `--soa` pin wins; every SET_REPO_KEYS key is present (the writer
+    // skips the ones that don't exist on disk).
+    expect(claim.repoRoots.soa).toBe(SOA_ROOT);
+    expect(Object.keys(claim.repoRoots)).toHaveLength(9);
+    expect(claim.repoRoots).toHaveProperty('sds');
+  });
+
+  it('an explicit --state-dir beats the derived slot state dir', async () => {
+    await StackSeed.run(['--state-dir', '/tmp/claim-hook-test-sd', ...WS], config);
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0]!.stateDir).toBe('/tmp/claim-hook-test-sd');
+    expect(writes[0]!.slot).toBe(0);
+  });
+
+  it('the per-process latch: a nested in-process re-invocation never overwrites the first claim', async () => {
+    // cold-start/bootstrap chain StackUp.run() IN-PROCESS — the inner parse
+    // must not clobber the user's real command line with a synthetic argv.
+    await StackSeed.run(['--slot', '2', ...WS], config);
+    await StackUp.run(['--slot', '2', ...WS, '--dry-run'], config);
+    await StackSeed.run(['--slot', '3', ...WS], config);
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0]!.slot).toBe(2);
+    expect(writes[0]!.command).toContain('stack:seed');
+  });
+});
+
+describe('non-claiming paths write NOTHING', () => {
+  it('a read-only command (stack status) never claims', async () => {
+    vi.spyOn(
+      BaseCommand.prototype as unknown as { getProber: () => unknown },
+      'getProber',
+    ).mockReturnValue({ async probe() { return { ok: true, status: 200 }; } });
+
+    await StackStatus.run([...WS], config);
+    expect(writes).toHaveLength(0);
+  });
+
+  it('--dry-run suppresses the claim (nothing mutated ⇒ nothing claimed)', async () => {
+    await StackUp.run(['--only', 'iam-api', '--dry-run', '--slot', '1', ...WS], config);
+    expect(writes).toHaveLength(0);
+  });
+});
+
+describe('advisory means advisory: a claim-write failure never breaks the command', () => {
+  it('the REAL writer folds a throwing writeFile to a no-op and seed still succeeds', async () => {
+    // Real makeClaimWriter, fake deps: writeFile always throws (an unwritable
+    // state dir), dirExists false (no git spawns for sourceAtLaunch), SS_ACTOR
+    // pinned (no /proc ancestry walk).
+    vi.spyOn(
+      BaseCommand.prototype as unknown as { getClaimWriter: () => unknown },
+      'getClaimWriter',
+    ).mockReturnValue(
+      makeClaimWriter({
+        env: { SS_ACTOR: 'claim-hook-test' },
+        dirExists: () => false,
+        writeFile: () => {
+          throw new Error('EACCES: permission denied');
+        },
+      }),
+    );
+
+    await expect(StackSeed.run([...WS], config)).resolves.toBeUndefined();
+  });
+});

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/slots.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/slots.int.test.ts
@@ -1,0 +1,296 @@
+/**
+ * `stack slots` integration tests (slot claims) — in-process
+ * (`Config.load(process.cwd())` + `StackSlots.run(argv, config)`), every seam
+ * faked on `BaseCommand.prototype`: the slot-activity probe + set store via the
+ * shared set-fakes helpers, the claim reader (canned per state dir — the
+ * ADVISORY claim.json is never read off disk in a test), a local git runner
+ * with `headSha` (the drift-since-launch column needs it; the shared
+ * `spyGitRunner` fake doesn't carry it), and the repo-dir check (exact-path
+ * allowlist so a developer's real checkouts / env pins never leak in).
+ *
+ * Covers: mixed active/claimed/set slots render rows while unused slots
+ * collapse into one line; a dead-pid claim renders '(stale)'; the
+ * `--output-json` shape (claim null when absent, posture rows, the
+ * `postureSkipped` note for an active set-less slot > 0); porcelain TSV
+ * stability (no color codes); and that a set-less active slot > 0 postures
+ * nothing (zero git spawns).
+ */
+
+import { Config } from '@oclif/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { spySetStore, spySlotActive } from '../../../__tests__/helpers/set-fakes.js';
+import { BaseCommand } from '../../../base-command.js';
+import type { ClaimReadResult, ClaimReader, GitRunner, SlotClaim } from '../../../runtime/index.js';
+import StackSlots from '../slots.js';
+
+const PKG_ROOT = process.cwd();
+const DEV_ROOT = '/fixed/dev';
+// Pin the two repos the slot-0 posture assertions touch so a developer's
+// $SOA/$SAGA_DASH env (baked into the flag defaults at import time) can't leak in.
+const SOA_ROOT = `${DEV_ROOT}/soa`;
+const DASH_ROOT = `${DEV_ROOT}/saga-dash`;
+const WS = ['--dev', DEV_ROOT, '--soa', SOA_ROOT, '--saga-dash', DASH_ROOT];
+
+/** deriveInstance's state dirs — the claim reader is keyed by them. */
+const STATE_S2 = '/tmp/sds-synthetic-s2';
+const STATE_S4 = '/tmp/sds-synthetic-s4';
+
+/** The worktree path the `journey-fix` set (slot 2) pins saga-dash at. */
+const WT_DASH = '/wt/dash-j';
+
+let config: Config;
+let out: string[];
+let gitCalls: string[];
+
+/** A canned claim-read result; `over` patches the claim fields, `live` the pid verdict. */
+function claimResult(over: Partial<SlotClaim> = {}, live = true): ClaimReadResult {
+  return {
+    live,
+    claim: {
+      version: 1,
+      actor: 'coach-aug3-training',
+      actorSource: 'env',
+      pid: 41234,
+      command: 'ss stack:up --slot 2',
+      at: '2026-07-16T12:00:00.000Z',
+      cwd: '/home/x',
+      slot: 2,
+      sourceAtLaunch: {},
+      ...over,
+    },
+  };
+}
+
+/** Spy `getClaimReader` to a canned reader keyed by state dir (unknown dirs ⇒ null). */
+function installClaimReader(byStateDir: Record<string, ClaimReadResult> = {}): void {
+  const reader: ClaimReader = {
+    read: (stateDir: string) => byStateDir[stateDir] ?? null,
+  };
+  vi.spyOn(
+    BaseCommand.prototype as unknown as { getClaimReader: () => ClaimReader },
+    'getClaimReader',
+  ).mockReturnValue(reader);
+}
+
+/**
+ * Local git fake (the shared `spyGitRunner` lacks `headSha`, which the
+ * drift-since-launch column reads): branches/dirtiness/behind-count/HEAD keyed
+ * by repo path, every call recorded in `gitCalls` for the zero-spawn assertion.
+ */
+function installGit(
+  opts: {
+    branches?: Record<string, string>;
+    dirty?: string[];
+    behind?: Record<string, number>;
+    heads?: Record<string, string>;
+  } = {},
+): void {
+  gitCalls = [];
+  const fake: Partial<GitRunner> = {
+    branchShowCurrent: async (p: string) => {
+      gitCalls.push(`branch:${p}`);
+      return opts.branches?.[p] ?? 'main';
+    },
+    statusPorcelain: async (p: string) => {
+      gitCalls.push(`status:${p}`);
+      return (opts.dirty ?? []).includes(p) ? ' M src/x.ts\n' : '';
+    },
+    symbolicRefDefault: async (p: string) => {
+      gitCalls.push(`default:${p}`);
+      return 'main';
+    },
+    revParseVerify: async (p: string) => {
+      gitCalls.push(`verify:${p}`);
+      return true;
+    },
+    isAncestorOfHead: async (p: string) => {
+      gitCalls.push(`ancestor:${p}`);
+      return (opts.behind?.[p] ?? 0) === 0;
+    },
+    countBehindRef: async (p: string) => {
+      gitCalls.push(`behind:${p}`);
+      return opts.behind?.[p] ?? 0;
+    },
+    headSha: async (p: string) => {
+      gitCalls.push(`head:${p}`);
+      return opts.heads?.[p] ?? 'sha-current';
+    },
+  };
+  vi.spyOn(
+    BaseCommand.prototype as unknown as { getGitRunner: () => GitRunner },
+    'getGitRunner',
+  ).mockReturnValue(fake as GitRunner);
+}
+
+/** Only the listed EXACT paths exist — env-pinned real checkouts can never match. */
+function installDirCheck(present: string[]): void {
+  const set = new Set(present);
+  vi.spyOn(
+    BaseCommand.prototype as unknown as { getRepoDirCheck: () => (dir: string) => boolean },
+    'getRepoDirCheck',
+  ).mockReturnValue((dir: string) => set.has(dir));
+}
+
+beforeEach(async () => {
+  config = await Config.load(PKG_ROOT);
+  out = [];
+  vi.spyOn(
+    BaseCommand.prototype as unknown as { log: (msg?: string) => void },
+    'log',
+  ).mockImplementation((msg?: string) => {
+    out.push(String(msg ?? ''));
+  });
+  // Safe defaults so NO test ever touches docker/state dirs/real git/claim files.
+  spySlotActive([]);
+  spySetStore({ version: 1, sets: {} });
+  installClaimReader();
+  installGit();
+  installDirCheck([]);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('stack slots — who is on what slot (read-only)', () => {
+  it('mixed active/claimed/set slots render rows; unused slots collapse into one line', async () => {
+    spySlotActive(['soa', 'soa-s2']);
+    spySetStore({
+      version: 1,
+      sets: { 'journey-fix': { slot: 2, repos: { 'saga-dash': WT_DASH } } },
+    });
+    installClaimReader({
+      [STATE_S2]: claimResult({ actor: 'coach-aug3-training' }, true),
+      [STATE_S4]: claimResult({ actor: 'claude:41234', actorSource: 'claude', slot: 4 }, false),
+    });
+    installGit({ branches: { [WT_DASH]: 'feat/x' } });
+    installDirCheck([WT_DASH]);
+
+    await StackSlots.run([...WS], config);
+    const text = out.join('\n');
+
+    // One row per active/claimed/set slot.
+    expect(text).toMatch(/^0\s+● up\s+—\s+—/m); // active, no set, no claim
+    expect(text).toMatch(/^2\s+● up\s+journey-fix\s+coach-aug3-training\s+2026-07-16T12:00:00\.000Z/m);
+    expect(text).toMatch(/^4\s+—\s+—\s+claude:41234 \(stale\)/m); // dead pid ⇒ stale
+    // The set-bound active slot postures its pinned repo.
+    expect(text).toMatch(/saga-dash\s+@ feat\/x\s+\(clean\)/);
+    // Slots with nothing collapse into ONE dim summary line.
+    expect(text).toContain('slots 1, 3, 5, 6, 7, 8, 9: unused');
+    expect(text.match(/unused/g)).toHaveLength(1);
+  });
+
+  it('nothing anywhere ⇒ a single idle note (and exit 0 — the command never fails)', async () => {
+    await expect(StackSlots.run([...WS], config)).resolves.toBeUndefined();
+    expect(out.join('\n')).toContain('No slots in use');
+  });
+
+  it('--output-json: pinned shape — claim null when absent, posture rows, postureSkipped for a set-less slot > 0', async () => {
+    spySlotActive(['soa-s2', 'soa-s5']);
+    spySetStore({
+      version: 1,
+      sets: { 'journey-fix': { slot: 2, repos: { 'saga-dash': WT_DASH } } },
+    });
+    installClaimReader({
+      [STATE_S2]: claimResult({
+        actor: 'coach-aug3-training',
+        set: 'journey-fix',
+        sourceAtLaunch: { 'saga-dash': { branch: 'feat/x', headSha: 'aaa111', dirty: false } },
+      }),
+      [STATE_S4]: claimResult({ actor: 'claude:41234', actorSource: 'claude', slot: 4 }, false),
+    });
+    installGit({
+      branches: { [WT_DASH]: 'feat/x' },
+      dirty: [WT_DASH],
+      behind: { [WT_DASH]: 3 },
+      heads: { [WT_DASH]: 'bbb222' }, // ≠ the claim's recorded launch HEAD ⇒ drifted
+    });
+    installDirCheck([WT_DASH]);
+
+    await StackSlots.run([...WS, '--output-json'], config);
+    const json = JSON.parse(out.join('\n'));
+
+    expect(json.slots.map((s: { slot: number }) => s.slot)).toEqual([2, 4, 5]);
+
+    const s2 = json.slots[0];
+    expect(s2).toMatchObject({
+      slot: 2,
+      active: true,
+      project: 'soa-s2',
+      stateDir: STATE_S2,
+      set: 'journey-fix',
+      claim: {
+        actor: 'coach-aug3-training',
+        actorSource: 'env',
+        live: true,
+        at: '2026-07-16T12:00:00.000Z',
+        pid: 41234,
+        command: 'ss stack:up --slot 2',
+        set: 'journey-fix',
+      },
+    });
+    expect(s2.posture).toEqual([
+      { repo: 'saga-dash', branch: 'feat/x', dirty: true, behind: 3, driftedSinceLaunch: true },
+    ]);
+
+    // Inactive claimed slot: claim carried (stale), posture skipped ⇒ [].
+    const s4 = json.slots[1];
+    expect(s4).toMatchObject({ slot: 4, active: false, set: null });
+    expect(s4.claim).toMatchObject({ actor: 'claude:41234', live: false });
+    expect(s4.posture).toEqual([]);
+
+    // Active set-less slot > 0: no posture, an explicit reason instead.
+    const s5 = json.slots[2];
+    expect(s5).toMatchObject({ slot: 5, active: true, set: null, claim: null });
+    expect(s5.posture).toEqual([]);
+    expect(s5.postureSkipped).toBe('shared checkouts (see slot 0)');
+  });
+
+  it('porcelain: one stable TSV line per row-worthy slot, no color codes', async () => {
+    spySlotActive(['soa-s2']);
+    spySetStore({
+      version: 1,
+      sets: { 'journey-fix': { slot: 2, repos: { 'saga-dash': WT_DASH } } },
+    });
+    installClaimReader({
+      [STATE_S2]: claimResult({ actor: 'coach-aug3-training' }),
+      [STATE_S4]: claimResult({ actor: 'claude:41234', actorSource: 'claude', slot: 4 }, false),
+    });
+    installDirCheck([WT_DASH]);
+
+    await StackSlots.run([...WS, '--porcelain'], config);
+
+    expect(out).toEqual([
+      '2\tactive\tjourney-fix\tcoach-aug3-training\tlive\t2026-07-16T12:00:00.000Z',
+      '4\t-\t-\tclaude:41234\tstale\t2026-07-16T12:00:00.000Z',
+    ]);
+  });
+
+  it('an active set-less slot > 0 postures NOTHING (zero git spawns; dim shared-checkouts note)', async () => {
+    spySlotActive(['soa-s5']);
+
+    await StackSlots.run([...WS], config);
+
+    expect(gitCalls).toEqual([]); // cost control: no posture probes off-slot-0 without a set
+    expect(out.join('\n')).toContain('shared checkouts (see slot 0)');
+  });
+
+  it('slot 0 active postures every shared checkout that EXISTS (missing roots skipped)', async () => {
+    spySlotActive(['soa']);
+    installGit({ branches: { [SOA_ROOT]: 'main', [DASH_ROOT]: 'feat/y' } });
+    installDirCheck([SOA_ROOT, DASH_ROOT]); // the other 7 roots are absent ⇒ skipped
+
+    await StackSlots.run([...WS, '--output-json'], config);
+    const json = JSON.parse(out.join('\n'));
+
+    const s0 = json.slots[0];
+    expect(s0.slot).toBe(0);
+    expect(s0.posture.map((p: { repo: string }) => p.repo).sort()).toEqual(['saga-dash', 'soa']);
+    expect(s0.posture.find((p: { repo: string }) => p.repo === 'saga-dash')).toMatchObject({
+      branch: 'feat/y',
+      dirty: false,
+      behind: 0,
+      driftedSinceLaunch: false, // no claim ⇒ no recorded launch HEAD ⇒ never drifted
+    });
+  });
+});

--- a/packages/node/saga-stack-cli/src/commands/stack/bootstrap.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/bootstrap.ts
@@ -55,6 +55,11 @@ export default class StackBootstrap extends BaseCommand {
     }),
   };
 
+  /** Slot claims: the bootstrap chain DRIVES the (slot-0) stack — record the advisory claim on entry. */
+  protected claimsSlot(): boolean {
+    return true;
+  }
+
   async run(): Promise<void> {
     const { flags } = await this.parse(StackBootstrap);
 

--- a/packages/node/saga-stack-cli/src/commands/stack/cold-start.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/cold-start.ts
@@ -109,6 +109,11 @@ export default class StackColdStart extends BaseCommand {
     }),
   };
 
+  /** Slot claims: the factory reset DRIVES the (slot-0) stack — record the advisory claim on entry. */
+  protected claimsSlot(): boolean {
+    return true;
+  }
+
   async run(): Promise<void> {
     const { flags } = await this.parse(StackColdStart);
     const dry = flags['dry-run'];

--- a/packages/node/saga-stack-cli/src/commands/stack/down.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/down.ts
@@ -64,6 +64,11 @@ export default class StackDown extends BaseCommand {
     return true;
   }
 
+  /** Slot claims: a teardown DRIVES the slot — record the advisory claim on entry. */
+  protected claimsSlot(): boolean {
+    return true;
+  }
+
   async run(): Promise<void> {
     const { flags } = await this.parse(StackDown);
 

--- a/packages/node/saga-stack-cli/src/commands/stack/login.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/login.ts
@@ -60,6 +60,11 @@ export default class StackLogin extends BaseCommand {
     return true;
   }
 
+  /** Slot claims: minting the jar writes slot state — record the advisory claim on entry. */
+  protected claimsSlot(): boolean {
+    return true;
+  }
+
   async run(): Promise<void> {
     const { args, flags } = await this.parse(StackLogin);
 

--- a/packages/node/saga-stack-cli/src/commands/stack/overlay.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/overlay.ts
@@ -104,6 +104,13 @@ export default class StackOverlay extends BaseCommand {
     }),
   };
 
+  /** Slot claims: apply/reset/compose-rest mutate the checkouts; `list` is read-only.
+   * Dispatch on the PARSED verb positional — raw-argv sniffing would match flag
+   * values too (`--prs list` is a legal branch name). */
+  protected claimsSlot(positionals?: readonly string[]): boolean {
+    return (positionals?.[0] ?? 'apply') !== 'list';
+  }
+
   async run(): Promise<void> {
     const { argv, flags } = await this.parse(StackOverlay);
 

--- a/packages/node/saga-stack-cli/src/commands/stack/reset.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/reset.ts
@@ -55,6 +55,11 @@ export default class StackReset extends BaseCommand {
     return true;
   }
 
+  /** Slot claims: a DB wipe DRIVES the slot — record the advisory claim on entry. */
+  protected claimsSlot(): boolean {
+    return true;
+  }
+
   async run(): Promise<void> {
     const { flags } = await this.parse(StackReset);
     const withPlayback = effectiveWithPlayback(flags.with);

--- a/packages/node/saga-stack-cli/src/commands/stack/restart.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/restart.ts
@@ -39,6 +39,11 @@ export default class StackRestart extends BaseCommand {
   // to slot 0, so a `--slot > 0` is rejected by the central guard. The teardown is still
   // dir-scoped/slot-safe (launcher kill-by-pidfile, never a host-global `pkill`).
 
+  /** Slot claims: a bounce DRIVES the (slot-0) stack — record the advisory claim on entry. */
+  protected claimsSlot(): boolean {
+    return true;
+  }
+
   async run(): Promise<void> {
     const { flags } = await this.parse(StackRestart);
 

--- a/packages/node/saga-stack-cli/src/commands/stack/seed.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/seed.ts
@@ -115,6 +115,11 @@ export default class StackSeed extends BaseCommand {
     return true;
   }
 
+  /** Slot claims: seeding rewrites the slot's data — record the advisory claim on entry. */
+  protected claimsSlot(): boolean {
+    return true;
+  }
+
   async run(): Promise<void> {
     const { args, flags } = await this.parse(StackSeed);
     const profile = args.profile as SeedProfile;

--- a/packages/node/saga-stack-cli/src/commands/stack/slots.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/slots.ts
@@ -1,0 +1,325 @@
+/**
+ * `saga-stack stack slots` — who is on what slot (slot claims; read-only glance).
+ *
+ * One row per slot 0-9 that is ACTIVE (the live `SlotActiveProbe` — state-dir pid
+ * liveness OR running `soa[-s<N>]` compose containers), CLAIMED
+ * (`<stateDir>/claim.json`), or SET-BOUND (a worktree set owns the slot); slots
+ * with none of the three collapse into one dim summary line. claim.json is
+ * ADVISORY "who last drove this slot" state — the deliberate counterpart to
+ * slot-active.ts's "no recorded active state" stance: ACTIVITY is always derived
+ * live (nothing to go stale), while the claim is recorded history a stack
+ * outlives by design ("last driven by", not a lock). Claim staleness is derived
+ * at READ time from the recorded pid's liveness (`live`/`stale`), and nothing
+ * ever deletes claim.json — a stale claim on an inactive slot is normal history,
+ * not an error.
+ *
+ * ACTIVE slots additionally get a per-repo source POSTURE (branch / dirty /
+ * behind-origin — `set show`'s exact mainline-currency recipe, as-of the last
+ * fetch) plus drift-since-launch (the claim's recorded HEAD vs the checkout's
+ * HEAD now). Posture is probed ONLY for active slots (cost control): a set-bound
+ * slot postures the set's pinned repos; slot 0 postures every shared checkout
+ * that exists; an active slot > 0 WITHOUT a set runs the shared checkouts too,
+ * so it postures nothing and points at slot 0 instead (no git spawns).
+ *
+ * READ-ONLY: always reports ALL slots 0-9 (`--slot` is accepted but does not
+ * narrow the report); never exits non-zero.
+ *
+ *   node bin/dev.js stack slots
+ *   node bin/dev.js stack slots --output-json
+ */
+
+import { BaseCommand } from '../../base-command.js';
+import { cyan, dim, yellow } from '../../color.js';
+import { deriveInstance } from '../../core/derive-instance.js';
+import { SET_REPO_KEYS, emptyWorktreeSetsFile } from '../../core/set/index.js';
+import type {
+  SetRepoEntry,
+  SetRepoKey,
+  WorktreeSet,
+  WorktreeSetsFile,
+} from '../../core/set/index.js';
+import {
+  REPO_ENV_VAR,
+  hasTrackedChanges,
+  repoContextFromFlags,
+  resolveRepoRoot,
+} from '../../runtime/index.js';
+import type { ClaimReadResult, GitRunner } from '../../runtime/index.js';
+
+/** The posture note rendered for an active slot > 0 with no set (shared checkouts). */
+const POSTURE_SKIPPED_SHARED = 'shared checkouts (see slot 0)';
+
+export default class StackSlots extends BaseCommand {
+  static description =
+    'Show who is on what slot: live activity, worktree-set binding, and the last advisory claim per slot — always reports ALL slots 0-9 (read-only).';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --output-json',
+  ];
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+  };
+
+  /** Accepting --slot is harmless — the report ALWAYS covers all slots 0-9. */
+  protected slotAware(): boolean {
+    return true;
+  }
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(StackSlots);
+
+    // Every slot 0-9, unconditionally (the verify --all-slots sweep's shape).
+    const profiles = Array.from({ length: 10 }, (_, slot) => deriveInstance({ slot }));
+
+    const probe = this.getSlotActiveProbe();
+    // A corrupt/hand-edited sets file must not kill the glance — the activity
+    // and claim halves don't depend on it ("never exits non-zero").
+    let file: WorktreeSetsFile;
+    try {
+      file = this.getSetStore().load();
+    } catch (error) {
+      this.warn(
+        `worktree-sets file unreadable — reporting without set bindings (${error instanceof Error ? error.message : String(error)})`,
+      );
+      file = emptyWorktreeSetsFile();
+    }
+    const reader = this.getClaimReader();
+    const slots = await Promise.all(
+      profiles.map(async (profile) => ({
+        profile,
+        active: await probe.isActive(profile.stateDir, profile.project),
+        // Reverse lookup — slots are schema-unique across sets (set create's guard).
+        set: Object.values(file.sets).find((s) => s.slot === profile.slot),
+        claim: reader.read(profile.stateDir),
+      })),
+    );
+
+    // A slot gets a row iff it is active, claimed, or set-bound; the rest collapse.
+    const worthy = slots.filter((s) => s.active || s.claim !== null || s.set !== undefined);
+    const unused = slots.filter((s) => !worthy.includes(s)).map((s) => s.profile.slot);
+
+    const git = this.getGitRunner();
+    const ctx = repoContextFromFlags(flags as unknown as Record<string, unknown>);
+    const dirExists = this.getRepoDirCheck();
+    const rows = await Promise.all(
+      worthy.map(async (s): Promise<SlotRow> => {
+        let posture: PostureRow[] = [];
+        let postureSkipped: string | undefined;
+        // Posture is probed for ACTIVE slots only (cost control — git spawns).
+        if (s.active) {
+          if (s.set !== undefined) {
+            const entries = (Object.entries(s.set.repos) as [SetRepoKey, SetRepoEntry][]).map(
+              ([repo, entry]) => ({ repo, root: entry.path }),
+            );
+            posture = await readPosture(entries.filter((e) => dirExists(e.root)), git, s.claim);
+          } else if (s.profile.slot === 0) {
+            const entries = SET_REPO_KEYS.map((repo) => ({
+              repo,
+              root: resolveRepoRoot(REPO_ENV_VAR[repo], ctx),
+            }));
+            posture = await readPosture(entries.filter((e) => dirExists(e.root)), git, s.claim);
+          } else {
+            // An active slot > 0 with no set runs the shared checkouts — their
+            // posture belongs to slot 0's rows; probing here would double the spawns.
+            postureSkipped = POSTURE_SKIPPED_SHARED;
+          }
+        }
+        return {
+          slot: s.profile.slot,
+          active: s.active,
+          project: s.profile.project,
+          stateDir: s.profile.stateDir,
+          set: s.set,
+          claim: s.claim,
+          posture,
+          postureSkipped,
+        };
+      }),
+    );
+
+    if (flags['output-json']) {
+      this.log(
+        JSON.stringify(
+          {
+            slots: rows.map((r) => ({
+              slot: r.slot,
+              active: r.active,
+              project: r.project,
+              stateDir: r.stateDir,
+              set: r.set?.name ?? null,
+              claim:
+                r.claim === null
+                  ? null
+                  : {
+                      actor: r.claim.claim.actor,
+                      actorSource: r.claim.claim.actorSource,
+                      live: r.claim.live,
+                      at: r.claim.claim.at,
+                      pid: r.claim.claim.pid,
+                      command: r.claim.claim.command,
+                      ...(r.claim.claim.set !== undefined ? { set: r.claim.claim.set } : {}),
+                    },
+              posture: r.posture.map((p) => ({
+                repo: p.repo,
+                branch: p.branch,
+                dirty: p.dirty,
+                behind: p.behind,
+                driftedSinceLaunch: p.driftedSinceLaunch,
+                ...(p.notCheckout === true ? { notCheckout: true } : {}),
+              })),
+              ...(r.postureSkipped !== undefined ? { postureSkipped: r.postureSkipped } : {}),
+            })),
+          },
+          null,
+          2,
+        ),
+      );
+      return;
+    }
+
+    if (rows.length === 0) {
+      if (!flags.porcelain) {
+        this.log('No slots in use — nothing active, no claims, no sets (slots 0-9 all idle).');
+      }
+      return;
+    }
+
+    if (flags.porcelain) {
+      for (const r of rows) {
+        this.log(
+          [
+            String(r.slot),
+            r.active ? 'active' : '-',
+            r.set?.name ?? '-',
+            r.claim?.claim.actor ?? '-',
+            r.claim === null ? '-' : r.claim.live ? 'live' : 'stale',
+            r.claim?.claim.at ?? '-',
+          ].join('\t'),
+        );
+      }
+      return;
+    }
+
+    const setW = Math.max(3, ...rows.map((r) => (r.set?.name ?? '—').length));
+    const actorW = Math.max(5, ...rows.map((r) => actorText(r).length));
+    this.log(`SLOT  ACTIVE  ${'SET'.padEnd(setW)}  ${'ACTOR'.padEnd(actorW)}  SINCE`);
+    this.log('─'.repeat(setW + actorW + 40));
+    for (const r of rows) {
+      this.log(
+        `${String(r.slot).padEnd(4)}  ${(r.active ? '● up' : '—').padEnd(6)}  ` +
+          `${(r.set?.name ?? '—').padEnd(setW)}  ${renderActor(r, actorW)}  ${r.claim?.claim.at ?? '—'}`,
+      );
+      if (r.postureSkipped !== undefined) this.log(dim(`      · posture: ${r.postureSkipped}`));
+      for (const p of r.posture) {
+        if (p.notCheckout === true) {
+          this.log(`      ${p.repo.padEnd(12)} ${yellow('(not a git checkout)')}`);
+          continue;
+        }
+        const dirtiness = p.dirty ? yellow('(dirty)') : dim('(clean)');
+        const behind =
+          p.behind !== null && p.behind > 0
+            ? `  ${yellow(`[⚠ behind ${p.mainRef} by ${p.behind}]`)}`
+            : '';
+        const drifted = p.driftedSinceLaunch ? `  ${yellow('⚠ drifted since launch')}` : '';
+        this.log(`      ${p.repo.padEnd(12)} @ ${cyan(p.branch)}  ${dirtiness}${behind}${drifted}`);
+      }
+    }
+    if (unused.length > 0) {
+      this.log(dim(`slots ${unused.join(', ')}: unused — no live activity, no claim, no set`));
+    }
+  }
+}
+
+/** One per-repo posture reading for an active slot (set/show's currency recipe). */
+interface PostureRow {
+  repo: SetRepoKey;
+  branch: string;
+  dirty: boolean;
+  /** Commits behind `origin/<default>`; 0 when the tip is contained; null = could not compare. */
+  behind: number | null;
+  /** The ref `behind` was measured against (human rendering only — not projected to JSON). */
+  mainRef: string;
+  /** The claim recorded a launch HEAD for this repo and the checkout's HEAD differs now. */
+  driftedSinceLaunch: boolean;
+  /** The root exists on disk but is not a git checkout (HEAD does not verify). */
+  notCheckout?: boolean;
+}
+
+/** One row-worthy slot (active, claimed, or set-bound), posture attached. */
+interface SlotRow {
+  slot: number;
+  active: boolean;
+  project: string;
+  stateDir: string;
+  set?: WorktreeSet;
+  claim: ClaimReadResult | null;
+  posture: PostureRow[];
+  /** Why posture was skipped (active slot > 0 with no set — shared checkouts). */
+  postureSkipped?: string;
+}
+
+/** The raw (uncolored) ACTOR cell — the claim's actor, '(stale)'-suffixed when its pid is dead. */
+function actorText(r: SlotRow): string {
+  if (r.claim === null) return '—';
+  return r.claim.claim.actor + (r.claim.live ? '' : ' (stale)');
+}
+
+/** Pad the raw ACTOR cell FIRST, then dim the '(stale)' suffix — codes are zero-width. */
+function renderActor(r: SlotRow, width: number): string {
+  const padded = actorText(r).padEnd(width);
+  if (r.claim !== null && !r.claim.live) return padded.replace(' (stale)', dim(' (stale)'));
+  return padded;
+}
+
+/**
+ * Read each existing repo root's posture (Promise.all, mirroring `set show`):
+ * live branch, tracked-change dirtiness, mainline currency (`origin/<default>`
+ * contained ⇒ 0, else the behind count, null when the ref can't be compared),
+ * and drift-since-launch against the claim's recorded HEAD.
+ */
+async function readPosture(
+  entries: { repo: SetRepoKey; root: string }[],
+  git: GitRunner,
+  claim: ClaimReadResult | null,
+): Promise<PostureRow[]> {
+  return Promise.all(
+    entries.map(async ({ repo, root }): Promise<PostureRow> => {
+      // An existing dir that is NOT a git checkout must not render as
+      // '@ (detached)  (clean)' — set/show's exact guard (every probe below
+      // folds errors into healthy-looking answers).
+      if (!(await git.revParseVerify(root, 'HEAD'))) {
+        return {
+          repo,
+          branch: '',
+          dirty: false,
+          behind: null,
+          mainRef: '',
+          driftedSinceLaunch: false,
+          notCheckout: true,
+        };
+      }
+      const branch = (await git.branchShowCurrent(root)) || '(detached)';
+      const dirty = hasTrackedChanges(await git.statusPorcelain(root));
+      // Mainline currency — set/show's exact recipe (as-of the last fetch; no network).
+      const mainRef = `origin/${await git.symbolicRefDefault(root)}`;
+      let behind: number | null = null;
+      if (await git.revParseVerify(root, mainRef)) {
+        behind = (await git.isAncestorOfHead(root, mainRef))
+          ? 0
+          : await git.countBehindRef(root, mainRef); // null = could not compare
+      }
+      const launchSha = claim?.claim.sourceAtLaunch[repo]?.headSha;
+      const currentSha = await git.headSha(root);
+      // An empty sha on EITHER side means "unresolvable", never comparable —
+      // prep-stamp's stampMatches invariant (a stored '' can never self-match).
+      const driftedSinceLaunch =
+        launchSha !== undefined &&
+        launchSha !== '' &&
+        currentSha !== '' &&
+        launchSha !== currentSha;
+      return { repo, branch, dirty, behind, mainRef, driftedSinceLaunch };
+    }),
+  );
+}

--- a/packages/node/saga-stack-cli/src/commands/stack/snapshot/delete.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/snapshot/delete.ts
@@ -33,6 +33,11 @@ export default class SnapshotDelete extends BaseCommand {
     return true;
   }
 
+  /** Slot claims: deleting a snapshot mutates the slot's state — record the advisory claim on entry. */
+  protected claimsSlot(): boolean {
+    return true;
+  }
+
   async run(): Promise<void> {
     const { args, flags } = await this.parse(SnapshotDelete);
     // M13-A: apply the slot env seam BEFORE any snapshot-store resolver runs —

--- a/packages/node/saga-stack-cli/src/commands/stack/snapshot/restore.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/snapshot/restore.ts
@@ -91,6 +91,11 @@ export default class SnapshotRestore extends BaseCommand {
     return true;
   }
 
+  /** Slot claims: a restore rewrites the slot's data — record the advisory claim on entry. */
+  protected claimsSlot(): boolean {
+    return true;
+  }
+
   async run(): Promise<void> {
     const { args, flags } = await this.parse(SnapshotRestore);
     // M13-A: apply the slot env seam BEFORE any snapshot-store resolver runs —

--- a/packages/node/saga-stack-cli/src/commands/stack/snapshot/store.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/snapshot/store.ts
@@ -85,6 +85,11 @@ export default class SnapshotStore extends BaseCommand {
     return true;
   }
 
+  /** Slot claims: the dump writes the slot's snapshot state — record the advisory claim on entry. */
+  protected claimsSlot(): boolean {
+    return true;
+  }
+
   async run(): Promise<void> {
     const { flags } = await this.parse(SnapshotStore);
     // M13-A: apply the slot env seam BEFORE any snapshot-store resolver runs —

--- a/packages/node/saga-stack-cli/src/commands/stack/tunnel.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/tunnel.ts
@@ -63,6 +63,11 @@ export default class StackTunnel extends BaseCommand {
     }),
   };
 
+  /** Slot claims: the tunnel repoints the (slot-0) browser plane — record the advisory claim on entry. */
+  protected claimsSlot(): boolean {
+    return true;
+  }
+
   async run(): Promise<void> {
     const { args, flags } = await this.parse(StackTunnel);
     // Reuse the pure flag→argv/env mapping, but RESOLVE + RUN the VENDORED copy

--- a/packages/node/saga-stack-cli/src/commands/stack/up.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/up.ts
@@ -161,6 +161,11 @@ export default class StackUp extends BaseCommand {
     return true;
   }
 
+  /** Slot claims: `up` DRIVES the slot's stack — record the advisory claim on entry. */
+  protected claimsSlot(): boolean {
+    return true;
+  }
+
   async run(): Promise<void> {
     const { flags } = await this.parse(StackUp);
 

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/claim.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/claim.unit.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Slot claims: the actor-resolution ladder (SS_ACTOR > claude-ancestry >
+ * user@host:tty), the never-throws advisory writer + sourceAtLaunch folding,
+ * and the null-on-anything-suspect reader with read-time pid liveness.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { SlotClaim } from '../claim.js';
+import { CLAIM_FILE, makeClaimReader, makeClaimWriter, resolveActor } from '../claim.js';
+import type { GitRunner } from '../git.js';
+
+/** A `/proc/<pid>/stat` blob whose ppid (field 2 after the comm `)`) is `ppid`. */
+function statBlob(pid: number, ppid: number): string {
+  return `${pid} (node) S ${ppid} ${pid} ${pid} 34820 ${pid} 4194304 1234`;
+}
+
+describe('resolveActor', () => {
+  it('a non-empty SS_ACTOR wins without touching /proc', () => {
+    let procAsked = false;
+    const resolved = resolveActor({
+      env: { SS_ACTOR: '  coach-aug3-training ' },
+      readProcStat: () => {
+        procAsked = true;
+        return null;
+      },
+      readProcCmdline: () => null,
+    });
+    expect(resolved).toEqual({ actor: 'coach-aug3-training', actorSource: 'env' });
+    expect(procAsked).toBe(false);
+  });
+
+  it('finds a claude ancestor two hops up the ppid chain', () => {
+    // 4100 (ss) → 4000 (a shell) → 3900 (claude).
+    const stats: Record<number, string> = {
+      4100: statBlob(4100, 4000),
+      4000: statBlob(4000, 3900),
+      3900: statBlob(3900, 1),
+    };
+    const cmdlines: Record<number, string> = {
+      4100: 'node\0/repo/bin/run.js\0stack:up',
+      4000: '/bin/bash\0-c\0ss stack:up',
+      3900: '/usr/local/bin/claude\0--resume',
+    };
+    const resolved = resolveActor({
+      env: {},
+      pid: 4100,
+      readProcStat: (pid) => stats[pid] ?? null,
+      readProcCmdline: (pid) => cmdlines[pid] ?? null,
+    });
+    expect(resolved).toEqual({ actor: 'claude:3900', actorSource: 'claude' });
+  });
+
+  it('parses ppid past a comm containing spaces and ")" (the lastIndexOf guard)', () => {
+    // The comm field is parenthesised and may itself contain spaces and ')' —
+    // a naive indexOf(')') / split(' ') parse would misread ppid here and
+    // truncate the walk before reaching the claude ancestor.
+    const stats: Record<number, string> = {
+      5100: `5100 (tmux: server) (v3) S 5000 5100 5100 34820 5100 4194304 1234`,
+      5000: statBlob(5000, 1),
+    };
+    const cmdlines: Record<number, string> = {
+      5100: '/usr/bin/tmux\0new-session',
+      5000: '/usr/local/bin/claude\0--resume',
+    };
+    const resolved = resolveActor({
+      env: {},
+      pid: 5100,
+      readProcStat: (pid) => stats[pid] ?? null,
+      readProcCmdline: (pid) => cmdlines[pid] ?? null,
+    });
+    expect(resolved).toEqual({ actor: 'claude:5000', actorSource: 'claude' });
+  });
+
+  it('terminates on a ppid cycle and falls back', () => {
+    const stats: Record<number, string> = {
+      10: statBlob(10, 20),
+      20: statBlob(20, 10), // cycle back
+    };
+    const resolved = resolveActor({
+      env: {},
+      pid: 10,
+      readProcStat: (pid) => stats[pid] ?? null,
+      readProcCmdline: () => '/bin/bash',
+      username: () => 'skelly',
+      hostname: () => 'devbox',
+      ttyName: () => null,
+    });
+    expect(resolved).toEqual({ actor: 'skelly@devbox', actorSource: 'fallback' });
+  });
+
+  it('terminates on an unreadable /proc entry and falls back', () => {
+    const resolved = resolveActor({
+      env: {},
+      pid: 4100,
+      readProcStat: () => null, // walk cannot move past the first pid
+      readProcCmdline: () => null,
+      username: () => 'skelly',
+      hostname: () => 'devbox',
+      ttyName: () => null,
+    });
+    expect(resolved.actorSource).toBe('fallback');
+  });
+
+  it('the fallback carries the tty when there is one, and omits it off-tty', () => {
+    const base = {
+      env: {},
+      pid: 2,
+      readProcStat: () => null,
+      readProcCmdline: () => null,
+      username: () => 'skelly',
+      hostname: () => 'devbox',
+    };
+    expect(resolveActor({ ...base, ttyName: () => 'pts/4' })).toEqual({
+      actor: 'skelly@devbox:pts/4',
+      actorSource: 'fallback',
+    });
+    expect(resolveActor({ ...base, ttyName: () => null })).toEqual({
+      actor: 'skelly@devbox',
+      actorSource: 'fallback',
+    });
+  });
+});
+
+/** A branch+dirty-only fake — the writer touches no other GitRunner verb. */
+function fakeGit(over: Partial<GitRunner> = {}): GitRunner {
+  return {
+    branchShowCurrent: async () => 'main',
+    statusPorcelain: async () => '',
+    ...over,
+  } as unknown as GitRunner;
+}
+
+describe('makeClaimWriter', () => {
+  const baseDeps = {
+    env: { SS_ACTOR: 'tester' }, // keep resolution off the real /proc
+    now: () => '2026-07-16T12:00:00.000Z',
+    pid: 4242,
+    cwd: () => '/work',
+  };
+
+  it('writes a full claim to <stateDir>/claim.json', async () => {
+    const written: Record<string, string> = {};
+    const writer = makeClaimWriter({
+      ...baseDeps,
+      git: fakeGit({ statusPorcelain: async () => ' M src/app.ts\n?? notes.txt\n' }),
+      headShaOf: () => 'abc1234',
+      dirExists: () => true,
+      writeFile: (path, data) => {
+        written[path] = data;
+      },
+    });
+    await writer.write({
+      slot: 2,
+      stateDir: '/state/s2',
+      command: 'ss stack:up --slot 2',
+      set: 'aug3',
+      repoRoots: { soa: '/repos/soa' },
+    });
+
+    const raw = written[`/state/s2/${CLAIM_FILE}`];
+    expect(raw).toBeDefined();
+    expect(raw!.endsWith('\n')).toBe(true);
+    expect(JSON.parse(raw!)).toEqual({
+      version: 1,
+      actor: 'tester',
+      actorSource: 'env',
+      pid: 4242,
+      command: 'ss stack:up --slot 2',
+      at: '2026-07-16T12:00:00.000Z',
+      cwd: '/work',
+      slot: 2,
+      set: 'aug3',
+      sourceAtLaunch: { soa: { branch: 'main', headSha: 'abc1234', dirty: true } },
+    });
+  });
+
+  it('sourceAtLaunch skips roots that do not exist on disk', async () => {
+    const written: Record<string, string> = {};
+    const writer = makeClaimWriter({
+      ...baseDeps,
+      git: fakeGit(),
+      headShaOf: () => 'abc1234',
+      dirExists: (p) => p === '/repos/soa',
+      writeFile: (path, data) => {
+        written[path] = data;
+      },
+    });
+    await writer.write({
+      slot: 0,
+      stateDir: '/state/s0',
+      command: 'ss stack:up',
+      repoRoots: { soa: '/repos/soa', coach: '/repos/coach' },
+    });
+
+    const claim = JSON.parse(written[`/state/s0/${CLAIM_FILE}`]!) as SlotClaim;
+    expect(Object.keys(claim.sourceAtLaunch)).toEqual(['soa']);
+    expect(claim.set).toBeUndefined();
+  });
+
+  it('a throwing git probe costs only its own repo entry, not the claim', async () => {
+    const written: Record<string, string> = {};
+    const writer = makeClaimWriter({
+      ...baseDeps,
+      git: fakeGit({
+        branchShowCurrent: async (repoPath) => {
+          if (repoPath === '/repos/coach') throw new Error('boom');
+          return 'main';
+        },
+      }),
+      headShaOf: () => 'abc1234',
+      dirExists: () => true,
+      writeFile: (path, data) => {
+        written[path] = data;
+      },
+    });
+    await writer.write({
+      slot: 1,
+      stateDir: '/state/s1',
+      command: 'ss stack:up --slot 1',
+      repoRoots: { soa: '/repos/soa', coach: '/repos/coach' },
+    });
+
+    const claim = JSON.parse(written[`/state/s1/${CLAIM_FILE}`]!) as SlotClaim;
+    expect(Object.keys(claim.sourceAtLaunch)).toEqual(['soa']);
+  });
+
+  it('never throws — a failing writeFile folds to a silent no-op', async () => {
+    const writer = makeClaimWriter({
+      ...baseDeps,
+      git: fakeGit(),
+      headShaOf: () => '',
+      dirExists: () => true,
+      writeFile: () => {
+        throw new Error('EACCES');
+      },
+    });
+    await expect(
+      writer.write({ slot: 3, stateDir: '/nope', command: 'ss stack:up --slot 3', repoRoots: {} }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('makeClaimReader', () => {
+  const validClaim: SlotClaim = {
+    version: 1,
+    actor: 'claude:3900',
+    actorSource: 'claude',
+    pid: 4242,
+    command: 'ss stack:up --slot 2',
+    at: '2026-07-16T12:00:00.000Z',
+    cwd: '/work',
+    slot: 2,
+    sourceAtLaunch: {},
+  };
+
+  it('reads a valid claim and reports the writer pid live', () => {
+    const reader = makeClaimReader({
+      readFile: (path) => (path === `/state/s2/${CLAIM_FILE}` ? JSON.stringify(validClaim) : null),
+      pidAlive: (pid) => pid === 4242,
+    });
+    expect(reader.read('/state/s2')).toEqual({ claim: validClaim, live: true });
+  });
+
+  it('live=false when the writer pid is gone (stale claim)', () => {
+    const reader = makeClaimReader({
+      readFile: () => JSON.stringify(validClaim),
+      pidAlive: () => false,
+    });
+    expect(reader.read('/state/s2')?.live).toBe(false);
+  });
+
+  it('null on a missing file', () => {
+    const reader = makeClaimReader({ readFile: () => null, pidAlive: () => true });
+    expect(reader.read('/state/s2')).toBeNull();
+  });
+
+  it('null on garbage JSON', () => {
+    const reader = makeClaimReader({ readFile: () => '{not json', pidAlive: () => true });
+    expect(reader.read('/state/s2')).toBeNull();
+  });
+
+  it('null on an unknown claim version', () => {
+    const reader = makeClaimReader({
+      readFile: () => JSON.stringify({ ...validClaim, version: 2 }),
+      pidAlive: () => true,
+    });
+    expect(reader.read('/state/s2')).toBeNull();
+  });
+
+  it('null on a shape-invalid body', () => {
+    const reader = makeClaimReader({
+      readFile: () => JSON.stringify({ version: 1, actor: 42 }),
+      pidAlive: () => true,
+    });
+    expect(reader.read('/state/s2')).toBeNull();
+  });
+});

--- a/packages/node/saga-stack-cli/src/runtime/claim.ts
+++ b/packages/node/saga-stack-cli/src/runtime/claim.ts
@@ -1,0 +1,345 @@
+/**
+ * Slot claims (advisory "who last drove this slot" state): `<stateDir>/claim.json`.
+ *
+ * A claim is written on entry by every command that DRIVES a slot's stack and
+ * records the resolved actor (SS_ACTOR > claude-ancestry > user@host:tty), the
+ * exact command line, and each repo's source posture at launch. It is ADVISORY —
+ * the deliberate counterpart to slot-active.ts's "no recorded active state"
+ * stance: activity stays DERIVED LIVE (nothing to go stale), while identity is
+ * RECORDED history (staleness is judged at READ time by pid liveness, because
+ * the stack outlives its driver by design). Nothing ever deletes claim.json —
+ * a stale claim on an inactive slot is normal "last driven by" history.
+ *
+ * Everything folds: the writer NEVER throws (a claim must never break a
+ * bring-up), the reader answers `null` on missing/garbage/wrong-shape files.
+ *
+ * DEDUP DEBT: `defaultPidAlive` is the third copy of the signal-0 EPERM=alive
+ * helper (lock.ts + slot-active.ts keep module-private twins) — worth a shared
+ * home if a fourth caller appears.
+ */
+
+import { existsSync, mkdirSync, readFileSync, readlinkSync, writeFileSync } from 'node:fs';
+import { hostname as osHostname, userInfo } from 'node:os';
+import { basename, dirname, join } from 'node:path';
+import type { SetRepoKey } from '../core/set/worktree-sets.js';
+import { hasTrackedChanges, makeRealGitRunner } from './git.js';
+import type { GitRunner } from './git.js';
+import { resolveHeadSha } from './prep-stamp.js';
+
+/** The claim file name under a slot's state dir. */
+export const CLAIM_FILE = 'claim.json';
+
+/** One repo's source posture captured at launch time (drift baseline). */
+export interface ClaimRepoSource {
+  branch: string;
+  headSha: string;
+  dirty: boolean;
+}
+
+/** The advisory claim body — `<stateDir>/claim.json`. */
+export interface SlotClaim {
+  version: 1;
+  /** Resolved identity, e.g. "coach-aug3-training" | "claude:41234" | "skelly@host:pts/4". */
+  actor: string;
+  actorSource: 'env' | 'claude' | 'fallback';
+  /** The `ss` process pid — claim staleness = pid liveness at READ time. */
+  pid: number;
+  /** e.g. "ss stack:up --slot 2 --only iam-api". */
+  command: string;
+  /** ISO-8601. */
+  at: string;
+  cwd: string;
+  slot: number;
+  /** Worktree-set name when the invocation was --set-driven. */
+  set?: string;
+  sourceAtLaunch: Partial<Record<SetRepoKey, ClaimRepoSource>>;
+}
+
+/** What a claiming command hands the writer. */
+export interface ClaimWriteInput {
+  slot: number;
+  stateDir: string;
+  command: string;
+  set?: string;
+  /** Absolute paths; the writer SKIPS roots that don't exist on disk. */
+  repoRoots: Partial<Record<SetRepoKey, string>>;
+}
+
+/** Injectable deps (seam style: slot-active.ts SlotActiveDeps / lock.ts PrepLockOptions). */
+export interface ClaimDeps {
+  /** Default `process.env` (actor resolution reads SS_ACTOR). */
+  env?: NodeJS.ProcessEnv;
+  /** Injectable clock (the timestamp is informational). */
+  now?: () => string;
+  /** The `ss` process pid — both the claim body and the ancestry-walk start. */
+  pid?: number;
+  cwd?: () => string;
+  /** Branch + dirty probes only; default the real runner. */
+  git?: GitRunner;
+  /** HEAD sha per repo root; default prep-stamp's ZERO-SPAWN resolveHeadSha. */
+  headShaOf?: (repoRoot: string) => string;
+  dirExists?: (p: string) => boolean;
+  /** Default: recursive-mkdir the parent, then writeFileSync. */
+  writeFile?: (path: string, data: string) => void;
+  /** Default: readFileSync folded to `null`. */
+  readFile?: (path: string) => string | null;
+  /** Liveness: signal-0 the pid (EPERM counts as alive). */
+  pidAlive?: (pid: number) => boolean;
+  /** Raw `/proc/<pid>/stat` folded to `null` (ancestry-walk ppid source). */
+  readProcStat?: (pid: number) => string | null;
+  /** Raw `/proc/<pid>/cmdline` folded to `null` (`\0`-separated). */
+  readProcCmdline?: (pid: number) => string | null;
+  /** Default node:os userInfo().username folded to 'unknown'. */
+  username?: () => string;
+  /** Default node:os hostname() folded to ''. */
+  hostname?: () => string;
+  /** Default readlink /proc/self/fd/2 → e.g. 'pts/4'; `null` off-tty/error. */
+  ttyName?: () => string | null;
+}
+
+/** The resolved actor identity + which rung of the ladder produced it. */
+export interface ResolvedActor {
+  actor: string;
+  actorSource: SlotClaim['actorSource'];
+}
+
+/** The advisory writer — NEVER throws; all errors fold to a silent no-op. */
+export interface ClaimWriter {
+  write(input: ClaimWriteInput): Promise<void>;
+}
+
+/** What a read yields: the claim + whether its writer pid is still alive. */
+export interface ClaimReadResult {
+  claim: SlotClaim;
+  live: boolean;
+}
+
+/** Sync reader — `null` on missing/unparseable/shape-invalid claim files. */
+export interface ClaimReader {
+  read(stateDir: string): ClaimReadResult | null;
+}
+
+function defaultPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // EPERM = the process exists but is not ours — still alive.
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+function defaultReadProcStat(pid: number): string | null {
+  try {
+    return readFileSync(`/proc/${pid}/stat`, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function defaultReadProcCmdline(pid: number): string | null {
+  try {
+    return readFileSync(`/proc/${pid}/cmdline`, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function defaultUsername(): string {
+  try {
+    return userInfo().username;
+  } catch {
+    return 'unknown';
+  }
+}
+
+function defaultHostname(): string {
+  try {
+    return osHostname();
+  } catch {
+    return '';
+  }
+}
+
+function defaultTtyName(): string | null {
+  try {
+    const link = readlinkSync('/proc/self/fd/2');
+    // Only real terminal nodes count — /dev/null (`2>/dev/null`) and other
+    // /dev non-terminals must fold to null, not render as "user@host:null".
+    const name = link.startsWith('/dev/') ? link.slice('/dev/'.length) : null;
+    return name !== null && /^(pts\/|tty)/.test(name) ? name : null;
+  } catch {
+    return null;
+  }
+}
+
+function defaultWriteFile(path: string, data: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, data, 'utf8');
+}
+
+function defaultReadFile(path: string): string | null {
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse the ppid out of a raw `/proc/<pid>/stat` blob. The `comm` field is
+ * parenthesised and may itself contain spaces/`)`, so split AFTER the last `)`:
+ * the remaining fields are `state ppid pgrp …` (same trick as lock.ts's
+ * module-private readProcState, which returns pgid not ppid — hence new code).
+ */
+function ppidFromStat(raw: string | null): number | null {
+  if (raw === null) return null;
+  const rp = raw.lastIndexOf(')');
+  if (rp < 0) return null;
+  const rest = raw.slice(rp + 2).trim().split(/\s+/);
+  const ppid = Number(rest[1]);
+  return Number.isInteger(ppid) && ppid >= 0 ? ppid : null;
+}
+
+/** True iff any `\0`-separated cmdline token's basename is exactly `claude`. */
+function cmdlineIsClaude(cmdline: string): boolean {
+  return cmdline.split('\0').some((token) => token !== '' && basename(token) === 'claude');
+}
+
+/**
+ * Resolve the actor identity, in order:
+ * 1. non-empty `SS_ACTOR` (an agent declares itself) → `actorSource: 'env'`;
+ * 2. a `claude` process anywhere up the ppid chain (max 25 hops, cycle-safe,
+ *    stops at pid ≤ 1 or an unreadable /proc entry) → `claude:<pid>`;
+ * 3. fallback `<username>@<hostname>[:<tty>]`.
+ */
+export function resolveActor(deps: ClaimDeps = {}): ResolvedActor {
+  const env = deps.env ?? process.env;
+  const fromEnv = (env.SS_ACTOR ?? '').trim();
+  if (fromEnv !== '') return { actor: fromEnv, actorSource: 'env' };
+
+  const readProcStat = deps.readProcStat ?? defaultReadProcStat;
+  const readProcCmdline = deps.readProcCmdline ?? defaultReadProcCmdline;
+  const seen = new Set<number>();
+  let pid: number | null = deps.pid ?? process.pid;
+  for (let hop = 0; hop < 25 && pid !== null && pid > 1 && !seen.has(pid); hop++) {
+    seen.add(pid);
+    const cmdline = readProcCmdline(pid);
+    if (cmdline !== null && cmdlineIsClaude(cmdline)) {
+      return { actor: `claude:${pid}`, actorSource: 'claude' };
+    }
+    pid = ppidFromStat(readProcStat(pid));
+  }
+
+  const username = (deps.username ?? defaultUsername)();
+  const host = (deps.hostname ?? defaultHostname)();
+  const tty = (deps.ttyName ?? defaultTtyName)();
+  return {
+    actor: `${username}@${host}${tty !== null ? `:${tty}` : ''}`,
+    actorSource: 'fallback',
+  };
+}
+
+/**
+ * Build the advisory claim writer. `write` never throws: a per-repo probe
+ * failure drops just that repo from `sourceAtLaunch`; any other failure
+ * (unwritable state dir, a throwing seam) folds to a silent no-op.
+ */
+export function makeClaimWriter(deps: ClaimDeps = {}): ClaimWriter {
+  const now = deps.now ?? (() => new Date().toISOString());
+  const pid = deps.pid ?? process.pid;
+  const cwd = deps.cwd ?? process.cwd;
+  const git = deps.git ?? makeRealGitRunner();
+  const headShaOf = deps.headShaOf ?? resolveHeadSha;
+  const dirExists = deps.dirExists ?? existsSync;
+  const writeFile = deps.writeFile ?? defaultWriteFile;
+
+  return {
+    async write(input: ClaimWriteInput): Promise<void> {
+      try {
+        const { actor, actorSource } = resolveActor(deps);
+
+        const sourceAtLaunch: Partial<Record<SetRepoKey, ClaimRepoSource>> = {};
+        const roots = Object.entries(input.repoRoots) as [SetRepoKey, string][];
+        await Promise.all(
+          roots.map(async ([repo, root]) => {
+            try {
+              if (!dirExists(root)) return;
+              const [branch, porcelain] = await Promise.all([
+                git.branchShowCurrent(root),
+                git.statusPorcelain(root),
+              ]);
+              sourceAtLaunch[repo] = {
+                branch,
+                headSha: headShaOf(root),
+                dirty: hasTrackedChanges(porcelain),
+              };
+            } catch {
+              // A broken repo probe costs only its own entry, never the claim.
+            }
+          }),
+        );
+
+        const claim: SlotClaim = {
+          version: 1,
+          actor,
+          actorSource,
+          pid,
+          command: input.command,
+          at: now(),
+          cwd: cwd(),
+          slot: input.slot,
+          set: input.set,
+          sourceAtLaunch,
+        };
+        writeFile(join(input.stateDir, CLAIM_FILE), `${JSON.stringify(claim, null, 2)}\n`);
+      } catch {
+        // Advisory: a claim must never break the command that writes it.
+      }
+    },
+  };
+}
+
+/** Minimal shape gate — enough to trust the fields the CLI renders. */
+function isSlotClaim(value: unknown): value is SlotClaim {
+  if (typeof value !== 'object' || value === null) return false;
+  const c = value as Record<string, unknown>;
+  return (
+    c.version === 1 &&
+    typeof c.actor === 'string' &&
+    (c.actorSource === 'env' || c.actorSource === 'claude' || c.actorSource === 'fallback') &&
+    // pid must be a real positive integer — `process.kill(0|-1, 0)` signals the
+    // reader's own group/everything and always "succeeds" (slot-active's guard).
+    typeof c.pid === 'number' &&
+    Number.isInteger(c.pid) &&
+    c.pid > 0 &&
+    typeof c.command === 'string' &&
+    typeof c.at === 'string' &&
+    typeof c.cwd === 'string' &&
+    typeof c.slot === 'number' &&
+    (c.set === undefined || typeof c.set === 'string') &&
+    typeof c.sourceAtLaunch === 'object' &&
+    c.sourceAtLaunch !== null
+  );
+}
+
+/** Build the sync reader; `live` is judged fresh on every read (pid liveness). */
+export function makeClaimReader(deps: ClaimDeps = {}): ClaimReader {
+  const readFile = deps.readFile ?? defaultReadFile;
+  const pidAlive = deps.pidAlive ?? defaultPidAlive;
+
+  return {
+    read(stateDir: string): ClaimReadResult | null {
+      const raw = readFile(join(stateDir, CLAIM_FILE));
+      if (raw === null) return null;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        return null;
+      }
+      if (!isSlotClaim(parsed)) return null;
+      return { claim: parsed, live: pidAlive(parsed.pid) };
+    },
+  };
+}

--- a/packages/node/saga-stack-cli/src/runtime/index.ts
+++ b/packages/node/saga-stack-cli/src/runtime/index.ts
@@ -53,3 +53,4 @@ export * from './lock.js';
 export * from './checkpoint-store.js';
 export * from './trace-preserve.js';
 export * from './foreign-procs.js';
+export * from './claim.js';


### PR DESCRIPTION
## What

Answers *"what slots are in use, what's their source posture, and which agent/session is driving them?"* in one glance:

```
$ ss stack slots
SLOT  ACTIVE  SET             ACTOR                   SINCE
────────────────────────────────────────────────────────────────────────────
0     ● up    —               claude:4077903 (stale)  2026-07-16T19:39:02.307Z
      soa          @ main  (dirty)
      saga-dash    @ main  (clean)  [⚠ behind origin/main by 11]
2     ● up    session-dosage  claude:4077903 (stale)  2026-07-16T19:39:00.536Z
      qboard       @ rc_connect-session-telemetry  (clean)  [⚠ behind origin/main by 148]
slots 4, 5, 6, 7, 8, 9: unused — no live activity, no claim, no set
```
(real output from the dev box; `--porcelain` and `--output-json` supported)

## How

- **`runtime/claim.ts`** — advisory `<stateDir>/claim.json`, written on entry by every slot-*driving* command via a new `claimsSlot()` opt-in in `BaseCommand.parse()` (exactly the `slotAware()`/`setAware()` pattern).
  - **Actor ladder:** `SS_ACTOR` env (agents self-identify) → `/proc` ppid-chain walk detecting a `claude` ancestor (`claude:<pid>`) → `user@host:tty` fallback.
  - Records pid (staleness derived at **read** time from pid liveness — the stack outlives its driver by design), the typed command line, and per-repo `sourceAtLaunch {branch, headSha, dirty}` (zero-spawn `resolveHeadSha` reuse).
  - Never throws, never deleted, advisory-not-exclusive — the deliberate counterpart to `slot-active.ts`'s "no recorded active state" stance. First claim per process wins (cold-start/bootstrap re-invoke commands in-process).
- **`commands/stack/slots.ts`** — read-only; sweeps all slots 0–9; row per active/claimed/set-bound slot; per-repo posture for active slots only (`set show`'s mainline-currency recipe + non-checkout guard) plus **drift-since-launch** (claim's recorded HEAD vs now). Corrupt `worktree-sets.json` folds to a warning ("never exits non-zero" honored).
- `docs/slots.md` section; unit + int tests (1304 passing); regenerated committed `oclif.manifest.json`.

## Review

Built and reviewed multi-agent: a 4-lens adversarial review (correctness / command / wiring-regression / conventions), every finding judged by an independent 3-refuter panel. **10 confirmed findings fixed** (e.g. nested in-process re-invocation clobbering the claim, `--prs list` defeating overlay's verb heuristic, `2>/dev/null` yielding `user@host:null`, non-checkout dirs rendering as clean detached checkouts); 4 refuted findings deliberately left alone (e.g. pid-reuse liveness — matches the existing `slot-active.ts`/`lock.ts` convention).

## Follow-ups (separate PRs)

- saga-iac `ss` skill: routing-table row for `ss stack slots` + "export `SS_ACTOR=<session-name>` before mutating commands" guidance.
- Optional later: exclusivity (`--claim`/refuse-if-live-other) can hang off the same claim file if we ever want it; advisory-first was the deliberate starting posture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)