### PR TITLE
fix(saga-stack-cli): connect-api slot>0 sessions mis-dial — stamp the winning SESSIONS_API_URL alias (closes soa#348)

### DIFF
--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
@@ -206,6 +206,10 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
     expect(manifest.services['ads-adm-api'].adoptEnv).toContain('ADM_ALLOW_ROSTER_MODE_OVERRIDE');
   });
 
+  it('connect-api: the sessions dial is adoption-guarded (a stale slot-0-dialing process is refused, not adopted)', () => {
+    expect(manifest.services['connect-api'].adoptEnv).toContain('SESSIONS_API_URL');
+  });
+
   it('ads-adm-api: the session-data provider is adoption-guarded (a stale legacy-provider process is refused, not adopted)', () => {
     expect(manifest.services['ads-adm-api'].adoptEnv).toContain('ADS_ADM_SESSION_DATA_PROVIDER');
     expect(manifest.services['ads-adm-api'].adoptEnv).toContain('ADS_ADM_MOCK_SESSION_DATA_ENABLED');
@@ -233,6 +237,9 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
       // #222 port: dash joins the CORS allowlist; rtsm wired for private-convos.
       ALLOWED_ORIGINS: 'http://localhost:6210,http://localhost:8900',
       SESSIONS_API_BASE_URL: 'http://localhost:3007',
+      // soa#348: the WINNING config alias (qboard .env bakes the slot-0
+      // literal; real env must out-rank dotenv at every slot).
+      SESSIONS_API_URL: 'http://localhost:3007',
       SAGA_API_TARGET: 'https://wootmath.com',
       CONTENT_API_URL: 'http://localhost:3009',
       PUBLIC_API_URL: 'http://localhost:6106',

--- a/packages/node/saga-stack-cli/src/core/manifest/services.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/services.ts
@@ -483,6 +483,14 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
         // the one cross-slot literal that made connect-api un-slottable; the
         // remaining literals (livekit/FLEEK ws:7880) are AV and stay slot-0-pinned.
         SESSIONS_API_BASE_URL: 'http://localhost:${SESSIONS_PORT}',
+        // soa#348: SESSIONS_API_URL is the WINNING alias in connectv3-api's
+        // config (SESSIONS_API_URL || SESSIONS_API_BASE_URL), and the qboard
+        // repo .env bakes it to the slot-0 literal :3007. dotenv never
+        // overrides real env — so set the winner here too, or every slot>0
+        // connect-api silently dials slot-0 sessions-api, whose iam keys
+        // reject the other slot's JWTs ("Authentication required to view a
+        // session" on every telemetry ping; no dosage accrues off slot 0).
+        SESSIONS_API_URL: 'http://localhost:${SESSIONS_PORT}',
         SAGA_API_TARGET: '${SAGA_API_TARGET}',
         CONTENT_API_URL: '${CONTENT_API_URL}',
         PUBLIC_API_URL: '${CONNECT_API_URL}',
@@ -505,6 +513,10 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
     tunnelSlug: 'connect-api',
     isFrontend: false,
     optional: false,
+    // soa#348 adoption guard (soa#305 pattern): a connect-api launched before
+    // SESSIONS_API_URL was stamped dials slot-0 sessions via the .env alias —
+    // refuse to adopt it so slot>0 telemetry can't silently mis-dial.
+    adoptEnv: ['SESSIONS_API_URL'],
   },
   'connect-web': {
     id: 'connect-web',


### PR DESCRIPTION
Closes #348.

**Mechanism (bisected live on slot 1):** slot-N sessions-api accepts slot-N JWTs in both Bearer and cookie form (verified by direct probes — authenticated calls return NOT_FOUND for bogus ids, naked calls return the exact "Authentication required to view a session" from #348's log). So connect-api's forwarded credentials were fine — it was **dialing the wrong slot**: connectv3-api's config resolves `SESSIONS_API_URL || SESSIONS_API_BASE_URL`, qboard's repo `.env` bakes `SESSIONS_API_URL=http://localhost:3007` (slot-0), and the manifest tokenized only the losing alias. dotenv never overrides real env → stamping the winner in the launcher fixes every slot; slot-0 behavior is byte-identical.

Also adoption-guards `SESSIONS_API_URL` on connect-api (soa#305 pattern) so a pre-fix process that would mis-dial is refused rather than silently adopted.

Tests: env assertion updated + new guard case; 1390 pass.

**Unblocks:** `ss develop session-adm --slot N` accruing real dosage off slot 0 (the remaining slot-0 pin is AV/LiveKit only). Live slot-1 verification: stage-8 LAYER-3 telemetry test (the reliable red) run below in the thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GaRPfxJgeQqpzGp4NeVcRt