### PR TITLE
fix(saga-stack-cli): adoption-guard the ads-adm rosterMode override gate (soa#333 review follow-up)

### DIFF
--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
@@ -193,6 +193,10 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
     });
   });
 
+  it('ads-adm-api: the override gate is adoption-guarded (a stale gate-less process is refused, not adopted)', () => {
+    expect(manifest.services['ads-adm-api'].adoptEnv).toContain('ADM_ALLOW_ROSTER_MODE_OVERRIDE');
+  });
+
   it('saga-dash', () => {
     expect(env('saga-dash')).toEqual({
       VITE_ADS_ADM_REAL: 'true',

--- a/packages/node/saga-stack-cli/src/core/manifest/services.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/services.ts
@@ -353,6 +353,13 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
     tunnelSlug: 'ads-adm',
     isFrontend: false,
     optional: false,
+    // Adoption guard (soa#305 pattern): a process launched before this flag
+    // existed carries no gate, and the launcher would happily adopt it — the
+    // #446/#570 period-path probe then hard-fails with a confusing cause
+    // ("ignoring client-supplied rosterMode"). Fingerprinting the key refuses
+    // the stale process instead. One-time "stop and re-run" cost for
+    // pre-existing processes, same as iam-api/saga-dash paid.
+    adoptEnv: ['ADM_ALLOW_ROSTER_MODE_OVERRIDE'],
   },
   'saga-dash': {
     id: 'saga-dash',


### PR DESCRIPTION
The review finding on soa#333 (adoption guard) was pushed to the branch after the PR merged, so main carries the gate but not the guard: without `adoptEnv: ['ADM_ALLOW_ROSTER_MODE_OVERRIDE']` the launcher silently adopts an ads-adm-api launched before the gate existed, and the saga-dash#446/#570 period-path probe hard-fails with a confusing cause ("ignoring client-supplied rosterMode").

One commit: the manifest guard (soa#305 `JWT_ISSUER` pattern) + launcher/manifest test pins. One-time "stop and re-run" cost for pre-existing processes, same as iam-api/saga-dash paid.

Tests: 76/76 in launch-plan/launcher suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3pxfgM1MASnsndUZU7wxd