### PR TITLE
develop coach --scenario playlist: invoke built coach-content CLI directly + built-bin precheck (soa#335 items 2+3)

### DIFF
--- a/packages/node/saga-stack-cli/src/commands/develop/__tests__/coach.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/__tests__/coach.int.test.ts
@@ -6,8 +6,9 @@
  * Coverage: command wiring (`--help` renders; the command resolves), the
  * scenario→flow/persona/route mapping (content-viewer→module-playback→demo-tutor-1
  * vs admin→dashboard→demo-dadmin), the mock-backed admin note, --reuse, and the
- * `--scenario playlist` coach#238 feature-detect (fail-fast when the verb is
- * absent; orchestrate publish/assign/materialize when present).
+ * `--scenario playlist` prechecks (fail-fast when the coach#238 verb, the BUILT
+ * dist/cli.js (soa#335), or the seeded 2nd track is absent; orchestrate
+ * assign/materialize via direct node invocation when all are present).
  *
  * Hermetic: a real coach `flows.json` (copied structure) is written into a temp
  * COACH checkout that `--coach` points at, so discovery resolves coach-web's
@@ -132,9 +133,15 @@ function playwrightRuns(): ScriptInvocation[] {
 function browserRuns(): ScriptInvocation[] {
   return runs.filter((r) => r.command === 'node' && (r.args[0] ?? '').endsWith('browser-login.mjs'));
 }
-/** The coach-content CLI invocations the Runner recorded (playlist orchestration). */
+/**
+ * The coach-content CLI invocations the Runner recorded (playlist orchestration).
+ * soa#335: the orchestration invokes the BUILT entry directly (`node …/dist/cli.js`)
+ * — pnpm `exec` cannot resolve a workspace package's own bin — so match on that.
+ */
 function coachContentRuns(): ScriptInvocation[] {
-  return runs.filter((r) => r.command === 'pnpm' && r.args.includes('coach-content'));
+  return runs.filter(
+    (r) => r.command === 'node' && (r.args[0] ?? '').endsWith(join('coach-content-publish', 'dist', 'cli.js')),
+  );
 }
 
 // Native-login seams (cookie poster + jar writer), mirroring run.int.test.ts.
@@ -162,8 +169,9 @@ function installLoginSeams(result: PostResult = OK_COOKIES): void {
 
 /**
  * Stub the repo-dir existence seam. `playlistVerb` controls whether the coach#238
- * `coach-content/src/playlist.ts` feature-detect passes; every OTHER path
- * (coach-web appDir for the browser step) reports present so the hand-off runs.
+ * `coach-content/src/playlist.ts` feature-detect passes; `builtCli` controls the
+ * soa#335 `dist/cli.js` built-bin precheck; every OTHER path (coach-web appDir for
+ * the browser step) reports present so the hand-off runs.
  */
 /** Stub the repo-dir seam so the `--real-content` precheck sees (or misses) an archive checkout. */
 function installArchiveDirCheck(present: boolean): void {
@@ -173,9 +181,10 @@ function installArchiveDirCheck(present: boolean): void {
   }) as never);
 }
 
-function installRepoDirCheck(playlistVerb: boolean): void {
+function installRepoDirCheck(playlistVerb: boolean, builtCli = true): void {
   vi.spyOn(BaseCommand.prototype as never, 'getRepoDirCheck' as never).mockReturnValue(((dir: string) => {
     if (dir.endsWith(join('coach-content-publish', 'src', 'playlist.ts'))) return playlistVerb;
+    if (dir.endsWith(join('coach-content-publish', 'dist', 'cli.js'))) return builtCli;
     return true;
   }) as never);
 }
@@ -375,6 +384,19 @@ describe('develop coach — playlist (coach#238 feature-detect)', () => {
     expect(playwrightRuns()).toHaveLength(0);
   });
 
+  it('fails fast with a BUILD-pointing message when the verb is present but dist/cli.js is NOT built — before any bring-up', async () => {
+    // soa#335: orchestratePlaylist invokes the BUILT entry via node directly, so
+    // src/playlist.ts alone is not enough. The error must point at the package's
+    // build script (the fix is local), NOT at coach#238 (which HAS landed here).
+    installRepoDirCheck(true, false); // verb present, dist/cli.js absent
+    await expect(DevelopCoach.run(['--scenario', 'playlist', ...ws()], config)).rejects.toMatchObject({
+      message: expect.stringContaining('pnpm --filter @saga-ed/coach-content-publish build'),
+    });
+    // fail-fast: nothing was launched and no Playwright ran.
+    expect(launches).toEqual([]);
+    expect(playwrightRuns()).toHaveLength(0);
+  });
+
   it('fails fast when the coach seed does NOT ship the materializable 2nd track — before any bring-up', async () => {
     installRepoDirCheck(true); // verb present…
     installRepoFileRead(['curriculum-coach']); // …but the seed lacks curriculum-coach-b
@@ -398,6 +420,16 @@ describe('develop coach — playlist (coach#238 feature-detect)', () => {
     expect(assign).toBeDefined();
     expect(assign?.args).toContain('playlist');
     expect(assign?.args).toContain('--group');
+
+    // soa#335: BOTH invocations run the BUILT entry directly from the coach root
+    // (`node <coachRoot>/…/dist/cli.js`) — pnpm `--filter … exec coach-content`
+    // cannot resolve the package's own bin (ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL).
+    const expectedCli = join(COACH_ROOT, 'packages', 'node', 'coach-content-publish', 'dist', 'cli.js');
+    for (const r of [assign, materialize]) {
+      expect(r?.command).toBe('node');
+      expect(r?.args[0]).toBe(expectedCli);
+      expect(r?.cwd).toBe(COACH_ROOT);
+    }
 
     // The materialize target is the SAME track the assign uses AND the one the
     // precheck confirmed the seed ships — not a name nothing ensures exists.

--- a/packages/node/saga-stack-cli/src/commands/develop/coach.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/coach.ts
@@ -384,14 +384,17 @@ export default class DevelopCoach extends BaseCommand {
   }
 
   /**
-   * PRECHECK both prerequisites the coach-owned playlist switch needs, BEFORE any
-   * bring-up, so a stale coach checkout fails fast with an actionable message
+   * PRECHECK all three prerequisites the coach-owned playlist switch needs, BEFORE
+   * any bring-up, so a stale coach checkout fails fast with an actionable message
    * instead of an opaque throw mid-orchestration:
    *
    *   1. the coach#238 `coach-content playlist` verb group — placed at
    *      `packages/node/coach-content-publish/src/playlist.ts` (beside `store.ts`),
    *      per playlisting-port-plan.md §Decision. Absent ⇒ point at coach#238.
-   *   2. the seeded 2nd track (`PLAYLIST_TRACK_2`) — a MATERIALIZABLE curriculum in
+   *   2. the BUILT CLI entry (`dist/cli.js`) — orchestratePlaylist invokes it with
+   *      node directly (soa#335), so source alone is not enough. A checkout with
+   *      the verb but no build ⇒ point at the package's build script, NOT coach#238.
+   *   3. the seeded 2nd track (`PLAYLIST_TRACK_2`) — a MATERIALIZABLE curriculum in
    *      coach-db's offline seed release (fixtures/content-release.json). Without it
    *      `materialize --content` throws `active release has no curriculum doc named`
    *      deep in the run. We read the fixture and confirm the track is present so
@@ -439,6 +442,23 @@ export default class DevelopCoach extends BaseCommand {
       );
     }
 
+    // The BUILT CLI entry must exist too: orchestratePlaylist runs it via node
+    // directly (soa#335 — pnpm `exec` cannot resolve the package's own bin), so a
+    // checkout with src/playlist.ts but no dist/ would otherwise crash AFTER the
+    // full docker + seed bring-up. Distinct from the src check above: src absent
+    // means coach#238 hasn't landed; dist absent means the developer just needs to
+    // build the package.
+    const cliJs = join(coachRoot, 'packages', 'node', 'coach-content-publish', 'dist', 'cli.js');
+    if (!this.getRepoDirCheck()(cliJs)) {
+      this.error(
+        `--scenario playlist needs the BUILT \`coach-content\` CLI, but your coach checkout has not built it.\n` +
+          `  expected: ${cliJs}\n` +
+          `  Build it from the coach root (${coachRoot}):\n` +
+          `    pnpm --filter @saga-ed/coach-content-publish build\n` +
+          `  then retry.`,
+      );
+    }
+
     // The 2nd track must exist as a materializable curriculum in coach-db's seed
     // release — otherwise the later `materialize --content ${PLAYLIST_TRACK_2}`
     // aborts with `active release has no curriculum doc named …`.
@@ -482,16 +502,25 @@ export default class DevelopCoach extends BaseCommand {
    * ONLY group_id→content_name), then `materialize --replace` demo-tutor-1's
    * instance — keyed by the tutor's DERIVED user id, the id coach-web reads by —
    * onto it. No publish step: `PLAYLIST_TRACK_2` is already in coach-db's seed
-   * release, and `assertPlaylistPrereqs` has confirmed both the verb and the track.
+   * release, and `assertPlaylistPrereqs` has confirmed the verb, the track AND the
+   * built CLI bin below.
+   *
+   * The CLI is invoked as `node <coachRoot>/packages/node/coach-content-publish/
+   * dist/cli.js …` — NOT `pnpm --filter … exec coach-content`. pnpm cannot resolve
+   * a workspace package's OWN `bin` through `exec` (live result, soa#335:
+   * ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL "Command coach-content not found", even with
+   * dist/ freshly built); direct node invocation of the built entry works and is
+   * exactly what coach#238's docs run.
    */
   private async orchestratePlaylist(coachRoot: string, databaseUrl: string): Promise<void> {
     const runner = this.getRunner();
+    const cliJs = join(coachRoot, 'packages', 'node', 'coach-content-publish', 'dist', 'cli.js');
     const coachContent = async (label: string, args: string[]): Promise<void> => {
       this.log(`==> playlist: ${label} (coach-content ${args.join(' ')})`);
       const { code } = await runner.run({
         cwd: coachRoot,
-        command: 'pnpm',
-        args: ['--filter', '@saga-ed/coach-content-publish', 'exec', 'coach-content', ...args],
+        command: 'node',
+        args: [cliJs, ...args],
         env: { DATABASE_URL: databaseUrl },
         stdio: 'inherit',
       });


### PR DESCRIPTION
Fixes #335 items 2+3 (the orchestration exec fix + the built-bin precheck).

## What

**Item 2 — the exec fix** (`orchestratePlaylist`): the track switch invoked
`pnpm --filter @saga-ed/coach-content-publish exec coach-content …`, which pnpm cannot resolve for a workspace package's **own** bin — live-reproduced as `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL "Command coach-content not found"` even with `dist/` freshly built (#335). Both invocations (`playlist assign`, `materialize --replace`) now run the built entry directly: `node <coachRoot>/packages/node/coach-content-publish/dist/cli.js …`, keeping the same cwd/`DATABASE_URL` env/stdio.

**Item 3 — the precheck** (`assertPlaylistPrereqs`): added a third precheck (same `getRepoDirCheck` seam) that the **built** `dist/cli.js` exists. It is deliberately distinct from the existing `src/playlist.ts` check, which stays: src absent ⇒ coach#238 hasn't landed in the checkout; dist absent ⇒ the developer just needs to build — the error says exactly that (`pnpm --filter @saga-ed/coach-content-publish build` from the coach root) and fires **before** any docker + seed bring-up.

## Deliberately deferred

**Item 1 (the smoke gate)** is NOT addressed here: the playlist scenario still resolves the `module-playback` flow, whose smoke fails on the synthetic seed until coach#228 lands. Re-gating (or skipping) that smoke is deferred pending coach#228.

## Tests

- `coach.int.test.ts`: `coachContentRuns()` + the orchestration assertions updated to pin the new node-invocation shape (command `node`, `args[0]` = the coach-root `dist/cli.js` path, cwd = coach root); new precheck test for the verb-present/dist-absent case asserting the error points at the build script and nothing launches.
- `pnpm --filter @saga-ed/saga-stack-cli test`: **111 files, 1321 passed** (14 todo), including the 14 coach.int tests (13 → 14 with the new one).
- `pnpm --filter @saga-ed/saga-stack-cli build` and `check-types`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ytWXyyWTvmzHtzYWevD94