### PR TITLE
Polish `ss stack slots` output + document --porcelain in help

### DIFF
--- a/packages/node/saga-stack-cli/docs/slots.md
+++ b/packages/node/saga-stack-cli/docs/slots.md
@@ -72,18 +72,21 @@ ss stack slots --porcelain       # one TSV line per row-worthy slot (active, cla
 ss stack slots --output-json     # full claim + per-repo posture detail
 ```
 
-<details><summary>Columns SLOT · ACTIVE · SET · ACTOR · SINCE, per-repo posture under active slots, unused slots collapsed</summary>
+<details><summary>Columns SLOT · ACTIVE · SET · ACTOR · LAST DRIVEN (relative age), per-repo posture under active slots, unused slots collapsed</summary>
 
 ```
-SLOT  ACTIVE  SET          ACTOR                          SINCE
-──────────────────────────────────────────────────────────────────────────────
-0     ● up    —            skelly@devbox:pts/4            2026-07-16T09:12:31Z
-      soa          @ main  (clean)
-      saga-dash    @ main  (dirty)
-1     ● up    journey-fix  claude:41234                   2026-07-16T10:02:07Z
-      saga-dash    @ feat/journey-weekends  (clean)  ⚠ drifted since launch
-2     —       —            coach-aug3-training (stale)    2026-07-15T18:40:11Z
-slots 3, 4, 5, 6, 7, 8, 9: unused — no live activity, no claim, no set
+SLOT  ACTIVE  SET          ACTOR                        LAST DRIVEN
+───────────────────────────────────────────────────────────────────
+0     ● up    —            skelly@devbox:pts/4          2h ago
+      soa          @ main   clean
+      saga-dash    @ main   dirty  behind by 2
+
+1     ● up    journey-fix  claude:41234                 45m ago
+      saga-dash    @ feat/journey-weekends   clean  ⚠ drifted since launch
+
+2     —       —            coach-aug3-training (stale)  1d ago
+
+slots 3-9: unused
 ```
 
 A slot earns a row when it's **active, claimed, or set-bound**; the rest collapse into one

--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -361,532 +361,6 @@
         "connect.js"
       ]
     },
-    "e2e:list": {
-      "aliases": [],
-      "args": {},
-      "description": "List discoverable SPAs, their e2e flows, and phases (reads flows.json / the bundled example).",
-      "examples": [
-        "<%= config.bin %> <%= command.id %>",
-        "<%= config.bin %> <%= command.id %> --output-json"
-      ],
-      "flags": {
-        "porcelain": {
-          "description": "machine-readable output; no color, minimal noise",
-          "name": "porcelain",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
-          "name": "slot",
-          "default": 0,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "output-json": {
-          "description": "emit structured JSON on stdout instead of human-readable text",
-          "name": "output-json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "set": {
-          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
-          "name": "set",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dev": {
-          "description": "sibling-repo workspace root (where the saga repos are checked out)",
-          "name": "dev",
-          "noCacheDefault": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
-          "name": "state-dir",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "soa": {
-          "description": "override path to the soa repo checkout",
-          "name": "soa",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rostering": {
-          "description": "override path to the rostering repo checkout",
-          "name": "rostering",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "program-hub": {
-          "description": "override path to the program-hub repo checkout",
-          "name": "program-hub",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "saga-dash": {
-          "description": "override path to the saga-dash repo checkout",
-          "name": "saga-dash",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "coach": {
-          "description": "override path to the coach repo checkout",
-          "name": "coach",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "sds": {
-          "description": "override path to the sds (student-data-system) repo checkout",
-          "name": "sds",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "qboard": {
-          "description": "override path to the qboard repo checkout",
-          "name": "qboard",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rtsm": {
-          "description": "override path to the rtsm repo checkout",
-          "name": "rtsm",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fleek": {
-          "description": "override path to the fleek repo checkout",
-          "name": "fleek",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "spa-path": {
-          "description": "explicit path to a flows.json (file or dir) — highest-priority discovery override",
-          "name": "spa-path",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "e2e:list",
-      "pluginAlias": "@saga-ed/saga-stack-cli",
-      "pluginName": "@saga-ed/saga-stack-cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "slotClaimWritten": false,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "e2e",
-        "list.js"
-      ]
-    },
-    "e2e:run": {
-      "aliases": [],
-      "args": {},
-      "description": "Run an e2e flow in-process: discover flows.json -> closure -> StackApi up/reset/seed/verify -> Playwright. --dry-run prints the plan.",
-      "examples": [
-        "<%= config.bin %> <%= command.id %> journey --through pods --dry-run",
-        "<%= config.bin %> <%= command.id %> saga-dash/journey --through 2 --headless",
-        "<%= config.bin %> <%= command.id %> journey --skip-reset -- --debug",
-        "<%= config.bin %> <%= command.id %> saga-dash/periods-ordering --capture --headless"
-      ],
-      "flags": {
-        "porcelain": {
-          "description": "machine-readable output; no color, minimal noise",
-          "name": "porcelain",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
-          "name": "slot",
-          "default": 0,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "output-json": {
-          "description": "emit structured JSON on stdout instead of human-readable text",
-          "name": "output-json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "set": {
-          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
-          "name": "set",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dev": {
-          "description": "sibling-repo workspace root (where the saga repos are checked out)",
-          "name": "dev",
-          "noCacheDefault": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
-          "name": "state-dir",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "soa": {
-          "description": "override path to the soa repo checkout",
-          "name": "soa",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rostering": {
-          "description": "override path to the rostering repo checkout",
-          "name": "rostering",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "program-hub": {
-          "description": "override path to the program-hub repo checkout",
-          "name": "program-hub",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "saga-dash": {
-          "description": "override path to the saga-dash repo checkout",
-          "name": "saga-dash",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "coach": {
-          "description": "override path to the coach repo checkout",
-          "name": "coach",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "sds": {
-          "description": "override path to the sds (student-data-system) repo checkout",
-          "name": "sds",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "qboard": {
-          "description": "override path to the qboard repo checkout",
-          "name": "qboard",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rtsm": {
-          "description": "override path to the rtsm repo checkout",
-          "name": "rtsm",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fleek": {
-          "description": "override path to the fleek repo checkout",
-          "name": "fleek",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "through": {
-          "description": "run THROUGH this phase/stage (name, number, or project); progressive flows run 1..N",
-          "name": "through",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "phase": {
-          "description": "alias of --through",
-          "name": "phase",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "to": {
-          "description": "Plan 13: run UP TO but NOT INCLUDING this phase/stage (name, number, or project) — leaves the stack at that stage's ENTRY state for manual testing. Progressive flows only; mutually exclusive with --through. Pair with --hold for a logged-in browser at the boundary.",
-          "name": "to",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "hold": {
-          "description": "Plan 13: after the run goes green, mint the dev-persona cookie jar and open a logged-in browser at the SPA (slot-offset URL), print a held-state summary, and exit 0 — the stack stays up. Best-effort browser (a headless host warns, never errors).",
-          "name": "hold",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "lane": {
-          "description": "URL lane to target",
-          "name": "lane",
-          "default": "stack",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "options": [
-            "stack",
-            "sandbox"
-          ],
-          "type": "option"
-        },
-        "headed": {
-          "description": "force a headed (windowed) run (foreground flows are headed by default)",
-          "name": "headed",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "headless": {
-          "description": "force a headless (CI-style) run; flips a foreground flow off headed",
-          "name": "headless",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "skip-reset": {
-          "description": "reuse the current stack state; skip the reset+seed before Playwright",
-          "name": "skip-reset",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "from": {
-          "description": "M14: start AT this stage (id / number / project — same matching as --through) by RESTORING the predecessor stage's checkpoint instead of replaying earlier Playwright stages. Bake checkpoints first with --snapshot-stages.",
-          "name": "from",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "snapshot-stages": {
-          "description": "M14: bake a DB checkpoint after each green stage (Playwright runs once per stage) so later runs can --from into the middle of the flow. Progressive flows only.",
-          "name": "snapshot-stages",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "from-stale-ok": {
-          "description": "M14: accept a checkpoint older than the 7-day staleness cliff (its baked dates may no longer fit the calendar — you're overriding that guard). Only meaningful with --from.",
-          "name": "from-stale-ok",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "prereq-from-snapshot": {
-          "description": "M14-C: satisfy a flow's prerequisite by RESTORING its terminal-stage checkpoint (when a valid one is baked) instead of the full headless replay; silently falls back to the replay when absent/invalid. NOTE the restore flushes redis (the replay leaves it warm). --no-prereq-from-snapshot forces the replay.",
-          "name": "prereq-from-snapshot",
-          "allowNo": true,
-          "type": "boolean"
-        },
-        "spa-path": {
-          "description": "explicit path to a flows.json (file or dir) — highest-priority discovery override",
-          "name": "spa-path",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dry-run": {
-          "description": "plan only: print the resolved flow + closure + seed plan + playwright argv + occurrence date; touch nothing",
-          "name": "dry-run",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "tunnel": {
-          "description": "point the Playwright browser at the vms tunnel hosts (https://<label>.<moniker>.<VMS_BASE>) instead of localhost, so a REMOTE peer can drive this slot-0 stack. Resolves the moniker via the vendored tunnel.sh (same machinery as `stack up --tunnel`); writes the dash tunnel config; exports PLAYWRIGHT_TUNNEL_TIMEOUT_MS for the SPA config. Slot-0 only (hard-errors at --slot > 0 / --set).",
-          "name": "tunnel",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "capture": {
-          "description": "exploratory-review capture: run Playwright with PLAYWRIGHT_CAPTURE=all (per-action trace + video on every test) and PRESERVE the artifacts under <stateDir>/e2e-runs/<runId>/ (Playwright wipes test-results/ at the next run's start). A FAILED stage's artifacts are preserved even without this flag. Review with `e2e traces`.",
-          "name": "capture",
-          "allowNo": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "e2e:run",
-      "pluginAlias": "@saga-ed/saga-stack-cli",
-      "pluginName": "@saga-ed/saga-stack-cli",
-      "pluginType": "core",
-      "strict": false,
-      "enableJsonFlag": false,
-      "slotClaimWritten": false,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "e2e",
-        "run.js"
-      ]
-    },
-    "e2e:traces": {
-      "aliases": [],
-      "args": {},
-      "description": "List preserved e2e run traces (from `e2e run --capture` / failed stages), newest first, with paste-ready show-trace commands.",
-      "examples": [
-        "<%= config.bin %> <%= command.id %>",
-        "<%= config.bin %> <%= command.id %> --flow saga-dash/periods-ordering",
-        "<%= config.bin %> <%= command.id %> --open"
-      ],
-      "flags": {
-        "porcelain": {
-          "description": "machine-readable output; no color, minimal noise",
-          "name": "porcelain",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
-          "name": "slot",
-          "default": 0,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "output-json": {
-          "description": "emit structured JSON on stdout instead of human-readable text",
-          "name": "output-json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "set": {
-          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
-          "name": "set",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dev": {
-          "description": "sibling-repo workspace root (where the saga repos are checked out)",
-          "name": "dev",
-          "noCacheDefault": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
-          "name": "state-dir",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "soa": {
-          "description": "override path to the soa repo checkout",
-          "name": "soa",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rostering": {
-          "description": "override path to the rostering repo checkout",
-          "name": "rostering",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "program-hub": {
-          "description": "override path to the program-hub repo checkout",
-          "name": "program-hub",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "saga-dash": {
-          "description": "override path to the saga-dash repo checkout",
-          "name": "saga-dash",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "coach": {
-          "description": "override path to the coach repo checkout",
-          "name": "coach",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "sds": {
-          "description": "override path to the sds (student-data-system) repo checkout",
-          "name": "sds",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "qboard": {
-          "description": "override path to the qboard repo checkout",
-          "name": "qboard",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rtsm": {
-          "description": "override path to the rtsm repo checkout",
-          "name": "rtsm",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fleek": {
-          "description": "override path to the fleek repo checkout",
-          "name": "fleek",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "flow": {
-          "description": "filter to one flow ('<spa>/<flow>' or a bare '<flow>' across SPAs)",
-          "name": "flow",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "open": {
-          "description": "open the newest preserved run: PREFERS the whole-run HTML report (`playwright show-report`) when one exists, else falls back to the newest trace (`show-trace`). Best-effort; a headless host warns.",
-          "name": "open",
-          "allowNo": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "e2e:traces",
-      "pluginAlias": "@saga-ed/saga-stack-cli",
-      "pluginName": "@saga-ed/saga-stack-cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "slotClaimWritten": false,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "e2e",
-        "traces.js"
-      ]
-    },
     "stack:bootstrap": {
       "aliases": [],
       "args": {},
@@ -2148,11 +1622,12 @@
       "description": "Show who is on what slot: live activity, worktree-set binding, and the last advisory claim per slot — always reports ALL slots 0-9 (read-only).",
       "examples": [
         "<%= config.bin %> <%= command.id %>",
+        "<%= config.bin %> <%= command.id %> --porcelain",
         "<%= config.bin %> <%= command.id %> --output-json"
       ],
       "flags": {
         "porcelain": {
-          "description": "machine-readable output; no color, minimal noise",
+          "description": "machine-readable TSV, one line per row-worthy slot (active, claimed, or set-bound): slot ⇥ active|- ⇥ set|- ⇥ actor|- ⇥ live|stale|- ⇥ at (ISO-8601)",
           "name": "porcelain",
           "allowNo": false,
           "type": "boolean"
@@ -3008,6 +2483,532 @@
         "commands",
         "stack",
         "verify.js"
+      ]
+    },
+    "e2e:list": {
+      "aliases": [],
+      "args": {},
+      "description": "List discoverable SPAs, their e2e flows, and phases (reads flows.json / the bundled example).",
+      "examples": [
+        "<%= config.bin %> <%= command.id %>",
+        "<%= config.bin %> <%= command.id %> --output-json"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "spa-path": {
+          "description": "explicit path to a flows.json (file or dir) — highest-priority discovery override",
+          "name": "spa-path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "e2e:list",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "slotClaimWritten": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "e2e",
+        "list.js"
+      ]
+    },
+    "e2e:run": {
+      "aliases": [],
+      "args": {},
+      "description": "Run an e2e flow in-process: discover flows.json -> closure -> StackApi up/reset/seed/verify -> Playwright. --dry-run prints the plan.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> journey --through pods --dry-run",
+        "<%= config.bin %> <%= command.id %> saga-dash/journey --through 2 --headless",
+        "<%= config.bin %> <%= command.id %> journey --skip-reset -- --debug",
+        "<%= config.bin %> <%= command.id %> saga-dash/periods-ordering --capture --headless"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "through": {
+          "description": "run THROUGH this phase/stage (name, number, or project); progressive flows run 1..N",
+          "name": "through",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "phase": {
+          "description": "alias of --through",
+          "name": "phase",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "to": {
+          "description": "Plan 13: run UP TO but NOT INCLUDING this phase/stage (name, number, or project) — leaves the stack at that stage's ENTRY state for manual testing. Progressive flows only; mutually exclusive with --through. Pair with --hold for a logged-in browser at the boundary.",
+          "name": "to",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "hold": {
+          "description": "Plan 13: after the run goes green, mint the dev-persona cookie jar and open a logged-in browser at the SPA (slot-offset URL), print a held-state summary, and exit 0 — the stack stays up. Best-effort browser (a headless host warns, never errors).",
+          "name": "hold",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "lane": {
+          "description": "URL lane to target",
+          "name": "lane",
+          "default": "stack",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "stack",
+            "sandbox"
+          ],
+          "type": "option"
+        },
+        "headed": {
+          "description": "force a headed (windowed) run (foreground flows are headed by default)",
+          "name": "headed",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "headless": {
+          "description": "force a headless (CI-style) run; flips a foreground flow off headed",
+          "name": "headless",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "skip-reset": {
+          "description": "reuse the current stack state; skip the reset+seed before Playwright",
+          "name": "skip-reset",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "from": {
+          "description": "M14: start AT this stage (id / number / project — same matching as --through) by RESTORING the predecessor stage's checkpoint instead of replaying earlier Playwright stages. Bake checkpoints first with --snapshot-stages.",
+          "name": "from",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "snapshot-stages": {
+          "description": "M14: bake a DB checkpoint after each green stage (Playwright runs once per stage) so later runs can --from into the middle of the flow. Progressive flows only.",
+          "name": "snapshot-stages",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "from-stale-ok": {
+          "description": "M14: accept a checkpoint older than the 7-day staleness cliff (its baked dates may no longer fit the calendar — you're overriding that guard). Only meaningful with --from.",
+          "name": "from-stale-ok",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "prereq-from-snapshot": {
+          "description": "M14-C: satisfy a flow's prerequisite by RESTORING its terminal-stage checkpoint (when a valid one is baked) instead of the full headless replay; silently falls back to the replay when absent/invalid. NOTE the restore flushes redis (the replay leaves it warm). --no-prereq-from-snapshot forces the replay.",
+          "name": "prereq-from-snapshot",
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "spa-path": {
+          "description": "explicit path to a flows.json (file or dir) — highest-priority discovery override",
+          "name": "spa-path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dry-run": {
+          "description": "plan only: print the resolved flow + closure + seed plan + playwright argv + occurrence date; touch nothing",
+          "name": "dry-run",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "tunnel": {
+          "description": "point the Playwright browser at the vms tunnel hosts (https://<label>.<moniker>.<VMS_BASE>) instead of localhost, so a REMOTE peer can drive this slot-0 stack. Resolves the moniker via the vendored tunnel.sh (same machinery as `stack up --tunnel`); writes the dash tunnel config; exports PLAYWRIGHT_TUNNEL_TIMEOUT_MS for the SPA config. Slot-0 only (hard-errors at --slot > 0 / --set).",
+          "name": "tunnel",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "capture": {
+          "description": "exploratory-review capture: run Playwright with PLAYWRIGHT_CAPTURE=all (per-action trace + video on every test) and PRESERVE the artifacts under <stateDir>/e2e-runs/<runId>/ (Playwright wipes test-results/ at the next run's start). A FAILED stage's artifacts are preserved even without this flag. Review with `e2e traces`.",
+          "name": "capture",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "e2e:run",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": false,
+      "enableJsonFlag": false,
+      "slotClaimWritten": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "e2e",
+        "run.js"
+      ]
+    },
+    "e2e:traces": {
+      "aliases": [],
+      "args": {},
+      "description": "List preserved e2e run traces (from `e2e run --capture` / failed stages), newest first, with paste-ready show-trace commands.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %>",
+        "<%= config.bin %> <%= command.id %> --flow saga-dash/periods-ordering",
+        "<%= config.bin %> <%= command.id %> --open"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "flow": {
+          "description": "filter to one flow ('<spa>/<flow>' or a bare '<flow>' across SPAs)",
+          "name": "flow",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "open": {
+          "description": "open the newest preserved run: PREFERS the whole-run HTML report (`playwright show-report`) when one exists, else falls back to the newest trace (`show-trace`). Best-effort; a headless host warns.",
+          "name": "open",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "e2e:traces",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "slotClaimWritten": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "e2e",
+        "traces.js"
       ]
     },
     "set:check": {
@@ -4311,7 +4312,7 @@
           "type": "option"
         },
         "force": {
-          "description": "bypass the profile-mismatch guard (does NOT bypass the snapshot-ahead guard)",
+          "description": "bypass the profile-mismatch guard (does NOT bypass the snapshot-ahead / db-ahead guards)",
           "name": "force",
           "allowNo": false,
           "type": "boolean"

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/slots.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/slots.int.test.ts
@@ -146,9 +146,13 @@ beforeEach(async () => {
   installClaimReader();
   installGit();
   installDirCheck([]);
+  // Pin "now" (Date only — real timers) so LAST DRIVEN relative ages are stable:
+  // the canned claims are at 12:00Z ⇒ they render as "2h ago".
+  vi.useFakeTimers({ now: new Date('2026-07-16T14:00:00.000Z'), toFake: ['Date'] });
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
 });
 
@@ -171,13 +175,18 @@ describe('stack slots — who is on what slot (read-only)', () => {
 
     // One row per active/claimed/set slot.
     expect(text).toMatch(/^0\s+● up\s+—\s+—/m); // active, no set, no claim
-    expect(text).toMatch(/^2\s+● up\s+journey-fix\s+coach-aug3-training\s+2026-07-16T12:00:00\.000Z/m);
-    expect(text).toMatch(/^4\s+—\s+—\s+claude:41234 \(stale\)/m); // dead pid ⇒ stale
-    // The set-bound active slot postures its pinned repo.
-    expect(text).toMatch(/saga-dash\s+@ feat\/x\s+\(clean\)/);
-    // Slots with nothing collapse into ONE dim summary line.
-    expect(text).toContain('slots 1, 3, 5, 6, 7, 8, 9: unused');
+    expect(text).toMatch(/^2\s+● up\s+journey-fix\s+coach-aug3-training\s+2h ago/m); // relative age
+    expect(text).toMatch(/^4\s+—\s+—\s+claude:41234 \(stale\)\s+2h ago/m); // dead pid ⇒ stale
+    // The set-bound active slot postures its pinned repo (aligned annotation column).
+    expect(text).toMatch(/saga-dash\s+@ feat\/x\s+clean/);
+    // The separator matches the header width exactly.
+    const [headerLine, sepLine] = out;
+    expect(sepLine).toBe('─'.repeat(headerLine!.length));
+    // Slots with nothing collapse into ONE dim, range-collapsed summary line.
+    expect(text).toContain('slots 1, 3, 5-9: unused');
     expect(text.match(/unused/g)).toHaveLength(1);
+    // Blank line between slot blocks (and before the unused line).
+    expect(out.filter((l) => l === '').length).toBeGreaterThanOrEqual(2);
   });
 
   it('nothing anywhere ⇒ a single idle note (and exit 0 — the command never fails)', async () => {

--- a/packages/node/saga-stack-cli/src/commands/stack/slots.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/slots.ts
@@ -28,6 +28,7 @@
  *   node bin/dev.js stack slots --output-json
  */
 
+import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command.js';
 import { cyan, dim, yellow } from '../../color.js';
 import { deriveInstance } from '../../core/derive-instance.js';
@@ -55,11 +56,19 @@ export default class StackSlots extends BaseCommand {
 
   static examples = [
     '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --porcelain',
     '<%= config.bin %> <%= command.id %> --output-json',
   ];
 
   static flags = {
     ...BaseCommand.baseFlags,
+    // Same universal flag, slots-specific help: document THIS command's TSV shape.
+    porcelain: Flags.boolean({
+      description:
+        'machine-readable TSV, one line per row-worthy slot (active, claimed, or set-bound): ' +
+        'slot ⇥ active|- ⇥ set|- ⇥ actor|- ⇥ live|stale|- ⇥ at (ISO-8601)',
+      default: false,
+    }),
   };
 
   /** Accepting --slot is harmless — the report ALWAYS covers all slots 0-9. */
@@ -204,32 +213,66 @@ export default class StackSlots extends BaseCommand {
 
     const setW = Math.max(3, ...rows.map((r) => (r.set?.name ?? '—').length));
     const actorW = Math.max(5, ...rows.map((r) => actorText(r).length));
-    this.log(`SLOT  ACTIVE  ${'SET'.padEnd(setW)}  ${'ACTOR'.padEnd(actorW)}  SINCE`);
-    this.log('─'.repeat(setW + actorW + 40));
-    for (const r of rows) {
+    const header = `SLOT  ACTIVE  ${'SET'.padEnd(setW)}  ${'ACTOR'.padEnd(actorW)}  LAST DRIVEN`;
+    this.log(header);
+    this.log('─'.repeat(header.length));
+    const now = Date.now();
+    rows.forEach((r, i) => {
+      if (i > 0) this.log(''); // one blank line between slot blocks
       this.log(
         `${String(r.slot).padEnd(4)}  ${(r.active ? '● up' : '—').padEnd(6)}  ` +
-          `${(r.set?.name ?? '—').padEnd(setW)}  ${renderActor(r, actorW)}  ${r.claim?.claim.at ?? '—'}`,
+          `${(r.set?.name ?? '—').padEnd(setW)}  ${renderActor(r, actorW)}  ` +
+          `${r.claim === null ? '—' : relativeAge(r.claim.claim.at, now)}`,
       );
       if (r.postureSkipped !== undefined) this.log(dim(`      · posture: ${r.postureSkipped}`));
+      // Pad branches per slot so the annotation column aligns down the block.
+      const branchW = Math.max(
+        0,
+        ...r.posture.filter((p) => p.notCheckout !== true).map((p) => p.branch.length),
+      );
       for (const p of r.posture) {
         if (p.notCheckout === true) {
-          this.log(`      ${p.repo.padEnd(12)} ${yellow('(not a git checkout)')}`);
+          this.log(`      ${p.repo.padEnd(12)} ${yellow('not a git checkout')}`);
           continue;
         }
-        const dirtiness = p.dirty ? yellow('(dirty)') : dim('(clean)');
-        const behind =
-          p.behind !== null && p.behind > 0
-            ? `  ${yellow(`[⚠ behind ${p.mainRef} by ${p.behind}]`)}`
-            : '';
-        const drifted = p.driftedSinceLaunch ? `  ${yellow('⚠ drifted since launch')}` : '';
-        this.log(`      ${p.repo.padEnd(12)} @ ${cyan(p.branch)}  ${dirtiness}${behind}${drifted}`);
+        const notes = [
+          p.dirty ? yellow('dirty') : dim('clean'),
+          ...(p.behind !== null && p.behind > 0 ? [yellow(`behind by ${p.behind}`)] : []),
+          ...(p.driftedSinceLaunch ? [yellow('⚠ drifted since launch')] : []),
+        ];
+        this.log(`      ${p.repo.padEnd(12)} @ ${cyan(p.branch.padEnd(branchW))}   ${notes.join('  ')}`);
       }
-    }
+    });
     if (unused.length > 0) {
-      this.log(dim(`slots ${unused.join(', ')}: unused — no live activity, no claim, no set`));
+      if (rows.length > 0) this.log('');
+      this.log(dim(`slot${unused.length === 1 ? '' : 's'} ${collapseRuns(unused)}: unused`));
     }
   }
+}
+
+/** Human age of an ISO timestamp ("2h ago"); the raw string when unparseable. */
+function relativeAge(at: string, now: number): string {
+  const t = Date.parse(at);
+  if (!Number.isFinite(t)) return at;
+  const s = Math.max(0, Math.floor((now - t) / 1000));
+  if (s < 60) return 'just now';
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
+}
+
+/** Collapse sorted slot numbers into range text: [1, 3, 5, 6, 7] → "1, 3, 5-7". */
+function collapseRuns(slots: number[]): string {
+  const parts: string[] = [];
+  for (let i = 0; i < slots.length; ) {
+    let j = i;
+    while (j + 1 < slots.length && slots[j + 1] === (slots[j] ?? Number.NaN) + 1) j++;
+    parts.push(i === j ? String(slots[i]) : `${slots[i]}-${slots[j]}`);
+    i = j + 1;
+  }
+  return parts.join(', ');
 }
 
 /** One per-repo posture reading for an active slot (set/show's currency recipe). */


### PR DESCRIPTION
Formatting feedback from first manual use of #334.

**Before → after (real slot-0 data):**
- `SINCE 2026-07-16T21:15:48.770Z` → `LAST DRIVEN  2h ago` (porcelain/JSON keep ISO)
- `@ main  (clean)  [⚠ behind origin/main by 2]` → aligned annotation column: `@ main   clean  behind by 2`
- separator now matches the header width; blank line between slot blocks
- `slots 4, 5, 6, 7, 8, 9: unused — no live activity, no claim, no set` → `slots 4-9: unused`
- `--help` now documents the `--porcelain` TSV columns for this command (was the generic base-flag blurb) + a `--porcelain` example

Human path only — porcelain/JSON byte-identical to #334. Docs sample updated; int test pins the new layout with a faked `Date` (`toFake: ['Date']`, real timers) so relative ages are stable. Suite: 1328 passed.

Layout chosen by skelly from three mockup options ("polish only" — full posture inventory retained).

🤖 Generated with [Claude Code](https://claude.com/claude-code)