### PR TITLE
fix(saga-stack-cli): bootstrap ledger hardening — phase-2 pruning + argv-faithful resume (#341)

### DIFF
--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -189,7 +189,9 @@
         "<%= config.bin %> <%= command.id %>",
         "<%= config.bin %> <%= command.id %> --reuse -- --debug",
         "<%= config.bin %> <%= command.id %> --fake-media",
-        "<%= config.bin %> <%= command.id %> --refresh-snapshot"
+        "<%= config.bin %> <%= command.id %> --refresh-snapshot",
+        "<%= config.bin %> <%= command.id %> --tunnel --bootstrap",
+        "<%= config.bin %> <%= command.id %> --tunnel --bootstrap --rebuild --student-login 1"
       ],
       "flags": {
         "porcelain": {
@@ -341,6 +343,18 @@
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
+        },
+        "bootstrap": {
+          "description": "with --tunnel: automate docs/tunnel.md's two-phase bridge before opening the room. Phase 1 rebuilds usable state LOCALLY (down → up --seed full --reset → journey prerequisite → settle → snapshot store tunnel-connect); phase 2 relaunches in tunnel mode and restores it (down → up --tunnel --reset (hard stop if a foreign process survives) → snapshot restore → persona preflight). SKIPS phase 1 when a fresh (<7d) tunnel-connect fixture exists (--rebuild forces it). Progress is ledgered in <stateDir>/bootstrap.json, so a failed run RESUMES at the failed step; implies --reuse for the final session. Slot-0 only.",
+          "name": "bootstrap",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "rebuild": {
+          "description": "with --bootstrap: run the full phase-1 local rebuild even when a fresh (<7d) tunnel-connect fixture exists (the fast path would otherwise skip it).",
+          "name": "rebuild",
+          "allowNo": false,
+          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
@@ -2656,6 +2670,13 @@
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
+        },
+        "forbid-foreign": {
+          "description": "hard-error (instead of warn) when the bring-up ADOPTS an already-up process this CLI did not launch (no pidfile — env unverifiable).",
+          "hidden": true,
+          "name": "forbid-foreign",
+          "allowNo": false,
+          "type": "boolean"
         },
         "workspace": {
           "description": "NATIVE (Phase 2): a switchboard workspace.json selecting per-service run mode (local-source/sandbox) — the general case of --only/--sandbox.",

--- a/packages/node/saga-stack-cli/src/base-command.ts
+++ b/packages/node/saga-stack-cli/src/base-command.ts
@@ -57,6 +57,7 @@ import type { NativeLoginResult } from './runtime/login.js';
 import {
   buildRepoEnv,
   makeRealConfirm,
+  makeRealBootstrapLedgerIO,
   makeRealCookiePoster,
   makeRealDashFs,
   makeRealCoachWebFs,
@@ -96,6 +97,7 @@ import {
   REPO_DEFAULT_DIR,
 } from './runtime/index.js';
 import type {
+  BootstrapLedgerIO,
   ConfirmSeam,
   CookiePoster,
   CoachWebFs,
@@ -704,6 +706,16 @@ export abstract class BaseCommand extends Command {
       slot,
       sleep: this.getSleep(),
     });
+  }
+
+  /**
+   * The bootstrap-ledger fs seam (soa#329 `develop connect --bootstrap`) —
+   * production is the ONLY place `<stateDir>/bootstrap.json` is read/written/
+   * cleared. The sequencer consumes it injected, so its resume/clear logic is
+   * fake-testable (the CoachWebFs precedent).
+   */
+  protected getBootstrapLedgerIO(): BootstrapLedgerIO {
+    return makeRealBootstrapLedgerIO();
   }
 
   /**

--- a/packages/node/saga-stack-cli/src/bootstrap-connect.ts
+++ b/packages/node/saga-stack-cli/src/bootstrap-connect.ts
@@ -1,0 +1,164 @@
+/**
+ * `develop connect --tunnel --bootstrap` — the two-phase-bridge step sequencer
+ * (soa#329, decisions recorded on the issue).
+ *
+ * WHY two phases: one iam serves EITHER localhost OR the tunnel hosts, never
+ * both (AUTH_SESSIONCOOKIEDOMAIN is baked into the launch env — docs/tunnel.md's
+ * cookie-domain physics). So usable tunnel state is built LOCALLY first (fast,
+ * tested), snapshotted, and then RESTORED over a tunnel-mode relaunch:
+ *
+ *   PHASE 1 (local):  down → up --seed full --reset → journey prerequisite
+ *                     (checkpoint restore if usable, else headless replay;
+ *                     retry-once on the known async-settle stage-flake class) →
+ *                     settle barrier → snapshot store tunnel-connect --force
+ *   PHASE 2 (tunnel): down → up --tunnel --reset --forbid-foreign (HARD STOP
+ *                     when a foreign process survived — phase-2 correctness
+ *                     DEPENDS on every service relaunching with the tunnel env)
+ *                     → snapshot restore tunnel-connect → persona preflight
+ *                     (the soa#331 devLogin probe) → hand off to the existing
+ *                     `--reuse` live-session path.
+ *
+ * This module owns the SEQUENCING (ledger consult/record around every step, the
+ * fixture fast-path decision, the failure/resume messages); the STEPS themselves
+ * are closures the command builds over the existing facades/sub-commands. Ledger
+ * fs IO stays behind the injectable `BootstrapLedgerIO` seam (runtime/**), so
+ * everything here is unit-testable with fakes. Lives at src ROOT (not under
+ * `commands/`) for the same reason as e2e-orchestrate.ts: oclif treats every
+ * file under `commands/` as a command, and `oclif manifest` fails on a module.
+ *
+ * FAILURE CONTRACT: stop at the failed step, keep the ledger, print it plus the
+ * exact command that resumes. NEVER auto-teardown — half-built state is
+ * debugging evidence.
+ */
+
+import { CHECKPOINT_MAX_AGE_DAYS } from './core/flow/index.js';
+import type { SnapshotManifest } from './core/snapshot/index.js';
+import { REPO_ENV_VAR } from './runtime/index.js';
+import type { BootstrapLedger, BootstrapLedgerIO } from './runtime/index.js';
+import type { WorkspaceFlags } from './base-command.js';
+
+/** The snapshot fixture the bridge stores/restores (docs/tunnel.md's name). */
+export const TUNNEL_CONNECT_FIXTURE_ID = 'tunnel-connect';
+
+/** The exact command a failed bootstrap tells the user to re-run (it resumes). */
+export const BOOTSTRAP_RESUME_COMMAND = 'ss develop connect --tunnel --bootstrap';
+
+/** One sequencer step: a stable ledger id, a human title, and the work. */
+export interface BootstrapStep {
+  /** Stable id — the ledger key. NEVER renumber/rename without a ledger version bump. */
+  id: string;
+  /** Human-first progress line (matches `up`'s emit style). */
+  title: string;
+  run(): Promise<void>;
+}
+
+/** What the sequencer needs beyond the steps (all injectable). */
+export interface BootstrapRunDeps {
+  ledger: BootstrapLedgerIO;
+  ledgerPath: string;
+  log: (line: string) => void;
+  now: Date;
+}
+
+/** A step failure, message pre-built with the ledger + resume remediation. */
+export class BootstrapStepError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BootstrapStepError';
+  }
+}
+
+/**
+ * FAST-PATH decision: phase 1 is skippable iff a tunnel-connect fixture exists,
+ * parses, and its `createdAt` is younger than the checkpoint staleness cliff
+ * (7d — the SAME constant the M14 checkpoints use, so "fresh" means one thing).
+ * `--rebuild` overrides at the caller.
+ */
+export function tunnelFixtureFresh(manifest: SnapshotManifest | null, now: Date): boolean {
+  if (manifest === null || manifest.createdAt === undefined) return false;
+  const created = Date.parse(manifest.createdAt);
+  if (Number.isNaN(created)) return false;
+  const ageDays = (now.getTime() - created) / 86_400_000;
+  return ageDays < CHECKPOINT_MAX_AGE_DAYS;
+}
+
+/**
+ * Run the steps with the ledger consulted BEFORE and written AFTER each one:
+ * a step recorded as completed by a previous (failed) run is skipped, every
+ * fresh success is persisted immediately, and the ledger is cleared ONLY when
+ * every step completed. A step failure throws `BootstrapStepError` carrying the
+ * ledger state + the resume command; nothing is torn down.
+ */
+export async function runBootstrapSteps(steps: BootstrapStep[], deps: BootstrapRunDeps): Promise<void> {
+  const existing = deps.ledger.read(deps.ledgerPath);
+  let ledger: BootstrapLedger =
+    existing ?? { version: 1, startedAt: deps.now.toISOString(), completed: [] };
+  if (existing !== null && existing.completed.length > 0) {
+    deps.log(
+      `==> bootstrap: RESUMING — ${deps.ledgerPath} records ${existing.completed.length} ` +
+        `completed step(s) from ${existing.startedAt}: ${existing.completed.join(', ')}`,
+    );
+  }
+
+  const done = new Set(ledger.completed);
+  for (const [i, step] of steps.entries()) {
+    const label = `${i + 1}/${steps.length} ${step.title}`;
+    if (done.has(step.id)) {
+      deps.log(`▶ ${label} — SKIPPED (ledger: already completed)`);
+      continue;
+    }
+    deps.log(`▶ ${label}`);
+    try {
+      await step.run();
+    } catch (err) {
+      // Keep the ledger (it already records everything BEFORE this step) and
+      // stop. No teardown: the half-built state is what the user debugs.
+      throw new BootstrapStepError(
+        bootstrapFailureMessage(step, ledger, deps.ledgerPath, (err as Error).message ?? String(err)),
+      );
+    }
+    ledger = { ...ledger, completed: [...ledger.completed, step.id] };
+    deps.ledger.write(deps.ledgerPath, ledger);
+  }
+
+  // Success only: the next --bootstrap starts from a clean ledger (the fixture
+  // fast-path, not the ledger, is what makes IT fast).
+  deps.ledger.clear(deps.ledgerPath);
+}
+
+/** The stop-and-resume message a failed step surfaces (pure; unit-tested). */
+export function bootstrapFailureMessage(
+  step: BootstrapStep,
+  ledger: BootstrapLedger,
+  ledgerPath: string,
+  cause: string,
+): string {
+  return [
+    `bootstrap FAILED at step '${step.id}' (${step.title}):`,
+    cause.replace(/^/gm, '  '),
+    '',
+    `ledger (${ledgerPath}) — kept, nothing torn down (the half-built state is debugging evidence):`,
+    `  completed: ${ledger.completed.join(', ') || '(none)'}`,
+    `  failed:    ${step.id}`,
+    '',
+    `Fix the cause, then resume from '${step.id}' with:`,
+    `  ${BOOTSTRAP_RESUME_COMMAND}`,
+  ].join('\n');
+}
+
+/**
+ * Reconstruct the workspace-resolution argv (`--dev` + per-repo pins +
+ * `--state-dir`) forwarded to the phase sub-commands (`stack down/up`,
+ * `snapshot store/restore`) so they resolve the SAME checkouts + state dir this
+ * connect run did — the `stack bootstrap` precedent (workspaceArgs there).
+ */
+export function bootstrapWorkspaceArgv(flags: WorkspaceFlags & { 'state-dir'?: string }): string[] {
+  const args: string[] = [];
+  if (flags.dev) args.push('--dev', flags.dev);
+  for (const kebab of Object.keys(REPO_ENV_VAR) as (keyof typeof REPO_ENV_VAR)[]) {
+    const value = (flags as unknown as Record<string, string | undefined>)[kebab];
+    if (value) args.push(`--${kebab}`, value);
+  }
+  if (flags['state-dir']) args.push('--state-dir', flags['state-dir']);
+  return args;
+}

--- a/packages/node/saga-stack-cli/src/bootstrap-connect.ts
+++ b/packages/node/saga-stack-cli/src/bootstrap-connect.ts
@@ -40,8 +40,22 @@ import type { WorkspaceFlags } from './base-command.js';
 /** The snapshot fixture the bridge stores/restores (docs/tunnel.md's name). */
 export const TUNNEL_CONNECT_FIXTURE_ID = 'tunnel-connect';
 
-/** The exact command a failed bootstrap tells the user to re-run (it resumes). */
+/** The BASE resume command; `bootstrapResumeCommand` appends the run's flags. */
 export const BOOTSTRAP_RESUME_COMMAND = 'ss develop connect --tunnel --bootstrap';
+
+/**
+ * The EXACT command a failed bootstrap tells the user to re-run: the base plus
+ * `--rebuild` and the workspace/--state-dir pins THIS run was given. The bare
+ * base command is not always a resume — under a custom --state-dir it reads a
+ * different ledger, and after a failed `--rebuild` it would fast-path over the
+ * very rebuild the user asked for (restoring the old fixture as "success").
+ */
+export function bootstrapResumeCommand(
+  flags: WorkspaceFlags & { 'state-dir'?: string; rebuild?: boolean },
+): string {
+  const extra = [...(flags.rebuild ? ['--rebuild'] : []), ...bootstrapWorkspaceArgv(flags)];
+  return [BOOTSTRAP_RESUME_COMMAND, ...extra].join(' ');
+}
 
 /** One sequencer step: a stable ledger id, a human title, and the work. */
 export interface BootstrapStep {
@@ -58,6 +72,8 @@ export interface BootstrapRunDeps {
   ledgerPath: string;
   log: (line: string) => void;
   now: Date;
+  /** Failure-message resume command; the BASE constant when omitted (tests). */
+  resumeCommand?: string;
 }
 
 /** A step failure, message pre-built with the ledger + resume remediation. */
@@ -101,6 +117,32 @@ export async function runBootstrapSteps(steps: BootstrapStep[], deps: BootstrapR
   }
 
   const done = new Set(ledger.completed);
+
+  // A recorded completion is only valid while every step BEFORE it (in THIS
+  // run's step list) is also recorded: re-executing an earlier step rebuilds
+  // the world underneath the later one. Without this, a fast-path run that
+  // failed after tunnel-up leaves 'tunnel-down'/'tunnel-up' in the ledger, and
+  // a later --rebuild run would run phase 1 (localhost env) then SKIP both —
+  // bypassing the --forbid-foreign hard stop and finishing "successfully" on a
+  // localhost-mode stack. Prune the stale ids and PERSIST the prune, so they
+  // cannot resurface in a later resume with a different step shape either.
+  const resumeIdx = steps.findIndex((s) => !done.has(s.id));
+  if (resumeIdx >= 0) {
+    const stale = steps
+      .slice(resumeIdx + 1)
+      .filter((s) => done.has(s.id))
+      .map((s) => s.id);
+    if (stale.length > 0) {
+      deps.log(
+        `==> bootstrap: recorded step(s) ${stale.join(', ')} follow the resume point ` +
+          `('${steps[resumeIdx]?.id}') and are invalidated by its re-run — they will re-execute`,
+      );
+      for (const id of stale) done.delete(id);
+      ledger = { ...ledger, completed: ledger.completed.filter((id) => !stale.includes(id)) };
+      deps.ledger.write(deps.ledgerPath, ledger);
+    }
+  }
+
   for (const [i, step] of steps.entries()) {
     const label = `${i + 1}/${steps.length} ${step.title}`;
     if (done.has(step.id)) {
@@ -114,7 +156,13 @@ export async function runBootstrapSteps(steps: BootstrapStep[], deps: BootstrapR
       // Keep the ledger (it already records everything BEFORE this step) and
       // stop. No teardown: the half-built state is what the user debugs.
       throw new BootstrapStepError(
-        bootstrapFailureMessage(step, ledger, deps.ledgerPath, (err as Error).message ?? String(err)),
+        bootstrapFailureMessage(
+          step,
+          ledger,
+          deps.ledgerPath,
+          (err as Error).message ?? String(err),
+          deps.resumeCommand,
+        ),
       );
     }
     ledger = { ...ledger, completed: [...ledger.completed, step.id] };
@@ -132,6 +180,7 @@ export function bootstrapFailureMessage(
   ledger: BootstrapLedger,
   ledgerPath: string,
   cause: string,
+  resumeCommand: string = BOOTSTRAP_RESUME_COMMAND,
 ): string {
   return [
     `bootstrap FAILED at step '${step.id}' (${step.title}):`,
@@ -142,7 +191,7 @@ export function bootstrapFailureMessage(
     `  failed:    ${step.id}`,
     '',
     `Fix the cause, then resume from '${step.id}' with:`,
-    `  ${BOOTSTRAP_RESUME_COMMAND}`,
+    `  ${resumeCommand}`,
   ].join('\n');
 }
 

--- a/packages/node/saga-stack-cli/src/commands/develop/__tests__/bootstrap-connect.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/__tests__/bootstrap-connect.unit.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Unit tests for the --bootstrap sequencer building blocks (soa#329): the
+ * fixture fast-path freshness rule, the ledger-driven step sequencer
+ * (skip/record/clear/resume semantics with a FAKE LedgerIO — no fs), the
+ * failure/resume message, and the real ledger IO's corrupt-file boundary.
+ */
+
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { SnapshotManifest } from '../../../core/snapshot/index.js';
+import {
+  bootstrapLedgerPath,
+  makeRealBootstrapLedgerIO,
+} from '../../../runtime/index.js';
+import type { BootstrapLedger, BootstrapLedgerIO } from '../../../runtime/index.js';
+import {
+  BOOTSTRAP_RESUME_COMMAND,
+  BootstrapStepError,
+  bootstrapFailureMessage,
+  runBootstrapSteps,
+  tunnelFixtureFresh,
+} from '../../../bootstrap-connect.js';
+import type { BootstrapStep } from '../../../bootstrap-connect.js';
+import { forbidForeignMessage } from '../../stack/up.js';
+
+const NOW = new Date('2026-07-16T12:00:00Z');
+
+function manifestCreatedAt(iso: string | undefined): SnapshotManifest {
+  return { createdAt: iso } as unknown as SnapshotManifest;
+}
+
+describe('tunnelFixtureFresh — the phase-1 fast-path decision', () => {
+  it('null manifest (fixture absent/corrupt) is never fresh', () => {
+    expect(tunnelFixtureFresh(null, NOW)).toBe(false);
+  });
+
+  it('a fixture younger than 7 days is fresh', () => {
+    expect(tunnelFixtureFresh(manifestCreatedAt('2026-07-15T12:00:00Z'), NOW)).toBe(true); // 1d
+    expect(tunnelFixtureFresh(manifestCreatedAt('2026-07-09T12:00:01Z'), NOW)).toBe(true); // 7d - 1s
+  });
+
+  it('a fixture at/over the 7-day cliff is stale (boundary excluded)', () => {
+    expect(tunnelFixtureFresh(manifestCreatedAt('2026-07-09T12:00:00Z'), NOW)).toBe(false); // exactly 7d
+    expect(tunnelFixtureFresh(manifestCreatedAt('2026-07-01T12:00:00Z'), NOW)).toBe(false); // 15d
+  });
+
+  it('a missing/unparseable createdAt is stale (rebuild rather than trust garbage)', () => {
+    expect(tunnelFixtureFresh(manifestCreatedAt(undefined), NOW)).toBe(false);
+    expect(tunnelFixtureFresh(manifestCreatedAt('not-a-date'), NOW)).toBe(false);
+  });
+});
+
+/** A fake LedgerIO backed by a plain variable — records every write. */
+function fakeLedgerIO(initial: BootstrapLedger | null = null): {
+  io: BootstrapLedgerIO;
+  writes: BootstrapLedger[];
+  current: () => BootstrapLedger | null;
+} {
+  let state = initial;
+  const writes: BootstrapLedger[] = [];
+  return {
+    io: {
+      read: () => state,
+      write: (_p, l) => {
+        state = l;
+        writes.push(l);
+      },
+      clear: () => {
+        state = null;
+      },
+    },
+    writes,
+    current: () => state,
+  };
+}
+
+function step(id: string, impl?: () => Promise<void>): BootstrapStep & { calls: number[] } {
+  const calls: number[] = [];
+  let n = 0;
+  return {
+    id,
+    title: `step ${id}`,
+    calls,
+    run: async () => {
+      n += 1;
+      calls.push(n);
+      if (impl) await impl();
+    },
+  };
+}
+
+describe('runBootstrapSteps — ledger sequencing', () => {
+  const deps = (io: BootstrapLedgerIO, log: string[] = []) => ({
+    ledger: io,
+    ledgerPath: '/state/bootstrap.json',
+    log: (l: string) => log.push(l),
+    now: NOW,
+  });
+
+  it('runs every step in order, writes the ledger after EACH, and clears it on success', async () => {
+    const { io, writes, current } = fakeLedgerIO();
+    const a = step('a');
+    const b = step('b');
+    await runBootstrapSteps([a, b], deps(io));
+
+    expect(a.calls).toHaveLength(1);
+    expect(b.calls).toHaveLength(1);
+    // Incremental persistence: a alone, then a+b — a crash between steps loses nothing.
+    expect(writes.map((w) => w.completed)).toEqual([['a'], ['a', 'b']]);
+    // Success clears (the fixture fast path, not the ledger, makes the NEXT run fast).
+    expect(current()).toBeNull();
+  });
+
+  it('a step failure stops the run, KEEPS the ledger, and reports ledger + resume command', async () => {
+    const { io, current } = fakeLedgerIO();
+    const a = step('a');
+    const boom = step('boom', async () => {
+      throw new Error('psql exploded');
+    });
+    const never = step('never');
+
+    await expect(runBootstrapSteps([a, boom, never], deps(io))).rejects.toThrow(BootstrapStepError);
+    expect(never.calls).toHaveLength(0);
+    expect(current()?.completed).toEqual(['a']); // kept, not cleared — nothing torn down
+
+    const err = await runBootstrapSteps([a, boom, never], deps(io)).catch((e: Error) => e);
+    expect((err as Error).message).toContain('psql exploded');
+    expect((err as Error).message).toContain("failed:    boom");
+    expect((err as Error).message).toContain(BOOTSTRAP_RESUME_COMMAND);
+  });
+
+  it('a re-run RESUMES: steps recorded completed are skipped, the failed step re-runs', async () => {
+    const { io, current } = fakeLedgerIO({ version: 1, startedAt: 'x', completed: ['a', 'b'] });
+    const a = step('a');
+    const b = step('b');
+    const c = step('c');
+    const log: string[] = [];
+    await runBootstrapSteps([a, b, c], deps(io, log));
+
+    expect(a.calls).toHaveLength(0);
+    expect(b.calls).toHaveLength(0);
+    expect(c.calls).toHaveLength(1);
+    expect(log.some((l) => l.includes('RESUMING'))).toBe(true);
+    expect(current()).toBeNull(); // completed ⇒ cleared
+  });
+});
+
+describe('bootstrapFailureMessage', () => {
+  it('names the failed step, embeds the cause, prints the ledger and the exact resume command', () => {
+    const msg = bootstrapFailureMessage(
+      { id: 'tunnel-up', title: 'phase 2 — up', run: async () => {} },
+      { version: 1, startedAt: 't0', completed: ['local-down', 'local-up'] },
+      '/tmp/sds-synthetic/bootstrap.json',
+      'up exploded',
+    );
+    expect(msg).toContain("bootstrap FAILED at step 'tunnel-up'");
+    expect(msg).toContain('up exploded');
+    expect(msg).toContain('completed: local-down, local-up');
+    expect(msg).toContain('/tmp/sds-synthetic/bootstrap.json');
+    expect(msg).toContain(BOOTSTRAP_RESUME_COMMAND);
+    // The contract: NOTHING is torn down on failure.
+    expect(msg).toContain('nothing torn down');
+  });
+});
+
+describe('makeRealBootstrapLedgerIO — fs boundary', () => {
+  let dir: string;
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('round-trips a ledger, mkdir -p on write, and clear removes it', () => {
+    dir = mkdtempSync(join(tmpdir(), 'saga-bootstrap-ledger-'));
+    const path = bootstrapLedgerPath(join(dir, 'deep', 'state')); // parent does not exist yet
+    const io = makeRealBootstrapLedgerIO();
+    expect(io.read(path)).toBeNull();
+
+    const ledger: BootstrapLedger = { version: 1, startedAt: NOW.toISOString(), completed: ['local-down'] };
+    io.write(path, ledger);
+    expect(io.read(path)).toEqual(ledger);
+    expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual(ledger);
+
+    io.clear(path);
+    expect(existsSync(path)).toBe(false);
+    io.clear(path); // idempotent
+  });
+
+  it('a corrupt/foreign bootstrap.json degrades to null (full run), never a crash', () => {
+    dir = mkdtempSync(join(tmpdir(), 'saga-bootstrap-ledger-'));
+    const path = bootstrapLedgerPath(dir);
+    const io = makeRealBootstrapLedgerIO();
+
+    writeFileSync(path, 'not json');
+    expect(io.read(path)).toBeNull();
+    writeFileSync(path, JSON.stringify({ version: 2, startedAt: 'x', completed: [] }));
+    expect(io.read(path)).toBeNull();
+    writeFileSync(path, JSON.stringify({ version: 1, startedAt: 'x', completed: [1, 2] }));
+    expect(io.read(path)).toBeNull();
+  });
+});
+
+describe('forbidForeignMessage (stack up --forbid-foreign, the phase-2 hard stop)', () => {
+  it('lists each foreign service with its port + the lsof that reveals the pid, and the resume remediation', () => {
+    const msg = forbidForeignMessage(['programs-api', 'iam-api'], { 'programs-api': 4011, 'iam-api': 3010 });
+    expect(msg).toContain('adopted 2 process(es) NOT launched by this CLI');
+    expect(msg).toContain('programs-api (port 4011)');
+    expect(msg).toContain('lsof -nP -iTCP:4011 -sTCP:LISTEN');
+    expect(msg).toContain('iam-api (port 3010)');
+    expect(msg).toContain('relaunch');
+    expect(msg).toContain('ledger resumes at this step');
+  });
+
+  it('degrades to a health-URL hint when a service has no resolved port', () => {
+    const msg = forbidForeignMessage(['iam-api'], {});
+    expect(msg).toContain('no resolved port');
+  });
+});

--- a/packages/node/saga-stack-cli/src/commands/develop/__tests__/bootstrap-connect.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/__tests__/bootstrap-connect.unit.test.ts
@@ -145,6 +145,39 @@ describe('runBootstrapSteps — ledger sequencing', () => {
     expect(log.some((l) => l.includes('RESUMING'))).toBe(true);
     expect(current()).toBeNull(); // completed ⇒ cleared
   });
+
+  it('recorded completions AFTER the resume point are stale: pruned (persisted) and re-run', async () => {
+    // The cross-shape poisoning case: a failed FAST-PATH run recorded the
+    // phase-2 ids ('c','d'); the re-run has the FULL shape and must not skip
+    // them after re-executing the phase-1 steps ('a','b') underneath them.
+    const { io, writes } = fakeLedgerIO({ version: 1, startedAt: 'x', completed: ['c', 'd'] });
+    const a = step('a');
+    const b = step('b');
+    const c = step('c');
+    const d = step('d');
+    const log: string[] = [];
+    await runBootstrapSteps([a, b, c, d], deps(io, log));
+
+    for (const s of [a, b, c, d]) expect(s.calls).toHaveLength(1);
+    expect(log.some((l) => l.includes('invalidated'))).toBe(true);
+    // The prune itself is persisted BEFORE any step runs, so a crash mid-run
+    // cannot resurrect the stale ids in a later differently-shaped resume.
+    expect(writes[0]?.completed).toEqual([]);
+  });
+
+  it('recorded completions BEFORE the resume point (even from another shape) still skip', async () => {
+    // Full-run failure at 'c' then a fast-path-shaped resume [b, c, d]: 'b' is
+    // a valid leading prefix — only ids AFTER the first un-recorded step die.
+    const { io } = fakeLedgerIO({ version: 1, startedAt: 'x', completed: ['a', 'b'] });
+    const b = step('b');
+    const c = step('c');
+    const d = step('d');
+    await runBootstrapSteps([b, c, d], deps(io));
+
+    expect(b.calls).toHaveLength(0);
+    expect(c.calls).toHaveLength(1);
+    expect(d.calls).toHaveLength(1);
+  });
 });
 
 describe('bootstrapFailureMessage', () => {

--- a/packages/node/saga-stack-cli/src/commands/develop/__tests__/bootstrap.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/__tests__/bootstrap.int.test.ts
@@ -323,6 +323,80 @@ describe('develop connect --bootstrap — ledger: failure stops, re-run resumes,
     expect(existsSync(ledgerPath())).toBe(false); // success clears
     expect(liveRun()).toBeDefined();
   });
+
+  it('phase-2 ids from a failed FAST-PATH run do NOT skip tunnel-down/tunnel-up in a --rebuild re-run', async () => {
+    // Run 1: fresh fixture ⇒ fast path (phase 2 only); restore fails, leaving
+    // 'tunnel-down'/'tunnel-up' in the ledger. Run 2 (--rebuild) executes
+    // phase 1 (localhost env) UNDER those recorded completions — honoring them
+    // would bypass the --forbid-foreign hard stop and declare the bridge up on
+    // a localhost-mode stack.
+    vi.restoreAllMocks();
+    installSeams({ fixture: fixtureAgedDays(1) });
+    vi.spyOn(BaseCommand.prototype, 'log').mockImplementation(() => {});
+    vi.spyOn(BaseCommand.prototype, 'warn').mockImplementation(((m: string) => m) as never);
+
+    (snapRestoreSpy as unknown as { mockRejectedValueOnce: (e: Error) => void }).mockRejectedValueOnce(
+      new Error('fixture torn'),
+    );
+    await expect(DevelopConnect.run(['--tunnel', '--bootstrap', ...ws()], config)).rejects.toThrow(
+      /bootstrap FAILED at step 'snapshot-restore'/,
+    );
+    expect(ledgerCompleted()).toEqual(['tunnel-down', 'tunnel-up']);
+
+    // ── Run 2: the natural remediation `--bootstrap --rebuild`. ──
+    downSpy.mockClear();
+    upSpy.mockClear();
+    snapStoreSpy.mockClear();
+    snapRestoreSpy.mockClear();
+
+    await DevelopConnect.run(['--tunnel', '--bootstrap', '--rebuild', ...ws()], config);
+
+    // BOTH phases ran: local down/up AND tunnel down/up (with the hard stop).
+    expect(downSpy).toHaveBeenCalledTimes(2);
+    expect(upSpy).toHaveBeenCalledTimes(2);
+    expect(argvOf(upSpy, 0)).toEqual(expect.arrayContaining(['--seed', 'full', '--reset']));
+    expect(argvOf(upSpy, 0)).not.toContain('--tunnel');
+    expect(argvOf(upSpy, 1)).toEqual(expect.arrayContaining(['--tunnel', '--reset', '--forbid-foreign']));
+    expect(snapStoreSpy).toHaveBeenCalledTimes(1);
+    expect(snapRestoreSpy).toHaveBeenCalledTimes(1);
+    expect(existsSync(ledgerPath())).toBe(false);
+    expect(liveRun()).toBeDefined();
+  });
+
+  it('a failed --rebuild prints a resume command carrying --rebuild + pins; even a bare re-run resumes the rebuild', async () => {
+    // Run 1: fresh-but-bad fixture ⇒ --rebuild; the journey replay fails both
+    // attempts, stopping phase 1 at 'prerequisite'. Without the run-shaped
+    // resume command AND the in-flight-ledger fast-path override, the re-run
+    // would fast-path (fixture still fresh), restore the OLD fixture the user
+    // asked to replace, and clear the ledger as "success".
+    vi.restoreAllMocks();
+    installSeams({ fixture: fixtureAgedDays(1), playwrightFail: 'stage-5-schedule' });
+    vi.spyOn(BaseCommand.prototype, 'log').mockImplementation(() => {});
+    vi.spyOn(BaseCommand.prototype, 'warn').mockImplementation(((m: string) => m) as never);
+
+    const err = await DevelopConnect.run(['--tunnel', '--bootstrap', '--rebuild', ...ws()], config).catch(
+      (e: Error) => e,
+    );
+    expect((err as Error).message).toMatch(/bootstrap FAILED at step 'prerequisite'/);
+    expect((err as Error).message).toContain('ss develop connect --tunnel --bootstrap --rebuild');
+    expect((err as Error).message).toContain(`--state-dir ${STATE_DIR}`);
+    expect(ledgerCompleted()).toEqual(['local-down', 'local-up']);
+
+    // ── Run 2: the BARE command (shell-history hazard). Must resume phase 1. ──
+    vi.restoreAllMocks();
+    installSeams({ fixture: fixtureAgedDays(1) }); // journeys green now
+    vi.spyOn(BaseCommand.prototype, 'log').mockImplementation(() => {});
+    vi.spyOn(BaseCommand.prototype, 'warn').mockImplementation(((m: string) => m) as never);
+
+    await DevelopConnect.run(['--tunnel', '--bootstrap', ...ws()], config);
+
+    expect(journeyRuns()).toHaveLength(1); // prerequisite resumed (fresh runs array)
+    expect(snapStoreSpy).toHaveBeenCalledTimes(1); // the rebuild's NEW fixture stored
+    expect(upSpy).toHaveBeenCalledTimes(1); // local-up skipped via ledger; only tunnel up ran
+    expect(argvOf(upSpy, 0)).toContain('--tunnel');
+    expect(existsSync(ledgerPath())).toBe(false);
+    expect(liveRun()).toBeDefined();
+  });
 });
 
 describe('develop connect --bootstrap — phase-2 foreign hard stop', () => {

--- a/packages/node/saga-stack-cli/src/commands/develop/__tests__/bootstrap.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/__tests__/bootstrap.int.test.ts
@@ -1,0 +1,413 @@
+/**
+ * `develop connect --tunnel --bootstrap` integration tests (soa#329) — the real
+ * oclif command with every BaseCommand IO seam faked (connect.int.test.ts
+ * harness) AND the four phase sub-commands (`stack down/up`, `snapshot
+ * store/restore`) mocked at their static `run` so this suite owns exactly the
+ * SEQUENCER axis: flag rejections, the fixture fast path, ledger resume/clear,
+ * the foreign hard stop, the persona preflight verdicts, and the retry-once
+ * prerequisite. The sub-commands' own behavior has its own suites
+ * (up-native.int / snapshot.int); the prerequisite step is NOT mocked — it
+ * drives the real in-process orchestrator against the fake seams.
+ */
+
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { Config } from '@oclif/core';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BaseCommand } from '../../../base-command.js';
+import type { SnapshotManifest } from '../../../core/snapshot/index.js';
+import type { CheckpointStore, Runner, ScriptInvocation } from '../../../runtime/index.js';
+import { useTempSnapshotsDir } from '../../../__tests__/helpers/env.js';
+import { installCoreSeams } from '../../../__tests__/helpers/seams.js';
+import type { CoreSeams } from '../../../__tests__/helpers/seams.js';
+import StackDown from '../../stack/down.js';
+import StackUp from '../../stack/up.js';
+import SnapshotRestore from '../../stack/snapshot/restore.js';
+import SnapshotStore from '../../stack/snapshot/store.js';
+import DevelopConnect from '../connect.js';
+
+const PKG_ROOT = process.cwd();
+const SOA_ROOT = resolve(PKG_ROOT, '..', '..', '..');
+const DEV_ROOT = '/fixed/dev';
+
+let DASH_ROOT: string;
+let STATE_DIR: string;
+let config: Config;
+let runs: ScriptInvocation[];
+let barrierCalls: CoreSeams['barrierCalls'];
+let posterCalls: string[];
+let posterStatus: number;
+let downSpy: ReturnType<typeof vi.spyOn>;
+let upSpy: ReturnType<typeof vi.spyOn>;
+let snapStoreSpy: ReturnType<typeof vi.spyOn>;
+let snapRestoreSpy: ReturnType<typeof vi.spyOn>;
+
+useTempSnapshotsDir('saga-connect-bootstrap-');
+
+/** A fresh/stale tunnel-connect fixture manifest (only createdAt is consulted). */
+function fixtureAgedDays(days: number): SnapshotManifest {
+  return { createdAt: new Date(Date.now() - days * 86_400_000).toISOString() } as unknown as SnapshotManifest;
+}
+
+function installSeams(opts: { fixture?: SnapshotManifest | null; playwrightFail?: string } = {}): void {
+  const seams = installCoreSeams({
+    pidBase: 2000,
+    prepFresh: false,
+    ...(opts.playwrightFail !== undefined ? { playwrightFail: opts.playwrightFail } : {}),
+  });
+  runs = seams.runs;
+  barrierCalls = seams.barrierCalls;
+
+  const proto = BaseCommand.prototype as unknown as Record<string, () => unknown>;
+
+  // Checkpoint store fake: `load('tunnel-connect')` answers the FAST-PATH fixture
+  // (or null); every stage-checkpoint id answers null so the phase-1 prerequisite
+  // falls back to the local headless replay — hermetic, no snapshot IO.
+  const store: CheckpointStore = {
+    load: (id: string) => (id === 'tunnel-connect' ? (opts.fixture ?? null) : null),
+    bake: async () => {},
+    restore: async () => {},
+  };
+  vi.spyOn(proto, 'getCheckpointStore').mockReturnValue(store);
+
+  // Never spawn the vendored tunnel.sh.
+  vi.spyOn(proto, 'getTunnelMoniker').mockReturnValue(async () => 'testmoniker');
+
+  // The persona-preflight devLogin poster (soa#331). `posterStatus` scripts the verdict.
+  posterCalls = [];
+  posterStatus = 200;
+  vi.spyOn(proto, 'getCookiePoster').mockReturnValue({
+    post: async (url: string) => {
+      posterCalls.push(url);
+      return { status: posterStatus, ok: posterStatus === 200, setCookies: [] };
+    },
+  });
+
+  // The four phase sub-commands, mocked at their static run (argv recorded).
+  downSpy = vi.spyOn(StackDown, 'run').mockResolvedValue(undefined as never) as never;
+  upSpy = vi.spyOn(StackUp, 'run').mockResolvedValue(undefined as never) as never;
+  snapStoreSpy = vi.spyOn(SnapshotStore, 'run').mockResolvedValue(undefined as never) as never;
+  snapRestoreSpy = vi.spyOn(SnapshotRestore, 'run').mockResolvedValue(undefined as never) as never;
+}
+
+function ws(): string[] {
+  return ['--saga-dash', DASH_ROOT, '--soa', SOA_ROOT, '--dev', DEV_ROOT, '--state-dir', STATE_DIR];
+}
+
+function playwrightRuns(): ScriptInvocation[] {
+  return runs.filter((r) => r.command === 'pnpm' && r.args.includes('playwright'));
+}
+
+/** The phase-1 journey replay spawns (terminal project stage-5-schedule). */
+function journeyRuns(): ScriptInvocation[] {
+  return playwrightRuns().filter((r) => r.args.includes('stage-5-schedule'));
+}
+
+/** The headed live-session spawn (the hand-off's terminal stage). */
+function liveRun(): ScriptInvocation | undefined {
+  return playwrightRuns().find((r) => r.args.includes('interactive-connect'));
+}
+
+function ledgerPath(): string {
+  return join(STATE_DIR, 'bootstrap.json');
+}
+
+function ledgerCompleted(): string[] {
+  return (JSON.parse(readFileSync(ledgerPath(), 'utf8')) as { completed: string[] }).completed;
+}
+
+/** argv of the i-th recorded call of a mocked sub-command run. */
+function argvOf(spy: ReturnType<typeof vi.spyOn>, i: number): string[] {
+  return spy.mock.calls[i]?.[0] as unknown as string[];
+}
+
+beforeAll(() => {
+  DASH_ROOT = mkdtempSync(join(tmpdir(), 'saga-dash-bootstrap-'));
+});
+afterAll(() => {
+  rmSync(DASH_ROOT, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  config = await Config.load(PKG_ROOT);
+  STATE_DIR = mkdtempSync(join(tmpdir(), 'saga-bootstrap-state-'));
+  installSeams();
+  vi.spyOn(BaseCommand.prototype, 'log').mockImplementation(() => {});
+  vi.spyOn(BaseCommand.prototype, 'warn').mockImplementation(((m: string) => m) as never);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  rmSync(STATE_DIR, { recursive: true, force: true });
+});
+
+describe('develop connect --bootstrap — flag rejections (FIRST, before any IO)', () => {
+  async function expectRejected(argv: string[], re: RegExp): Promise<void> {
+    await expect(DevelopConnect.run([...argv, ...ws()], config)).rejects.toThrow(re);
+    // Rejected BEFORE any phase/bring-up work.
+    expect(downSpy).not.toHaveBeenCalled();
+    expect(upSpy).not.toHaveBeenCalled();
+    expect(snapStoreSpy).not.toHaveBeenCalled();
+    expect(playwrightRuns()).toHaveLength(0);
+  }
+
+  it('--bootstrap without --tunnel', async () => {
+    await expectRejected(['--bootstrap'], /--bootstrap.*two-phase tunnel bridge.*--tunnel/is);
+  });
+
+  it('--bootstrap --tunnel --slot 2 (bootstrap-specific message, not the generic tunnel guard)', async () => {
+    await expectRejected(['--bootstrap', '--tunnel', '--slot', '2'], /slot 2: --bootstrap.*peer slot/s);
+  });
+
+  it('--bootstrap --tunnel --no-prereq-from-snapshot', async () => {
+    await expectRejected(
+      ['--bootstrap', '--tunnel', '--no-prereq-from-snapshot'],
+      /--bootstrap owns the prerequisite strategy/,
+    );
+  });
+
+  it('--rebuild without --bootstrap', async () => {
+    await expectRejected(['--rebuild', '--tunnel'], /--rebuild only modifies --bootstrap/);
+  });
+
+  it('--bootstrap --tunnel --refresh-snapshot', async () => {
+    await expectRejected(
+      ['--bootstrap', '--tunnel', '--refresh-snapshot'],
+      /--bootstrap and --refresh-snapshot are mutually exclusive/,
+    );
+  });
+
+  it('--set (connect is not set-aware; the central parse guard rejects)', async () => {
+    await expectRejected(['--bootstrap', '--tunnel', '--set', 'foo'], /--set is not supported/);
+  });
+});
+
+describe('develop connect --bootstrap — full two-phase run (no fixture)', () => {
+  it('runs phase 1 + phase 2 in order, then hands off to the reuse live session', async () => {
+    await DevelopConnect.run(['--tunnel', '--bootstrap', ...ws()], config);
+
+    // Phase sub-commands: down×2, up×2 (local then tunnel), store, restore.
+    expect(downSpy).toHaveBeenCalledTimes(2);
+    expect(upSpy).toHaveBeenCalledTimes(2);
+    const upLocal = argvOf(upSpy, 0);
+    expect(upLocal).toEqual(expect.arrayContaining(['--seed', 'full', '--reset']));
+    expect(upLocal).not.toContain('--tunnel');
+    const upTunnel = argvOf(upSpy, 1);
+    expect(upTunnel).toEqual(expect.arrayContaining(['--tunnel', '--reset', '--forbid-foreign']));
+    expect(argvOf(snapStoreSpy, 0)).toEqual(
+      expect.arrayContaining(['--fixture-id', 'tunnel-connect', '--force']),
+    );
+    expect(argvOf(snapRestoreSpy, 0)[0]).toBe('tunnel-connect');
+
+    // Workspace forwarding: the sub-commands resolve the SAME checkouts + state dir.
+    for (const argv of [upLocal, upTunnel, argvOf(downSpy, 0), argvOf(snapStoreSpy, 0), argvOf(snapRestoreSpy, 0)]) {
+      expect(argv).toEqual(expect.arrayContaining(['--saga-dash', DASH_ROOT, '--state-dir', STATE_DIR]));
+    }
+
+    // Order: local-down → local-up → snapshot-store → tunnel-down → tunnel-up → restore.
+    const order = [
+      downSpy.mock.invocationCallOrder[0],
+      upSpy.mock.invocationCallOrder[0],
+      snapStoreSpy.mock.invocationCallOrder[0],
+      downSpy.mock.invocationCallOrder[1],
+      upSpy.mock.invocationCallOrder[1],
+      snapRestoreSpy.mock.invocationCallOrder[0],
+    ];
+    expect([...order].sort((a, b) => (a ?? 0) - (b ?? 0))).toEqual(order);
+
+    // The prerequisite ran LOCALLY (localhost iam, never the tunnel host) exactly once.
+    const journeys = journeyRuns();
+    expect(journeys).toHaveLength(1);
+    expect(journeys[0]?.env?.PLAYWRIGHT_IAM_URL).toBe('http://localhost:3010');
+
+    // Settle barrier gated the snapshot (soa#327): one call, the journey personas.
+    expect(barrierCalls).toHaveLength(1);
+    expect(barrierCalls[0]).toMatchObject({
+      fixtureId: 'tunnel-connect',
+      stageId: 'schedule',
+      personas: ['alex.tutor@example.org'],
+    });
+
+    // Persona preflight probed devLogin over the TUNNEL iam host (soa#331).
+    expect(posterCalls).toHaveLength(1);
+    expect(posterCalls[0]).toMatch(/^https:\/\/iam\.testmoniker\./);
+
+    // Success clears the ledger.
+    expect(existsSync(ledgerPath())).toBe(false);
+
+    // Hand-off: the headed room drives the tunnel hosts, with NO second journey
+    // replay (--bootstrap implies --reuse — the restored fixture must survive).
+    expect(liveRun()?.env?.PLAYWRIGHT_BASE_URL).toMatch(/^https:\/\/dash\.testmoniker\./);
+    expect(journeyRuns()).toHaveLength(1);
+  });
+});
+
+describe('develop connect --bootstrap — fixture fast path', () => {
+  it('a fresh (<7d) tunnel-connect fixture skips phase 1 entirely', async () => {
+    vi.restoreAllMocks();
+    installSeams({ fixture: fixtureAgedDays(1) });
+    vi.spyOn(BaseCommand.prototype, 'log').mockImplementation(() => {});
+    vi.spyOn(BaseCommand.prototype, 'warn').mockImplementation(((m: string) => m) as never);
+
+    await DevelopConnect.run(['--tunnel', '--bootstrap', ...ws()], config);
+
+    // Only the tunnel phase: one down, one (tunnel) up, NO store, restore still runs.
+    expect(downSpy).toHaveBeenCalledTimes(1);
+    expect(upSpy).toHaveBeenCalledTimes(1);
+    expect(argvOf(upSpy, 0)).toEqual(expect.arrayContaining(['--tunnel', '--forbid-foreign']));
+    expect(snapStoreSpy).not.toHaveBeenCalled();
+    expect(snapRestoreSpy).toHaveBeenCalledTimes(1);
+    // No local rebuild: no journey replay, no settle barrier.
+    expect(journeyRuns()).toHaveLength(0);
+    expect(barrierCalls).toHaveLength(0);
+    expect(liveRun()).toBeDefined();
+  });
+
+  it('--rebuild forces the full phase-1 rebuild past a fresh fixture', async () => {
+    vi.restoreAllMocks();
+    installSeams({ fixture: fixtureAgedDays(1) });
+    vi.spyOn(BaseCommand.prototype, 'log').mockImplementation(() => {});
+    vi.spyOn(BaseCommand.prototype, 'warn').mockImplementation(((m: string) => m) as never);
+
+    await DevelopConnect.run(['--tunnel', '--bootstrap', '--rebuild', ...ws()], config);
+
+    expect(upSpy).toHaveBeenCalledTimes(2);
+    expect(snapStoreSpy).toHaveBeenCalledTimes(1);
+    expect(journeyRuns()).toHaveLength(1);
+  });
+
+  it('a stale (>7d) fixture does NOT take the fast path', async () => {
+    vi.restoreAllMocks();
+    installSeams({ fixture: fixtureAgedDays(8) });
+    vi.spyOn(BaseCommand.prototype, 'log').mockImplementation(() => {});
+    vi.spyOn(BaseCommand.prototype, 'warn').mockImplementation(((m: string) => m) as never);
+
+    await DevelopConnect.run(['--tunnel', '--bootstrap', ...ws()], config);
+
+    expect(upSpy).toHaveBeenCalledTimes(2);
+    expect(snapStoreSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('develop connect --bootstrap — ledger: failure stops, re-run resumes, success clears', () => {
+  it('a failed step keeps the ledger + prints the resume command; the re-run resumes AT that step', async () => {
+    (snapStoreSpy as unknown as { mockRejectedValueOnce: (e: Error) => void }).mockRejectedValueOnce(
+      new Error('pg_dump exploded'),
+    );
+
+    await expect(DevelopConnect.run(['--tunnel', '--bootstrap', ...ws()], config)).rejects.toThrow(
+      /bootstrap FAILED at step 'snapshot-store'[\s\S]*pg_dump exploded[\s\S]*ss develop connect --tunnel --bootstrap/,
+    );
+
+    // Everything BEFORE the failed step is recorded; nothing was torn down and
+    // phase 2 never started.
+    expect(ledgerCompleted()).toEqual(['local-down', 'local-up', 'prerequisite', 'settle']);
+    expect(downSpy).toHaveBeenCalledTimes(1);
+    expect(snapRestoreSpy).not.toHaveBeenCalled();
+
+    // ── RE-RUN: resumes at snapshot-store; phase-1 down/up/prerequisite are SKIPPED. ──
+    downSpy.mockClear();
+    upSpy.mockClear();
+    snapStoreSpy.mockClear();
+    snapRestoreSpy.mockClear();
+    const journeysBefore = journeyRuns().length;
+
+    await DevelopConnect.run(['--tunnel', '--bootstrap', ...ws()], config);
+
+    expect(snapStoreSpy).toHaveBeenCalledTimes(1); // the failed step re-ran
+    expect(upSpy).toHaveBeenCalledTimes(1); // ONLY the tunnel up — local-up was skipped
+    expect(argvOf(upSpy, 0)).toContain('--tunnel');
+    expect(downSpy).toHaveBeenCalledTimes(1); // only tunnel-down
+    expect(journeyRuns().length).toBe(journeysBefore); // prerequisite NOT replayed
+    expect(existsSync(ledgerPath())).toBe(false); // success clears
+    expect(liveRun()).toBeDefined();
+  });
+});
+
+describe('develop connect --bootstrap — phase-2 foreign hard stop', () => {
+  it('an up --forbid-foreign abort stops the bridge before the restore, ledger kept', async () => {
+    (upSpy as unknown as { mockImplementation: (fn: (argv: string[]) => Promise<void>) => void }).mockImplementation(
+      async (argv: string[]) => {
+        if (argv.includes('--forbid-foreign')) {
+          throw new Error(
+            '--forbid-foreign: adopted 1 process(es) NOT launched by this CLI (already up, no pidfile — env unverifiable):\n  ✗ programs-api (port 4011)',
+          );
+        }
+      },
+    );
+
+    await expect(DevelopConnect.run(['--tunnel', '--bootstrap', ...ws()], config)).rejects.toThrow(
+      /bootstrap FAILED at step 'tunnel-up'[\s\S]*NOT launched by this CLI/,
+    );
+
+    // Aborted BEFORE the restore/preflight; the ledger records through tunnel-down.
+    expect(snapRestoreSpy).not.toHaveBeenCalled();
+    expect(posterCalls).toHaveLength(0);
+    expect(ledgerCompleted()).toEqual([
+      'local-down',
+      'local-up',
+      'prerequisite',
+      'settle',
+      'snapshot-store',
+      'tunnel-down',
+    ]);
+  });
+});
+
+describe('develop connect --bootstrap — persona preflight verdicts (soa#331)', () => {
+  it('devLogin 401 after the restore fails the bridge as a TORN checkpoint, ledger kept', async () => {
+    posterStatus = 401;
+
+    await expect(DevelopConnect.run(['--tunnel', '--bootstrap', ...ws()], config)).rejects.toThrow(
+      /bootstrap FAILED at step 'persona-preflight'[\s\S]*TORN/,
+    );
+
+    // The restore itself completed; only the preflight is outstanding.
+    expect(ledgerCompleted()).toContain('snapshot-restore');
+    expect(ledgerCompleted()).not.toContain('persona-preflight');
+    // The room never opened.
+    expect(liveRun()).toBeUndefined();
+  });
+});
+
+describe('develop connect --bootstrap — prerequisite retry-once (stage-flake class)', () => {
+  function failJourneyTimes(n: number): void {
+    // Wrap the battery runner: the first `n` journey spawns exit 1, later ones 0.
+    const proto = BaseCommand.prototype as unknown as { getRunner: () => Runner };
+    const base = proto.getRunner();
+    let left = n;
+    vi.spyOn(proto as unknown as Record<string, () => unknown>, 'getRunner').mockReturnValue({
+      run: async (spec: ScriptInvocation) => {
+        const res = await base.run(spec);
+        if (left > 0 && spec.args.includes('playwright') && spec.args.includes('stage-5-schedule')) {
+          left -= 1;
+          return { code: 1 };
+        }
+        return res;
+      },
+    } satisfies Runner);
+  }
+
+  it('one failed journey replay is retried once and the bridge completes', async () => {
+    failJourneyTimes(1);
+
+    await DevelopConnect.run(['--tunnel', '--bootstrap', ...ws()], config);
+
+    expect(journeyRuns()).toHaveLength(2); // fail + green retry
+    expect(existsSync(ledgerPath())).toBe(false);
+    expect(liveRun()).toBeDefined();
+  });
+
+  it('a second failure is NOT a flake: the step fails after exactly one retry', async () => {
+    failJourneyTimes(99);
+
+    await expect(DevelopConnect.run(['--tunnel', '--bootstrap', ...ws()], config)).rejects.toThrow(
+      /bootstrap FAILED at step 'prerequisite'/,
+    );
+
+    expect(journeyRuns()).toHaveLength(2); // one retry, then stop — never a loop
+    expect(ledgerCompleted()).toEqual(['local-down', 'local-up']);
+    expect(snapStoreSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/node/saga-stack-cli/src/commands/develop/connect.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/connect.ts
@@ -75,6 +75,7 @@ import SnapshotRestore from '../stack/snapshot/restore.js';
 import SnapshotStore from '../stack/snapshot/store.js';
 import {
   BootstrapStepError,
+  bootstrapResumeCommand,
   bootstrapWorkspaceArgv,
   runBootstrapSteps,
   tunnelFixtureFresh,
@@ -484,20 +485,12 @@ export default class DevelopConnect extends BaseCommand {
     // before calling this) — the store's resolvers read $SAGA_MESH_* at CALL time.
     const store = this.getCheckpointStore(this.scriptContextFromFlags(flags));
 
-    // FAST PATH: a fresh (<7d) tunnel-connect fixture makes phase 1 pure waste —
-    // phase 2 restores the fixture anyway. --rebuild forces the full rebuild.
+    // FAST-PATH input: a fresh (<7d) tunnel-connect fixture makes phase 1 pure
+    // waste — phase 2 restores the fixture anyway. The DECISION sits below the
+    // step lists: it must also consult the ledger (an in-flight phase-1 rebuild
+    // must resume, never be fast-pathed over).
     const fixture = store.load(TUNNEL_CONNECT_FIXTURE_ID);
     const fresh = tunnelFixtureFresh(fixture, now);
-    const skipPhase1 = fresh && !flags.rebuild;
-    if (skipPhase1) {
-      this.log(
-        `==> bootstrap FAST PATH: fixture '${TUNNEL_CONNECT_FIXTURE_ID}' is fresh (created ${fixture?.createdAt}) — skipping phase 1 (--rebuild forces the full rebuild)`,
-      );
-    } else if (fresh && flags.rebuild) {
-      this.log(
-        `==> bootstrap: --rebuild — ignoring the fresh '${TUNNEL_CONNECT_FIXTURE_ID}' fixture; running the full phase-1 rebuild`,
-      );
-    }
 
     // PHASE-1 stack context: NO tunnelDomain. Phase 1 rebuilds state against
     // localhost — anything IT launches must get the plain local browser env, and
@@ -592,12 +585,40 @@ export default class DevelopConnect extends BaseCommand {
       },
     ];
 
+    // FAST-PATH decision. A ledger recording completed PHASE-1 steps means a
+    // rebuild is mid-flight from a failed run: the fast path would discard it —
+    // restore the OLD fixture the user asked to replace and clear the ledger as
+    // "success" — so an in-flight rebuild always disables the fast path. The
+    // resume command mirrors this run's shape (--rebuild + workspace pins); the
+    // bare base command would not resume under a custom --state-dir.
+    const ledgerIO = this.getBootstrapLedgerIO();
+    const ledgerPath = bootstrapLedgerPath(stateDir);
+    const phase1Ids = new Set(phase1.map((s) => s.id));
+    const rebuildInFlight = (ledgerIO.read(ledgerPath)?.completed ?? []).some((id) =>
+      phase1Ids.has(id),
+    );
+    const skipPhase1 = fresh && !flags.rebuild && !rebuildInFlight;
+    if (skipPhase1) {
+      this.log(
+        `==> bootstrap FAST PATH: fixture '${TUNNEL_CONNECT_FIXTURE_ID}' is fresh (created ${fixture?.createdAt}) — skipping phase 1 (--rebuild forces the full rebuild)`,
+      );
+    } else if (fresh && flags.rebuild) {
+      this.log(
+        `==> bootstrap: --rebuild — ignoring the fresh '${TUNNEL_CONNECT_FIXTURE_ID}' fixture; running the full phase-1 rebuild`,
+      );
+    } else if (fresh && rebuildInFlight) {
+      this.log(
+        `==> bootstrap: ledger records an in-flight phase-1 rebuild — resuming it past the fresh '${TUNNEL_CONNECT_FIXTURE_ID}' fixture`,
+      );
+    }
+
     try {
       await runBootstrapSteps(skipPhase1 ? phase2 : [...phase1, ...phase2], {
-        ledger: this.getBootstrapLedgerIO(),
-        ledgerPath: bootstrapLedgerPath(stateDir),
+        ledger: ledgerIO,
+        ledgerPath,
         log: (l) => this.log(l),
         now,
+        resumeCommand: bootstrapResumeCommand(flags),
       });
     } catch (err) {
       if (err instanceof BootstrapStepError) this.error(err.message);

--- a/packages/node/saga-stack-cli/src/commands/develop/connect.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/connect.ts
@@ -35,28 +35,52 @@
  * or the journey stages changed. Requires the default `--prereq-from-snapshot` (it
  * bakes so that path can restore); mutually exclusive with `--reuse`.
  *
+ * `--bootstrap` (soa#329, with `--tunnel` only) automates docs/tunnel.md's
+ * two-phase bridge before the room opens: phase 1 rebuilds usable state LOCALLY
+ * and snapshots it (`tunnel-connect`); phase 2 relaunches the stack in tunnel
+ * mode and restores it (one iam serves localhost OR the tunnel — never both).
+ * Ledgered in `<stateDir>/bootstrap.json` (a failed run resumes); a fresh (<7d)
+ * fixture skips phase 1 (`--rebuild` forces it). Implies `--reuse`.
+ *
  *   node bin/dev.js develop connect
  *   node bin/dev.js develop connect --reuse -- --debug
  *   node bin/dev.js develop connect --fake-media
  *   node bin/dev.js develop connect --refresh-snapshot
+ *   node bin/dev.js develop connect --tunnel --bootstrap
  */
 
 import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command.js';
 import type { WorkspaceFlags } from '../../base-command.js';
 import { deriveInstance } from '../../core/derive-instance.js';
+import type { InstanceProfile } from '../../core/derive-instance.js';
 import { resolveFlow } from '../../core/flow/index.js';
+import type { ResolvedFlow } from '../../core/flow/index.js';
 import { manifest as serviceManifest } from '../../core/manifest/index.js';
 import type { ScriptPlan } from '../../core/flag-map.js';
 import { makeStackApi } from '../../stack-api.js';
-import { makePersonaPreflight, resolveVendorScript } from '../../runtime/index.js';
+import { bootstrapLedgerPath, makePersonaPreflight, resolveVendorScript } from '../../runtime/index.js';
 import {
   buildStackContext,
   discoverFlowManifest,
   executeResolvedFlow,
   FlowExecError,
   resolveAppCwd,
+  tunnelPersonaPreflight,
 } from '../../e2e-orchestrate.js';
+import type { ExecDeps, StackSeams } from '../../e2e-orchestrate.js';
+import StackDown from '../stack/down.js';
+import StackUp from '../stack/up.js';
+import SnapshotRestore from '../stack/snapshot/restore.js';
+import SnapshotStore from '../stack/snapshot/store.js';
+import {
+  BootstrapStepError,
+  bootstrapWorkspaceArgv,
+  runBootstrapSteps,
+  tunnelFixtureFresh,
+  TUNNEL_CONNECT_FIXTURE_ID,
+} from '../../bootstrap-connect.js';
+import type { BootstrapStep } from '../../bootstrap-connect.js';
 
 /** The connect-session flow is a built-in saga-dash flow. */
 const CONNECT_SPA = 'saga-dash';
@@ -78,6 +102,8 @@ export default class DevelopConnect extends BaseCommand {
     '<%= config.bin %> <%= command.id %> --reuse -- --debug',
     '<%= config.bin %> <%= command.id %> --fake-media',
     '<%= config.bin %> <%= command.id %> --refresh-snapshot',
+    '<%= config.bin %> <%= command.id %> --tunnel --bootstrap',
+    '<%= config.bin %> <%= command.id %> --tunnel --bootstrap --rebuild --student-login 1',
   ];
 
   // Allow trailing playwright passthrough args (after `--`).
@@ -120,6 +146,16 @@ export default class DevelopConnect extends BaseCommand {
       description:
         'how many of the 2 students THIS run logs in + joins locally (0, 1, or 2; default 2). The rest stay OPEN for a REMOTE peer to take — pair with --tunnel to invite coworkers. The tutor always auto-hosts and starts the session; login URLs for EVERY participant are printed regardless. Sets CONNECT_LOCAL_STUDENTS on the headed interactive-connect run.',
     }),
+    bootstrap: Flags.boolean({
+      default: false,
+      description:
+        "with --tunnel: automate docs/tunnel.md's two-phase bridge before opening the room. Phase 1 rebuilds usable state LOCALLY (down → up --seed full --reset → journey prerequisite → settle → snapshot store tunnel-connect); phase 2 relaunches in tunnel mode and restores it (down → up --tunnel --reset (hard stop if a foreign process survives) → snapshot restore → persona preflight). SKIPS phase 1 when a fresh (<7d) tunnel-connect fixture exists (--rebuild forces it). Progress is ledgered in <stateDir>/bootstrap.json, so a failed run RESUMES at the failed step; implies --reuse for the final session. Slot-0 only.",
+    }),
+    rebuild: Flags.boolean({
+      default: false,
+      description:
+        'with --bootstrap: run the full phase-1 local rebuild even when a fresh (<7d) tunnel-connect fixture exists (the fast path would otherwise skip it).',
+    }),
   };
 
   /**
@@ -138,6 +174,43 @@ export default class DevelopConnect extends BaseCommand {
   async run(): Promise<void> {
     const { argv, flags } = await this.parse(DevelopConnect);
     const passthrough = (argv as string[]).filter((a) => a !== CONNECT_FLOW);
+
+    // ── soa#329 --bootstrap rejections FIRST (before any resolution/IO). Manual,
+    // not oclif `exclusive:` — the M14 lesson (a defaulted value counts as
+    // provided there). `--set` needs no check here: connect is not setAware(),
+    // so BaseCommand.parse already rejected it above. ──
+    if (flags.rebuild && !flags.bootstrap) {
+      this.error(
+        '--rebuild only modifies --bootstrap (it forces the full phase-1 rebuild past a fresh tunnel-connect fixture). Add --bootstrap or drop --rebuild.',
+      );
+    }
+    if (flags.bootstrap) {
+      if (!flags.tunnel) {
+        this.error(
+          "--bootstrap automates docs/tunnel.md's TWO-PHASE TUNNEL bridge — it is meaningless without --tunnel. Add --tunnel (or drop --bootstrap for a local session).",
+        );
+      }
+      if (flags.slot > 0) {
+        this.error(
+          `slot ${flags.slot}: --bootstrap rebuilds slot 0's stack and snapshots/restores its tunnel bridge (the tunnel fronts the FIXED slot-0 browser ports), so it cannot run against a peer slot. Drop --slot.`,
+        );
+      }
+      if (!flags['prereq-from-snapshot']) {
+        this.error(
+          '--bootstrap owns the prerequisite strategy (restore a usable checkpoint, else the local headless replay) — --no-prereq-from-snapshot would force the slow replay inside the bridge. Drop it.',
+        );
+      }
+      if (flags['refresh-snapshot']) {
+        this.error(
+          '--bootstrap and --refresh-snapshot are mutually exclusive: phase 1 already rebuilds the state the bridge needs. Use --bootstrap --rebuild to force the full rebuild.',
+        );
+      }
+    }
+
+    // --bootstrap implies --reuse for the final hand-off: the phases below leave the
+    // stack tunnel-mode with the tunnel-connect fixture restored — exactly the state
+    // the reuse path runs against (rebuilding the prerequisite again would wipe it).
+    const reuse = flags.reuse || flags.bootstrap;
 
     // --tunnel fronts the FIXED slot-0 browser ports via the vms rendezvous box, so
     // it is slot-0-only — mirroring `develop coach`, `e2e run --tunnel` and `stack up
@@ -174,7 +247,7 @@ export default class DevelopConnect extends BaseCommand {
     // Foreground + headed by default (the flow is `foreground:true`); --reuse drops
     // the prerequisite + reset entirely, exactly like connect-session.sh.
     const resolved = resolveFlow(disco.manifest, CONNECT_FLOW, { lane: 'stack' });
-    const base = flags.reuse ? { ...resolved, prerequisite: undefined } : resolved;
+    const base = reuse ? { ...resolved, prerequisite: undefined } : resolved;
     // --fake-media (FAKE_MEDIA=1) and --student-login (CONNECT_LOCAL_STUDENTS=N) pin
     // env into THIS flow's env (merged last by computeEnv), so they reach only the
     // connect-session stage (headed interactive-connect) — not the journey
@@ -245,6 +318,25 @@ export default class DevelopConnect extends BaseCommand {
 
     const { runtime } = buildStackContext(flags, seams, delegate, profile, tunnelDomain);
     const api = makeStackApi(serviceManifest, runtime);
+
+    // ── soa#329 --bootstrap: run the two-phase bridge BEFORE the live session.
+    // On success the stack is up in TUNNEL mode with the tunnel-connect fixture
+    // restored — exactly the state the --reuse hand-off below runs against.
+    // tunnelDomain is guaranteed here (--bootstrap requires --tunnel, rejected
+    // above), so the room's browsers drive the tunnel hosts. ──
+    if (flags.bootstrap) {
+      await this.runBootstrapPhases({
+        flags,
+        resolved,
+        appCwd,
+        now,
+        seams,
+        delegate,
+        profile,
+        stateDir,
+        tunnelDomain: tunnelDomain as string,
+      });
+    }
 
     // M14-C: the checkpoint store so the journey prerequisite can be RESTORED
     // instead of replayed (--reuse strips the prerequisite entirely, so nothing to
@@ -346,7 +438,7 @@ export default class DevelopConnect extends BaseCommand {
         },
         {
           lane: 'stack',
-          skipReset: flags.reuse,
+          skipReset: reuse,
           passthrough,
           prereqFromSnapshot: flags['prereq-from-snapshot'],
         },
@@ -355,6 +447,199 @@ export default class DevelopConnect extends BaseCommand {
     } catch (err) {
       if (err instanceof FlowExecError) this.error(err.message);
       throw err;
+    }
+  }
+
+  /**
+   * soa#329: the --bootstrap two-phase bridge. Builds the step list (phase 1 is
+   * dropped entirely on the fast path — a fresh <7d tunnel-connect fixture; the
+   * ledger separately skips steps a previous FAILED run completed) and hands it
+   * to the sequencer. The steps compose EXISTING machinery only: the stack/
+   * snapshot sub-commands (forwarded the same workspace argv, the `stack
+   * bootstrap` precedent), the in-process flow orchestrator for the prerequisite,
+   * and the soa#327 settle-barrier/preflight seams.
+   */
+  private async runBootstrapPhases(ctx: {
+    flags: WorkspaceFlags & Record<string, unknown> & { 'state-dir'?: string; rebuild: boolean };
+    resolved: ResolvedFlow;
+    appCwd: string;
+    now: Date;
+    seams: StackSeams;
+    delegate: (plan: ScriptPlan) => Promise<number>;
+    profile: InstanceProfile;
+    stateDir: string;
+    tunnelDomain: string;
+  }): Promise<void> {
+    const { flags, resolved, profile, now, stateDir, tunnelDomain } = ctx;
+    const prereq = resolved.prerequisite;
+    if (prereq === undefined) {
+      this.error(
+        `--bootstrap: flow '${CONNECT_FLOW}' declares no prerequisite — there is no journey state to bake into the '${TUNNEL_CONNECT_FIXTURE_ID}' fixture.`,
+      );
+    }
+    const terminalStage = prereq.stages.at(-1)?.id ?? '';
+
+    // The checkpoint store doubles as the fixture-manifest reader (fast path) and
+    // the prerequisite's restore source. Built AFTER applyInstanceEnv (run() did,
+    // before calling this) — the store's resolvers read $SAGA_MESH_* at CALL time.
+    const store = this.getCheckpointStore(this.scriptContextFromFlags(flags));
+
+    // FAST PATH: a fresh (<7d) tunnel-connect fixture makes phase 1 pure waste —
+    // phase 2 restores the fixture anyway. --rebuild forces the full rebuild.
+    const fixture = store.load(TUNNEL_CONNECT_FIXTURE_ID);
+    const fresh = tunnelFixtureFresh(fixture, now);
+    const skipPhase1 = fresh && !flags.rebuild;
+    if (skipPhase1) {
+      this.log(
+        `==> bootstrap FAST PATH: fixture '${TUNNEL_CONNECT_FIXTURE_ID}' is fresh (created ${fixture?.createdAt}) — skipping phase 1 (--rebuild forces the full rebuild)`,
+      );
+    } else if (fresh && flags.rebuild) {
+      this.log(
+        `==> bootstrap: --rebuild — ignoring the fresh '${TUNNEL_CONNECT_FIXTURE_ID}' fixture; running the full phase-1 rebuild`,
+      );
+    }
+
+    // PHASE-1 stack context: NO tunnelDomain. Phase 1 rebuilds state against
+    // localhost — anything IT launches must get the plain local browser env, and
+    // the prerequisite must keep the LOCAL lane's restore-else-replay fallback
+    // (the tunnel fail-loud gates key off deps.tunnelDomain).
+    const { runtime: localRuntime } = buildStackContext(flags, ctx.seams, ctx.delegate, profile);
+    const localApi = makeStackApi(serviceManifest, localRuntime);
+    const localDeps: ExecDeps = {
+      api: localApi,
+      runner: ctx.seams.runner,
+      appCwd: ctx.appCwd,
+      now,
+      log: (l) => this.log(l),
+      slot: profile.slot,
+      ports: localRuntime.launchContext.ports,
+      checkpoints: store,
+    };
+
+    // The workspace argv every sub-command step gets, so down/up/store/restore
+    // resolve the SAME checkouts + state dir this run did.
+    const ws = bootstrapWorkspaceArgv(flags);
+
+    const phase1: BootstrapStep[] = [
+      {
+        id: 'local-down',
+        title: 'phase 1 — stack down (clean local relaunch)',
+        run: async () => void (await StackDown.run([...ws], this.config)),
+      },
+      {
+        id: 'local-up',
+        title: 'phase 1 — stack up --seed full --reset (local baseline)',
+        run: async () => void (await StackUp.run(['--seed', 'full', '--reset', ...ws], this.config)),
+      },
+      {
+        id: 'prerequisite',
+        title: `phase 1 — journey prerequisite through '${terminalStage}' (checkpoint restore if usable, else headless replay; retry-once on stage flake)`,
+        run: () => this.runBootstrapPrerequisite(resolved, localDeps),
+      },
+      {
+        id: 'settle',
+        title: 'phase 1 — settle barrier (roster-sync drain + persona devLogin)',
+        run: async () => {
+          await this.getSettleBarrier(profile.slot, (l) => this.log(l))({
+            fixtureId: TUNNEL_CONNECT_FIXTURE_ID,
+            stageId: terminalStage,
+            personas: prereq.flow.settlePersonas ?? [],
+          });
+        },
+      },
+      {
+        id: 'snapshot-store',
+        title: `phase 1 — snapshot store --fixture-id ${TUNNEL_CONNECT_FIXTURE_ID} --force`,
+        run: async () =>
+          void (await SnapshotStore.run(
+            ['--fixture-id', TUNNEL_CONNECT_FIXTURE_ID, '--profile', 'full', '--force', ...ws],
+            this.config,
+          )),
+      },
+    ];
+
+    const phase2: BootstrapStep[] = [
+      {
+        id: 'tunnel-down',
+        title: 'phase 2 — stack down (every service must RELAUNCH with the tunnel env)',
+        run: async () => void (await StackDown.run([...ws], this.config)),
+      },
+      {
+        id: 'tunnel-up',
+        title: 'phase 2 — stack up --tunnel --reset (hard stop if a foreign process survived)',
+        run: async () =>
+          void (await StackUp.run(['--tunnel', '--reset', '--forbid-foreign', ...ws], this.config)),
+      },
+      {
+        id: 'snapshot-restore',
+        title: `phase 2 — snapshot restore ${TUNNEL_CONNECT_FIXTURE_ID}`,
+        run: async () => void (await SnapshotRestore.run([TUNNEL_CONNECT_FIXTURE_ID, ...ws], this.config)),
+      },
+      {
+        id: 'persona-preflight',
+        title: 'phase 2 — persona preflight (devLogin over the tunnel iam host, soa#331)',
+        run: async () => {
+          await tunnelPersonaPreflight(prereq.flow, {
+            ...localDeps,
+            tunnelDomain,
+            preflight: makePersonaPreflight({
+              poster: this.getCookiePoster(),
+              log: (l) => this.log(l),
+              sleep: this.getSleep(),
+            }),
+          });
+        },
+      },
+    ];
+
+    try {
+      await runBootstrapSteps(skipPhase1 ? phase2 : [...phase1, ...phase2], {
+        ledger: this.getBootstrapLedgerIO(),
+        ledgerPath: bootstrapLedgerPath(stateDir),
+        log: (l) => this.log(l),
+        now,
+      });
+    } catch (err) {
+      if (err instanceof BootstrapStepError) this.error(err.message);
+      throw err;
+    }
+    this.log('✓ bootstrap complete — two-phase bridge up; handing off to the live session (--reuse).');
+  }
+
+  /**
+   * Phase-1 'prerequisite' step: put the LOCAL stack into the journey@schedule
+   * end-state via the EXISTING orchestrator. Executes a stages-empty variant of
+   * the connect-session flow, so executeResolvedFlow's own prerequisite handling
+   * supplies the strategy — restore the baked journey@schedule checkpoint when
+   * one is usable, else the full headless replay (local lane ⇒ silent fallback)
+   * — then up+verify the connect closure and stop before any Playwright spawn
+   * (`stages: []` is the Plan-13 empty window). One retry on failure: a single
+   * failed journey stage is the known async-settle flake class (soa#327).
+   */
+  private async runBootstrapPrerequisite(resolved: ResolvedFlow, deps: ExecDeps): Promise<void> {
+    const stateOnly: ResolvedFlow = { ...resolved, stages: [], reset: false, seedSelection: undefined };
+    const attempt = (): Promise<number> =>
+      executeResolvedFlow(stateOnly, deps, {
+        lane: 'stack',
+        skipReset: false,
+        passthrough: [],
+        prereqFromSnapshot: true,
+      });
+
+    try {
+      const code = await attempt();
+      if (code === 0) return;
+      this.log(`⚠ bootstrap prerequisite exited ${code} — retrying once (known async-settle stage-flake class)`);
+    } catch (err) {
+      if (!(err instanceof FlowExecError)) throw err;
+      this.log(
+        `⚠ bootstrap prerequisite failed — retrying once (known async-settle stage-flake class):\n${err.message}`,
+      );
+    }
+
+    const code = await attempt();
+    if (code !== 0) {
+      throw new Error(`prerequisite failed twice (exit ${code}) — not the retry-once flake class`);
     }
   }
 }

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/up-forbid-foreign.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/up-forbid-foreign.int.test.ts
@@ -1,0 +1,92 @@
+/**
+ * `stack up --forbid-foreign` (soa#329 — the bootstrap phase-2 hard stop):
+ * the REAL StackUp command with the core seam battery, whose launcher is
+ * re-spied to ADOPT a foreign process (already-up, no pidfile). The hidden flag
+ * escalates the report-time adoption warning into a hard abort BEFORE
+ * reset/seed run; without the flag the warning path is byte-identical.
+ */
+
+import { resolve } from 'node:path';
+import { Config } from '@oclif/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BaseCommand } from '../../../base-command.js';
+import type {
+  LaunchResult,
+  LaunchSpec,
+  ScriptInvocation,
+  ServiceLauncher,
+  StopResult,
+} from '../../../runtime/index.js';
+import { installCoreSeams } from '../../../__tests__/helpers/seams.js';
+import StackUp from '../up.js';
+
+const PKG_ROOT = process.cwd();
+const SOA_ROOT = resolve(PKG_ROOT, '..', '..', '..');
+const WS = ['--soa', SOA_ROOT, '--dev', '/fixed/dev'];
+
+let config: Config;
+let runs: ScriptInvocation[];
+let warns: string[];
+
+/** Re-spy the launcher so `foreign` ids come back adopted-foreign (alreadyUp, no pidfile). */
+function foreignLauncher(foreign: Set<string>, pidBase = 5000): void {
+  let n = 0;
+  const launcher: ServiceLauncher = {
+    async launch(spec: LaunchSpec): Promise<LaunchResult> {
+      n += 1;
+      return foreign.has(spec.id)
+        ? { id: spec.id, ok: true, alreadyUp: true, adoptedForeign: true }
+        : { id: spec.id, ok: true, pid: pidBase + n };
+    },
+    async stopServices(ids: string[]): Promise<StopResult[]> {
+      return ids.map((id) => ({ id, stopped: true }));
+    },
+  };
+  vi.spyOn(
+    BaseCommand.prototype as unknown as { getLauncher: () => ServiceLauncher },
+    'getLauncher',
+  ).mockReturnValue(launcher);
+}
+
+beforeEach(async () => {
+  config = await Config.load(PKG_ROOT);
+  runs = installCoreSeams({ pidBase: 2000, prepFresh: true }).runs;
+  warns = [];
+  vi.spyOn(BaseCommand.prototype, 'log').mockImplementation(() => {});
+  vi.spyOn(BaseCommand.prototype, 'warn').mockImplementation(((m: string) => {
+    warns.push(m);
+    return m;
+  }) as never);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('stack up --forbid-foreign', () => {
+  it('hard-errors on a foreign adoption, naming the service + its port lsof, BEFORE seed runs', async () => {
+    foreignLauncher(new Set(['iam-api']));
+
+    await expect(StackUp.run(['--only', 'iam-api', '--forbid-foreign', ...WS], config)).rejects.toThrow(
+      /adopted 1 process\(es\) NOT launched by this CLI[\s\S]*iam-api \(port 3010\)[\s\S]*lsof -nP -iTCP:3010/,
+    );
+
+    // The abort fires BEFORE the seed phase — a foreign iam must not be seeded against.
+    expect(runs.some((r) => r.args.some((a) => a.includes('db:seed')))).toBe(false);
+  });
+
+  it('WITHOUT the flag the same adoption stays the existing WARNING (up completes + seeds)', async () => {
+    foreignLauncher(new Set(['iam-api']));
+
+    await StackUp.run(['--only', 'iam-api', ...WS], config);
+
+    expect(warns.some((w) => w.includes('NOT launched by this CLI'))).toBe(true);
+    expect(runs.some((r) => r.args.some((a) => a.includes('db:seed')))).toBe(true);
+  });
+
+  it('with the flag but NO foreign adoption, up completes normally (the gate keys on adoptedForeign)', async () => {
+    await StackUp.run(['--only', 'iam-api', '--forbid-foreign', ...WS], config);
+
+    expect(runs.some((r) => r.args.some((a) => a.includes('db:seed')))).toBe(true);
+  });
+});

--- a/packages/node/saga-stack-cli/src/commands/stack/up.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/up.ts
@@ -145,6 +145,16 @@ export default class StackUp extends BaseCommand {
       description:
         'NATIVE (Phase 2): point a local service set at a cloud sandbox — the sandbox_env dep-repoint overlay (iam URL flip + preview-routing header). Accompanies --only/--with.',
     }),
+    'forbid-foreign': Flags.boolean({
+      // INTERNAL (soa#329 `develop connect --bootstrap` phase 2): hidden — a human
+      // running `stack up` gets the existing WARNING; only the bootstrap sequencer,
+      // whose phase-2 correctness DEPENDS on every service relaunching with the
+      // tunnel env, escalates it to a hard abort.
+      hidden: true,
+      default: false,
+      description:
+        'hard-error (instead of warn) when the bring-up ADOPTS an already-up process this CLI did not launch (no pidfile — env unverifiable).',
+    }),
     workspace: Flags.string({
       description:
         'NATIVE (Phase 2): a switchboard workspace.json selecting per-service run mode (local-source/sandbox) — the general case of --only/--sandbox.',
@@ -507,7 +517,8 @@ export default class StackUp extends BaseCommand {
       );
     }
 
-    const api = makeStackApi(manifest, this.buildRuntime(flags, profile, overlays));
+    const runtime = this.buildRuntime(flags, profile, overlays);
+    const api = makeStackApi(manifest, runtime);
 
     // 1. native bring-up (mesh + topo-wave service launch + M9 auto-pull + AV).
     const up = await api.up(services);
@@ -533,6 +544,18 @@ export default class StackUp extends BaseCommand {
       this.logUpFailure(up);
       this.exit(1);
       return;
+    }
+
+    // soa#329 `--forbid-foreign` (develop connect --bootstrap phase 2): adopting a
+    // FOREIGN process (already up, no pidfile — env unverifiable) silently voids the
+    // down→relaunch guarantee the two-phase tunnel bridge depends on: the survivor
+    // still carries its OLD (e.g. non-tunnel) env. Escalate the report-time warning
+    // below to a hard abort HERE — before reset/seed/tunnel touch anything else.
+    if (flags['forbid-foreign']) {
+      const foreignIds = up.launched.filter((r) => r.adoptedForeign).map((r) => r.id as ServiceId);
+      if (foreignIds.length > 0) {
+        this.error(forbidForeignMessage(foreignIds, runtime.launchContext.ports));
+      }
     }
 
     // 2. (optional) reset — NATIVE (M8 R4). Truncates the closure's DBs to an empty
@@ -774,6 +797,32 @@ export function describeUpFailure(up: UpFailureView): string[] {
   ];
 }
 
+/**
+ * PURE builder for the `--forbid-foreign` abort (soa#329 bootstrap phase 2). A
+ * foreign adoptee by definition has NO pid on record (no pidfile is what makes it
+ * foreign), so the actionable identification is its LISTEN port: each line carries
+ * the exact `lsof` that reveals the pid to kill. Remediation = stop them and
+ * re-run (the bootstrap ledger resumes at the aborted step).
+ */
+export function forbidForeignMessage(
+  ids: ServiceId[],
+  ports: Partial<Record<ServiceId, number>>,
+): string {
+  const rows = ids.map((id) => {
+    const port = ports[id];
+    return port !== undefined
+      ? `  ✗ ${id} (port ${port}) — find the pid:  lsof -nP -iTCP:${port} -sTCP:LISTEN`
+      : `  ✗ ${id} — no resolved port; find it via its health URL's port`;
+  });
+  return [
+    `--forbid-foreign: adopted ${ids.length} process(es) NOT launched by this CLI (already up, no pidfile — env unverifiable):`,
+    ...rows,
+    'They survived `stack down` (down reaps only the pids this CLI recorded), so they still run',
+    'with their OLD launch env — this bring-up REQUIRES every service to relaunch (tunnel bridge).',
+    'Kill the listed listeners, then re-run — the bootstrap ledger resumes at this step.',
+  ].join('\n');
+}
+
 // Local flag shapes (subset of the parsed StackUp flags each path reads).
 type DryRunFlags = WorkspaceFlags & {
   porcelain: boolean;
@@ -790,6 +839,8 @@ type NativeFlags = DryRunFlags & {
   'skip-prep': boolean;
   pull: boolean;
   'no-auto-pull': boolean;
+  /** soa#329 bootstrap phase 2: hard-error on a foreign (pidfile-less) adoption. */
+  'forbid-foreign'?: boolean;
 };
 /**
  * BLOCKER-1 launch-set narrowing for the sandbox/workspace cases (Phase 2). Absent

--- a/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
+++ b/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
@@ -884,8 +884,11 @@ export function tunnelAuthMisconfigMessage(email: string, iamUrl: string): strin
  * Callers gate on `deps.tunnelDomain !== undefined`; a flow with no declared
  * personas skips with a warning (nothing trustworthy to probe — the seed-alias
  * personas exist even in torn dumps).
+ *
+ * EXPORTED (soa#329): `develop connect --bootstrap` runs the SAME probe as its
+ * phase-2 'persona-preflight' step, right after the tunnel-connect restore.
  */
-async function tunnelPersonaPreflight(flow: FlowDef, deps: ExecDeps): Promise<void> {
+export async function tunnelPersonaPreflight(flow: FlowDef, deps: ExecDeps): Promise<void> {
   const domain = deps.tunnelDomain as string;
   const personas = flow.settlePersonas ?? [];
   if (personas.length === 0) {

--- a/packages/node/saga-stack-cli/src/runtime/bootstrap-ledger.ts
+++ b/packages/node/saga-stack-cli/src/runtime/bootstrap-ledger.ts
@@ -1,0 +1,76 @@
+/**
+ * Bootstrap ledger (soa#329 `develop connect --bootstrap`) — the on-disk record
+ * of which two-phase-bridge steps have completed, written to
+ * `<stateDir>/bootstrap.json` after EVERY successful step so a failed run can
+ * RESUME at the failed step instead of rebuilding the world. The sequencer
+ * (commands/develop/bootstrap-connect.ts) NEVER auto-tears-down on failure —
+ * half-built state is debugging evidence — so the ledger is the only thing that
+ * carries progress across runs. It is cleared ONLY when every step completed.
+ *
+ * fs IO lives HERE (src/runtime/** owns real IO); the sequencer consumes it only
+ * through the injectable `BootstrapLedgerIO` seam (the CoachWebFs/settle-barrier
+ * seam precedent), so its resume/clear logic is unit-testable with a fake.
+ */
+
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+/** The on-disk `bootstrap.json` shape. */
+export interface BootstrapLedger {
+  version: 1;
+  /** ISO timestamp of the run that STARTED this ledger (resumes keep it). */
+  startedAt: string;
+  /** Step ids completed so far, in completion order. */
+  completed: string[];
+}
+
+/** The injectable ledger-IO seam (`BaseCommand.getBootstrapLedgerIO`). */
+export interface BootstrapLedgerIO {
+  /** Read + shape-check the ledger; null when absent/corrupt (corrupt ⇒ start over). */
+  read(path: string): BootstrapLedger | null;
+  /** Persist the ledger (mkdir -p the state dir first — a fresh slot has none). */
+  write(path: string, ledger: BootstrapLedger): void;
+  /** Remove the ledger (success-only; force so a missing file is a no-op). */
+  clear(path: string): void;
+}
+
+/** The ledger's canonical location inside a slot's state dir. */
+export function bootstrapLedgerPath(stateDir: string): string {
+  return join(stateDir, 'bootstrap.json');
+}
+
+/** Production ledger IO — the only place bootstrap.json touches the real fs. */
+export function makeRealBootstrapLedgerIO(): BootstrapLedgerIO {
+  return {
+    read(path: string): BootstrapLedger | null {
+      if (!existsSync(path)) return null;
+      let raw: unknown;
+      try {
+        raw = JSON.parse(readFileSync(path, 'utf8'));
+      } catch {
+        return null;
+      }
+      const l = raw as BootstrapLedger;
+      // Minimal boundary check: a corrupt/foreign file must degrade to "no
+      // ledger" (full run), never crash or resume from garbage step ids.
+      if (
+        l === null ||
+        typeof l !== 'object' ||
+        l.version !== 1 ||
+        typeof l.startedAt !== 'string' ||
+        !Array.isArray(l.completed) ||
+        !l.completed.every((s) => typeof s === 'string')
+      ) {
+        return null;
+      }
+      return l;
+    },
+    write(path: string, ledger: BootstrapLedger): void {
+      mkdirSync(dirname(path), { recursive: true });
+      writeFileSync(path, `${JSON.stringify(ledger, null, 2)}\n`);
+    },
+    clear(path: string): void {
+      rmSync(path, { force: true });
+    },
+  };
+}

--- a/packages/node/saga-stack-cli/src/runtime/index.ts
+++ b/packages/node/saga-stack-cli/src/runtime/index.ts
@@ -22,6 +22,7 @@ export * from './prep-repair.js';
 export * from './orphan-audit.js';
 export * from './dash-defaults.js';
 export * from './coach-web-env.js';
+export * from './bootstrap-ledger.js';
 export * from './flows.js';
 export * from './pg-probe.js';
 export * from './prep.js';


### PR DESCRIPTION
Follow-up to #332 (merged ahead of verification) addressing the confirmed findings in **#341**, most importantly the **critical**: stale phase-2 ledger entries skipping tunnel-down/up and thereby **bypassing the foreign hard-stop**.

**Fixes:** phase-2 ledger entries are pruned whenever phase 1 re-runs (kills the critical + both major bypass routes + the fast-path/ledger disagreement); the printed resume command is rebuilt from the actual argv so `--rebuild` and workspace pins survive (kills both resume-command findings).

**Provenance, honestly:** these fixes were authored by the verification pipeline's own fix stage moments before an API-529 outage killed it, then re-derived and gated here: residue-checked, tsc 0, **1312 passed / 110 files** (merged with current main). 

**Draft because the live acceptance is STILL OWED** — rejections → full two-phase from a deleted fixture → fast-path re-run → resume-after-failure. #341 stays open until that evidence exists; this PR closes the ledger findings only.

Refs #341, #332, #329.

🤖 Generated with [Claude Code](https://claude.com/claude-code)