### PR TITLE
feat(saga-stack-cli): ss develop session-adm — Connect→ADM telemetry demo concierge

### DIFF
--- a/claude/projects/ss-develop-session-adm-plan.md
+++ b/claude/projects/ss-develop-session-adm-plan.md
@@ -119,3 +119,24 @@ of this one. Slot 1 was the gh_275 effort's test slot; that effort shipped
 
 M0 ✅ merged. M1+M2 ≈ one focused session in the soa repo (`saga-stack-cli`),
 M3 spans claude-plugins + saga-dash docs.
+
+
+## Slot-1 mechanics validation (2026-07-17)
+
+Ran `develop session-adm --slot 1 --no-hold --no-admin` against a virgin slot 1
+(twice; second run `--reuse` after building journey@attendance-personas). Results:
+
+- **Command mechanics: pass** — closure bounce with the demo VITE env, #346-baked
+  `ADS_ADM_*` adoption stamps, journey prerequisite recursion, headless flow launch,
+  failure-path browser/abort handling, and non-zero exit on flow failure (int-test
+  covered; an earlier "exits 0" observation was a `| tail` pipeline artifact).
+- **Demo spec bug found + fixed upstream:** the spec resolved the program by
+  navigating the TUTOR to `/programs`; dash#580 (landing redirects in load()) bounces
+  non-elevated users to `/sessions/list/today`, so resolution dead-ends on any fresh
+  env (slot 0 only appeared to work from pre-#580 residue). Fixed via API-based
+  resolution → saga-dash#650 (draft).
+- **Slot>0 telemetry boundary characterized:** connect-api's ping handler 500s at
+  slot>0 — s2s `sessions.itemGet` UNAUTHORIZED (connect not slot-tokenized). Filed
+  soa#348. Consequence: dosage can only accrue on slot 0, which is now the concrete
+  content of the "AV requires slot 0" doctrine in the command help. Full demo
+  validation (counters climbing, freeze-on-close) happens on slot 0 with a desktop.

--- a/claude/projects/ss-develop-session-adm-plan.md
+++ b/claude/projects/ss-develop-session-adm-plan.md
@@ -1,0 +1,121 @@
+# Plan — `ss develop session-adm` (Connect session-based ADM demo as a develop target)
+
+**Goal:** promote the 3-student staggered self-report Connect→ADM demo from a repo-local
+shell script into the `ss develop` concierge family (today: `coach`, `connect`), so
+"show me live SESSION attendance" is one durable command.
+
+## What exists today (located 2026-07-17)
+
+| Piece | Where |
+|---|---|
+| Demo spec (the showpiece) | `saga-dash/apps/web/dash/e2e/interactive/connect-session-demo.e2e.test.ts` — tutor (alex) + pod-A trio (ann, cara, gina) join a real Connect room staggered ~15s; each runs the real connectv3 `SessionHeartbeat`; ads-adm accrues TELEMETRY dosage; closing one student's window freezes only their counter |
+| Flow registration | `saga-dash/apps/web/dash/e2e/flows.json` → `connect-session-demo` (@interactive, av; prereq: journey@attendance) |
+| Concierge script | `saga-dash/apps/web/dash/e2e/telemetry-demo-multi.sh` — `ss stack down` → held flow w/ demo env → wait for dosage → admin browser |
+| Runbook | `saga-dash/claude/projects/e2e-testing/telemetry-demo.md` ("3 students, staggered self-report" variant) |
+| Single-student sibling | `connect-session-dosage.e2e.test.ts` + `telemetry-demo.sh` |
+| CI-safe half | `e2e/telemetry/ping-dosage-harness.mjs` (direct HTTP pings, no AV) |
+
+Demo env the script injects: `VITE_DASH_LIVE_SESSIONS`, `VITE_DEMO_LIVE_ATTENDANCE`,
+`VITE_CONNECTV3_HEARTBEAT_INTERVAL_MS=3000`, `DEMO_HOLD=1`, plus (today)
+`ADS_ADM_MOCK_SESSION_DATA_ENABLED=true` + `ADS_ADM_SESSION_DATA_PROVIDER=sessions-api`.
+
+## M0 — land soa#346 first ✅ (merged 2026-07-17 18:02, `3051f6b`; primary soa checkout on main, CLI rebuilt)
+
+soa#346 bakes both `ADS_ADM_*` gates into the launcher manifest with adoption guards.
+Once merged, the demo's ads-adm env needs **zero** hand-injection and survives every
+relaunch — the shell script's biggest fragility (and the cause of today's
+"SESSION view regressed" hunt) disappears. The develop target should *assume* #346
+and not re-inject those two vars.
+
+## M1 — the command (`packages/node/saga-stack-cli/src/commands/develop/session-adm.ts`)
+
+Mirror `develop/connect.ts` (BaseCommand → `resolveFlow('saga-dash/connect-session-demo')`
+→ in-process orchestration; the resolver already recurses the journey@attendance
+prerequisite with reset+seed).
+
+Concierge sequence (folding `telemetry-demo-multi.sh` in):
+1. `stack down` (unless `--reuse`) so saga-dash boots with the demo VITE env —
+   the three `VITE_*` flags must be present at dash dev-server launch. Inject them
+   through the launch context as a per-invocation env overlay on the `saga-dash`
+   service (investigate the cleanest seam: `ScriptPlan` / flag-map / manifest env
+   merge — task M1.1).
+2. Bring-up window: journey@attendance prerequisite (checkpoint restore when baked) +
+   up/verify of the demo closure, WITHOUT spawning the demo spec (stages-empty
+   `executeResolvedFlow` — splitting here is what lets step 3 run before the held
+   spawn owns the TTY).
+3. Open the admin view **before** the held run (skip with `--no-admin`): reuse the
+   vendored `browser-login.mjs` path (`stack login empty@saga.org --browser`
+   equivalent) at `/dashboard/attendance?mode=session`. _Reconciled 2026-07-17 (was:
+   poll ads-adm for dosage, then open the browser — see Decision 4 below)._
+4. Run the held flow headed (`DEMO_HOLD=1` equivalent) — foreground, stdio inherited,
+   same AV constraints as `develop connect` (slot-0 LiveKit, `DISPLAY`; media is always
+   Chromium-synthetic — the connect-session-demo project hardcodes it). No CLI-side
+   dosage polling: the spec itself polls ads-adm and prints `[DEMO] Dosage landed`.
+
+Flags (family-consistent):
+- `--reuse` — skip down/rebuild, run against current stack (documents the caveat:
+  VITE demo flags require the dash server to have been launched with them; the
+  known vite stale-serve trap means "touch vite.config.ts" is NOT enough for env)
+- `--fake-media` — accepted for family muscle-memory but a DOCUMENTED NO-OP here: the
+  connect-session-demo Playwright project hardcodes synthetic cam/mic in its
+  launchOptions and never reads `FAKE_MEDIA` (unlike `develop connect`, where it is
+  load-bearing)
+- `--no-admin` — skip the admin browser (script's `--no-admin` parity)
+- `--stagger-ms <n>` — passthrough to `DEMO_STAGGER_MS` (default 15000)
+- `--no-hold` — CI/headless mode (no `page.pause`)
+- `--refresh-snapshot` — rebake journey prerequisite checkpoints (mirrors connect)
+- `-- <argv>` — passthrough to Playwright
+
+## M2 — tests + guardrails
+
+- Unit tests in `commands/develop/__tests__/` for flag→plan mapping (mirror connect's).
+- No CI AV run: the @interactive tag already excludes it; the CI-safe telemetry story
+  stays with the existing `telemetry-dosage` flow.
+- Pod-drift guard: the spec hard-asserts pod-A membership (loud failure on roster
+  drift) — keep; the command should surface that failure with a "re-run journey"
+  remedy hint.
+
+## M3 — docs + retirement
+
+- `ss` skill reference (claude-plugins repo): add `develop session-adm` to the
+  develop-target table + one worked recipe.
+- saga-dash runbook (`telemetry-demo.md`): point the 3-student section at the new
+  command; keep manual steps as the troubleshooting appendix.
+- Fix the known doc inconsistency: runbook/banner say `erin.smith`, spec uses
+  `gina.park` (erin is in Morgan's pod — spec is authoritative).
+- Convert `telemetry-demo-multi.sh` into a 3-line deprecation shim that execs
+  `ss develop session-adm` (same pattern as `e2e connect` → `develop connect`
+  deprecating alias), one release of overlap, then delete.
+
+## Decisions (skelly, 2026-07-17)
+
+1. Name: **`ss develop session-adm`**.
+2. **Multi-only v1** — no `--single`; the single-student sibling stays reachable via
+   `ss e2e run saga-dash/connect-session-dosage`.
+3. **Admin browser auto-opens** (`--no-admin` to opt out) — script parity.
+4. **Admin browser opens BEFORE the held run; no CLI-side dosage gating** (reconciled
+   2026-07-17, build session). The shell script grepped its flow log for
+   `[DEMO] Dosage landed` before opening the dash; in-process the Runner has no output
+   capture, and the spec's 20s DEMO_HOLD pre-join pause exists precisely so an
+   already-open dash watches the counters climb from zero — better choreography, zero
+   new machinery. Accepted tradeoff: a room that never accrues dosage briefly shows a
+   zero dash (the script's sentinel gate prevented that); mitigations shipped — the
+   failure surfaces loud in the Playwright terminal with the pod-drift remedy warn,
+   and the command now CLOSES the admin browser on every failure path rather than
+   leaving a dead zero dash + orphaned Chromium behind.
+
+## Testing posture (skelly, 2026-07-17): slot 1
+
+Development testing targets **slot 1** (`--slot 1` / a worktree set) for everything
+non-AV: the journey@attendance prerequisite, stack lifecycle + adoption guards, the
+VITE env-overlay seam, dosage polling, and the admin-browser plumbing. The **held AV
+demo run itself validates on slot 0** — `ss` pins Connect/AV (LiveKit/coturn) to
+slot 0 by design ("sets are backend+dash contexts at slot>0 — connect stays on
+slot 0"). If lifting that constraint is wanted, it's a separate ss effort, not part
+of this one. Slot 1 was the gh_275 effort's test slot; that effort shipped
+2026-07-16 — reclaim includes clearing its leftover test data.
+
+## Effort & sequencing
+
+M0 ✅ merged. M1+M2 ≈ one focused session in the soa repo (`saga-stack-cli`),
+M3 spans claude-plugins + saga-dash docs.

--- a/packages/node/saga-stack-cli/README.md
+++ b/packages/node/saga-stack-cli/README.md
@@ -123,6 +123,7 @@ the closure, reset + seed it, then drop you into a running app to drive by hand.
 | Command | What it does |
 | --- | --- |
 | **`connect`** | Open a live interactive Connect session (1 tutor + 2 students). Migrated from `e2e connect` (the old id still works with a deprecation warning). |
+| **`session-adm`** | The live SESSION-attendance ADM demo: 3 staggered Connect students self-report telemetry dosage onto an auto-opened admin attendance dash. |
 
 → [docs/develop.md](./docs/develop.md)
 

--- a/packages/node/saga-stack-cli/docs/develop.md
+++ b/packages/node/saga-stack-cli/docs/develop.md
@@ -10,7 +10,7 @@ It is the sibling of [`ss e2e …`](./e2e.md), and the two split by intent:
 
 | Topic | Intent | Commands |
 | --- | --- | --- |
-| **`develop`** | **set up + hand off** a developable stack for an app/workflow | `connect`, `coach` (more coming) |
+| **`develop`** | **set up + hand off** a developable stack for an app/workflow | `connect`, `coach`, `session-adm` (more coming) |
 | **`e2e`** | **run test flows** (assertions, CI, traces) against a stack | `run`, `list`, `traces` |
 
 Reach for `develop` when you want to *use* the app; reach for `e2e` when you want to
@@ -47,6 +47,18 @@ ss develop connect --refresh-snapshot   # rebake the journey prerequisite, then 
   `--student-login <0-2>` leaves some students OPEN for remote peers to take — pair with
   `--tunnel` to invite coworkers. → [tunnel.md](./tunnel.md)
 - Anything after `--` passes straight through to Playwright.
+
+### Deprecation note: `e2e connect` → `develop connect`
+
+`connect` moved from the `e2e` topic to `develop` (dev-setup, not a test flow). The old id
+still works for one cycle via a deprecating alias — `ss e2e connect` dispatches to
+`ss develop connect` and prints:
+
+```
+The "e2e connect" command has been deprecated. Use "develop connect" instead.
+```
+
+Update scripts to `ss develop connect`; the alias is removed in a later release.
 
 ## `develop coach` — a running, logged-in coach
 
@@ -86,16 +98,49 @@ ss develop coach --reuse -- --debug       # against the current stack, playwrigh
 > Requires the `COACH` repo checked out (`$COACH` / `--coach`). coach-web signs in against the local
 > iam via the soa#300 manifest wiring (`PUBLIC_IAM_API_URL` + iam CORS), landed with this topic.
 
-### Deprecation note: `e2e connect` → `develop connect`
+## `develop session-adm` — the live SESSION-attendance ADM demo
 
-`connect` moved from the `e2e` topic to `develop` (dev-setup, not a test flow). The old id
-still works for one cycle via a deprecating alias — `ss e2e connect` dispatches to
-`ss develop connect` and prints:
-
-```
-The "e2e connect" command has been deprecated. Use "develop connect" instead.
+```bash
+ss develop session-adm
 ```
 
-Update scripts to `ss develop connect`; the alias is removed in a later release.
+The 3-student staggered self-report demo as one durable command (promoted from saga-dash's
+`telemetry-demo-multi.sh`): a tutor + Alex's 3 pod-A students (`ann.lee` / `cara.diaz` /
+`gina.park`) join a real Connect room **staggered 15s apart**, each running the real
+connectv3 `SessionHeartbeat`; ads-adm accrues **TELEMETRY dosage** live; closing one
+student's window freezes **only that** counter. The command: `stack down` → relaunch with
+the demo env (live dash polling + 3s heartbeat; the `ADS_ADM_*` session-source gates are
+baked into the manifest since soa#346) → journey@attendance prerequisite (checkpoint
+restore when baked) → **auto-open a logged-in admin browser** at
+`/dashboard/attendance?mode=session` (as `empty@saga.org`; `$ADMIN_EMAIL` overrides) →
+the held headed demo. The admin dash opens **before** the students join — the demo's
+pre-join hold exists so you watch the counters climb from zero. Pick
+**"E2E Journey Program"** in the dash. Resume (▶) in the Playwright Inspector ends the
+run; the stack stays up (`ss stack down` when done).
+
+```bash
+ss develop session-adm                       # full: down → demo env → prereq → admin dash → held demo
+ss develop session-adm --reuse --no-admin    # against the current stack, no admin browser
+ss develop session-adm --stagger-ms 6000     # faster joins (DEMO_STAGGER_MS)
+ss develop session-adm --refresh-snapshot    # rebake journey@attendance, then run the demo
+```
+
+- `--no-admin` skips the admin browser and prints the manual login one-liner (script parity;
+  at `--slot N` the one-liner carries `--slot N` so the jar mints against the right iam).
+- `--no-hold` drops `DEMO_HOLD` (no pre-join pause, no Inspector hold) — a straight-through
+  run; the auto-opened admin browser is closed at the end instead of holding the terminal.
+- `--stagger-ms <n>` pins `DEMO_STAGGER_MS` (default **15000** — pinned explicitly; the spec's
+  own fallback is 6s).
+- `--reuse` skips the down + prerequisite + reset. **Caveat:** the demo VITE env only reaches
+  services *this run launches* — an already-up saga-dash/connect-web keeps its stale env, so
+  `--reuse` presumes a previous `session-adm` bring-up.
+- `--refresh-snapshot` / `--` passthrough: as `develop connect`. Media is **always synthetic**:
+  the demo's Playwright project hardcodes Chromium's fake cam/mic (+ mute) in its
+  launchOptions, so a camera-less box needs nothing — `--fake-media` is accepted as a no-op
+  for family muscle-memory only (unlike `connect`, nothing here reads `FAKE_MEDIA`).
+- **AV stays on slot 0**: `--slot N` runs all non-AV mechanics on slot N, but LiveKit/coturn
+  are the shared slot-0 containers (started by `ss stack up`, not this command) — without them
+  heartbeats never start and dosage never lands. Multi-only v1: the single-student sibling
+  stays reachable via `ss e2e run saga-dash/connect-session-dosage`.
 
 ← [snapshots](./snapshots.md) · [e2e](./e2e.md) · [integration →](./integration.md)

--- a/packages/node/saga-stack-cli/examples/flows/saga-dash.flows.json
+++ b/packages/node/saga-stack-cli/examples/flows/saga-dash.flows.json
@@ -79,6 +79,24 @@
       ]
     },
     {
+      "name": "connect-session-demo",
+      "description": "STANDUP DEMO of per-student SESSION self-report telemetry (qboard#302 emitters + connectv3-api v3 ingress + student-data-system#251 v3 single-subject consumer). A tutor joins, then Alex's 3 pod-A students (ann.lee/cara.diaz/gina.park) JOIN staggered 15s apart, each in its OWN closeable Connect window (FAKE media). Each student's SESSION measured-time counter climbs independently on the admin dash; closing one student's window FREEZES only that counter (its self-report pings stop) while the others keep climbing. Held open via DEMO_HOLD for a presenter. Needs the connectv3 build with VITE_CONNECTV3_HEARTBEAT_INTERVAL_MS small for a fast cadence, and the ads-adm SLS-grouping fix (student-data-system) so the rows group UNDER their session, not Unscheduled.",
+      "lanes": ["stack"],
+      "progressive": false,
+      "foreground": true,
+      "av": true,
+      "prerequisite": { "flow": "journey", "throughStage": "attendance" },
+      "stages": [
+        {
+          "id": "connect-session-demo",
+          "project": "connect-session-demo",
+          "spec": "interactive/connect-session-demo.e2e.test.ts",
+          "requiredSystems": ["connect-web", "connect-api", "rtsm-api", "sessions-api", "ads-adm-api", "iam-api", "programs-api"],
+          "tags": ["@interactive"]
+        }
+      ]
+    },
+    {
       "name": "connect-session",
       "description": "Live interactive Connect tutoring session (1 tutor + 2 students). Builds the journey end-state through 'schedule' first, then drives a real Connect room.",
       "lanes": ["stack"],

--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -507,13 +507,15 @@
         "connect.js"
       ]
     },
-    "e2e:list": {
+    "develop:session-adm": {
       "aliases": [],
       "args": {},
-      "description": "List discoverable SPAs, their e2e flows, and phases (reads flows.json / the bundled example).",
+      "description": "Run the live SESSION-attendance ADM demo: 3 staggered Connect students self-report telemetry dosage onto an auto-opened admin attendance dash (in-process; journey prerequisite, then a held headed room).",
       "examples": [
         "<%= config.bin %> <%= command.id %>",
-        "<%= config.bin %> <%= command.id %> --output-json"
+        "<%= config.bin %> <%= command.id %> --reuse --no-admin",
+        "<%= config.bin %> <%= command.id %> --stagger-ms 6000 -- --debug",
+        "<%= config.bin %> <%= command.id %> --refresh-snapshot"
       ],
       "flags": {
         "porcelain": {
@@ -621,227 +623,22 @@
           "multiple": false,
           "type": "option"
         },
-        "spa-path": {
-          "description": "explicit path to a flows.json (file or dir) — highest-priority discovery override",
-          "name": "spa-path",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "e2e:list",
-      "pluginAlias": "@saga-ed/saga-stack-cli",
-      "pluginName": "@saga-ed/saga-stack-cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "slotClaimWritten": false,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "e2e",
-        "list.js"
-      ]
-    },
-    "e2e:run": {
-      "aliases": [],
-      "args": {},
-      "description": "Run an e2e flow in-process: discover flows.json -> closure -> StackApi up/reset/seed/verify -> Playwright. --dry-run prints the plan.",
-      "examples": [
-        "<%= config.bin %> <%= command.id %> journey --through pods --dry-run",
-        "<%= config.bin %> <%= command.id %> saga-dash/journey --through 2 --headless",
-        "<%= config.bin %> <%= command.id %> journey --skip-reset -- --debug",
-        "<%= config.bin %> <%= command.id %> saga-dash/periods-ordering --capture --headless"
-      ],
-      "flags": {
-        "porcelain": {
-          "description": "machine-readable output; no color, minimal noise",
-          "name": "porcelain",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
-          "name": "slot",
-          "default": 0,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "output-json": {
-          "description": "emit structured JSON on stdout instead of human-readable text",
-          "name": "output-json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "set": {
-          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
-          "name": "set",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dev": {
-          "description": "sibling-repo workspace root (where the saga repos are checked out)",
-          "name": "dev",
-          "noCacheDefault": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
-          "name": "state-dir",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "soa": {
-          "description": "override path to the soa repo checkout",
-          "name": "soa",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rostering": {
-          "description": "override path to the rostering repo checkout",
-          "name": "rostering",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "program-hub": {
-          "description": "override path to the program-hub repo checkout",
-          "name": "program-hub",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "saga-dash": {
-          "description": "override path to the saga-dash repo checkout",
-          "name": "saga-dash",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "coach": {
-          "description": "override path to the coach repo checkout",
-          "name": "coach",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "sds": {
-          "description": "override path to the sds (student-data-system) repo checkout",
-          "name": "sds",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "qboard": {
-          "description": "override path to the qboard repo checkout",
-          "name": "qboard",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rtsm": {
-          "description": "override path to the rtsm repo checkout",
-          "name": "rtsm",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fleek": {
-          "description": "override path to the fleek repo checkout",
-          "name": "fleek",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "through": {
-          "description": "run THROUGH this phase/stage (name, number, or project); progressive flows run 1..N",
-          "name": "through",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "phase": {
-          "description": "alias of --through",
-          "name": "phase",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "to": {
-          "description": "Plan 13: run UP TO but NOT INCLUDING this phase/stage (name, number, or project) — leaves the stack at that stage's ENTRY state for manual testing. Progressive flows only; mutually exclusive with --through. Pair with --hold for a logged-in browser at the boundary.",
-          "name": "to",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "hold": {
-          "description": "Plan 13: after the run goes green, mint the dev-persona cookie jar and open a logged-in browser at the SPA (slot-offset URL), print a held-state summary, and exit 0 — the stack stays up. Best-effort browser (a headless host warns, never errors).",
-          "name": "hold",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "lane": {
-          "description": "URL lane to target",
-          "name": "lane",
-          "default": "stack",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "options": [
-            "stack",
-            "sandbox"
-          ],
-          "type": "option"
-        },
-        "headed": {
-          "description": "force a headed (windowed) run (foreground flows are headed by default)",
-          "name": "headed",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "headless": {
-          "description": "force a headless (CI-style) run; flips a foreground flow off headed",
-          "name": "headless",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "skip-reset": {
-          "description": "reuse the current stack state; skip the reset+seed before Playwright",
-          "name": "skip-reset",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "from": {
-          "description": "M14: start AT this stage (id / number / project — same matching as --through) by RESTORING the predecessor stage's checkpoint instead of replaying earlier Playwright stages. Bake checkpoints first with --snapshot-stages.",
-          "name": "from",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "snapshot-stages": {
-          "description": "M14: bake a DB checkpoint after each green stage (Playwright runs once per stage) so later runs can --from into the middle of the flow. Progressive flows only.",
-          "name": "snapshot-stages",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "from-stale-ok": {
-          "description": "M14: accept a checkpoint older than the 7-day staleness cliff (its baked dates may no longer fit the calendar — you're overriding that guard). Only meaningful with --from.",
-          "name": "from-stale-ok",
+        "reuse": {
+          "description": "skip the stack down + journey-prerequisite rebuild + reset; run the demo against the CURRENT stack state. CAVEAT: the demo VITE env only reaches services THIS run launches — an already-up saga-dash/connect-web is adopted untouched, so live polling / the 3s heartbeat need the stack to have been brought up by a previous session-adm run.",
+          "name": "reuse",
           "allowNo": false,
           "type": "boolean"
         },
         "prereq-from-snapshot": {
-          "description": "M14-C: satisfy a flow's prerequisite by RESTORING its terminal-stage checkpoint (when a valid one is baked) instead of the full headless replay; silently falls back to the replay when absent/invalid. NOTE the restore flushes redis (the replay leaves it warm). --no-prereq-from-snapshot forces the replay.",
+          "description": "restore the journey@attendance checkpoint (when a valid one is baked) instead of replaying the whole journey headless — the big accelerant (mirrors develop connect). Falls back to the replay when absent/invalid; --reuse trumps this entirely.",
           "name": "prereq-from-snapshot",
           "allowNo": true,
+          "type": "boolean"
+        },
+        "refresh-snapshot": {
+          "description": "bake the journey prerequisite checkpoints FRESH (headless replay through `attendance`, --snapshot-stages) BEFORE the demo, then restore that just-made checkpoint — the one-command reseed for a stale (>7d) or drifted journey (and the remedy for the pod-A roster-drift guard). Requires --prereq-from-snapshot (the default); mutually exclusive with --reuse.",
+          "name": "refresh-snapshot",
+          "allowNo": false,
           "type": "boolean"
         },
         "spa-path": {
@@ -851,28 +648,36 @@
           "multiple": false,
           "type": "option"
         },
-        "dry-run": {
-          "description": "plan only: print the resolved flow + closure + seed plan + playwright argv + occurrence date; touch nothing",
-          "name": "dry-run",
+        "fake-media": {
+          "description": "NO-OP for this demo, accepted only for develop-family muscle-memory: the connect-session-demo Playwright project HARDCODES Chromium's synthetic camera + mic (+ --mute-audio) in its launchOptions, so the demo NEVER captures real devices — with or without this flag. (Unlike develop connect, where FAKE_MEDIA=1 is load-bearing.) Still pins FAKE_MEDIA=1 on the demo spawn; nothing in that project reads it.",
+          "name": "fake-media",
           "allowNo": false,
           "type": "boolean"
         },
-        "tunnel": {
-          "description": "point the Playwright browser at the vms tunnel hosts (https://<label>.<moniker>.<VMS_BASE>) instead of localhost, so a REMOTE peer can drive this slot-0 stack. Resolves the moniker via the vendored tunnel.sh (same machinery as `stack up --tunnel`); writes the dash tunnel config; exports PLAYWRIGHT_TUNNEL_TIMEOUT_MS for the SPA config. Slot-0 only (hard-errors at --slot > 0 / --set).",
-          "name": "tunnel",
-          "allowNo": false,
+        "admin": {
+          "description": "auto-open the vendored logged-in admin browser (empty@saga.org, override via $ADMIN_EMAIL) at /dashboard/attendance?mode=session once the stack is ready, BEFORE the students join — the pre-join hold exists so the counters visibly climb from zero. --no-admin skips it and prints the manual login one-liner instead (script parity).",
+          "name": "admin",
+          "allowNo": true,
           "type": "boolean"
         },
-        "capture": {
-          "description": "exploratory-review capture: run Playwright with PLAYWRIGHT_CAPTURE=all (per-action trace + video on every test) and PRESERVE the artifacts under <stateDir>/e2e-runs/<runId>/ (Playwright wipes test-results/ at the next run's start). A FAILED stage's artifacts are preserved even without this flag. Review with `e2e traces`.",
-          "name": "capture",
-          "allowNo": false,
+        "hold": {
+          "description": "hold the demo open for a presenter (DEMO_HOLD=1): a 20s pre-join pause (open the admin dash now), then after dosage lands every window stays open via the Playwright Inspector — close one student window to freeze its counter, Resume (▶) to end. --no-hold drops the pauses for a CI-ish straight-through run (the auto-opened admin browser is closed at the end instead of holding the terminal).",
+          "name": "hold",
+          "allowNo": true,
           "type": "boolean"
+        },
+        "stagger-ms": {
+          "description": "gap between student joins (DEMO_STAGGER_MS). Default 15000 — the demo's advertised 15s cadence, pinned EXPLICITLY because the spec's own fallback is 6s.",
+          "name": "stagger-ms",
+          "default": 15000,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         }
       },
       "hasDynamicHelp": false,
       "hiddenAliases": [],
-      "id": "e2e:run",
+      "id": "develop:session-adm",
       "pluginAlias": "@saga-ed/saga-stack-cli",
       "pluginName": "@saga-ed/saga-stack-cli",
       "pluginType": "core",
@@ -883,154 +688,8 @@
       "relativePath": [
         "dist",
         "commands",
-        "e2e",
-        "run.js"
-      ]
-    },
-    "e2e:traces": {
-      "aliases": [],
-      "args": {},
-      "description": "List preserved e2e run traces (from `e2e run --capture` / failed stages), newest first, with paste-ready show-trace commands.",
-      "examples": [
-        "<%= config.bin %> <%= command.id %>",
-        "<%= config.bin %> <%= command.id %> --flow saga-dash/periods-ordering",
-        "<%= config.bin %> <%= command.id %> --open"
-      ],
-      "flags": {
-        "porcelain": {
-          "description": "machine-readable output; no color, minimal noise",
-          "name": "porcelain",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
-          "name": "slot",
-          "default": 0,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "output-json": {
-          "description": "emit structured JSON on stdout instead of human-readable text",
-          "name": "output-json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "set": {
-          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
-          "name": "set",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dev": {
-          "description": "sibling-repo workspace root (where the saga repos are checked out)",
-          "name": "dev",
-          "noCacheDefault": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
-          "name": "state-dir",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "soa": {
-          "description": "override path to the soa repo checkout",
-          "name": "soa",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rostering": {
-          "description": "override path to the rostering repo checkout",
-          "name": "rostering",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "program-hub": {
-          "description": "override path to the program-hub repo checkout",
-          "name": "program-hub",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "saga-dash": {
-          "description": "override path to the saga-dash repo checkout",
-          "name": "saga-dash",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "coach": {
-          "description": "override path to the coach repo checkout",
-          "name": "coach",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "sds": {
-          "description": "override path to the sds (student-data-system) repo checkout",
-          "name": "sds",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "qboard": {
-          "description": "override path to the qboard repo checkout",
-          "name": "qboard",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rtsm": {
-          "description": "override path to the rtsm repo checkout",
-          "name": "rtsm",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fleek": {
-          "description": "override path to the fleek repo checkout",
-          "name": "fleek",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "flow": {
-          "description": "filter to one flow ('<spa>/<flow>' or a bare '<flow>' across SPAs)",
-          "name": "flow",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "open": {
-          "description": "open the newest preserved run: PREFERS the whole-run HTML report (`playwright show-report`) when one exists, else falls back to the newest trace (`show-trace`). Best-effort; a headless host warns.",
-          "name": "open",
-          "allowNo": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "e2e:traces",
-      "pluginAlias": "@saga-ed/saga-stack-cli",
-      "pluginName": "@saga-ed/saga-stack-cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "slotClaimWritten": false,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "e2e",
-        "traces.js"
+        "develop",
+        "session-adm.js"
       ]
     },
     "stack:bootstrap": {
@@ -3162,6 +2821,532 @@
         "commands",
         "stack",
         "verify.js"
+      ]
+    },
+    "e2e:list": {
+      "aliases": [],
+      "args": {},
+      "description": "List discoverable SPAs, their e2e flows, and phases (reads flows.json / the bundled example).",
+      "examples": [
+        "<%= config.bin %> <%= command.id %>",
+        "<%= config.bin %> <%= command.id %> --output-json"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "spa-path": {
+          "description": "explicit path to a flows.json (file or dir) — highest-priority discovery override",
+          "name": "spa-path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "e2e:list",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "slotClaimWritten": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "e2e",
+        "list.js"
+      ]
+    },
+    "e2e:run": {
+      "aliases": [],
+      "args": {},
+      "description": "Run an e2e flow in-process: discover flows.json -> closure -> StackApi up/reset/seed/verify -> Playwright. --dry-run prints the plan.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> journey --through pods --dry-run",
+        "<%= config.bin %> <%= command.id %> saga-dash/journey --through 2 --headless",
+        "<%= config.bin %> <%= command.id %> journey --skip-reset -- --debug",
+        "<%= config.bin %> <%= command.id %> saga-dash/periods-ordering --capture --headless"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "through": {
+          "description": "run THROUGH this phase/stage (name, number, or project); progressive flows run 1..N",
+          "name": "through",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "phase": {
+          "description": "alias of --through",
+          "name": "phase",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "to": {
+          "description": "Plan 13: run UP TO but NOT INCLUDING this phase/stage (name, number, or project) — leaves the stack at that stage's ENTRY state for manual testing. Progressive flows only; mutually exclusive with --through. Pair with --hold for a logged-in browser at the boundary.",
+          "name": "to",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "hold": {
+          "description": "Plan 13: after the run goes green, mint the dev-persona cookie jar and open a logged-in browser at the SPA (slot-offset URL), print a held-state summary, and exit 0 — the stack stays up. Best-effort browser (a headless host warns, never errors).",
+          "name": "hold",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "lane": {
+          "description": "URL lane to target",
+          "name": "lane",
+          "default": "stack",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "stack",
+            "sandbox"
+          ],
+          "type": "option"
+        },
+        "headed": {
+          "description": "force a headed (windowed) run (foreground flows are headed by default)",
+          "name": "headed",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "headless": {
+          "description": "force a headless (CI-style) run; flips a foreground flow off headed",
+          "name": "headless",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "skip-reset": {
+          "description": "reuse the current stack state; skip the reset+seed before Playwright",
+          "name": "skip-reset",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "from": {
+          "description": "M14: start AT this stage (id / number / project — same matching as --through) by RESTORING the predecessor stage's checkpoint instead of replaying earlier Playwright stages. Bake checkpoints first with --snapshot-stages.",
+          "name": "from",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "snapshot-stages": {
+          "description": "M14: bake a DB checkpoint after each green stage (Playwright runs once per stage) so later runs can --from into the middle of the flow. Progressive flows only.",
+          "name": "snapshot-stages",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "from-stale-ok": {
+          "description": "M14: accept a checkpoint older than the 7-day staleness cliff (its baked dates may no longer fit the calendar — you're overriding that guard). Only meaningful with --from.",
+          "name": "from-stale-ok",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "prereq-from-snapshot": {
+          "description": "M14-C: satisfy a flow's prerequisite by RESTORING its terminal-stage checkpoint (when a valid one is baked) instead of the full headless replay; silently falls back to the replay when absent/invalid. NOTE the restore flushes redis (the replay leaves it warm). --no-prereq-from-snapshot forces the replay.",
+          "name": "prereq-from-snapshot",
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "spa-path": {
+          "description": "explicit path to a flows.json (file or dir) — highest-priority discovery override",
+          "name": "spa-path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dry-run": {
+          "description": "plan only: print the resolved flow + closure + seed plan + playwright argv + occurrence date; touch nothing",
+          "name": "dry-run",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "tunnel": {
+          "description": "point the Playwright browser at the vms tunnel hosts (https://<label>.<moniker>.<VMS_BASE>) instead of localhost, so a REMOTE peer can drive this slot-0 stack. Resolves the moniker via the vendored tunnel.sh (same machinery as `stack up --tunnel`); writes the dash tunnel config; exports PLAYWRIGHT_TUNNEL_TIMEOUT_MS for the SPA config. Slot-0 only (hard-errors at --slot > 0 / --set).",
+          "name": "tunnel",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "capture": {
+          "description": "exploratory-review capture: run Playwright with PLAYWRIGHT_CAPTURE=all (per-action trace + video on every test) and PRESERVE the artifacts under <stateDir>/e2e-runs/<runId>/ (Playwright wipes test-results/ at the next run's start). A FAILED stage's artifacts are preserved even without this flag. Review with `e2e traces`.",
+          "name": "capture",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "e2e:run",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": false,
+      "enableJsonFlag": false,
+      "slotClaimWritten": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "e2e",
+        "run.js"
+      ]
+    },
+    "e2e:traces": {
+      "aliases": [],
+      "args": {},
+      "description": "List preserved e2e run traces (from `e2e run --capture` / failed stages), newest first, with paste-ready show-trace commands.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %>",
+        "<%= config.bin %> <%= command.id %> --flow saga-dash/periods-ordering",
+        "<%= config.bin %> <%= command.id %> --open"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "flow": {
+          "description": "filter to one flow ('<spa>/<flow>' or a bare '<flow>' across SPAs)",
+          "name": "flow",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "open": {
+          "description": "open the newest preserved run: PREFERS the whole-run HTML report (`playwright show-report`) when one exists, else falls back to the newest trace (`show-trace`). Best-effort; a headless host warns.",
+          "name": "open",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "e2e:traces",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "slotClaimWritten": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "e2e",
+        "traces.js"
       ]
     },
     "set:check": {

--- a/packages/node/saga-stack-cli/src/base-command.ts
+++ b/packages/node/saga-stack-cli/src/base-command.ts
@@ -1073,7 +1073,7 @@ export abstract class BaseCommand extends Command {
    * propagated (unless `propagateExit:false`, e.g. the best-effort browser step).
    */
   protected async runVendor(
-    spec: { cwd: string; command: string; args: string[]; env: Record<string, string> },
+    spec: { cwd: string; command: string; args: string[]; env: Record<string, string>; signal?: AbortSignal },
     flags: WorkspaceFlags,
     opts: { propagateExit?: boolean } = {},
   ): Promise<number> {
@@ -1085,6 +1085,7 @@ export abstract class BaseCommand extends Command {
       args: spec.args,
       env,
       stdio: 'inherit',
+      signal: spec.signal,
     });
     if (opts.propagateExit !== false && code !== 0) {
       this.exit(code);
@@ -1159,6 +1160,13 @@ export abstract class BaseCommand extends Command {
        * is absent (a bare `stack login` with no run-resolved URL).
        */
       spa?: { repoEnvVar: ManifestRepoKey; appDir: string; port?: number };
+      /**
+       * Optional caller-owned abort handle (develop session-adm's admin-browser
+       * lifecycle): aborting kills the vendored browser child instead of leaving
+       * it orphaned when the command exits first. An abort-triggered spawn
+       * rejection is the CALLER's own close request — swallowed, never warned.
+       */
+      signal?: AbortSignal;
     },
   ): Promise<void> {
     const script = resolveVendorScript('browser-login.mjs');
@@ -1196,10 +1204,15 @@ export abstract class BaseCommand extends Command {
       SAGA_DASH_DASH: spaAppDir,
     };
     try {
-      await this.runVendor({ cwd: spaAppDir, command: 'node', args: [script], env }, flags, {
-        propagateExit: false,
-      });
+      await this.runVendor(
+        { cwd: spaAppDir, command: 'node', args: [script], env, signal: ctx.signal },
+        flags,
+        { propagateExit: false },
+      );
     } catch (err) {
+      // The caller aborted (killed the browser child on its own exit path) —
+      // the AbortError rejection is the requested close, not a failure.
+      if (ctx.signal?.aborted) return;
       // spawn-level failure (node missing, ENOENT race, …) — warn, never redden.
       this.warn(`headful browser skipped — ${err instanceof Error ? err.message : String(err)}`);
     }

--- a/packages/node/saga-stack-cli/src/commands/develop/__tests__/session-adm.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/__tests__/session-adm.int.test.ts
@@ -1,0 +1,424 @@
+/**
+ * `develop session-adm` integration tests (M2, ss-develop-session-adm plan) —
+ * the demo concierge driven through the REAL oclif command with every
+ * BaseCommand IO seam faked (connect.int/coach.int harness). NOTHING is
+ * spawned; the fake Runner/Launcher record the intended invocations.
+ *
+ * Coverage owned here (the axes the sibling suites don't):
+ *  - the DEMO SERVICE ENV seam: the three VITE_* keys are in `process.env` at
+ *    the moment saga-dash/connect-web LAUNCH (the launcher spreads process.env
+ *    into fresh spawns), and the soa#346-baked ADS_ADM_* gates are NOT
+ *    re-injected by the command;
+ *  - the down-first contract (StackDown runs, slot-forwarded, unless --reuse);
+ *  - the held-run Playwright env (DEMO_HOLD / DEMO_STAGGER_MS / FAKE_MEDIA)
+ *    reaching ONLY the demo spawn, never the journey prerequisite;
+ *  - the admin hand-off (jar + vendored browser at the SESSION-mode attendance
+ *    dash, fired BEFORE the held spawn; --no-admin / mint-failure degradations);
+ *  - the admin-browser LIFECYCLE (held-success awaits the window; --no-hold and
+ *    the demo-failure path ABORT the child — never orphaned);
+ *  - slot plumbing (offset state dir / iam / dash URL / slot-pinned login
+ *    remediation one-liners — concrete slot-2 proofs);
+ *  - the --refresh-snapshot bake path (the shared bakePrerequisiteCheckpoints
+ *    helper, wired with THIS command's slot-offset deps).
+ */
+
+import { join, resolve } from 'node:path';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { Config } from '@oclif/core';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BaseCommand } from '../../../base-command.js';
+import type { ScriptInvocation } from '../../../runtime/index.js';
+import type { CheckpointStore, CookiePoster, JarWriter, LaunchResult, LaunchSpec, PostOptions, PostResult, ServiceLauncher, StopResult } from '../../../runtime/index.js';
+import { restoreEnv, saveEnv, useTempSnapshotsDir } from '../../../__tests__/helpers/env.js';
+import type { EnvSnapshot } from '../../../__tests__/helpers/env.js';
+import { installCoreSeams } from '../../../__tests__/helpers/seams.js';
+import StackDown from '../../stack/down.js';
+import DevelopSessionAdm from '../session-adm.js';
+
+const PKG_ROOT = process.cwd();
+const SOA_ROOT = resolve(PKG_ROOT, '..', '..', '..');
+const DEV_ROOT = '/fixed/dev';
+
+/** The command MUTATES process.env (the service-env seam) — snapshot + restore per test. */
+const ENV_KEYS = [
+  'VITE_DASH_LIVE_SESSIONS',
+  'VITE_DEMO_LIVE_ATTENDANCE',
+  'VITE_CONNECTV3_HEARTBEAT_INTERVAL_MS',
+  'ADS_ADM_SESSION_DATA_PROVIDER',
+  'ADS_ADM_MOCK_SESSION_DATA_ENABLED',
+  'ADMIN_EMAIL',
+  'LOGIN_IAM_URL',
+  'LOGIN_DASH_URL',
+] as const;
+
+let DASH_ROOT: string;
+let config: Config;
+let runs: ScriptInvocation[];
+let envSnapshot: EnvSnapshot;
+let warns: string[];
+let logs: string[];
+
+/**
+ * Per-launch sample of the demo/service env AT LAUNCH TIME. The real launcher
+ * spawns with `{ ...process.env, ...launchEnv }`, so what matters is the value
+ * of `process.env` at the MOMENT `launch()` is called — sampled here, not after
+ * the run (a post-hoc read cannot distinguish "set before the launch" from
+ * "set after", which is the whole seam).
+ */
+interface LaunchEnvSample {
+  id: string;
+  dashLive: string | undefined;
+  demoLive: string | undefined;
+  heartbeat: string | undefined;
+  adsProvider: string | undefined;
+  adsMock: string | undefined;
+}
+let launchSamples: LaunchEnvSample[];
+let launcherStateDirs: unknown[];
+
+useTempSnapshotsDir('saga-session-adm-');
+
+function installSeams(opts: { playwrightFail?: string } = {}): void {
+  const seams = installCoreSeams({
+    pidBase: 2000,
+    prepFresh: false,
+    captureLauncherSpy: true,
+    ...(opts.playwrightFail !== undefined ? { playwrightFail: opts.playwrightFail } : {}),
+  });
+  runs = seams.runs;
+
+  // Replace the battery's launcher with an ENV-SAMPLING twin (same contract).
+  launchSamples = [];
+  launcherStateDirs = [];
+  const launcher: ServiceLauncher = {
+    async launch(spec: LaunchSpec): Promise<LaunchResult> {
+      launchSamples.push({
+        id: spec.id,
+        dashLive: process.env.VITE_DASH_LIVE_SESSIONS,
+        demoLive: process.env.VITE_DEMO_LIVE_ATTENDANCE,
+        heartbeat: process.env.VITE_CONNECTV3_HEARTBEAT_INTERVAL_MS,
+        adsProvider: process.env.ADS_ADM_SESSION_DATA_PROVIDER,
+        adsMock: process.env.ADS_ADM_MOCK_SESSION_DATA_ENABLED,
+      });
+      return { id: spec.id, ok: true, pid: 4000 + launchSamples.length };
+    },
+    async stopServices(ids: string[]): Promise<StopResult[]> {
+      return ids.map((id) => ({ id, stopped: true }));
+    },
+  };
+  (seams.launcherSpy as ReturnType<typeof vi.spyOn>).mockImplementation(((stateDir: unknown) => {
+    launcherStateDirs.push(stateDir);
+    return launcher;
+  }) as never);
+
+  // No-checkpoint store: the journey prerequisite always falls back to the
+  // headless replay — hermetic, and it makes the prereq spawns observable.
+  const store: CheckpointStore = { load: () => null, bake: async () => {}, restore: async () => {} };
+  vi.spyOn(
+    BaseCommand.prototype as unknown as { getCheckpointStore: () => CheckpointStore },
+    'getCheckpointStore',
+  ).mockImplementation(() => store);
+}
+
+// Native-login seams (cookie poster + jar writer), mirroring coach.int.test.ts.
+let posts: { url: string; opts: PostOptions }[];
+const OK_COOKIES: PostResult = {
+  status: 200,
+  ok: true,
+  setCookies: ['iam_session=jwt.tok.sig; Path=/; HttpOnly', 'iam_refresh=refr; Path=/; HttpOnly'],
+};
+
+function installLoginSeams(result: PostResult = OK_COOKIES): void {
+  posts = [];
+  const poster: CookiePoster = {
+    async post(url: string, opts: PostOptions): Promise<PostResult> {
+      posts.push({ url, opts });
+      return result;
+    },
+  };
+  const jar: JarWriter = { write: () => {} };
+  vi.spyOn(BaseCommand.prototype as never, 'getCookiePoster' as never).mockReturnValue(poster as never);
+  vi.spyOn(BaseCommand.prototype as never, 'getJarWriter' as never).mockReturnValue(jar as never);
+}
+
+/** Workspace flags: stub saga-dash (no flows.json → bundled example) + real soa. */
+function ws(): string[] {
+  return ['--saga-dash', DASH_ROOT, '--soa', SOA_ROOT, '--dev', DEV_ROOT];
+}
+
+function playwrightRuns(): ScriptInvocation[] {
+  return runs.filter((r) => r.command === 'pnpm' && r.args.includes('playwright'));
+}
+
+/** The held demo spawn (the flow's single stage). */
+function demoRun(): ScriptInvocation | undefined {
+  return playwrightRuns().find((r) => r.args.includes('connect-session-demo'));
+}
+
+/** The journey prerequisite's terminal-stage spawn (the replay's signature). */
+function prereqRun(): ScriptInvocation | undefined {
+  return playwrightRuns().find((r) => r.args.includes('stage-7-attendance'));
+}
+
+/** The vendored browser-login.mjs child invocation (the admin hand-off). */
+function browserRuns(): ScriptInvocation[] {
+  return runs.filter((r) => r.command === 'node' && (r.args[0] ?? '').endsWith('browser-login.mjs'));
+}
+
+beforeAll(() => {
+  DASH_ROOT = mkdtempSync(join(tmpdir(), 'saga-dash-session-adm-'));
+});
+afterAll(() => {
+  rmSync(DASH_ROOT, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  envSnapshot = saveEnv(ENV_KEYS);
+  for (const k of ENV_KEYS) delete process.env[k];
+  config = await Config.load(PKG_ROOT);
+  installSeams();
+  installLoginSeams();
+  vi.spyOn(StackDown, 'run').mockResolvedValue(undefined as never);
+  logs = [];
+  vi.spyOn(BaseCommand.prototype, 'log').mockImplementation(((m?: string) => {
+    logs.push(m ?? '');
+  }) as never);
+  warns = [];
+  vi.spyOn(BaseCommand.prototype, 'warn').mockImplementation(((m: string) => {
+    warns.push(m);
+    return m;
+  }) as never);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  restoreEnv(envSnapshot);
+});
+
+describe('develop session-adm — flag rejections', () => {
+  it('--refresh-snapshot --reuse hard-errors (nothing to bake)', async () => {
+    await expect(DevelopSessionAdm.run(['--refresh-snapshot', '--reuse', ...ws()], config)).rejects.toThrow(
+      /--refresh-snapshot and --reuse are mutually exclusive/,
+    );
+    expect(playwrightRuns()).toHaveLength(0);
+  });
+
+  it('--refresh-snapshot --no-prereq-from-snapshot hard-errors (bakes what could never restore)', async () => {
+    await expect(
+      DevelopSessionAdm.run(['--refresh-snapshot', '--no-prereq-from-snapshot', ...ws()], config),
+    ).rejects.toThrow(/--refresh-snapshot needs --prereq-from-snapshot/);
+    expect(playwrightRuns()).toHaveLength(0);
+  });
+});
+
+describe('develop session-adm — the demo service-env seam', () => {
+  it('the three VITE_* demo keys are in process.env when saga-dash/connect-web LAUNCH', async () => {
+    await DevelopSessionAdm.run([...ws()], config);
+
+    const sampled = launchSamples.filter((s) => s.id === 'saga-dash' || s.id === 'connect-web');
+    expect(sampled.length).toBeGreaterThan(0);
+    for (const s of sampled) {
+      expect(s.dashLive).toBe('true');
+      expect(s.demoLive).toBe('true');
+      expect(s.heartbeat).toBe('3000');
+    }
+  });
+
+  it('does NOT re-inject the soa#346-baked ADS_ADM_* gates (ground rule)', async () => {
+    await DevelopSessionAdm.run([...ws()], config);
+
+    // The manifest owns these now; the command shadowing them would defeat the
+    // adoption-guard fingerprint. Every launch must see them UNSET in process.env.
+    for (const s of launchSamples) {
+      expect(s.adsProvider).toBeUndefined();
+      expect(s.adsMock).toBeUndefined();
+    }
+  });
+
+  it('runs `stack down` FIRST (slot-forwarded) so the demo env reaches fresh spawns', async () => {
+    await DevelopSessionAdm.run([...ws()], config);
+
+    expect(StackDown.run).toHaveBeenCalledTimes(1);
+    const argv = (StackDown.run as unknown as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string[];
+    expect(argv.slice(0, 2)).toEqual(['--slot', '0']);
+    expect(argv).toContain('--saga-dash');
+  });
+
+  it('--reuse skips the down AND the prerequisite (current-stack mode, caveat warned)', async () => {
+    await DevelopSessionAdm.run(['--reuse', ...ws()], config);
+
+    expect(StackDown.run).not.toHaveBeenCalled();
+    expect(prereqRun()).toBeUndefined();
+    expect(runs.some((r) => r.args.includes('db:seed'))).toBe(false);
+    expect(demoRun()).toBeDefined();
+    expect(warns.some((w) => /--reuse: skipping the stack down/.test(w))).toBe(true);
+  });
+});
+
+describe('develop session-adm — the held demo run env', () => {
+  it('defaults pin DEMO_HOLD=1 + the ADVERTISED 15s stagger onto the demo spawn ONLY', async () => {
+    await DevelopSessionAdm.run([...ws()], config);
+
+    const demo = demoRun();
+    expect(demo?.env?.DEMO_HOLD).toBe('1');
+    // Pinned EXPLICITLY: the spec's own fallback is 6s, the advertised cadence 15s.
+    expect(demo?.env?.DEMO_STAGGER_MS).toBe('15000');
+
+    // Flow-env overlay scoping: the journey prerequisite (a separate
+    // ResolvedFlow) must NOT inherit the demo knobs — a held journey stage
+    // would wedge the headless replay.
+    const prereq = prereqRun();
+    expect(prereq).toBeDefined();
+    expect(prereq?.env?.DEMO_HOLD).toBeUndefined();
+    expect(prereq?.env?.DEMO_STAGGER_MS).toBeUndefined();
+  });
+
+  it('--no-hold drops DEMO_HOLD (straight-through run); the stagger stays pinned', async () => {
+    await DevelopSessionAdm.run(['--no-hold', ...ws()], config);
+    expect(demoRun()?.env?.DEMO_HOLD).toBeUndefined();
+    expect(demoRun()?.env?.DEMO_STAGGER_MS).toBe('15000');
+  });
+
+  it('--stagger-ms reaches the demo spawn; --fake-media still pins FAKE_MEDIA (documented no-op)', async () => {
+    // FAKE_MEDIA is consumed by NOTHING in the connect-session-demo project (its
+    // launchOptions hardcode synthetic media) — the flag is kept for family
+    // muscle-memory only, so this pins the env plumbing, not any behavior.
+    await DevelopSessionAdm.run(['--stagger-ms', '6000', '--fake-media', ...ws()], config);
+    expect(demoRun()?.env?.DEMO_STAGGER_MS).toBe('6000');
+    expect(demoRun()?.env?.FAKE_MEDIA).toBe('1');
+  });
+
+  it('forwards passthrough args after `--` to the demo spawn only, never the prerequisite', async () => {
+    await DevelopSessionAdm.run([...ws(), '--', '--debug'], config);
+    expect(demoRun()?.args.at(-1)).toBe('--debug');
+    expect(prereqRun()?.args).not.toContain('--debug');
+  });
+});
+
+describe('develop session-adm — the admin hand-off', () => {
+  it('mints empty@saga.org and opens the SESSION-mode attendance dash BEFORE the held spawn', async () => {
+    await DevelopSessionAdm.run([...ws()], config);
+
+    // Jar minted against the base iam for the default admin persona.
+    expect(posts).toHaveLength(1);
+    expect(posts[0]?.url).toContain('http://localhost:3010');
+    expect(JSON.stringify(posts[0]?.opts)).toContain('empty@saga.org');
+
+    const [browser] = browserRuns();
+    expect(browser).toBeDefined();
+    expect(browser?.env?.DASH_URL).toBe('http://localhost:8900/dashboard/attendance?mode=session');
+    expect(browser?.env?.LOGIN_EMAIL).toBe('empty@saga.org');
+
+    // ORDER: the browser child is fired before the held demo spawn owns the TTY
+    // (the spec's pre-join hold is the window in which the dash must already be
+    // open). Both land in the SAME recording Runner, so the order is provable.
+    const browserIdx = runs.indexOf(browser as ScriptInvocation);
+    const demoIdx = runs.indexOf(demoRun() as ScriptInvocation);
+    expect(browserIdx).toBeGreaterThanOrEqual(0);
+    expect(demoIdx).toBeGreaterThan(browserIdx);
+  });
+
+  it('--no-admin skips the jar + browser entirely; the demo still runs', async () => {
+    await DevelopSessionAdm.run(['--no-admin', ...ws()], config);
+    expect(posts).toHaveLength(0);
+    expect(browserRuns()).toHaveLength(0);
+    expect(demoRun()).toBeDefined();
+  });
+
+  it('a failed mint WARNS and skips the browser — the demo is never blocked', async () => {
+    installLoginSeams({ status: 500, ok: false, setCookies: [] });
+    await DevelopSessionAdm.run([...ws()], config);
+    expect(browserRuns()).toHaveLength(0);
+    expect(warns.some((w) => /session mint failed \(HTTP 500\)/.test(w))).toBe(true);
+    expect(demoRun()).toBeDefined();
+  });
+});
+
+describe('develop session-adm — the admin-browser lifecycle (never orphaned)', () => {
+  it('held success AWAITS the window: the browser child is never aborted', async () => {
+    await DevelopSessionAdm.run([...ws()], config);
+    expect(browserRuns()[0]?.signal?.aborted).toBe(false);
+  });
+
+  it('--no-hold does NOT hold on the admin window: the child is closed after the run', async () => {
+    // --no-hold is the advertised CI-ish straight-through run — awaiting a human
+    // closing the window would hang it; exiting without the abort would orphan
+    // the child onto the freed TTY.
+    await DevelopSessionAdm.run(['--no-hold', ...ws()], config);
+    expect(browserRuns()[0]?.signal?.aborted).toBe(true);
+    expect(logs.some((l) => /--no-hold: closing the admin browser/.test(l))).toBe(true);
+  });
+
+  it('a failing demo run closes the browser child too, then exits with the demo code', async () => {
+    // The shell-script spec killed the admin browser in its cleanup trap — the
+    // failure path must not leave an orphaned Chromium presenting a zero dash.
+    installSeams({ playwrightFail: 'connect-session-demo' });
+    await expect(DevelopSessionAdm.run([...ws()], config)).rejects.toMatchObject({ oclif: { exit: 1 } });
+    expect(warns.some((w) => /pod-A membership guard/.test(w))).toBe(true);
+    expect(browserRuns()[0]?.signal?.aborted).toBe(true);
+  });
+});
+
+describe('develop session-adm — the --refresh-snapshot bake path (shared helper wired)', () => {
+  it('bakes the journey prerequisite off the slot-2 stack BEFORE the demo', async () => {
+    await DevelopSessionAdm.run(['--refresh-snapshot', '--slot', '2', ...ws()], config);
+
+    // The bake is its OWN executeResolvedFlow call (a stage-by-stage headless
+    // replay from stage 1) and must ride the slot's OFFSET ports — a bake driven
+    // against the base iam would bake slot-0 data into the slot-2 checkpoint
+    // root (the connect.int twin, pinned HERE because the wiring is this
+    // command's own call into the shared bakePrerequisiteCheckpoints).
+    const bake = playwrightRuns().find((r) => r.args.includes('stage-1-roster'));
+    expect(bake).toBeDefined();
+    expect(bake?.env?.PLAYWRIGHT_IAM_URL).toBe('http://localhost:5010');
+
+    // The held demo still runs, AFTER the bake.
+    const demo = demoRun();
+    expect(demo).toBeDefined();
+    expect(runs.indexOf(demo as ScriptInvocation)).toBeGreaterThan(runs.indexOf(bake as ScriptInvocation));
+  });
+});
+
+describe('develop session-adm — slot awareness (slot > 0)', () => {
+  it('--slot 2 targets slot 2 end-to-end: state dir, iam, dash URL, down argv — and warns the AV caveat', async () => {
+    await DevelopSessionAdm.run(['--slot', '2', ...ws()], config);
+
+    // Launcher pinned at the slot's state dir.
+    expect(launcherStateDirs[0]).toBe('/tmp/sds-synthetic-s2');
+
+    // The held demo drives the slot-2 OFFSET services (offset = slot * 1000)…
+    expect(demoRun()?.env?.PLAYWRIGHT_IAM_URL).toBe('http://localhost:5010');
+    // …and the prerequisite rides the same deps (the soa#300 tail).
+    expect(prereqRun()?.env?.PLAYWRIGHT_IAM_URL).toBe('http://localhost:5010');
+
+    // Admin jar + browser on the slot's OWN iam + dash.
+    expect(posts[0]?.url).toContain('http://localhost:5010');
+    expect(browserRuns()[0]?.env?.DASH_URL).toBe('http://localhost:10900/dashboard/attendance?mode=session');
+
+    // The down step tears down the SLOT's services, not slot 0's.
+    const argv = (StackDown.run as unknown as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string[];
+    expect(argv.slice(0, 2)).toEqual(['--slot', '2']);
+
+    // AV stays on slot 0 (post-soa#271 doctrine) — warned, never errored.
+    expect(warns.some((w) => /AV stays on slot 0/.test(w))).toBe(true);
+  });
+
+  it('--no-admin at --slot 2 prints a SLOT-PINNED login one-liner (stack login defaults to slot 0)', async () => {
+    await DevelopSessionAdm.run(['--slot', '2', '--no-admin', ...ws()], config);
+    const line = logs.find((l) => /ss stack login/.test(l));
+    expect(line).toBeDefined();
+    // Without --slot 2 the pasted command mints against slot 0's iam (:3010)
+    // while LOGIN_DASH_URL points at the slot-2 dash — wrong-iam jar.
+    expect(line).toContain('--slot 2');
+    expect(line).toContain('http://localhost:10900/dashboard/attendance?mode=session');
+  });
+
+  it('the mint-failure remediation carries the slot AND a pinned --state-dir', async () => {
+    installLoginSeams({ status: 500, ok: false, setCookies: [] });
+    await DevelopSessionAdm.run(['--slot', '2', '--state-dir', '/tmp/pinned', ...ws()], config);
+    const warn = warns.find((w) => /session mint failed/.test(w));
+    expect(warn).toContain('--slot 2');
+    expect(warn).toContain('--state-dir /tmp/pinned');
+  });
+});

--- a/packages/node/saga-stack-cli/src/commands/develop/connect.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/connect.ts
@@ -61,6 +61,7 @@ import type { ScriptPlan } from '../../core/flag-map.js';
 import { makeStackApi } from '../../stack-api.js';
 import { bootstrapLedgerPath, makePersonaPreflight, resolveVendorScript } from '../../runtime/index.js';
 import {
+  bakePrerequisiteCheckpoints,
   buildStackContext,
   discoverFlowManifest,
   executeResolvedFlow,
@@ -373,45 +374,29 @@ export default class DevelopConnect extends BaseCommand {
     // Deterministic fixtureIds ⇒ the bake OVERWRITES any stale checkpoint; the main run
     // below then restores the just-made journey@schedule (prereq-from-snapshot path).
     if (flags['refresh-snapshot'] && toRun.prerequisite !== undefined) {
-      const prereq = toRun.prerequisite;
-      // M14 §2.3 (advisory): stamp the SPA checkout HEAD into the bake so a later
-      // restore can WARN on drift. '' sha (not a git checkout) ⇒ omitted.
-      let spaHead: { sha: string; dirty: boolean } | undefined;
-      const spaRepoRoot = appCwd.slice(0, appCwd.length - resolved.spa.appDir.length - 1);
-      const git = this.getGitRunner();
-      const sha = await git.headSha(spaRepoRoot);
-      if (sha !== '') spaHead = { sha, dirty: (await git.statusPorcelain(spaRepoRoot)).trim() !== '' };
-
-      this.log(
-        `==> refresh-snapshot: baking ${prereq.flow.name}@${prereq.stages.at(-1)?.id} checkpoints (headless replay, --snapshot-stages)…`,
+      await bakePrerequisiteCheckpoints(
+        toRun.prerequisite,
+        resolved.spa.appDir,
+        // The bake is a headless replay against THIS slot's stack, so it needs the
+        // same slot-offset ports as the main run below — otherwise its Playwright
+        // children mint against the base iam and bake a slot-0-shaped checkpoint.
+        // The settle barrier (soa#327) is REQUIRED by the shared helper: the fresh
+        // bake must wait out the roster-sync pipeline before each per-stage dump —
+        // this bake path exists precisely to produce the checkpoint the tunnel
+        // session will trust.
+        {
+          api,
+          runner: seams.runner,
+          appCwd,
+          now,
+          log: (l) => this.log(l),
+          slot: profile.slot,
+          ports: runtime.launchContext.ports,
+          checkpoints,
+          settleBarrier: this.getSettleBarrier(profile.slot, (l) => this.log(l)),
+        },
+        { git: this.getGitRunner(), log: (l) => this.log(l), fail: (msg: string): never => this.error(msg) },
       );
-      try {
-        const bakeCode = await executeResolvedFlow(
-          prereq,
-          // The bake is a headless replay against THIS slot's stack, so it needs the
-          // same slot-offset ports as the main run below — otherwise its Playwright
-          // children mint against the base iam and bake a slot-0-shaped checkpoint.
-          {
-            api,
-            runner: seams.runner,
-            appCwd,
-            now,
-            log: (l) => this.log(l),
-            slot: profile.slot,
-            ports: runtime.launchContext.ports,
-            checkpoints,
-            // soa#327: the fresh bake must wait out the roster-sync pipeline
-            // before each per-stage dump — this bake path exists precisely to
-            // produce the checkpoint the tunnel session will trust.
-            settleBarrier: this.getSettleBarrier(profile.slot, (l) => this.log(l)),
-          },
-          { lane: 'stack', skipReset: false, passthrough: [], snapshotStages: true, prereqFromSnapshot: false, spaHead },
-        );
-        if (bakeCode !== 0) this.error(`--refresh-snapshot: prerequisite bake failed (exit ${bakeCode}).`);
-      } catch (err) {
-        if (err instanceof FlowExecError) this.error(`--refresh-snapshot: ${err.message}`);
-        throw err;
-      }
     }
 
     try {

--- a/packages/node/saga-stack-cli/src/commands/develop/session-adm.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/session-adm.ts
@@ -1,0 +1,455 @@
+/**
+ * `saga-stack develop session-adm` — the live SESSION-attendance ADM demo as a
+ * durable concierge (gh session-adm plan, claude/projects/ss-develop-session-adm-plan.md).
+ *
+ * Promotes saga-dash's `telemetry-demo-multi.sh` into the `develop` family: a
+ * tutor (alex.tutor) + Alex's 3 pod-A students (ann.lee / cara.diaz / gina.park)
+ * join a real Connect room STAGGERED, each running the real connectv3
+ * `SessionHeartbeat`; ads-adm accrues TELEMETRY dosage live; closing one
+ * student's window freezes ONLY that counter. Multi-only v1 by decision — the
+ * single-student sibling stays reachable via `ss e2e run saga-dash/connect-session-dosage`.
+ *
+ * It resolves the `connect-session-demo` flow from saga-dash's `flows.json`
+ * (bundled example fallback) and drives the SAME in-process orchestration as
+ * `e2e run`, folding the concierge script's sequence in:
+ *
+ *   1. `stack down` (unless `--reuse`) — LOAD-BEARING: saga-dash + connect-web
+ *      must RELAUNCH so the demo env below reaches their dev servers (an
+ *      already-up server is adopted untouched and keeps its stale env).
+ *   2. Pin the demo env into `process.env` — the launcher spawns every service
+ *      with `{ ...process.env, ...launchEnv }`, so this is the supported
+ *      per-invocation service-env seam (the coach `ARCHIVE_DIR` precedent):
+ *      `VITE_DASH_LIVE_SESSIONS` + `VITE_DEMO_LIVE_ATTENDANCE` (live dash
+ *      polling) and `VITE_CONNECTV3_HEARTBEAT_INTERVAL_MS=3000` (fast pings,
+ *      qboard#298). The `ADS_ADM_*` session-source gates are NOT re-injected —
+ *      soa#346 baked them into the ads-adm-api manifest env + adoption guard.
+ *   3. Bring-up window: the journey@attendance prerequisite (checkpoint restore
+ *      when baked, else headless replay — owning the reset+seed) + up/verify of
+ *      the demo closure, via a stages-empty `executeResolvedFlow` (the Plan-13
+ *      empty window, same as connect's bootstrap prerequisite step).
+ *   4. Unless `--no-admin`: mint the admin jar (empty@saga.org, slot-aware iam)
+ *      and open the vendored logged-in browser at
+ *      `/dashboard/attendance?mode=session` — UN-awaited, BEFORE the held run
+ *      (every exit path then AWAITS the window or ABORTS the child: held-success
+ *      waits, --no-hold and the failure paths kill it — never an orphan).
+ *      The shell script could only open the admin dash after grepping its log
+ *      for the spec's `[DEMO] Dosage landed` sentinel; in-process the Runner has
+ *      no output capture, and the spec's DEMO_HOLD pre-join pause (20s) exists
+ *      precisely so an ALREADY-OPEN admin dash watches the counters climb from
+ *      zero — strictly better demo choreography, zero new machinery.
+ *   5. The held demo run: headed foreground Playwright (the flow is
+ *      `foreground:true`), stdio inherited, with `DEMO_HOLD=1` (drop via
+ *      `--no-hold`) + `DEMO_STAGGER_MS` (default 15000 — the ADVERTISED 15s
+ *      cadence; the spec's own default is 6s) pinned onto THIS flow's env only
+ *      (merged last by computeEnv — the journey prerequisite is unaffected).
+ *      The spec itself polls ads-adm for fresh TELEMETRY dosage and prints
+ *      `[DEMO] Dosage landed`, then holds every window open via the Playwright
+ *      Inspector — Resume (▶) ends the run. Ctrl-C reaches the inherited-stdio
+ *      Playwright child and the admin browser (same process group); the stack's
+ *      detached services stay up (`ss stack down` when done — printed).
+ *
+ * AV: the LiveKit/coturn pair is the SHARED slot-0 docker pair and this command
+ * does not start it (`ss stack up` at slot 0 does, best-effort) — at `--slot N`
+ * the non-AV mechanics all run against slot N, but media needs slot 0's AV
+ * containers already up. Media capture is ALWAYS synthetic: the
+ * `connect-session-demo` Playwright project HARDCODES Chromium's fake cam/mic
+ * (+ --mute-audio) in its launchOptions, so a camera-less box needs nothing —
+ * `--fake-media` is accepted only for develop-family muscle-memory (a no-op
+ * here; unlike `develop connect`, nothing in this project reads FAKE_MEDIA).
+ *
+ *   node bin/dev.js develop session-adm
+ *   node bin/dev.js develop session-adm --reuse --no-admin
+ *   node bin/dev.js develop session-adm --stagger-ms 6000 -- --debug
+ *   node bin/dev.js develop session-adm --refresh-snapshot
+ */
+
+import { Flags } from '@oclif/core';
+import { BaseCommand } from '../../base-command.js';
+import type { WorkspaceFlags } from '../../base-command.js';
+import { deriveInstance } from '../../core/derive-instance.js';
+import { resolveFlow } from '../../core/flow/index.js';
+import type { ResolvedFlow } from '../../core/flow/index.js';
+import { manifest as serviceManifest } from '../../core/manifest/index.js';
+import type { ScriptPlan } from '../../core/flag-map.js';
+import { makeStackApi } from '../../stack-api.js';
+import {
+  bakePrerequisiteCheckpoints,
+  buildStackContext,
+  discoverFlowManifest,
+  executeResolvedFlow,
+  FlowExecError,
+  resolveAppCwd,
+} from '../../e2e-orchestrate.js';
+import type { ExecDeps } from '../../e2e-orchestrate.js';
+import StackDown from '../stack/down.js';
+import { bootstrapWorkspaceArgv } from '../../bootstrap-connect.js';
+
+/** The demo flow is a built-in saga-dash flow. */
+const DEMO_SPA = 'saga-dash';
+const DEMO_FLOW = 'connect-session-demo';
+
+/** The admin persona the hand-off browser logs in (script parity: $ADMIN_EMAIL). */
+const DEFAULT_ADMIN_EMAIL = 'empty@saga.org';
+
+/** The admin view: SESSION-mode attendance (script parity: LOGIN_DASH_URL). */
+const ADMIN_DASH_PATH = '/dashboard/attendance?mode=session';
+
+/**
+ * connectv3 heartbeat cadence for the demo (qboard#298 test hook): 3s instead of
+ * the 60s production interval, so the 2nd self-report ping — the spec's
+ * freshness gate — lands within seconds of a join.
+ */
+const HEARTBEAT_INTERVAL_MS = 3000;
+
+export default class DevelopSessionAdm extends BaseCommand {
+  static description =
+    'Run the live SESSION-attendance ADM demo: 3 staggered Connect students self-report telemetry dosage onto an auto-opened admin attendance dash (in-process; journey prerequisite, then a held headed room).';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --reuse --no-admin',
+    '<%= config.bin %> <%= command.id %> --stagger-ms 6000 -- --debug',
+    '<%= config.bin %> <%= command.id %> --refresh-snapshot',
+  ];
+
+  // Allow trailing playwright passthrough args (after `--`).
+  static strict = false;
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    reuse: Flags.boolean({
+      default: false,
+      description:
+        'skip the stack down + journey-prerequisite rebuild + reset; run the demo against the CURRENT stack state. CAVEAT: the demo VITE env only reaches services THIS run launches — an already-up saga-dash/connect-web is adopted untouched, so live polling / the 3s heartbeat need the stack to have been brought up by a previous session-adm run.',
+    }),
+    'prereq-from-snapshot': Flags.boolean({
+      default: true,
+      allowNo: true,
+      description:
+        'restore the journey@attendance checkpoint (when a valid one is baked) instead of replaying the whole journey headless — the big accelerant (mirrors develop connect). Falls back to the replay when absent/invalid; --reuse trumps this entirely.',
+    }),
+    'refresh-snapshot': Flags.boolean({
+      default: false,
+      description:
+        'bake the journey prerequisite checkpoints FRESH (headless replay through `attendance`, --snapshot-stages) BEFORE the demo, then restore that just-made checkpoint — the one-command reseed for a stale (>7d) or drifted journey (and the remedy for the pod-A roster-drift guard). Requires --prereq-from-snapshot (the default); mutually exclusive with --reuse.',
+    }),
+    'spa-path': Flags.string({
+      description: 'explicit path to a flows.json (file or dir) — highest-priority discovery override',
+    }),
+    'fake-media': Flags.boolean({
+      default: false,
+      description:
+        "NO-OP for this demo, accepted only for develop-family muscle-memory: the connect-session-demo Playwright project HARDCODES Chromium's synthetic camera + mic (+ --mute-audio) in its launchOptions, so the demo NEVER captures real devices — with or without this flag. (Unlike develop connect, where FAKE_MEDIA=1 is load-bearing.) Still pins FAKE_MEDIA=1 on the demo spawn; nothing in that project reads it.",
+    }),
+    admin: Flags.boolean({
+      default: true,
+      allowNo: true,
+      description:
+        `auto-open the vendored logged-in admin browser (${DEFAULT_ADMIN_EMAIL}, override via $ADMIN_EMAIL) at ${ADMIN_DASH_PATH} once the stack is ready, BEFORE the students join — the pre-join hold exists so the counters visibly climb from zero. --no-admin skips it and prints the manual login one-liner instead (script parity).`,
+    }),
+    hold: Flags.boolean({
+      default: true,
+      allowNo: true,
+      description:
+        'hold the demo open for a presenter (DEMO_HOLD=1): a 20s pre-join pause (open the admin dash now), then after dosage lands every window stays open via the Playwright Inspector — close one student window to freeze its counter, Resume (▶) to end. --no-hold drops the pauses for a CI-ish straight-through run (the auto-opened admin browser is closed at the end instead of holding the terminal).',
+    }),
+    'stagger-ms': Flags.integer({
+      default: 15000,
+      min: 0,
+      description:
+        "gap between student joins (DEMO_STAGGER_MS). Default 15000 — the demo's advertised 15s cadence, pinned EXPLICITLY because the spec's own fallback is 6s.",
+    }),
+  };
+
+  /**
+   * `develop session-adm` brings up an isolated `soa-s<N>` demo sub-stack at
+   * slot > 0 — the non-AV mechanics (journey prerequisite, demo env, dosage,
+   * admin hand-off) all run against slot N (dev-test posture: slot 1). ONLY the
+   * AV media plane is slot-0-pinned: LiveKit/coturn are the shared slot-0
+   * containers (`stack-api` gates their bring-up on slot 0), so a slot-N room
+   * gets media only while slot 0's AV pair is already up — warned in run().
+   */
+  protected slotAware(): boolean {
+    return true;
+  }
+
+  /** Slot claims: the demo brings up + DRIVES the slot's sub-stack — record the advisory claim on entry. */
+  protected claimsSlot(): boolean {
+    return true;
+  }
+
+  async run(): Promise<void> {
+    const { argv, flags } = await this.parse(DevelopSessionAdm);
+    const passthrough = argv as string[];
+
+    // --refresh-snapshot rejections FIRST (manual, not oclif `exclusive:` — a
+    // defaulted value counts as provided there; the M14 lesson).
+    if (flags['refresh-snapshot']) {
+      if (flags.reuse) {
+        this.error('--refresh-snapshot and --reuse are mutually exclusive: --reuse skips the prerequisite entirely, so there is nothing to bake.');
+      }
+      if (!flags['prereq-from-snapshot']) {
+        this.error('--refresh-snapshot needs --prereq-from-snapshot (the default): it bakes the journey checkpoint so the demo can restore it. Drop --no-prereq-from-snapshot.');
+      }
+    }
+
+    const disco = discoverFlowManifest(DEMO_SPA, flags, process.env);
+    if (disco.usedBundledExample) {
+      this.warn(
+        `no flows.json found for '${DEMO_SPA}' in the repo; using the BUNDLED EXAMPLE shipped with @saga-ed/saga-stack-cli (${disco.sourcePath}).`,
+      );
+    }
+
+    // Foreground + headed by default (the flow is `foreground:true`); --reuse
+    // drops the prerequisite + reset entirely (mirrors develop connect).
+    const resolved = resolveFlow(disco.manifest, DEMO_FLOW, { lane: 'stack' });
+    const base = flags.reuse ? { ...resolved, prerequisite: undefined } : resolved;
+
+    // Playwright-process knobs, pinned into THIS flow's env (merged last by
+    // computeEnv) so they reach ONLY the demo spec — never the journey
+    // prerequisite, a separate ResolvedFlow. DEMO_STAGGER_MS is ALWAYS pinned:
+    // the advertised cadence is 15s but the spec's own fallback is 6s, so
+    // relying on the default would silently under-stagger (the shell script's
+    // known gap).
+    const stageEnv: Record<string, string> = {
+      DEMO_STAGGER_MS: String(flags['stagger-ms']),
+    };
+    if (flags.hold) stageEnv.DEMO_HOLD = '1';
+    // Documented no-op (see the flag): the demo project hardcodes synthetic media
+    // and reads no FAKE_MEDIA — pinned anyway so the env mirrors the user's intent.
+    if (flags['fake-media']) stageEnv.FAKE_MEDIA = '1';
+    const toRun: ResolvedFlow = { ...base, flow: { ...base.flow, env: { ...base.flow.env, ...stageEnv } } };
+
+    const appCwd = resolveAppCwd(resolved.spa, flags, process.env);
+    const now = new Date();
+
+    // M7: resolve the slot profile once — offset ports/project/container-env,
+    // per-slot state dir, per-slot checkpoint root (mirrors e2e run / connect).
+    // WITHOUT this, `--slot N` would silently target slot 0.
+    const profile = deriveInstance({ slot: flags.slot });
+    // ORDER-CRITICAL: the checkpoint store's resolvers read $SAGA_MESH_* when
+    // INVOKED, so this must land before any bake/restore below.
+    this.applyInstanceEnv(profile);
+    const stateDir = flags['state-dir'] ?? profile.stateDir;
+
+    // AV doctrine (post-soa#271 nuance): connect-api/connect-web DO run at
+    // slot > 0 — only the AV MEDIA plane (LiveKit/coturn bring-up) is pinned to
+    // slot 0. Warn, don't error: slot > 0 is the supported dev-test posture for
+    // everything non-AV; the held AV demo itself validates at slot 0.
+    if (flags.slot > 0) {
+      this.warn(
+        `slot ${flags.slot}: AV stays on slot 0 — this slot's room reuses the SHARED slot-0 LiveKit/coturn ` +
+          'containers (started by `ss stack up` at slot 0, not by this command). Without them the room is ' +
+          'CRDT-only (no media), heartbeats never start, and dosage never lands. Non-AV mechanics all run on this slot.',
+      );
+    }
+
+    const seams = {
+      launcher: this.getLauncher(stateDir),
+      meshExec: this.getMeshExec(),
+      portProbe: this.getPortProbe(),
+      dashFs: this.getDashFs(),
+      // soa#300: coach-web `.env.local` prelaunch seam — harmless here (coach-web
+      // is not in the demo closure), wired for parity with the other bring-up paths.
+      coachWebFs: this.getCoachWebFs(),
+      prober: this.getProber(),
+      runner: this.getRunner(),
+      // Native-prep seams: R2 provision + R3 migrate on the slot's offset DBs
+      // before launch+seed — required for a slot > 0 bring-up (mirrors connect).
+      pgProbe: this.getPgProbe(),
+      prepIsFresh: this.getPrepFreshCheck(),
+      prepWriteStamp: this.getPrepStampWriter(),
+      prepRepairDeps: this.getPrepDepRepairer(),
+      prepDbGenerateScan: this.getDbGenerateScan(),
+      repoDirExists: this.getRepoDirCheck(),
+    };
+    const delegate = (plan: ScriptPlan): Promise<number> =>
+      this.runScript(plan, flags as WorkspaceFlags, { propagateExit: false });
+
+    const { runtime } = buildStackContext(flags, seams, delegate, profile);
+    const api = makeStackApi(serviceManifest, runtime);
+
+    // ── 1. stack down (unless --reuse) — LOAD-BEARING (script step 1): an
+    // already-up saga-dash/connect-web would be ADOPTED untouched (their
+    // adoptEnv fingerprints don't cover the demo keys), silently keeping stale
+    // env. Down forces the relaunch that inherits the demo env below. The
+    // in-process sub-command precedent is connect's bootstrap 'local-down'. ──
+    if (!flags.reuse) {
+      this.log('==> stack down — saga-dash + connect-web must RELAUNCH with the demo env (skip with --reuse)…');
+      await StackDown.run(['--slot', String(flags.slot), ...bootstrapWorkspaceArgv(flags)], this.config);
+    } else {
+      this.warn(
+        '--reuse: skipping the stack down — the demo VITE env (live polling + 3s heartbeat) only reaches ' +
+          'services THIS run launches; an already-up saga-dash/connect-web keeps whatever env it booted with.',
+      );
+    }
+
+    // ── 2. the demo SERVICE env — the launcher spawns every service with
+    // `{ ...process.env, ...launchEnv }` (up.sh `env "$@"` parity), so
+    // process-env inheritance is the supported per-invocation seam (the coach
+    // ARCHIVE_DIR/DATABASE_URL precedent). Verified collision-free: no manifest
+    // launch.env or adoptEnv key overlaps these three. The ADS_ADM_* session
+    // gates are DELIBERATELY not set — soa#346 baked them into the ads-adm-api
+    // manifest env + adoption fingerprint; re-injecting would just shadow it. ──
+    process.env.VITE_DASH_LIVE_SESSIONS = 'true';
+    process.env.VITE_DEMO_LIVE_ATTENDANCE = 'true';
+    process.env.VITE_CONNECTV3_HEARTBEAT_INTERVAL_MS = String(HEARTBEAT_INTERVAL_MS);
+
+    // M14-C: the checkpoint store so the journey prerequisite can be RESTORED
+    // instead of replayed. ORDER-CRITICAL: constructed AFTER applyInstanceEnv
+    // (call-time env contract) — same invariant connect.int.test.ts pins.
+    const checkpoints =
+      toRun.prerequisite !== undefined && (flags['prereq-from-snapshot'] || flags['refresh-snapshot'])
+        ? this.getCheckpointStore(this.scriptContextFromFlags(flags))
+        : undefined;
+
+    const deps: ExecDeps = {
+      api,
+      runner: seams.runner,
+      appCwd,
+      now,
+      log: (l) => this.log(l),
+      // Slot + OFFSET ports (mirrors e2e run) so every Playwright spawn — the
+      // prerequisite's and the demo's — mints against THIS slot's iam and
+      // drives its service URLs (the soa#300 tail). Ride the recursion via deps.
+      slot: profile.slot,
+      ports: runtime.launchContext.ports,
+      checkpoints,
+    };
+
+    // --refresh-snapshot: bake the prerequisite's stage checkpoints FRESH before
+    // the demo — a headless replay of journey 1..attendance with --snapshot-stages
+    // (the SHARED helper connect's bake also drives, one stage further here).
+    // Deterministic fixtureIds ⇒ the bake OVERWRITES any stale checkpoint; the
+    // bring-up below restores it. The settle barrier (soa#327) is REQUIRED by the
+    // helper's type — this bake exists precisely to produce the checkpoint the
+    // demo will trust.
+    if (flags['refresh-snapshot'] && toRun.prerequisite !== undefined) {
+      await bakePrerequisiteCheckpoints(
+        toRun.prerequisite,
+        resolved.spa.appDir,
+        { ...deps, settleBarrier: this.getSettleBarrier(profile.slot, (l) => this.log(l)) },
+        { git: this.getGitRunner(), log: (l) => this.log(l), fail: (msg: string): never => this.error(msg) },
+      );
+    }
+
+    // ── 3. bring-up window: prerequisite (checkpoint restore else replay,
+    // owning reset+seed) + up/verify of the demo closure, WITHOUT spawning the
+    // demo spec — `stages: []` is the Plan-13 empty window (the same pattern as
+    // connect's bootstrap prerequisite step). Splitting the run here is what
+    // lets the admin browser open BEFORE the held foreground spawn owns the TTY. ──
+    try {
+      const upCode = await executeResolvedFlow(
+        { ...toRun, stages: [] },
+        deps,
+        { lane: 'stack', skipReset: flags.reuse, passthrough: [], prereqFromSnapshot: flags['prereq-from-snapshot'] },
+      );
+      if (upCode !== 0) this.exit(upCode);
+    } catch (err) {
+      if (err instanceof FlowExecError) this.error(err.message);
+      throw err;
+    }
+
+    // ── 4. the admin hand-off — jar + vendored browser at the SESSION-mode
+    // attendance dash, deliberately UN-awaited: the headful browser never exits
+    // until its window closes, and the held demo below needs the TTY. Fired
+    // BEFORE the joins so the presenter watches the counters climb from zero
+    // (the spec's DEMO_HOLD pre-join pause is this window). Best-effort
+    // throughout: a failed mint / headless host WARNS, never blocks the demo.
+    // The AbortController owns the child's LIFECYCLE: every exit path below
+    // either awaits the window or aborts it — the child is never orphaned. ──
+    const dashPort = runtime.launchContext.ports['saga-dash'];
+    const adminEmail = process.env.ADMIN_EMAIL ?? DEFAULT_ADMIN_EMAIL;
+    const adminUrl = dashPort !== undefined ? `http://localhost:${dashPort}${ADMIN_DASH_PATH}` : undefined;
+    // The printed `ss stack login` remediations must CARRY the slot/state-dir
+    // pins: `stack login` is slot-aware but defaults to slot 0, so a bare paste
+    // at --slot N would mint against slot 0's iam while LOGIN_DASH_URL points at
+    // slot N's dash — an unauthenticated browser against the wrong iam.
+    const loginPins =
+      (flags.slot > 0 ? ` --slot ${flags.slot}` : '') +
+      (flags['state-dir'] !== undefined ? ` --state-dir ${flags['state-dir']}` : '');
+    const loginOneLiner = (url: string): string =>
+      `LOGIN_DASH_URL="${url}" ss stack login ${adminEmail} --browser${loginPins}`;
+    const browserAbort = new AbortController();
+    let browserDone: Promise<void> | undefined;
+    if (flags.admin) {
+      const res = await this.mintNativeLoginJar({ email: adminEmail, slot: profile.slot, stateDir });
+      if (!res.ok) {
+        this.warn(
+          `admin hand-off: session mint failed (HTTP ${res.status}) for ${adminEmail} — the stack is up but no ` +
+            'admin browser opens. Confirm the seed materialized the persona, or log in manually: ' +
+            loginOneLiner(adminUrl ?? ADMIN_DASH_PATH),
+        );
+      } else if (adminUrl === undefined) {
+        this.warn('admin hand-off: no saga-dash port resolved — browser open skipped.');
+      } else {
+        this.log(`==> opening the admin dash as ${adminEmail} at ${adminUrl} (best-effort; a headless host warns)…`);
+        this.log('    pick "E2E Journey Program" — the pre-join hold gives you ~20s before the students join.');
+        // openVendoredBrowser never rejects (spawn failures warn internally; an
+        // ABORT-triggered rejection is swallowed as the requested close), so the
+        // un-awaited promise is safe; it resolves when the window closes.
+        browserDone = this.openVendoredBrowser(flags, {
+          email: adminEmail,
+          iamUrl: res.iamUrl,
+          stateDir,
+          dashUrl: adminUrl,
+          signal: browserAbort.signal,
+        });
+      }
+    } else if (adminUrl !== undefined) {
+      // Script parity: --no-admin prints the manual login one-liner.
+      this.log(`--no-admin: log in yourself with  ${loginOneLiner(adminUrl)}`);
+    }
+    // Failure-path twin of the success-path hold below: the shell-script spec
+    // KILLS the admin browser in its cleanup trap — exiting with the vendored
+    // Chromium still writing to the freed TTY (and presenting a dead zero-dosage
+    // dash) would orphan it.
+    const closeAdminBrowser = async (): Promise<void> => {
+      if (browserDone === undefined) return;
+      browserAbort.abort();
+      await browserDone;
+    };
+
+    // ── 5. the held demo run — headed foreground, stdio inherited; the hold IS
+    // the spec's DEMO_HOLD pause (pre-join, then the Inspector after `[DEMO]
+    // Dosage landed`). Prerequisite stripped (the window above owns it),
+    // skipReset (already reset+seeded there). ──
+    this.log('==> demo: tutor + 3 staggered students (ann.lee / cara.diaz / gina.park) — close a student window to freeze its counter; Resume (▶) in the Inspector ends the run.');
+    try {
+      const code = await executeResolvedFlow(
+        { ...toRun, prerequisite: undefined },
+        deps,
+        { lane: 'stack', skipReset: true, passthrough },
+      );
+      if (code !== 0) {
+        // M2 guardrail: the spec HARD-asserts pod-A membership (ann/cara/gina in
+        // Alex's pod), so roster drift fails loud — surface the remedy.
+        this.warn(
+          'demo flow failed. If the failure is the pod-A membership guard (ann.lee/cara.diaz/gina.park not in ' +
+            "Alex's pod), the seeded roster has drifted — rebake the journey prerequisite: ss develop session-adm --refresh-snapshot",
+        );
+        await closeAdminBrowser();
+        this.exit(code);
+      }
+    } catch (err) {
+      await closeAdminBrowser();
+      if (err instanceof FlowExecError) this.error(err.message);
+      throw err;
+    }
+
+    this.log('✓ demo complete — the stack stays up. Teardown when done: ss stack down');
+    if (browserDone !== undefined) {
+      if (flags.hold) {
+        // Hold for the admin window (if still open) so its child is never orphaned —
+        // mirrors coach's "the browser holds the terminal until closed".
+        await browserDone;
+      } else {
+        // --no-hold is the advertised CI-ish straight-through run: never block on
+        // a human closing the admin window — close it (reopen any time with the
+        // login one-liner) instead of orphaning it past our exit.
+        this.log(`--no-hold: closing the admin browser. Reopen with  ${loginOneLiner(adminUrl ?? ADMIN_DASH_PATH)}`);
+        await closeAdminBrowser();
+      }
+    }
+  }
+}

--- a/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
+++ b/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
@@ -71,6 +71,7 @@ import {
 import type {
   CoachWebFs,
   DashFs,
+  GitRunner,
   HealthProber,
   MeshExec,
   PgProbe,
@@ -1349,5 +1350,53 @@ export async function executeResolvedFlow(
     }
   }
   return 0;
+}
+
+/**
+ * The `--refresh-snapshot` prerequisite bake, shared by the develop concierges
+ * (`connect`, `session-adm`): a headless stage-by-stage replay of the flow's
+ * prerequisite with `--snapshot-stages`, so the just-made checkpoint is what the
+ * main run restores. ONE copy on purpose — the two commands' near-verbatim
+ * twins drifted apart in review (soa session-adm fix pass), and the SETTLE
+ * BARRIER is REQUIRED in the deps type so dropping it (the soa#327 torn-
+ * checkpoint regression) fails typecheck, not a demo.
+ *
+ * The bake stamps the SPA checkout HEAD (M14 §2.3, advisory) so a later restore
+ * can WARN on drift; a '' sha (not a git checkout) omits the stamp. `deps` must
+ * carry the SAME slot-offset `ports` as the caller's main run — a bake driven
+ * against the base iam would bake slot-0 data into the slot-N checkpoint root.
+ * `io.fail` is the caller's `this.error` (returns never); a non-FlowExecError
+ * rethrows untouched.
+ */
+export async function bakePrerequisiteCheckpoints(
+  prereq: ResolvedFlow,
+  spaAppDir: string,
+  deps: ExecDeps & { settleBarrier: SettleBarrier },
+  io: { git: GitRunner; log: (line: string) => void; fail: (msg: string) => never },
+): Promise<void> {
+  // M14 §2.3 (advisory): stamp the SPA checkout HEAD into the bake so a later
+  // restore can WARN on drift. '' sha (not a git checkout) ⇒ omitted.
+  let spaHead: { sha: string; dirty: boolean } | undefined;
+  const spaRepoRoot = deps.appCwd.slice(0, deps.appCwd.length - spaAppDir.length - 1);
+  const sha = await io.git.headSha(spaRepoRoot);
+  if (sha !== '') spaHead = { sha, dirty: (await io.git.statusPorcelain(spaRepoRoot)).trim() !== '' };
+
+  io.log(
+    `==> refresh-snapshot: baking ${prereq.flow.name}@${prereq.stages.at(-1)?.id} checkpoints (headless replay, --snapshot-stages)…`,
+  );
+  try {
+    const bakeCode = await executeResolvedFlow(prereq, deps, {
+      lane: 'stack',
+      skipReset: false,
+      passthrough: [],
+      snapshotStages: true,
+      prereqFromSnapshot: false,
+      spaHead,
+    });
+    if (bakeCode !== 0) io.fail(`--refresh-snapshot: prerequisite bake failed (exit ${bakeCode}).`);
+  } catch (err) {
+    if (err instanceof FlowExecError) io.fail(`--refresh-snapshot: ${err.message}`);
+    throw err;
+  }
 }
 

--- a/packages/node/saga-stack-cli/src/runtime/exec.ts
+++ b/packages/node/saga-stack-cli/src/runtime/exec.ts
@@ -63,6 +63,13 @@ export interface ScriptInvocation {
    * Ignored together with `stdinFile` (install never redirects stdin).
    */
   detectUnauthorized?: boolean;
+  /**
+   * Optional caller-owned abort handle: the real runner passes it straight to
+   * `spawn`, so aborting kills the child (SIGTERM) instead of orphaning it when
+   * the CLI exits first (the `develop session-adm` admin-browser lifecycle). A
+   * fake runner just records it — a test can assert `signal.aborted` afterwards.
+   */
+  signal?: AbortSignal;
 }
 
 /** The result of running a script: the process exit code (+ FLIP 4 auth signal). */
@@ -107,6 +114,7 @@ export function makeRealRunner(): Runner {
             cwd: spec.cwd,
             env: { ...process.env, ...spec.env },
             stdio: ['inherit', 'pipe', 'pipe'],
+            signal: spec.signal,
           });
           let buf = '';
           const tee = (out: NodeJS.WriteStream) => (d: Buffer): void => {
@@ -136,6 +144,7 @@ export function makeRealRunner(): Runner {
           cwd: spec.cwd,
           env: { ...process.env, ...spec.env },
           stdio,
+          signal: spec.signal,
         });
         // Node does NOT auto-close a raw fd passed in the stdio array — close it
         // once the child has been wired up (spawn has already dup'd it).


### PR DESCRIPTION
Promotes the 3-student staggered Connect→ADM telemetry demo (saga-dash `connect-session-demo` spec + `telemetry-demo-multi.sh`) into the `ss develop` family, per the plan in `claude/projects/ss-develop-session-adm-plan.md` (decisions: name `session-adm`, multi-only v1, admin auto-open with `--no-admin`).

**What the command does:** unless `--reuse`, bounce the closure so saga-dash launches with the demo VITE env (`VITE_DASH_LIVE_SESSIONS`, `VITE_DEMO_LIVE_ATTENDANCE`, heartbeat 3s) → auto-open the vendored logged-in admin browser at `?mode=session` (pre-join, so counters visibly climb from zero) → run the held headed room (tutor + 3 staggered students, real connectv3 heartbeats → ads-adm TELEMETRY dosage). `ADS_ADM_*` gates are **not** injected — assumed from the #346 manifest defaults (adoption-guarded).

**Design deviation from the shell script, recorded as plan Decision 4:** the script opened the admin browser *after* dosage; the command opens it *before the students join* — the pre-join hold makes the from-zero climb part of the show, and the AbortSignal plumbing closes the browser on failure paths. Flag if you want script-parity instead.

**Shared refactors:** `bakePrerequisiteCheckpoints` extracted (connect + session-adm), `ScriptInvocation.signal` for child-process lifecycle.

**Verification:** 1389 tests pass (20 new), build + oclif manifest clean, `develop --help` lists the target. Multi-agent adversarial review: 8 confirmed findings, all fixed (notably: `--fake-media` is a documented no-op for this demo — the spec hardcodes synthetic media). **Not yet run live** — next: non-AV mechanics on slot 1, full AV demo hold on slot 0 (needs a desktop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GaRPfxJgeQqpzGp4NeVcRt