### PR TITLE
Add `ss version` / `ss -v` — runtime-derived auto-incrementing 1.0.x

### DIFF
--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -1,5 +1,137 @@
 {
   "commands": {
+    "version": {
+      "aliases": [],
+      "args": {},
+      "description": "Print the CLI version: major.minor from package.json, auto-incrementing patch = commit count of the CLI package (+short sha, .dirty when the checkout has uncommitted changes).",
+      "examples": [
+        "<%= config.bin %> version",
+        "<%= config.bin %> -v",
+        "<%= config.bin %> version --output-json"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "version",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "slotClaimWritten": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "version.js"
+      ]
+    },
     "develop:coach": {
       "aliases": [],
       "args": {},
@@ -359,6 +491,532 @@
         "commands",
         "develop",
         "connect.js"
+      ]
+    },
+    "e2e:list": {
+      "aliases": [],
+      "args": {},
+      "description": "List discoverable SPAs, their e2e flows, and phases (reads flows.json / the bundled example).",
+      "examples": [
+        "<%= config.bin %> <%= command.id %>",
+        "<%= config.bin %> <%= command.id %> --output-json"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "spa-path": {
+          "description": "explicit path to a flows.json (file or dir) — highest-priority discovery override",
+          "name": "spa-path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "e2e:list",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "slotClaimWritten": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "e2e",
+        "list.js"
+      ]
+    },
+    "e2e:run": {
+      "aliases": [],
+      "args": {},
+      "description": "Run an e2e flow in-process: discover flows.json -> closure -> StackApi up/reset/seed/verify -> Playwright. --dry-run prints the plan.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> journey --through pods --dry-run",
+        "<%= config.bin %> <%= command.id %> saga-dash/journey --through 2 --headless",
+        "<%= config.bin %> <%= command.id %> journey --skip-reset -- --debug",
+        "<%= config.bin %> <%= command.id %> saga-dash/periods-ordering --capture --headless"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "through": {
+          "description": "run THROUGH this phase/stage (name, number, or project); progressive flows run 1..N",
+          "name": "through",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "phase": {
+          "description": "alias of --through",
+          "name": "phase",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "to": {
+          "description": "Plan 13: run UP TO but NOT INCLUDING this phase/stage (name, number, or project) — leaves the stack at that stage's ENTRY state for manual testing. Progressive flows only; mutually exclusive with --through. Pair with --hold for a logged-in browser at the boundary.",
+          "name": "to",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "hold": {
+          "description": "Plan 13: after the run goes green, mint the dev-persona cookie jar and open a logged-in browser at the SPA (slot-offset URL), print a held-state summary, and exit 0 — the stack stays up. Best-effort browser (a headless host warns, never errors).",
+          "name": "hold",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "lane": {
+          "description": "URL lane to target",
+          "name": "lane",
+          "default": "stack",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "stack",
+            "sandbox"
+          ],
+          "type": "option"
+        },
+        "headed": {
+          "description": "force a headed (windowed) run (foreground flows are headed by default)",
+          "name": "headed",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "headless": {
+          "description": "force a headless (CI-style) run; flips a foreground flow off headed",
+          "name": "headless",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "skip-reset": {
+          "description": "reuse the current stack state; skip the reset+seed before Playwright",
+          "name": "skip-reset",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "from": {
+          "description": "M14: start AT this stage (id / number / project — same matching as --through) by RESTORING the predecessor stage's checkpoint instead of replaying earlier Playwright stages. Bake checkpoints first with --snapshot-stages.",
+          "name": "from",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "snapshot-stages": {
+          "description": "M14: bake a DB checkpoint after each green stage (Playwright runs once per stage) so later runs can --from into the middle of the flow. Progressive flows only.",
+          "name": "snapshot-stages",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "from-stale-ok": {
+          "description": "M14: accept a checkpoint older than the 7-day staleness cliff (its baked dates may no longer fit the calendar — you're overriding that guard). Only meaningful with --from.",
+          "name": "from-stale-ok",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "prereq-from-snapshot": {
+          "description": "M14-C: satisfy a flow's prerequisite by RESTORING its terminal-stage checkpoint (when a valid one is baked) instead of the full headless replay; silently falls back to the replay when absent/invalid. NOTE the restore flushes redis (the replay leaves it warm). --no-prereq-from-snapshot forces the replay.",
+          "name": "prereq-from-snapshot",
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "spa-path": {
+          "description": "explicit path to a flows.json (file or dir) — highest-priority discovery override",
+          "name": "spa-path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dry-run": {
+          "description": "plan only: print the resolved flow + closure + seed plan + playwright argv + occurrence date; touch nothing",
+          "name": "dry-run",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "tunnel": {
+          "description": "point the Playwright browser at the vms tunnel hosts (https://<label>.<moniker>.<VMS_BASE>) instead of localhost, so a REMOTE peer can drive this slot-0 stack. Resolves the moniker via the vendored tunnel.sh (same machinery as `stack up --tunnel`); writes the dash tunnel config; exports PLAYWRIGHT_TUNNEL_TIMEOUT_MS for the SPA config. Slot-0 only (hard-errors at --slot > 0 / --set).",
+          "name": "tunnel",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "capture": {
+          "description": "exploratory-review capture: run Playwright with PLAYWRIGHT_CAPTURE=all (per-action trace + video on every test) and PRESERVE the artifacts under <stateDir>/e2e-runs/<runId>/ (Playwright wipes test-results/ at the next run's start). A FAILED stage's artifacts are preserved even without this flag. Review with `e2e traces`.",
+          "name": "capture",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "e2e:run",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": false,
+      "enableJsonFlag": false,
+      "slotClaimWritten": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "e2e",
+        "run.js"
+      ]
+    },
+    "e2e:traces": {
+      "aliases": [],
+      "args": {},
+      "description": "List preserved e2e run traces (from `e2e run --capture` / failed stages), newest first, with paste-ready show-trace commands.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %>",
+        "<%= config.bin %> <%= command.id %> --flow saga-dash/periods-ordering",
+        "<%= config.bin %> <%= command.id %> --open"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "flow": {
+          "description": "filter to one flow ('<spa>/<flow>' or a bare '<flow>' across SPAs)",
+          "name": "flow",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "open": {
+          "description": "open the newest preserved run: PREFERS the whole-run HTML report (`playwright show-report`) when one exists, else falls back to the newest trace (`show-trace`). Best-effort; a headless host warns.",
+          "name": "open",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "e2e:traces",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "slotClaimWritten": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "e2e",
+        "traces.js"
       ]
     },
     "stack:bootstrap": {
@@ -2485,532 +3143,6 @@
         "verify.js"
       ]
     },
-    "e2e:list": {
-      "aliases": [],
-      "args": {},
-      "description": "List discoverable SPAs, their e2e flows, and phases (reads flows.json / the bundled example).",
-      "examples": [
-        "<%= config.bin %> <%= command.id %>",
-        "<%= config.bin %> <%= command.id %> --output-json"
-      ],
-      "flags": {
-        "porcelain": {
-          "description": "machine-readable output; no color, minimal noise",
-          "name": "porcelain",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
-          "name": "slot",
-          "default": 0,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "output-json": {
-          "description": "emit structured JSON on stdout instead of human-readable text",
-          "name": "output-json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "set": {
-          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
-          "name": "set",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dev": {
-          "description": "sibling-repo workspace root (where the saga repos are checked out)",
-          "name": "dev",
-          "noCacheDefault": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
-          "name": "state-dir",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "soa": {
-          "description": "override path to the soa repo checkout",
-          "name": "soa",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rostering": {
-          "description": "override path to the rostering repo checkout",
-          "name": "rostering",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "program-hub": {
-          "description": "override path to the program-hub repo checkout",
-          "name": "program-hub",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "saga-dash": {
-          "description": "override path to the saga-dash repo checkout",
-          "name": "saga-dash",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "coach": {
-          "description": "override path to the coach repo checkout",
-          "name": "coach",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "sds": {
-          "description": "override path to the sds (student-data-system) repo checkout",
-          "name": "sds",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "qboard": {
-          "description": "override path to the qboard repo checkout",
-          "name": "qboard",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rtsm": {
-          "description": "override path to the rtsm repo checkout",
-          "name": "rtsm",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fleek": {
-          "description": "override path to the fleek repo checkout",
-          "name": "fleek",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "spa-path": {
-          "description": "explicit path to a flows.json (file or dir) — highest-priority discovery override",
-          "name": "spa-path",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "e2e:list",
-      "pluginAlias": "@saga-ed/saga-stack-cli",
-      "pluginName": "@saga-ed/saga-stack-cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "slotClaimWritten": false,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "e2e",
-        "list.js"
-      ]
-    },
-    "e2e:run": {
-      "aliases": [],
-      "args": {},
-      "description": "Run an e2e flow in-process: discover flows.json -> closure -> StackApi up/reset/seed/verify -> Playwright. --dry-run prints the plan.",
-      "examples": [
-        "<%= config.bin %> <%= command.id %> journey --through pods --dry-run",
-        "<%= config.bin %> <%= command.id %> saga-dash/journey --through 2 --headless",
-        "<%= config.bin %> <%= command.id %> journey --skip-reset -- --debug",
-        "<%= config.bin %> <%= command.id %> saga-dash/periods-ordering --capture --headless"
-      ],
-      "flags": {
-        "porcelain": {
-          "description": "machine-readable output; no color, minimal noise",
-          "name": "porcelain",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
-          "name": "slot",
-          "default": 0,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "output-json": {
-          "description": "emit structured JSON on stdout instead of human-readable text",
-          "name": "output-json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "set": {
-          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
-          "name": "set",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dev": {
-          "description": "sibling-repo workspace root (where the saga repos are checked out)",
-          "name": "dev",
-          "noCacheDefault": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
-          "name": "state-dir",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "soa": {
-          "description": "override path to the soa repo checkout",
-          "name": "soa",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rostering": {
-          "description": "override path to the rostering repo checkout",
-          "name": "rostering",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "program-hub": {
-          "description": "override path to the program-hub repo checkout",
-          "name": "program-hub",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "saga-dash": {
-          "description": "override path to the saga-dash repo checkout",
-          "name": "saga-dash",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "coach": {
-          "description": "override path to the coach repo checkout",
-          "name": "coach",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "sds": {
-          "description": "override path to the sds (student-data-system) repo checkout",
-          "name": "sds",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "qboard": {
-          "description": "override path to the qboard repo checkout",
-          "name": "qboard",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rtsm": {
-          "description": "override path to the rtsm repo checkout",
-          "name": "rtsm",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fleek": {
-          "description": "override path to the fleek repo checkout",
-          "name": "fleek",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "through": {
-          "description": "run THROUGH this phase/stage (name, number, or project); progressive flows run 1..N",
-          "name": "through",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "phase": {
-          "description": "alias of --through",
-          "name": "phase",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "to": {
-          "description": "Plan 13: run UP TO but NOT INCLUDING this phase/stage (name, number, or project) — leaves the stack at that stage's ENTRY state for manual testing. Progressive flows only; mutually exclusive with --through. Pair with --hold for a logged-in browser at the boundary.",
-          "name": "to",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "hold": {
-          "description": "Plan 13: after the run goes green, mint the dev-persona cookie jar and open a logged-in browser at the SPA (slot-offset URL), print a held-state summary, and exit 0 — the stack stays up. Best-effort browser (a headless host warns, never errors).",
-          "name": "hold",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "lane": {
-          "description": "URL lane to target",
-          "name": "lane",
-          "default": "stack",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "options": [
-            "stack",
-            "sandbox"
-          ],
-          "type": "option"
-        },
-        "headed": {
-          "description": "force a headed (windowed) run (foreground flows are headed by default)",
-          "name": "headed",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "headless": {
-          "description": "force a headless (CI-style) run; flips a foreground flow off headed",
-          "name": "headless",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "skip-reset": {
-          "description": "reuse the current stack state; skip the reset+seed before Playwright",
-          "name": "skip-reset",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "from": {
-          "description": "M14: start AT this stage (id / number / project — same matching as --through) by RESTORING the predecessor stage's checkpoint instead of replaying earlier Playwright stages. Bake checkpoints first with --snapshot-stages.",
-          "name": "from",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "snapshot-stages": {
-          "description": "M14: bake a DB checkpoint after each green stage (Playwright runs once per stage) so later runs can --from into the middle of the flow. Progressive flows only.",
-          "name": "snapshot-stages",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "from-stale-ok": {
-          "description": "M14: accept a checkpoint older than the 7-day staleness cliff (its baked dates may no longer fit the calendar — you're overriding that guard). Only meaningful with --from.",
-          "name": "from-stale-ok",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "prereq-from-snapshot": {
-          "description": "M14-C: satisfy a flow's prerequisite by RESTORING its terminal-stage checkpoint (when a valid one is baked) instead of the full headless replay; silently falls back to the replay when absent/invalid. NOTE the restore flushes redis (the replay leaves it warm). --no-prereq-from-snapshot forces the replay.",
-          "name": "prereq-from-snapshot",
-          "allowNo": true,
-          "type": "boolean"
-        },
-        "spa-path": {
-          "description": "explicit path to a flows.json (file or dir) — highest-priority discovery override",
-          "name": "spa-path",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dry-run": {
-          "description": "plan only: print the resolved flow + closure + seed plan + playwright argv + occurrence date; touch nothing",
-          "name": "dry-run",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "tunnel": {
-          "description": "point the Playwright browser at the vms tunnel hosts (https://<label>.<moniker>.<VMS_BASE>) instead of localhost, so a REMOTE peer can drive this slot-0 stack. Resolves the moniker via the vendored tunnel.sh (same machinery as `stack up --tunnel`); writes the dash tunnel config; exports PLAYWRIGHT_TUNNEL_TIMEOUT_MS for the SPA config. Slot-0 only (hard-errors at --slot > 0 / --set).",
-          "name": "tunnel",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "capture": {
-          "description": "exploratory-review capture: run Playwright with PLAYWRIGHT_CAPTURE=all (per-action trace + video on every test) and PRESERVE the artifacts under <stateDir>/e2e-runs/<runId>/ (Playwright wipes test-results/ at the next run's start). A FAILED stage's artifacts are preserved even without this flag. Review with `e2e traces`.",
-          "name": "capture",
-          "allowNo": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "e2e:run",
-      "pluginAlias": "@saga-ed/saga-stack-cli",
-      "pluginName": "@saga-ed/saga-stack-cli",
-      "pluginType": "core",
-      "strict": false,
-      "enableJsonFlag": false,
-      "slotClaimWritten": false,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "e2e",
-        "run.js"
-      ]
-    },
-    "e2e:traces": {
-      "aliases": [],
-      "args": {},
-      "description": "List preserved e2e run traces (from `e2e run --capture` / failed stages), newest first, with paste-ready show-trace commands.",
-      "examples": [
-        "<%= config.bin %> <%= command.id %>",
-        "<%= config.bin %> <%= command.id %> --flow saga-dash/periods-ordering",
-        "<%= config.bin %> <%= command.id %> --open"
-      ],
-      "flags": {
-        "porcelain": {
-          "description": "machine-readable output; no color, minimal noise",
-          "name": "porcelain",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
-          "name": "slot",
-          "default": 0,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "output-json": {
-          "description": "emit structured JSON on stdout instead of human-readable text",
-          "name": "output-json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "set": {
-          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
-          "name": "set",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dev": {
-          "description": "sibling-repo workspace root (where the saga repos are checked out)",
-          "name": "dev",
-          "noCacheDefault": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
-          "name": "state-dir",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "soa": {
-          "description": "override path to the soa repo checkout",
-          "name": "soa",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rostering": {
-          "description": "override path to the rostering repo checkout",
-          "name": "rostering",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "program-hub": {
-          "description": "override path to the program-hub repo checkout",
-          "name": "program-hub",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "saga-dash": {
-          "description": "override path to the saga-dash repo checkout",
-          "name": "saga-dash",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "coach": {
-          "description": "override path to the coach repo checkout",
-          "name": "coach",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "sds": {
-          "description": "override path to the sds (student-data-system) repo checkout",
-          "name": "sds",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "qboard": {
-          "description": "override path to the qboard repo checkout",
-          "name": "qboard",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rtsm": {
-          "description": "override path to the rtsm repo checkout",
-          "name": "rtsm",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fleek": {
-          "description": "override path to the fleek repo checkout",
-          "name": "fleek",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "flow": {
-          "description": "filter to one flow ('<spa>/<flow>' or a bare '<flow>' across SPAs)",
-          "name": "flow",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "open": {
-          "description": "open the newest preserved run: PREFERS the whole-run HTML report (`playwright show-report`) when one exists, else falls back to the newest trace (`show-trace`). Best-effort; a headless host warns.",
-          "name": "open",
-          "allowNo": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "e2e:traces",
-      "pluginAlias": "@saga-ed/saga-stack-cli",
-      "pluginName": "@saga-ed/saga-stack-cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "slotClaimWritten": false,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "e2e",
-        "traces.js"
-      ]
-    },
     "set:check": {
       "aliases": [],
       "args": {
@@ -4666,5 +4798,5 @@
       ]
     }
   },
-  "version": "0.0.1"
+  "version": "1.0.0"
 }

--- a/packages/node/saga-stack-cli/package.json
+++ b/packages/node/saga-stack-cli/package.json
@@ -1,88 +1,93 @@
 {
-  "name": "@saga-ed/saga-stack-cli",
-  "version": "0.0.1",
-  "type": "module",
-  "description": "Unified CLI for bringing up, seeding, verifying, and e2e-testing the synthetic saga dev stack across all repos. Supersedes mesh-fixture-cli. saga-ed/soa#214.",
-  "bin": {
-    "saga-stack": "./bin/run.js",
-    "ss": "./bin/run.js"
-  },
-  "exports": {
-    "./core": {
-      "import": "./dist/core/index.js",
-      "types": "./dist/core/index.d.ts"
+    "name": "@saga-ed/saga-stack-cli",
+    "version": "1.0.0",
+    "type": "module",
+    "description": "Unified CLI for bringing up, seeding, verifying, and e2e-testing the synthetic saga dev stack across all repos. Supersedes mesh-fixture-cli. saga-ed/soa#214.",
+    "bin": {
+        "saga-stack": "./bin/run.js",
+        "ss": "./bin/run.js"
     },
-    "./stack-api": {
-      "import": "./dist/stack-api.js",
-      "types": "./dist/stack-api.d.ts"
-    }
-  },
-  "oclif": {
-    "bin": "saga-stack",
-    "dirname": "saga-stack",
-    "commands": {
-      "strategy": "pattern",
-      "target": "./dist/commands"
+    "exports": {
+        "./core": {
+            "import": "./dist/core/index.js",
+            "types": "./dist/core/index.d.ts"
+        },
+        "./stack-api": {
+            "import": "./dist/stack-api.js",
+            "types": "./dist/stack-api.d.ts"
+        }
     },
-    "plugins": [
-      "@oclif/plugin-help"
+    "oclif": {
+        "bin": "saga-stack",
+        "dirname": "saga-stack",
+        "commands": {
+            "strategy": "pattern",
+            "target": "./dist/commands"
+        },
+        "plugins": [
+            "@oclif/plugin-help"
+        ],
+        "topicSeparator": " ",
+        "topics": {
+            "stack": {
+                "description": "Bring the synthetic dev stack up/down, seed, reset, verify, and log in."
+            },
+            "stack:snapshot": {
+                "description": "Store, restore, list, validate, and delete native DB snapshots (all pg app DBs + connectv3 mongo)."
+            },
+            "e2e": {
+                "description": "Run end-to-end flows in-process against a running stack."
+            },
+            "develop": {
+                "description": "Concierge scripts that set up and drop you into a developable stack for a specific app or workflow (seed, reset, prerequisites, then hand off a running app)."
+            },
+            "set": {
+                "description": "Worktree sets (M13): named repo\u2192path maps bound to slots \u2014 list, show, and check the parallel dev contexts --set runs against."
+            }
+        },
+        "hooks": {
+            "init": [
+                "./dist/hooks/init/version-flag.js"
+            ]
+        }
+    },
+    "files": [
+        "dist",
+        "vendor",
+        "bin",
+        "examples",
+        "oclif.manifest.json",
+        "README.md"
     ],
-    "topicSeparator": " ",
-    "topics": {
-      "stack": {
-        "description": "Bring the synthetic dev stack up/down, seed, reset, verify, and log in."
-      },
-      "stack:snapshot": {
-        "description": "Store, restore, list, validate, and delete native DB snapshots (all pg app DBs + connectv3 mongo)."
-      },
-      "e2e": {
-        "description": "Run end-to-end flows in-process against a running stack."
-      },
-      "develop": {
-        "description": "Concierge scripts that set up and drop you into a developable stack for a specific app or workflow (seed, reset, prerequisites, then hand off a running app)."
-      },
-      "set": {
-        "description": "Worktree sets (M13): named repo→path maps bound to slots — list, show, and check the parallel dev contexts --set runs against."
-      }
+    "scripts": {
+        "build": "tsc && oclif manifest",
+        "dev": "tsc --watch",
+        "check-types": "tsc --noEmit",
+        "clean": "rm -rf dist oclif.manifest.json",
+        "test": "vitest run",
+        "lint": "eslint src/",
+        "saga-stack": "node bin/run.js"
+    },
+    "dependencies": {
+        "@oclif/core": "^4.0.0",
+        "@oclif/plugin-help": "^6.0.0",
+        "zod": "3.25.67"
+    },
+    "devDependencies": {
+        "@saga-ed/soa-typescript-config": "workspace:*",
+        "@types/node": "latest",
+        "oclif": "^4.22.93",
+        "tsx": "^4.20.3",
+        "typescript": "^5.8.3",
+        "vitest": "^1.5.0"
+    },
+    "publishConfig": {
+        "registry": "https://saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/",
+        "access": "public"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/saga-ed/soa.git",
+        "directory": "packages/node/saga-stack-cli"
     }
-  },
-  "files": [
-    "dist",
-    "vendor",
-    "bin",
-    "examples",
-    "oclif.manifest.json",
-    "README.md"
-  ],
-  "scripts": {
-    "build": "tsc && oclif manifest",
-    "dev": "tsc --watch",
-    "check-types": "tsc --noEmit",
-    "clean": "rm -rf dist oclif.manifest.json",
-    "test": "vitest run",
-    "lint": "eslint src/",
-    "saga-stack": "node bin/run.js"
-  },
-  "dependencies": {
-    "@oclif/core": "^4.0.0",
-    "@oclif/plugin-help": "^6.0.0",
-    "zod": "3.25.67"
-  },
-  "devDependencies": {
-    "@saga-ed/soa-typescript-config": "workspace:*",
-    "@types/node": "latest",
-    "oclif": "^4.22.93",
-    "tsx": "^4.20.3",
-    "typescript": "^5.8.3",
-    "vitest": "^1.5.0"
-  },
-  "publishConfig": {
-    "registry": "https://saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/",
-    "access": "public"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/saga-ed/soa.git",
-    "directory": "packages/node/saga-stack-cli"
-  }
 }

--- a/packages/node/saga-stack-cli/src/commands/version.ts
+++ b/packages/node/saga-stack-cli/src/commands/version.ts
@@ -1,0 +1,62 @@
+/**
+ * `saga-stack version` — print the CLI's runtime-derived version (soa#341).
+ *
+ * `1.0.<n>+<sha>[.dirty]`: major.minor from package.json, patch = commit count
+ * of the CLI package at HEAD (see runtime/cli-version.ts for the full design).
+ * Also reachable as `ss -v` / `ss --version` via the init hook
+ * (src/hooks/init/version-flag.ts). Read-only; never exits non-zero — a
+ * git-less environment folds to the static package.json version.
+ */
+
+import { BaseCommand } from '../base-command.js';
+import { dim } from '../color.js';
+import { computeCliVersion } from '../runtime/index.js';
+
+export default class Version extends BaseCommand {
+  static description =
+    'Print the CLI version: major.minor from package.json, auto-incrementing patch = commit count of the CLI package (+short sha, .dirty when the checkout has uncommitted changes).';
+
+  static examples = [
+    '<%= config.bin %> version',
+    '<%= config.bin %> -v',
+    '<%= config.bin %> version --output-json',
+  ];
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(Version);
+    const v = await computeCliVersion({
+      pkgVersion: this.config.version,
+      pkgRoot: this.config.root,
+      git: this.getGitRunner(),
+    });
+
+    if (flags['output-json']) {
+      this.log(
+        JSON.stringify(
+          {
+            version: v.semver,
+            base: v.base,
+            patch: v.patch,
+            sha: v.sha,
+            dirty: v.dirty,
+            node: process.version,
+            platform: `${process.platform}-${process.arch}`,
+          },
+          null,
+          2,
+        ),
+      );
+      return;
+    }
+    if (flags.porcelain) {
+      this.log(v.semver);
+      return;
+    }
+    this.log(`${this.config.bin} ${v.semver}`);
+    this.log(dim(`${process.platform}-${process.arch} node ${process.version}`));
+  }
+}

--- a/packages/node/saga-stack-cli/src/hooks/init/version-flag.ts
+++ b/packages/node/saga-stack-cli/src/hooks/init/version-flag.ts
@@ -1,0 +1,24 @@
+/**
+ * init hook: route `ss -v` / `ss --version` to the `version` command (soa#341).
+ *
+ * oclif's built-in `--version` prints the STATIC package.json version; ours is
+ * runtime-derived (auto patch + sha + dirty), so both spellings must reach the
+ * same command or the two outputs would disagree. The hook fires before
+ * command dispatch: on a version spelling it runs `version` and exits 0, so
+ * the built-in handler (and the "command not found" error for `-v`) is never
+ * reached. Everything else falls through untouched.
+ */
+
+import type { Hook } from '@oclif/core';
+
+const hook: Hook<'init'> = async function (opts) {
+  if (opts.id === '-v' || opts.id === '--version') {
+    await opts.config.runCommand('version', []);
+    // NOT this.exit(): runHook() CAPTURES hook exceptions (including ExitError),
+    // so dispatch would continue and die on "command -v not found". A hard exit
+    // is safe here: the version command's output is synchronous tty writes.
+    process.exit(0);
+  }
+};
+
+export default hook;

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/cli-version.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/cli-version.unit.test.ts
@@ -1,0 +1,63 @@
+/**
+ * cli-version (soa#341): base from package.json, auto patch from the package's
+ * commit count, sha+dirty build metadata, and the git-less fallback.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { computeCliVersion } from '../cli-version.js';
+import type { GitRunner } from '../git.js';
+
+function fakeGit(over: Partial<GitRunner>): GitRunner {
+  return {
+    commitCount: async () => 218,
+    headSha: async () => '65a9c3fdeadbeef0000000000000000000000000',
+    statusPorcelain: async () => '',
+    ...over,
+  } as GitRunner;
+}
+
+const BASE = { pkgVersion: '1.0.0', pkgRoot: '/repo/packages/node/saga-stack-cli' };
+
+describe('computeCliVersion', () => {
+  it('renders base.patch+shortsha from a clean checkout', async () => {
+    const v = await computeCliVersion({ ...BASE, git: fakeGit({}) });
+    expect(v).toEqual({
+      semver: '1.0.218+65a9c3f',
+      base: '1.0',
+      patch: 218,
+      sha: '65a9c3f',
+      dirty: false,
+    });
+  });
+
+  it('appends .dirty for tracked changes only (untracked files do not count)', async () => {
+    const dirty = await computeCliVersion({
+      ...BASE,
+      git: fakeGit({ statusPorcelain: async () => ' M src/x.ts\n' }),
+    });
+    expect(dirty.semver).toBe('1.0.218+65a9c3f.dirty');
+    const untracked = await computeCliVersion({
+      ...BASE,
+      git: fakeGit({ statusPorcelain: async () => '?? scratch.md\n' }),
+    });
+    expect(untracked.semver).toBe('1.0.218+65a9c3f');
+  });
+
+  it('major.minor track package.json (a manual 1.1.0 bump flows through)', async () => {
+    const v = await computeCliVersion({ ...BASE, pkgVersion: '1.1.0', git: fakeGit({}) });
+    expect(v.semver).toBe('1.1.218+65a9c3f');
+  });
+
+  it('git-less environment folds to the raw package.json version', async () => {
+    const v = await computeCliVersion({
+      ...BASE,
+      git: fakeGit({ commitCount: async () => null, headSha: async () => '' }),
+    });
+    expect(v).toEqual({ semver: '1.0.0', base: '1.0', patch: null, sha: '', dirty: false });
+  });
+
+  it('count without a sha still renders a bare semver (no dangling +)', async () => {
+    const v = await computeCliVersion({ ...BASE, git: fakeGit({ headSha: async () => '' }) });
+    expect(v.semver).toBe('1.0.218');
+  });
+});

--- a/packages/node/saga-stack-cli/src/runtime/cli-version.ts
+++ b/packages/node/saga-stack-cli/src/runtime/cli-version.ts
@@ -1,0 +1,60 @@
+/**
+ * `ss version` — the CLI's auto-incrementing semantic version (soa#341).
+ *
+ * The CLI is repo-resident (always run out of a soa checkout), so the version
+ * is DERIVED AT RUNTIME from git instead of maintained by hand or stamped by
+ * CI: major.minor come from package.json (bumped deliberately on breaking /
+ * feature-line changes), while the PATCH is the commit count of the CLI
+ * package directory at HEAD — monotonic on main, no release process, no bump
+ * commits. Build metadata (semver `+…`, ignored by precedence) carries the
+ * short HEAD sha plus a `.dirty` marker when the checkout has uncommitted
+ * tracked changes — an honest "this binary may not match any commit".
+ *
+ * Every git probe folds to the package.json version on failure (tarball
+ * install, deleted .git, detached environments): `ss version` never throws.
+ * Seam style mirrors slot-active.ts — deps injectable, real defaults inside.
+ */
+
+import { hasTrackedChanges } from './git.js';
+import type { GitRunner } from './git.js';
+
+/** What `ss version` reports. `patch === null` ⇒ git unavailable ⇒ `semver` is the raw package.json version. */
+export interface CliVersion {
+  /** Full rendered version, e.g. `1.0.412+8c1f2ab` or `1.0.412+8c1f2ab.dirty`. */
+  semver: string;
+  /** `major.minor` from package.json, e.g. `1.0`. */
+  base: string;
+  /** Auto patch — commits reaching HEAD that touch the CLI package; null when git failed. */
+  patch: number | null;
+  /** Short (7-char) HEAD sha, `''` when unresolvable. */
+  sha: string;
+  /** The checkout has uncommitted tracked changes (repo-wide — the honest marker). */
+  dirty: boolean;
+}
+
+export interface CliVersionInput {
+  /** package.json `version` — supplies `major.minor`, and the whole fallback. */
+  pkgVersion: string;
+  /** The CLI package root (`this.config.root`) — `git -C` works from any subdir. */
+  pkgRoot: string;
+  /** Injectable git seam (tests); default `makeRealGitRunner()` is supplied by the caller. */
+  git: GitRunner;
+}
+
+/** Compute the runtime version. Pathspec `.` under `-C <pkgRoot>` scopes the count to the package. */
+export async function computeCliVersion({ pkgVersion, pkgRoot, git }: CliVersionInput): Promise<CliVersion> {
+  const base = pkgVersion.split('.').slice(0, 2).join('.');
+  const [patch, headSha, porcelain] = await Promise.all([
+    git.commitCount(pkgRoot, '.'),
+    git.headSha(pkgRoot),
+    git.statusPorcelain(pkgRoot),
+  ]);
+  const sha = headSha.slice(0, 7);
+  const dirty = hasTrackedChanges(porcelain);
+  if (patch === null) {
+    // Git unavailable — fold to the static package.json version, unadorned.
+    return { semver: pkgVersion, base, patch: null, sha, dirty };
+  }
+  const meta = sha === '' ? '' : `+${sha}${dirty ? '.dirty' : ''}`;
+  return { semver: `${base}.${patch}${meta}`, base, patch, sha, dirty };
+}

--- a/packages/node/saga-stack-cli/src/runtime/git.ts
+++ b/packages/node/saga-stack-cli/src/runtime/git.ts
@@ -56,6 +56,12 @@ export interface GitRunner {
   hasUpstream(repoPath: string): Promise<boolean>;
   /** `git rev-list --count HEAD..@{u}` — commits behind upstream (`0` on any error). */
   revListCount(repoPath: string): Promise<number>;
+  /**
+   * `git rev-list --count HEAD [-- <pathspec>]` — total commits reaching HEAD,
+   * optionally restricted to a pathspec (the CLI's auto-incrementing patch
+   * number, soa#—`ss version`). `null` on any error (not a checkout, no HEAD).
+   */
+  commitCount(repoPath: string, pathspec?: string): Promise<number | null>;
   /** `git merge --ff-only @{u}` — true iff it exited 0 (false ⇒ diverged / no ff possible). */
   mergeFfOnly(repoPath: string): Promise<boolean>;
 
@@ -199,6 +205,13 @@ export function makeRealGitRunner(): GitRunner {
       const out = await gitOut(repoPath, ['rev-list', '--count', 'HEAD..@{u}']);
       const n = Number.parseInt(out, 10);
       return Number.isFinite(n) ? n : 0;
+    },
+    async commitCount(repoPath: string, pathspec?: string): Promise<number | null> {
+      const args = ['rev-list', '--count', 'HEAD'];
+      if (pathspec !== undefined) args.push('--', pathspec);
+      const out = await gitOut(repoPath, args);
+      const n = Number.parseInt(out, 10);
+      return Number.isFinite(n) ? n : null;
     },
     mergeFfOnly(repoPath: string): Promise<boolean> {
       return gitOk(repoPath, ['merge', '--ff-only', '@{u}']);

--- a/packages/node/saga-stack-cli/src/runtime/index.ts
+++ b/packages/node/saga-stack-cli/src/runtime/index.ts
@@ -54,3 +54,4 @@ export * from './checkpoint-store.js';
 export * from './trace-preserve.js';
 export * from './foreign-procs.js';
 export * from './claim.js';
+export * from './cli-version.js';


### PR DESCRIPTION
`ss` had no version surface. This adds one with **zero release process** — the version is derived from git at runtime, which works because the CLI always runs out of a soa checkout:

```
$ ss -v
saga-stack 1.0.218+65a9c3f.dirty
linux-x64 node v24.12.0
```

- **`1.0`** — major.minor from `package.json` (bumped to 1.0.0 here; future minor/major bumps are deliberate edits)
- **`.218`** — auto patch: `git rev-list --count HEAD -- <cli package>` — increments with every merged commit touching the package, monotonic on main
- **`+65a9c3f.dirty`** — semver build metadata: short HEAD sha, `.dirty` iff tracked changes exist (honest "this binary may not match any commit")
- git-less environments fold to the raw package.json version; the command never throws

Spellings: `ss version` (+ `--porcelain` bare semver, `--output-json` with node/platform), `ss -v`, `ss --version` — the latter two via an oclif `init` hook, since the built-in `--version` prints the static package.json version and would disagree. `GitRunner` grows `commitCount(repoPath, pathspec?)`.

Suite: 1333 passed (112 files). Smoked live: all three spellings byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)