### PR TITLE
Widen adoption env-contracts: iam-api tunnel keys + coach-web/connect-web guards (soa#336 seams 1+2)

### DIFF
--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/up-native.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/up-native.int.test.ts
@@ -492,10 +492,21 @@ describe('stack up --slot N — isolated bring-up (M7 Phase 2)', () => {
     const iam = launches.find((s) => s.id === 'iam-api');
     expect(iam?.env.AUTH_SESSIONCOOKIEDOMAIN).toBe('.testmoniker.vms.wootdev.com');
     expect(iam?.env.CORS_ORIGIN).toContain('https://dash.testmoniker.vms.wootdev.com');
+    // … and its launch spec GUARDS those tunnel-rewritten keys (soa#336): the
+    // lane-independent JWT_ISSUER alone stamped identical fingerprints across
+    // modes, so a tunnel-leftover iam was silently adopted by a plain run.
+    expect(iam?.adoptEnv).toEqual(
+      expect.arrayContaining(['JWT_ISSUER', 'CORS_ORIGIN', 'AUTH_SESSIONCOOKIEDOMAIN']),
+    );
     // connect-web's VITE_* deps flip to the tunnel hosts.
     const cweb = launches.find((s) => s.id === 'connect-web');
     expect(cweb?.env.VITE_IAM_API_URL).toBe('https://iam.testmoniker.vms.wootdev.com');
     expect(cweb?.env.VITE_CONNECTV3_API_URL).toBe('https://connect-api.testmoniker.vms.wootdev.com');
+    // … and the browser-plane deps are adoption-guarded too (soa#336, the
+    // saga-dash idiom below extended to the remaining frontends).
+    expect(cweb?.adoptEnv).toEqual(
+      expect.arrayContaining(['VITE_CONNECTV3_API_URL', 'VITE_IAM_API_URL']),
+    );
     // the VENDORED tunnel.sh up ran after the launch (not soa's tools/synthetic-dev copy).
     const tun = runs.find((r) => r.command.endsWith('tunnel.sh'));
     expect(tun?.args).toEqual(['up']);

--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.overlay.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.overlay.unit.test.ts
@@ -13,6 +13,7 @@
 import { describe, expect, it } from 'vitest';
 import { defaultLaunchContext, resolveLaunchEnv } from '../launch-plan.js';
 import type { LaunchContextInputs } from '../launch-plan.js';
+import { getService } from '../manifest/index.js';
 import type { RepoKey, ServiceId } from '../manifest/index.js';
 
 const REPO_ROOTS: Record<RepoKey, string> = {
@@ -190,4 +191,35 @@ describe('sandbox + tunnel compose (tunnel wins last, matching up.sh splat order
     // … and tunnel_env CORS (splatted after, last-wins on the shared key).
     expect(e.CORS_ORIGIN).toContain('https://dash.m1.vms.wootdev.com');
   });
+});
+
+describe('soa#336: tunnel-rewritten keys are covered by the adoption contract', () => {
+  // The guard's fingerprint (`ServiceDef.adoptEnv`) must SEE every key
+  // tunnelOverlay() rewrites on these services — any uncovered key is a lane
+  // drift a tunnel leftover could carry through a plain run's adoption check
+  // unnoticed (finding A: iam's JWT_ISSUER-only fingerprint was byte-identical
+  // across modes, so a tunnel-env'd iam was silently adopted). Computes the
+  // rewrite set as the plain-vs-tunnel env DIFF against the REAL manifest, so
+  // a future overlay key can't silently escape the guard.
+  //
+  // __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS is exempt: it's the vite dev
+  // server's host allow-list (server-plane, not inlined into the browser
+  // bundle), and any mode switch that matters flips a guarded key with it.
+  const EXEMPT = new Set(['__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS']);
+  const TD = 'm1.vms.wootdev.com';
+
+  for (const id of ['iam-api', 'coach-web', 'connect-web'] as ServiceId[]) {
+    it(`${id}: adoptEnv ⊇ its tunnelOverlay() rewrite set`, () => {
+      const plain = envFor(id, {});
+      const tunneled = envFor(id, { tunnel: { domain: TD } });
+      const rewritten = Object.keys(tunneled).filter(
+        (k) => !EXEMPT.has(k) && tunneled[k] !== plain[k],
+      );
+      expect(rewritten.length).toBeGreaterThan(0); // the overlay really touches this service
+      const guard = getService(id).adoptEnv ?? [];
+      for (const k of rewritten) {
+        expect(guard, `${k} is tunnel-rewritten on ${id} but not adoption-guarded`).toContain(k);
+      }
+    });
+  }
 });

--- a/packages/node/saga-stack-cli/src/core/manifest/services.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/services.ts
@@ -128,7 +128,22 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
     // falls back to iam-api's saga.org default and mints a token coach-api rejects
     // (invalid-issuer → 401) — so a drifted/adopted iam is worse than none. Guard
     // adoption on it (soa#305).
-    adoptEnv: ['JWT_ISSUER'],
+    //
+    // soa#336: JWT_ISSUER alone can't tell a tunnel leftover from a plain run —
+    // ${IAM_ISSUER} is lane-independent, so both modes stamp the SAME fingerprint
+    // and a tunnel-env'd iam gets silently adopted by a plain `up`/`develop`.
+    // What tunnelOverlay() actually rewrites on iam-api is the browser-plane trio
+    // below, so fingerprint those too:
+    //  - CORS_ORIGIN / MAIL_FRONTEND_BASE_URL: in the plain launch env AND
+    //    value-flipped under --tunnel ⇒ the fingerprints differ in both directions.
+    //  - AUTH_SESSIONCOOKIEDOMAIN: tunnel-ONLY (no plain-env entry). The
+    //    fingerprint OMITS absent keys, so a plain stamp lacks it while a tunnel
+    //    stamp carries it — present-vs-omitted still mismatches BOTH ways, which
+    //    is exactly the refusal we want (the saga-dash DASH_CONFIG_LOCAL_JSON
+    //    guard relies on the same asymmetry).
+    // Same one-time "stop and re-run" cost as saga-dash for processes stamped by
+    // a pre-#336 CLI (their recorded contract is the JWT_ISSUER-only shape).
+    adoptEnv: ['JWT_ISSUER', 'CORS_ORIGIN', 'MAIL_FRONTEND_BASE_URL', 'AUTH_SESSIONCOOKIEDOMAIN'],
   },
   'sis-api': {
     id: 'sis-api',
@@ -489,6 +504,24 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
     tunnelSlug: 'connect',
     isFrontend: true,
     optional: false,
+    // soa#336 (the saga-dash soa#328 idiom): connect-web's VITE_* deps are
+    // BROWSER-plane, resolved by the vite dev server from its launch env at
+    // start — an adopted dev server keeps serving whatever hosts it started
+    // with, and nothing written to disk afterward can win (launch env >
+    // dotfiles). In the tunnel-then-plain incident that meant a leftover
+    // `--tunnel` frontend rode into a plain run still dialing the dead
+    // https://*.vms.wootdev.com hosts. Fingerprint the tunnel-rewritten dep
+    // URLs (all five are in the plain launch env above AND value-flipped by
+    // tunnelOverlay(), so tunnel-vs-plain mismatches in both directions) so a
+    // mode-drifted connect-web is REFUSED loudly and relaunched with the
+    // current mode's env — refuse-or-relaunch, never adopt.
+    adoptEnv: [
+      'VITE_CONNECTV3_API_URL',
+      'VITE_IAM_API_URL',
+      'VITE_RTSM_BOOTSTRAP_URL',
+      'VITE_JANUS_LOGIN_HOST',
+      'VITE_DASHBOARD_URL',
+    ],
   },
   'rtsm-api': {
     id: 'rtsm-api',
@@ -591,6 +624,31 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
     tunnelSlug: 'coach-web',
     isFrontend: true,
     optional: false,
+    // soa#336 (the saga-dash soa#328 idiom): coach-web's PUBLIC_* vars are
+    // SvelteKit `$env/static/public` — INLINED into the bundle at vite-dev
+    // start with launch env > .env.local > .env precedence (coach-web-env.ts,
+    // soa#298). An adopted vite therefore serves the hosts baked in at ITS
+    // start forever; no post-hoc .env.local write can win. That is exactly the
+    // 2026-07-16 slot-0 incident: a plain `develop coach` adopted a leftover
+    // `--tunnel` coach-web and the browser whoami dialed the dead tunnel iam →
+    // the misleading soa#300 "503 — Unable to reach the sign-in service".
+    // Fingerprint the four browser-plane keys tunnelOverlay() rewrites:
+    //  - PUBLIC_COACH_API_URL / PUBLIC_IAM_API_URL (boot-critical): in the
+    //    plain launch env above AND value-flipped under --tunnel ⇒ the
+    //    fingerprints differ in both directions.
+    //  - PUBLIC_LOGIN_URL / PUBLIC_DASHBOARD_URL: tunnel-ONLY (no plain-env
+    //    entry — plain runs let them fall through to coach-web's dotfiles).
+    //    The fingerprint OMITS absent keys, so plain stamps lack them while
+    //    tunnel stamps carry them — present-vs-omitted still mismatches BOTH
+    //    ways, the same asymmetry saga-dash's guard relies on.
+    // A mode-drifted coach-web is REFUSED loudly and relaunched with the
+    // current mode's env — refuse-or-relaunch, never adopt.
+    adoptEnv: [
+      'PUBLIC_COACH_API_URL',
+      'PUBLIC_IAM_API_URL',
+      'PUBLIC_LOGIN_URL',
+      'PUBLIC_DASHBOARD_URL',
+    ],
   },
   'transcripts-api': {
     id: 'transcripts-api',

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/launcher.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/launcher.unit.test.ts
@@ -358,6 +358,142 @@ describe('makeRealLauncher.launch adopt-contract guard (soa#305)', () => {
     expect(res).toEqual({ id: 'saga-dash', ok: true, alreadyUp: true });
   });
 
+  // coach-web's guard (soa#336): its PUBLIC_* map is INLINED at vite-dev start
+  // (launch env > .env.local > .env), so an adopted vite serves the hosts it
+  // started with forever — the only correct handling of a mode-mismatched
+  // frontend is refuse-or-relaunch, never adopt. Two of the four guarded keys
+  // are tunnel-ONLY (PUBLIC_LOGIN_URL / PUBLIC_DASHBOARD_URL): absent from a
+  // plain launch env, they're OMITTED from a plain fingerprint but PRESENT in a
+  // tunnel one — that presence asymmetry alone mismatches in both directions.
+  const COACH_ADOPT = [
+    'PUBLIC_COACH_API_URL',
+    'PUBLIC_IAM_API_URL',
+    'PUBLIC_LOGIN_URL',
+    'PUBLIC_DASHBOARD_URL',
+  ];
+  // Plain slot-0 launch env: only the two boot-critical keys (manifest launch.env).
+  const COACH_PLAIN_ENV = {
+    PUBLIC_COACH_API_URL: 'http://localhost:6105',
+    PUBLIC_IAM_API_URL: 'http://localhost:3010',
+  };
+  // Tunnel launch env: all four, rewritten to the public hosts (tunnelOverlay()).
+  const COACH_TUNNEL_ENV = {
+    PUBLIC_COACH_API_URL: 'https://coach-api.sk.vms.wootdev.com',
+    PUBLIC_IAM_API_URL: 'https://iam.sk.vms.wootdev.com',
+    PUBLIC_LOGIN_URL: 'https://iam.sk.vms.wootdev.com',
+    PUBLIC_DASHBOARD_URL: 'https://dash.sk.vms.wootdev.com',
+  };
+
+  it('refuses to adopt a TUNNEL-leftover coach-web on a plain run (the 2026-07-16 slot-0 incident)', async () => {
+    const { prober } = seqProber([true]); // the leftover vite still 200s on :8800
+    const { spawn, calls } = fakeSpawn(1);
+    const launcher = makeRealLauncher({
+      stateDir: STATE,
+      prober,
+      spawn,
+      readContract: () => JSON.stringify(COACH_TUNNEL_ENV), // stamped by `develop --tunnel`
+    });
+
+    const res = await launcher.launch({
+      ...SPEC,
+      id: 'coach-web',
+      env: COACH_PLAIN_ENV, // plain `develop coach`
+      adoptEnv: COACH_ADOPT,
+    });
+
+    // Pre-#336 this was a silent adoption → browser whoami dialed the dead
+    // tunnel iam → the misleading soa#300 503. Now: loud refusal, no spawn.
+    expect(res.ok).toBe(false);
+    expect(res.alreadyUp).toBeUndefined();
+    expect(res.reason).toMatch(/contract/);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('refuses the REVERSE switch: plain-stamped coach-web vs a tunnel run (presence asymmetry)', async () => {
+    const { prober } = seqProber([true]);
+    const launcher = makeRealLauncher({
+      stateDir: STATE,
+      prober,
+      spawn: fakeSpawn(1).spawn,
+      // A plain spawn's stamp OMITS the tunnel-only keys — even if the two
+      // boot-critical values somehow agreed, present-vs-omitted still refuses.
+      readContract: () => JSON.stringify(COACH_PLAIN_ENV),
+    });
+
+    const res = await launcher.launch({
+      ...SPEC,
+      id: 'coach-web',
+      env: COACH_TUNNEL_ENV,
+      adoptEnv: COACH_ADOPT,
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.reason).toMatch(/contract/);
+  });
+
+  it('adopts a same-mode coach-web re-run (plain → plain: tunnel-only keys omitted on BOTH sides)', async () => {
+    const { prober } = seqProber([true]);
+    const launcher = makeRealLauncher({
+      stateDir: STATE,
+      prober,
+      readContract: () => JSON.stringify(COACH_PLAIN_ENV),
+    });
+
+    const res = await launcher.launch({
+      ...SPEC,
+      id: 'coach-web',
+      env: COACH_PLAIN_ENV,
+      adoptEnv: COACH_ADOPT,
+    });
+
+    expect(res).toEqual({ id: 'coach-web', ok: true, alreadyUp: true });
+  });
+
+  it("refuses a tunnel-leftover iam-api whose JWT_ISSUER alone would MATCH (soa#336's finding A)", async () => {
+    // The widened iam guard: JWT_ISSUER is lane-independent, so the old
+    // single-key fingerprint was byte-identical across modes and a tunnel
+    // leftover was silently adopted. The tunnel-rewritten browser-plane trio
+    // (CORS_ORIGIN / MAIL_FRONTEND_BASE_URL / tunnel-only
+    // AUTH_SESSIONCOOKIEDOMAIN) now makes the modes distinguishable.
+    const IAM_ADOPT = [
+      'JWT_ISSUER',
+      'CORS_ORIGIN',
+      'MAIL_FRONTEND_BASE_URL',
+      'AUTH_SESSIONCOOKIEDOMAIN',
+    ];
+    const { prober } = seqProber([true]);
+    const { spawn, calls } = fakeSpawn(1);
+    const launcher = makeRealLauncher({
+      stateDir: STATE,
+      prober,
+      spawn,
+      // Stamped by the earlier `stack tunnel`: same issuer, tunnel browser plane.
+      readContract: () =>
+        JSON.stringify({
+          JWT_ISSUER: 'https://iam.wootdev.com',
+          CORS_ORIGIN:
+            'http://localhost:8900,http://localhost:6210,https://dash.sk.vms.wootdev.com,https://connect.sk.vms.wootdev.com',
+          MAIL_FRONTEND_BASE_URL: 'https://iam.sk.vms.wootdev.com/demo',
+          AUTH_SESSIONCOOKIEDOMAIN: '.sk.vms.wootdev.com',
+        }),
+    });
+
+    const res = await launcher.launch({
+      ...SPEC,
+      env: {
+        // plain-mode launch env: SAME issuer, localhost browser plane, no cookie domain.
+        JWT_ISSUER: 'https://iam.wootdev.com',
+        CORS_ORIGIN: 'http://localhost:8900,http://localhost:6210,http://localhost:8800',
+        MAIL_FRONTEND_BASE_URL: 'http://localhost:3010/demo',
+      },
+      adoptEnv: IAM_ADOPT,
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.reason).toMatch(/contract/);
+    expect(calls).toHaveLength(0);
+  });
+
   it('leaves an UNguarded service (no adoptEnv) adopted unconditionally', async () => {
     const { prober } = seqProber([true]);
     const readContract = vi.fn(() => null);


### PR DESCRIPTION
Addresses soa#336 seams 1+2 (seam 3 — the up-time service-port preflight — is deferred to a follow-up).

## What

A plain `ss develop coach` / `stack up` on a slot still holding a `--tunnel` session's leftovers silently **adopted** a browser-plane-broken frontend: every leftover answered its health probe, iam-api's `adoptEnv` fingerprint matched (JWT_ISSUER is lane-independent), and coach-web/connect-web had no contract at all — so the run came up "healthy" and failed its smoke with the misleading soa#300 503 signature (2026-07-16 slot-0 incident).

## Key choices

**iam-api** — `adoptEnv: ['JWT_ISSUER', 'CORS_ORIGIN', 'MAIL_FRONTEND_BASE_URL', 'AUTH_SESSIONCOOKIEDOMAIN']`
- `JWT_ISSUER` kept: still guards the original soa#305 drift (older CLI / different iss).
- `CORS_ORIGIN` + `MAIL_FRONTEND_BASE_URL`: in the plain launch env (`services.ts` iam block) **and** value-flipped by `tunnelOverlay()` (`launch-plan.ts:337-342`) — fingerprints differ in both directions.
- `AUTH_SESSIONCOOKIEDOMAIN`: tunnel-**only** (no plain-env entry). `contractFingerprint()` omits absent keys, so a plain stamp lacks it while a tunnel stamp carries it — present-vs-omitted mismatches both ways, the same asymmetry saga-dash's `DASH_CONFIG_LOCAL_JSON` guard already relies on. Documented in the manifest comment.

**coach-web** — `adoptEnv: ['PUBLIC_COACH_API_URL', 'PUBLIC_IAM_API_URL', 'PUBLIC_LOGIN_URL', 'PUBLIC_DASHBOARD_URL']` (the four keys `tunnelOverlay()` rewrites; the first two are boot-critical and in the plain launch env, the last two are tunnel-only and rely on the presence asymmetry). SvelteKit inlines `PUBLIC_*` at vite-dev start with launch env > dotfiles precedence, so an adopted vite serves stale hosts forever — refuse-or-relaunch, never adopt.

**connect-web** — `adoptEnv` = the five tunnel-rewritten `VITE_*` dep URLs (`VITE_CONNECTV3_API_URL`, `VITE_IAM_API_URL`, `VITE_RTSM_BOOTSTRAP_URL`, `VITE_JANUS_LOGIN_HOST`, `VITE_DASHBOARD_URL`) — all present in the plain launch env, all value-flipped under `--tunnel`, so the flip is symmetric with no asymmetry subtleties.

`__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS` is deliberately unguarded (vite server-plane host allow-list, not inlined into the bundle; any mode switch that matters flips a guarded key with it).

No mechanism changes: the launcher guard (`launcher.ts:282-298`) and the spec plumbing (`stack-api.ts:981` passes the manifest field generically) are untouched — this is manifest data + tests only. One-time cost, same as saga-dash's guard: processes stamped by a pre-#336 CLI get a loud "stop and re-run" refusal on their next adoption attempt.

## Tests

- `launcher.unit.test.ts`: tunnel-leftover coach-web refused on a plain run (the incident path), the reverse plain→tunnel presence-asymmetry refusal, same-mode plain→plain adoption still works, and a tunnel-leftover iam-api whose JWT_ISSUER alone would match is now refused (finding A pinned).
- `launch-plan.overlay.unit.test.ts`: consistency pin — for iam-api/coach-web/connect-web, every key the real manifest's plain-vs-tunnel env diff shows rewritten must appear in that service's `adoptEnv`, so a future overlay key can't silently escape the guard.
- `up-native.int.test.ts`: the BARE `up --tunnel` launch specs carry the new guard keys.
- Full gate: `pnpm --filter @saga-ed/saga-stack-cli build` + `check-types` + `test` — **111 files, 1327 passed / 14 todo, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ytWXyyWTvmzHtzYWevD94