### PR TITLE
ss stack wipe --slot all — sweep every non-empty slot 1..9

### DIFF
--- a/packages/node/saga-stack-cli/docs/slots.md
+++ b/packages/node/saga-stack-cli/docs/slots.md
@@ -74,6 +74,8 @@ ss stack wipe --slot 3              # prompts, enumerating exactly what dies
 ss stack wipe --set journey-fix --yes   # non-interactive; the set's slot
 ss stack wipe --slot 3 --dry-run    # the same enumeration; changes nothing
 ss stack wipe --slot 3 --snapshots --yes  # also remove ~/.saga-mesh/snapshots-s3
+ss stack wipe --slot all --dry-run  # enumerate EVERY non-empty slot 1..9
+ss stack wipe --slot all --yes      # wipe them all in one sweep
 ```
 
 <details><summary>✓ slot 3 wiped — containers + volumes + state dir gone; snapshots and worktrees kept</summary>
@@ -105,6 +107,14 @@ Notes:
 - `--dry-run` prints the same enumeration and exits 0 without writing a claim;
   `--output-json` reports `{slot, project, stateDir, stopped, volumesRemoved,
   stateDirRemoved, snapshotsRemoved}`.
+- **`--slot all` sweeps slots 1–9.** A slot is a candidate iff it left something behind:
+  its state dir exists, it is live (pids/containers), or — only under `--snapshots` —
+  its snapshot root exists. Slot 0 is never a candidate. A **live-claimed** candidate is
+  *skipped with a warning* instead of aborting the sweep; `--yes` includes it. `--set`
+  and `--state-dir` are ambiguous with `all` and rejected. One confirmation covers the
+  whole sweep, and each wiped slot gets its own advisory claim (a failed wipe still
+  records who attempted it). `--output-json` reports `{mode: "all", wiped: [...per-slot
+  records], skipped: [...slot numbers]}`.
 
 ## Who's on what slot — `ss stack slots` and claim files
 

--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -1218,6 +1218,766 @@
         "traces.js"
       ]
     },
+    "set:check": {
+      "aliases": [],
+      "args": {
+        "name": {
+          "description": "set name (see `set list`)",
+          "name": "name",
+          "required": true
+        }
+      },
+      "description": "Validate a worktree set: paths, buildable-vs-prebuilt, branch drift (warn), primary-checkout posture, cross-set build collisions. Exit 1 on violations.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> journey-fix"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "set:check",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "slotClaimWritten": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "set",
+        "check.js"
+      ]
+    },
+    "set:create": {
+      "aliases": [],
+      "args": {
+        "name": {
+          "description": "set name (must be unused)",
+          "name": "name",
+          "required": true
+        }
+      },
+      "description": "Create a worktree set: git worktree add (new/existing branch) off the primary checkout, pnpm install, and record it in the sets file (createdBy: ss). Single repo per call.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> sched --slot 1 --repo saga-dash --path ~/dev/worktrees/saga-dash-sched --branch feat/sched",
+        "<%= config.bin %> <%= command.id %> topo --slot 2 --repo saga-dash --path ~/dev/worktrees/saga-dash-topo --branch flow/topology --no-install"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "slot the set binds (1..9; slot 0 is the primary-checkout baseline)",
+          "name": "slot",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "repo": {
+          "description": "repo to make a worktree for",
+          "name": "repo",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "soa",
+            "rostering",
+            "program-hub",
+            "saga-dash",
+            "coach",
+            "sds",
+            "qboard",
+            "rtsm",
+            "fleek"
+          ],
+          "type": "option"
+        },
+        "path": {
+          "description": "worktree checkout path (recorded verbatim; `~` stays portable)",
+          "name": "path",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "branch": {
+          "description": "branch to check out — created if new, attached if it exists (default: the set name)",
+          "name": "branch",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "base": {
+          "description": "start point for a NEW branch (default: the primary checkout HEAD, e.g. main)",
+          "name": "base",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "note": {
+          "description": "optional note stored on the set",
+          "name": "note",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "install": {
+          "description": "pnpm install in the new worktree so `--set` up/e2e fresh-skip (use --no-install to skip)",
+          "name": "install",
+          "allowNo": true,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "set:create",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "slotClaimWritten": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "set",
+        "create.js"
+      ]
+    },
+    "set:list": {
+      "aliases": [],
+      "args": {},
+      "description": "List the worktree sets (name, slot, live ACTIVE state, repos) from the sets file (read-only).",
+      "examples": [
+        "<%= config.bin %> <%= command.id %>",
+        "<%= config.bin %> <%= command.id %> --output-json"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "set:list",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "slotClaimWritten": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "set",
+        "list.js"
+      ]
+    },
+    "set:rm": {
+      "aliases": [],
+      "args": {
+        "name": {
+          "description": "set name (see `set list`)",
+          "name": "name",
+          "required": true
+        }
+      },
+      "description": "Remove a worktree set from the sets file. --and-worktrees also `git worktree remove`s the ss-created worktrees (createdBy: ss); hand-recorded paths are never touched.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> sched",
+        "<%= config.bin %> <%= command.id %> sched --and-worktrees --yes"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "and-worktrees": {
+          "description": "also `git worktree remove` the worktrees ss created (createdBy: ss); requires --yes",
+          "name": "and-worktrees",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "force": {
+          "description": "pass --force to `git worktree remove` (a dirty/locked worktree)",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "yes": {
+          "description": "confirm the destructive --and-worktrees removal (required with it)",
+          "name": "yes",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "set:rm",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "slotClaimWritten": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "set",
+        "rm.js"
+      ]
+    },
+    "set:show": {
+      "aliases": [],
+      "args": {
+        "name": {
+          "description": "set name (see `set list`)",
+          "name": "name",
+          "required": true
+        }
+      },
+      "description": "Show one worktree set: slot, repos, and each repo’s live branch + dirty state (read-only).",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> journey-fix"
+      ],
+      "flags": {
+        "porcelain": {
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "slot": {
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "name": "slot",
+          "default": 0,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-json": {
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "name": "set",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "name": "dev",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "name": "state-dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "name": "soa",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "name": "rostering",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "name": "program-hub",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "name": "saga-dash",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "name": "coach",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "name": "sds",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "name": "qboard",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "name": "rtsm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "name": "fleek",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fetch": {
+          "description": "git fetch each repo first so the mainline-currency report reflects the REMOTE tip (network); without it, currency is as-of the last fetch",
+          "name": "fetch",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "set:show",
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "slotClaimWritten": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "set",
+        "show.js"
+      ]
+    },
     "stack:bootstrap": {
       "aliases": [],
       "args": {},
@@ -3352,12 +4112,14 @@
     "stack:wipe": {
       "aliases": [],
       "args": {},
-      "description": "Pristine-reset ONE slot (1..9): stop its native services, docker compose -p soa-s<N> down -v (containers + volumes), rm -rf its state dir; --snapshots also removes ~/.saga-mesh/snapshots-s<N>. Never touches source checkouts. Destructive; requires an explicit --slot 1..9 or --set.",
+      "description": "Pristine-reset ONE slot (1..9) or --slot all (every non-empty slot): stop its native services, docker compose -p soa-s<N> down -v (containers + volumes), rm -rf its state dir; --snapshots also removes ~/.saga-mesh/snapshots-s<N>. Never touches source checkouts. Destructive; requires an explicit --slot 1..9, --slot all, or --set.",
       "examples": [
         "<%= config.bin %> <%= command.id %> --slot 2 --dry-run",
         "<%= config.bin %> <%= command.id %> --slot 2",
         "<%= config.bin %> <%= command.id %> --set my-set --yes",
-        "<%= config.bin %> <%= command.id %> --slot 3 --snapshots --yes"
+        "<%= config.bin %> <%= command.id %> --slot 3 --snapshots --yes",
+        "<%= config.bin %> <%= command.id %> --slot all --dry-run",
+        "<%= config.bin %> <%= command.id %> --slot all --yes"
       ],
       "flags": {
         "porcelain": {
@@ -3367,7 +4129,7 @@
           "type": "boolean"
         },
         "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "description": "slot to wipe: 1..9 (an isolated soa-s<N> sub-stack), or 'all' to wipe every non-empty slot 1..9. Slot 0 (the default) is refused — the shared baseline resets via `stack cold-start`.",
           "name": "slot",
           "default": 0,
           "hasDynamicHelp": false,
@@ -3472,7 +4234,7 @@
           "type": "boolean"
         },
         "yes": {
-          "description": "non-interactive: skip the destructive-action prompt AND override the live-claim guard (CI / agents).",
+          "description": "non-interactive: skip the destructive-action prompt AND override the live-claim guard (CI / agents). With --slot all, also INCLUDES live-claimed slots the sweep would otherwise skip.",
           "name": "yes",
           "allowNo": false,
           "type": "boolean"
@@ -3499,766 +4261,6 @@
         "commands",
         "stack",
         "wipe.js"
-      ]
-    },
-    "set:check": {
-      "aliases": [],
-      "args": {
-        "name": {
-          "description": "set name (see `set list`)",
-          "name": "name",
-          "required": true
-        }
-      },
-      "description": "Validate a worktree set: paths, buildable-vs-prebuilt, branch drift (warn), primary-checkout posture, cross-set build collisions. Exit 1 on violations.",
-      "examples": [
-        "<%= config.bin %> <%= command.id %> journey-fix"
-      ],
-      "flags": {
-        "porcelain": {
-          "description": "machine-readable output; no color, minimal noise",
-          "name": "porcelain",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
-          "name": "slot",
-          "default": 0,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "output-json": {
-          "description": "emit structured JSON on stdout instead of human-readable text",
-          "name": "output-json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "set": {
-          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
-          "name": "set",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dev": {
-          "description": "sibling-repo workspace root (where the saga repos are checked out)",
-          "name": "dev",
-          "noCacheDefault": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
-          "name": "state-dir",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "soa": {
-          "description": "override path to the soa repo checkout",
-          "name": "soa",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rostering": {
-          "description": "override path to the rostering repo checkout",
-          "name": "rostering",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "program-hub": {
-          "description": "override path to the program-hub repo checkout",
-          "name": "program-hub",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "saga-dash": {
-          "description": "override path to the saga-dash repo checkout",
-          "name": "saga-dash",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "coach": {
-          "description": "override path to the coach repo checkout",
-          "name": "coach",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "sds": {
-          "description": "override path to the sds (student-data-system) repo checkout",
-          "name": "sds",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "qboard": {
-          "description": "override path to the qboard repo checkout",
-          "name": "qboard",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rtsm": {
-          "description": "override path to the rtsm repo checkout",
-          "name": "rtsm",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fleek": {
-          "description": "override path to the fleek repo checkout",
-          "name": "fleek",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "set:check",
-      "pluginAlias": "@saga-ed/saga-stack-cli",
-      "pluginName": "@saga-ed/saga-stack-cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "slotClaimWritten": false,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "set",
-        "check.js"
-      ]
-    },
-    "set:create": {
-      "aliases": [],
-      "args": {
-        "name": {
-          "description": "set name (must be unused)",
-          "name": "name",
-          "required": true
-        }
-      },
-      "description": "Create a worktree set: git worktree add (new/existing branch) off the primary checkout, pnpm install, and record it in the sets file (createdBy: ss). Single repo per call.",
-      "examples": [
-        "<%= config.bin %> <%= command.id %> sched --slot 1 --repo saga-dash --path ~/dev/worktrees/saga-dash-sched --branch feat/sched",
-        "<%= config.bin %> <%= command.id %> topo --slot 2 --repo saga-dash --path ~/dev/worktrees/saga-dash-topo --branch flow/topology --no-install"
-      ],
-      "flags": {
-        "porcelain": {
-          "description": "machine-readable output; no color, minimal noise",
-          "name": "porcelain",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "slot": {
-          "description": "slot the set binds (1..9; slot 0 is the primary-checkout baseline)",
-          "name": "slot",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "output-json": {
-          "description": "emit structured JSON on stdout instead of human-readable text",
-          "name": "output-json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "set": {
-          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
-          "name": "set",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dev": {
-          "description": "sibling-repo workspace root (where the saga repos are checked out)",
-          "name": "dev",
-          "noCacheDefault": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
-          "name": "state-dir",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "soa": {
-          "description": "override path to the soa repo checkout",
-          "name": "soa",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rostering": {
-          "description": "override path to the rostering repo checkout",
-          "name": "rostering",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "program-hub": {
-          "description": "override path to the program-hub repo checkout",
-          "name": "program-hub",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "saga-dash": {
-          "description": "override path to the saga-dash repo checkout",
-          "name": "saga-dash",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "coach": {
-          "description": "override path to the coach repo checkout",
-          "name": "coach",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "sds": {
-          "description": "override path to the sds (student-data-system) repo checkout",
-          "name": "sds",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "qboard": {
-          "description": "override path to the qboard repo checkout",
-          "name": "qboard",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rtsm": {
-          "description": "override path to the rtsm repo checkout",
-          "name": "rtsm",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fleek": {
-          "description": "override path to the fleek repo checkout",
-          "name": "fleek",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "repo": {
-          "description": "repo to make a worktree for",
-          "name": "repo",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "options": [
-            "soa",
-            "rostering",
-            "program-hub",
-            "saga-dash",
-            "coach",
-            "sds",
-            "qboard",
-            "rtsm",
-            "fleek"
-          ],
-          "type": "option"
-        },
-        "path": {
-          "description": "worktree checkout path (recorded verbatim; `~` stays portable)",
-          "name": "path",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "branch": {
-          "description": "branch to check out — created if new, attached if it exists (default: the set name)",
-          "name": "branch",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "base": {
-          "description": "start point for a NEW branch (default: the primary checkout HEAD, e.g. main)",
-          "name": "base",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "note": {
-          "description": "optional note stored on the set",
-          "name": "note",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "install": {
-          "description": "pnpm install in the new worktree so `--set` up/e2e fresh-skip (use --no-install to skip)",
-          "name": "install",
-          "allowNo": true,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "set:create",
-      "pluginAlias": "@saga-ed/saga-stack-cli",
-      "pluginName": "@saga-ed/saga-stack-cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "slotClaimWritten": false,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "set",
-        "create.js"
-      ]
-    },
-    "set:list": {
-      "aliases": [],
-      "args": {},
-      "description": "List the worktree sets (name, slot, live ACTIVE state, repos) from the sets file (read-only).",
-      "examples": [
-        "<%= config.bin %> <%= command.id %>",
-        "<%= config.bin %> <%= command.id %> --output-json"
-      ],
-      "flags": {
-        "porcelain": {
-          "description": "machine-readable output; no color, minimal noise",
-          "name": "porcelain",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
-          "name": "slot",
-          "default": 0,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "output-json": {
-          "description": "emit structured JSON on stdout instead of human-readable text",
-          "name": "output-json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "set": {
-          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
-          "name": "set",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dev": {
-          "description": "sibling-repo workspace root (where the saga repos are checked out)",
-          "name": "dev",
-          "noCacheDefault": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
-          "name": "state-dir",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "soa": {
-          "description": "override path to the soa repo checkout",
-          "name": "soa",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rostering": {
-          "description": "override path to the rostering repo checkout",
-          "name": "rostering",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "program-hub": {
-          "description": "override path to the program-hub repo checkout",
-          "name": "program-hub",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "saga-dash": {
-          "description": "override path to the saga-dash repo checkout",
-          "name": "saga-dash",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "coach": {
-          "description": "override path to the coach repo checkout",
-          "name": "coach",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "sds": {
-          "description": "override path to the sds (student-data-system) repo checkout",
-          "name": "sds",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "qboard": {
-          "description": "override path to the qboard repo checkout",
-          "name": "qboard",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rtsm": {
-          "description": "override path to the rtsm repo checkout",
-          "name": "rtsm",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fleek": {
-          "description": "override path to the fleek repo checkout",
-          "name": "fleek",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "set:list",
-      "pluginAlias": "@saga-ed/saga-stack-cli",
-      "pluginName": "@saga-ed/saga-stack-cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "slotClaimWritten": false,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "set",
-        "list.js"
-      ]
-    },
-    "set:rm": {
-      "aliases": [],
-      "args": {
-        "name": {
-          "description": "set name (see `set list`)",
-          "name": "name",
-          "required": true
-        }
-      },
-      "description": "Remove a worktree set from the sets file. --and-worktrees also `git worktree remove`s the ss-created worktrees (createdBy: ss); hand-recorded paths are never touched.",
-      "examples": [
-        "<%= config.bin %> <%= command.id %> sched",
-        "<%= config.bin %> <%= command.id %> sched --and-worktrees --yes"
-      ],
-      "flags": {
-        "porcelain": {
-          "description": "machine-readable output; no color, minimal noise",
-          "name": "porcelain",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
-          "name": "slot",
-          "default": 0,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "output-json": {
-          "description": "emit structured JSON on stdout instead of human-readable text",
-          "name": "output-json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "set": {
-          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
-          "name": "set",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dev": {
-          "description": "sibling-repo workspace root (where the saga repos are checked out)",
-          "name": "dev",
-          "noCacheDefault": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
-          "name": "state-dir",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "soa": {
-          "description": "override path to the soa repo checkout",
-          "name": "soa",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rostering": {
-          "description": "override path to the rostering repo checkout",
-          "name": "rostering",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "program-hub": {
-          "description": "override path to the program-hub repo checkout",
-          "name": "program-hub",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "saga-dash": {
-          "description": "override path to the saga-dash repo checkout",
-          "name": "saga-dash",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "coach": {
-          "description": "override path to the coach repo checkout",
-          "name": "coach",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "sds": {
-          "description": "override path to the sds (student-data-system) repo checkout",
-          "name": "sds",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "qboard": {
-          "description": "override path to the qboard repo checkout",
-          "name": "qboard",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rtsm": {
-          "description": "override path to the rtsm repo checkout",
-          "name": "rtsm",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fleek": {
-          "description": "override path to the fleek repo checkout",
-          "name": "fleek",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "and-worktrees": {
-          "description": "also `git worktree remove` the worktrees ss created (createdBy: ss); requires --yes",
-          "name": "and-worktrees",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "force": {
-          "description": "pass --force to `git worktree remove` (a dirty/locked worktree)",
-          "name": "force",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "yes": {
-          "description": "confirm the destructive --and-worktrees removal (required with it)",
-          "name": "yes",
-          "allowNo": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "set:rm",
-      "pluginAlias": "@saga-ed/saga-stack-cli",
-      "pluginName": "@saga-ed/saga-stack-cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "slotClaimWritten": false,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "set",
-        "rm.js"
-      ]
-    },
-    "set:show": {
-      "aliases": [],
-      "args": {
-        "name": {
-          "description": "set name (see `set list`)",
-          "name": "name",
-          "required": true
-        }
-      },
-      "description": "Show one worktree set: slot, repos, and each repo’s live branch + dirty state (read-only).",
-      "examples": [
-        "<%= config.bin %> <%= command.id %> journey-fix"
-      ],
-      "flags": {
-        "porcelain": {
-          "description": "machine-readable output; no color, minimal noise",
-          "name": "porcelain",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "slot": {
-          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
-          "name": "slot",
-          "default": 0,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "output-json": {
-          "description": "emit structured JSON on stdout instead of human-readable text",
-          "name": "output-json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "set": {
-          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
-          "name": "set",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dev": {
-          "description": "sibling-repo workspace root (where the saga repos are checked out)",
-          "name": "dev",
-          "noCacheDefault": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "state-dir": {
-          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
-          "name": "state-dir",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "soa": {
-          "description": "override path to the soa repo checkout",
-          "name": "soa",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rostering": {
-          "description": "override path to the rostering repo checkout",
-          "name": "rostering",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "program-hub": {
-          "description": "override path to the program-hub repo checkout",
-          "name": "program-hub",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "saga-dash": {
-          "description": "override path to the saga-dash repo checkout",
-          "name": "saga-dash",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "coach": {
-          "description": "override path to the coach repo checkout",
-          "name": "coach",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "sds": {
-          "description": "override path to the sds (student-data-system) repo checkout",
-          "name": "sds",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "qboard": {
-          "description": "override path to the qboard repo checkout",
-          "name": "qboard",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "rtsm": {
-          "description": "override path to the rtsm repo checkout",
-          "name": "rtsm",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fleek": {
-          "description": "override path to the fleek repo checkout",
-          "name": "fleek",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "fetch": {
-          "description": "git fetch each repo first so the mainline-currency report reflects the REMOTE tip (network); without it, currency is as-of the last fetch",
-          "name": "fetch",
-          "allowNo": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "set:show",
-      "pluginAlias": "@saga-ed/saga-stack-cli",
-      "pluginName": "@saga-ed/saga-stack-cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "slotClaimWritten": false,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "set",
-        "show.js"
       ]
     },
     "stack:bundle:list": {

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/wipe.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/wipe.int.test.ts
@@ -23,6 +23,12 @@
  * the live-claim guard (refuses without `--yes`, proceeds with it, stale claims
  * never block); the set-binding "worktrees are NOT touched" notice; a declined
  * prompt tearing down nothing; and the pinned `--output-json` shape.
+ *
+ * `--slot all` (soa#351): candidacy (state dir / live activity / snapshots-only
+ * under `--snapshots`), slot-ordered sweep with PER-SLOT claims (the central hook
+ * — which would resolve `all` to slot 0 — must stay suppressed), live-claimed
+ * slots skipped without `--yes` and included with it, `--state-dir`/`--set`
+ * rejected, and the all-mode `--output-json` shape {mode, wiped[], skipped[]}.
  */
 
 import { homedir } from 'node:os';
@@ -126,8 +132,9 @@ function installDockerWipe(ok = true): void {
  * prototype, `vi.spyOn` throws in beforeEach — failing FAST before any real
  * rm could run.
  */
-function installSlotWipe(): void {
+function installSlotWipe(existing: string[] = []): void {
   const fake: SlotWipe = {
+    exists: (dir: string) => existing.includes(dir),
     remove(dir: string): boolean {
       events.push(`rm:${dir}`);
       return true;
@@ -349,6 +356,149 @@ describe('stack wipe — set-bound slot', () => {
     expect(text).toMatch(/not touched|never touched|untouched|not removed|left (as-is|in place|alone)/i);
     // The wipe itself still ran — only the slot's runtime residue dies, never source.
     expect(events).toEqual(S3_TEARDOWN);
+  });
+});
+
+describe('stack wipe --slot all (soa#351) — sweep every non-empty slot 1..9', () => {
+  const STATE_S2 = '/tmp/sds-synthetic-s2';
+  const STATE_S5 = '/tmp/sds-synthetic-s5';
+  const S2_TEARDOWN = [`stop:${STATE_S2}`, 'docker-down-v:soa-s2', `rm:${STATE_S2}`];
+  const S5_TEARDOWN = [`stop:${STATE_S5}`, 'docker-down-v:soa-s5', `rm:${STATE_S5}`];
+
+  it('--dry-run enumerates ONLY the non-empty slots, tears down and claims NOTHING', async () => {
+    installSlotWipe([STATE_S2, STATE_S5]);
+
+    await expect(StackWipe.run(['--slot', 'all', '--dry-run', ...WS], config)).resolves.toBeUndefined();
+
+    const text = out.join('\n');
+    expect(text).toContain('soa-s2');
+    expect(text).toContain('soa-s5');
+    expect(text).not.toContain('soa-s3'); // empty slots are not candidates.
+    expect(events).toEqual([]);
+    expect(claimWrites).toHaveLength(0); // NO claim in all-mode dry-run — including slot 0.
+    expect(prompts).toHaveLength(0);
+  });
+
+  it('--yes wipes each candidate in slot order with a PER-SLOT claim (never slot 0)', async () => {
+    installSlotWipe([STATE_S2, STATE_S5]);
+
+    await expect(StackWipe.run(['--slot', 'all', '--yes', ...WS], config)).resolves.toBeUndefined();
+
+    expect(events).toEqual([...S2_TEARDOWN, ...S5_TEARDOWN]);
+    expect(events).not.toContain('system-prune');
+    expect(prompts).toHaveLength(0);
+    // One advisory claim per wiped slot — the central hook (which would resolve
+    // `all` to slot 0) stayed suppressed.
+    expect(claimWrites.map((c) => c.slot)).toEqual([2, 5]);
+    expect(claimWrites.map((c) => c.stateDir)).toEqual([STATE_S2, STATE_S5]);
+  });
+
+  it('an ACTIVE slot with no state dir is still a candidate (live containers count)', async () => {
+    installSlotWipe([]);
+    spySlotActive(['soa-s4']);
+
+    await expect(StackWipe.run(['--slot', 'all', '--yes', ...WS], config)).resolves.toBeUndefined();
+
+    expect(events).toEqual(['stop:/tmp/sds-synthetic-s4', 'docker-down-v:soa-s4', 'rm:/tmp/sds-synthetic-s4']);
+  });
+
+  it('a live-claimed slot is SKIPPED (sweep continues) without --yes; one prompt covers the rest', async () => {
+    installSlotWipe([STATE_S2, STATE_S3]);
+    installClaimReader({ [STATE_S3]: claimResult({}, true) });
+    installConfirm(true);
+
+    await expect(StackWipe.run(['--slot', 'all', ...WS], config)).resolves.toBeUndefined();
+
+    expect(prompts).toHaveLength(1);
+    expect(events).toEqual(S2_TEARDOWN); // slot 3 skipped, slot 2 wiped.
+    expect(claimWrites.map((c) => c.slot)).toEqual([2]);
+  });
+
+  it('--yes INCLUDES the live-claimed slot in the sweep', async () => {
+    installSlotWipe([STATE_S2, STATE_S3]);
+    installClaimReader({ [STATE_S3]: claimResult({}, true) });
+
+    await expect(StackWipe.run(['--slot', 'all', '--yes', ...WS], config)).resolves.toBeUndefined();
+
+    expect(events).toEqual([...S2_TEARDOWN, ...S3_TEARDOWN]);
+    expect(claimWrites.map((c) => c.slot)).toEqual([2, 3]);
+  });
+
+  it('--snapshots widens candidacy to snapshot-only slots and removes their roots', async () => {
+    const SNAP_S7 = join(homedir(), '.saga-mesh', 'snapshots-s7');
+    installSlotWipe([SNAP_S7]);
+
+    await expect(
+      StackWipe.run(['--slot', 'all', '--snapshots', '--yes', ...WS], config),
+    ).resolves.toBeUndefined();
+
+    expect(events).toContain(`rm:${SNAP_S7}`);
+  });
+
+  it('no non-empty slots ⇒ clean exit 0, nothing executed, nothing claimed', async () => {
+    installSlotWipe([]);
+
+    await expect(StackWipe.run(['--slot', 'all', '--yes', ...WS], config)).resolves.toBeUndefined();
+
+    expect(events).toEqual([]);
+    expect(claimWrites).toHaveLength(0);
+    expect(out.join('\n')).toContain('nothing to wipe');
+  });
+
+  it('a declined prompt tears down NOTHING across the whole sweep', async () => {
+    installSlotWipe([STATE_S2, STATE_S5]);
+    installConfirm(false);
+
+    await StackWipe.run(['--slot', 'all', ...WS], config).catch(() => undefined);
+
+    expect(prompts).toHaveLength(1);
+    expect(events).toEqual([]);
+    expect(claimWrites).toHaveLength(0);
+  });
+
+  it('--state-dir is rejected as ambiguous with --slot all', async () => {
+    installSlotWipe([STATE_S2]);
+
+    await expect(
+      StackWipe.run(['--slot', 'all', '--state-dir', '/tmp/x', '--yes', ...WS], config),
+    ).rejects.toThrow(/ambiguous/);
+    expect(events).toEqual([]);
+  });
+
+  it('--set is rejected with --slot all (the set owns ONE slot)', async () => {
+    spySetStore({
+      version: 1,
+      sets: { 'journey-fix': { slot: 3, repos: { 'saga-dash': '/wt/dash-j' } } },
+    });
+    installSlotWipe([STATE_S3]);
+
+    await expect(
+      StackWipe.run(['--slot', 'all', '--set', 'journey-fix', '--yes', ...WS], config),
+    ).rejects.toThrow(/bound to slot 3/);
+    expect(events).toEqual([]);
+  });
+
+  it('--output-json emits the pinned all-mode shape {mode, wiped[], skipped[]}', async () => {
+    installSlotWipe([STATE_S2]);
+
+    await expect(
+      StackWipe.run(['--slot', 'all', '--yes', '--output-json', ...WS], config),
+    ).resolves.toBeUndefined();
+
+    const json = emittedJson();
+    expect(Object.keys(json).sort()).toEqual(['mode', 'skipped', 'wiped']);
+    expect(json.mode).toBe('all');
+    expect(json.skipped).toEqual([]);
+    const wiped = json.wiped as Record<string, unknown>[];
+    expect(wiped).toHaveLength(1);
+    expect(wiped[0]).toMatchObject({
+      slot: 2,
+      project: 'soa-s2',
+      stateDir: STATE_S2,
+      volumesRemoved: true,
+      stateDirRemoved: true,
+      snapshotsRemoved: false,
+    });
   });
 });
 

--- a/packages/node/saga-stack-cli/src/commands/stack/wipe.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/wipe.ts
@@ -1,5 +1,6 @@
 /**
- * `saga-stack stack wipe` — pristine-reset ONE slot 1..9 (soa#340).
+ * `saga-stack stack wipe` — pristine-reset ONE slot 1..9 (soa#340), or every
+ * non-empty slot at once via `--slot all` (soa#351).
  *
  * Where `stack down` stops a slot's services (volumes preserved) and `stack cold-start`
  * factory-resets the WHOLE slot-0 baseline, `wipe` makes a single isolated slot vanish:
@@ -22,10 +23,21 @@
  * NEVER touches source checkouts/worktrees — no git operations at all (worktree removal
  * stays `ss set rm --and-worktrees`).
  *
+ * `--slot all` (soa#351) sweeps slots 1..9 and runs the same per-slot teardown on every
+ * NON-EMPTY one — a slot is a candidate iff its state dir exists, the slot is live
+ * (pids/containers — the SlotActiveProbe), or (`--snapshots` only) its snapshot root
+ * exists. Slot 0 is never a candidate. A live-claimed candidate is SKIPPED with a
+ * warning instead of aborting the sweep (the single-slot hard refusal would strand the
+ * rest); `--yes` includes it. `--set` and `--state-dir` are ambiguous with `all` and
+ * rejected. CLAIM WRINKLE: BaseCommand's central claim hook resolves a non-numeric
+ * `--slot` to slot 0 — in all-mode it is suppressed (`claimsSlot()` ⇒ false) and run()
+ * writes a per-slot claim itself before each teardown, so a failed wipe still records
+ * who attempted it and slot 0's claim is never clobbered.
+ *
  * GUARDS:
  *   - slot 0 (including a bare invocation — `--slot` defaults to 0) is REFUSED with a
- *     pointer to `stack cold-start`; an explicit `--slot 1..9` or `--set <name>` (the set
- *     owns its slot) is required. Non-zero exit.
+ *     pointer to `stack cold-start`; an explicit `--slot 1..9`, `--slot all`, or
+ *     `--set <name>` (the set owns its slot) is required. Non-zero exit.
  *   - live-claim guard: if the slot's PRIOR `claim.json` records a pid that is still alive
  *     (and isn't this process's own claim), another driver is running — refuse ("claimed by
  *     <actor> <age> ago and still running"); `--yes` overrides. Stale claims never block.
@@ -40,6 +52,8 @@
  *   ss stack wipe --slot 2                 # prompt, then wipe slot 2 (snapshots kept)
  *   ss stack wipe --set my-set --yes       # non-interactive (agent/CI); set supplies the slot
  *   ss stack wipe --slot 3 --snapshots     # also drop ~/.saga-mesh/snapshots-s3
+ *   ss stack wipe --slot all --dry-run     # enumerate every non-empty slot 1..9
+ *   ss stack wipe --slot all --yes         # wipe them all (live-claimed slots included)
  */
 
 import { Flags } from '@oclif/core';
@@ -47,30 +61,67 @@ import type { Interfaces } from '@oclif/core';
 import { BaseCommand } from '../../base-command.js';
 import { deriveInstance } from '../../core/derive-instance.js';
 import type { InstanceProfile } from '../../core/derive-instance.js';
-import type { WorktreeSet } from '../../core/set/index.js';
+import { SET_REPO_KEYS } from '../../core/set/index.js';
+import type { SetRepoKey, WorktreeSet } from '../../core/set/index.js';
 import {
   composeDownVArgs,
   relativeAge,
   repoContextFromFlags,
   resolveRepoRoot,
+  REPO_ENV_VAR,
 } from '../../runtime/index.js';
 import type { ClaimReadResult, StopServiceResult } from '../../runtime/index.js';
 
+/**
+ * `--slot` for wipe ONLY: the base integer 0..9 (`shared-flags.ts` semantics) OR the
+ * literal `all` (soa#351). Overriding here keeps the shared flag an integer everywhere
+ * else — no other command accepts `all`.
+ */
+const slotOrAll = Flags.custom<number | 'all'>({
+  default: 0,
+  description:
+    "slot to wipe: 1..9 (an isolated soa-s<N> sub-stack), or 'all' to wipe every non-empty " +
+    'slot 1..9. Slot 0 (the default) is refused — the shared baseline resets via `stack cold-start`.',
+  parse: async (input: string) => {
+    if (input === 'all') return 'all';
+    const n = Number(input);
+    if (!Number.isInteger(n) || n < 0 || n > 9) {
+      throw new Error("--slot must be an integer 0..9 or 'all'");
+    }
+    return n;
+  },
+});
+
+/** The per-slot outcome record shared by the single-slot emit and the all-mode summary. */
+interface WipeOutcome {
+  slot: number;
+  project: string;
+  stateDir: string;
+  stopped: number;
+  volumesRemoved: boolean;
+  stateDirRemoved: boolean;
+  snapshotsRemoved: boolean;
+}
+
 export default class StackWipe extends BaseCommand {
   static description =
-    'Pristine-reset ONE slot (1..9): stop its native services, docker compose -p soa-s<N> down -v ' +
-    '(containers + volumes), rm -rf its state dir; --snapshots also removes ~/.saga-mesh/snapshots-s<N>. ' +
-    'Never touches source checkouts. Destructive; requires an explicit --slot 1..9 or --set.';
+    'Pristine-reset ONE slot (1..9) or --slot all (every non-empty slot): stop its native services, ' +
+    'docker compose -p soa-s<N> down -v (containers + volumes), rm -rf its state dir; --snapshots also ' +
+    'removes ~/.saga-mesh/snapshots-s<N>. Never touches source checkouts. Destructive; requires an ' +
+    'explicit --slot 1..9, --slot all, or --set.';
 
   static examples = [
     '<%= config.bin %> <%= command.id %> --slot 2 --dry-run',
     '<%= config.bin %> <%= command.id %> --slot 2',
     '<%= config.bin %> <%= command.id %> --set my-set --yes',
     '<%= config.bin %> <%= command.id %> --slot 3 --snapshots --yes',
+    '<%= config.bin %> <%= command.id %> --slot all --dry-run',
+    '<%= config.bin %> <%= command.id %> --slot all --yes',
   ];
 
   static flags = {
     ...BaseCommand.baseFlags,
+    slot: slotOrAll(),
     'dry-run': Flags.boolean({
       description:
         'print exactly what would die (containers/volumes, state dir, snapshots posture) and exit 0 without touching anything — no claim is written.',
@@ -78,7 +129,8 @@ export default class StackWipe extends BaseCommand {
     }),
     yes: Flags.boolean({
       description:
-        'non-interactive: skip the destructive-action prompt AND override the live-claim guard (CI / agents).',
+        'non-interactive: skip the destructive-action prompt AND override the live-claim guard (CI / agents). ' +
+        'With --slot all, also INCLUDES live-claimed slots the sweep would otherwise skip.',
       default: false,
     }),
     snapshots: Flags.boolean({
@@ -100,11 +152,16 @@ export default class StackWipe extends BaseCommand {
 
   /**
    * Slot claims: a wipe DRIVES the slot — a FAILED wipe usefully records who attempted;
-   * a successful one deletes the claim along with the state dir (step c).
+   * a successful one deletes the claim along with the state dir (step c). SUPPRESSED in
+   * all-mode: the central hook resolves a non-numeric `--slot` to slot 0 and would
+   * clobber slot 0's claim; `runAll` writes a per-slot claim itself instead.
    */
   protected claimsSlot(): boolean {
-    return true;
+    return !this.allMode;
   }
+
+  /** `--slot all` detected from the raw argv in `parse` (before flag parsing). */
+  private allMode = false;
 
   /**
    * The prior driver's claim per state dir, captured BEFORE BaseCommand's claim hook
@@ -119,7 +176,9 @@ export default class StackWipe extends BaseCommand {
    * claim, and the prior driver's claim (the one the live-claim guard needs) would
    * already be destroyed. Capture the pre-existing claims here, before delegating to
    * super.parse. The candidate state dirs are deterministic (slots 1..9) plus any raw
-   * `--state-dir` token, so no flag parsing is needed to enumerate them.
+   * `--state-dir` token, so no flag parsing is needed to enumerate them. The same raw
+   * scan detects `--slot all` (soa#351) so `claimsSlot()` can suppress the central
+   * hook before it runs.
    */
   protected async parse<
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -132,8 +191,20 @@ export default class StackWipe extends BaseCommand {
     options?: Interfaces.Input<F, B, A>,
     argv?: string[],
   ): Promise<Interfaces.ParserOutput<F, B, A>> {
-    this.capturePriorClaims(argv ?? this.argv);
+    const raw = argv ?? this.argv;
+    this.allMode = StackWipe.hasAllToken(raw);
+    this.capturePriorClaims(raw);
     return super.parse<F, B, A>(options, argv);
+  }
+
+  /** Raw-argv detection of `--slot all` / `--slot=all` (runs before oclif parsing). */
+  private static hasAllToken(rawArgv: readonly string[]): boolean {
+    for (let i = 0; i < rawArgv.length; i++) {
+      const token = rawArgv[i];
+      if (token === '--slot' && rawArgv[i + 1] === 'all') return true;
+      if (token === '--slot=all') return true;
+    }
+    return false;
   }
 
   /** Read (and remember) the current claim of every candidate state dir. Reads only — never writes. */
@@ -162,17 +233,35 @@ export default class StackWipe extends BaseCommand {
     // output stays parseable; warnings still go to stderr via this.warn.
     const human = !flags['output-json'] && !flags.porcelain;
 
+    // oclif infers the parsed flag bag from `flags` AND the inherited `baseFlags`,
+    // and the base integer `slot` collapses the union to `number` (overriding
+    // `static baseFlags` is a TS2417 static-side violation) — re-widen once here;
+    // the runtime value is exactly what slotOrAll's parser returned.
+    const slot = flags.slot as number | 'all';
+
+    if (slot === 'all') {
+      // `--set` + `--slot all` already died in the central set-injection guard
+      // (a typed --slot that disagrees with the set's slot is a hard error).
+      if (flags['state-dir'] !== undefined) {
+        this.error(
+          "--state-dir pins ONE slot's state and is ambiguous with --slot all — drop one of them.",
+        );
+      }
+      await this.runAll(flags, dry, human);
+      return;
+    }
+
     // ── GUARD: slot 0 / bare invocation refused (non-zero). `--slot` defaults to 0, so a
     // bare `ss stack wipe` lands here too; `--set` always passes (a set is bound to 1..9,
     // and its slot was injected into flags.slot during parse — "the set owns its slot").
-    if (flags.slot === 0) {
+    if (slot === 0) {
       this.error(
-        'stack wipe pristine-resets ONE isolated slot and requires an explicit --slot 1..9 ' +
-          'or --set <name>. Slot 0 is the shared baseline — use `ss stack cold-start` to reset it.',
+        'stack wipe pristine-resets isolated slots and requires an explicit --slot 1..9, ' +
+          '--slot all, or --set <name>. Slot 0 is the shared baseline — use `ss stack cold-start` to reset it.',
       );
     }
 
-    const profile = deriveInstance({ slot: flags.slot });
+    const profile = deriveInstance({ slot });
     // Mirror down/up's resolution: an EXPLICIT --state-dir wins (that's where up recorded
     // the pids), otherwise the slot's canonical /tmp/sds-synthetic-s<N>.
     const stateDir = flags['state-dir'] ?? profile.stateDir;
@@ -237,10 +326,159 @@ export default class StackWipe extends BaseCommand {
       for (const line of plan) this.log(line);
     }
 
+    const outcome = await this.teardownSlot(profile, stateDir, withSnapshots, flags, human, '');
+
+    this.emit(
+      flags,
+      { ...outcome },
+      `✓ slot ${profile.slot} wiped — ${profile.project} down -v'd, ${stateDir} removed` +
+        (withSnapshots ? ', snapshots removed.' : ' (snapshots kept).'),
+    );
+  }
+
+  /**
+   * `--slot all` (soa#351): sweep slots 1..9 and wipe every non-empty one. Candidacy is
+   * cheap and local — state dir on disk, live activity (the same probe `stack slots`
+   * trusts), or (only when they are in scope via `--snapshots`) a snapshot root. A
+   * live-claimed candidate is skipped with a warning rather than aborting the sweep;
+   * `--yes` includes it.
+   */
+  private async runAll(
+    flags: {
+      yes: boolean;
+      snapshots: boolean;
+      porcelain: boolean;
+      'output-json': boolean;
+      [k: string]: unknown;
+    },
+    dry: boolean,
+    human: boolean,
+  ): Promise<void> {
+    const remover = this.getSlotWipe();
+    const probe = this.getSlotActiveProbe();
+    const withSnapshots = flags.snapshots;
+
+    const candidates: InstanceProfile[] = [];
+    const skipped: { profile: InstanceProfile; prior: ClaimReadResult }[] = [];
+    for (let slot = 1; slot <= 9; slot++) {
+      const profile = deriveInstance({ slot });
+      const nonEmpty =
+        remover.exists(profile.stateDir) ||
+        (await probe.isActive(profile.stateDir, profile.project)) ||
+        (withSnapshots && profile.snapshotsDir !== undefined && remover.exists(profile.snapshotsDir));
+      if (!nonEmpty) continue;
+      const prior = this.priorClaims.get(profile.stateDir);
+      const foreignLive = prior !== undefined && prior.live && prior.claim.pid !== process.pid;
+      if (foreignLive && !flags.yes) {
+        skipped.push({ profile, prior });
+        continue;
+      }
+      candidates.push(profile);
+    }
+
+    const skipLine = ({ profile, prior }: { profile: InstanceProfile; prior: ClaimReadResult }): string =>
+      `slot ${profile.slot}: live-claimed by ${prior.claim.actor} (${relativeAge(prior.claim.at)} ago, ` +
+      `pid ${prior.claim.pid} still running) — skipped; pass --yes to include it.`;
+
+    if (candidates.length === 0) {
+      for (const s of skipped) this.warn(skipLine(s));
+      const message =
+        skipped.length === 0
+          ? '✓ nothing to wipe — no non-empty slots (1..9).'
+          : `✓ nothing wiped — ${skipped.length} non-empty slot(s) live-claimed (--yes includes them).`;
+      if (dry) {
+        this.log(message);
+        return;
+      }
+      this.emit(flags, { mode: 'all', wiped: [], skipped: skipped.map((s) => s.profile.slot) }, message);
+      return;
+    }
+
+    // ── the sweep enumeration: every candidate's full plan, then the skips ──
+    const header = dry
+      ? `▶ stack wipe DRY RUN — ALL non-empty slots (nothing will be changed):`
+      : `▶ stack wipe — ALL non-empty slots (pristine reset${flags.yes ? ', --yes' : ''}):`;
+    if (human || !flags.yes || dry) this.log(header);
+    for (const profile of candidates) {
+      this.log(`  slot ${profile.slot}:`);
+      const set = this.ownerSet(profile.slot);
+      for (const line of this.planLines(profile, profile.stateDir, withSnapshots, set)) this.log(line);
+    }
+    for (const s of skipped) {
+      if (dry) this.log(`  note: ${skipLine(s)}`);
+      else this.warn(skipLine(s));
+    }
+
+    if (dry) {
+      this.log('✓ wipe dry run complete — no changes made.');
+      return;
+    }
+
+    if (!flags.yes) {
+      const ok = await this.getConfirm().prompt(
+        `\n  This DESTROYS ${candidates.length} slot(s) (${candidates.map((p) => p.slot).join(', ')}): ` +
+          `containers, DB volumes, and run state${withSnapshots ? ' AND snapshots' : ''}. Continue? [y/N] `,
+      );
+      if (!ok) {
+        this.log('wipe aborted — nothing changed.');
+        return;
+      }
+    }
+
+    // Per-slot advisory claim (the central hook is suppressed in all-mode — it would
+    // resolve `all` to slot 0): written before each teardown so a failed wipe still
+    // records who attempted it; a successful one deletes it with the state dir.
+    const ctx = repoContextFromFlags(flags as unknown as Record<string, unknown>);
+    const repoRoots: Partial<Record<SetRepoKey, string>> = {};
+    for (const repo of SET_REPO_KEYS) repoRoots[repo] = resolveRepoRoot(REPO_ENV_VAR[repo], ctx);
+    const command = [this.config.bin, this.id, ...this.argv].join(' ');
+
+    const wiped: WipeOutcome[] = [];
+    for (const profile of candidates) {
+      await this.getClaimWriter().write({
+        slot: profile.slot,
+        stateDir: profile.stateDir,
+        command,
+        repoRoots,
+      });
+      wiped.push(
+        await this.teardownSlot(
+          profile,
+          profile.stateDir,
+          withSnapshots,
+          flags,
+          human,
+          `slot ${profile.slot} · `,
+        ),
+      );
+    }
+
+    this.emit(
+      flags,
+      { mode: 'all', wiped, skipped: skipped.map((s) => s.profile.slot) },
+      `✓ ${wiped.length} slot(s) wiped — ${wiped.map((w) => w.project).join(', ')} down -v'd, state dirs removed` +
+        (withSnapshots ? ', snapshots removed' : ' (snapshots kept)') +
+        (skipped.length > 0 ? `; ${skipped.length} live-claimed slot(s) skipped.` : '.'),
+    );
+  }
+
+  /**
+   * Steps a–d for ONE slot — the shared teardown behind both the single-slot path and
+   * the `--slot all` sweep. `tag` prefixes the human step lines (`''` single-slot,
+   * `slot <N> · ` in a sweep) so single-slot output stays byte-identical to soa#340.
+   */
+  private async teardownSlot(
+    profile: InstanceProfile,
+    stateDir: string,
+    withSnapshots: boolean,
+    flags: { [k: string]: unknown },
+    human: boolean,
+    tag: string,
+  ): Promise<WipeOutcome> {
     const total = withSnapshots ? 4 : 3;
 
     // ── (a) stop the slot's services natively (down's exact runtime path) ──
-    if (human) this.log(`▶ 1/${total} services — stop natives recorded under ${stateDir} (kill-by-pidfile)`);
+    if (human) this.log(`▶ ${tag}1/${total} services — stop natives recorded under ${stateDir} (kill-by-pidfile)`);
     const stopResults: StopServiceResult[] = await this.getServiceStopper()(stateDir);
     const stoppedList = stopResults.filter((s) => s.outcome === 'term' || s.outcome === 'kill');
     const survived = stopResults.filter((s) => s.outcome === 'alive');
@@ -265,7 +503,7 @@ export default class StackWipe extends BaseCommand {
 
     // ── (b) docker compose -p soa-s<N> down -v (containers + volumes) — the existing
     // project-scoped DockerWipe seam; NEVER systemPrune (host-global) from here. ──
-    if (human) this.log(`▶ 2/${total} docker — compose -p ${profile.project} down -v (containers + volumes)`);
+    if (human) this.log(`▶ ${tag}2/${total} docker — compose -p ${profile.project} down -v (containers + volumes)`);
     const ctx = repoContextFromFlags(flags as unknown as Record<string, unknown>);
     const soaRoot = resolveRepoRoot('SOA', ctx);
     const down = await this.getDockerWipe().composeDownVolumes({
@@ -283,7 +521,7 @@ export default class StackWipe extends BaseCommand {
     }
 
     // ── (c) rm -rf the slot's state dir (pids/logs/cookies/claim.json) ──
-    if (human) this.log(`▶ 3/${total} state — rm -rf ${stateDir}`);
+    if (human) this.log(`▶ ${tag}3/${total} state — rm -rf ${stateDir}`);
     const remover = this.getSlotWipe();
     const stateDirRemoved = remover.remove(stateDir);
     if (human) {
@@ -297,7 +535,7 @@ export default class StackWipe extends BaseCommand {
     // ── (d) --snapshots only: rm -rf ~/.saga-mesh/snapshots-s<N> (default keeps them) ──
     let snapshotsRemoved = false;
     if (withSnapshots && profile.snapshotsDir !== undefined) {
-      if (human) this.log(`▶ 4/${total} snapshots — rm -rf ${profile.snapshotsDir}`);
+      if (human) this.log(`▶ ${tag}4/${total} snapshots — rm -rf ${profile.snapshotsDir}`);
       snapshotsRemoved = remover.remove(profile.snapshotsDir);
       if (human) {
         this.log(
@@ -308,20 +546,15 @@ export default class StackWipe extends BaseCommand {
       }
     }
 
-    this.emit(
-      flags,
-      {
-        slot: profile.slot,
-        project: profile.project,
-        stateDir,
-        stopped: stoppedList.length,
-        volumesRemoved,
-        stateDirRemoved,
-        snapshotsRemoved,
-      },
-      `✓ slot ${profile.slot} wiped — ${profile.project} down -v'd, ${stateDir} removed` +
-        (withSnapshots ? ', snapshots removed.' : ' (snapshots kept).'),
-    );
+    return {
+      slot: profile.slot,
+      project: profile.project,
+      stateDir,
+      stopped: stoppedList.length,
+      volumesRemoved,
+      stateDirRemoved,
+      snapshotsRemoved,
+    };
   }
 
   /**

--- a/packages/node/saga-stack-cli/src/runtime/slot-wipe.ts
+++ b/packages/node/saga-stack-cli/src/runtime/slot-wipe.ts
@@ -40,12 +40,16 @@ export function relativeAge(atIso: string, nowMs: number = Date.now()): string {
 }
 
 /**
- * The injectable slot-dir removal seam (`stack wipe` steps c/d). One verb:
- * `rm -rf` a single absolute dir. Production wires `makeSlotWipe()`
- * (the only place this module's real `rmSync` runs); tests pass a recording
- * fake so the removal PLAN (which paths, in what order) is asserted with no fs.
+ * The injectable slot-dir removal seam (`stack wipe` steps c/d). Two verbs:
+ * `rm -rf` a single absolute dir, and the existence probe `--slot all` uses to
+ * decide which slots are non-empty candidates (soa#351). Production wires
+ * `makeSlotWipe()` (the only place this module's real `rmSync` runs); tests pass
+ * a recording fake so the removal PLAN (which paths, in what order) is asserted
+ * with no fs.
  */
 export interface SlotWipe {
+  /** Does the dir exist? (candidate detection for `--slot all`; folds errors to `false`). */
+  exists(dir: string): boolean;
   /** `rm -rf dir`; `true` iff the dir existed and was removed, `false` otherwise (best-effort — never throws). */
   remove(dir: string): boolean;
 }
@@ -81,6 +85,9 @@ export function makeSlotWipe(deps: RealSlotWipeDeps = {}): SlotWipe {
     });
 
   return {
+    exists(dir: string): boolean {
+      return exists(dir);
+    },
     remove(dir: string): boolean {
       if (!exists(dir)) return false;
       try {


### PR DESCRIPTION
Closes #351. Follow-up to #350 (`stack wipe --slot N`).

## What

`ss stack wipe --slot all` runs the same per-slot pristine reset (stop natives → `compose -p soa-s<N> down -v` → `rm -rf` state dir → `--snapshots` opt-in) on **every non-empty slot 1–9** in one sweep, with one confirmation.

```
ss stack wipe --slot all --dry-run   # enumerate every non-empty slot, change nothing
ss stack wipe --slot all --yes       # wipe them all (live-claimed slots included)
```

## Semantics

- **Candidacy:** a slot is wiped iff it left something behind — state dir on disk, live activity (the same `SlotActiveProbe` that `stack slots` trusts), or (only under `--snapshots`) a snapshot root. Slot 0 is never a candidate; empty slots are untouched.
- **Live-claim handling:** in a sweep, a live-claimed slot is *skipped with a warning* rather than aborting the whole run (the single-slot hard refusal would strand the rest); `--yes` includes it. Single-slot behavior is unchanged.
- **Rejected combinations:** `--set` (a set owns ONE slot — the existing central guard fires) and `--state-dir` (pins one slot's state) are ambiguous with `all`.
- **JSON:** `{mode: "all", wiped: [...per-slot records], skipped: [...slot numbers]}`; the single-slot shape is untouched.

## How

- `--slot` is overridden **on wipe only** via a `Flags.custom` (integer 0–9 or the literal `all`); the shared base flag stays an integer for every other command. (A quirk: oclif infers the parsed flag types from `flags` *and* the inherited `baseFlags`, which collapses the union — re-widened once at the parse site with a documented cast, since overriding `static baseFlags` is a TS2417 static-side violation.)
- **Claim wrinkle:** BaseCommand's central claim hook resolves a non-numeric `--slot` to slot 0 and would clobber slot 0's `claim.json`. All-mode is detected from the raw argv before parsing, `claimsSlot()` suppresses the hook, and `runAll` writes a **per-slot** claim before each teardown — a failed wipe still records who attempted it.
- Steps a–d extracted into a shared `teardownSlot()`; single-slot human output stays byte-identical to #350 (existing tests pin it).
- The `SlotWipe` runtime seam gains an `exists` probe for candidate detection.

## Testing

- 11 new integration tests (22 in the file, all seams faked): candidacy incl. active-without-state-dir and snapshots-only, slot-ordered sweep with per-slot claims (and **zero** slot-0 claims), live-claim skip vs `--yes` include, declined prompt, `--set`/`--state-dir` rejection, all-mode JSON shape.
- Full package suite: 1412 tests / 117 files green; `tsc --noEmit` and eslint clean.
- Live smoke on this host: `--slot all --dry-run` enumerated exactly the three non-empty slots (3, 4, 9) and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jxm7ZSGT58TQj8WAP1bcGf
