### PR TITLE
fix(saga-stack-cli): default ADS_ADM_SESSION_DATA_PROVIDER=sessions-api (SESSION grouping survives relaunch)

### DIFF
--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
@@ -175,6 +175,10 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
       // so without this live SESSION rows lose their SLS linkage and render
       // ungrouped (saga-dash gh_560 manual pass).
       ADS_ADM_SESSION_DATA_PROVIDER: 'sessions-api',
+      // Companion gate: the mock policy provider's per-program
+      // sessionDataEnabled default is false — without this the collator
+      // ignores the session layer regardless of the provider binding.
+      ADS_ADM_MOCK_SESSION_DATA_ENABLED: 'true',
       SESSIONS_API_CLIENT_BASEURL: 'http://localhost:3007',
       // NOT an up.sh literal — a deliberate post-up.sh addition (sds#275). ads-adm
       // resolves program display names from programs-api because sessions-api
@@ -204,6 +208,7 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
 
   it('ads-adm-api: the session-data provider is adoption-guarded (a stale legacy-provider process is refused, not adopted)', () => {
     expect(manifest.services['ads-adm-api'].adoptEnv).toContain('ADS_ADM_SESSION_DATA_PROVIDER');
+    expect(manifest.services['ads-adm-api'].adoptEnv).toContain('ADS_ADM_MOCK_SESSION_DATA_ENABLED');
   });
 
   it('saga-dash', () => {

--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
@@ -170,6 +170,11 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
   it('ads-adm-api (tokenized env resolves to exactly up.sh literals at base ports, + PROGRAMS_API_CLIENT_BASEURL)', () => {
     expect(env('ads-adm-api')).toEqual({
       ADS_ADM_SCHEDULE_PROVIDER: 'program-hub',
+      // NOT an up.sh literal — session layer via sessions-api (sds e693d82);
+      // the legacy program-hub provider's ars bridge never runs in the mesh,
+      // so without this live SESSION rows lose their SLS linkage and render
+      // ungrouped (saga-dash gh_560 manual pass).
+      ADS_ADM_SESSION_DATA_PROVIDER: 'sessions-api',
       SESSIONS_API_CLIENT_BASEURL: 'http://localhost:3007',
       // NOT an up.sh literal — a deliberate post-up.sh addition (sds#275). ads-adm
       // resolves program display names from programs-api because sessions-api
@@ -195,6 +200,10 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
 
   it('ads-adm-api: the override gate is adoption-guarded (a stale gate-less process is refused, not adopted)', () => {
     expect(manifest.services['ads-adm-api'].adoptEnv).toContain('ADM_ALLOW_ROSTER_MODE_OVERRIDE');
+  });
+
+  it('ads-adm-api: the session-data provider is adoption-guarded (a stale legacy-provider process is refused, not adopted)', () => {
+    expect(manifest.services['ads-adm-api'].adoptEnv).toContain('ADS_ADM_SESSION_DATA_PROVIDER');
   });
 
   it('saga-dash', () => {

--- a/packages/node/saga-stack-cli/src/core/manifest/services.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/services.ts
@@ -326,6 +326,16 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
       // the tokens expand to exactly the old literals (byte-identity holds).
       env: {
         ADS_ADM_SCHEDULE_PROVIDER: 'program-hub',
+        // Session layer resolves via program-hub's sessions-api (sds e693d82).
+        // Without this the DI default falls back to the legacy program-hub
+        // provider whose saga_api `ars` bridge is retired and never runs in
+        // the synthetic mesh — the collator then never stamps the SLS linkage
+        // (externalSourceType/Id) and every live SESSION row renders under
+        // "Unscheduled" with no per-session grouping (saga-dash gh_560 manual
+        // pass, 2026-07-17). Was previously a hand-exported demo var that
+        // silently died on relaunch; baking it here makes grouping survive
+        // cold-start. Prod is masked by design (never ss-launched).
+        ADS_ADM_SESSION_DATA_PROVIDER: 'sessions-api',
         SESSIONS_API_CLIENT_BASEURL: 'http://localhost:${SESSIONS_PORT}',
         PROGRAMS_API_CLIENT_BASEURL: 'http://localhost:${PROGRAMS_PORT}',
         IAM_API_CLIENT_BASEURL: '${IAM_URL}/trpc',
@@ -359,7 +369,10 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
     // ("ignoring client-supplied rosterMode"). Fingerprinting the key refuses
     // the stale process instead. One-time "stop and re-run" cost for
     // pre-existing processes, same as iam-api/saga-dash paid.
-    adoptEnv: ['ADM_ALLOW_ROSTER_MODE_OVERRIDE'],
+    // ADS_ADM_SESSION_DATA_PROVIDER joins the fingerprint so a pre-existing
+    // process launched without it (legacy provider ⇒ no SESSION grouping) is
+    // refused rather than silently adopted — same trap, same cure.
+    adoptEnv: ['ADM_ALLOW_ROSTER_MODE_OVERRIDE', 'ADS_ADM_SESSION_DATA_PROVIDER'],
   },
   'saga-dash': {
     id: 'saga-dash',

--- a/packages/node/saga-stack-cli/src/core/manifest/services.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/services.ts
@@ -336,6 +336,12 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
         // silently died on relaunch; baking it here makes grouping survive
         // cold-start. Prod is masked by design (never ss-launched).
         ADS_ADM_SESSION_DATA_PROVIDER: 'sessions-api',
+        // Second half of the same gate (sds e693d82): the mock policy
+        // provider defaults sessionDataEnabled=false per program, which makes
+        // the collator IGNORE the session layer (ignoreSessionData) and clear
+        // the SLS stamp even when the provider above is bound. Both vars are
+        // required for grouped SESSION rows; both died together on relaunch.
+        ADS_ADM_MOCK_SESSION_DATA_ENABLED: 'true',
         SESSIONS_API_CLIENT_BASEURL: 'http://localhost:${SESSIONS_PORT}',
         PROGRAMS_API_CLIENT_BASEURL: 'http://localhost:${PROGRAMS_PORT}',
         IAM_API_CLIENT_BASEURL: '${IAM_URL}/trpc',
@@ -372,7 +378,11 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
     // ADS_ADM_SESSION_DATA_PROVIDER joins the fingerprint so a pre-existing
     // process launched without it (legacy provider ⇒ no SESSION grouping) is
     // refused rather than silently adopted — same trap, same cure.
-    adoptEnv: ['ADM_ALLOW_ROSTER_MODE_OVERRIDE', 'ADS_ADM_SESSION_DATA_PROVIDER'],
+    adoptEnv: [
+      'ADM_ALLOW_ROSTER_MODE_OVERRIDE',
+      'ADS_ADM_SESSION_DATA_PROVIDER',
+      'ADS_ADM_MOCK_SESSION_DATA_ENABLED',
+    ],
   },
   'saga-dash': {
     id: 'saga-dash',


### PR DESCRIPTION
Found in the gh_560 attendance manual pass (saga-dash): SESSION-mode attendance rendered **ungrouped** ("Unscheduled", no per-session headers) after this morning's cold start — not a dash regression.

**Chain:** dash groups SESSION rows by the SLS linkage (`externalSourceType='SLS'` + `externalSourceId`) → stamped by ads-adm's collator only when `ADS_ADM_SESSION_DATA_PROVIDER=sessions-api` (sds `e693d82`, env-gated; the DI-default program-hub provider's `ars` bridge is retired and never runs in the mesh) → the var was hand-exported during the gh_570 demos and died on relaunch → cold start dropped it → all rows fall to "Unscheduled".

**Fix:** bake the var into the ads-adm-api manifest env, and add it to the `adoptEnv` fingerprint (soa#305 adoption-guard pattern) so a pre-existing legacy-provider process is refused rather than silently adopted.

Tests: manifest env assertion updated + new adoption-guard case; 1369 pass.

Related: soa#345 (the seed-rerun half of the same relaunch trap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GaRPfxJgeQqpzGp4NeVcRt