### PR TITLE
ss env — shared-env (dev/training) org debug + surgical reset (Phase 0+1)

### DIFF
--- a/claude/projects/gh_355/ss-env-reset-manual-test-plan.md
+++ b/claude/projects/gh_355/ss-env-reset-manual-test-plan.md
@@ -1,0 +1,302 @@
+# `ss env` — shared-env org debug + reset: manual test plan
+
+_soa#355 · PR soa#356 · 2026-07-21. Companion to `~/dev/shared-env-reset-research.md`._
+
+**Goal under test:** start from the Empty Org on **dev** (`dash.wootdev.com`), inspect its
+data footprint, and reset it back to the seeded skeleton — repeatably, without touching any
+other org (especially the hand-built training orgs Jenny uses). Dev is the first target;
+`training` and other deployed sandboxes are design targets (env is a flag, never a hardcode).
+
+---
+
+## 0. Prerequisites
+
+- **AWS session**: `aws sso login --profile dev_admin` (dev account `396913734878`).
+- **Tier**: SSM port-forwarding needs **app-infra** (`SagaCap-SSMPortForward`) or **app-deploy**.
+  Observer/app-runtime cannot open sessions *or* read the control-plane ledger — an AccessDenied
+  from `env list` means *wrong tier*, not a missing env. Run `/discover-aws-access` to reconcile.
+- **Binaries**: `aws` and `session-manager-plugin` on PATH. `psql` optional — the CLI falls back
+  to `docker run --network host postgres:18-alpine psql` automatically.
+- **CLI build** (branch not yet released):
+  ```bash
+  cd ~/dev/soa-worktrees/gh340-wipe/packages/node/saga-stack-cli && npm run build
+  CLI="$PWD/bin/run.js"          # use `node $CLI env …` below; `ss` still points at released main
+  ```
+
+---
+
+## 1. Full command surface added
+
+All under the `env` topic. Read-only unless noted **[DESTRUCTIVE]**.
+
+| Command | Purpose | Key flags |
+|---|---|---|
+| `env list` | Deployed envs (dev, training) + dev-platform ledger footprint | `--profile`, `--output-json` |
+| `env discover` | Walk an env's SSM param roots (data-store wiring) + resolve the Online SSM jump host | `--env`, `--profile`, `--filter <regex>` |
+| `env connect <store>` | Open an SSM tunnel to a store's Postgres; print a ready `DATABASE_URL`; holds until Ctrl-C | `--env`, `--profile`, `--local-port`, `--host`, `--remote-port`, `--username`, `--database`, `--print-only` |
+| `env verify` | Health-gate every deployed service (judged by **response body**, not status code) + optional ECS platform check; non-zero exit if a required service is down | `--env`, `--tolerate <ids>`, `--ecs`, `--profile`, `--org <slug>` (+ `--url iam=…`) |
+| `env org status --org <slug>` | One fixture org's cross-store footprint (per-table counts; projections marked) | `--url <store>=<conn>` (repeatable), `--offline` |
+| `env org reset --org <slug>` **[DESTRUCTIVE]** | Surgically delete the org's data back to the seeded skeleton | `--url <store>=<conn>` (repeatable), `--dry-run`, `--yes`, `--snapshot`, `--snapshot-service <store>=<name>`, `--env`, `--profile` |
+
+**Store keys** (`--url` / `connect <store>`): `iam`, `programs`, `scheduling`, `sessions`,
+`ads-adm`, `coach` (all connectable). `iam-pii` is a reset store key but **not yet connectable**
+via `env connect` (known gap — see §6).
+
+**Targeting safety (the Jenny guard):** `env org …` accepts catalog **slugs** only (`--org emptyOrg`);
+the UUID is derived (uuidv5 seed-id scheme). Raw UUIDs and unknown slugs are refused, so every
+hand-built org (training) is structurally untargetable. Catalog today: `emptyOrg` only.
+
+**Live-verified store routing** (dev, 2026-07-21 — each store is a db-host-v2 container reached via
+CloudMap → the container's own EC2 instance with a 127.0.0.1 dial; the shared jump host's SG cannot
+reach the containers):
+
+| store | CloudMap service | remote port | suggested local port |
+|---|---|---|---|
+| iam | `rostering-iam-canonical` | 5440 | 15432 |
+| programs | `program-hub-programs-canonical` | 5432 | 15433 |
+| scheduling | `program-hub-scheduling-canonical` | 5433 | 15434 |
+| sessions | `program-hub-sessions-postgres` | 5436 | 15435 |
+| ads-adm | `ads-adm-postgres` | 5471 | 15436 |
+| coach | `coach-api-runtime` | 5445 | 15437 |
+
+---
+
+## 1b. `env verify` — what it actually checks (read this before T2b)
+
+Two traps make this command non-obvious; both were found live and are the reason
+it exists in this shape:
+
+- **HTTP 200 is NOT a health signal here.** `*.wootdev.com` / `*.saga-training.org`
+  are wildcard DNS onto the shared ALB, whose default action answers **200 with the
+  body `dev-account-alb`** for *any* unmatched hostname. A status-code-only check
+  reports services that don't exist as healthy. Verify judges the **body**: APIs must
+  answer JSON with a `service` and an allowlisted `status` — the fleet uses three
+  different words (`ok`: iam/programs/scheduling/sessions/content · `running`:
+  sis/ads-adm · `healthy`: coach); `degraded`/`down` fail. Frontends must answer HTML.
+- **Deployed hostnames are not the manifest slug.** `iam`/`sis` are short; the rest are
+  the full service id (`programs-api`, `sessions-api`, …); `coach.<domain>` is the coach
+  **web app** (the API is `coach-api`).
+
+Coverage today: **dev 16/16, training 15/16**. The map is taken from the ALB host-header
+rules, Route53, and each owning repo's deploy docs — never guessed:
+
+| service | host | source |
+|---|---|---|
+| connect-api | `connectv3-api.<domain>` `/connectv3/v1/health` | qboard/CLAUDE.md:112 |
+| rtsm-api | `chi-1.rtsm.<domain>` `/health` | rtsm/README.md + Jeff (canonical route) |
+| fleek | `chi-1.fleek.<domain>` `/health` (Caddy, 200/empty) | fleek/OPS.md:92,145 |
+| fleek-recorder | `recorder-chi-1.fleek.wootdev.com` `/v1/health` | fleek/OPS.md:93 (livekit half) |
+| connect-web | `<branch>.d2ezd4i8b4uexc.amplifyapp.com` (`dev` / `training`) | qboard/CLAUDE.md "Web main" — Amplify app `connectv3`, **no custom domain** |
+
+`rtsm`/`fleek` run on their **own non-AWS clusters** (`*.rtsm.` / `*.fleek.` — geo nodes
+chi-1/nyc-1/phx-1/…), which is why they are absent from ECS and the ALBs. They are **SHARED
+between dev and training** — one fleet pinned to `*.wootdev.com`, never domain-templated per
+env. Evidence: the **training** `qboard-connectv3-api-training` task definition sets
+`RECORDER_URL_TEMPLATE = https://recorder-{node}.fleek.wootdev.com` (dev additionally sets
+`RTSM_API_URL = https://core-a.rtsm.wootdev.com` and a `FLEEK_TOPOLOGY_JSON` whose `domain`
+is `fleek.wootdev.com`). Reading a training service's own task-def env is the general way to
+tell shared infra from per-env infra. Only Amplify-hosted `connect-web`
+has no HTTP route at all. **Operator SSH** to the fleek/rtsm nodes needs a 12h cert —
+`saws.js cert -n fleek -n rtsm -p dev_admin`, then `ssh -p 727 root@chi-1.fleek.wootdev.com` —
+that is *not* needed for these HTTP probes.
+
+`--ecs` adds the platform truth HTTP cannot see — running/desired tasks and rollout
+state, so a crash-loop behind a still-healthy ALB target, or a stuck deploy, fails the
+gate. It needs dev-account credentials; the default HTTP-only run needs none.
+
+---
+
+## 2. Read-only walkthrough (do this first — zero risk)
+
+### T1 — `env list`
+```bash
+node $CLI env list --profile dev_admin
+```
+**Expect:** two rows — `dev (main) *.wootdev.com` with `ecr×… ecs×… routing×…`, and
+`training (training) *.saga-training.org` with `db×14 …`. No error.
+
+### T2 — `env discover`
+```bash
+node $CLI env discover --env dev --profile dev_admin
+```
+**Expect:** a filtered list of `/shared/infra/dev/*` and `/dev/*` data-store params, ending with
+`jump host: i-… (tag Name=dev-shared-ecs-instance, Online)`.
+
+### T2b — `env verify` (the health gate)
+```bash
+node $CLI env verify --env dev                      # HTTP only — needs no AWS credentials
+node $CLI env verify --env dev --ecs --profile dev_admin   # + ECS running/desired + rollout
+node $CLI env verify --env training --ecs --profile dev_admin
+```
+**Expect:** a ✓ line per healthy service showing the probed URL (and, with `--ecs`,
+`· ecs N/N task(s) running`); ○ lines with a reason for the optional/dev-only ones; and
+**`✓ verify passed — 16/16 service(s) healthy.`** on dev, **15/16** on training (only
+`transcripts-api` is dev-only; rtsm/fleek/fleek-recorder are shared and green on both). Exit 0.
+
+An in-flight ECS deploy (`rollout IN_PROGRESS`) at full task count is reported but does **not**
+fail the gate; a FAILED rollout, under-running tasks, or scale-to-zero do.
+
+**Negative check (proves the ALB trap is really handled)** — point it at a hostname that
+isn't routed and confirm it is called out rather than passing:
+```bash
+curl -s https://programs.wootdev.com/health    # → `dev-account-alb` (the 200 that means nothing)
+```
+`programs.` (no `-api`) is exactly the shape that a status-code-only gate would score green;
+verify's map deliberately uses `programs-api.`.
+
+### T3 — `env connect` (open the tunnels)
+Open each store in the background on its own local port (foreground holds until Ctrl-C):
+```bash
+for s in iam:15432 programs:15433 scheduling:15434 sessions:15435 ads-adm:15436 coach:15437; do
+  store=${s%%:*}; port=${s##*:}
+  node $CLI env connect $store --env dev --profile dev_admin --local-port $port &
+done
+# wait for each to print "✓ tunnel up"
+```
+**Expect per store:** `route: db-host i-… (CloudMap <service>, local dial :<port>)` then
+`✓ tunnel up — 127.0.0.1:<local> → <service>.dbs-v2.local:<remote>` and a
+`DATABASE_URL=postgres://…` line. Sanity: `node $CLI env connect iam --print-only` resolves
+everything without opening a tunnel.
+
+### T4 — `env org status` (footprint)
+```bash
+node $CLI env org status --org emptyOrg \
+  --url iam=<IAM_URL> --url programs=<PGM_URL> --url scheduling=<SCH_URL> \
+  --url sessions=<SES_URL> --url ads-adm=<ADS_URL> --url coach=<COA_URL>
+```
+**Expect:** `resolution: live`, `id-sets: groups=31 users=22 programs=7 …`, per-table counts,
+`[projection]`-marked rows, and a footprint total. Baseline observed: **~980 org-reachable rows**
+(sessions 463, programs 212, iam 152, scheduling 90, ads-adm 63, coach 0).
+
+---
+
+## 3. Reset walkthrough
+
+### T5 — `env org reset --dry-run` (the safe proof; = the review gate)
+```bash
+node $CLI env org reset --org emptyOrg \
+  --url iam=<IAM_URL> --url programs=<PGM_URL> --url scheduling=<SCH_URL> \
+  --url sessions=<SES_URL> --url ads-adm=<ADS_URL> --url coach=<COA_URL> --dry-run
+```
+**Expect:** `▶ env org reset DRY RUN`, the org/env/kept/id-sets header, per-store per-table
+`N row(s) will be DELETED`, and `✓ reset dry run complete — 980 row(s) would be deleted across
+6 store(s); no changes made.` **Nothing is written** (every SQL that ran was a SELECT). Note
+`deletable-users=0` on this org — its 22 users are multi-org/shared and are correctly kept
+(only their Empty-Org memberships die).
+
+### T6 — `env org reset --snapshot --yes` **[DESTRUCTIVE]**
+Snapshot-first so there's an undo point, then delete:
+```bash
+node $CLI env org reset --org emptyOrg \
+  --url iam=<IAM_URL> --url programs=<PGM_URL> --url scheduling=<SCH_URL> \
+  --url sessions=<SES_URL> --url ads-adm=<ADS_URL> --url coach=<COA_URL> \
+  --snapshot --profile dev_admin --yes
+```
+**Expect:**
+1. `✓ snapshot <store> (<name>) → profile 'pre-org-reset'` for stores with a known registry name
+   (iam, ads-adm out of the box; others warn "no registry name" unless `--snapshot-service` given).
+2. `▶ N/6 <store> — … one transaction` then `✓ <store> reset` per store, leaf stores first, **iam last**.
+3. Post-verify: no `⚠ … REMAIN` warnings; self-blinding tables (`"DayTypeBlock"`,
+   `"ProgramSectionMapping"`) reported `verify indirect`, not a fake 0.
+4. Final: `✓ Empty Org reset — ~980 row(s) deleted across 6 store(s); skeleton intact.` **Exit 0.**
+
+**Skeleton check (pass criterion):** the run's own skeleton check must say **intact**. Independently
+confirm the seed survived:
+```bash
+# via the iam tunnel
+psql "<IAM_URL>" -Atc "SELECT display_name FROM groups WHERE id='52a00136-285b-522c-bc70-0887cf46463a'"  # → Empty Org
+psql "<IAM_URL>" -Atc "SELECT username FROM users WHERE id='506605c6-f2c5-5785-9837-7970e7a2594c'"        # → empty
+```
+
+### T7 — the repeatable loop (the actual goal)
+```
+env verify --ecs   (services healthy before you trust a journey result)
+env org status  (≈0 org-reachable rows beyond the skeleton)
+→ run the saga-dash e2e journey against dev (Empty Org)
+→ env org status  (footprint grows)
+→ env org reset --snapshot --yes
+→ env org status  (back to skeleton)
+→ repeat
+```
+**Pass:** each cycle ends at the skeleton, the journey runs clean from a fresh Empty Org, and no
+other org's counts ever change.
+
+---
+
+## 4. Negative / guard tests (all should REFUSE, non-zero, before touching data)
+
+| # | Command | Expected refusal |
+|---|---|---|
+| N1 | `env org reset --org jennys-training-org --url iam=x --url programs=y --yes` | "not a resettable fixture org … deliberately untargetable" |
+| N2 | `env org reset --org 52a00136-285b-522c-bc70-0887cf46463a …` (raw UUID) | same — slug-only targeting |
+| N3 | `env org reset --org emptyOrg --url sessions=x --yes` (missing anchors) | "requires BOTH anchor stores … iam AND programs" |
+| N4 | `env org reset --org emptyOrg --url iam= --url programs=p --yes` (empty conn) | "empty connection string" |
+| N5 | `env org reset --org emptyOrg --url iam=<wrong-db> --url programs=… --yes` | "IDENTITY ASSERTION FAILED — … expected 'empty'" (points at a DB that isn't the seeded org) |
+| N6 | `env org reset --org emptyOrg --url iam=… --url programs=… --snapshot --env training` | "--snapshot drives the dev db-host orchestrator … no orchestrator for 'training'" |
+| N7 | `env org reset --org emptyOrg …` (interactive, no `--yes`) → answer `n` | "reset aborted — nothing changed" (exit 0, nothing deleted) |
+| N8 | `env verify --env dev --org jennys-org --url iam=…` | "not a known fixture org" (slug guard applies to verify too) |
+| N9 | `env verify --env dev --org emptyOrg` (no `--url iam=`) | "--org needs the iam connection" |
+| N10 | `env list` / `env verify --ecs` with a **prod** profile (`--profile default`) | "AWS account mismatch — … pass --profile dev_admin" (not a cryptic ResourceNotFound) |
+
+---
+
+## 5. PRs
+
+| PR / issue | What | State |
+|---|---|---|
+| **soa#356** | `ss env` — Phase 0 (list/discover/connect/org status), Phase 1 (`org reset`), **and `env verify`** (+`--ecs`). The whole deliverable under test here. | **OPEN (draft), mergeable** — `skelly/gh355-env-phase0 → main` |
+| soa#355 | Epic: the `env` command family (design + phases). | OPEN (closed by #356) |
+| soa#350 | `ss stack wipe --slot N` — same worktree lineage, unrelated to env. | MERGED |
+| soa#352 | `ss stack wipe --slot all` — same lineage, unrelated to env. | MERGED |
+| `~/dev/shared-env-reset-research.md` | Research: how these envs reset, SSM access, the org-purge design. | doc |
+
+`#356` branched from `main` **after** #350/#352 merged, so it has no dependency on unmerged work.
+
+---
+
+## 6. Suggested drop order
+
+`#356` currently bundles read-only Phase 0 with the destructive Phase 1. Recommended landing —
+gate destructive capability behind a successful live run:
+
+1. **Split & land Phase 0 first (low risk, immediately useful).** Carve `list`/`discover`/`connect`/
+   `org status`/**`verify`** (+ their core: registry, seed-ids, footprint, taskdef, services, the
+   aws/psql/prober seams) into a first merge. `verify` is pure-read and needs no credentials at all
+   in its default form, so it is the safest, highest-value thing to land early. It's read-only, unblocks everyone's shared-env debugging, and de-risks the review of
+   the destructive half. Gate: full suite green (already 1486/123), T1–T4 pass on dev.
+2. **Close the `iam-pii` connect gap** (see §7) before Phase 1 merges — a complete reset needs it.
+3. **Execute T5 → T6 → T7 on dev once** (real reset of Empty Org, skeleton verified, loop proven),
+   then **land Phase 1 (`org reset`)** as the follow-up merge with that evidence attached.
+4. **Phase 2 (separate, later):** service-side org purge that *emits delete events* (extend sis-api
+   `demo.reset` → iam-api `service.demo.hardDeleteCsvUsers`), after which `env org reset` becomes an
+   invoker + verifier + reconcile. Tracked under the epic.
+
+If you'd rather keep it as one PR: merge `#356` whole **after step 3** (the live T6/T7 evidence),
+since that's the only thing that meaningfully de-risks the destructive path.
+
+---
+
+## 7. Known gaps / notes to carry into review
+
+- **`iam-pii` not connectable** via `env connect` (no footprint `STORES` entry / ecsService), so a
+  fully-complete reset can't yet clear `user_pii`. `env org reset` warns + skips it. Cheap follow-up:
+  add its ecsService (`rostering-iam-pii-*`) to the connect resolution.
+- **`env verify` coverage: dev 16/16, training 15/16** — every mapped service is HTTP-verifiable;
+  only `transcripts-api` is dev-only. rtsm/fleek/fleek-recorder are SHARED infra (one fleet, both
+  envs); `connect-web` is per-env but on Amplify's own domain, so it is pinned by branch rather
+  than templated off the env domain. Adding a service means editing `src/core/env/services.ts` — a
+  reviewed change, because a wrong host silently reads as an ALB "down".
+- **Known geo-node gap:** `nyc-1` (and `par-1` on rtsm) were unreachable on 2026-07-22 for BOTH
+  fleek and rtsm, while chi-1/phx-1/vet-1/core-a/core-b answered. Verify probes ONE canonical node
+  per fleet, so a single dead region will not fail the gate — worth confirming with Jeff/Seth
+  whether those nodes are decommissioned or genuinely down, and whether verify should probe the
+  whole fleet.
+- **`coach = 0` rows** for Empty Org is expected (coach is consumer-only; the journey may seed no
+  coach content) — not a miss.
+- **Multi-org users** (`deletable-users=0` here) are kept by design; their org memberships are
+  removed, their iam rows survive. Confirm this matches the "back to empty" you want for the loop.
+- **`--output-json` + `--dry-run`:** dry-run emits human enumeration, not JSON (it returns before
+  `emit`). Use a real (non-dry) run for machine-readable output.
+- **Snapshot registry names:** only `iam` and `ads-adm` are known out of the box; supply the rest
+  with `--snapshot-service <store>=<name>` once confirmed against the db-host-v2 registry (the
+  program-hub trio may share one entry — verify before the first real `--snapshot`).

--- a/packages/node/saga-stack-cli/docs/env.md
+++ b/packages/node/saga-stack-cli/docs/env.md
@@ -1,0 +1,203 @@
+# `ss env` — deployed shared environments (dev / training)
+
+_soa#355. Phase 0: list, discover, tunnel, and inspect (read-only).
+Phase 1: `env org reset` — the surgical fixture-org delete (below)._
+
+Where every other `ss` topic drives the **local** synthetic stack, `env`
+targets the **deployed shared** compositions — `dev` (`*.wootdev.com`, the
+fleet CI deploys to on merge to main) and `training` (`*.saga-training.org`,
+the persistent staff-training tenant). Both live in the dev AWS account.
+Access is data-plane: SSM port-forwarding straight to the underlying stores —
+no janus cookie, no API layer.
+
+## Prerequisites
+
+- An authenticated AWS session **in the dev account** (`396913734878`):
+  `aws sso login --profile dev_admin`, then pass `--profile dev_admin` (or set
+  `AWS_PROFILE`). Both `dev` and `training` live in the dev account; `list`,
+  `discover`, and `connect` run an account preflight and refuse with a
+  switch-profile hint if your credentials resolve elsewhere (e.g. the prod
+  account) — no more cryptic `ResourceNotFoundException`.
+- **Tier:** SSM port-forwarding needs `app-infra` (`SagaCap-SSMPortForward`)
+  or `app-deploy`. The observer tier cannot open sessions and cannot read the
+  control-plane ledger (an AccessDenied from `env list` means *wrong tier*,
+  not a missing environment). `/discover-aws-access` reconciles your profiles.
+- `aws` and `psql` binaries on PATH (the CLI shells out; it carries no AWS SDK
+  or DB driver).
+
+## Commands
+
+```bash
+ss env list                              # environments + control-plane ledger footprint
+ss env discover --env dev                # SSM params (data-store wiring) + the SSM jump host
+ss env connect iam --env dev             # SSM tunnel to shared Postgres; prints DATABASE_URL; Ctrl-C closes
+ss env connect programs --local-port 15433 --print-only   # resolve only, no tunnel
+ss env verify --env dev                  # health-gate every deployed service (non-zero if a required one is down)
+ss env org status --org emptyOrg \
+  --url iam=postgres://…:15432/iam \
+  --url programs=postgres://…:15433/programs              # the org's cross-store footprint
+```
+
+## `env verify` — the deployed-env health gate
+
+The `stack verify` analogue for dev/training. It probes every deployed service
+and **judges health by the response BODY, not the status code** — that is not
+stylistic:
+
+> `*.wootdev.com` and `*.saga-training.org` are wildcard DNS onto the shared
+> ALB, whose default action answers **HTTP 200 with the body `dev-account-alb`**
+> for *any* unmatched hostname. A status-code-only gate therefore reports
+> services that do not exist as healthy. Verified live 2026-07-21.
+
+So a healthy API must answer JSON with a `service` and a healthy `status` — the
+live fleet uses three different words (`ok`: iam/programs/scheduling/sessions/
+content · `running`: sis/ads-adm · `healthy`: coach), all allowlisted; a
+`degraded`/`down` status still fails. Frontends must answer an HTML document.
+
+Deployed hostnames are **not** the manifest `tunnelSlug` — the map is explicit
+and body-verified (`core/env/services.ts`): `iam`/`sis` are short, the rest are
+the full service id (`programs-api`, `sessions-api`, …), and `coach.<domain>` is
+the coach **web** app (the API is `coach-api`). `connect-api`, `connect-web`, and
+`rtsm-api` have **no public route** on either env — they are reported as
+"not HTTP-verifiable" (optional, so they don't fail the gate) rather than
+silently green; an ECS platform check is the follow-up that covers them.
+
+```bash
+ss env verify --env dev                          # 10/13 healthy, 3 unroutable
+ss env verify --env training --tolerate sis-api  # accept a known-down service
+ss env verify --env dev --org emptyOrg --url iam=postgres://…:15432/iam
+```
+
+`--org` additionally asserts the fixture org's **seed skeleton** (org row +
+admin + admin membership) over the iam connection — i.e. "is this org usable?"
+as opposed to "are the services up?". A broken skeleton fails the gate.
+
+`env connect` resolves the DB target **from the service's own live ECS task
+definition** (`<ecsService>-<identifier>` across the shared clusters): either
+its `DATABASE_URL` secret (iam, program-hub, coach) or its split `POSTGRES_*`
+env + password secret (ads-adm). That makes it self-maintaining — the same
+store on `training` differs only by name suffix. Routing (live-verified
+2026-07-21): `.dbs-v2.local` targets tunnel **via the container's own db-host
+instance with a 127.0.0.1 dial** (CloudMap `discover-instances` → host + port;
+the shared jump host's SG cannot reach the containers — a dial from it hangs);
+anything else (shared RDS) goes via the shared jump host. Resolution is
+transparent (every candidate printed) and overridable: `--host`,
+`--remote-port`, `--username`, `--database`. The tunnel holds in the
+foreground — it dies with the command, never orphaned. Postgres-first; Mongo
+(needs `directConnection=true` through SSM tunnels) is a follow-up. If `psql`
+is not installed, queries fall back to `docker run --network host
+postgres:18-alpine psql` automatically.
+
+## Org targeting is slug-only (the Jenny guard)
+
+`env org …` commands accept **catalog slugs** (`--org emptyOrg`), never raw
+UUIDs — the UUID is *derived* via the fleet's uuidv5 seed-id scheme
+(byte-verified against `@saga-ed/iam-seed-ids` in unit tests). Anything not in
+the resettable catalog — every hand-built org, e.g. the training orgs used for
+real staff sessions — is structurally untargetable. Growing the catalog is a
+reviewed code change (`src/core/env/seed-ids.ts`), not a runtime input.
+
+## `env org status`
+
+The debug primitive and the dry-run half of the future reset. It resolves the
+org's id-sets — org id + admin offline from the catalog; group / member-user /
+program ids **live** from the two anchor stores when `--url iam=…` and
+`--url programs=…` are given (else `partial-offline`, and each table says so)
+— then counts org-linked rows per store/table. Rows marked `[projection]` are
+event-materialized mirrors (the orphan category: projections never self-heal;
+a future reset must sweep them by the same id-sets, and a planned `--orphans`
+mode will diff them against source).
+
+The footprint map (`src/core/env/footprint.ts`) is the anchor + first ring,
+verified against each repo's prisma schema, and deliberately extensible —
+stores/tables not yet mapped are visible as absent, never silently skipped.
+
+## `env org reset` (Phase 1 — destructive)
+
+Surgically deletes ONE fixture org's data across the connected stores, back
+to the seeded skeleton. Follows `stack wipe`'s destructive canon: `--dry-run`
+enumerates per-table DELETE counts (projections marked) and exits 0 touching
+nothing; a plain run shows the same enumeration and prompts once; `--yes`
+skips the prompt; a declined prompt aborts with exit 0.
+
+```bash
+ss env org reset --org emptyOrg \
+  --url iam=postgres://…15432/rostering-iam-canonical \
+  --url programs=postgres://…15433/programs \
+  --url scheduling=… --url sessions=… --url ads-adm=… --url coach=… --url iam-pii=… \
+  --dry-run                        # counts only, nothing changes
+ss env org reset --org emptyOrg --url iam=… --url programs=… --snapshot --yes
+```
+
+### Guards (structural, not flag-skippable)
+
+1. **Slug-only targeting** — the same catalog guard as `org status`.
+2. **Both anchors mandatory** — `--url iam=…` AND `--url programs=…` or the
+   command refuses (dry-run included): id-sets resolve live or not at all.
+   Other stores without a `--url` are **skipped with loud warnings** — their
+   org rows survive, and orphan-union resolution sourced there is incomplete.
+3. **Pre-flight identity assertion** — the org group row must exist with the
+   catalog display name AND the admin user must exist with the catalog email,
+   or the run refuses: proof the connected DB really holds the seeded org.
+
+### Skeleton semantics
+
+The seeded skeleton **survives by explicit SQL predicates** on deterministic
+catalog ids (never by command logic): the org `groups` row, the admin user,
+the admin's seeded membership, the org's seeded personas (and their cascaded
+permissions), and the org row's seeded `group_attributes`/`group_auth_config`.
+Multi-org users are never deleted — a user with ANY membership outside the
+org's groups (any status) survives — and neither are **env-wide actors**: iam
+grants environment-level identity without membership rows (`users.role` other
+than `USER`, `user_system_roles`), so users carrying either marker survive
+even when their only membership is inside the org. Every cross-store user
+sweep (projection mirrors, `user_pii`, coach progress) keys on the
+survivors-excluded `userDelIds` set — which carries the same exclusions — so
+their mirrors survive with them.
+Deletes run **one BEGIN/COMMIT transaction per store** (single `psql -c`,
+`ON_ERROR_STOP` — all-or-nothing per store), leaf stores first, iam last, then
+a post-verify recount reports before/after per table (leftovers flagged loud;
+tables whose delete predicate subqueries rows deleted in the same transaction
+— `DayTypeBlock`, `ProgramSectionMapping` — are reported `verify: indirect`
+instead of a self-blinded 0, and `users` recounts by the pre-resolved
+`userDelIds` literal set) and a skeleton check (org row + admin + membership)
+— a broken skeleton exits non-zero after the full report.
+
+### `--snapshot` (best-effort restore points)
+
+Takes a per-store dump via the db-host-v2 orchestrator Lambda
+(`dev-db-host-orchestrator`, profile `pre-org-reset`, versioned + immutable in
+`s3://saga-db-seeds-dev/<serviceName>/`) BEFORE deleting. **Dev only**: the
+orchestrator is dev's control plane, so `--snapshot` with any other `--env`
+is refused up front (a "successful" snapshot of the wrong environment's
+databases would be worse than none). Best-effort by
+design (dev-only data, regenerable seed): an unreachable orchestrator or a
+failed dump warns and proceeds — but a **"not in registry"** response means
+the target name is wrong and aborts the whole reset. Registry names are known
+for `iam` (`rostering-iam-canonical`) and `ads-adm` (`ads-adm-postgres`);
+supply others with `--snapshot-service <store>=<serviceName>`. Undo a botched
+reset with the orchestrator's `switch`/`restore` against that profile.
+
+### Explicit non-goals
+
+- **No cross-store atomicity** — one transaction per store; a mid-run failure
+  leaves later stores untouched (iam last keeps the resolution evidence for a
+  re-run).
+- **Never touched anywhere**: `outbox_event`, `consumed_events`,
+  `snapshot_metadata`, `audit_logs` (DB-rule append-only), sessions'
+  `projection_readiness` + `authz_persona_definition`, coach's authored
+  content + `persona_definition`, programs' `content_item`, and the whole
+  content-api database (no org-reachable column exists).
+- **Known residue**: `session_alias` rows minted before their lazily-written
+  session row (unreachable via sessionIds), and journey-test-added attributes
+  on the org row itself (kept with the seeded ones).
+- No claim record yet (env-level claims are a follow-up), and no Mongo stores.
+
+## Safety posture
+
+Phase 0 is read-only: ledger queries, SSM parameter reads, a port-forward,
+and `SELECT count(*)`. All id inlining is gated (`assertUuids`; session ids
+are base64url natural keys with their own strict-charset gate) so no
+untrusted string ever reaches SQL.
+
+See `~/dev/shared-env-reset-research.md` (research) and soa#355 (the epic).

--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -1086,6 +1086,1015 @@
       "slotClaimWritten": false,
       "strict": true
     },
+    "env:connect": {
+      "aliases": [],
+      "args": {
+        "store": {
+          "description": "store key (iam | programs | scheduling | sessions | ads-adm | coach)",
+          "name": "store",
+          "required": true
+        }
+      },
+      "description": "Open an SSM port-forward to a shared environment's Postgres, resolved from the service's live ECS task definition, and print a ready DATABASE_URL. Holds until Ctrl-C; --print-only resolves without connecting.",
+      "enableJsonFlag": false,
+      "examples": [
+        "<%= config.bin %> <%= command.id %> iam --env dev --profile dev_admin",
+        "<%= config.bin %> <%= command.id %> programs --env dev --local-port 15433",
+        "<%= config.bin %> <%= command.id %> iam --host mydb.dbs-v2.local --remote-port 5440 --database rostering-iam-canonical --print-only"
+      ],
+      "flags": {
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "coach",
+          "type": "option"
+        },
+        "database": {
+          "description": "override the resolved database name.",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "database",
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "dev",
+          "noCacheDefault": true,
+          "type": "option"
+        },
+        "env": {
+          "default": "dev",
+          "description": "target environment (dev | training)",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "env",
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "fleek",
+          "type": "option"
+        },
+        "host": {
+          "description": "remote DB endpoint (skips task-definition resolution).",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "host",
+          "type": "option"
+        },
+        "local-port": {
+          "default": 15432,
+          "description": "local end of the tunnel",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "local-port",
+          "type": "option"
+        },
+        "output-json": {
+          "allowNo": false,
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "type": "boolean"
+        },
+        "porcelain": {
+          "allowNo": false,
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "type": "boolean"
+        },
+        "print-only": {
+          "allowNo": false,
+          "description": "resolve and print everything, but do not open the tunnel.",
+          "name": "print-only",
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "AWS profile to use (defaults to the ambient credential chain).",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "profile",
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "program-hub",
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "qboard",
+          "type": "option"
+        },
+        "remote-port": {
+          "default": 5432,
+          "description": "remote DB port (with --host)",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "remote-port",
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "rostering",
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "rtsm",
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "saga-dash",
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "sds",
+          "type": "option"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "set",
+          "type": "option"
+        },
+        "slot": {
+          "default": 0,
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "slot",
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "soa",
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "state-dir",
+          "type": "option"
+        },
+        "username": {
+          "description": "override the resolved user (URL carries no password then).",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "username",
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "env:connect",
+      "isESM": true,
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "relativePath": [
+        "dist",
+        "commands",
+        "env",
+        "connect.js"
+      ],
+      "slotClaimWritten": false,
+      "strict": true
+    },
+    "env:discover": {
+      "aliases": [],
+      "args": {},
+      "description": "Discover a shared environment's data-plane wiring: SSM params under its discovery roots (filtered to data-store names) and the Online SSM jump host. Read-only.",
+      "enableJsonFlag": false,
+      "examples": [
+        "<%= config.bin %> <%= command.id %> --env dev --profile dev_admin",
+        "<%= config.bin %> <%= command.id %> --env dev --filter mongodb"
+      ],
+      "flags": {
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "coach",
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "dev",
+          "noCacheDefault": true,
+          "type": "option"
+        },
+        "env": {
+          "default": "dev",
+          "description": "target environment (dev | training)",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "env",
+          "type": "option"
+        },
+        "filter": {
+          "default": "postgres|mongo|mongodb|db-host|rabbit|redis|rds|secret",
+          "description": "case-insensitive regex over parameter names",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "filter",
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "fleek",
+          "type": "option"
+        },
+        "output-json": {
+          "allowNo": false,
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "type": "boolean"
+        },
+        "porcelain": {
+          "allowNo": false,
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "AWS profile to use (defaults to the ambient credential chain).",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "profile",
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "program-hub",
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "qboard",
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "rostering",
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "rtsm",
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "saga-dash",
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "sds",
+          "type": "option"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "set",
+          "type": "option"
+        },
+        "slot": {
+          "default": 0,
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "slot",
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "soa",
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "state-dir",
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "env:discover",
+      "isESM": true,
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "relativePath": [
+        "dist",
+        "commands",
+        "env",
+        "discover.js"
+      ],
+      "slotClaimWritten": false,
+      "strict": true
+    },
+    "env:list": {
+      "aliases": [],
+      "args": {},
+      "description": "List deployed shared environments (dev, training) and their dev-platform ledger footprint. Read-only.",
+      "enableJsonFlag": false,
+      "examples": [
+        "<%= config.bin %> <%= command.id %>",
+        "<%= config.bin %> <%= command.id %> --profile dev_admin --output-json"
+      ],
+      "flags": {
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "coach",
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "dev",
+          "noCacheDefault": true,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "fleek",
+          "type": "option"
+        },
+        "output-json": {
+          "allowNo": false,
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "type": "boolean"
+        },
+        "porcelain": {
+          "allowNo": false,
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "AWS profile to use (defaults to the ambient credential chain).",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "profile",
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "program-hub",
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "qboard",
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "rostering",
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "rtsm",
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "saga-dash",
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "sds",
+          "type": "option"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "set",
+          "type": "option"
+        },
+        "slot": {
+          "default": 0,
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "slot",
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "soa",
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "state-dir",
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "env:list",
+      "isESM": true,
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "relativePath": [
+        "dist",
+        "commands",
+        "env",
+        "list.js"
+      ],
+      "slotClaimWritten": false,
+      "strict": true
+    },
+    "env:org:reset": {
+      "aliases": [],
+      "args": {},
+      "description": "DELETE a fixture org's data across the shared environment's Postgres stores, back to the seeded skeleton (org row + admin + seeded personas survive). Destructive; slug-only targeting, identity-asserted, one confirm, per-store transactions, post-verified.",
+      "enableJsonFlag": false,
+      "examples": [
+        "<%= config.bin %> <%= command.id %> --org emptyOrg --url iam=postgres://…15432/iam --url programs=postgres://…15433/programs --dry-run",
+        "<%= config.bin %> <%= command.id %> --org emptyOrg --url iam=… --url programs=… --url sessions=… --url scheduling=… --yes",
+        "<%= config.bin %> <%= command.id %> --org emptyOrg --url iam=… --url programs=… --snapshot --profile dev_admin"
+      ],
+      "flags": {
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "coach",
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "dev",
+          "noCacheDefault": true,
+          "type": "option"
+        },
+        "dry-run": {
+          "allowNo": false,
+          "description": "resolve id-sets, run the identity assertion, and print exactly what would be deleted (per-table counts) — then exit 0 without deleting anything.",
+          "name": "dry-run",
+          "type": "boolean"
+        },
+        "env": {
+          "default": "dev",
+          "description": "target environment (dev | training)",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "env",
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "fleek",
+          "type": "option"
+        },
+        "org": {
+          "description": "fixture org slug (emptyOrg)",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "org",
+          "required": true,
+          "type": "option"
+        },
+        "output-json": {
+          "allowNo": false,
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "type": "boolean"
+        },
+        "porcelain": {
+          "allowNo": false,
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "AWS profile for the --snapshot Lambda call (defaults to the ambient chain).",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "profile",
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "program-hub",
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "qboard",
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "rostering",
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "rtsm",
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "saga-dash",
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "sds",
+          "type": "option"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "set",
+          "type": "option"
+        },
+        "slot": {
+          "default": 0,
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "slot",
+          "type": "option"
+        },
+        "snapshot": {
+          "allowNo": false,
+          "description": "best-effort pre-delete snapshot per store via the db-host-v2 orchestrator (profile 'pre-org-reset', versioned). Unreachable orchestrator ⇒ warn and proceed; an unknown registry name skips that store (see --snapshot-service).",
+          "name": "snapshot",
+          "type": "boolean"
+        },
+        "snapshot-service": {
+          "description": "db-host-v2 registry serviceName override as <store>=<serviceName> (repeatable, with --snapshot).",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "name": "snapshot-service",
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "soa",
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "state-dir",
+          "type": "option"
+        },
+        "url": {
+          "description": "store connection as <store>=<connString> (repeatable; store keys: sessions, scheduling, programs, ads-adm, coach, iam-pii, iam). iam AND programs are mandatory anchors; other stores without a --url are skipped with a warning.",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "name": "url",
+          "type": "option"
+        },
+        "yes": {
+          "allowNo": false,
+          "description": "non-interactive: skip the destructive-action prompt (CI / agents).",
+          "name": "yes",
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "env:org:reset",
+      "isESM": true,
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "relativePath": [
+        "dist",
+        "commands",
+        "env",
+        "org",
+        "reset.js"
+      ],
+      "slotClaimWritten": false,
+      "strict": true
+    },
+    "env:org:status": {
+      "aliases": [],
+      "args": {},
+      "description": "Show a fixture org's data footprint across the mesh's Postgres stores (per-table row counts, projections marked). Read-only; targets orgs by catalog slug only.",
+      "enableJsonFlag": false,
+      "examples": [
+        "<%= config.bin %> <%= command.id %> --org emptyOrg --url iam=postgres://…15432/iam --url programs=postgres://…15433/programs",
+        "<%= config.bin %> <%= command.id %> --org emptyOrg --offline"
+      ],
+      "flags": {
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "coach",
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "dev",
+          "noCacheDefault": true,
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "fleek",
+          "type": "option"
+        },
+        "offline": {
+          "allowNo": false,
+          "description": "catalog-derived ids only — no live id resolution even if anchor URLs are given.",
+          "name": "offline",
+          "type": "boolean"
+        },
+        "org": {
+          "description": "fixture org slug (emptyOrg)",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "org",
+          "required": true,
+          "type": "option"
+        },
+        "output-json": {
+          "allowNo": false,
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "type": "boolean"
+        },
+        "porcelain": {
+          "allowNo": false,
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "type": "boolean"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "program-hub",
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "qboard",
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "rostering",
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "rtsm",
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "saga-dash",
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "sds",
+          "type": "option"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "set",
+          "type": "option"
+        },
+        "slot": {
+          "default": 0,
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "slot",
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "soa",
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "state-dir",
+          "type": "option"
+        },
+        "url": {
+          "description": "store connection as <store>=<connString> (repeatable; store keys: iam, programs, scheduling, sessions, ads-adm, coach)",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "name": "url",
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "env:org:status",
+      "isESM": true,
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "relativePath": [
+        "dist",
+        "commands",
+        "env",
+        "org",
+        "status.js"
+      ],
+      "slotClaimWritten": false,
+      "strict": true
+    },
+    "env:verify": {
+      "aliases": [],
+      "args": {},
+      "description": "Health-gate a deployed shared environment (dev/training): probe every service's health endpoint and judge it by RESPONSE BODY (the shared ALB answers 200 for unrouted hosts). Non-zero exit if a required service is unhealthy. --org additionally asserts a fixture org's seed skeleton.",
+      "enableJsonFlag": false,
+      "examples": [
+        "<%= config.bin %> <%= command.id %> --env dev",
+        "<%= config.bin %> <%= command.id %> --env training --tolerate connect-api,rtsm-api",
+        "<%= config.bin %> <%= command.id %> --env dev --org emptyOrg --url iam=postgres://…15432/iam"
+      ],
+      "flags": {
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "coach",
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "dev",
+          "noCacheDefault": true,
+          "type": "option"
+        },
+        "ecs": {
+          "allowNo": false,
+          "description": "ALSO check the ECS platform state (running/desired tasks, rollout) — the truth HTTP cannot see (crash-loops behind a healthy target, stuck deploys). Covers services with no public route. Needs dev-account AWS credentials.",
+          "name": "ecs",
+          "type": "boolean"
+        },
+        "env": {
+          "default": "dev",
+          "description": "target environment (dev | training)",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "env",
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "fleek",
+          "type": "option"
+        },
+        "org": {
+          "description": "also assert this fixture org's seed skeleton (emptyOrg); needs --url iam=<conn>.",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "org",
+          "type": "option"
+        },
+        "output-json": {
+          "allowNo": false,
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "type": "boolean"
+        },
+        "porcelain": {
+          "allowNo": false,
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "AWS profile for --ecs (defaults to the ambient chain).",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "profile",
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "program-hub",
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "qboard",
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "rostering",
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "rtsm",
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "saga-dash",
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "sds",
+          "type": "option"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "set",
+          "type": "option"
+        },
+        "slot": {
+          "default": 0,
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "slot",
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "soa",
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "state-dir",
+          "type": "option"
+        },
+        "tolerate": {
+          "description": "comma-separated service ids whose being down does NOT fail the gate.",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "tolerate",
+          "type": "option"
+        },
+        "url": {
+          "description": "store connection as <store>=<connString> (only iam is used, for --org).",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "name": "url",
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "env:verify",
+      "isESM": true,
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "relativePath": [
+        "dist",
+        "commands",
+        "env",
+        "verify.js"
+      ],
+      "slotClaimWritten": false,
+      "strict": true
+    },
     "set:check": {
       "aliases": [],
       "args": {

--- a/packages/node/saga-stack-cli/package.json
+++ b/packages/node/saga-stack-cli/package.json
@@ -43,6 +43,12 @@
             },
             "set": {
                 "description": "Worktree sets (M13): named repo\u2192path maps bound to slots \u2014 list, show, and check the parallel dev contexts --set runs against."
+            },
+            "env": {
+                "description": "Deployed shared environments (dev *.wootdev.com, training *.saga-training.org): list, discover data-plane wiring, and open SSM tunnels to the underlying stores."
+            },
+            "env:org": {
+                "description": "Org-scoped operations against a shared environment's data stores \u2014 fixture orgs only (catalog-slug targeting)."
             }
         },
         "hooks": {

--- a/packages/node/saga-stack-cli/src/base-command.ts
+++ b/packages/node/saga-stack-cli/src/base-command.ts
@@ -83,6 +83,8 @@ import {
   makeRealSnapshotIO,
   makeRealViteClear,
   makeSettleBarrier,
+  makeRealEnvAws,
+  makeRealEnvPsql,
   makeSlotWipe,
   realSleep,
   makeRealDockerWipe,
@@ -127,6 +129,8 @@ import type {
   ServiceStopper,
   SettleBarrier,
   SleepFn,
+  EnvAws,
+  EnvPsql,
   SlotWipe,
   SnapshotIO,
   ViteClear,
@@ -836,6 +840,24 @@ export abstract class BaseCommand extends Command {
    */
   protected getSlotWipe(): SlotWipe {
     return makeSlotWipe();
+  }
+
+  /**
+   * The AWS CLI seam (`ss env` — soa#355) — production is the only place `aws` is
+   * shelled out to (captured JSON calls + SSM port-forward sessions). Injected so
+   * env commands are tested against canned AWS responses with no credentials.
+   */
+  protected getEnvAws(): EnvAws {
+    return makeRealEnvAws();
+  }
+
+  /**
+   * The psql seam (`ss env org` — soa#355) — production is the only place `psql`
+   * runs against a (port-forwarded) shared-environment database. Injected so
+   * footprint/reset SQL is asserted byte-for-byte with no live database.
+   */
+  protected getEnvPsql(): EnvPsql {
+    return makeRealEnvPsql();
   }
 
   /**

--- a/packages/node/saga-stack-cli/src/commands/env/__tests__/env-reset.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/env/__tests__/env-reset.int.test.ts
@@ -1,0 +1,447 @@
+/**
+ * `ss env org reset` integration tests (soa#355, Phase 1) — in-process runs
+ * with the IO seams (`getEnvPsql`, `getEnvAws`, `getConfirm`) faked on
+ * `BaseCommand.prototype`; no aws call, tunnel, or database is ever touched.
+ *
+ * Covers the destructive canon end-to-end: slug refusal, the both-anchors
+ * requirement, the pre-flight identity assertion, --dry-run zero-mutation
+ * (every SQL that reaches psql is a SELECT), a declined confirm aborting
+ * clean, --yes executing the per-store transactions in leaf→iam order with
+ * the iam compound asserted BYTE-EXACT (skeleton predicates included), the
+ * post-verify before/after report + skeleton check, and --snapshot's
+ * best-effort ladder (success, unreachable ⇒ warn+proceed, not-in-registry ⇒
+ * abort before any delete).
+ */
+
+import { Config } from '@oclif/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BaseCommand } from '../../../base-command.js';
+import type { ConfirmSeam, EnvAws, EnvPsql, LambdaInvokeRequest, PortForwardHandle } from '../../../runtime/index.js';
+import EnvOrgReset from '../org/reset.js';
+
+const PKG_ROOT = process.cwd();
+
+const ORG_ID = '52a00136-285b-522c-bc70-0887cf46463a';
+const ADMIN = '506605c6-f2c5-5785-9837-7970e7a2594c';
+const MEMB = '80089e21-6aea-520e-8940-d292e0e12f92';
+const SCHOOL = 'b39f3ea1-0ee5-5a61-afdd-65e8c2b30db6';
+const USER = '92c6c9f4-c764-519f-9873-7df7b77f5410';
+const PROGRAM = 'ea1562ee-a620-5d5c-82a8-768da7f798c2';
+const PERIOD = 'a0da8362-1a93-5d1d-aeaa-b6d8960e9821';
+const SCHEDULE = 'c1d2e3f4-0000-4000-8000-000000000001';
+const SESSION = 'MjAyNi0wNy0yMXxwZXJ8c2xvdHxwb2Q';
+
+const URLS = {
+  iam: 'postgres://iam',
+  programs: 'postgres://pgm',
+  scheduling: 'postgres://sch',
+  sessions: 'postgres://ses',
+  'ads-adm': 'postgres://ads',
+  coach: 'postgres://coach',
+  'iam-pii': 'postgres://pii',
+} as const;
+
+const urlArgs = (...stores: (keyof typeof URLS)[]): string[] =>
+  stores.flatMap((s) => ['--url', `${s}=${URLS[s]}`]);
+
+const ALL_URLS = urlArgs('iam', 'programs', 'scheduling', 'sessions', 'ads-adm', 'coach', 'iam-pii');
+
+let config: Config;
+let out: string[];
+let warns: string[];
+let prompts: string[];
+let psqlCalls: { conn: string; sql: string }[];
+let lambdaCalls: LambdaInvokeRequest[];
+
+const text = (): string => out.join('\n');
+
+/**
+ * The scripted database: identity rows, one school group, one mono-org user,
+ * one program/period, one session; counts are 2 before the store's
+ * transaction ran and 0 after (the post-verify recount flips).
+ * `leftoverTable` keeps that table's post-delete recount at 1 (the REMAIN
+ * path); `breakSkeleton` makes the admin-membership probe come back empty
+ * after the transactions (the SKELETON CHECK FAILED path).
+ */
+function installEnvPsql(
+  opts: { orgName?: string; adminLogin?: string; leftoverTable?: string; breakSkeleton?: boolean } = {},
+): void {
+  let deleted = false;
+  const fake: EnvPsql = {
+    async query(conn, sql): Promise<string[][]> {
+      psqlCalls.push({ conn, sql });
+      if (sql.startsWith('BEGIN;')) {
+        deleted = true;
+        return [];
+      }
+      if (sql === `SELECT display_name FROM groups WHERE id = '${ORG_ID}'`) return [[opts.orgName ?? 'Empty Org']];
+      // iam.users.username is the seeded admin HANDLE (the catalog slug 'empty'),
+      // not the email — the identity assertion checks it against org.adminSlug.
+      if (sql === `SELECT username FROM users WHERE id = '${ADMIN}'`) return [[opts.adminLogin ?? 'empty']];
+      if (sql === `SELECT id FROM group_memberships WHERE id = '${MEMB}'`) {
+        return deleted && opts.breakSkeleton === true ? [] : [[MEMB]];
+      }
+      if (sql.startsWith('SELECT count(*)')) {
+        if (deleted && opts.leftoverTable !== undefined && sql.includes(`FROM ${opts.leftoverTable} `)) return [['1']];
+        return [[deleted ? '0' : '2']];
+      }
+      if (sql.startsWith('SELECT id FROM groups WHERE org_id')) return [[SCHOOL]];
+      if (sql.includes('gm.user_id') && sql.includes('NOT EXISTS')) return [[USER]]; // userDelIds
+      if (sql.startsWith('SELECT DISTINCT user_id FROM group_memberships')) return [[USER]];
+      if (sql.startsWith('SELECT id FROM "Program"')) return [[PROGRAM]];
+      if (sql.startsWith('SELECT id FROM "TutoringPeriod"')) return [[PERIOD]];
+      if (sql.startsWith('SELECT id FROM "Schedule"')) return [[SCHEDULE]];
+      if (sql.startsWith('SELECT id FROM tutoring_session')) return [[SESSION]];
+      if (sql.startsWith('SELECT')) return []; // remaining resolution rings: empty
+      throw new Error(`unexpected sql: ${sql}`);
+    },
+  };
+  vi.spyOn(BaseCommand.prototype as unknown as { getEnvPsql: () => EnvPsql }, 'getEnvPsql').mockReturnValue(fake);
+}
+
+function installEnvAws(lambda: (req: LambdaInvokeRequest) => unknown = () => null): void {
+  const fake: EnvAws = {
+    async json(): Promise<unknown> {
+      throw new Error('unexpected aws json call in reset tests');
+    },
+    async lambdaInvoke(req): Promise<unknown> {
+      lambdaCalls.push(req);
+      return lambda(req);
+    },
+    portForward(): PortForwardHandle {
+      throw new Error('unexpected portForward in reset tests');
+    },
+  };
+  vi.spyOn(BaseCommand.prototype as unknown as { getEnvAws: () => EnvAws }, 'getEnvAws').mockReturnValue(fake);
+}
+
+function installConfirm(answer: boolean): void {
+  const confirm: ConfirmSeam = {
+    isTTY: () => true,
+    async prompt(question: string): Promise<boolean> {
+      prompts.push(question);
+      return answer;
+    },
+  };
+  vi.spyOn(BaseCommand.prototype as unknown as { getConfirm: () => ConfirmSeam }, 'getConfirm').mockReturnValue(confirm);
+}
+
+/** Every executed store transaction (BEGIN…COMMIT compound), in call order, keyed by conn. */
+const transactions = (): { conn: string; sql: string }[] => psqlCalls.filter((c) => c.sql.startsWith('BEGIN;'));
+
+/** Extract the emitted JSON object from the captured log lines. */
+function emittedJson(): Record<string, unknown> {
+  const t = text();
+  const start = t.indexOf('{');
+  expect(start).toBeGreaterThanOrEqual(0);
+  return JSON.parse(t.slice(start)) as Record<string, unknown>;
+}
+
+beforeEach(async () => {
+  config = await Config.load(PKG_ROOT);
+  out = [];
+  warns = [];
+  prompts = [];
+  psqlCalls = [];
+  lambdaCalls = [];
+  vi.spyOn(BaseCommand.prototype as unknown as { log: (msg?: string) => void }, 'log').mockImplementation(
+    (msg?: string) => {
+      out.push(String(msg ?? ''));
+    },
+  );
+  vi.spyOn(BaseCommand.prototype as unknown as { warn: (msg: string | Error) => void }, 'warn').mockImplementation(
+    (msg: string | Error) => {
+      warns.push(String(msg));
+    },
+  );
+  installEnvPsql();
+  installEnvAws();
+  installConfirm(true);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('refusals (non-zero, nothing touched)', () => {
+  it('refuses unknown slugs and raw UUIDs with the catalog listing', async () => {
+    await expect(EnvOrgReset.run(['--org', 'jennys-training-org', ...ALL_URLS], config)).rejects.toThrow(
+      /not a resettable fixture org/,
+    );
+    await expect(EnvOrgReset.run(['--org', ORG_ID, ...ALL_URLS], config)).rejects.toThrow(/not a resettable fixture org/);
+    expect(psqlCalls).toHaveLength(0);
+  });
+
+  it('refuses to run without BOTH anchor urls (iam + programs)', async () => {
+    await expect(EnvOrgReset.run(['--org', 'emptyOrg', ...urlArgs('iam'), '--yes'], config)).rejects.toThrow(
+      /BOTH anchor stores/,
+    );
+    await expect(EnvOrgReset.run(['--org', 'emptyOrg', ...urlArgs('programs'), '--dry-run'], config)).rejects.toThrow(
+      /BOTH anchor stores/,
+    );
+    expect(psqlCalls).toHaveLength(0);
+  });
+
+  it('bad --url store keys are refused with the reset store-key list (iam-pii included)', async () => {
+    await expect(EnvOrgReset.run(['--org', 'emptyOrg', '--url', 'nope=postgres://x'], config)).rejects.toThrow(
+      /expected <store>=<connString>.*iam-pii/,
+    );
+  });
+
+  it('an EMPTY --url connection string is refused (no silent libpq env fallback)', async () => {
+    await expect(
+      EnvOrgReset.run(['--org', 'emptyOrg', '--url', 'iam=', '--url', 'programs=postgres://p', '--yes'], config),
+    ).rejects.toThrow(/empty connection string/);
+    expect(psqlCalls).toHaveLength(0);
+  });
+
+  it('IDENTITY ASSERTION: a wrong org display name refuses before any delete', async () => {
+    installEnvPsql({ orgName: 'Jennys Training District' });
+    await expect(EnvOrgReset.run(['--org', 'emptyOrg', ...ALL_URLS, '--yes'], config)).rejects.toThrow(
+      /IDENTITY ASSERTION FAILED.*Jennys Training District/,
+    );
+    expect(transactions()).toHaveLength(0);
+    expect(psqlCalls.every((c) => c.sql.startsWith('SELECT'))).toBe(true);
+  });
+
+  it('IDENTITY ASSERTION: a wrong admin username refuses before any delete', async () => {
+    installEnvPsql({ adminLogin: 'someone-else@saga.org' });
+    await expect(EnvOrgReset.run(['--org', 'emptyOrg', ...ALL_URLS, '--yes'], config)).rejects.toThrow(
+      /IDENTITY ASSERTION FAILED.*someone-else@saga.org/,
+    );
+    expect(transactions()).toHaveLength(0);
+  });
+});
+
+describe('--dry-run — enumerate and exit 0, zero mutation', () => {
+  it('prints per-table counts (projections marked) and sends ONLY SELECTs to psql', async () => {
+    await expect(EnvOrgReset.run(['--org', 'emptyOrg', ...ALL_URLS, '--dry-run'], config)).resolves.toBeUndefined();
+
+    expect(text()).toContain('DRY RUN');
+    expect(text()).toContain('will be DELETED');
+    expect(text()).toContain('[projection]');
+    expect(text()).toContain('no changes made');
+    expect(prompts).toHaveLength(0);
+    expect(psqlCalls.length).toBeGreaterThan(0);
+    for (const c of psqlCalls) {
+      expect(c.sql.startsWith('SELECT')).toBe(true);
+      expect(c.sql).not.toContain('DELETE');
+    }
+  });
+});
+
+describe('confirm flow', () => {
+  it('a declined prompt aborts clean — exit 0, nothing deleted', async () => {
+    installConfirm(false);
+    await expect(EnvOrgReset.run(['--org', 'emptyOrg', ...ALL_URLS], config)).resolves.toBeUndefined();
+    expect(prompts).toHaveLength(1);
+    expect(prompts[0]).toContain('DELETES');
+    expect(text()).toContain('reset aborted — nothing changed.');
+    expect(transactions()).toHaveLength(0);
+  });
+});
+
+describe('--yes execution — per-store transactions, order, skeleton predicates', () => {
+  it('executes leaf stores first, iam LAST, one BEGIN/COMMIT compound per store', async () => {
+    await expect(EnvOrgReset.run(['--org', 'emptyOrg', ...ALL_URLS, '--yes'], config)).resolves.toBeUndefined();
+
+    const tx = transactions();
+    expect(tx.map((t) => t.conn)).toEqual([
+      URLS.sessions,
+      URLS.scheduling,
+      URLS.programs,
+      URLS['ads-adm'],
+      URLS.coach,
+      URLS['iam-pii'],
+      URLS.iam,
+    ]);
+    for (const t of tx) {
+      expect(t.sql.startsWith('BEGIN;\n')).toBe(true);
+      expect(t.sql.endsWith('COMMIT;')).toBe(true);
+    }
+    expect(prompts).toHaveLength(0);
+  });
+
+  it('the iam transaction is BYTE-EXACT: multi-org users rule + every skeleton predicate', async () => {
+    await expect(EnvOrgReset.run(['--org', 'emptyOrg', ...ALL_URLS, '--yes'], config)).resolves.toBeUndefined();
+
+    const G = `'${ORG_ID}', '${SCHOOL}'`;
+    const expected =
+      [
+        'BEGIN',
+        `DELETE FROM users WHERE id IN (SELECT DISTINCT gm.user_id FROM group_memberships gm WHERE gm.group_id IN (${G}))` +
+          ` AND id <> '${ADMIN}'` +
+          ` AND NOT EXISTS (SELECT 1 FROM group_memberships gm2 WHERE gm2.user_id = users.id AND gm2.group_id NOT IN (${G}))` +
+          ` AND users.role = 'USER'` +
+          ` AND NOT EXISTS (SELECT 1 FROM user_system_roles usr WHERE usr.user_id = users.id)`,
+        `DELETE FROM group_memberships WHERE group_id IN (${G}) AND id <> '${MEMB}'`,
+        `DELETE FROM personas WHERE group_id IN (${G})` +
+          ` AND id NOT IN ('00000000-0000-4000-a003-000000000021', '00000000-0000-4000-a003-000000000022', '00000000-0000-4000-a003-000000000023')` +
+          ` AND id NOT IN (SELECT persona_id FROM group_memberships WHERE id = '${MEMB}' AND persona_id IS NOT NULL)`,
+        `DELETE FROM user_policies WHERE group_id IN (${G})`,
+        `DELETE FROM group_auth_config WHERE group_id IN (${G}) AND group_id <> '${ORG_ID}'`,
+        `DELETE FROM login_profiles WHERE group_id IN (${G}) AND group_id <> '${ORG_ID}'`,
+        `DELETE FROM group_attributes WHERE group_id IN (${G}) AND group_id <> '${ORG_ID}'`,
+        `DELETE FROM groups WHERE org_id = '${ORG_ID}' AND id <> '${ORG_ID}'`,
+        'COMMIT',
+      ].join(';\n') + ';';
+    const iamTx = transactions().find((t) => t.conn === URLS.iam);
+    expect(iamTx?.sql).toBe(expected);
+  });
+
+  it('the iam-pii sweep uses userDelIds with the admin belt-and-braces', async () => {
+    await expect(EnvOrgReset.run(['--org', 'emptyOrg', ...ALL_URLS, '--yes'], config)).resolves.toBeUndefined();
+    const piiTx = transactions().find((t) => t.conn === URLS['iam-pii']);
+    expect(piiTx?.sql).toBe(
+      `BEGIN;\nDELETE FROM user_pii WHERE user_id IN ('${USER}') AND user_id <> '${ADMIN}';\nCOMMIT;`,
+    );
+  });
+
+  it('post-verify reports before/after per table and the skeleton check passes', async () => {
+    await expect(
+      EnvOrgReset.run(['--org', 'emptyOrg', ...ALL_URLS, '--yes', '--output-json'], config),
+    ).resolves.toBeUndefined();
+
+    const json = emittedJson();
+    expect(json.skeletonIntact).toBe(true);
+    expect(json.leftoverRows).toBe(0);
+    const stores = json.stores as { store: string; tables: { table: string; before: number | null; after: number | null }[] }[];
+    expect(stores.map((s) => s.store)).toEqual(['sessions', 'scheduling', 'programs', 'ads-adm', 'coach', 'iam-pii', 'iam']);
+    const iam = stores.find((s) => s.store === 'iam')!;
+    const users = iam.tables.find((t) => t.table === 'users')!;
+    expect(users.before).toBe(2);
+    expect(users.after).toBe(0);
+    expect(warns.filter((w) => w.includes('REMAIN'))).toHaveLength(0);
+  });
+
+  it('leftover rows warn REMAIN (loud), land in leftoverRows, and still exit 0', async () => {
+    installEnvPsql({ leftoverTable: 'adm_attendance' });
+    await expect(
+      EnvOrgReset.run(['--org', 'emptyOrg', ...ALL_URLS, '--yes', '--output-json'], config),
+    ).resolves.toBeUndefined();
+
+    expect(warns.some((w) => w.includes('ads-adm.adm_attendance: 1 row(s) REMAIN after reset'))).toBe(true);
+    const json = emittedJson();
+    expect(json.leftoverRows).toBe(1);
+    expect(json.skeletonIntact).toBe(true);
+    const stores = json.stores as { store: string; tables: { table: string; after: number | null }[] }[];
+    const ads = stores.find((s) => s.store === 'ads-adm')!;
+    expect(ads.tables.find((t) => t.table === 'adm_attendance')!.after).toBe(1);
+  });
+
+  it('a broken skeleton is a NON-ZERO exit — after the full JSON report was still emitted', async () => {
+    installEnvPsql({ breakSkeleton: true });
+    await expect(
+      EnvOrgReset.run(['--org', 'emptyOrg', ...ALL_URLS, '--yes', '--output-json'], config),
+    ).rejects.toThrow(/SKELETON CHECK FAILED/);
+
+    // The report reached the operator BEFORE the non-zero exit.
+    const json = emittedJson();
+    expect(json.skeletonIntact).toBe(false);
+    expect(transactions()).toHaveLength(7); // the deletes did run; the probe failed after
+  });
+
+  it('self-blinding tables (DayTypeBlock/ProgramSectionMapping) are reported verify-indirect, never a fake 0', async () => {
+    await expect(
+      EnvOrgReset.run(['--org', 'emptyOrg', ...ALL_URLS, '--yes', '--output-json'], config),
+    ).resolves.toBeUndefined();
+
+    const json = emittedJson();
+    const stores = json.stores as {
+      store: string;
+      tables: { table: string; before: number | null; after: number | null; verify?: string }[];
+    }[];
+    const dtb = stores.find((s) => s.store === 'scheduling')!.tables.find((t) => t.table === '"DayTypeBlock"')!;
+    expect(dtb.before).toBe(2);
+    expect(dtb.after).toBeNull();
+    expect(dtb.verify).toBe('indirect');
+    const psm = stores.find((s) => s.store === 'programs')!.tables.find((t) => t.table === '"ProgramSectionMapping"')!;
+    expect(psm.verify).toBe('indirect');
+    // users is recounted for real, via the pre-resolved literal set.
+    const users = stores.find((s) => s.store === 'iam')!.tables.find((t) => t.table === 'users')!;
+    expect(users.after).toBe(0);
+    expect(users.verify).toBeUndefined();
+  });
+
+  it('stores without a --url are skipped LOUDLY and their tables reported unconnected', async () => {
+    await expect(
+      EnvOrgReset.run(['--org', 'emptyOrg', ...urlArgs('iam', 'programs'), '--yes', '--output-json'], config),
+    ).resolves.toBeUndefined();
+
+    expect(warns.some((w) => w.includes("store 'sessions' SKIPPED — no --url"))).toBe(true);
+    expect(warns.some((w) => w.includes("store 'coach' SKIPPED"))).toBe(true);
+    // Resolution steps for missing stores warned too (orphan unions unswept).
+    expect(warns.some((w) => w.includes("store 'scheduling' has no --url"))).toBe(true);
+    expect(transactions().map((t) => t.conn)).toEqual([URLS.programs, URLS.iam]);
+  });
+});
+
+describe('--snapshot — best-effort orchestrator ladder', () => {
+  it('snapshots stores with known registry names before deleting; unknown names warn+skip', async () => {
+    // The orchestrator success body is FLAT ({ ok, name, profile, … }) — no nested `snapshot`.
+    installEnvAws((req) => ({ ok: true, name: (req.payload as { serviceName: string }).serviceName, profile: 'pre-org-reset' }));
+
+    await expect(
+      EnvOrgReset.run(['--org', 'emptyOrg', ...ALL_URLS, '--yes', '--snapshot', '--profile', 'dev_admin', '--output-json'], config),
+    ).resolves.toBeUndefined();
+
+    // Known registry names: iam + ads-adm (others warn about the missing name).
+    expect(lambdaCalls.map((c) => c.payload)).toEqual([
+      { action: 'snapshot', serviceName: 'ads-adm-postgres', profile: 'pre-org-reset' },
+      { action: 'snapshot', serviceName: 'rostering-iam-canonical', profile: 'pre-org-reset' },
+    ]);
+    expect(lambdaCalls[0]).toMatchObject({ functionName: 'dev-db-host-orchestrator', profile: 'dev_admin', region: 'us-west-2' });
+    expect(warns.some((w) => w.includes("no db-host registry name known for store 'sessions'"))).toBe(true);
+    const json = emittedJson();
+    const snaps = json.snapshots as { store: string; ok: boolean; name?: string; profile?: string }[];
+    expect(snaps.filter((s) => s.ok).map((s) => s.store)).toEqual(['ads-adm', 'iam']);
+    // The restore-point reference is captured from the flat body (finding: was always blank).
+    const iamSnap = snaps.find((s) => s.store === 'iam')!;
+    expect(iamSnap.profile).toBe('pre-org-reset');
+    expect(iamSnap.name).toBe('rostering-iam-canonical');
+    expect(transactions()).toHaveLength(7); // snapshot ran BEFORE the deletes, which still all executed
+  });
+
+  it('--snapshot-service supplies a registry name for an unhinted store', async () => {
+    installEnvAws(() => ({ ok: true, name: 'program-hub-postgres', profile: 'pre-org-reset' }));
+    await expect(
+      EnvOrgReset.run(
+        ['--org', 'emptyOrg', ...urlArgs('iam', 'programs'), '--yes', '--snapshot', '--snapshot-service', 'programs=program-hub-postgres'],
+        config,
+      ),
+    ).resolves.toBeUndefined();
+    expect(lambdaCalls.map((c) => (c.payload as { serviceName: string }).serviceName)).toEqual([
+      'program-hub-postgres',
+      'rostering-iam-canonical',
+    ]);
+  });
+
+  it('--snapshot with --env training is refused up front (dev-only orchestrator), nothing touched', async () => {
+    await expect(
+      EnvOrgReset.run(['--org', 'emptyOrg', ...ALL_URLS, '--yes', '--snapshot', '--env', 'training'], config),
+    ).rejects.toThrow(/--snapshot drives the dev db-host orchestrator/);
+    expect(psqlCalls).toHaveLength(0);
+    expect(lambdaCalls).toHaveLength(0);
+    expect(transactions()).toHaveLength(0);
+  });
+
+  it('an unreachable orchestrator degrades to WARN and the reset proceeds', async () => {
+    installEnvAws(() => {
+      throw new Error('aws lambda invoke dev-db-host-orchestrator exited 255: Unable to locate credentials');
+    });
+
+    await expect(EnvOrgReset.run(['--org', 'emptyOrg', ...ALL_URLS, '--yes', '--snapshot'], config)).resolves.toBeUndefined();
+
+    expect(warns.some((w) => w.includes('orchestrator unreachable'))).toBe(true);
+    expect(transactions()).toHaveLength(7);
+  });
+
+  it("a 'not in registry' response means the TARGET is wrong — abort before any delete", async () => {
+    installEnvAws(() => ({ ok: false, error: "DB 'ads-adm-postgres' not in registry" }));
+
+    await expect(EnvOrgReset.run(['--org', 'emptyOrg', ...ALL_URLS, '--yes', '--snapshot'], config)).rejects.toThrow(
+      /not in the db-host registry.*aborting the reset/,
+    );
+    expect(transactions()).toHaveLength(0);
+  });
+});

--- a/packages/node/saga-stack-cli/src/commands/env/__tests__/env-verify.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/env/__tests__/env-verify.int.test.ts
@@ -1,0 +1,303 @@
+/**
+ * `ss env verify` tests (soa#355) — the deployed-env health gate.
+ *
+ * The load-bearing case is the SHARED-ALB TRAP: `*.wootdev.com` is wildcard DNS
+ * onto an ALB whose default action answers **200 with body `dev-account-alb`**
+ * for unmatched hosts, so a status-code-only gate would call a non-existent
+ * service healthy. These tests pin that a 200 + ALB body is a FAILURE, plus the
+ * probe URL map, no-public-route handling, --tolerate, --org skeleton assertion,
+ * and the exit codes.
+ */
+
+import { Config } from '@oclif/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BaseCommand } from '../../../base-command.js';
+import { buildEnvHealthProbes, classifyEcsState, classifyProbeBody } from '../../../core/env/index.js';
+import type { EnvPsql, HealthProber, ProbeResult } from '../../../runtime/index.js';
+import EnvVerify from '../verify.js';
+
+const PKG_ROOT = process.cwd();
+const ORG_ID = '52a00136-285b-522c-bc70-0887cf46463a';
+const ADMIN = '506605c6-f2c5-5785-9837-7970e7a2594c';
+const MEMB = '80089e21-6aea-520e-8940-d292e0e12f92';
+
+const okApi = (name: string): ProbeResult => ({ ok: true, status: 200, body: `{"status":"ok","service":"${name}"}` });
+const albDefault: ProbeResult = { ok: true, status: 200, body: 'dev-account-alb' };
+const okFrontend: ProbeResult = { ok: true, status: 200, body: '<!doctype html><html><head></head></html>' };
+
+let config: Config;
+let out: string[];
+let probed: string[];
+
+const text = (): string => out.join('\n');
+
+/** Every service healthy unless `overrides` says otherwise (keyed by URL substring). */
+function installProber(overrides: Record<string, ProbeResult> = {}): void {
+  const fake: HealthProber = {
+    async probe(url): Promise<ProbeResult> {
+      probed.push(url);
+      for (const [needle, result] of Object.entries(overrides)) {
+        if (url.includes(needle)) return result;
+      }
+      return url.endsWith('/health') ? okApi('Some API') : okFrontend;
+    },
+  };
+  vi.spyOn(BaseCommand.prototype as unknown as { getProber: () => HealthProber }, 'getProber').mockReturnValue(fake);
+}
+
+function installEnvPsql(rows: { org?: string; admin?: string; memb?: boolean } = {}): void {
+  const fake: EnvPsql = {
+    async query(_conn, sql): Promise<string[][]> {
+      if (sql.includes('FROM groups')) return [[rows.org ?? 'Empty Org']];
+      if (sql.includes('FROM users')) return [[rows.admin ?? 'empty']];
+      if (sql.includes('FROM group_memberships')) return (rows.memb ?? true) ? [[MEMB]] : [];
+      throw new Error(`unexpected sql: ${sql}`);
+    },
+  };
+  vi.spyOn(BaseCommand.prototype as unknown as { getEnvPsql: () => EnvPsql }, 'getEnvPsql').mockReturnValue(fake);
+}
+
+beforeEach(async () => {
+  config = await Config.load(PKG_ROOT);
+  out = [];
+  probed = [];
+  vi.spyOn(BaseCommand.prototype as unknown as { log: (m?: string) => void }, 'log').mockImplementation((m?: string) => {
+    out.push(String(m ?? ''));
+  });
+  installProber();
+  installEnvPsql();
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('probe planning (pure)', () => {
+  it('maps each service to its VERIFIED deployed host, not the manifest tunnelSlug', () => {
+    const byId = Object.fromEntries(buildEnvHealthProbes('wootdev.com', 'dev').map((p) => [p.id, p.url]));
+    // Short slugs…
+    expect(byId['iam-api']).toBe('https://iam.wootdev.com/health');
+    expect(byId['sis-api']).toBe('https://sis.wootdev.com/health');
+    // …full service ids (programs.wootdev.com is the ALB default, not the API).
+    expect(byId['programs-api']).toBe('https://programs-api.wootdev.com/health');
+    expect(byId['sessions-api']).toBe('https://sessions-api.wootdev.com/health');
+    // coach.<domain> is the WEB frontend; the API is coach-api.
+    expect(byId['coach-api']).toBe('https://coach-api.wootdev.com/health');
+    expect(byId['coach-web']).toBe('https://coach.wootdev.com/');
+    expect(byId['saga-dash']).toBe('https://dash.wootdev.com/');
+    // connect-api answers on connectv3-api (from the ALB host-header rules).
+    expect(byId['connect-api']).toBe('https://connectv3-api.wootdev.com/connectv3/v1/health');
+    // rtsm runs on its own geo cluster; the bare `core` alias fails TLS, core-a answers.
+    expect(byId['rtsm-api']).toBe('https://chi-1.rtsm.wootdev.com/health');
+    // fleek is its own Caddy recording fleet.
+    expect(byId['fleek']).toBe('https://chi-1.fleek.wootdev.com/health');
+    expect(byId['fleek-recorder']).toBe('https://recorder-chi-1.fleek.wootdev.com/v1/health');
+    // connect-web is on Amplify with NO custom domain — a per-env branch URL.
+    expect(byId['connect-web']).toBe('https://dev.d2ezd4i8b4uexc.amplifyapp.com/');
+  });
+
+  it('re-targets per-env services, but pins SHARED fleets to their real host', () => {
+    const byId = Object.fromEntries(buildEnvHealthProbes('saga-training.org', 'training').map((p) => [p.id, p.url]));
+    expect(byId['iam-api']).toBe('https://iam.saga-training.org/health');
+    // rtsm/fleek are ONE fleet serving both envs — training's own connectv3-api
+    // task def points at .wootdev.com — so they must NOT be domain-templated.
+    expect(byId['rtsm-api']).toBe('https://chi-1.rtsm.wootdev.com/health');
+    expect(byId['fleek']).toBe('https://chi-1.fleek.wootdev.com/health');
+    expect(byId['fleek-recorder']).toBe('https://recorder-chi-1.fleek.wootdev.com/v1/health');
+    // connect-web resolves to the TRAINING Amplify branch, not a wootdev host.
+    expect(byId['connect-web']).toBe('https://training.d2ezd4i8b4uexc.amplifyapp.com/');
+  });
+});
+
+describe('body classification — the shared-ALB trap', () => {
+  it('treats the ALB default body as NOT healthy even though it is a 200', () => {
+    expect(classifyProbeBody('dev-account-alb', 'api')).toBe('alb-default');
+    expect(classifyProbeBody('dev-account-alb', 'frontend')).toBe('alb-default');
+  });
+
+  it('accepts every status word the live fleet actually uses, and real frontend HTML', () => {
+    // Surveyed live on dev: services disagree on the word — all mean healthy.
+    expect(classifyProbeBody('{"status":"ok","service":"IAM API"}', 'api')).toBe('healthy');
+    expect(classifyProbeBody('{"status":"running","service":"SIS API","uptime":1,"sisDb":"connected"}', 'api')).toBe('healthy');
+    expect(classifyProbeBody('{"status":"running","service":"ADS/ADM API","uptime":1}', 'api')).toBe('healthy');
+    expect(classifyProbeBody('{"status":"healthy","service":"Coach API","uptime":1}', 'api')).toBe('healthy');
+    // connect-api carries NO `service` key — a healthy status is the signal.
+    expect(classifyProbeBody('{"status":"ok","mongo":"ok"}', 'api')).toBe('healthy');
+    expect(classifyProbeBody('<!doctype html><html></html>', 'frontend')).toBe('healthy');
+  });
+
+  it("'plain' hosts (fleek's own Caddy fleet) accept an empty/plain 2xx body, but never the ALB default", () => {
+    // fleek /health answers 200 with content-length: 0 — that IS its signal.
+    expect(classifyProbeBody('', 'plain')).toBe('healthy');
+    expect(classifyProbeBody(undefined, 'plain')).toBe('healthy');
+    expect(classifyProbeBody('OK', 'plain')).toBe('healthy');
+    // The ALB guard still wins, so a mis-mapped host can never sneak through.
+    expect(classifyProbeBody('dev-account-alb', 'plain')).toBe('alb-default');
+    // An empty body is still NOT health for a JSON API.
+    expect(classifyProbeBody('', 'api')).toBe('empty');
+  });
+
+  it('still fails an explicitly unhealthy status (allowlist, not "anything non-error")', () => {
+    expect(classifyProbeBody('{"status":"degraded","service":"IAM API"}', 'api')).toBe('unexpected');
+    expect(classifyProbeBody('{"status":"down","service":"IAM API"}', 'api')).toBe('unexpected');
+  });
+
+  it('rejects wrong-shaped, empty, and cross-kind bodies', () => {
+    expect(classifyProbeBody('{"status":"degraded","service":"X"}', 'api')).toBe('unexpected');
+    expect(classifyProbeBody('<!doctype html>', 'api')).toBe('unexpected'); // HTML where JSON is required
+    expect(classifyProbeBody('{"status":"ok","service":"X"}', 'frontend')).toBe('unexpected');
+    expect(classifyProbeBody('', 'api')).toBe('empty');
+    expect(classifyProbeBody(undefined, 'api')).toBe('empty');
+  });
+});
+
+describe('ECS platform verdicts (pure)', () => {
+  it('healthy only when ACTIVE, fully running, and rollout complete', () => {
+    expect(classifyEcsState({ running: 2, desired: 2, status: 'ACTIVE', rollout: 'COMPLETED' }).healthy).toBe(true);
+    expect(classifyEcsState({ running: 1, desired: 2, status: 'ACTIVE', rollout: 'COMPLETED' })).toMatchObject({
+      healthy: false,
+      summary: expect.stringContaining('under-running 1/2'),
+    });
+    // A routine in-flight deploy at full task count is noted, NOT failed.
+    expect(classifyEcsState({ running: 2, desired: 2, status: 'ACTIVE', rollout: 'IN_PROGRESS' })).toMatchObject({
+      healthy: true,
+      summary: expect.stringContaining('rollout IN_PROGRESS'),
+    });
+    // A genuinely failed rollout still fails.
+    expect(classifyEcsState({ running: 2, desired: 2, status: 'ACTIVE', rollout: 'FAILED' }).healthy).toBe(false);
+    expect(classifyEcsState({ running: 0, desired: 0, status: 'ACTIVE' })).toMatchObject({
+      healthy: false,
+      summary: expect.stringContaining('scaled to zero'),
+    });
+    expect(classifyEcsState(undefined)).toMatchObject({ healthy: false, summary: expect.stringContaining('no such ECS service') });
+  });
+});
+
+describe('env verify --ecs', () => {
+  const ecsAws = (state: Record<string, unknown> | null): void => {
+    const fake = {
+      async json(args: string[]): Promise<unknown> {
+        if (args[0] === 'sts') return '396913734878';
+        if (args[1] === 'describe-services') return state;
+        return null;
+      },
+      async lambdaInvoke(): Promise<unknown> {
+        throw new Error('unexpected');
+      },
+      portForward(): never {
+        throw new Error('unexpected');
+      },
+    };
+    vi.spyOn(BaseCommand.prototype as unknown as { getEnvAws: () => unknown }, 'getEnvAws').mockReturnValue(fake);
+  };
+
+  it('reports the ECS verdict alongside the HTTP result', async () => {
+    ecsAws({ running: 2, desired: 2, status: 'ACTIVE', rollout: 'COMPLETED' });
+
+    await expect(EnvVerify.run(['--env', 'dev', '--ecs'], config)).resolves.toBeUndefined();
+    expect(text()).toMatch(/connect-api.*ecs 2\/2/s);
+    expect(text()).toContain('verify passed');
+  });
+
+  it('FAILS a service whose HTTP is green but whose ECS is under-running', async () => {
+    ecsAws({ running: 0, desired: 2, status: 'ACTIVE', rollout: 'IN_PROGRESS' }); // under-running ⇒ real failure
+
+    await expect(EnvVerify.run(['--env', 'dev', '--ecs'], config)).rejects.toThrow(/env verify FAILED/);
+    expect(text()).toContain('ECS: under-running 0/2');
+  });
+
+  it('refuses on the wrong AWS account before any ECS call', async () => {
+    const fake = {
+      async json(args: string[]): Promise<unknown> {
+        if (args[0] === 'sts') return '531314149529'; // prod
+        throw new Error('must not query ECS on an account mismatch');
+      },
+      async lambdaInvoke(): Promise<unknown> {
+        throw new Error('unexpected');
+      },
+      portForward(): never {
+        throw new Error('unexpected');
+      },
+    };
+    vi.spyOn(BaseCommand.prototype as unknown as { getEnvAws: () => unknown }, 'getEnvAws').mockReturnValue(fake);
+
+    await expect(EnvVerify.run(['--env', 'dev', '--ecs'], config)).rejects.toThrow(/account mismatch/);
+  });
+});
+
+describe('env verify — the gate', () => {
+  it('passes when every routed service answers a real health body', async () => {
+    await expect(EnvVerify.run(['--env', 'dev'], config)).resolves.toBeUndefined();
+
+    expect(text()).toContain('verify passed');
+    expect(probed).toContain('https://iam.wootdev.com/health');
+    expect(probed).toContain('https://dash.wootdev.com/');
+    // rtsm IS probed now — on its own cluster host, not the shared domain.
+    expect(probed).toContain('https://chi-1.rtsm.wootdev.com/health');
+    // connect-web is probed at its Amplify branch URL.
+    expect(probed).toContain('https://dev.d2ezd4i8b4uexc.amplifyapp.com/');
+  });
+
+  it('FAILS (non-zero) when a service returns the ALB default — the 200-is-not-health case', async () => {
+    installProber({ 'programs-api': albDefault });
+
+    await expect(
+      EnvVerify.run(['--env', 'dev'], config),
+    ).rejects.toThrow(/env verify FAILED.*programs-api/s);
+    expect(text()).toContain('not routed');
+  });
+
+  it('FAILS on an unreachable service and on a non-2xx', async () => {
+    installProber({ 'sessions-api': { ok: false } });
+    await expect(EnvVerify.run(['--env', 'dev'], config)).rejects.toThrow(
+      /sessions-api/,
+    );
+    expect(text()).toContain('unreachable');
+  });
+
+  it('--tolerate downgrades a failure to a non-fatal note', async () => {
+    installProber({ 'ads-adm-api': albDefault });
+
+    await expect(
+      EnvVerify.run(['--env', 'dev', '--tolerate', 'ads-adm-api'], config),
+    ).resolves.toBeUndefined();
+    expect(text()).toContain('(tolerated)');
+    expect(text()).toContain('verify passed');
+  });
+
+  it('every mapped service now has an HTTP route on dev', async () => {
+    await expect(EnvVerify.run(['--env', 'dev'], config)).resolves.toBeUndefined();
+    expect(text()).not.toContain('no public route');
+    expect(text()).toContain('verify passed');
+  });
+
+  it('--org asserts the seed skeleton and passes when intact', async () => {
+    await expect(
+      EnvVerify.run(
+        ['--env', 'dev', '--org', 'emptyOrg', '--url', 'iam=postgres://iam'],
+        config,
+      ),
+    ).resolves.toBeUndefined();
+    expect(text()).toContain('org skeleton intact');
+  });
+
+  it('--org FAILS the gate when the skeleton is broken', async () => {
+    installEnvPsql({ memb: false });
+
+    await expect(
+      EnvVerify.run(
+        ['--env', 'dev', '--org', 'emptyOrg', '--url', 'iam=postgres://iam'],
+        config,
+      ),
+    ).rejects.toThrow(/org skeleton/);
+    expect(text()).toContain('MISSING: admin membership');
+  });
+
+  it('--org without the iam connection refuses up front', async () => {
+    await expect(EnvVerify.run(['--env', 'dev', '--org', 'emptyOrg'], config)).rejects.toThrow(/needs the iam connection/);
+  });
+
+  it('--org rejects a non-catalog slug', async () => {
+    await expect(
+      EnvVerify.run(['--env', 'dev', '--org', 'jennys-org', '--url', 'iam=postgres://iam'], config),
+    ).rejects.toThrow(/not a known fixture org/);
+  });
+});

--- a/packages/node/saga-stack-cli/src/commands/env/__tests__/env.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/env/__tests__/env.int.test.ts
@@ -1,0 +1,364 @@
+/**
+ * `ss env` integration tests (soa#355, Phase 0) — in-process command runs with
+ * the two IO seams (`getEnvAws`, `getEnvPsql`) faked on `BaseCommand.prototype`,
+ * so NO aws call, tunnel, or database is ever touched.
+ *
+ * Covers: `env list` ledger summarization + the AccessDenied tier hint;
+ * `env discover` pagination, name filtering, and jump-host resolution;
+ * `env connect` candidate-order endpoint/secret resolution, `--print-only`
+ * (no tunnel), and the tunnel request shape; `env org status` slug-only
+ * targeting (unknown org / raw UUID refused), offline-partial vs live id-set
+ * resolution, and per-table counts with projections marked.
+ */
+
+import { Config } from '@oclif/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BaseCommand } from '../../../base-command.js';
+import type { EnvAws, EnvPsql, PortForwardHandle, PortForwardRequest } from '../../../runtime/index.js';
+import EnvConnect from '../connect.js';
+import EnvDiscover from '../discover.js';
+import EnvList from '../list.js';
+import EnvOrgStatus from '../org/status.js';
+
+const PKG_ROOT = process.cwd();
+const ORG_ID = '52a00136-285b-522c-bc70-0887cf46463a';
+
+let config: Config;
+let out: string[];
+/** Recorded aws json calls: [joined args, opts]. */
+let awsCalls: { args: string[]; opts?: { profile?: string; region?: string } }[];
+let portForwards: PortForwardRequest[];
+/** Recorded psql calls: [connString, sql]. */
+let psqlCalls: { conn: string; sql: string }[];
+
+type AwsHandler = (args: string[]) => unknown;
+type PsqlHandler = (conn: string, sql: string) => string[][];
+
+/** Account the sts preflight resolves to (default: the dev account; a test flips it to simulate a mismatch). */
+const DEV_ACCOUNT = '396913734878';
+let callerAccount = DEV_ACCOUNT;
+
+function installEnvAws(handler: AwsHandler): void {
+  const fake: EnvAws = {
+    async json(args, opts): Promise<unknown> {
+      awsCalls.push({ args, opts });
+      // The account preflight (env list/discover/connect) — answered here so no
+      // per-test handler needs to know about it; a test sets callerAccount to flip it.
+      if (args[0] === 'sts' && args[1] === 'get-caller-identity') return callerAccount;
+      return handler(args);
+    },
+    async lambdaInvoke(): Promise<unknown> {
+      throw new Error('unexpected lambdaInvoke in Phase-0 env tests');
+    },
+    portForward(req): PortForwardHandle {
+      portForwards.push(req);
+      return { pid: 4242, ready: Promise.resolve(), exited: Promise.resolve(0), stop: () => undefined };
+    },
+  };
+  vi.spyOn(
+    BaseCommand.prototype as unknown as { getEnvAws: () => EnvAws },
+    'getEnvAws',
+  ).mockReturnValue(fake);
+}
+
+function installEnvPsql(handler: PsqlHandler = () => [['0']]): void {
+  const fake: EnvPsql = {
+    async query(conn, sql): Promise<string[][]> {
+      psqlCalls.push({ conn, sql });
+      return handler(conn, sql);
+    },
+  };
+  vi.spyOn(
+    BaseCommand.prototype as unknown as { getEnvPsql: () => EnvPsql },
+    'getEnvPsql',
+  ).mockReturnValue(fake);
+}
+
+beforeEach(async () => {
+  config = await Config.load(PKG_ROOT);
+  out = [];
+  awsCalls = [];
+  portForwards = [];
+  psqlCalls = [];
+  callerAccount = DEV_ACCOUNT;
+  vi.spyOn(
+    BaseCommand.prototype as unknown as { log: (msg?: string) => void },
+    'log',
+  ).mockImplementation((msg?: string) => {
+    out.push(String(msg ?? ''));
+  });
+  installEnvAws(() => null);
+  installEnvPsql();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const text = (): string => out.join('\n');
+
+describe('env list — ledger summary', () => {
+  it('summarizes resource kinds per environment from the ledger query', async () => {
+    installEnvAws((args) => {
+      if (args[0] === 'dynamodb') {
+        return { Items: [{ sk: { S: 'RES#ecs#svc-a' } }, { sk: { S: 'RES#ecs#svc-b' } }, { sk: { S: 'RES#db#x' } }] };
+      }
+      return null;
+    });
+
+    await expect(EnvList.run([], config)).resolves.toBeUndefined();
+
+    expect(text()).toContain('Deployed shared environments');
+    // Colour is TTY-gated (off under vitest), so assert the aligned plain text.
+    expect(text()).toMatch(/dev\s+\*\.wootdev\.com\s+\(main\)/);
+    expect(text()).toMatch(/training\s+\*\.saga-training\.org\s+\(training\)/);
+    expect(text()).toContain('db×1  ecs×2');
+    // One ledger query per registered env.
+    expect(awsCalls.filter((c) => c.args[0] === 'dynamodb')).toHaveLength(2);
+  });
+
+  it('wrong AWS account is refused up front with the switch-profile hint (not a cryptic ledger error)', async () => {
+    callerAccount = '531314149529'; // the prod account — the dev ledger does not exist there
+    installEnvAws(() => {
+      throw new Error('the ledger must never be queried on an account mismatch');
+    });
+
+    await expect(EnvList.run([], config)).rejects.toThrow(/account mismatch.*531314149529.*dev_admin/s);
+    // No dynamodb query was attempted (only the sts preflight ran).
+    expect(awsCalls.every((c) => c.args[0] === 'sts')).toBe(true);
+  });
+
+  it('maps AccessDenied to the tier hint (wrong tier, not missing env)', async () => {
+    installEnvAws(() => {
+      throw new Error('An error occurred (AccessDeniedException): … AccessDenied');
+    });
+
+    await expect(EnvList.run([], config)).resolves.toBeUndefined();
+    expect(text()).toContain('observer tier cannot read the ledger');
+  });
+});
+
+describe('env discover — SSM walk + jump host', () => {
+  it('pages get-parameters-by-path, filters names, and resolves the Online jump host', async () => {
+    installEnvAws((args) => {
+      if (args[1] === 'get-parameters-by-path') {
+        const paged = args.includes('--next-token');
+        if (args.includes('/shared/infra/dev') && !paged) {
+          return {
+            Parameters: [
+              { Name: '/shared/infra/dev/postgres-endpoint', Type: 'String' },
+              { Name: '/shared/infra/dev/app-alb-443-listener-arn', Type: 'String' }, // filtered out
+            ],
+            NextToken: 'page2',
+          };
+        }
+        if (paged) return { Parameters: [{ Name: '/shared/infra/dev/mongodb-hosts', Type: 'StringList' }] };
+        return { Parameters: [] };
+      }
+      if (args[0] === 'ec2') return ['i-0abc'];
+      if (args[1] === 'describe-instance-information') return ['i-0abc'];
+      return null;
+    });
+
+    await expect(EnvDiscover.run(['--env', 'dev'], config)).resolves.toBeUndefined();
+
+    expect(text()).toContain('/shared/infra/dev/postgres-endpoint');
+    expect(text()).toContain('/shared/infra/dev/mongodb-hosts');
+    expect(text()).not.toContain('app-alb-443-listener-arn');
+    expect(text()).toContain('jump host: i-0abc');
+  });
+});
+
+describe('env connect — task-definition resolution + tunnel', () => {
+  /** Live-verified shapes: iam = DATABASE_URL secret on the arm cluster; ads-adm = split POSTGRES_* env. */
+  const awsForConnect = (args: string[]): unknown => {
+    if (args[1] === 'describe-services') {
+      const cluster = args[args.indexOf('--cluster') + 1];
+      const service = args[args.indexOf('--services') + 1];
+      if (service === 'rostering-iam-api-main' && cluster === 'dev-shared-arm') return 'arn:td/iam:251';
+      if (service === 'sds-ads-adm-api-main' && cluster === 'dev-shared') return 'arn:td/adsadm:26';
+      return null; // oclif --query yields null for a missing service
+    }
+    if (args[1] === 'describe-task-definition') {
+      const td = args[args.indexOf('--task-definition') + 1];
+      if (td === 'arn:td/iam:251') {
+        return [
+          {
+            name: 'iam-api',
+            secrets: [{ name: 'DATABASE_URL', valueFrom: 'arn:aws:secretsmanager:us-west-2:396913734878:secret:rostering/dev/database-url' }],
+          },
+        ];
+      }
+      return [
+        {
+          name: 'ads-adm-api',
+          environment: [
+            { name: 'POSTGRES_HOST', value: 'ads-adm-postgres.dbs-v2.local' },
+            { name: 'POSTGRES_PORT', value: '5471' },
+            { name: 'POSTGRES_DATABASE', value: 'ads_adm' },
+            { name: 'POSTGRES_USERNAME', value: 'ads_adm_app' },
+          ],
+          secrets: [{ name: 'POSTGRES_PASSWORD', valueFrom: 'arn:aws:secretsmanager:us-west-2:396913734878:secret:sds/ads-adm-api/postgres-creds' }],
+        },
+      ];
+    }
+    if (args[0] === 'secretsmanager') {
+      const id = args[args.indexOf('--secret-id') + 1];
+      if (id.includes('rostering/dev/database-url')) return 'postgresql://postgres_admin:p%40ss@rostering-iam-canonical.dbs-v2.local:5440/rostering-iam-canonical';
+      return 'split-pw';
+    }
+    if (args[0] === 'servicediscovery') {
+      return { Instances: [{ Attributes: { AWS_INSTANCE_IPV4: '10.3.0.9', AWS_INSTANCE_PORT: '5440' } }] };
+    }
+    if (args[0] === 'ec2' && args.some((a) => a.includes('private-ip-address'))) return ['i-0dbhost'];
+    if (args[0] === 'ec2') return ['i-0jump'];
+    if (args[1] === 'describe-instance-information') return ['i-0jump'];
+    return null;
+  };
+
+  it('--print-only resolves a DATABASE_URL-secret service and opens NO tunnel', async () => {
+    installEnvAws(awsForConnect);
+
+    await expect(EnvConnect.run(['iam', '--print-only'], config)).resolves.toBeUndefined();
+
+    expect(text()).toContain('service candidate dev-shared-arm/rostering-iam-api-main: arn:td/iam:251');
+    expect(text()).toContain('rostering-iam-canonical.dbs-v2.local:5440/rostering-iam-canonical');
+    // .dbs-v2.local ⇒ the CloudMap route via the container's own host instance.
+    expect(text()).toContain('db-host i-0dbhost (CloudMap rostering-iam-canonical, local dial :5440)');
+    expect(text()).toContain('DATABASE_URL=postgres://postgres_admin:p%40ss@127.0.0.1:15432/rostering-iam-canonical');
+    expect(portForwards).toHaveLength(0);
+  });
+
+  it('resolves a split POSTGRES_* service (second cluster) and tunnels via the db-host with a local dial', async () => {
+    installEnvAws(awsForConnect);
+
+    await expect(EnvConnect.run(['ads-adm', '--local-port', '15433'], config)).resolves.toBeUndefined();
+
+    expect(text()).toContain('service candidate dev-shared-arm/sds-ads-adm-api-main: not found');
+    expect(portForwards).toEqual([
+      {
+        target: 'i-0dbhost',
+        host: '127.0.0.1',
+        remotePort: 5440, // the CloudMap-registered port wins over the env var
+        localPort: 15433,
+        region: 'us-west-2',
+        profile: undefined,
+      },
+    ]);
+    expect(text()).toContain('DATABASE_URL=postgres://ads_adm_app:split-pw@127.0.0.1:15433/ads_adm');
+  });
+
+  it('a service deployed on neither cluster is a hard error naming both', async () => {
+    installEnvAws((args) => (args[1] === 'describe-services' ? null : ['i-0jump']));
+
+    await expect(EnvConnect.run(['coach'], config)).rejects.toThrow(/not found in dev-shared-arm or dev-shared/);
+    expect(portForwards).toHaveLength(0);
+  });
+
+  it('--host skips task-def resolution but still routes .dbs-v2.local via CloudMap', async () => {
+    installEnvAws((args) => {
+      if (args[0] === 'servicediscovery') return { Instances: [{ Attributes: { AWS_INSTANCE_IPV4: '10.3.0.9' } }] };
+      if (args[0] === 'ec2' && args.some((a) => a.includes('private-ip-address'))) return ['i-0dbhost'];
+      throw new Error(`unexpected aws call: ${args.join(' ')}`);
+    });
+
+    await expect(
+      EnvConnect.run(['iam', '--host', 'x.dbs-v2.local', '--remote-port', '5440', '--database', 'iamdb', '--print-only'], config),
+    ).resolves.toBeUndefined();
+    expect(text()).toContain('x.dbs-v2.local:5440/iamdb (--host)');
+    expect(text()).toContain('db-host i-0dbhost (CloudMap x, local dial :5440)');
+  });
+
+  it('a non-CloudMap host (shared RDS) routes via the shared jump host', async () => {
+    installEnvAws((args) => {
+      if (args[0] === 'ec2') return ['i-0jump'];
+      if (args[1] === 'describe-instance-information') return ['i-0jump'];
+      throw new Error(`unexpected aws call: ${args.join(' ')}`);
+    });
+
+    await expect(
+      EnvConnect.run(['coach', '--host', 'shared.rds.amazonaws.com', '--database', 'coach', '--print-only'], config),
+    ).resolves.toBeUndefined();
+    expect(text()).toContain('route:     jump host i-0jump');
+  });
+});
+
+describe('env org status — slug-only targeting + footprint', () => {
+  it('refuses unknown slugs AND raw UUIDs with the catalog listing', async () => {
+    await expect(EnvOrgStatus.run(['--org', 'jennys-training-org'], config)).rejects.toThrow(/not a resettable fixture org/);
+    await expect(EnvOrgStatus.run(['--org', ORG_ID], config)).rejects.toThrow(/not a resettable fixture org/);
+    expect(psqlCalls).toHaveLength(0);
+  });
+
+  it('offline mode: catalog ids only, every store skipped without a connection', async () => {
+    await expect(EnvOrgStatus.run(['--org', 'emptyOrg', '--offline'], config)).resolves.toBeUndefined();
+
+    expect(text()).toContain(ORG_ID);
+    expect(text()).toContain('resolution: partial-offline');
+    expect(text()).toContain('groups=1 users=1 programs=0');
+    expect(text()).toContain('no connection (--url)');
+    expect(psqlCalls).toHaveLength(0);
+  });
+
+  it('live mode: resolves id-sets from the anchors and counts per table (projections marked)', async () => {
+    const SCHOOL = 'b39f3ea1-0ee5-5a61-afdd-65e8c2b30db6';
+    const USER = '92c6c9f4-c764-519f-9873-7df7b77f5410';
+    const PROGRAM = 'ea1562ee-a620-5d5c-82a8-768da7f798c2';
+    installEnvPsql((conn, sql) => {
+      if (sql.startsWith('SELECT id FROM groups')) return [[SCHOOL]];
+      if (sql.includes('DISTINCT user_id')) return [[USER]];
+      if (sql.startsWith('SELECT id FROM "Program"')) return [[PROGRAM]];
+      if (sql.startsWith('SELECT count(*)')) return [['7']];
+      throw new Error(`unexpected sql: ${sql}`);
+    });
+
+    await expect(
+      EnvOrgStatus.run(
+        ['--org', 'emptyOrg', '--url', 'iam=postgres://iam', '--url', 'programs=postgres://pgm'],
+        config,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(text()).toContain('resolution: live');
+    // org + school groups; admin + resolved user; one program.
+    expect(text()).toContain('groups=2 users=2 programs=1');
+    expect(text()).toContain('groups: 7');
+    expect(text()).toContain('[projection]');
+    // Counts ran only against the two connected stores; others skipped.
+    expect(text()).toContain('no connection (--url)');
+    const countCalls = psqlCalls.filter((c) => c.sql.startsWith('SELECT count(*)'));
+    expect(new Set(countCalls.map((c) => c.conn))).toEqual(new Set(['postgres://iam', 'postgres://pgm']));
+  });
+
+  it('ads-adm live: adm_attendance counts by programIds; period_attendance_status reads UNRESOLVED, not empty', async () => {
+    const SCHOOL = 'b39f3ea1-0ee5-5a61-afdd-65e8c2b30db6';
+    const USER = '92c6c9f4-c764-519f-9873-7df7b77f5410';
+    const PROGRAM = 'ea1562ee-a620-5d5c-82a8-768da7f798c2';
+    installEnvPsql((conn, sql) => {
+      if (sql.startsWith('SELECT id FROM groups')) return [[SCHOOL]];
+      if (sql.includes('DISTINCT user_id')) return [[USER]];
+      if (sql.startsWith('SELECT id FROM "Program"')) return [[PROGRAM]];
+      if (sql.startsWith('SELECT count(*)')) return [['7']];
+      throw new Error(`unexpected sql: ${sql}`);
+    });
+
+    await expect(
+      EnvOrgStatus.run(
+        ['--org', 'emptyOrg', '--url', 'iam=postgres://iam', '--url', 'programs=postgres://pgm', '--url', 'ads-adm=postgres://ads'],
+        config,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(text()).toContain('adm_attendance: 7');
+    // periodIds is a deeper ring status never resolves — the skip must say
+    // UNRESOLVED, not read like a resolved-and-empty id-set.
+    expect(text()).toContain('period_attendance_status: — (periodIds not resolved by status)');
+    expect(psqlCalls.some((c) => c.sql.includes('period_attendance_status'))).toBe(false);
+  });
+
+  it("bad --url shapes are refused with the store-key list", async () => {
+    await expect(
+      EnvOrgStatus.run(['--org', 'emptyOrg', '--url', 'nope=postgres://x'], config),
+    ).rejects.toThrow(/expected <store>=<connString>/);
+  });
+});

--- a/packages/node/saga-stack-cli/src/commands/env/connect.ts
+++ b/packages/node/saga-stack-cli/src/commands/env/connect.ts
@@ -1,0 +1,276 @@
+/**
+ * `saga-stack env connect <store>` — open an SSM data-plane tunnel to a shared
+ * environment's Postgres and hand back a ready connection string (soa#355,
+ * Phase 0 — read-only; the tunnel itself mutates nothing).
+ *
+ * RESOLUTION — from the service's own live task definition, which is what
+ * makes this self-maintaining across environments and store moves (verified
+ * live on dev 2026-07-21: iam/program-hub/coach carry a `DATABASE_URL` secret;
+ * ads-adm uses split `POSTGRES_*` env + a password secret; targets range from
+ * db-host-v2 CloudMap DNS like `rostering-iam-canonical.dbs-v2.local:5440` to
+ * the shared RDS):
+ *
+ *   1. ECS service `<store.ecsService>-<env.ledgerIdentifier>` looked up across
+ *      the shared clusters (`dev-shared-arm`, `dev-shared`).
+ *   2. Its task definition yields either the DATABASE_URL secret or the split
+ *      POSTGRES_* fields (`core/env/taskdef.ts`); referenced secrets are
+ *      fetched (Secrets Manager or SSM parameter refs both handled).
+ *   3. Jump host = newest running EC2 tagged `Name=dev-shared-ecs-instance`
+ *      that is Online in SSM; CloudMap `.dbs-v2.local` names resolve THERE.
+ *
+ * `--host/--remote-port/--database/--username` skip resolution entirely;
+ * `--print-only` stops before the tunnel. Once the session-manager plugin
+ * reports listening, prints a rewritten `DATABASE_URL` (127.0.0.1:local-port)
+ * and HOLDS until Ctrl-C — the tunnel dies with the command. Requires
+ * app-infra tier (SagaCap-SSMPortForward) or app-deploy. Postgres-first;
+ * Mongo (needs `directConnection=true` through tunnels) is a follow-up.
+ */
+
+import { Args, Flags } from '@oclif/core';
+import { BaseCommand } from '../../base-command.js';
+import {
+  DB_HOST_CLOUDMAP_NAMESPACE,
+  ECS_CLUSTERS,
+  ENV_NAMES,
+  JUMP_HOST_NAME_TAG,
+  STORES,
+  accountMismatchError,
+  extractDbTarget,
+  localUrl,
+  parseDatabaseUrl,
+  resolveEnv,
+} from '../../core/env/index.js';
+import type { SecretRef, TaskDefContainer } from '../../core/env/index.js';
+import { bold, cyan, dim, green } from '../../color.js';
+import { resolveCallerAccount, resolveJumpHost } from '../../runtime/index.js';
+
+interface ResolvedTarget {
+  host: string;
+  port: number;
+  database: string;
+  username?: string;
+  password?: string;
+  source: string;
+}
+
+export default class EnvConnect extends BaseCommand {
+  static description =
+    "Open an SSM port-forward to a shared environment's Postgres, resolved from the service's live ECS task definition, and print a ready DATABASE_URL. Holds until Ctrl-C; --print-only resolves without connecting.";
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> iam --env dev --profile dev_admin',
+    '<%= config.bin %> <%= command.id %> programs --env dev --local-port 15433',
+    '<%= config.bin %> <%= command.id %> iam --host mydb.dbs-v2.local --remote-port 5440 --database rostering-iam-canonical --print-only',
+  ];
+
+  static args = {
+    store: Args.string({
+      description: `store key (${STORES.map((s) => s.key).join(' | ')})`,
+      required: true,
+    }),
+  };
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    env: Flags.string({ description: `target environment (${ENV_NAMES.join(' | ')})`, default: 'dev' }),
+    profile: Flags.string({ description: 'AWS profile to use (defaults to the ambient credential chain).' }),
+    host: Flags.string({ description: 'remote DB endpoint (skips task-definition resolution).' }),
+    'remote-port': Flags.integer({ description: 'remote DB port (with --host)', default: 5432 }),
+    'local-port': Flags.integer({ description: 'local end of the tunnel', default: 15432 }),
+    username: Flags.string({ description: 'override the resolved user (URL carries no password then).' }),
+    database: Flags.string({ description: 'override the resolved database name.' }),
+    'print-only': Flags.boolean({ description: 'resolve and print everything, but do not open the tunnel.', default: false }),
+  };
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(EnvConnect);
+    const env = resolveEnv(flags.env);
+    if (env === undefined) this.error(`unknown --env '${flags.env}' — expected one of: ${ENV_NAMES.join(', ')}`);
+    const store = STORES.find((s) => s.key === args.store);
+    if (store === undefined && flags.host === undefined) {
+      this.error(`unknown store '${args.store}' — expected one of: ${STORES.map((s) => s.key).join(', ')} (or pass --host)`);
+    }
+    const opts = { profile: flags.profile, region: env.awsRegion };
+
+    // ── account preflight (see env list): fail actionably on the wrong account ──
+    const mismatch = accountMismatchError(await resolveCallerAccount(this.getEnvAws(), opts), [env.awsAccountId], `'${env.name}'`);
+    if (mismatch !== null) this.error(mismatch);
+
+    // ── target resolution: explicit flags beat the task definition ──
+    let target: ResolvedTarget;
+    if (flags.host !== undefined) {
+      target = {
+        host: flags.host,
+        port: flags['remote-port'],
+        database: flags.database ?? store?.database ?? args.store,
+        username: flags.username,
+        source: '--host',
+      };
+    } else {
+      const serviceName = `${store!.ecsService}-${env.ledgerIdentifier}`;
+      target = await this.resolveFromTaskDef(serviceName, opts);
+      if (flags.database !== undefined) target.database = flags.database;
+      if (flags.username !== undefined) {
+        target.username = flags.username;
+        target.password = undefined;
+      }
+    }
+
+    // ── route: db-host-v2 CloudMap targets tunnel via the container's OWN host
+    // instance with a 127.0.0.1 dial (the shared jump host's SG cannot reach the
+    // containers — task-SG allowlists); everything else via the shared jump host. ──
+    let ssmTarget: string;
+    let dialHost: string;
+    let dialPort = target.port;
+    let route: string;
+    if (target.host.endsWith(`.${DB_HOST_CLOUDMAP_NAMESPACE}`)) {
+      const serviceName = target.host.slice(0, -(DB_HOST_CLOUDMAP_NAMESPACE.length + 1));
+      const found = await this.discoverDbHostInstance(serviceName, opts);
+      ssmTarget = found.instanceId;
+      dialHost = '127.0.0.1';
+      dialPort = found.port ?? target.port;
+      route = `db-host ${found.instanceId} (CloudMap ${serviceName}, local dial :${dialPort})`;
+    } else {
+      const jump = await resolveJumpHost(this.getEnvAws(), JUMP_HOST_NAME_TAG, opts);
+      if (jump === undefined) {
+        this.error(`no running+Online SSM jump host tagged Name=${JUMP_HOST_NAME_TAG} — check tier/region/profile.`);
+      }
+      ssmTarget = jump;
+      dialHost = target.host;
+      route = `jump host ${jump}`;
+    }
+
+    const url = localUrl(target, flags['local-port']);
+    this.log(`${bold('▶ env connect')} — ${bold(cyan(env.name))}${dim('/')}${cyan(args.store)}`);
+    this.log(`  ${dim('target:')}    ${target.host}:${target.port}/${target.database} ${dim(`(${target.source})`)}`);
+    this.log(`  ${dim('route:')}     ${route}`);
+    if (flags['print-only']) {
+      this.emit(
+        flags,
+        { env: env.name, store: args.store, host: target.host, port: target.port, database: target.database, ssmTarget, url },
+        `DATABASE_URL=${url}`,
+      );
+      return;
+    }
+
+    const handle = this.getEnvAws().portForward({
+      target: ssmTarget,
+      host: dialHost,
+      remotePort: dialPort,
+      localPort: flags['local-port'],
+      region: env.awsRegion,
+      profile: flags.profile,
+    });
+    process.on('SIGINT', () => handle.stop());
+    process.on('SIGTERM', () => handle.stop());
+    await handle.ready;
+    this.log(`${green('✓ tunnel up')} — 127.0.0.1:${bold(String(flags['local-port']))} → ${target.host}:${target.port}`);
+    this.log(`  DATABASE_URL=${url}`); // left plain — meant to be copy-pasted
+    this.log(`  ${dim(`psql '${url}'`)}`);
+    this.log(dim('  (holding — Ctrl-C closes the tunnel)'));
+    const code = await handle.exited;
+    this.log(dim(`tunnel closed (${code ?? 'signal'}).`));
+  }
+
+  /** ECS service → task definition → DB target, secrets fetched through the aws seam. */
+  private async resolveFromTaskDef(
+    serviceName: string,
+    opts: { profile?: string; region: string },
+  ): Promise<ResolvedTarget> {
+    const aws = this.getEnvAws();
+    let taskDefArn: string | undefined;
+    let clusterUsed: string | undefined;
+    for (const cluster of ECS_CLUSTERS) {
+      const described = (await aws.json(
+        ['ecs', 'describe-services', '--cluster', cluster, '--services', serviceName, '--query', 'services[0].taskDefinition'],
+        opts,
+      )) as string | null;
+      this.log(
+        `  ${dim('service candidate')} ${cluster}/${serviceName}: ${described === null ? dim('not found') : green(described)}`,
+      );
+      if (described !== null) {
+        taskDefArn = described;
+        clusterUsed = cluster;
+        break;
+      }
+    }
+    if (taskDefArn === undefined) {
+      this.error(
+        `ECS service '${serviceName}' not found in ${ECS_CLUSTERS.join(' or ')} — is the store deployed on this env? (--host overrides resolution)`,
+      );
+    }
+
+    const td = (await aws.json(
+      ['ecs', 'describe-task-definition', '--task-definition', taskDefArn, '--query', 'taskDefinition.containerDefinitions'],
+      opts,
+    )) as TaskDefContainer[] | null;
+    const dbTarget = extractDbTarget(td ?? []);
+    if (dbTarget === undefined) {
+      this.error(`task definition ${taskDefArn} carries neither a DATABASE_URL secret nor POSTGRES_* env — cannot resolve.`);
+    }
+
+    if (dbTarget.shape === 'url') {
+      const raw = await this.fetchSecret(dbTarget.urlSecret, opts);
+      const parsed = parseDatabaseUrl(raw);
+      return { ...parsed, source: `${clusterUsed}/${serviceName} DATABASE_URL secret` };
+    }
+    const password = dbTarget.passwordSecret === undefined ? undefined : await this.fetchSecret(dbTarget.passwordSecret, opts);
+    return {
+      host: dbTarget.host,
+      port: dbTarget.port,
+      database: dbTarget.database,
+      username: dbTarget.username,
+      password,
+      source: `${clusterUsed}/${serviceName} POSTGRES_* env`,
+    };
+  }
+
+  /** CloudMap discover-instances → the db container's EC2 host + registered port. */
+  private async discoverDbHostInstance(
+    serviceName: string,
+    opts: { profile?: string; region: string },
+  ): Promise<{ instanceId: string; port?: number }> {
+    const aws = this.getEnvAws();
+    const discovered = (await aws.json(
+      ['servicediscovery', 'discover-instances', '--namespace-name', DB_HOST_CLOUDMAP_NAMESPACE, '--service-name', serviceName],
+      opts,
+    )) as { Instances?: { Attributes?: Record<string, string> }[] } | null;
+    const attrs = discovered?.Instances?.[0]?.Attributes;
+    const ip = attrs?.AWS_INSTANCE_IPV4;
+    if (ip === undefined) {
+      this.error(`CloudMap has no instance for ${serviceName}.${DB_HOST_CLOUDMAP_NAMESPACE} — is the DB container up?`);
+    }
+    const ids = (await aws.json(
+      [
+        'ec2',
+        'describe-instances',
+        '--filters',
+        `Name=private-ip-address,Values=${ip}`,
+        '--query',
+        'Reservations[].Instances[].InstanceId',
+      ],
+      opts,
+    )) as string[] | null;
+    const instanceId = (ids ?? [])[0];
+    if (instanceId === undefined) this.error(`no EC2 instance owns db-host IP ${ip} — CloudMap record stale?`);
+    const port = attrs?.AWS_INSTANCE_PORT;
+    return { instanceId, port: port === undefined ? undefined : Number(port) };
+  }
+
+  /** Fetch a container-secret reference: Secrets Manager value or SSM parameter. */
+  private async fetchSecret(ref: SecretRef, opts: { profile?: string; region: string }): Promise<string> {
+    const aws = this.getEnvAws();
+    const value =
+      ref.kind === 'ssm'
+        ? ((await aws.json(
+            ['ssm', 'get-parameter', '--name', ref.valueFrom, '--with-decryption', '--query', 'Parameter.Value'],
+            opts,
+          )) as string | null)
+        : ((await aws.json(
+            ['secretsmanager', 'get-secret-value', '--secret-id', ref.valueFrom, '--query', 'SecretString'],
+            opts,
+          )) as string | null);
+    if (value === null) this.error(`secret ${ref.valueFrom} resolved to nothing`);
+    return value;
+  }
+}

--- a/packages/node/saga-stack-cli/src/commands/env/discover.ts
+++ b/packages/node/saga-stack-cli/src/commands/env/discover.ts
@@ -1,0 +1,94 @@
+/**
+ * `saga-stack env discover` — walk an environment's SSM parameter roots and
+ * surface the data-plane wiring (soa#355, Phase 0 — read-only).
+ *
+ * The registry deliberately hardcodes no endpoint that can drift; this command
+ * is how the live values are found: it pages `ssm get-parameters-by-path` under
+ * the env's discovery roots, filters to data-store-shaped names, and resolves
+ * the SSM jump host (EC2 tag `Name=dev-shared-ecs-instance`, Online only) that
+ * `env connect` tunnels through. Use it once per session to fill/verify the
+ * values `env connect` needs.
+ */
+
+import { Flags } from '@oclif/core';
+import { BaseCommand } from '../../base-command.js';
+import { bold, cyan, dim, green, red } from '../../color.js';
+import { ENV_NAMES, JUMP_HOST_NAME_TAG, accountMismatchError, resolveEnv } from '../../core/env/index.js';
+import { resolveCallerAccount, resolveJumpHost } from '../../runtime/index.js';
+
+const DEFAULT_FILTER = 'postgres|mongo|mongodb|db-host|rabbit|redis|rds|secret';
+
+interface SsmParam {
+  Name?: string;
+  Type?: string;
+}
+
+export default class EnvDiscover extends BaseCommand {
+  static description =
+    "Discover a shared environment's data-plane wiring: SSM params under its discovery roots (filtered to data-store names) and the Online SSM jump host. Read-only.";
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> --env dev --profile dev_admin',
+    '<%= config.bin %> <%= command.id %> --env dev --filter mongodb',
+  ];
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    env: Flags.string({ description: `target environment (${ENV_NAMES.join(' | ')})`, default: 'dev' }),
+    profile: Flags.string({ description: 'AWS profile to use (defaults to the ambient credential chain).' }),
+    filter: Flags.string({
+      description: 'case-insensitive regex over parameter names',
+      default: DEFAULT_FILTER,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(EnvDiscover);
+    const env = resolveEnv(flags.env);
+    if (env === undefined) this.error(`unknown --env '${flags.env}' — expected one of: ${ENV_NAMES.join(', ')}`);
+    const aws = this.getEnvAws();
+    const opts = { profile: flags.profile, region: env.awsRegion };
+    const filter = new RegExp(flags.filter, 'i');
+
+    // ── account preflight (see env list): fail actionably on the wrong account ──
+    const mismatch = accountMismatchError(await resolveCallerAccount(aws, opts), [env.awsAccountId], `'${env.name}'`);
+    if (mismatch !== null) this.error(mismatch);
+
+    // ── SSM parameters under each discovery root (paged) ──
+    const params: { name: string; type: string }[] = [];
+    for (const root of env.ssmDiscoveryRoots) {
+      let nextToken: string | undefined;
+      do {
+        const args = [
+          'ssm',
+          'get-parameters-by-path',
+          '--path',
+          root,
+          '--recursive',
+          '--max-results',
+          '10',
+        ];
+        if (nextToken !== undefined) args.push('--next-token', nextToken);
+        const page = (await aws.json(args, opts)) as { Parameters?: SsmParam[]; NextToken?: string } | null;
+        for (const p of page?.Parameters ?? []) {
+          if (p.Name !== undefined && filter.test(p.Name)) params.push({ name: p.Name, type: p.Type ?? '' });
+        }
+        nextToken = page?.NextToken;
+      } while (nextToken !== undefined);
+    }
+    params.sort((a, b) => a.name.localeCompare(b.name));
+
+    // ── the SSM jump host (running + Online) ──
+    const jump = await resolveJumpHost(aws, JUMP_HOST_NAME_TAG, opts);
+
+    const lines: string[] = [
+      `${bold('▶ env discover')} — ${bold(cyan(env.name))} ${dim(`(roots: ${env.ssmDiscoveryRoots.join(', ')}; filter: /${flags.filter}/i)`)}`,
+      ...params.map((p) => `  ${p.name}  ${dim(`[${p.type}]`)}`),
+      params.length === 0 ? dim('  (no matching parameters — check tier/filter)') : '',
+      jump === undefined
+        ? `  ${dim('jump host:')} ${red(`✗ no running+Online instance tagged Name=${JUMP_HOST_NAME_TAG}`)}`
+        : `  ${dim('jump host:')} ${green(jump)} ${dim(`(tag Name=${JUMP_HOST_NAME_TAG}, Online)`)}`,
+    ].filter((l) => l !== '');
+    this.emit(flags, { env: env.name, parameters: params, jumpHost: jump ?? null }, lines);
+  }
+}

--- a/packages/node/saga-stack-cli/src/commands/env/list.ts
+++ b/packages/node/saga-stack-cli/src/commands/env/list.ts
@@ -1,0 +1,115 @@
+/**
+ * `saga-stack env list` — the deployed shared environments and their
+ * control-plane footprint (soa#355, Phase 0 — read-only).
+ *
+ * For each registered env (dev = `*.wootdev.com`, training = `*.saga-training.org`)
+ * queries the dev-platform Environment ledger (DynamoDB, one record per
+ * identifier: `pk=ENV#<identifier>`, resource rows `sk=RES#<kind>#<id>`) and
+ * summarizes the resource kinds. Requires an authenticated AWS session; the
+ * observer tier CANNOT read the ledger (explicit deny) — an AccessDenied here
+ * means "wrong tier", not "environment missing", and the error text says so.
+ */
+
+import { Flags } from '@oclif/core';
+import { BaseCommand } from '../../base-command.js';
+import { bold, cyan, dim, green, red } from '../../color.js';
+import { DEPLOYED_ENVS, LEDGER_TABLE, accountMismatchError } from '../../core/env/index.js';
+import { resolveCallerAccount } from '../../runtime/index.js';
+
+interface LedgerItem {
+  sk?: { S?: string };
+}
+
+export default class EnvList extends BaseCommand {
+  static description =
+    'List deployed shared environments (dev, training) and their dev-platform ledger footprint. Read-only.';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --profile dev_admin --output-json',
+  ];
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    profile: Flags.string({ description: 'AWS profile to use (defaults to the ambient credential chain).' }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(EnvList);
+    const aws = this.getEnvAws();
+
+    // ── account preflight: every env's ledger lives in the dev account; a run
+    // pointed at the wrong account otherwise fails with a cryptic per-env
+    // ResourceNotFoundException instead of "switch profile". ──
+    const expectedAccounts = [...new Set(Object.values(DEPLOYED_ENVS).map((e) => e.awsAccountId))];
+    const caller = await resolveCallerAccount(aws, { profile: flags.profile, region: 'us-west-2' });
+    const mismatch = accountMismatchError(caller, expectedAccounts, 'the env ledger');
+    if (mismatch !== null) this.error(mismatch);
+
+    const rows: { name: string; identifier: string; domain: string; resources: Record<string, number>; error?: string }[] = [];
+    for (const env of Object.values(DEPLOYED_ENVS)) {
+      try {
+        const result = (await aws.json(
+          [
+            'dynamodb',
+            'query',
+            '--table-name',
+            LEDGER_TABLE,
+            '--key-condition-expression',
+            'pk = :pk',
+            '--expression-attribute-values',
+            JSON.stringify({ ':pk': { S: `ENV#${env.ledgerIdentifier}` } }),
+            '--projection-expression',
+            'sk',
+          ],
+          { profile: flags.profile, region: env.awsRegion },
+        )) as { Items?: LedgerItem[] } | null;
+        const resources: Record<string, number> = {};
+        for (const item of result?.Items ?? []) {
+          const sk = item.sk?.S ?? '';
+          if (!sk.startsWith('RES#')) continue;
+          const kind = sk.split('#')[1] ?? 'unknown';
+          resources[kind] = (resources[kind] ?? 0) + 1;
+        }
+        rows.push({ name: env.name, identifier: env.ledgerIdentifier, domain: env.domain, resources });
+      } catch (err) {
+        const message = (err as Error).message;
+        rows.push({
+          name: env.name,
+          identifier: env.ledgerIdentifier,
+          domain: env.domain,
+          resources: {},
+          error: message.includes('AccessDenied')
+            ? 'AccessDenied — the observer tier cannot read the ledger (wrong tier, not a missing env); use app-deploy/app-infra'
+            : message,
+        });
+      }
+    }
+
+    const nameW = Math.max(...rows.map((r) => r.name.length));
+    const domainW = Math.max(...rows.map((r) => r.domain.length + 2)); // '*.' + domain
+    const SUB = '      '; // sub-line indent (description, ledger)
+
+    const lines: string[] = [bold('Deployed shared environments'), ''];
+    for (const r of rows) {
+      const env = DEPLOYED_ENVS[r.name];
+      const domain = `*.${r.domain}`;
+      lines.push(
+        `  ${bold(cyan(r.name.padEnd(nameW)))}  ${green(domain.padEnd(domainW))}  ${dim(`(${r.identifier})`)}`,
+      );
+      if (env !== undefined) lines.push(`${SUB}${dim(env.description)}`);
+      if (r.error !== undefined) {
+        lines.push(`${SUB}${dim('ledger')}  ${red(`✗ ${r.error}`)}`);
+      } else {
+        const kinds = Object.entries(r.resources)
+          .sort(([a], [b]) => a.localeCompare(b))
+          .map(([k, n]) => `${dim(`${k}×`)}${bold(String(n))}`)
+          .join('  ');
+        lines.push(`${SUB}${dim('ledger')}  ${kinds === '' ? dim('(no resource rows)') : kinds}`);
+      }
+      lines.push('');
+    }
+    if (lines[lines.length - 1] === '') lines.pop(); // drop trailing blank
+    this.emit(flags, { environments: rows }, lines);
+  }
+}

--- a/packages/node/saga-stack-cli/src/commands/env/org/reset.ts
+++ b/packages/node/saga-stack-cli/src/commands/env/org/reset.ts
@@ -1,0 +1,468 @@
+/**
+ * `saga-stack env org reset` — surgically delete ONE fixture org's data across
+ * the shared environment's Postgres stores, back to the seeded skeleton
+ * (soa#355, Phase 1 — the first destructive `env` command).
+ *
+ * Follows `stack wipe`'s destructive canon: `--dry-run` enumerates (per-table
+ * DELETE counts, projections marked) and exits 0 touching nothing; a plain run
+ * shows the same enumeration and prompts ONCE; `--yes` skips the prompt;
+ * a declined prompt aborts with exit 0; hard refusals (unknown slug, missing
+ * anchors, failed identity assertion) are non-zero via `this.error`.
+ *
+ * GUARD LADDER (all structural, none skippable by flags):
+ *   1. slug-only targeting — orgs outside `RESETTABLE_ORGS` are untargetable.
+ *   2. BOTH anchor stores connected (`--url iam=…` AND `--url programs=…`) —
+ *      id-sets resolve live or not at all. Other stores without a `--url` are
+ *      SKIPPED with loud warnings (their org rows survive).
+ *   3. PRE-FLIGHT IDENTITY ASSERTION — the org group row must exist and carry
+ *      the catalog display name, and the admin user must exist with the
+ *      catalog email, or the whole run refuses: proof the connected database
+ *      actually holds the seeded fixture org.
+ *   4. Skeleton protection is IN the SQL (`core/env/reset-plan.ts`): the org
+ *      row, admin user, admin membership, and seeded personas survive by
+ *      explicit predicates on their deterministic ids; multi-org users are
+ *      never deleted anywhere.
+ *
+ * `--snapshot` takes a best-effort restore point per store through the
+ * db-host-v2 orchestrator Lambda BEFORE deleting (profile `pre-org-reset`,
+ * versioned + immutable). Unreachable orchestrator / failed dump ⇒ WARN and
+ * proceed (dev-only data; the seed skeleton is regenerable) — EXCEPT a
+ * "not in registry" response, which means the target name is wrong and aborts
+ * the reset. Stores whose registry name is unknown are warned and skipped
+ * (`--snapshot-service <store>=<serviceName>` supplies it).
+ *
+ * Execution: one BEGIN/COMMIT transaction per store (single `psql -c`,
+ * ON_ERROR_STOP — all-or-nothing per store), leaf stores first, iam last (the
+ * resolution evidence dies at the very end). Then a post-verify recount per
+ * table (before/after; leftovers flagged LOUD; tables whose delete predicate
+ * would self-blind the recount are reported verify-indirect instead of a
+ * structurally-zero number) and a skeleton check (org row + admin user +
+ * admin membership still present) — a broken skeleton is a non-zero exit
+ * after the full report is emitted.
+ */
+
+import { Flags } from '@oclif/core';
+import { BaseCommand } from '../../../base-command.js';
+import { bold, cyan, dim, green, red, yellow } from '../../../color.js';
+import {
+  ENV_NAMES,
+  ORCHESTRATOR_LAMBDA,
+  RESETTABLE_ORGS,
+  RESET_GUARD_SQL,
+  RESET_RESOLVE_STEPS,
+  RESET_STORE_KEYS,
+  SNAPSHOT_PROFILE,
+  assertSessionIds,
+  assertUuids,
+  buildResetPlan,
+  initialResetIds,
+  resolveEnv,
+  resolveFixtureOrg,
+} from '../../../core/env/index.js';
+import type { ResetIdSets } from '../../../core/env/index.js';
+
+/** One table's report row (before = pre-delete count, after = post-verify recount). */
+interface TableReport {
+  table: string;
+  projection: boolean;
+  before: number | null;
+  after: number | null;
+  /** The delete predicate self-blinds post-delete — no meaningful recount exists. */
+  verify?: 'indirect';
+  skipped?: string;
+}
+
+interface StoreReport {
+  store: string;
+  service: string;
+  connected: boolean;
+  tables: TableReport[];
+}
+
+interface SnapshotReport {
+  store: string;
+  service?: string;
+  ok: boolean;
+  /** Restore-point identity from the orchestrator's flat success body ({ok, name, profile, …}). */
+  name?: string;
+  profile?: string;
+  skipped?: string;
+  error?: string;
+}
+
+export default class EnvOrgReset extends BaseCommand {
+  static description =
+    "DELETE a fixture org's data across the shared environment's Postgres stores, back to the seeded skeleton (org row + admin + seeded personas survive). Destructive; slug-only targeting, identity-asserted, one confirm, per-store transactions, post-verified.";
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> --org emptyOrg --url iam=postgres://…15432/iam --url programs=postgres://…15433/programs --dry-run',
+    '<%= config.bin %> <%= command.id %> --org emptyOrg --url iam=… --url programs=… --url sessions=… --url scheduling=… --yes',
+    '<%= config.bin %> <%= command.id %> --org emptyOrg --url iam=… --url programs=… --snapshot --profile dev_admin',
+  ];
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    org: Flags.string({
+      description: `fixture org slug (${Object.keys(RESETTABLE_ORGS).join(' | ')})`,
+      required: true,
+    }),
+    url: Flags.string({
+      description:
+        'store connection as <store>=<connString> (repeatable; store keys: ' +
+        RESET_STORE_KEYS.join(', ') +
+        '). iam AND programs are mandatory anchors; other stores without a --url are skipped with a warning.',
+      multiple: true,
+    }),
+    'dry-run': Flags.boolean({
+      description:
+        'resolve id-sets, run the identity assertion, and print exactly what would be deleted (per-table counts) — then exit 0 without deleting anything.',
+      default: false,
+    }),
+    yes: Flags.boolean({
+      description: 'non-interactive: skip the destructive-action prompt (CI / agents).',
+      default: false,
+    }),
+    snapshot: Flags.boolean({
+      description:
+        `best-effort pre-delete snapshot per store via the db-host-v2 orchestrator (profile '${SNAPSHOT_PROFILE}', versioned). ` +
+        'Unreachable orchestrator ⇒ warn and proceed; an unknown registry name skips that store (see --snapshot-service).',
+      default: false,
+    }),
+    'snapshot-service': Flags.string({
+      description: 'db-host-v2 registry serviceName override as <store>=<serviceName> (repeatable, with --snapshot).',
+      multiple: true,
+    }),
+    env: Flags.string({ description: `target environment (${ENV_NAMES.join(' | ')})`, default: 'dev' }),
+    profile: Flags.string({ description: 'AWS profile for the --snapshot Lambda call (defaults to the ambient chain).' }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(EnvOrgReset);
+    const dry = flags['dry-run'];
+    const human = !flags['output-json'] && !flags.porcelain;
+
+    // ── guard 1: slug-only targeting (status's exact refusal) ──
+    const org = resolveFixtureOrg(flags.org);
+    if (org === undefined) {
+      this.error(
+        `'${flags.org}' is not a resettable fixture org. Known slugs: ${Object.keys(RESETTABLE_ORGS).join(', ')}. ` +
+          'Orgs outside the seed catalog (e.g. hand-built training orgs) are deliberately untargetable.',
+      );
+    }
+    const env = resolveEnv(flags.env);
+    if (env === undefined) this.error(`unknown --env '${flags.env}' — expected one of: ${ENV_NAMES.join(', ')}`);
+    if (flags.snapshot && env.name !== 'dev') {
+      // ORCHESTRATOR_LAMBDA is the DEV control plane; both envs share an
+      // account+region, so a training run would "successfully" snapshot dev's
+      // databases while the deletes hit training — a wrong restore point is
+      // worse than none.
+      this.error(
+        `--snapshot drives the dev db-host orchestrator ('${ORCHESTRATOR_LAMBDA}') and would snapshot dev's databases, ` +
+          `not '${env.name}'s — no orchestrator exists for '${env.name}' yet. Re-run without --snapshot.`,
+      );
+    }
+
+    // ── parse --url map against the RESET store keys ──
+    const urls = new Map<string, string>();
+    for (const entry of flags.url ?? []) {
+      const eq = entry.indexOf('=');
+      const key = eq === -1 ? '' : entry.slice(0, eq);
+      if (eq === -1 || !RESET_STORE_KEYS.includes(key)) {
+        this.error(`bad --url '${entry}' — expected <store>=<connString> with store one of: ${RESET_STORE_KEYS.join(', ')}`);
+      }
+      const conn = entry.slice(eq + 1);
+      if (conn.trim() === '') {
+        // An empty conn string would let psql fall back to libpq env-var
+        // defaults (PGHOST/PGDATABASE/…) and silently retarget the run.
+        this.error(`bad --url '${entry}' — empty connection string; pass a real conn (from \`ss env connect\`).`);
+      }
+      urls.set(key, conn);
+    }
+
+    // ── guard 2: both anchors, or nothing runs (dry-run included — the
+    // enumeration is meaningless without live id-sets). ──
+    const iamUrl = urls.get('iam');
+    const programsUrl = urls.get('programs');
+    if (iamUrl === undefined || programsUrl === undefined) {
+      this.error(
+        'env org reset requires BOTH anchor stores connected: pass --url iam=<conn> AND --url programs=<conn> ' +
+          '(from `ss env connect`). Id-sets resolve live from the anchors or the reset does not run at all.',
+      );
+    }
+
+    const psql = this.getEnvPsql();
+
+    // ── id-set resolution (dependency order, all before ANY delete) ──
+    const ids = initialResetIds(org);
+    const resolveSkipStores = new Set<string>();
+    for (const step of RESET_RESOLVE_STEPS) {
+      const url = urls.get(step.store);
+      if (url === undefined) {
+        resolveSkipStores.add(step.store);
+        continue;
+      }
+      const sql = step.sql(ids);
+      if (sql === null) continue; // prerequisite set empty — nothing can exist
+      const rows = await psql.query(url, sql);
+      const values = rows.map((r) => r[0] ?? '').filter((v) => v.length > 0);
+      if (step.set === 'sessionIds') assertSessionIds(values);
+      else assertUuids(values, `live ${step.set}`);
+      ids[step.set] = [...new Set([...ids[step.set], ...values])];
+    }
+    for (const store of resolveSkipStores) {
+      this.warn(
+        `⚠ store '${store}' has no --url — its id-resolution steps were SKIPPED; ` +
+          'orphan ids sourced there will not be swept (dependent deletes may be incomplete).',
+      );
+    }
+
+    // ── guard 3: pre-flight identity assertion (refuse-on-mismatch) ──
+    const orgRow = await psql.query(iamUrl, RESET_GUARD_SQL.orgRow(org.orgId));
+    const orgName = orgRow[0]?.[0];
+    if (orgRow.length === 0 || orgName !== org.displayName) {
+      this.error(
+        `IDENTITY ASSERTION FAILED — iam groups row ${org.orgId} ` +
+          (orgRow.length === 0 ? 'does not exist' : `is named '${orgName ?? ''}'`) +
+          `, expected '${org.displayName}'. This database does not look like it holds the seeded ${org.slug} — refusing to touch anything.`,
+      );
+    }
+    // iam.users has a unique `username` (the seeded admin HANDLE = the catalog
+    // slug, e.g. 'empty') and NO email column — emails are PII in iam_pii. So the
+    // in-iam identity check compares username against the slug, not the email.
+    const adminRow = await psql.query(iamUrl, RESET_GUARD_SQL.adminUser(org.adminUserId));
+    const adminLogin = adminRow[0]?.[0];
+    if (adminRow.length === 0 || adminLogin !== org.adminSlug) {
+      this.error(
+        `IDENTITY ASSERTION FAILED — iam users row ${org.adminUserId} ` +
+          (adminRow.length === 0 ? 'does not exist' : `has username '${adminLogin ?? ''}'`) +
+          `, expected '${org.adminSlug}' (the seeded admin handle for ${org.adminEmail}). ` +
+          `This database does not look like it holds the seeded ${org.slug} — refusing to touch anything.`,
+      );
+    }
+
+    // ── plan + pre-delete counts (the enumeration; also the before-half of post-verify) ──
+    const plan = buildResetPlan(ids);
+    const reports: StoreReport[] = [];
+    for (const store of plan) {
+      const url = urls.get(store.store);
+      const report: StoreReport = { store: store.store, service: store.service, connected: url !== undefined, tables: [] };
+      for (const t of store.tables) {
+        if (url === undefined) {
+          report.tables.push({ table: t.table, projection: t.projection, before: null, after: null, skipped: 'no connection (--url)' });
+          continue;
+        }
+        if (t.countSql === null) {
+          report.tables.push({ table: t.table, projection: t.projection, before: null, after: null, skipped: t.skipped ?? 'skipped' });
+          continue;
+        }
+        const rows = await psql.query(url, t.countSql);
+        report.tables.push({ table: t.table, projection: t.projection, before: Number(rows[0]?.[0] ?? 0), after: null });
+      }
+      reports.push(report);
+    }
+
+    const totalBefore = reports.reduce((sum, s) => sum + s.tables.reduce((n, t) => n + (t.before ?? 0), 0), 0);
+    const connectedStores = plan.filter((s) => urls.has(s.store));
+    const skippedStores = plan.filter((s) => !urls.has(s.store));
+
+    const enumeration = this.enumerationLines(org.displayName, org.slug, org.orgId, org.adminEmail, env.name, ids, reports);
+
+    if (dry) {
+      this.log(`${bold('▶ env org reset DRY RUN')} ${dim('— nothing will be changed:')}`);
+      for (const line of enumeration) this.log(line);
+      for (const s of skippedStores) {
+        this.log(dim(`    note: store '${s.store}' has no --url — a real run SKIPS it (its org rows survive).`));
+      }
+      this.log(
+        `${green('✓ reset dry run complete')} — ${bold(String(totalBefore))} row(s) would be deleted across ${bold(String(connectedStores.length))} store(s); ${dim('no changes made.')}`,
+      );
+      return;
+    }
+
+    if (!flags.yes) {
+      // Enumeration + ONE prompt, even under --output-json/--porcelain — a
+      // destructive command never proceeds silently; agents pass --yes.
+      this.log(`${bold('▶ env org reset')} — ${bold(cyan(org.displayName))} ${dim(`(${org.slug})`)}:`);
+      for (const line of enumeration) this.log(line);
+      // No environment name in the prompt: --env is an UNVERIFIED label (it
+      // only feeds display + the Lambda region) — the --url tunnels decide
+      // what is actually deleted, and fixture-org UUIDs are identical across
+      // environments, so an env claim here could assert the wrong thing.
+      const ok = await this.getConfirm().prompt(
+        `\n  This DELETES ${totalBefore} row(s) across ${connectedStores.length} store(s) for ${org.displayName} ` +
+          `in whatever databases the --url connections point at, back to the seeded skeleton (org row + admin kept). Continue? [y/N] `,
+      );
+      if (!ok) {
+        // Declined prompt = abort, not refusal — exit 0, nothing changed.
+        this.log(dim('reset aborted — nothing changed.'));
+        return;
+      }
+    } else if (human) {
+      this.log(`${bold('▶ env org reset')} — ${bold(cyan(org.displayName))} ${dim(`(${org.slug}, --yes)`)}:`);
+      for (const line of enumeration) this.log(line);
+    }
+
+    // ── best-effort snapshots (before ANY delete) ──
+    const snapshots: SnapshotReport[] = [];
+    if (flags.snapshot) {
+      const overrides = new Map<string, string>();
+      for (const entry of flags['snapshot-service'] ?? []) {
+        const eq = entry.indexOf('=');
+        if (eq === -1) this.error(`bad --snapshot-service '${entry}' — expected <store>=<serviceName>`);
+        overrides.set(entry.slice(0, eq), entry.slice(eq + 1));
+      }
+      const aws = this.getEnvAws();
+      for (const store of plan) {
+        if (!urls.has(store.store) || store.transactionSql === null) continue; // nothing will die there
+        const service = overrides.get(store.store) ?? store.dbService;
+        if (service === undefined) {
+          this.warn(
+            `⚠ snapshot: no db-host registry name known for store '${store.store}' — ` +
+              `pass --snapshot-service ${store.store}=<serviceName>; proceeding WITHOUT a restore point for it.`,
+          );
+          snapshots.push({ store: store.store, ok: false, skipped: 'no registry name known' });
+          continue;
+        }
+        // Invoke inside try (unreachable ⇒ warn+proceed); judge the BODY outside
+        // it so the not-in-registry abort is never swallowed as "unreachable".
+        // Success is a FLAT body { ok, name, profile, …engine-specific } (orchestrator
+        // API.md §snapshot) — there is no nested `snapshot` object; the restore point
+        // is identified by (name/serviceName, profile).
+        let body: { ok?: boolean; error?: string; name?: string; profile?: string } | null | undefined;
+        try {
+          body = (await aws.lambdaInvoke({
+            functionName: ORCHESTRATOR_LAMBDA,
+            payload: { action: 'snapshot', serviceName: service, profile: SNAPSHOT_PROFILE },
+            profile: flags.profile,
+            region: env.awsRegion,
+          })) as typeof body;
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          this.warn(`⚠ snapshot for '${store.store}' (${service}) skipped — orchestrator unreachable (${msg}); proceeding best-effort.`);
+          snapshots.push({ store: store.store, service, ok: false, error: msg });
+          continue;
+        }
+        if (body?.ok === true) {
+          const profile = body.profile ?? SNAPSHOT_PROFILE;
+          snapshots.push({ store: store.store, service, ok: true, name: body.name ?? service, profile });
+          if (human) this.log(`  ${green('✓ snapshot')} ${cyan(store.store)} ${dim(`(${body.name ?? service})`)} → profile ${dim(`'${profile}'`)}`);
+          continue;
+        }
+        const errMsg = body?.error ?? 'unknown orchestrator error';
+        if (errMsg.includes('not in registry')) {
+          // The control plane does not know this DB — the TARGET is wrong,
+          // not just the snapshot. Abort the whole reset (nothing deleted).
+          this.error(
+            `snapshot: db '${service}' is not in the db-host registry (${errMsg}) — the target looks wrong; aborting the reset, nothing deleted.`,
+          );
+        }
+        this.warn(`⚠ snapshot for '${store.store}' (${service}) FAILED — ${errMsg}; proceeding best-effort without a restore point.`);
+        snapshots.push({ store: store.store, service, ok: false, error: errMsg });
+      }
+    }
+
+    // ── execute: one transaction per store, leaf stores first, iam last ──
+    const executable = connectedStores.filter((s) => s.transactionSql !== null);
+    let step = 0;
+    for (const store of plan) {
+      const url = urls.get(store.store);
+      if (url === undefined) {
+        this.warn(`⚠ store '${store.store}' SKIPPED — no --url; its org-linked rows SURVIVE this reset.`);
+        continue;
+      }
+      if (store.transactionSql === null) continue; // every table skipped (empty id-sets)
+      step++;
+      if (human) this.log(`${bold(`▶ ${step}/${executable.length}`)} ${cyan(store.store)} ${dim(`— ${store.statements.length} table(s), one transaction`)}`);
+      await psql.query(url, store.transactionSql);
+      if (human) this.log(`  ${green('✓')} ${cyan(store.store)} ${dim('reset')}`);
+    }
+
+    // ── post-verify: recount every table; leftovers are LOUD ──
+    let leftoverRows = 0;
+    for (const [i, store] of plan.entries()) {
+      const url = urls.get(store.store);
+      if (url === undefined) continue;
+      for (const [j, t] of store.tables.entries()) {
+        if (t.countSql === null) continue;
+        const row = reports[i]?.tables[j];
+        if (t.verify === 'indirect') {
+          // The predicate subqueries rows deleted in the same transaction — a
+          // recount is structurally 0 whether or not the delete worked. Report
+          // the gap instead of a self-blinded number.
+          if (row !== undefined) row.verify = 'indirect';
+          if (human) this.log(dim(`  ○ ${store.store}.${t.table}: verify indirect — the delete predicate self-blinds post-delete; no recount.`));
+          continue;
+        }
+        const rows = await psql.query(url, t.countSql);
+        const after = Number(rows[0]?.[0] ?? 0);
+        if (row !== undefined) row.after = after;
+        if (after > 0) {
+          leftoverRows += after;
+          this.warn(`⚠ ${store.store}.${t.table}: ${after} row(s) REMAIN after reset — investigate before trusting this org.`);
+        }
+      }
+    }
+
+    // ── skeleton check: the seeded anchors must still be present and intact ──
+    const orgAfter = await psql.query(iamUrl, RESET_GUARD_SQL.orgRow(org.orgId));
+    const adminAfter = await psql.query(iamUrl, RESET_GUARD_SQL.adminUser(org.adminUserId));
+    const membAfter = await psql.query(iamUrl, RESET_GUARD_SQL.adminMembership(org.adminMembershipId));
+    const skeletonIntact =
+      orgAfter[0]?.[0] === org.displayName && adminAfter[0]?.[0] === org.adminSlug && membAfter.length === 1;
+
+    const deleted = totalBefore - leftoverRows;
+    this.emit(
+      flags,
+      {
+        org: { slug: org.slug, orgId: org.orgId, adminEmail: org.adminEmail },
+        env: env.name,
+        idSets: ids,
+        snapshots,
+        stores: reports,
+        skeletonIntact,
+        leftoverRows,
+        deletedRows: deleted,
+      },
+      `${skeletonIntact ? green('✓') : red('✗')} ${bold(cyan(org.displayName))} reset — ${bold(String(deleted))} row(s) deleted across ${bold(String(step))} store(s)` +
+        (skippedStores.length > 0 ? dim(`; ${skippedStores.length} store(s) skipped (no --url)`) : '') +
+        (leftoverRows > 0 ? yellow(`; ⚠ ${leftoverRows} leftover row(s)`) : '') +
+        `; skeleton ${skeletonIntact ? green('intact') : red('BROKEN')}.`,
+    );
+    if (!skeletonIntact) {
+      this.error(
+        `SKELETON CHECK FAILED — the seeded org row / admin user / admin membership did not all survive. ` +
+          `Restore from the '${SNAPSHOT_PROFILE}' snapshot or re-run the seed before using ${org.slug}.`,
+      );
+    }
+  }
+
+  /** The destruction enumeration — identical for --dry-run, the confirm header, and --yes. */
+  private enumerationLines(
+    displayName: string,
+    slug: string,
+    orgId: string,
+    adminEmail: string,
+    envName: string,
+    ids: ResetIdSets,
+    reports: StoreReport[],
+  ): string[] {
+    const n = (v: number): string => (v > 0 ? bold(String(v)) : dim('0'));
+    const lines: string[] = [
+      `    ${dim('org:')}     ${bold(cyan(displayName))} ${dim(`(${slug}) ${orgId}`)}`,
+      `    ${dim('env:')}     ${dim(`--env ${envName} (flag label only, UNVERIFIED — the --url connections decide what is deleted)`)}`,
+      `    ${dim('kept:')}    ${dim(`org group row, admin ${adminEmail}, admin membership, ${ids.seededPersonaIds.length} seeded persona(s)`)}`,
+      `    ${dim('id-sets:')} ${dim('groups=')}${n(ids.groupIds.length)} ${dim('users=')}${n(ids.userIds.length)} ${dim('deletable-users=')}${n(ids.userDelIds.length)} ` +
+        `${dim('programs=')}${n(ids.programIds.length)} ${dim('periods=')}${n(ids.periodIds.length)} ${dim('cohorts=')}${n(ids.cohortIds.length)} ` +
+        `${dim('pods=')}${n(ids.podIds.length)} ${dim('slots=')}${n(ids.slotIds.length)} ${dim('schedules=')}${n(ids.scheduleIds.length)} ${dim('sessions=')}${n(ids.sessionIds.length)}`,
+    ];
+    for (const s of reports) {
+      lines.push(`    ${bold(cyan(s.store))} ${dim(`(${s.service})`)}${s.connected ? '' : dim(' — SKIPPED, no --url (rows survive)')}`);
+      for (const t of s.tables) {
+        const mark = t.projection ? dim(' [projection]') : '';
+        if (t.before === null) lines.push(`      ${t.table}${mark}: ${dim(`— (${t.skipped ?? 'skipped'})`)}`);
+        else lines.push(`      ${t.table}${mark}: ${t.before > 0 ? bold(String(t.before)) : dim('0')} ${dim('row(s) will be DELETED')}`);
+      }
+    }
+    return lines;
+  }
+}

--- a/packages/node/saga-stack-cli/src/commands/env/org/status.ts
+++ b/packages/node/saga-stack-cli/src/commands/env/org/status.ts
@@ -1,0 +1,173 @@
+/**
+ * `saga-stack env org status` — one fixture org's data footprint across the
+ * mesh's Postgres stores (soa#355, Phase 0 — read-only).
+ *
+ * The debug primitive AND, by construction, the dry-run half of the future
+ * `env org reset`: it resolves the org's id-sets and counts org-linked rows
+ * per store/table, marking event-materialized (projection) rows separately —
+ * the orphan category that never self-heals.
+ *
+ * TARGETING: orgs are addressed by catalog SLUG only (`--org emptyOrg`); the
+ * UUID is derived (uuidv5 seed-id scheme), never typed. Unknown slugs are
+ * refused with the catalog listing — that is the structural guard that keeps
+ * hand-built orgs (e.g. the training orgs) untargetable by mistake.
+ *
+ * ID RESOLUTION: the org id + admin ids come from the catalog offline. Group,
+ * member-user, and program id-sets resolve LIVE from the two anchor stores
+ * when their connections are given (`--url iam=…`, `--url programs=…` — from
+ * `env connect`); without them the footprint runs in `partial-offline` mode
+ * (catalog ids only) and says so per table. Live-resolved ids are UUID-validated
+ * before they are ever inlined into SQL.
+ */
+
+import { Flags } from '@oclif/core';
+import { BaseCommand } from '../../../base-command.js';
+import { bold, cyan, dim, green, yellow } from '../../../color.js';
+import {
+  RESETTABLE_ORGS,
+  RESOLVE_SQL,
+  STORES,
+  assertUuids,
+  countSql,
+  resolveFixtureOrg,
+} from '../../../core/env/index.js';
+import type { OrgIdSets, StoreFootprint } from '../../../core/env/index.js';
+
+export default class EnvOrgStatus extends BaseCommand {
+  static description =
+    "Show a fixture org's data footprint across the mesh's Postgres stores (per-table row counts, projections marked). Read-only; targets orgs by catalog slug only.";
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> --org emptyOrg --url iam=postgres://…15432/iam --url programs=postgres://…15433/programs',
+    '<%= config.bin %> <%= command.id %> --org emptyOrg --offline',
+  ];
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    org: Flags.string({ description: `fixture org slug (${Object.keys(RESETTABLE_ORGS).join(' | ')})`, required: true }),
+    url: Flags.string({
+      description: 'store connection as <store>=<connString> (repeatable; store keys: ' + STORES.map((s) => s.key).join(', ') + ')',
+      multiple: true,
+    }),
+    offline: Flags.boolean({
+      description: 'catalog-derived ids only — no live id resolution even if anchor URLs are given.',
+      default: false,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(EnvOrgStatus);
+    const org = resolveFixtureOrg(flags.org);
+    if (org === undefined) {
+      this.error(
+        `'${flags.org}' is not a resettable fixture org. Known slugs: ${Object.keys(RESETTABLE_ORGS).join(', ')}. ` +
+          'Orgs outside the seed catalog (e.g. hand-built training orgs) are deliberately untargetable.',
+      );
+    }
+
+    const urls = new Map<string, string>();
+    for (const entry of flags.url ?? []) {
+      const eq = entry.indexOf('=');
+      const key = eq === -1 ? '' : entry.slice(0, eq);
+      if (eq === -1 || STORES.every((s) => s.key !== key)) {
+        this.error(`bad --url '${entry}' — expected <store>=<connString> with store one of: ${STORES.map((s) => s.key).join(', ')}`);
+      }
+      urls.set(key, entry.slice(eq + 1));
+    }
+
+    const psql = this.getEnvPsql();
+
+    // ── id-set resolution: catalog offline, anchors live when reachable ──
+    const ids: OrgIdSets = {
+      orgId: org.orgId,
+      groupIds: [org.orgId], // the district group row IS the org anchor row
+      userIds: [org.adminUserId],
+      programIds: [],
+    };
+    let resolution: 'live' | 'partial-offline' = 'partial-offline';
+    const iamUrl = urls.get('iam');
+    const programsUrl = urls.get('programs');
+    if (!flags.offline && iamUrl !== undefined && programsUrl !== undefined) {
+      const groupRows = await psql.query(iamUrl, RESOLVE_SQL.groupIds(org.orgId));
+      const groupIds = groupRows.map((r) => r[0] ?? '');
+      assertUuids(groupIds, 'live groupIds');
+      // The district row itself carries org_id = its own id; keep the anchor present even if absent live.
+      ids.groupIds = [...new Set([org.orgId, ...groupIds])];
+      const userRows = ids.groupIds.length === 0 ? [] : await psql.query(iamUrl, RESOLVE_SQL.userIds(ids.groupIds));
+      const userIds = userRows.map((r) => r[0] ?? '');
+      assertUuids(userIds, 'live userIds');
+      ids.userIds = [...new Set([org.adminUserId, ...userIds])];
+      const programRows = await psql.query(programsUrl, RESOLVE_SQL.programIds(org.orgId));
+      const programIds = programRows.map((r) => r[0] ?? '');
+      assertUuids(programIds, 'live programIds');
+      ids.programIds = programIds;
+      resolution = 'live';
+    }
+
+    // ── per-store footprint ──
+    const stores: StoreFootprint[] = [];
+    for (const store of STORES) {
+      const url = urls.get(store.key);
+      const footprint: StoreFootprint = { store: store.key, service: store.service, tables: [] };
+      for (const rule of store.tables) {
+        if (url === undefined) {
+          footprint.tables.push({ table: rule.table, projection: rule.projection === true, count: null, skipped: 'no connection (--url)' });
+          continue;
+        }
+        const sql = countSql(rule, ids);
+        if (sql === null) {
+          // Distinguish "resolved and empty" from "status never resolves this
+          // set" (deeper rings like periodIds are Phase 1 / reset territory) —
+          // an unresolved set must not read as an empty one.
+          const param = ids[rule.param];
+          footprint.tables.push({
+            table: rule.table,
+            projection: rule.projection === true,
+            count: null,
+            skipped:
+              param === undefined
+                ? `${rule.param} not resolved by status`
+                : `empty ${rule.param} id-set${resolution === 'partial-offline' ? ' (offline)' : ''}`,
+          });
+          continue;
+        }
+        const rows = await psql.query(url, sql);
+        footprint.tables.push({ table: rule.table, projection: rule.projection === true, count: Number(rows[0]?.[0] ?? 0) });
+      }
+      stores.push(footprint);
+    }
+
+    // ── render (colour is TTY-gated in color.ts; plain text otherwise) ──
+    const num = (n: number): string => (n > 0 ? bold(String(n)) : dim('0'));
+    const resColor = resolution === 'live' ? green : yellow;
+    const lines: string[] = [
+      `${bold('▶ org status')} — ${bold(cyan(org.displayName))} ${dim(`(${org.slug})`)} ${dim(org.orgId)}`,
+      `  ${dim('admin:')} ${org.adminEmail} ${dim(`(${org.adminUserId})`)}`,
+      `  ${dim('resolution:')} ${resColor(resolution)}` +
+        (resolution === 'partial-offline' ? dim(' — pass --url iam=… and --url programs=… for live id-sets') : ''),
+      `  ${dim('id-sets:')} ${dim('groups=')}${num(ids.groupIds.length)} ${dim('users=')}${num(ids.userIds.length)} ${dim('programs=')}${num(ids.programIds.length)}`,
+    ];
+    let total = 0;
+    for (const s of stores) {
+      const connected = s.tables.some((t) => t.count !== null);
+      lines.push(
+        `  ${bold(cyan(s.store))} ${dim(`(${s.service})`)}${connected ? '' : dim(' — skipped, no connection')}`,
+      );
+      for (const t of s.tables) {
+        const mark = t.projection ? dim(' [projection]') : '';
+        if (t.count === null) {
+          lines.push(`    ${t.table}${mark}: ${dim(`— (${t.skipped ?? 'skipped'})`)}`);
+        } else {
+          total += t.count;
+          lines.push(`    ${t.table}${mark}: ${num(t.count)}`);
+        }
+      }
+    }
+    lines.push(`${green('✓')} ${dim('footprint total:')} ${bold(String(total))} ${dim('row(s) across connected stores.')}`);
+    this.emit(
+      flags,
+      { org: { slug: org.slug, orgId: org.orgId, adminEmail: org.adminEmail }, resolution, ids, stores, total },
+      lines,
+    );
+  }
+}

--- a/packages/node/saga-stack-cli/src/commands/env/verify.ts
+++ b/packages/node/saga-stack-cli/src/commands/env/verify.ts
@@ -1,0 +1,251 @@
+/**
+ * `saga-stack env verify` — health gate for a DEPLOYED shared environment
+ * (soa#355): the `stack verify` analogue for dev / training.
+ *
+ * Where `stack verify` probes the local mesh from the manifest, this probes the
+ * deployed hosts — and it judges health from the RESPONSE BODY, not the status
+ * code. That is not stylistic: `*.wootdev.com` / `*.saga-training.org` are
+ * wildcard DNS onto the shared ALB, whose default action answers **200 with the
+ * body `dev-account-alb`** for any unmatched host, so a status-only gate reports
+ * services that do not exist as healthy (verified live 2026-07-21). The body
+ * classifier in `core/env/services.ts` is the actual gate.
+ *
+ *   default            probe every deployed service; NON-ZERO exit if a required
+ *                      one is unhealthy. Services with no public route are
+ *                      reported as such, never silently green.
+ *   --tolerate <ids>   a listed service being down does not fail the gate
+ *                      (`stack verify`'s flag, same spirit).
+ *   --org <slug>       ALSO assert the fixture org's seed skeleton over the iam
+ *                      connection (`--url iam=…`) — "is this org usable?" as
+ *                      opposed to "are the services up?".
+ *
+ *   ss env verify --env dev
+ *   ss env verify --env training --tolerate connect-api,rtsm-api
+ *   ss env verify --env dev --org emptyOrg --url iam=postgres://…15432/iam
+ */
+
+import { Flags } from '@oclif/core';
+import { BaseCommand } from '../../base-command.js';
+import { bold, cyan, dim, green, red, yellow } from '../../color.js';
+import {
+  ECS_CLUSTERS,
+  ENV_NAMES,
+  RESETTABLE_ORGS,
+  RESET_GUARD_SQL,
+  accountMismatchError,
+  buildEnvHealthProbes,
+  classifyEcsState,
+  classifyProbeBody,
+  resolveEnv,
+  resolveFixtureOrg,
+  verdictReason,
+} from '../../core/env/index.js';
+import type { EcsServiceState } from '../../core/env/index.js';
+import { resolveCallerAccount } from '../../runtime/index.js';
+
+interface ServiceReport {
+  id: string;
+  url: string | null;
+  status: number | null;
+  healthy: boolean;
+  optional: boolean;
+  tolerated: boolean;
+  /** Why it is not healthy (empty when healthy). */
+  reason: string;
+  note?: string;
+  /** --ecs only: the platform verdict for this service. */
+  ecs?: { healthy: boolean; summary: string };
+}
+
+export default class EnvVerify extends BaseCommand {
+  static description =
+    "Health-gate a deployed shared environment (dev/training): probe every service's health endpoint and judge it by RESPONSE BODY (the shared ALB answers 200 for unrouted hosts). Non-zero exit if a required service is unhealthy. --org additionally asserts a fixture org's seed skeleton.";
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> --env dev',
+    '<%= config.bin %> <%= command.id %> --env training --tolerate connect-api,rtsm-api',
+    '<%= config.bin %> <%= command.id %> --env dev --org emptyOrg --url iam=postgres://…15432/iam',
+  ];
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    env: Flags.string({ description: `target environment (${ENV_NAMES.join(' | ')})`, default: 'dev' }),
+    tolerate: Flags.string({
+      description: 'comma-separated service ids whose being down does NOT fail the gate.',
+    }),
+    org: Flags.string({
+      description: `also assert this fixture org's seed skeleton (${Object.keys(RESETTABLE_ORGS).join(' | ')}); needs --url iam=<conn>.`,
+    }),
+    url: Flags.string({ description: 'store connection as <store>=<connString> (only iam is used, for --org).', multiple: true }),
+    ecs: Flags.boolean({
+      description:
+        'ALSO check the ECS platform state (running/desired tasks, rollout) — the truth HTTP cannot see (crash-loops behind a healthy target, stuck deploys). Covers services with no public route. Needs dev-account AWS credentials.',
+      default: false,
+    }),
+    profile: Flags.string({ description: 'AWS profile for --ecs (defaults to the ambient chain).' }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(EnvVerify);
+    const env = resolveEnv(flags.env);
+    if (env === undefined) this.error(`unknown --env '${flags.env}' — expected one of: ${ENV_NAMES.join(', ')}`);
+
+    const tolerated = new Set(
+      (flags.tolerate ?? '')
+        .split(',')
+        .map((t) => t.trim())
+        .filter((t) => t !== ''),
+    );
+
+    // ── probe every deployed service (concurrently) ──
+    const prober = this.getProber();
+    const probes = buildEnvHealthProbes(env.domain, env.name);
+    const reports: ServiceReport[] = await Promise.all(
+      probes.map(async (p): Promise<ServiceReport> => {
+        const base = { id: p.id, optional: p.optional, tolerated: tolerated.has(p.id), note: p.note };
+        if (p.url === null) {
+          // No public route — HTTP cannot verify it (ECS-only). Never green.
+          return { ...base, url: null, status: null, healthy: false, reason: 'no public route (not HTTP-verifiable)' };
+        }
+        const res = await prober.probe(p.url);
+        if (!res.ok) {
+          return {
+            ...base,
+            url: p.url,
+            status: res.status ?? null,
+            healthy: false,
+            reason: res.status === undefined ? 'unreachable (transport error/timeout)' : `HTTP ${res.status}`,
+          };
+        }
+        const verdict = classifyProbeBody(res.body, p.kind);
+        return {
+          ...base,
+          url: p.url,
+          status: res.status ?? null,
+          healthy: verdict === 'healthy',
+          reason: verdict === 'healthy' ? '' : verdictReason(verdict),
+        };
+      }),
+    );
+
+    // ── optional ECS platform pass ──
+    if (flags.ecs) {
+      const aws = this.getEnvAws();
+      const opts = { profile: flags.profile, region: env.awsRegion };
+      const mismatch = accountMismatchError(await resolveCallerAccount(aws, opts), [env.awsAccountId], `'${env.name}'`);
+      if (mismatch !== null) this.error(mismatch);
+      for (const report of reports) {
+        const probe = probes.find((p) => p.id === report.id);
+        if (probe?.ecsService === undefined) continue; // Amplify frontends / not deployed
+        const serviceName = `${probe.ecsService}-${env.ledgerIdentifier}`;
+        let state: EcsServiceState | undefined;
+        for (const cluster of ECS_CLUSTERS) {
+          const found = (await aws.json(
+            [
+              'ecs',
+              'describe-services',
+              '--cluster',
+              cluster,
+              '--services',
+              serviceName,
+              '--query',
+              'services[0].{running:runningCount,desired:desiredCount,status:status,rollout:deployments[0].rolloutState,taskDef:taskDefinition}',
+            ],
+            opts,
+          )) as EcsServiceState | null;
+          if (found !== null && found.status !== undefined) {
+            state = found;
+            break;
+          }
+        }
+        const verdict = classifyEcsState(state);
+        report.ecs = verdict;
+        // A service HTTP said nothing about (no public route) is now judged by ECS.
+        if (report.url === null && verdict.healthy) {
+          report.healthy = true;
+          report.reason = '';
+        } else if (!verdict.healthy) {
+          report.healthy = false;
+          report.reason = report.reason === '' ? `ECS: ${verdict.summary}` : `${report.reason}; ECS: ${verdict.summary}`;
+        }
+      }
+    }
+
+    // ── optional org-skeleton assertion ──
+    let orgReport: { slug: string; skeletonIntact: boolean; detail: string } | undefined;
+    if (flags.org !== undefined) {
+      const org = resolveFixtureOrg(flags.org);
+      if (org === undefined) {
+        this.error(
+          `'${flags.org}' is not a known fixture org. Known slugs: ${Object.keys(RESETTABLE_ORGS).join(', ')}.`,
+        );
+      }
+      const iamUrl = (flags.url ?? []).find((u) => u.startsWith('iam='))?.slice('iam='.length);
+      if (iamUrl === undefined || iamUrl.trim() === '') {
+        this.error(`--org needs the iam connection: pass --url iam=<connString> (from \`ss env connect iam\`).`);
+      }
+      const psql = this.getEnvPsql();
+      const orgRow = await psql.query(iamUrl, RESET_GUARD_SQL.orgRow(org.orgId));
+      const adminRow = await psql.query(iamUrl, RESET_GUARD_SQL.adminUser(org.adminUserId));
+      const membRow = await psql.query(iamUrl, RESET_GUARD_SQL.adminMembership(org.adminMembershipId));
+      const okOrg = orgRow[0]?.[0] === org.displayName;
+      const okAdmin = adminRow[0]?.[0] === org.adminSlug;
+      const okMemb = membRow.length === 1;
+      const missing = [!okOrg ? 'org row' : '', !okAdmin ? 'admin user' : '', !okMemb ? 'admin membership' : ''].filter(
+        (m) => m !== '',
+      );
+      orgReport = {
+        slug: org.slug,
+        skeletonIntact: missing.length === 0,
+        detail: missing.length === 0 ? `org row + admin ${org.adminEmail} + membership present` : `MISSING: ${missing.join(', ')}`,
+      };
+    }
+
+    // ── verdict: required + untolerated failures fail the gate ──
+    const failures = reports.filter((r) => !r.healthy && !r.optional && !r.tolerated);
+    const orgFailed = orgReport !== undefined && !orgReport.skeletonIntact;
+
+    // ── render ──
+    const idW = Math.max(...reports.map((r) => r.id.length));
+    const lines: string[] = [
+      `${bold('▶ env verify')} — ${bold(cyan(env.name))} ${dim(`(*.${env.domain}; health judged by response body)`)}`,
+    ];
+    for (const r of reports) {
+      const id = r.id.padEnd(idW);
+      if (r.healthy) {
+        const detail = r.ecs !== undefined ? `${r.url ?? 'no public route'} ${dim(`· ecs ${r.ecs.summary}`)}` : (r.url ?? '');
+        lines.push(`  ${green('✓')} ${id}  ${dim(detail)}`);
+        continue;
+      }
+      const soft = r.optional || r.tolerated;
+      const mark = soft ? yellow('○') : red('✗');
+      const why = r.tolerated ? `${r.reason} ${dim('(tolerated)')}` : r.optional ? `${r.reason} ${dim('(optional)')}` : r.reason;
+      lines.push(`  ${mark} ${id}  ${soft ? dim(why) : yellow(why)}`);
+      if (r.note !== undefined) lines.push(`    ${dim(r.note)}`);
+    }
+    if (orgReport !== undefined) {
+      lines.push(
+        `  ${orgReport.skeletonIntact ? green('✓') : red('✗')} ${bold('org')} ${cyan(orgReport.slug)}  ${orgReport.skeletonIntact ? dim(orgReport.detail) : yellow(orgReport.detail)}`,
+      );
+    }
+    const healthyCount = reports.filter((r) => r.healthy).length;
+    lines.push(
+      failures.length === 0 && !orgFailed
+        ? `${green('✓ verify passed')} — ${bold(String(healthyCount))}/${bold(String(reports.length))} service(s) healthy${orgReport !== undefined ? ', org skeleton intact' : ''}.`
+        : `${red('✗ verify FAILED')} — ${bold(String(failures.length))} required service(s) unhealthy${orgFailed ? ' + org skeleton broken' : ''} (${healthyCount}/${reports.length} healthy).`,
+    );
+
+    this.emit(
+      flags,
+      { env: env.name, services: reports, org: orgReport ?? null, healthy: healthyCount, failures: failures.map((f) => f.id) },
+      lines,
+    );
+
+    if (failures.length > 0 || orgFailed) {
+      this.error(
+        `env verify FAILED for '${env.name}': ${failures.map((f) => f.id).join(', ') || 'org skeleton'}` +
+          ` — see the report above. Use --tolerate <ids> to accept known-down services.`,
+      );
+    }
+  }
+}

--- a/packages/node/saga-stack-cli/src/core/env/__tests__/env-core.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/env/__tests__/env-core.unit.test.ts
@@ -1,0 +1,131 @@
+/**
+ * `ss env` pure-core units (soa#355): the seed-id derivation must byte-match
+ * the canonical `@saga-ed/iam-seed-ids` values (the reimplementation IS the
+ * contract — drift here means the safety catalog derives WRONG ids), and the
+ * footprint SQL builders must refuse anything that is not a UUID (ids are
+ * inlined as literals — the UUID gate is the injection guard).
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  RESETTABLE_ORGS,
+  RESOLVE_SQL,
+  assertUuids,
+  countSql,
+  deriveGroupId,
+  deriveGroupMembershipId,
+  deriveUserId,
+  extractDbTarget,
+  localUrl,
+  parseDatabaseUrl,
+  resolveFixtureOrg,
+  uuidv5,
+} from '../index.js';
+import type { OrgIdSets, TableRule } from '../index.js';
+
+describe('seed-id derivation — byte-match against iam-seed-ids canon', () => {
+  // Values asserted in rostering/packages/core/iam-seed-ids/src/ids.test.ts.
+  it('deriveGroupId matches the canonical district ids', () => {
+    expect(deriveGroupId('emptyOrg')).toBe('52a00136-285b-522c-bc70-0887cf46463a');
+    expect(deriveGroupId('oakdale')).toBe('b39f3ea1-0ee5-5a61-afdd-65e8c2b30db6');
+    expect(deriveGroupId('frontier')).toBe('ea1562ee-a620-5d5c-82a8-768da7f798c2');
+    expect(deriveGroupId('lincoln')).toBe('92c6c9f4-c764-519f-9873-7df7b77f5410');
+  });
+
+  it('emits RFC 4122 v5 UUIDs (version + variant nibbles)', () => {
+    const id = uuidv5('anything');
+    expect(id[14]).toBe('5');
+    expect(['8', '9', 'a', 'b']).toContain(id[19]!);
+  });
+
+  it('membership ids compose user and group deterministically', () => {
+    const u = deriveUserId('empty');
+    const g = deriveGroupId('emptyOrg');
+    expect(deriveGroupMembershipId(u, g)).toBe(uuidv5(`group_membership:${u}:${g}`));
+  });
+
+  it('the resettable catalog is emptyOrg-only and fully derived', () => {
+    expect(Object.keys(RESETTABLE_ORGS)).toEqual(['emptyOrg']);
+    const org = resolveFixtureOrg('emptyOrg')!;
+    expect(org.orgId).toBe('52a00136-285b-522c-bc70-0887cf46463a');
+    expect(org.adminEmail).toBe('empty@saga.org');
+    expect(org.adminUserId).toBe(deriveUserId('empty'));
+    expect(resolveFixtureOrg('oakdale')).toBeUndefined(); // real districts are NOT resettable
+    expect(resolveFixtureOrg('52a00136-285b-522c-bc70-0887cf46463a')).toBeUndefined(); // no UUID targeting
+  });
+});
+
+describe('taskdef extraction — the two live DB-wiring shapes', () => {
+  it('DATABASE_URL secret wins (URL shape)', () => {
+    const t = extractDbTarget([
+      { name: 'api', secrets: [{ name: 'DATABASE_URL', valueFrom: 'arn:aws:secretsmanager:us-west-2:1:secret:x' }] },
+    ]);
+    expect(t).toEqual({ shape: 'url', urlSecret: { valueFrom: 'arn:aws:secretsmanager:us-west-2:1:secret:x', kind: 'secretsmanager' } });
+  });
+
+  it('split POSTGRES_* env + password secret (ads-adm shape); SSM refs classified', () => {
+    const t = extractDbTarget([
+      {
+        environment: [
+          { name: 'POSTGRES_HOST', value: 'h.dbs-v2.local' },
+          { name: 'POSTGRES_PORT', value: '5471' },
+          { name: 'POSTGRES_DATABASE', value: 'ads_adm' },
+          { name: 'POSTGRES_USERNAME', value: 'app' },
+        ],
+        secrets: [{ name: 'POSTGRES_PASSWORD', valueFrom: 'arn:aws:ssm:us-west-2:1:parameter/x' }],
+      },
+    ]);
+    expect(t).toEqual({
+      shape: 'split',
+      host: 'h.dbs-v2.local',
+      port: 5471,
+      database: 'ads_adm',
+      username: 'app',
+      passwordSecret: { valueFrom: 'arn:aws:ssm:us-west-2:1:parameter/x', kind: 'ssm' },
+    });
+    expect(extractDbTarget([{ name: 'no-db' }])).toBeUndefined();
+  });
+
+  it('parseDatabaseUrl round-trips through localUrl with encoding preserved', () => {
+    const parsed = parseDatabaseUrl('postgresql://admin:p%40ss@h.dbs-v2.local:5440/mydb');
+    expect(parsed).toEqual({ host: 'h.dbs-v2.local', port: 5440, database: 'mydb', username: 'admin', password: 'p@ss' });
+    expect(localUrl(parsed, 15432)).toBe('postgres://admin:p%40ss@127.0.0.1:15432/mydb');
+    expect(() => parseDatabaseUrl('mysql://x/y')).toThrow(/unsupported/);
+  });
+});
+
+describe('footprint SQL builders — UUID gate + shapes', () => {
+  const ORG = '52a00136-285b-522c-bc70-0887cf46463a';
+  const IDS: OrgIdSets = {
+    orgId: ORG,
+    groupIds: [ORG],
+    userIds: ['e01466ba-97f4-5c74-8b87-4b63b6e9a1c1'],
+    programIds: [],
+  };
+
+  it('assertUuids refuses non-UUIDs (the SQL-injection gate)', () => {
+    expect(() => assertUuids(["x'; DROP TABLE groups;--"], 'evil')).toThrow(/not a UUID/);
+    expect(() => assertUuids([ORG], 'ok')).not.toThrow();
+  });
+
+  it('countSql: scalar param → equality; list param → IN; empty list → null; unresolved param → null', () => {
+    const orgRule: TableRule = { table: 'groups', param: 'orgId', column: 'org_id' };
+    expect(countSql(orgRule, IDS)).toBe(`SELECT count(*) FROM groups WHERE org_id = '${ORG}'`);
+    const listRule: TableRule = { table: 'group_memberships', param: 'groupIds', column: 'group_id' };
+    expect(countSql(listRule, IDS)).toBe(`SELECT count(*) FROM group_memberships WHERE group_id IN ('${ORG}')`);
+    const emptyRule: TableRule = { table: 'adm_attendance', param: 'programIds', column: 'program_id' };
+    expect(countSql(emptyRule, IDS)).toBeNull();
+    // A deeper-ring param the caller never resolved (undefined, not empty) —
+    // e.g. periodIds in Phase-0 status — must also be null (skipped, never
+    // silently mis-counted).
+    const unresolvedRule: TableRule = { table: 'period_attendance_status', param: 'periodIds', column: 'period_id' };
+    expect(countSql(unresolvedRule, IDS)).toBeNull();
+  });
+
+  it('RESOLVE_SQL anchors on the two org columns', () => {
+    expect(RESOLVE_SQL.groupIds(ORG)).toBe(`SELECT id FROM groups WHERE org_id = '${ORG}'`);
+    expect(RESOLVE_SQL.programIds(ORG)).toBe(`SELECT id FROM "Program" WHERE "organizationId" = '${ORG}'`);
+    expect(RESOLVE_SQL.userIds([ORG])).toContain('FROM group_memberships WHERE group_id IN');
+    expect(() => RESOLVE_SQL.groupIds('not-a-uuid')).toThrow(/not a UUID/);
+  });
+});

--- a/packages/node/saga-stack-cli/src/core/env/__tests__/reset-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/env/__tests__/reset-plan.unit.test.ts
@@ -1,0 +1,297 @@
+/**
+ * `env org reset` plan-builder units (soa#355 Phase 1): the UUID/base64url
+ * inlining gates, resolution-step dependency behavior, per-store delete
+ * ORDER (the FK-forced orderings), and — most importantly — the skeleton
+ * predicates: the org row, admin user, admin membership, and seeded personas
+ * must be excluded in the SQL ITSELF, and every cross-store user sweep must
+ * key on userDelIds (multi-org survivors excluded), never the raw set.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  RESETTABLE_ORGS,
+  RESET_GUARD_SQL,
+  RESET_RESOLVE_STEPS,
+  RESET_STORES,
+  assertSessionIds,
+  buildResetPlan,
+  initialResetIds,
+  validateResetIds,
+} from '../index.js';
+import type { ResetIdSets } from '../index.js';
+
+const ORG = RESETTABLE_ORGS.emptyOrg!;
+const SCHOOL = 'b39f3ea1-0ee5-5a61-afdd-65e8c2b30db6';
+const USER = '92c6c9f4-c764-519f-9873-7df7b77f5410';
+const PROGRAM = 'ea1562ee-a620-5d5c-82a8-768da7f798c2';
+const PERIOD = 'a0da8362-1a93-5d1d-aeaa-b6d8960e9821';
+const SCHEDULE = 'c1d2e3f4-0000-4000-8000-000000000001';
+
+function fullIds(): ResetIdSets {
+  const ids = initialResetIds(ORG);
+  ids.groupIds = [ORG.orgId, SCHOOL];
+  ids.userIds = [ORG.adminUserId, USER];
+  ids.userDelIds = [USER];
+  ids.programIds = [PROGRAM];
+  ids.periodIds = [PERIOD];
+  // A resolved reset carries the schedule ring too — schedule-keyed tables
+  // (e.g. "DayTypeBlock") are only exercised when scheduleIds is non-empty.
+  ids.scheduleIds = [SCHEDULE];
+  return ids;
+}
+
+describe('initialResetIds — catalog anchors', () => {
+  it('seeds anchors and empty live sets', () => {
+    const ids = initialResetIds(ORG);
+    expect(ids.orgId).toBe('52a00136-285b-522c-bc70-0887cf46463a');
+    expect(ids.adminMembershipId).toBe('80089e21-6aea-520e-8940-d292e0e12f92');
+    expect(ids.groupIds).toEqual([ids.orgId]);
+    expect(ids.userIds).toEqual([ids.adminUserId]);
+    expect(ids.userDelIds).toEqual([]);
+    expect(ids.seededPersonaIds).toEqual([
+      '00000000-0000-4000-a003-000000000021',
+      '00000000-0000-4000-a003-000000000022',
+      '00000000-0000-4000-a003-000000000023',
+    ]);
+  });
+});
+
+describe('inlining gates', () => {
+  it('validateResetIds refuses a non-UUID in any uuid set', () => {
+    const ids = fullIds();
+    ids.podIds = ["x'; DROP TABLE pods;--"];
+    expect(() => validateResetIds(ids)).toThrow(/not a UUID/);
+  });
+
+  it('sessionIds are base64url-gated, not UUID-gated', () => {
+    expect(() => assertSessionIds(['MjAyNi0wNy0yMXxwfHN8cA=='])).not.toThrow();
+    // Live dev shape: a `v2.`-versioned opaque key (the `.` is part of the charset).
+    expect(() => assertSessionIds(['v2.D1CLobLD1AACQACAAAAAAAAAkakvfCpmRVe-olzN7dO3fiMiMNFGqI5XVK5UqL_-XkoO'])).not.toThrow();
+    expect(() => assertSessionIds(["evil' OR 1=1--"])).toThrow(/not a base64url/);
+    const ids = fullIds();
+    ids.sessionIds = ['ok_-='];
+    expect(() => validateResetIds(ids)).not.toThrow();
+    ids.sessionIds = ["no'quote"];
+    expect(() => validateResetIds(ids)).toThrow(/base64url/);
+  });
+
+  it('buildResetPlan and every resolve step validate before inlining', () => {
+    const ids = fullIds();
+    ids.scheduleIds = ['nope'];
+    expect(() => buildResetPlan(ids)).toThrow(/not a UUID/);
+    for (const step of RESET_RESOLVE_STEPS) {
+      expect(() => step.sql(ids)).toThrow(/not a UUID/);
+    }
+  });
+});
+
+describe('resolution steps', () => {
+  it('run in dependency order and skip when prerequisites are empty', () => {
+    const ids = initialResetIds(ORG);
+    // With no programIds yet, every deeper-ring step short-circuits to null.
+    for (const step of RESET_RESOLVE_STEPS) {
+      if (['groupIds', 'userIds', 'userDelIds', 'programIds'].includes(step.set)) continue;
+      expect(step.sql(ids), step.label).toBeNull();
+    }
+  });
+
+  it('userDelIds carries the multi-org rule, the env-wide-actor rule, AND the admin exclusion', () => {
+    const step = RESET_RESOLVE_STEPS.find((s) => s.set === 'userDelIds')!;
+    const sql = step.sql(fullIds())!;
+    expect(sql).toContain(`gm.user_id <> '${ORG.adminUserId}'`);
+    expect(sql).toContain('NOT EXISTS (SELECT 1 FROM group_memberships gm2');
+    expect(sql).toContain(`gm2.group_id NOT IN ('${ORG.orgId}', '${SCHOOL}')`);
+    // Env-wide actors have identity WITHOUT membership rows — never deletable.
+    expect(sql).toContain(`NOT EXISTS (SELECT 1 FROM users u WHERE u.id = gm.user_id AND u.role <> 'USER')`);
+    expect(sql).toContain('NOT EXISTS (SELECT 1 FROM user_system_roles usr WHERE usr.user_id = gm.user_id)');
+  });
+
+  it('slot/schedule/pod sets union the projection-side orphan sources', () => {
+    const ids = fullIds();
+    const stores = (set: string): string[] =>
+      RESET_RESOLVE_STEPS.filter((s) => s.set === set && s.sql(ids) !== null).map((s) => s.store);
+    expect(stores('slotIds')).toEqual(['scheduling', 'programs', 'sessions']);
+    expect(stores('scheduleIds')).toEqual(['scheduling', 'sessions', 'sessions']);
+    expect(stores('podIds')).toEqual(['programs', 'sessions']);
+  });
+});
+
+describe('buildResetPlan — order, skeleton predicates, empty-set skips', () => {
+  it('stores execute leaf-first with iam LAST', () => {
+    expect(RESET_STORES.map((s) => s.key)).toEqual([
+      'sessions',
+      'scheduling',
+      'programs',
+      'ads-adm',
+      'coach',
+      'iam-pii',
+      'iam',
+    ]);
+  });
+
+  it('programs deletes pod_assignment BEFORE slot_projection (ON DELETE RESTRICT)', () => {
+    const tables = RESET_STORES.find((s) => s.key === 'programs')!.rules.map((r) => r.table);
+    expect(tables.indexOf('pod_assignment')).toBeGreaterThanOrEqual(0);
+    expect(tables.indexOf('pod_assignment')).toBeLessThan(tables.indexOf('slot_projection'));
+    expect(tables.indexOf('"Pod"')).toBeLessThan(tables.indexOf('"TutoringPeriod"'));
+    expect(tables.indexOf('"TutoringPeriod"')).toBeLessThan(tables.indexOf('"Program"'));
+  });
+
+  it('scheduling deletes CalendarEvent before RecurrenceRule/DayType', () => {
+    const tables = RESET_STORES.find((s) => s.key === 'scheduling')!.rules.map((r) => r.table);
+    expect(tables.indexOf('"CalendarEvent"')).toBeLessThan(tables.indexOf('"RecurrenceRule"'));
+    expect(tables.indexOf('"CalendarEvent"')).toBeLessThan(tables.indexOf('"DayType"'));
+    expect(tables.indexOf('"DayTypeBlock"')).toBe(0);
+  });
+
+  it('iam order: users first (the membership evidence), groups last', () => {
+    const tables = RESET_STORES.find((s) => s.key === 'iam')!.rules.map((r) => r.table);
+    expect(tables[0]).toBe('users');
+    expect(tables[tables.length - 1]).toBe('groups');
+    expect(tables.indexOf('users')).toBeLessThan(tables.indexOf('group_memberships'));
+  });
+
+  it('skeleton predicates are IN the SQL', () => {
+    const plan = buildResetPlan(fullIds());
+    const iam = plan.find((s) => s.store === 'iam')!;
+    const sql = (table: string): string => iam.tables.find((t) => t.table === table)!.deleteSql!;
+    expect(sql('users')).toContain(`id <> '${ORG.adminUserId}'`);
+    expect(sql('users')).toContain('NOT EXISTS (SELECT 1 FROM group_memberships gm2');
+    // Env-wide actors (staff/service accounts): role marker + system roles.
+    expect(sql('users')).toContain(`users.role = 'USER'`);
+    expect(sql('users')).toContain('NOT EXISTS (SELECT 1 FROM user_system_roles usr WHERE usr.user_id = users.id)');
+    expect(sql('group_memberships')).toContain(`id <> '${ORG.adminMembershipId}'`);
+    expect(sql('personas')).toContain(
+      `id NOT IN ('00000000-0000-4000-a003-000000000021', '00000000-0000-4000-a003-000000000022', '00000000-0000-4000-a003-000000000023')`,
+    );
+    expect(sql('personas')).toContain(`id = '${ORG.adminMembershipId}' AND persona_id IS NOT NULL`);
+    expect(sql('groups')).toBe(`DELETE FROM groups WHERE org_id = '${ORG.orgId}' AND id <> '${ORG.orgId}'`);
+    // Seeded org-row config survives; child-group config dies.
+    expect(sql('group_attributes')).toContain(`group_id <> '${ORG.orgId}'`);
+    expect(sql('group_auth_config')).toContain(`group_id <> '${ORG.orgId}'`);
+  });
+
+  it('sessions authz mirrors keep the admin membership + org hierarchy rows', () => {
+    const plan = buildResetPlan(fullIds());
+    const sessions = plan.find((s) => s.store === 'sessions')!;
+    const sql = (table: string): string => sessions.tables.find((t) => t.table === table)!.deleteSql!;
+    expect(sql('authz_group_membership')).toContain(`iam_row_id IS DISTINCT FROM '${ORG.adminMembershipId}'`);
+    expect(sql('authz_group_hierarchy')).toContain(`child_group_id <> '${ORG.orgId}'`);
+    expect(sql('authz_persona_assignment')).toContain(`user_id IN ('${USER}')`);
+    expect(sql('authz_persona_assignment')).toContain(`group_id <> '${ORG.orgId}'`);
+  });
+
+  it('every user-keyed sweep uses userDelIds (multi-org survivors keep mirrors/PII/progress)', () => {
+    const ids = fullIds();
+    ids.userDelIds = []; // everyone reachable is multi-org ⇒ nothing user-keyed dies
+    const plan = buildResetPlan(ids);
+    const table = (store: string, t: string) => plan.find((s) => s.store === store)!.tables.find((x) => x.table === t)!;
+    expect(table('iam-pii', 'user_pii').deleteSql).toBeNull();
+    expect(table('coach', 'content_instance').deleteSql).toBeNull();
+    expect(table('coach', 'module_answer').deleteSql).toBeNull();
+    expect(table('programs', 'user_projection').deleteSql).toBeNull();
+    expect(table('sessions', 'user_projection').deleteSql).toBeNull();
+    // Group-keyed halves still apply — minus the admin's kept mirror.
+    expect(table('coach', 'persona_assignment').deleteSql).toBe(
+      `DELETE FROM persona_assignment WHERE (group_id IN ('${ORG.orgId}', '${SCHOOL}') AND iam_row_id IS DISTINCT FROM '${ORG.adminMembershipId}')`,
+    );
+  });
+
+  it("coach persona_assignment keeps the admin's org-row mirror (its iam source row survives the reset)", () => {
+    const plan = buildResetPlan(fullIds());
+    const coach = plan.find((s) => s.store === 'coach')!;
+    const sql = coach.tables.find((t) => t.table === 'persona_assignment')!.deleteSql!;
+    expect(sql).toBe(
+      `DELETE FROM persona_assignment WHERE user_id IN ('${USER}')` +
+        ` OR (group_id IN ('${ORG.orgId}', '${SCHOOL}') AND iam_row_id IS DISTINCT FROM '${ORG.adminMembershipId}')`,
+    );
+  });
+
+  it("adm_attendance's user disjunct is SCOPED to the org's periods; period_attendance_status keys on period_id", () => {
+    const plan = buildResetPlan(fullIds());
+    const ads = plan.find((s) => s.store === 'ads-adm')!;
+    expect(ads.tables[0]!.deleteSql).toBe(
+      `DELETE FROM adm_attendance WHERE program_id IN ('${PROGRAM}') OR (iam_user_id IN ('${USER}') AND period_id IN ('${PERIOD}'))`,
+    );
+    expect(ads.tables[1]!.deleteSql).toBe(`DELETE FROM period_attendance_status WHERE period_id IN ('${PERIOD}')`);
+    // Never an unscoped user disjunct: with no periods resolved, only the
+    // program leg remains (a bare iam_user_id predicate could reach OTHER
+    // orgs' attendance rows).
+    const noPeriods = fullIds();
+    noPeriods.periodIds = [];
+    const plan2 = buildResetPlan(noPeriods);
+    expect(plan2.find((s) => s.store === 'ads-adm')!.tables[0]!.deleteSql).toBe(
+      `DELETE FROM adm_attendance WHERE program_id IN ('${PROGRAM}')`,
+    );
+  });
+
+  it('empty id-sets skip statements (IN () never emitted) and drop out of the transaction', () => {
+    const ids = initialResetIds(ORG); // nothing resolved
+    const plan = buildResetPlan(ids);
+    const scheduling = plan.find((s) => s.store === 'scheduling')!;
+    // Only the org-anchored program_projection survives the skips.
+    expect(scheduling.statements.map((s) => s.table)).toEqual(['program_projection']);
+    expect(scheduling.transactionSql).toBe(
+      `BEGIN;\nDELETE FROM program_projection WHERE organization_id = '${ORG.orgId}';\nCOMMIT;`,
+    );
+    const adsAdm = plan.find((s) => s.store === 'ads-adm')!;
+    expect(adsAdm.transactionSql).toBeNull();
+    for (const store of plan) {
+      for (const t of store.tables) {
+        if (t.deleteSql !== null) expect(t.deleteSql).not.toContain('IN ()');
+      }
+    }
+  });
+
+  it('countSql shares each delete predicate byte-for-byte — except self-blinding recounts', () => {
+    const plan = buildResetPlan(fullIds());
+    for (const store of plan) {
+      for (const t of store.tables) {
+        if (t.deleteSql === null) {
+          expect(t.countSql).toBeNull();
+          continue;
+        }
+        if (store.store === 'iam' && t.table === 'users') continue; // literal-set recount, asserted below
+        expect(t.countSql).toBe(t.deleteSql.replace(`DELETE FROM ${t.table}`, `SELECT count(*) FROM ${t.table}`));
+      }
+    }
+    // The users recount uses the pre-resolved userDelIds literal set (same
+    // rows at plan time): the delete's membership subquery would self-blind
+    // post-verify because group_memberships dies in the same transaction.
+    const users = plan.find((s) => s.store === 'iam')!.tables.find((t) => t.table === 'users')!;
+    expect(users.countSql).toBe(`SELECT count(*) FROM users WHERE id IN ('${USER}')`);
+  });
+
+  it('subquery-only predicates are marked verify-indirect (no meaningful recount exists)', () => {
+    const plan = buildResetPlan(fullIds());
+    const t = (store: string, table: string) => plan.find((s) => s.store === store)!.tables.find((x) => x.table === table)!;
+    expect(t('scheduling', '"DayTypeBlock"').verify).toBe('indirect');
+    expect(t('programs', '"ProgramSectionMapping"').verify).toBe('indirect');
+    // users is NOT indirect — its literal-set recount is meaningful.
+    expect(t('iam', 'users').verify).toBeUndefined();
+  });
+
+  it('transactions are BEGIN/COMMIT-wrapped compounds', () => {
+    const plan = buildResetPlan(fullIds());
+    for (const store of plan) {
+      if (store.transactionSql === null) continue;
+      expect(store.transactionSql.startsWith('BEGIN;\n')).toBe(true);
+      expect(store.transactionSql.endsWith('COMMIT;')).toBe(true);
+      // Every inner statement is a DELETE (subquery SELECTs are inside predicates only).
+      for (const stmt of store.transactionSql.split(';\n').slice(1, -1)) {
+        expect(stmt.startsWith('DELETE FROM ')).toBe(true);
+      }
+    }
+  });
+});
+
+describe('guard SQL', () => {
+  it('identity/skeleton probes are UUID-gated and target the deterministic ids', () => {
+    expect(RESET_GUARD_SQL.orgRow(ORG.orgId)).toBe(`SELECT display_name FROM groups WHERE id = '${ORG.orgId}'`);
+    expect(RESET_GUARD_SQL.adminUser(ORG.adminUserId)).toBe(`SELECT username FROM users WHERE id = '${ORG.adminUserId}'`);
+    expect(RESET_GUARD_SQL.adminMembership(ORG.adminMembershipId)).toBe(
+      `SELECT id FROM group_memberships WHERE id = '${ORG.adminMembershipId}'`,
+    );
+    expect(() => RESET_GUARD_SQL.orgRow('evil')).toThrow(/not a UUID/);
+  });
+});

--- a/packages/node/saga-stack-cli/src/core/env/footprint.ts
+++ b/packages/node/saga-stack-cli/src/core/env/footprint.ts
@@ -1,0 +1,221 @@
+/**
+ * Org data-footprint model for the `ss env org` commands (soa#355) — PURE.
+ *
+ * Encodes, per Postgres store in the mesh, which tables hold org-linked rows
+ * and by which id parameter they are reached. Org identity anchors in exactly
+ * two columns fleet-wide (iam `groups.org_id`, programs `Program."organizationId"`);
+ * everything else is TRANSITIVE via resolved id-sets (group ids → member user
+ * ids → program ids). `projection: true` marks event-materialized rows (the
+ * orphan category): projections never self-heal, so `org status` counts them
+ * separately and a reset must sweep them by the SAME id-sets.
+ *
+ * Table/column names are verified against the owning repos' prisma schemas
+ * (rostering iam-db, program-hub programs/scheduling/sessions, sds ads-adm-db,
+ * coach-db) as of 2026-07-21 — each StoreDef notes its schema source. The map
+ * is the ANCHOR + FIRST-RING footprint, deliberately extensible: growing it is
+ * a reviewed code change, and `env org status` prints per-table provenance so
+ * a missing table is visible, not silent.
+ *
+ * SQL SAFETY: ids are interpolated as literals (psql shell-out has no bind
+ * params), so every id MUST pass `assertUuids` first — derived catalog ids do
+ * by construction; live-resolved ids are validated before reuse.
+ */
+
+/**
+ * Which resolved id-set a table's rows are reached by. The first four are the
+ * Phase-0 sets `org status` resolves live; the deeper rings (periodIds, …) are
+ * resolved by Phase 1's reset — a footprint rule keyed on a set the caller has
+ * not resolved is reported as skipped, never silently mis-counted.
+ */
+export type IdParamKind =
+  | 'orgId'
+  | 'groupIds'
+  | 'userIds'
+  | 'programIds'
+  | 'periodIds'
+  | 'cohortIds'
+  | 'podIds'
+  | 'slotIds'
+  | 'scheduleIds';
+
+export interface TableRule {
+  /** Table name as it exists in the database (schema-qualified if not public). */
+  table: string;
+  /** The id parameter this table is filtered by. */
+  param: IdParamKind;
+  /** The column matched against the parameter. */
+  column: string;
+  /** Event-materialized row (projection/mirror) — the orphan category. */
+  projection?: boolean;
+  note?: string;
+}
+
+export interface StoreDef {
+  /** Store key used in `--url <key>=<conn>` overrides and output. */
+  key: string;
+  /** Owning deployable (for humans). */
+  service: string;
+  /**
+   * ECS service-name prefix in the shared cluster; the deployed instance is
+   * `<ecsService>-<ledgerIdentifier>` (e.g. `rostering-iam-api-main` on dev,
+   * `rostering-iam-api-training` on training). `env connect` resolves the DB
+   * target from THIS service's live task definition.
+   */
+  ecsService: string;
+  engine: 'postgres';
+  /** Logical database name hint (authoritative names come from live discovery). */
+  database: string;
+  /** Where the table map was verified from. */
+  schemaSource: string;
+  tables: TableRule[];
+}
+
+/** The resolved id-sets an org footprint is computed from (deep rings optional — Phase 1). */
+export interface OrgIdSets {
+  orgId: string;
+  groupIds: string[];
+  userIds: string[];
+  programIds: string[];
+  periodIds?: string[];
+  cohortIds?: string[];
+  podIds?: string[];
+  slotIds?: string[];
+  scheduleIds?: string[];
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Every id inlined into SQL must be a well-formed UUID — throws otherwise. */
+export function assertUuids(ids: readonly string[], label: string): void {
+  for (const id of ids) {
+    if (!UUID_RE.test(id)) throw new Error(`${label}: '${id}' is not a UUID — refusing to build SQL with it`);
+  }
+}
+
+export const STORES: StoreDef[] = [
+  {
+    key: 'iam',
+    ecsService: 'rostering-iam-api',
+    service: 'iam-api (rostering)',
+    engine: 'postgres',
+    database: 'iam',
+    schemaSource: 'rostering/packages/node/iam-db/src/prisma/schema.prisma',
+    tables: [
+      { table: 'groups', param: 'orgId', column: 'org_id', note: 'THE org anchor — district/school/section rows' },
+      { table: 'group_memberships', param: 'groupIds', column: 'group_id' },
+      { table: 'user_policies', param: 'groupIds', column: 'group_id' },
+      { table: 'users', param: 'userIds', column: 'id', note: 'users are NOT org-scoped — only members resolved via memberships; seed-protected rows excluded at reset' },
+      // audit_logs is append-only by DB rule — deliberately absent.
+    ],
+  },
+  {
+    key: 'programs',
+    ecsService: 'program-hub-programs-api',
+    service: 'programs-api (program-hub)',
+    engine: 'postgres',
+    database: 'programs',
+    schemaSource: 'program-hub/apps/node/programs-api/src/prisma/schema.prisma',
+    tables: [
+      { table: '"Program"', param: 'orgId', column: '"organizationId"', note: 'the second org anchor' },
+      // Pod/pod_assignment are period/cohort-keyed (a deeper ring) — Phase 1's
+      // resolver adds periodIds/podIds before they can be counted here.
+      { table: 'program_membership', param: 'programIds', column: 'program_id' },
+      { table: 'user_projection', param: 'userIds', column: 'id', projection: true, note: 'iam mirror' },
+    ],
+  },
+  {
+    key: 'scheduling',
+    ecsService: 'program-hub-scheduling-api',
+    service: 'scheduling-api (program-hub)',
+    engine: 'postgres',
+    database: 'scheduling',
+    schemaSource: 'program-hub/apps/node/scheduling-api/src/prisma/schema.prisma',
+    tables: [
+      { table: 'program_projection', param: 'orgId', column: 'organization_id', projection: true },
+      { table: 'period_projection', param: 'programIds', column: 'program_id', projection: true },
+    ],
+  },
+  {
+    key: 'sessions',
+    ecsService: 'program-hub-sessions-api',
+    service: 'sessions-api (program-hub)',
+    engine: 'postgres',
+    database: 'sessions',
+    schemaSource: 'program-hub/apps/node/sessions-api/src/prisma/schema.prisma',
+    tables: [
+      { table: 'tutoring_session', param: 'programIds', column: 'program_id' },
+      { table: 'schedule_projection', param: 'programIds', column: 'program_id', projection: true },
+      // projection_readiness is a parity-critical singleton — never org-scoped, never touched.
+    ],
+  },
+  {
+    key: 'ads-adm',
+    ecsService: 'sds-ads-adm-api',
+    service: 'ads-adm-api (student-data-system)',
+    engine: 'postgres',
+    database: 'ads_adm',
+    schemaSource: 'student-data-system/packages/node/ads-adm-db/src/prisma/schema.prisma',
+    tables: [
+      { table: 'adm_attendance', param: 'programIds', column: 'program_id' },
+      // CORRECTED 2026-07-21: this table has NO program_id column (only
+      // period_id/date/state/…) — reachable via periodIds, which `org status`
+      // does not resolve (reported skipped) and Phase 1's reset does.
+      { table: 'period_attendance_status', param: 'periodIds', column: 'period_id' },
+    ],
+  },
+  {
+    key: 'coach',
+    ecsService: 'coach-coach-api',
+    service: 'coach-api (coach)',
+    engine: 'postgres',
+    database: 'coach',
+    schemaSource: 'coach/packages/node/coach-db/src/prisma/schema.prisma',
+    tables: [
+      { table: 'content_instance', param: 'userIds', column: 'user_id' },
+      { table: 'module_answer', param: 'userIds', column: 'user_id' },
+      { table: 'persona_assignment', param: 'userIds', column: 'user_id', projection: true, note: 'converges from IAM replay' },
+      { table: 'group_track_map', param: 'groupIds', column: 'group_id', projection: true },
+    ],
+  },
+];
+
+/** The id-resolution SQL run against the two anchor stores (live resolution). */
+export const RESOLVE_SQL = {
+  /** iam: the org's group ids (district row included — org_id is self for the district). */
+  groupIds: (orgId: string): string => {
+    assertUuids([orgId], 'orgId');
+    return `SELECT id FROM groups WHERE org_id = '${orgId}'`;
+  },
+  /** iam: user ids reachable from the org's groups. */
+  userIds: (groupIds: readonly string[]): string => {
+    assertUuids(groupIds, 'groupIds');
+    return `SELECT DISTINCT user_id FROM group_memberships WHERE group_id IN (${inList(groupIds)})`;
+  },
+  /** programs: the org's program ids. */
+  programIds: (orgId: string): string => {
+    assertUuids([orgId], 'orgId');
+    return `SELECT id FROM "Program" WHERE "organizationId" = '${orgId}'`;
+  },
+};
+
+const inList = (ids: readonly string[]): string => ids.map((id) => `'${id}'`).join(', ');
+
+/** COUNT query for one table rule against resolved id-sets; null when the param set is empty/unresolved (count is trivially 0/unknowable). */
+export function countSql(rule: TableRule, ids: OrgIdSets): string | null {
+  const param = ids[rule.param];
+  if (param === undefined) return null;
+  if (typeof param === 'string') {
+    assertUuids([param], rule.param);
+    return `SELECT count(*) FROM ${rule.table} WHERE ${rule.column} = '${param}'`;
+  }
+  if (param.length === 0) return null;
+  assertUuids(param, rule.param);
+  return `SELECT count(*) FROM ${rule.table} WHERE ${rule.column} IN (${inList(param)})`;
+}
+
+/** One store's footprint rows for display/JSON. */
+export interface StoreFootprint {
+  store: string;
+  service: string;
+  tables: { table: string; projection: boolean; count: number | null; skipped?: string }[];
+}

--- a/packages/node/saga-stack-cli/src/core/env/index.ts
+++ b/packages/node/saga-stack-cli/src/core/env/index.ts
@@ -1,0 +1,12 @@
+/**
+ * `ss env` pure core (soa#355): deployed shared-environment registry,
+ * canonical seed-id derivation (fixture-org catalog + safety gate), and the
+ * org data-footprint model. Zero IO — AWS/psql live behind runtime seams.
+ */
+
+export * from './registry.js';
+export * from './seed-ids.js';
+export * from './footprint.js';
+export * from './reset-plan.js';
+export * from './taskdef.js';
+export * from './services.js';

--- a/packages/node/saga-stack-cli/src/core/env/registry.ts
+++ b/packages/node/saga-stack-cli/src/core/env/registry.ts
@@ -1,0 +1,106 @@
+/**
+ * Deployed shared-environment registry for the `ss env` family (soa#355).
+ *
+ * A DeployedEnv names one shared composition and how to reach its control
+ * plane: the dev-platform ledger identifier, the AWS account/region, the SSM
+ * jump host, and the SSM-parameter roots endpoint discovery walks. `dev`
+ * (the `*.wootdev.com` fleet, CI-deployed on merge to main) and `training`
+ * (the persistent `*.saga-training.org` tenant) ship built in; both live in
+ * the SAME dev AWS account — prod is a different account and deliberately NOT
+ * representable here.
+ *
+ * PURE data + lookups. All AWS IO happens behind the `runtime/aws-cli.ts`
+ * seam; endpoint values are DISCOVERED live (`ss env discover`) or overridden
+ * per-invocation — nothing here hardcodes a hostname that can drift.
+ */
+
+/** The dev AWS account that hosts BOTH shared environments. */
+export const DEV_ACCOUNT_ID = '396913734878';
+
+/** The dev-platform control-plane Environment ledger (DynamoDB). */
+export const LEDGER_TABLE = 'dev-platform-control-plane-environments-dev';
+
+/** EC2 Name tag of the SSM jump host (the shared ECS instances double as it). */
+export const JUMP_HOST_NAME_TAG = 'dev-shared-ecs-instance';
+
+/**
+ * Shared ECS clusters, in lookup order — services live on one or the other
+ * (live 2026-07-21: arm cluster carries most of the mesh).
+ */
+export const ECS_CLUSTERS = ['dev-shared-arm', 'dev-shared'];
+
+/**
+ * CloudMap private-DNS namespace of the db-host-v2 fleet. Hosts under it are
+ * per-service DB containers on db-host EC2 instances; the ASG runs SEVERAL
+ * instances, and the shared jump host's SG cannot reach the containers
+ * (task-SG allowlists — a dial from the jump host hangs on a dropped SYN,
+ * verified live 2026-07-21). Tunnels to these targets therefore route via
+ * CloudMap: discover-instances → the container's OWN host instance + port →
+ * SSM to THAT instance with a 127.0.0.1 dial (no SG in the path).
+ */
+export const DB_HOST_CLOUDMAP_NAMESPACE = 'dbs-v2.local';
+
+export interface DeployedEnv {
+  /** ss-facing name (`--env dev`). */
+  name: string;
+  /** dev-platform ledger identifier (`pk = ENV#<identifier>`). */
+  ledgerIdentifier: string;
+  /** Public apex the composition serves. */
+  domain: string;
+  awsRegion: string;
+  awsAccountId: string;
+  /**
+   * SSM parameter roots to walk when discovering data-store endpoints, in
+   * precedence order (the shared-infra target path first, legacy path second).
+   */
+  ssmDiscoveryRoots: string[];
+  /** One-line description for `ss env list`. */
+  description: string;
+}
+
+export const DEPLOYED_ENVS: Record<string, DeployedEnv> = {
+  dev: {
+    name: 'dev',
+    ledgerIdentifier: 'main',
+    domain: 'wootdev.com',
+    awsRegion: 'us-west-2',
+    awsAccountId: DEV_ACCOUNT_ID,
+    ssmDiscoveryRoots: ['/shared/infra/dev', '/dev'],
+    description: 'Shared dev fleet (*.wootdev.com) — CI-deployed on merge to main; data accumulates (no reset).',
+  },
+  training: {
+    name: 'training',
+    ledgerIdentifier: 'training',
+    domain: 'saga-training.org',
+    awsRegion: 'us-west-2',
+    awsAccountId: DEV_ACCOUNT_ID,
+    ssmDiscoveryRoots: ['/shared/infra/dev', '/dev'],
+    description:
+      'Persistent training tenant (*.saga-training.org) — manual dispatch deploys; whole-DB reset via rostering reset-training-data.yml only.',
+  },
+};
+
+/** Resolve a deployed env by name; undefined for unknown names. */
+export const resolveEnv = (name: string): DeployedEnv | undefined => DEPLOYED_ENVS[name];
+
+/**
+ * The account-preflight message (PURE): null when the caller is in one of the
+ * expected accounts (or the account couldn't be read — don't block on that),
+ * otherwise an actionable "wrong account — switch profile" string. `label`
+ * names what needs the account (an env name, or "the env ledger" for `list`).
+ */
+export function accountMismatchError(
+  callerAccount: string | undefined,
+  expectedAccountIds: readonly string[],
+  label: string,
+): string | null {
+  if (callerAccount === undefined || expectedAccountIds.includes(callerAccount)) return null;
+  return (
+    `AWS account mismatch — your credentials resolve to account ${callerAccount}, but ${label} ` +
+    `lives in ${expectedAccountIds.join('/')} (the dev account). Pass --profile <a dev-account profile> ` +
+    `(e.g. dev_admin) or set AWS_PROFILE, then retry.`
+  );
+}
+
+/** The `--env` flag's accepted values, for help text. */
+export const ENV_NAMES = Object.keys(DEPLOYED_ENVS);

--- a/packages/node/saga-stack-cli/src/core/env/reset-plan.ts
+++ b/packages/node/saga-stack-cli/src/core/env/reset-plan.ts
@@ -1,0 +1,739 @@
+/**
+ * `ss env org reset` delete-plan model (soa#355, Phase 1) — PURE.
+ *
+ * Extends the Phase-0 footprint with the FULL org-reachable delete cascade,
+ * verified table-by-table against the owning repos' prisma schemas
+ * (2026-07-21 mining pass; each rule's source is the store's `schemaSource`
+ * in `footprint.ts` plus rostering iam-pii-db and the program-hub trio):
+ *
+ *   - id-set RESOLUTION steps (`RESET_RESOLVE_STEPS`): programIds → periodIds
+ *     → cohortIds/podIds/slotIds/scheduleIds/sessionIds, run in dependency
+ *     order against the connected stores BEFORE any delete anywhere (deleting
+ *     destroys the resolution evidence). Projection-side unions sweep orphan
+ *     ids whose source rows are already gone (e.g. a schedule REPLACE mints a
+ *     new scheduleId — stale generations linger only in sessions refs).
+ *   - per-store ordered DELETE plans (`RESET_STORES` → `buildResetPlan`):
+ *     children before parents (the two hard FK constraints: programs
+ *     `pod_assignment`→`slot_projection` is ON DELETE RESTRICT; scheduling
+ *     `CalendarEvent` carries SetNull/default FKs to RecurrenceRule/DayType).
+ *     sessions-api is `relationMode = "prisma"` — zero DB-level FKs there.
+ *
+ * SKELETON PROTECTION IS IN THE SQL, not in command logic: the org group row,
+ * the admin user, the admin's seeded membership, and the org's seeded personas
+ * are excluded by explicit `<>` / `NOT IN` predicates on their deterministic
+ * catalog ids, and the `users` delete carries the multi-org rule — a user with
+ * ANY membership outside the org's groups (any status; historical rows still
+ * prove external existence) survives — plus the env-wide-actor rule: iam
+ * models environment-level identity WITHOUT membership rows (`users.role`
+ * other than USER, `user_system_roles`), so users carrying either marker
+ * survive even when their only membership is inside the org. Cross-store user
+ * sweeps (projections, PII, coach progress) use `userDelIds` — the
+ * survivors-excluded set, which carries the SAME exclusions — never the raw
+ * reachable set, so a surviving user's mirrors/PII/progress survive along
+ * with their iam row.
+ *
+ * SQL SAFETY: ids are inlined as literals (psql shell-out has no bind params).
+ * Every UUID set passes `assertUuids`; session ids are base64url-encoded
+ * natural keys (`tutoring_session.id = base64url(date|periodId|slotId|podId)`),
+ * NOT UUIDs, and pass their own strict-charset gate instead.
+ *
+ * Deliberately NEVER touched, in every store: `outbox_event`,
+ * `consumed_events`, `snapshot_metadata`, `audit_logs` (DB-rule append-only),
+ * sessions' `projection_readiness` + `authz_persona_definition`, coach's
+ * authored-content tables + `persona_definition`, programs' `content_item`
+ * (global catalog), and the whole content-api database (no org-reachable
+ * column anywhere).
+ */
+
+import { assertUuids } from './footprint.js';
+import type { FixtureOrg } from './seed-ids.js';
+
+/** db-host-v2 orchestrator Lambda (dev account; `${EnvironmentName}` is always `dev`). */
+export const ORCHESTRATOR_LAMBDA = 'dev-db-host-orchestrator';
+
+/** Snapshot profile name the reset writes restore points under (versioned, immutable). */
+export const SNAPSHOT_PROFILE = 'pre-org-reset';
+
+/** The list-valued id-sets a reset resolves and deletes by. */
+export type ResetSetKey =
+  | 'groupIds'
+  | 'userIds'
+  | 'userDelIds'
+  | 'programIds'
+  | 'periodIds'
+  | 'cohortIds'
+  | 'podIds'
+  | 'slotIds'
+  | 'scheduleIds'
+  | 'sessionIds';
+
+/** Everything the delete plans are parameterized by (catalog anchors + live-resolved sets). */
+export interface ResetIdSets {
+  orgId: string;
+  adminUserId: string;
+  adminMembershipId: string;
+  /** The org's seeded personas (fixed catalog ids) — part of the skeleton, never deleted. */
+  seededPersonaIds: string[];
+  /** All org group ids INCLUDING the org row itself (org_id is self for the district). */
+  groupIds: string[];
+  /** RAW reachable member set (reporting only — deletes use userDelIds). */
+  userIds: string[];
+  /** Deletable users: every membership inside the org's groups, admin excluded. */
+  userDelIds: string[];
+  programIds: string[];
+  periodIds: string[];
+  cohortIds: string[];
+  podIds: string[];
+  slotIds: string[];
+  scheduleIds: string[];
+  /** base64url-encoded natural keys, NOT UUIDs. */
+  sessionIds: string[];
+}
+
+/** Catalog-derived starting point: anchors present, live sets empty. */
+export function initialResetIds(org: FixtureOrg): ResetIdSets {
+  return {
+    orgId: org.orgId,
+    adminUserId: org.adminUserId,
+    adminMembershipId: org.adminMembershipId,
+    seededPersonaIds: [...org.seededPersonaIds],
+    groupIds: [org.orgId],
+    userIds: [org.adminUserId],
+    userDelIds: [],
+    programIds: [],
+    periodIds: [],
+    cohortIds: [],
+    podIds: [],
+    slotIds: [],
+    scheduleIds: [],
+    sessionIds: [],
+  };
+}
+
+/**
+ * `tutoring_session.id` is a versioned opaque key — live dev shape is
+ * `v2.<base64url payload>` (e.g. `v2.D1CLobLD1AAC…`); the version prefix and
+ * its `.` separator plus the base64url alphabet are the full charset. None of
+ * `[A-Za-z0-9._=-]` can smuggle a quote into an inlined literal (only `'`
+ * could, and standard_conforming_strings makes backslashes inert), so this is
+ * the sessionIds analogue of `assertUuids` — anything outside it is refused.
+ */
+const SESSION_ID_RE = /^[A-Za-z0-9._=-]+$/;
+
+/** Every session id inlined into SQL must be strict base64url — throws otherwise. */
+export function assertSessionIds(ids: readonly string[]): void {
+  for (const id of ids) {
+    if (!SESSION_ID_RE.test(id)) {
+      throw new Error(`sessionIds: '${id}' is not a base64url session id — refusing to build SQL with it`);
+    }
+  }
+}
+
+/** Validate EVERY id in a ResetIdSets before any of them is inlined into SQL. */
+export function validateResetIds(ids: ResetIdSets): void {
+  assertUuids([ids.orgId], 'orgId');
+  assertUuids([ids.adminUserId], 'adminUserId');
+  assertUuids([ids.adminMembershipId], 'adminMembershipId');
+  assertUuids(ids.seededPersonaIds, 'seededPersonaIds');
+  assertUuids(ids.groupIds, 'groupIds');
+  assertUuids(ids.userIds, 'userIds');
+  assertUuids(ids.userDelIds, 'userDelIds');
+  assertUuids(ids.programIds, 'programIds');
+  assertUuids(ids.periodIds, 'periodIds');
+  assertUuids(ids.cohortIds, 'cohortIds');
+  assertUuids(ids.podIds, 'podIds');
+  assertUuids(ids.slotIds, 'slotIds');
+  assertUuids(ids.scheduleIds, 'scheduleIds');
+  assertSessionIds(ids.sessionIds);
+}
+
+const lit = (ids: readonly string[]): string => ids.map((id) => `'${id}'`).join(', ');
+
+/** `<column> IN (…)` or null when the set is empty (`IN ()` is invalid SQL). */
+const inSet = (column: string, set: readonly string[]): string | null =>
+  set.length === 0 ? null : `${column} IN (${lit(set)})`;
+
+/** Wrap a SQL builder so the full UUID/charset gate runs before ANY inlining. */
+const guarded =
+  <T>(build: (ids: ResetIdSets) => T) =>
+  (ids: ResetIdSets): T => {
+    validateResetIds(ids);
+    return build(ids);
+  };
+
+/** One id-set resolution step (a SELECT against one store; results union into the set). */
+export interface ResetResolveStep {
+  set: ResetSetKey;
+  /** Store key whose `--url` connection the SELECT runs against. */
+  store: string;
+  label: string;
+  /** SQL, or null when a prerequisite set is empty (nothing to resolve). */
+  sql: (ids: ResetIdSets) => string | null;
+}
+
+/**
+ * Resolution steps in dependency order. Union semantics throughout: results
+ * merge into the (anchor-seeded) sets, deduped, so projection-side steps sweep
+ * orphan ids whose source-of-record rows are already gone.
+ */
+export const RESET_RESOLVE_STEPS: ResetResolveStep[] = [
+  {
+    set: 'groupIds',
+    store: 'iam',
+    label: 'org groups',
+    sql: guarded((ids) => `SELECT id FROM groups WHERE org_id = '${ids.orgId}'`),
+  },
+  {
+    set: 'userIds',
+    store: 'iam',
+    label: 'reachable member users',
+    sql: guarded((ids) => `SELECT DISTINCT user_id FROM group_memberships WHERE ${inSet('group_id', ids.groupIds)}`),
+  },
+  {
+    // The multi-org rule LIVES HERE (and again, belt-and-braces, in the users
+    // DELETE): a user with any membership outside the org's groups — any
+    // status; historical rows still prove external existence — is NOT
+    // deletable. Neither is an env-wide actor: iam grants environment-level
+    // identity WITHOUT membership rows (`users.role` other than USER,
+    // `user_system_roles`), so either marker means the user is NOT org-owned
+    // even if their only membership row is inside the org.
+    set: 'userDelIds',
+    store: 'iam',
+    label: 'deletable users (multi-org members, env-wide actors, and the admin excluded)',
+    sql: guarded(
+      (ids) =>
+        `SELECT DISTINCT gm.user_id FROM group_memberships gm WHERE gm.group_id IN (${lit(ids.groupIds)})` +
+        ` AND gm.user_id <> '${ids.adminUserId}'` +
+        ` AND NOT EXISTS (SELECT 1 FROM group_memberships gm2 WHERE gm2.user_id = gm.user_id AND gm2.group_id NOT IN (${lit(ids.groupIds)}))` +
+        ` AND NOT EXISTS (SELECT 1 FROM users u WHERE u.id = gm.user_id AND u.role <> 'USER')` +
+        ` AND NOT EXISTS (SELECT 1 FROM user_system_roles usr WHERE usr.user_id = gm.user_id)`,
+    ),
+  },
+  {
+    set: 'programIds',
+    store: 'programs',
+    label: 'programs',
+    sql: guarded((ids) => `SELECT id FROM "Program" WHERE "organizationId" = '${ids.orgId}'`),
+  },
+  {
+    // No deletedAt filter anywhere in resolution: tombstoned rows must be swept too.
+    set: 'periodIds',
+    store: 'programs',
+    label: 'tutoring periods',
+    sql: guarded((ids) => {
+      const c = inSet('"programId"', ids.programIds);
+      return c === null ? null : `SELECT id FROM "TutoringPeriod" WHERE ${c}`;
+    }),
+  },
+  {
+    set: 'cohortIds',
+    store: 'programs',
+    label: 'cohorts',
+    sql: guarded((ids) => {
+      const c = inSet('"periodId"', ids.periodIds);
+      return c === null ? null : `SELECT id FROM "Cohort" WHERE ${c}`;
+    }),
+  },
+  {
+    set: 'podIds',
+    store: 'programs',
+    label: 'pods',
+    sql: guarded((ids) => {
+      const c = inSet('"periodId"', ids.periodIds);
+      return c === null ? null : `SELECT id FROM "Pod" WHERE ${c}`;
+    }),
+  },
+  {
+    set: 'podIds',
+    store: 'sessions',
+    label: 'pods (sessions orphan union)',
+    sql: guarded((ids) => {
+      const c = inSet('period_id', ids.periodIds);
+      return c === null ? null : `SELECT id FROM pod_projection WHERE ${c}`;
+    }),
+  },
+  {
+    set: 'scheduleIds',
+    store: 'scheduling',
+    label: 'schedules',
+    sql: guarded((ids) => {
+      const c = inSet('"programId"', ids.programIds);
+      return c === null ? null : `SELECT id FROM "Schedule" WHERE ${c}`;
+    }),
+  },
+  {
+    // A schedule REPLACE mints a NEW scheduleId; stale generations linger only
+    // in sessions-side refs — union them in for the schedule-keyed ref sweeps.
+    set: 'scheduleIds',
+    store: 'sessions',
+    label: 'schedules (sessions projection union)',
+    sql: guarded((ids) => {
+      const c = inSet('program_id', ids.programIds);
+      return c === null ? null : `SELECT id FROM schedule_projection WHERE ${c}`;
+    }),
+  },
+  {
+    set: 'scheduleIds',
+    store: 'sessions',
+    label: 'schedules (recurrence-rule-ref union)',
+    sql: guarded((ids) => {
+      const c = inSet('period_id', ids.periodIds);
+      return c === null ? null : `SELECT DISTINCT schedule_id FROM recurrence_rule_ref WHERE ${c}`;
+    }),
+  },
+  {
+    // Slot rows ARE RecurrenceRule rows with a non-null periodId (scheduling
+    // is the source of record for slotIds).
+    set: 'slotIds',
+    store: 'scheduling',
+    label: 'slots (recurrence rules)',
+    sql: guarded((ids) => {
+      const c = inSet('"periodId"', ids.periodIds);
+      return c === null ? null : `SELECT id FROM "RecurrenceRule" WHERE ${c}`;
+    }),
+  },
+  {
+    set: 'slotIds',
+    store: 'programs',
+    label: 'slots (programs projection union)',
+    sql: guarded((ids) => {
+      const c = inSet('period_id', ids.periodIds);
+      return c === null ? null : `SELECT id FROM slot_projection WHERE ${c}`;
+    }),
+  },
+  {
+    set: 'slotIds',
+    store: 'sessions',
+    label: 'slots (sessions projection union)',
+    sql: guarded((ids) => {
+      const c = inSet('period_id', ids.periodIds);
+      return c === null ? null : `SELECT id FROM slot_projection WHERE ${c}`;
+    }),
+  },
+  {
+    // Resolve BEFORE tutoring_session is deleted — the rows are the evidence.
+    set: 'sessionIds',
+    store: 'sessions',
+    label: 'session ids',
+    sql: guarded((ids) => {
+      const c = inSet('"periodId"', ids.periodIds);
+      return c === null ? null : `SELECT id FROM tutoring_session WHERE ${c}`;
+    }),
+  },
+];
+
+/** One org-reachable table and how its rows die. */
+export interface ResetDeleteRule {
+  table: string;
+  /** Event-materialized mirror (the orphan category — never self-heals). */
+  projection?: boolean;
+  note?: string;
+  /** WHERE clause, or null to skip (empty id-set — the rows cannot exist). */
+  where: (ids: ResetIdSets) => string | null;
+  /**
+   * Count/verify predicate override for tables whose delete predicate would
+   * SELF-BLIND the post-verify recount (a subquery over rows deleted in the
+   * same transaction reads 0 whether or not the delete worked). Must select
+   * the same rows as `where` at plan time.
+   */
+  count?: (ids: ResetIdSets) => string | null;
+  /**
+   * No non-blinding recount predicate exists (the delete subquery is the only
+   * way to reach the rows) — post-verify reports the table as
+   * verify-indirect instead of a structurally-zero recount.
+   */
+  verify?: 'indirect';
+}
+
+/** One store's reset definition, listed in EXECUTION order (leaf stores first, iam last). */
+export interface ResetStoreDef {
+  /** Store key used in `--url <key>=<conn>` (superset of the footprint keys: adds `iam-pii`). */
+  key: string;
+  service: string;
+  /** db-host-v2 registry serviceName for `--snapshot`, where known. */
+  dbService?: string;
+  rules: ResetDeleteRule[];
+}
+
+/**
+ * The full delete cascade. Store order = execution order: leaf stores first so
+ * a mid-run failure leaves the iam anchor evidence (groups/memberships) intact
+ * for a re-run; iam — whose memberships are the resolution source — dies last.
+ */
+export const RESET_STORES: ResetStoreDef[] = [
+  {
+    key: 'sessions',
+    service: 'sessions-api (program-hub)',
+    rules: [
+      // relationMode="prisma" — no DB FKs; order is logical (session children first).
+      { table: 'session_observation_note', where: guarded((ids) => inSet('session_id', ids.sessionIds)) },
+      { table: 'qtf_evaluation', where: guarded((ids) => inSet('session_id', ids.sessionIds)) },
+      {
+        table: 'session_alias',
+        note: 'aliases minted before their lazily-written session row are unreachable via sessionIds (known residue)',
+        where: guarded((ids) => inSet('canonical_id', ids.sessionIds)),
+      },
+      { table: 'tutoring_session', where: guarded((ids) => inSet('"periodId"', ids.periodIds)) },
+      { table: 'session_instance_override', where: guarded((ids) => inSet('"periodId"', ids.periodIds)) },
+      { table: 'schedule_projection', projection: true, where: guarded((ids) => inSet('program_id', ids.programIds)) },
+      { table: 'slot_projection', projection: true, where: guarded((ids) => inSet('period_id', ids.periodIds)) },
+      { table: 'recurrence_rule_ref', projection: true, where: guarded((ids) => inSet('period_id', ids.periodIds)) },
+      { table: 'scheduling_holiday_ref', projection: true, where: guarded((ids) => inSet('schedule_id', ids.scheduleIds)) },
+      { table: 'occurrence_cancellation_ref', projection: true, where: guarded((ids) => inSet('period_id', ids.periodIds)) },
+      { table: 'slot_occurrence_cancellation_ref', projection: true, where: guarded((ids) => inSet('period_id', ids.periodIds)) },
+      { table: 'occurrence_time_override_ref', projection: true, where: guarded((ids) => inSet('period_id', ids.periodIds)) },
+      { table: 'manual_addition_ref', projection: true, where: guarded((ids) => inSet('period_id', ids.periodIds)) },
+      { table: 'period_meeting_ref', projection: true, where: guarded((ids) => inSet('period_id', ids.periodIds)) },
+      { table: 'period_membership', projection: true, where: guarded((ids) => inSet('period_id', ids.periodIds)) },
+      { table: 'pod_membership', projection: true, where: guarded((ids) => inSet('pod_id', ids.podIds)) },
+      { table: 'cohort_membership', projection: true, where: guarded((ids) => inSet('cohort_id', ids.cohortIds)) },
+      { table: 'pod_tutor_projection', projection: true, where: guarded((ids) => inSet('pod_id', ids.podIds)) },
+      { table: 'program_projection', projection: true, where: guarded((ids) => inSet('id', ids.programIds)) },
+      { table: 'period_projection', projection: true, where: guarded((ids) => inSet('program_id', ids.programIds)) },
+      { table: 'cohort_projection', projection: true, where: guarded((ids) => inSet('period_id', ids.periodIds)) },
+      { table: 'pod_projection', projection: true, where: guarded((ids) => inSet('period_id', ids.periodIds)) },
+      { table: 'pod_assignment_projection', projection: true, where: guarded((ids) => inSet('period_id', ids.periodIds)) },
+      { table: 'program_school_mapping_projection', projection: true, where: guarded((ids) => inSet('program_id', ids.programIds)) },
+      {
+        table: 'pod_assignment_override_projection',
+        projection: true,
+        note: 'prisma model is named PodAssignmentOverride; the TABLE is pod_assignment_override_projection',
+        where: guarded((ids) => inSet('slot_id', ids.slotIds)),
+      },
+      {
+        // The admin's org membership survives in iam — its mirror survives too.
+        table: 'authz_group_membership',
+        projection: true,
+        where: guarded(
+          (ids) => `group_id IN (${lit(ids.groupIds)}) AND iam_row_id IS DISTINCT FROM '${ids.adminMembershipId}'`,
+        ),
+      },
+      {
+        // The org group row survives in iam — keep its hierarchy mirror.
+        table: 'authz_group_hierarchy',
+        projection: true,
+        where: guarded((ids) => `child_group_id IN (${lit(ids.groupIds)}) AND child_group_id <> '${ids.orgId}'`),
+      },
+      {
+        // Two sweeps in one predicate: assignments OF deleted users anywhere in
+        // the org, plus assignments scoped to dying child groups (surviving
+        // users' org-row assignments — the admin's — are kept).
+        table: 'authz_persona_assignment',
+        projection: true,
+        where: guarded((ids) => {
+          const parts: string[] = [];
+          const u = inSet('user_id', ids.userDelIds);
+          if (u !== null) parts.push(u);
+          parts.push(`(group_id IN (${lit(ids.groupIds)}) AND group_id <> '${ids.orgId}')`);
+          return parts.join(' OR ');
+        }),
+      },
+      {
+        // userDelIds, NOT the raw reachable set: a multi-org user's iam row
+        // survives, so its mirror must too (a deleted mirror never self-heals).
+        table: 'user_projection',
+        projection: true,
+        where: guarded((ids) => inSet('id', ids.userDelIds)),
+      },
+    ],
+  },
+  {
+    key: 'scheduling',
+    service: 'scheduling-api (program-hub)',
+    rules: [
+      {
+        table: '"DayTypeBlock"',
+        // Reached ONLY through DayType (deleted later in the same transaction)
+        // — the recount would self-blind, so post-verify reports it indirect.
+        verify: 'indirect',
+        where: guarded((ids) => {
+          const c = inSet('"scheduleId"', ids.scheduleIds);
+          return c === null ? null : `"dayTypeId" IN (SELECT id FROM "DayType" WHERE ${c})`;
+        }),
+      },
+      // CalendarEvent BEFORE RecurrenceRule/DayType (SetNull/default FKs S:153-154).
+      { table: '"CalendarEvent"', where: guarded((ids) => inSet('"scheduleId"', ids.scheduleIds)) },
+      { table: '"RecurrenceRule"', where: guarded((ids) => inSet('"scheduleId"', ids.scheduleIds)) },
+      { table: '"DayType"', where: guarded((ids) => inSet('"scheduleId"', ids.scheduleIds)) },
+      { table: '"SlotOccurrenceCancellation"', where: guarded((ids) => inSet('"scheduleId"', ids.scheduleIds)) },
+      { table: '"OccurrenceTimeOverride"', where: guarded((ids) => inSet('"scheduleId"', ids.scheduleIds)) },
+      { table: '"ManualAddition"', where: guarded((ids) => inSet('"scheduleId"', ids.scheduleIds)) },
+      { table: '"PeriodScheduleConfig"', where: guarded((ids) => inSet('"scheduleId"', ids.scheduleIds)) },
+      { table: '"Schedule"', where: guarded((ids) => inSet('"programId"', ids.programIds)) },
+      // period_id is the PK; program_id is nullable — filter on period_id.
+      { table: 'rotation_config_projection', projection: true, where: guarded((ids) => inSet('period_id', ids.periodIds)) },
+      { table: 'period_projection', projection: true, where: guarded((ids) => inSet('program_id', ids.programIds)) },
+      { table: 'program_projection', projection: true, where: guarded((ids) => `organization_id = '${ids.orgId}'`) },
+    ],
+  },
+  {
+    key: 'programs',
+    service: 'programs-api (program-hub)',
+    rules: [
+      // pod_assignment → slot_projection is ON DELETE RESTRICT: #1 must precede
+      // the slot_projection delete below. Everything else child-first anyway.
+      { table: 'pod_assignment', where: guarded((ids) => inSet('pod_id', ids.podIds)) },
+      { table: 'pod_assignment_override', where: guarded((ids) => inSet('slot_id', ids.slotIds)) },
+      { table: '"PodTutor"', where: guarded((ids) => inSet('"podId"', ids.podIds)) },
+      { table: '"PodStudent"', where: guarded((ids) => inSet('"podId"', ids.podIds)) },
+      { table: '"PodGroup"', where: guarded((ids) => inSet('"podId"', ids.podIds)) },
+      { table: '"Pod"', where: guarded((ids) => inSet('"periodId"', ids.periodIds)) },
+      { table: '"SectionPeriodAssignment"', where: guarded((ids) => inSet('"periodId"', ids.periodIds)) },
+      {
+        table: '"ProgramSectionMapping"',
+        // Reached ONLY through ProgramSchoolMapping (deleted next in the same
+        // transaction) — the recount would self-blind; reported indirect.
+        verify: 'indirect',
+        where: guarded((ids) => {
+          const c = inSet('"programId"', ids.programIds);
+          return c === null ? null : `"schoolMappingId" IN (SELECT id FROM "ProgramSchoolMapping" WHERE ${c})`;
+        }),
+      },
+      { table: '"ProgramSchoolMapping"', where: guarded((ids) => inSet('"programId"', ids.programIds)) },
+      { table: '"Classroom"', where: guarded((ids) => inSet('"periodId"', ids.periodIds)) },
+      { table: '"RotationConfig"', where: guarded((ids) => inSet('"periodId"', ids.periodIds)) },
+      { table: '"RotationCalendarDay"', where: guarded((ids) => inSet('"periodId"', ids.periodIds)) },
+      { table: '"Cohort"', where: guarded((ids) => inSet('"periodId"', ids.periodIds)) },
+      { table: '"TutoringPeriod"', where: guarded((ids) => inSet('"programId"', ids.programIds)) },
+      { table: '"ProgramGroup"', where: guarded((ids) => inSet('"programId"', ids.programIds)) },
+      { table: '"ProgramLink"', where: guarded((ids) => inSet('"programId"', ids.programIds)) },
+      { table: '"ProgramFile"', where: guarded((ids) => inSet('"programId"', ids.programIds)) },
+      { table: '"Program"', where: guarded((ids) => `"organizationId" = '${ids.orgId}'`) },
+      { table: 'slot_projection', projection: true, where: guarded((ids) => inSet('period_id', ids.periodIds)) },
+      { table: 'period_membership', projection: true, where: guarded((ids) => inSet('period_id', ids.periodIds)) },
+      { table: 'cohort_membership', projection: true, where: guarded((ids) => inSet('cohort_id', ids.cohortIds)) },
+      { table: 'pod_membership', projection: true, where: guarded((ids) => inSet('pod_id', ids.podIds)) },
+      { table: 'program_membership', projection: true, where: guarded((ids) => inSet('program_id', ids.programIds)) },
+      { table: 'program_section_resolution', projection: true, where: guarded((ids) => inSet('program_id', ids.programIds)) },
+      { table: 'pod_tutor_projection', projection: true, where: guarded((ids) => inSet('pod_id', ids.podIds)) },
+      { table: 'user_projection', projection: true, where: guarded((ids) => inSet('id', ids.userDelIds)) },
+    ],
+  },
+  {
+    key: 'ads-adm',
+    service: 'ads-adm-api (student-data-system)',
+    dbService: 'ads-adm-postgres',
+    rules: [
+      {
+        // TEXT columns (branded strings) — literals are the same shape. The
+        // iam_user_id disjunct is the belt-and-braces orphan sweep, SCOPED to
+        // the org's periods: userDelIds membership is decided purely by iam
+        // group_memberships, and enrollment paths that feed ADS do not require
+        // an iam membership row in the owning org — unscoped, the disjunct
+        // could reach OTHER orgs' attendance rows.
+        table: 'adm_attendance',
+        where: guarded((ids) => {
+          const parts: string[] = [];
+          const p = inSet('program_id', ids.programIds);
+          if (p !== null) parts.push(p);
+          const u = inSet('iam_user_id', ids.userDelIds);
+          const per = inSet('period_id', ids.periodIds);
+          if (u !== null && per !== null) parts.push(`(${u} AND ${per})`);
+          return parts.length === 0 ? null : parts.join(' OR ');
+        }),
+      },
+      // NO program_id column exists here — reachable via periodIds only.
+      { table: 'period_attendance_status', where: guarded((ids) => inSet('period_id', ids.periodIds)) },
+    ],
+  },
+  {
+    key: 'coach',
+    service: 'coach-api (coach)',
+    rules: [
+      // Cascades content_instance_module + content_instance_completed_module (real FKs).
+      { table: 'content_instance', where: guarded((ids) => inSet('user_id', ids.userDelIds)) },
+      // content_instance_id is a PLAIN column (no FK) — explicit delete by user.
+      { table: 'module_answer', where: guarded((ids) => inSet('user_id', ids.userDelIds)) },
+      {
+        // The admin's org-row assignment mirrors the KEPT iam membership row
+        // (iam_row_id = adminMembershipId) — coach projections never re-emit
+        // for unchanged iam rows, so deleting it would break the admin's coach
+        // persona permanently. Same protection as sessions' authz mirrors.
+        table: 'persona_assignment',
+        projection: true,
+        where: guarded((ids) => {
+          const parts: string[] = [];
+          const u = inSet('user_id', ids.userDelIds);
+          if (u !== null) parts.push(u);
+          parts.push(`(group_id IN (${lit(ids.groupIds)}) AND iam_row_id IS DISTINCT FROM '${ids.adminMembershipId}')`);
+          return parts.join(' OR ');
+        }),
+      },
+      // Runtime config, not seed — the org row's mapping dies too (full G_ALL).
+      { table: 'group_track_map', projection: true, where: guarded((ids) => `group_id IN (${lit(ids.groupIds)})`) },
+    ],
+  },
+  {
+    key: 'iam-pii',
+    service: 'iam-pii (rostering, separate database)',
+    rules: [
+      {
+        // No cross-DB FK — swept explicitly with userDelIds; admin belt-and-braces.
+        table: 'user_pii',
+        where: guarded((ids) => {
+          const u = inSet('user_id', ids.userDelIds);
+          return u === null ? null : `${u} AND user_id <> '${ids.adminUserId}'`;
+        }),
+      },
+    ],
+  },
+  {
+    key: 'iam',
+    service: 'iam-api (rostering)',
+    dbService: 'rostering-iam-canonical',
+    rules: [
+      {
+        // MUST run before group_memberships dies — the membership rows are the
+        // multi-org evidence. Cascades profiles/qualifications/auth_associations/
+        // system_roles/memberships; user_policies.target_user_id SET NULLs.
+        // Mirrors the userDelIds resolution exclusions exactly (multi-org,
+        // env-wide actors, admin) so the cross-store sweeps agree with what
+        // actually dies here. The recount uses the pre-resolved userDelIds
+        // literal set — the subquery predicate would self-blind post-verify
+        // (group_memberships dies in the same transaction).
+        table: 'users',
+        note: 'multi-org members, env-wide actors (non-USER role or any system role), and the admin survive',
+        where: guarded(
+          (ids) =>
+            `id IN (SELECT DISTINCT gm.user_id FROM group_memberships gm WHERE gm.group_id IN (${lit(ids.groupIds)}))` +
+            ` AND id <> '${ids.adminUserId}'` +
+            ` AND NOT EXISTS (SELECT 1 FROM group_memberships gm2 WHERE gm2.user_id = users.id AND gm2.group_id NOT IN (${lit(ids.groupIds)}))` +
+            ` AND users.role = 'USER'` +
+            ` AND NOT EXISTS (SELECT 1 FROM user_system_roles usr WHERE usr.user_id = users.id)`,
+        ),
+        count: guarded((ids) => inSet('id', ids.userDelIds)),
+      },
+      {
+        // Remaining org memberships of SURVIVING multi-org users; the admin's
+        // seeded skeleton membership is kept by its deterministic id.
+        table: 'group_memberships',
+        where: guarded((ids) => `group_id IN (${lit(ids.groupIds)}) AND id <> '${ids.adminMembershipId}'`),
+      },
+      {
+        // Seeded org personas (fixed catalog ids) are skeleton — kept, along with
+        // whatever persona the kept admin membership references. Cascades
+        // persona_permissions + persona_policies.
+        table: 'personas',
+        where: guarded((ids) => {
+          const seeded = ids.seededPersonaIds.length > 0 ? ` AND id NOT IN (${lit(ids.seededPersonaIds)})` : '';
+          return (
+            `group_id IN (${lit(ids.groupIds)})${seeded}` +
+            ` AND id NOT IN (SELECT persona_id FROM group_memberships WHERE id = '${ids.adminMembershipId}' AND persona_id IS NOT NULL)`
+          );
+        }),
+      },
+      // Explicit — the kept org row never cascades its children.
+      { table: 'user_policies', where: guarded((ids) => `group_id IN (${lit(ids.groupIds)})`) },
+      {
+        // Org-row auth config is SEEDED config — excluded (child groups' rows die).
+        table: 'group_auth_config',
+        where: guarded((ids) => `group_id IN (${lit(ids.groupIds)}) AND group_id <> '${ids.orgId}'`),
+      },
+      {
+        // Org-row login profile is seeded auth config — excluded, like its
+        // siblings group_auth_config / group_attributes (child groups' die).
+        table: 'login_profiles',
+        where: guarded((ids) => `group_id IN (${lit(ids.groupIds)}) AND group_id <> '${ids.orgId}'`),
+      },
+      {
+        // Org-row attributes (e.g. trackingMode) are seeded config — excluded.
+        table: 'group_attributes',
+        where: guarded((ids) => `group_id IN (${lit(ids.groupIds)}) AND group_id <> '${ids.orgId}'`),
+      },
+      // Child groups only — the org anchor row survives (the skeleton).
+      { table: 'groups', where: guarded((ids) => `org_id = '${ids.orgId}' AND id <> '${ids.orgId}'`) },
+    ],
+  },
+];
+
+/** All store keys `env org reset --url` accepts (execution order). */
+export const RESET_STORE_KEYS: string[] = RESET_STORES.map((s) => s.key);
+
+/** One planned statement (kind is always 'delete' — resolution runs separately, cross-store). */
+export interface ResetStatement {
+  table: string;
+  kind: 'delete' | 'resolve';
+  sql: string;
+  projection: boolean;
+}
+
+/** One table's planned delete + its matching (same-rows-at-plan-time) count query. */
+export interface ResetTablePlan {
+  table: string;
+  projection: boolean;
+  deleteSql: string | null;
+  countSql: string | null;
+  /** Post-verify cannot recount this table meaningfully (see ResetDeleteRule.verify). */
+  verify?: 'indirect';
+  skipped?: string;
+  note?: string;
+}
+
+export interface StoreResetPlan {
+  store: string;
+  service: string;
+  dbService?: string;
+  tables: ResetTablePlan[];
+  statements: ResetStatement[];
+  /** BEGIN/COMMIT-wrapped compound of every applicable delete (ONE psql -c, all-or-nothing), or null. */
+  transactionSql: string | null;
+}
+
+/**
+ * Build every store's ordered, skeleton-protected delete plan from fully
+ * resolved id-sets. Pure; validates every id before inlining anything.
+ */
+export function buildResetPlan(ids: ResetIdSets): StoreResetPlan[] {
+  validateResetIds(ids);
+  return RESET_STORES.map((store) => {
+    const tables: ResetTablePlan[] = store.rules.map((rule) => {
+      const where = rule.where(ids);
+      if (where === null) {
+        return {
+          table: rule.table,
+          projection: rule.projection === true,
+          deleteSql: null,
+          countSql: null,
+          skipped: 'empty id-set',
+          note: rule.note,
+        };
+      }
+      const countWhere = rule.count === undefined ? where : rule.count(ids);
+      return {
+        table: rule.table,
+        projection: rule.projection === true,
+        deleteSql: `DELETE FROM ${rule.table} WHERE ${where}`,
+        countSql: countWhere === null ? null : `SELECT count(*) FROM ${rule.table} WHERE ${countWhere}`,
+        verify: rule.verify,
+        note: rule.note,
+      };
+    });
+    const statements: ResetStatement[] = tables
+      .filter((t) => t.deleteSql !== null)
+      .map((t) => ({ table: t.table, kind: 'delete' as const, sql: t.deleteSql as string, projection: t.projection }));
+    const transactionSql =
+      statements.length === 0 ? null : ['BEGIN', ...statements.map((s) => s.sql), 'COMMIT'].join(';\n') + ';';
+    return { store: store.key, service: store.service, dbService: store.dbService, tables, statements, transactionSql };
+  });
+}
+
+/**
+ * Pre-flight identity + post-run skeleton probes (iam). The reset refuses to
+ * run unless the org row IS the catalog org (display name) and the admin IS
+ * the catalog admin (username = catalog email) — the belt-and-braces check
+ * that the connected database really holds the seeded fixture org.
+ */
+export const RESET_GUARD_SQL = {
+  orgRow: (orgId: string): string => {
+    assertUuids([orgId], 'orgId');
+    return `SELECT display_name FROM groups WHERE id = '${orgId}'`;
+  },
+  adminUser: (adminUserId: string): string => {
+    assertUuids([adminUserId], 'adminUserId');
+    return `SELECT username FROM users WHERE id = '${adminUserId}'`;
+  },
+  adminMembership: (adminMembershipId: string): string => {
+    assertUuids([adminMembershipId], 'adminMembershipId');
+    return `SELECT id FROM group_memberships WHERE id = '${adminMembershipId}'`;
+  },
+};

--- a/packages/node/saga-stack-cli/src/core/env/seed-ids.ts
+++ b/packages/node/saga-stack-cli/src/core/env/seed-ids.ts
@@ -1,0 +1,107 @@
+/**
+ * Deterministic canonical seed-id derivation — a byte-exact reimplementation of
+ * `@saga-ed/iam-seed-ids` (`rostering/packages/core/iam-seed-ids/src/derive.ts`)
+ * for the `ss env` family (soa#355).
+ *
+ * Every canonical fixture UUID in the fleet is `uuidv5('<kind>:<slug>', ROOT_NAMESPACE)`.
+ * Reimplemented here (node:crypto SHA-1; RFC 4122 v5 is implementation-independent)
+ * instead of depending on the published package because saga-stack-cli deliberately
+ * carries no registry dependencies beyond oclif — and the derivation IS the contract:
+ * `seed-ids.unit.test.ts` byte-matches the canonical Empty Org id, so any drift from
+ * the rostering package fails loudly.
+ *
+ * SAFETY ROLE: `ss env org` commands target orgs by catalog SLUG only; the UUID is
+ * derived, never typed. An org id that this module cannot derive is not a fixture
+ * org and is refused by default — that is the structural guard protecting the
+ * hand-built training orgs from a mistyped target.
+ */
+
+import { createHash } from 'node:crypto';
+
+/**
+ * The fixed root namespace for ALL saga canonical seed ids (the contract value
+ * from iam-seed-ids — NEVER change it; changing it re-randomizes every id).
+ */
+export const ROOT_NAMESPACE = 'b2c4f1a0-5e3d-4c9a-8f6b-1d2e3f4a5b6c';
+
+/** RFC 4122 v5 (SHA-1) UUID, byte-identical to iam-seed-ids' @noble/hashes version. */
+export function uuidv5(name: string, namespace: string = ROOT_NAMESPACE): string {
+  const ns = Buffer.from(namespace.replace(/-/g, ''), 'hex');
+  const digest = createHash('sha1').update(Buffer.concat([ns, Buffer.from(name, 'utf8')])).digest();
+  const b = Uint8Array.prototype.slice.call(digest, 0, 16);
+  b[6] = (b[6]! & 0x0f) | 0x50; // version 5
+  b[8] = (b[8]! & 0x3f) | 0x80; // RFC 4122 variant
+  const h = Buffer.from(b).toString('hex');
+  return `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20)}`;
+}
+
+/** Deterministic UUID for a group (district/school/section) slug. */
+export const deriveGroupId = (slug: string): string => uuidv5(`group:${slug}`);
+
+/** Deterministic UUID for a user slug. */
+export const deriveUserId = (slug: string): string => uuidv5(`user:${slug}`);
+
+/** Deterministic UUID for the INITIAL seeded (user, group) membership row. */
+export const deriveGroupMembershipId = (userId: string, groupId: string): string =>
+  uuidv5(`group_membership:${userId}:${groupId}`);
+
+/**
+ * A resettable fixture org: the catalog entry `ss env org` commands accept.
+ * Only orgs listed in `RESETTABLE_ORGS` may be targeted by slug; everything
+ * else requires the unsafe escape hatch (and its typed-name confirm).
+ */
+export interface FixtureOrg {
+  slug: string;
+  displayName: string;
+  orgId: string;
+  adminSlug: string;
+  adminEmail: string;
+  adminUserId: string;
+  adminMembershipId: string;
+  /**
+   * The org's SEEDED persona rows (fixed ids from iam-seed-ids `personas.ts`
+   * — not uuidv5-derived). Part of the seed skeleton: `env org reset` keeps
+   * them (and their cascaded permissions) by explicit NOT IN predicates.
+   */
+  seededPersonaIds: string[];
+}
+
+function fixtureOrg(
+  slug: string,
+  displayName: string,
+  adminSlug: string,
+  adminEmail: string,
+  seededPersonaIds: string[],
+): FixtureOrg {
+  const orgId = deriveGroupId(slug);
+  const adminUserId = deriveUserId(adminSlug);
+  return {
+    slug,
+    displayName,
+    orgId,
+    adminSlug,
+    adminEmail,
+    adminUserId,
+    adminMembershipId: deriveGroupMembershipId(adminUserId, orgId),
+    seededPersonaIds,
+  };
+}
+
+/**
+ * The orgs `ss env org` will operate on, keyed by slug. Deliberately starts as
+ * Empty Org ONLY — the org whose whole purpose is scratch/journey testing
+ * ("district with an admin but NOTHING else", iam-seed-ids catalog). Growing
+ * this list is a reviewed code change, not a runtime input.
+ */
+export const RESETTABLE_ORGS: Record<string, FixtureOrg> = {
+  // Seeded personas: personaAdmin/Student/TutorEmptyOrg — fixed ids from
+  // rostering/packages/core/iam-seed-ids/src/personas.ts (verified 2026-07-21).
+  emptyOrg: fixtureOrg('emptyOrg', 'Empty Org', 'empty', 'empty@saga.org', [
+    '00000000-0000-4000-a003-000000000021',
+    '00000000-0000-4000-a003-000000000022',
+    '00000000-0000-4000-a003-000000000023',
+  ]),
+};
+
+/** Resolve a fixture org by slug; undefined for anything not in the catalog. */
+export const resolveFixtureOrg = (slug: string): FixtureOrg | undefined => RESETTABLE_ORGS[slug];

--- a/packages/node/saga-stack-cli/src/core/env/services.ts
+++ b/packages/node/saga-stack-cli/src/core/env/services.ts
@@ -1,0 +1,300 @@
+/**
+ * Deployed-service health model for `ss env verify` (soa#355) — PURE.
+ *
+ * The deployed-env analogue of `core/probe-plan.ts` (which `stack verify` uses
+ * for the LOCAL mesh). Two things make a deployed env different, both learned
+ * empirically against dev + training on 2026-07-21:
+ *
+ * 1. **HTTP 200 IS NOT A HEALTH SIGNAL HERE.** `*.wootdev.com` (and
+ *    `*.saga-training.org`) are wildcard DNS onto the shared ALB, whose default
+ *    action answers **200 with the body `dev-account-alb`** for ANY unmatched
+ *    hostname. A status-code-only probe therefore reports every service — even
+ *    ones that do not exist — as healthy. Health MUST be judged from the BODY
+ *    (`classifyProbeBody`): an API answers `{"status":"ok"|"healthy","service":…}`,
+ *    a frontend answers an HTML document.
+ * 2. **The deployed hostname is NOT the manifest `tunnelSlug`.** It varies per
+ *    service: `iam`/`sis` are short, the rest are the full service id
+ *    (`programs-api`, `sessions-api`, …), `coach` is the coach WEB frontend
+ *    (the API is `coach-api`), connect-api answers on `connectv3-api`, and
+ *    rtsm/fleek are SHARED fleets pinned to `*.wootdev.com` for every env
+ *    (`fqdn`), not per-env hosts.
+ *    The map is taken from the ALB host-header rules + a live body check, not
+ *    derived — a guessed host silently reads as an ALB "down".
+ *
+ * A service with no `host` cannot be verified over HTTP — it is reported as
+ * such (never silently green) and covered by the `--ecs` platform check where
+ * an ECS service exists. Today that is only `connect-web` (Amplify-hosted).
+ */
+
+/**
+ * How a healthy response is recognised.
+ *  - `api`      JSON body with an allowlisted `status` (the shared-ALB fleet + rtsm).
+ *  - `frontend` an HTML document (Amplify SPAs).
+ *  - `plain`    a 2xx is sufficient — the body may be empty or plain text.
+ *               ONLY for hosts that are NOT behind the shared ALB (fleek's own
+ *               Caddy cluster), where a 200 genuinely means "this host served
+ *               it" rather than "the wildcard default answered".
+ */
+export type ServiceKind = 'api' | 'frontend' | 'plain';
+
+export interface DeployedServiceDef {
+  /** Manifest service id (kept aligned with core/manifest for cross-reference). */
+  id: string;
+  /** Subdomain under the env's domain, or undefined when there is no public route. */
+  host?: string;
+  /**
+   * ABSOLUTE hostname, used INSTEAD of `<host>.<domain>` for infrastructure that
+   * is SHARED across environments rather than deployed per-env (rtsm, fleek —
+   * both envs' services point at the same `*.wootdev.com` fleet; see the
+   * `RECORDER_URL_TEMPLATE` / `RTSM_API_URL` env on the connectv3-api task
+   * definitions, where the TRAINING service names `.wootdev.com` hosts).
+   */
+  fqdn?: string;
+  /**
+   * Per-ENV absolute hostname, keyed by env name — for services deployed per
+   * env but NOT under the env's domain. connect-web (connectv3) is a Vite SPA
+   * on Amplify with no custom domain, so it lives at
+   * `<branch>.<amplify-app-id>.amplifyapp.com` (qboard/CLAUDE.md "Web main").
+   */
+  fqdnByEnv?: Record<string, string>;
+  /** Path probed for health (APIs `/health`; frontends `/`). */
+  healthPath: string;
+  kind: ServiceKind;
+  /** A down/unroutable OPTIONAL service does not fail the gate. */
+  optional?: boolean;
+  /**
+   * ECS service-name prefix in the shared cluster (`<ecsService>-<identifier>`)
+   * for the platform check. Undefined where the name is not yet confirmed —
+   * that check is then skipped with a note rather than guessed.
+   */
+  ecsService?: string;
+  note?: string;
+}
+
+/**
+ * The deployed service set, verified by response body against BOTH dev and
+ * training (identical map on both) on 2026-07-21. Growing/altering it is a
+ * reviewed change — a wrong host silently becomes an ALB-default "down".
+ */
+export const DEPLOYED_SERVICES: DeployedServiceDef[] = [
+  { id: 'iam-api', host: 'iam', healthPath: '/health', kind: 'api', ecsService: 'rostering-iam-api' },
+  { id: 'sis-api', host: 'sis', healthPath: '/health', kind: 'api', ecsService: 'rostering-sis-api' },
+  { id: 'programs-api', host: 'programs-api', healthPath: '/health', kind: 'api', ecsService: 'program-hub-programs-api' },
+  { id: 'scheduling-api', host: 'scheduling-api', healthPath: '/health', kind: 'api', ecsService: 'program-hub-scheduling-api' },
+  { id: 'sessions-api', host: 'sessions-api', healthPath: '/health', kind: 'api', ecsService: 'program-hub-sessions-api' },
+  { id: 'content-api', host: 'content-api', healthPath: '/health', kind: 'api', ecsService: 'program-hub-content-api' },
+  {
+    id: 'ads-adm-api',
+    host: 'ads-adm-api',
+    healthPath: '/health',
+    kind: 'api',
+    ecsService: 'sds-ads-adm-api',
+    note: 'also answers on ads-adm.<domain> (sds#288 multi-host ALB rule)',
+  },
+  { id: 'coach-api', host: 'coach-api', healthPath: '/health', kind: 'api', ecsService: 'coach-coach-api' },
+  { id: 'saga-dash', host: 'dash', healthPath: '/', kind: 'frontend', note: 'Amplify-hosted SPA (not an ECS service)' },
+  { id: 'coach-web', host: 'coach', healthPath: '/', kind: 'frontend', note: 'Amplify-hosted SPA, not ECS (the API is coach-api)' },
+  {
+    // Host is connectv3-api.<domain> (NOT connect-api/connect) — confirmed from
+    // the ALB host-header rules and live on both envs. Its body carries no
+    // `service` key: {"status":"ok","mongo":"ok"}.
+    id: 'connect-api',
+    host: 'connectv3-api',
+    healthPath: '/connectv3/v1/health',
+    kind: 'api',
+    ecsService: 'qboard-connectv3-api',
+  },
+  { id: 'transcripts-api', host: 'transcripts-api', healthPath: '/health', kind: 'api', optional: true, ecsService: 'sds-transcripts-api' },
+  {
+    // fleek is the recording fleet — its OWN Caddy cluster (`*.fleek.<domain>`,
+    // nodes chi-1/nyc-1/phx-1/vet-1 + recorder-*/recordings-* aliases), not the
+    // shared ALB. `/health` answers 200 with an EMPTY body (`/` answers "OK"),
+    // hence kind 'plain' — fleek/OPS.md:145 confirms "HTTP 200 on {node}/health"
+    // IS the Caddy signal. fleek/OPS.md:92-93 defines health as BOTH this and
+    // the livekit recorder endpoint (next entry). Probed via chi-1; nyc-1 was
+    // unreachable on 2026-07-22 (both fleek and rtsm).
+    // Operator (SSH) access to these nodes needs a short-lived cert:
+    //   saws.js cert -n fleek -n rtsm -p dev_admin
+    // — that is for ssh -p 727, NOT for this HTTP probe, which needs no cert.
+    id: 'fleek',
+    fqdn: 'chi-1.fleek.wootdev.com',
+    healthPath: '/health',
+    kind: 'plain',
+    note: 'shared Caddy recording fleet (*.fleek.wootdev.com) — BOTH envs use it',
+  },
+  {
+    // The second half of fleek health per fleek/OPS.md:93 — the livekit
+    // recorder, which a deploy polls alongside the node's Caddy /health.
+    // Answers {"ok":true} (no `status` key), so 'plain' rather than 'api'.
+    id: 'fleek-recorder',
+    fqdn: 'recorder-chi-1.fleek.wootdev.com',
+    healthPath: '/v1/health',
+    kind: 'plain',
+    note: 'livekit recorder (fleek/OPS.md:93); shared fleet — BOTH envs use it',
+  },
+  {
+    // The connectv3 SPA is on Amplify with NO custom domain (unlike dash/coach),
+    // which is why connect.<domain> hits the shared-ALB default. Its real home is
+    // <branch>.<app-id>.amplifyapp.com — app `connectv3` = d2ezd4i8b4uexc, with a
+    // branch per env (qboard/CLAUDE.md documents the shape).
+    id: 'connect-web',
+    fqdnByEnv: {
+      dev: 'dev.d2ezd4i8b4uexc.amplifyapp.com',
+      training: 'training.d2ezd4i8b4uexc.amplifyapp.com',
+    },
+    healthPath: '/',
+    kind: 'frontend',
+    note: 'Amplify app connectv3 (d2ezd4i8b4uexc), branch per env; no custom domain',
+  },
+  {
+    // RTSM runs on its OWN geo-distributed cluster, not the shared ECS/ALB:
+    // `*.rtsm.wootdev.com` on non-AWS IPs (core, core-a/b, chi-1, nyc-1, par-1,
+    // phx-1). `chi-1` is the canonical health route (per Jeff); rtsm/README.md
+    // documents /health (detailed) plus /health/live and /health/ready. NOTE the
+    // bare `core` alias fails the TLS handshake from outside, as do nyc-1/par-1.
+    // Optional because the fleet lives only under wootdev.com — there are no
+    // rtsm records in the saga-training.org zone.
+    id: 'rtsm-api',
+    fqdn: 'chi-1.rtsm.wootdev.com',
+    healthPath: '/health',
+    kind: 'api',
+    note: 'shared geo cluster (*.rtsm.wootdev.com) — BOTH envs use it; not shared ECS/ALB',
+  },
+];
+
+/** One planned deployed health probe. */
+export interface EnvHealthProbe {
+  id: string;
+  kind: ServiceKind;
+  optional: boolean;
+  /** Absolute URL, or null when the service has no public route. */
+  url: string | null;
+  ecsService?: string;
+  note?: string;
+}
+
+/**
+ * Build the probe list for an env (pure). Host resolution, in precedence order:
+ *   `fqdnByEnv[envName]`  per-env absolute host (Amplify apps with no custom domain)
+ *   `fqdn`                shared infra, same host for every env (rtsm/fleek)
+ *   `<host>.<domain>`     the normal per-env case
+ */
+export function buildEnvHealthProbes(
+  domain: string,
+  envName = '',
+  services: readonly DeployedServiceDef[] = DEPLOYED_SERVICES,
+): EnvHealthProbe[] {
+  return services.map((s) => ({
+    id: s.id,
+    kind: s.kind,
+    optional: s.optional === true,
+    url: resolveProbeUrl(s, domain, envName),
+    ecsService: s.ecsService,
+    note: s.note,
+  }));
+}
+
+/** Resolve a service's probe URL for one env (null when it has no HTTP route there). */
+function resolveProbeUrl(s: DeployedServiceDef, domain: string, envName: string): string | null {
+  const perEnv = s.fqdnByEnv?.[envName];
+  if (perEnv !== undefined) return `https://${perEnv}${s.healthPath}`;
+  if (s.fqdnByEnv !== undefined) return null; // per-env service with no host for THIS env
+  if (s.fqdn !== undefined) return `https://${s.fqdn}${s.healthPath}`;
+  if (s.host === undefined) return null;
+  return `https://${s.host}.${domain}${s.healthPath}`;
+}
+
+/** The verdict a probe body earns. */
+export type BodyVerdict = 'healthy' | 'alb-default' | 'unexpected' | 'empty';
+
+/** The shared-ALB default-action body — a 200 that means "nothing is routed here". */
+const ALB_DEFAULT_MARKER = 'dev-account-alb';
+
+/**
+ * Healthy `status` values, surveyed live across every deployed API on dev
+ * (2026-07-21) — each service picks its own word:
+ *   `ok`      iam, programs, scheduling, sessions, content
+ *   `running` sis, ads-adm
+ *   `healthy` coach
+ * Deliberately an ALLOWLIST, not "anything that isn't an error": a service
+ * reporting `degraded`/`down` must fail the gate, not pass it by omission.
+ */
+const HEALTHY_STATUSES = new Set(['ok', 'healthy', 'running', 'up']);
+
+/**
+ * Judge a probe response by its BODY, not its status (see the file header).
+ * An API must answer JSON carrying a non-error `status` and a `service`; a
+ * frontend must answer an HTML document. Anything matching the ALB default is
+ * `alb-default` — the service is NOT routed, which is a failure, never health.
+ */
+export function classifyProbeBody(body: string | undefined, kind: ServiceKind): BodyVerdict {
+  const text = (body ?? '').trim();
+  if (text.includes(ALB_DEFAULT_MARKER)) return 'alb-default';
+  // `plain` hosts are not behind the shared ALB, so the 2xx the caller already
+  // checked IS the signal — an empty body (fleek's /health) is healthy.
+  if (kind === 'plain') return 'healthy';
+  if (text === '') return 'empty';
+  if (kind === 'frontend') return /^<!doctype html|^<html/i.test(text) ? 'healthy' : 'unexpected';
+  try {
+    const parsed = JSON.parse(text) as { status?: unknown };
+    const status = typeof parsed.status === 'string' ? parsed.status.toLowerCase() : '';
+    // `service` is NOT universal — connect-api answers {"status":"ok","mongo":"ok"} —
+    // so an allowlisted `status` is the signal. (The ALB default is not JSON at all.)
+    return HEALTHY_STATUSES.has(status) ? 'healthy' : 'unexpected';
+  } catch {
+    return 'unexpected';
+  }
+}
+
+/** The ECS platform facts `--ecs` reads back for a service (describe-services). */
+export interface EcsServiceState {
+  running?: number;
+  desired?: number;
+  /** ECS service status — ACTIVE for a live service. */
+  status?: string;
+  /** Primary deployment rollout state (COMPLETED / IN_PROGRESS / FAILED). */
+  rollout?: string;
+  taskDef?: string;
+}
+
+export interface EcsVerdict {
+  healthy: boolean;
+  /** One-line summary for the report (always populated). */
+  summary: string;
+}
+
+/**
+ * Judge a service's ECS state (PURE). Healthy = ACTIVE, desired > 0,
+ * running >= desired, and no FAILED rollout. This is the platform truth HTTP
+ * cannot see: a crash-looping/under-running service behind a stale healthy ALB
+ * target. An IN_PROGRESS rollout at full task count is reported but NOT failed
+ * — routine deploys must not turn the gate red.
+ */
+export function classifyEcsState(state: EcsServiceState | undefined): EcsVerdict {
+  if (state === undefined) return { healthy: false, summary: 'no such ECS service in the shared clusters' };
+  const { running = 0, desired = 0, status = '', rollout } = state;
+  const counts = `${running}/${desired} task(s)`;
+  if (status !== '' && status !== 'ACTIVE') return { healthy: false, summary: `${status} (${counts})` };
+  if (desired === 0) return { healthy: false, summary: `scaled to zero (${counts})` };
+  if (running < desired) return { healthy: false, summary: `under-running ${counts}${rollout ? ` — rollout ${rollout}` : ''}` };
+  if (rollout === 'FAILED') return { healthy: false, summary: `${counts}, rollout FAILED` };
+  // An IN_PROGRESS rollout at full task count is a routine deploy, not an
+  // outage — the service is serving (its HTTP probe proves it). Note it, but
+  // do not fail the gate or every deploy window turns red.
+  if (rollout !== undefined && rollout !== 'COMPLETED') return { healthy: true, summary: `${counts} running, rollout ${rollout}` };
+  return { healthy: true, summary: `${counts} running` };
+}
+
+/** Human explanation for a non-healthy verdict (kept next to the classifier). */
+export function verdictReason(verdict: BodyVerdict): string {
+  switch (verdict) {
+    case 'alb-default':
+      return 'not routed (shared-ALB default response — no listener rule for this host)';
+    case 'empty':
+      return 'empty response body';
+    case 'unexpected':
+      return 'unexpected body (not a healthy service response)';
+    default:
+      return '';
+  }
+}

--- a/packages/node/saga-stack-cli/src/core/env/taskdef.ts
+++ b/packages/node/saga-stack-cli/src/core/env/taskdef.ts
@@ -1,0 +1,109 @@
+/**
+ * ECS task-definition → database-target extraction (soa#355) — PURE.
+ *
+ * Live discovery (2026-07-21, dev account) showed the mesh's DB wiring is
+ * heterogeneous but always lives in the service's OWN task definition, in one
+ * of two shapes:
+ *
+ *   URL shape    — a `DATABASE_URL` container secret whose Secrets Manager
+ *                  value is the full connection URL (iam-api →
+ *                  `rostering/dev/database-url` → db-host-v2 CloudMap DNS;
+ *                  program-hub apps; coach → the shared RDS).
+ *   SPLIT shape  — `POSTGRES_{HOST,PORT,DATABASE,USERNAME}` container env vars
+ *                  plus a `POSTGRES_PASSWORD` secret (ads-adm-api).
+ *
+ * Resolving from the task definition instead of hardcoded parameter names is
+ * what makes `env connect` self-maintaining across environments: the SAME
+ * service on `training` differs only by its `-training` name suffix, and a
+ * service that moves stores updates itself. This module is the pure half —
+ * given the described containers, say WHERE the target is; the command layer
+ * fetches the referenced secrets through the aws seam.
+ */
+
+export interface TaskDefContainer {
+  name?: string;
+  environment?: { name?: string; value?: string }[];
+  secrets?: { name?: string; valueFrom?: string }[];
+}
+
+/** A reference that still needs fetching: Secrets Manager ARN/name or SSM parameter ARN. */
+export interface SecretRef {
+  valueFrom: string;
+  /** Which AWS service the ref points at (SSM parameter ARNs appear in `secrets` too). */
+  kind: 'secretsmanager' | 'ssm';
+}
+
+export type DbTarget =
+  | { shape: 'url'; urlSecret: SecretRef }
+  | {
+      shape: 'split';
+      host: string;
+      port: number;
+      database: string;
+      username?: string;
+      passwordSecret?: SecretRef;
+    };
+
+const refKind = (valueFrom: string): SecretRef['kind'] =>
+  valueFrom.startsWith('arn:aws:ssm:') ? 'ssm' : 'secretsmanager';
+
+/**
+ * Find the database target in a task definition's containers. URL shape wins
+ * when both somehow exist; undefined when neither shape is present.
+ */
+export function extractDbTarget(containers: readonly TaskDefContainer[]): DbTarget | undefined {
+  for (const c of containers) {
+    const urlSecret = (c.secrets ?? []).find((s) => s.name === 'DATABASE_URL' && s.valueFrom !== undefined);
+    if (urlSecret?.valueFrom !== undefined) {
+      return { shape: 'url', urlSecret: { valueFrom: urlSecret.valueFrom, kind: refKind(urlSecret.valueFrom) } };
+    }
+  }
+  for (const c of containers) {
+    const env = new Map((c.environment ?? []).map((e) => [e.name ?? '', e.value ?? '']));
+    const host = env.get('POSTGRES_HOST');
+    if (host === undefined || host === '') continue;
+    const password = (c.secrets ?? []).find((s) => s.name === 'POSTGRES_PASSWORD' && s.valueFrom !== undefined);
+    return {
+      shape: 'split',
+      host,
+      port: Number(env.get('POSTGRES_PORT') ?? '5432'),
+      database: env.get('POSTGRES_DATABASE') ?? 'postgres',
+      username: env.get('POSTGRES_USERNAME'),
+      passwordSecret:
+        password?.valueFrom === undefined ? undefined : { valueFrom: password.valueFrom, kind: refKind(password.valueFrom) },
+    };
+  }
+  return undefined;
+}
+
+export interface ParsedDbUrl {
+  host: string;
+  port: number;
+  database: string;
+  username?: string;
+  password?: string;
+}
+
+/** Parse a postgres:// / postgresql:// URL into its parts (throws on garbage). */
+export function parseDatabaseUrl(raw: string): ParsedDbUrl {
+  const u = new URL(raw);
+  if (u.protocol !== 'postgres:' && u.protocol !== 'postgresql:') {
+    throw new Error(`unsupported database URL scheme '${u.protocol}' (postgres/postgresql only)`);
+  }
+  return {
+    host: u.hostname,
+    port: u.port === '' ? 5432 : Number(u.port),
+    database: u.pathname.replace(/^\//, ''),
+    username: u.username === '' ? undefined : decodeURIComponent(u.username),
+    password: u.password === '' ? undefined : decodeURIComponent(u.password),
+  };
+}
+
+/** Rebuild a local (tunneled) connection URL from resolved parts. */
+export function localUrl(parts: { username?: string; password?: string; database: string }, localPort: number): string {
+  const auth =
+    parts.username === undefined
+      ? ''
+      : `${encodeURIComponent(parts.username)}${parts.password === undefined ? '' : `:${encodeURIComponent(parts.password)}`}@`;
+  return `postgres://${auth}127.0.0.1:${localPort}/${parts.database}`;
+}

--- a/packages/node/saga-stack-cli/src/core/index.ts
+++ b/packages/node/saga-stack-cli/src/core/index.ts
@@ -34,3 +34,6 @@ export * from './set/index.js';
 
 // Native snapshot fast-path — per-snapshot manifest + pure planners (plan §4.3, M3).
 export * from './snapshot/index.js';
+
+// ss env — deployed shared-environment registry + org footprint model (soa#355).
+export * from './env/index.js';

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/env-aws.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/env-aws.unit.test.ts
@@ -1,0 +1,73 @@
+/**
+ * `env-aws` pure arg-builder units (soa#355) — the byte shape of every `aws`
+ * shell-out the `ss env` family makes. These builders are the only part of the
+ * seam testable without spawning; the real `capture`/`portForward`/`lambdaInvoke`
+ * IO is exercised through the command int tests' fakes.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { awsArgs, lambdaInvokeArgs, portForwardArgs } from '../env-aws.js';
+
+describe('awsArgs — profile/region threading', () => {
+  it('appends --profile and --region only when given', () => {
+    expect(awsArgs(['sts', 'get-caller-identity'])).toEqual(['sts', 'get-caller-identity']);
+    expect(awsArgs(['ssm', 'get-parameter'], { profile: 'dev_admin', region: 'us-west-2' })).toEqual([
+      'ssm',
+      'get-parameter',
+      '--profile',
+      'dev_admin',
+      '--region',
+      'us-west-2',
+    ]);
+    expect(awsArgs(['x'], { region: 'us-west-2' })).toEqual(['x', '--region', 'us-west-2']);
+  });
+});
+
+describe('portForwardArgs — SSM start-session to a remote host', () => {
+  it('builds the AWS-StartPortForwardingSessionToRemoteHost document with stringified ports', () => {
+    const argv = portForwardArgs({
+      target: 'i-0abc',
+      host: 'db.dbs-v2.local',
+      remotePort: 5440,
+      localPort: 15432,
+      region: 'us-west-2',
+      profile: 'dev_admin',
+    });
+    expect(argv.slice(0, 6)).toEqual([
+      'ssm',
+      'start-session',
+      '--target',
+      'i-0abc',
+      '--document-name',
+      'AWS-StartPortForwardingSessionToRemoteHost',
+    ]);
+    const params = JSON.parse(argv[argv.indexOf('--parameters') + 1]!);
+    expect(params).toEqual({ host: ['db.dbs-v2.local'], portNumber: ['5440'], localPortNumber: ['15432'] });
+    expect(argv).toContain('--profile');
+    expect(argv).toContain('dev_admin');
+  });
+});
+
+describe('lambdaInvokeArgs — orchestrator invoke', () => {
+  it('carries raw-in-base64-out, the 900s read timeout, the JSON payload, and the outfile last', () => {
+    const argv = lambdaInvokeArgs(
+      { functionName: 'dev-db-host-orchestrator', payload: { action: 'snapshot', serviceName: 'x', profile: 'pre-org-reset' }, region: 'us-west-2' },
+      '/tmp/out.json',
+    );
+    expect(argv).toEqual([
+      'lambda',
+      'invoke',
+      '--function-name',
+      'dev-db-host-orchestrator',
+      '--cli-binary-format',
+      'raw-in-base64-out',
+      '--cli-read-timeout',
+      '900',
+      '--payload',
+      '{"action":"snapshot","serviceName":"x","profile":"pre-org-reset"}',
+      '/tmp/out.json',
+      '--region',
+      'us-west-2',
+    ]);
+  });
+});

--- a/packages/node/saga-stack-cli/src/runtime/env-aws.ts
+++ b/packages/node/saga-stack-cli/src/runtime/env-aws.ts
@@ -1,0 +1,287 @@
+/**
+ * AWS CLI seam for the `ss env` family (soa#355).
+ *
+ * Deliberately a SHELL-OUT to the `aws` binary, not an SDK dependency — the
+ * CLI stays registry-dep-free (the gh_214 stance that keeps tunnel/overlay as
+ * script wrappers), the user's `aws sso login` session and `--profile`
+ * selection apply unchanged, and every call is visible in CloudTrail exactly
+ * as if typed. Two verbs:
+ *
+ *   - `json(args)`  — one captured `aws … --output json` invocation, parsed.
+ *   - `portForward` — the canonical SSM data-plane tunnel
+ *     (`AWS-StartPortForwardingSessionToRemoteHost` via the shared jump host,
+ *     the exact pattern iac's postgres-mirror workflow uses). Long-running
+ *     child; resolves READY when the session-manager-plugin prints its
+ *     "Waiting for connections" banner, rejects on early exit.
+ *
+ * INVARIANT: destructive/networked IO lives only in `src/runtime/**`; commands
+ * reach this through `BaseCommand.getEnvAws()`. Tests fake the interface —
+ * `makeRealEnvAws()` is the only spawn site.
+ */
+
+import { spawn } from 'node:child_process';
+import type { ChildProcess } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+export interface EnvAwsResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface PortForwardRequest {
+  /** SSM-managed instance id of the jump host (mi-… / i-…). */
+  target: string;
+  /** Remote endpoint the jump host forwards to (RDS/Mongo/db-host DNS). */
+  host: string;
+  remotePort: number;
+  localPort: number;
+  region: string;
+  profile?: string;
+}
+
+export interface PortForwardHandle {
+  pid: number | undefined;
+  /** Resolves when the plugin reports it is listening; rejects on early exit/timeout. */
+  ready: Promise<void>;
+  /** Resolves with the exit code when the session ends (SIGTERM on stop()). */
+  exited: Promise<number | null>;
+  stop(): void;
+}
+
+/** One buffered `aws lambda invoke` (`env org reset --snapshot` — the db-host-v2 orchestrator). */
+export interface LambdaInvokeRequest {
+  functionName: string;
+  /** JSON-serialized as the raw event payload. */
+  payload: unknown;
+  region: string;
+  profile?: string;
+}
+
+export interface EnvAws {
+  /** `aws <args> --output json`, captured and parsed. Throws (with stderr) on non-zero exit or unparseable output. */
+  json(args: string[], opts?: { profile?: string; region?: string }): Promise<unknown>;
+  /**
+   * `aws lambda invoke` with a raw JSON payload; resolves the parsed response
+   * BODY (the outfile), null when empty. Throws on non-zero exit, a
+   * `FunctionError`, or an unparseable body — callers branch on the body's
+   * own `ok` field per the orchestrator contract (exit code 0 is NOT success).
+   */
+  lambdaInvoke(req: LambdaInvokeRequest): Promise<unknown>;
+  /** Open an SSM port-forwarding session through the jump host. */
+  portForward(req: PortForwardRequest): PortForwardHandle;
+}
+
+/** Build the full argv for one `aws` call (exported for byte-level tests). */
+export function awsArgs(args: string[], opts?: { profile?: string; region?: string }): string[] {
+  const argv = [...args];
+  if (opts?.profile !== undefined) argv.push('--profile', opts.profile);
+  if (opts?.region !== undefined) argv.push('--region', opts.region);
+  return argv;
+}
+
+/** Build the SSM start-session argv for a port-forward (exported for tests). */
+export function portForwardArgs(req: PortForwardRequest): string[] {
+  return awsArgs(
+    [
+      'ssm',
+      'start-session',
+      '--target',
+      req.target,
+      '--document-name',
+      'AWS-StartPortForwardingSessionToRemoteHost',
+      '--parameters',
+      JSON.stringify({
+        host: [req.host],
+        portNumber: [String(req.remotePort)],
+        localPortNumber: [String(req.localPort)],
+      }),
+    ],
+    { profile: req.profile, region: req.region },
+  );
+}
+
+/**
+ * `aws lambda invoke` argv (exported for byte-level tests). The response body
+ * lands in `outfile` (the CLI cannot cleanly stream it to stdout — metadata
+ * shares the stream); `--cli-read-timeout 900` matches the Lambda's own 900s
+ * cap so a slow pg_dump is not severed by the CLI's default 60s.
+ */
+export function lambdaInvokeArgs(req: LambdaInvokeRequest, outfile: string): string[] {
+  return awsArgs(
+    [
+      'lambda',
+      'invoke',
+      '--function-name',
+      req.functionName,
+      '--cli-binary-format',
+      'raw-in-base64-out',
+      '--cli-read-timeout',
+      '900',
+      '--payload',
+      JSON.stringify(req.payload),
+      outfile,
+    ],
+    { profile: req.profile, region: req.region },
+  );
+}
+
+const READY_MARKER = 'Waiting for connections';
+const READY_TIMEOUT_MS = 30_000;
+
+export function makeRealEnvAws(): EnvAws {
+  return {
+    async json(args, opts): Promise<unknown> {
+      const argv = [...awsArgs(args, opts), '--output', 'json'];
+      const result = await capture('aws', argv);
+      if (result.code !== 0) {
+        throw new Error(`aws ${args.slice(0, 3).join(' ')} exited ${result.code}: ${result.stderr.trim()}`);
+      }
+      // Some aws verbs legitimately print nothing (e.g. empty result sets).
+      if (result.stdout.trim() === '') return null;
+      try {
+        return JSON.parse(result.stdout) as unknown;
+      } catch {
+        throw new Error(`aws ${args.slice(0, 3).join(' ')}: unparseable JSON output`);
+      }
+    },
+
+    async lambdaInvoke(req): Promise<unknown> {
+      const dir = mkdtempSync(join(tmpdir(), 'ss-env-lambda-'));
+      const outfile = join(dir, 'response.json');
+      try {
+        const result = await capture('aws', [...lambdaInvokeArgs(req, outfile), '--output', 'json']);
+        if (result.code !== 0) {
+          throw new Error(`aws lambda invoke ${req.functionName} exited ${result.code}: ${result.stderr.trim()}`);
+        }
+        // stdout carries the invoke METADATA; a FunctionError there means the
+        // body is an error blob, not the orchestrator response.
+        try {
+          const meta = JSON.parse(result.stdout) as { FunctionError?: string };
+          if (meta.FunctionError !== undefined) {
+            throw new Error(`lambda ${req.functionName} FunctionError: ${meta.FunctionError}`);
+          }
+        } catch (err) {
+          if (err instanceof Error && err.message.includes('FunctionError')) throw err;
+          // Unparseable metadata is tolerable — the body is the contract.
+        }
+        const body = readFileSync(outfile, 'utf8');
+        if (body.trim() === '') return null;
+        try {
+          return JSON.parse(body) as unknown;
+        } catch {
+          throw new Error(`lambda ${req.functionName}: unparseable response body`);
+        }
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+
+    portForward(req): PortForwardHandle {
+      const child: ChildProcess = spawn('aws', portForwardArgs(req), {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let output = '';
+      const exited = new Promise<number | null>((resolve) => {
+        child.on('exit', (code) => resolve(code));
+      });
+      const ready = new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          reject(new Error(`port-forward to ${req.host}:${req.remotePort} not ready after ${READY_TIMEOUT_MS / 1000}s`));
+        }, READY_TIMEOUT_MS);
+        const scan = (chunk: Buffer): void => {
+          output += chunk.toString();
+          if (output.includes(READY_MARKER)) {
+            clearTimeout(timer);
+            resolve();
+          }
+        };
+        child.stdout?.on('data', scan);
+        child.stderr?.on('data', scan);
+        void exited.then((code) => {
+          clearTimeout(timer);
+          reject(new Error(`port-forward exited early (${code}): ${output.trim().slice(-500)}`));
+        });
+      });
+      // A never-awaited ready must not crash the process on early exit.
+      ready.catch(() => undefined);
+      return {
+        pid: child.pid,
+        ready,
+        exited,
+        stop: () => {
+          child.kill('SIGTERM');
+        },
+      };
+    },
+  };
+}
+
+/**
+ * The AWS account id the current credentials resolve to (`sts get-caller-identity`).
+ * Used by the account preflight so a run pointed at the WRONG account fails with an
+ * actionable message instead of a cryptic per-service error (a dev-account ledger
+ * query in the prod account returns ResourceNotFoundException, ECS lookups return
+ * empty, etc.). Returns undefined if the identity can't be read (treated as "skip
+ * the guard" — a real AWS call downstream will surface the auth problem).
+ */
+export async function resolveCallerAccount(aws: EnvAws, opts: { profile?: string; region: string }): Promise<string | undefined> {
+  try {
+    const account = (await aws.json(['sts', 'get-caller-identity', '--query', 'Account'], opts)) as string | null;
+    return account ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Resolve the SSM jump host: newest running instance carrying the Name tag that
+ * is ALSO Online in SSM (the exact recipe iac's postgres-mirror workflow uses).
+ * Returns undefined when none qualifies.
+ */
+export async function resolveJumpHost(
+  aws: EnvAws,
+  nameTag: string,
+  opts: { profile?: string; region: string },
+): Promise<string | undefined> {
+  const ec2 = (await aws.json(
+    [
+      'ec2',
+      'describe-instances',
+      '--filters',
+      `Name=tag:Name,Values=${nameTag}`,
+      'Name=instance-state-name,Values=running',
+      '--query',
+      'Reservations[].Instances[].InstanceId',
+    ],
+    opts,
+  )) as string[] | null;
+  const candidates = ec2 ?? [];
+  if (candidates.length === 0) return undefined;
+  const online = (await aws.json(
+    [
+      'ssm',
+      'describe-instance-information',
+      '--filters',
+      `Key=InstanceIds,Values=${candidates.join(',')}`,
+      '--query',
+      "InstanceInformationList[?PingStatus=='Online'].InstanceId",
+    ],
+    opts,
+  )) as string[] | null;
+  return (online ?? [])[0];
+}
+
+function capture(command: string, args: string[]): Promise<EnvAwsResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (c: Buffer) => (stdout += c.toString()));
+    child.stderr.on('data', (c: Buffer) => (stderr += c.toString()));
+    child.on('error', reject); // ENOENT (aws not installed) surfaces directly
+    child.on('close', (code) => resolve({ code: code ?? 1, stdout, stderr }));
+  });
+}

--- a/packages/node/saga-stack-cli/src/runtime/env-psql.ts
+++ b/packages/node/saga-stack-cli/src/runtime/env-psql.ts
@@ -1,0 +1,80 @@
+/**
+ * psql shell-out seam for the `ss env org` commands (soa#355).
+ *
+ * Runs read/write SQL against a (usually SSM-port-forwarded) Postgres via the
+ * `psql` binary — no driver dependency, same stance as `env-aws.ts`. Rows come
+ * back as unit-separator-delimited fields (`-F $'\x1f'`), so values containing
+ * commas/tabs survive; `-X -A -t` strips rc files, alignment, and headers;
+ * `ON_ERROR_STOP=1` makes SQL errors exit non-zero instead of half-succeeding.
+ *
+ * INVARIANT: IO lives only in `src/runtime/**`; commands reach this through
+ * `BaseCommand.getEnvPsql()`. Tests fake the interface — `makeRealEnvPsql()`
+ * is the only spawn site.
+ */
+
+import { spawn } from 'node:child_process';
+
+const FIELD_SEP = '\u001f';
+
+export interface EnvPsql {
+  /**
+   * Run one SQL statement; resolve rows as arrays of string fields (empty
+   * array for zero rows). Throws with psql's stderr on non-zero exit.
+   */
+  query(connString: string, sql: string): Promise<string[][]>;
+}
+
+/** psql argv for one query (exported for byte-level tests). */
+export function psqlArgs(connString: string, sql: string): string[] {
+  return ['-X', '-A', '-t', '-F', FIELD_SEP, '-v', 'ON_ERROR_STOP=1', connString, '-c', sql];
+}
+
+/**
+ * Docker image used when `psql` is not on PATH: `docker run --network host`
+ * makes 127.0.0.1 tunnel ports reachable, so the same connection string works.
+ * The synthetic-dev hosts always carry a postgres image; a host with neither
+ * psql nor docker gets a clear ENOENT.
+ */
+const DOCKER_PSQL_IMAGE = 'postgres:18-alpine';
+
+export function makeRealEnvPsql(): EnvPsql {
+  let useDocker = false;
+  const run = (connString: string, sql: string): Promise<string[][]> =>
+    new Promise((resolve, reject) => {
+      const args = psqlArgs(connString, sql);
+      const [cmd, argv] = useDocker
+        ? (['docker', ['run', '--rm', '--network', 'host', DOCKER_PSQL_IMAGE, 'psql', ...args]] as const)
+        : (['psql', args] as const);
+      const child = spawn(cmd, argv, { stdio: ['ignore', 'pipe', 'pipe'] });
+      let stdout = '';
+      let stderr = '';
+      // A failed spawn fires BOTH 'error' and 'close' — the flag keeps the
+      // close handler from rejecting a promise the fallback retry now owns.
+      let handedToFallback = false;
+      child.stdout.on('data', (c: Buffer) => (stdout += c.toString()));
+      child.stderr.on('data', (c: Buffer) => (stderr += c.toString()));
+      child.on('error', (err) => {
+        // psql not installed → one-time switch to the docker fallback.
+        if (!useDocker && (err as NodeJS.ErrnoException).code === 'ENOENT') {
+          useDocker = true;
+          handedToFallback = true;
+          run(connString, sql).then(resolve, reject);
+          return;
+        }
+        reject(err);
+      });
+      child.on('close', (code) => {
+        if (handedToFallback) return;
+        if (code !== 0) {
+          reject(new Error(`psql exited ${code}: ${stderr.trim()}`));
+          return;
+        }
+        const rows = stdout
+          .split('\n')
+          .filter((line) => line.length > 0)
+          .map((line) => line.split(FIELD_SEP));
+        resolve(rows);
+      });
+    });
+  return { query: run };
+}

--- a/packages/node/saga-stack-cli/src/runtime/health.ts
+++ b/packages/node/saga-stack-cli/src/runtime/health.ts
@@ -28,7 +28,17 @@ export interface ProbeResult {
   ok: boolean;
   /** HTTP status code when a response was received; omitted on a transport/timeout error. */
   status?: number;
+  /**
+   * Response body, truncated to `BODY_LIMIT`. Required by `ss env verify`:
+   * deployed envs sit behind a wildcard ALB whose default action answers 200
+   * for any unmatched host, so ONLY the body distinguishes a real service from
+   * "nothing is routed here". Local callers (`stack verify`) ignore it.
+   */
+  body?: string;
 }
+
+/** Cap on the captured body — health payloads are tiny; frontends are not. */
+const BODY_LIMIT = 512;
 
 /**
  * The injectable HTTP seam. One method: GET a URL, resolve to a `ProbeResult`.
@@ -59,7 +69,13 @@ export function makeRealProber(opts: RealProberOptions = {}): HealthProber {
       const timer = setTimeout(() => controller.abort(), timeoutMs);
       try {
         const res = await fetch(url, { method: 'GET', signal: controller.signal });
-        return { ok: res.ok, status: res.status };
+        let body: string | undefined;
+        try {
+          body = (await res.text()).slice(0, BODY_LIMIT);
+        } catch {
+          body = undefined; // a body that won't read never invalidates the status
+        }
+        return { ok: res.ok, status: res.status, body };
       } catch {
         return { ok: false };
       } finally {

--- a/packages/node/saga-stack-cli/src/runtime/index.ts
+++ b/packages/node/saga-stack-cli/src/runtime/index.ts
@@ -57,3 +57,5 @@ export * from './foreign-procs.js';
 export * from './claim.js';
 export * from './cli-version.js';
 export * from './slot-wipe.js';
+export * from './env-aws.js';
+export * from './env-psql.js';


### PR DESCRIPTION
First slice of #355 (research: `~/dev/shared-env-reset-research.md`). Goal of the epic: start from the Empty Org on dev, run the e2e journey, reset the org's data between runs — repeatably — without touching any other org (e.g. the training orgs). This PR is the **read-only Phase 0**.

## Commands

| command | what it does |
|---|---|
| `ss env list` | deployed envs (dev `*.wootdev.com`, training `*.saga-training.org`) + their dev-platform ledger footprint; AccessDenied is mapped to the tier-ladder hint (observer can't read the ledger) |
| `ss env discover --env dev` | walks the env's SSM discovery roots (paged, name-filtered) and resolves the Online SSM jump host (`Name=dev-shared-ecs-instance`) |
| `ss env connect <store>` | SSM port-forward to shared Postgres via the jump host (iac's postgres-mirror recipe); candidate-order endpoint/secret resolution — every candidate printed, everything overridable; emits a ready `DATABASE_URL`, holds till Ctrl-C; `--print-only` resolves without connecting |
| `ss env org status --org emptyOrg` | the org's cross-store footprint: per-table counts by resolved id-set, `[projection]`-marked event-materialized rows (the orphan category); live id-set resolution from the two org anchors via `--url iam=… --url programs=…`, else `partial-offline` |

`org status` is deliberately the dry-run half of the future `env org reset`.

## Safety posture

- **Slug-only org targeting**: `--org emptyOrg` derives the UUID via a byte-exact reimplementation of `@saga-ed/iam-seed-ids`' uuidv5 scheme (unit tests assert the canonical ids, incl. `52a00136-…`). Unknown slugs AND raw UUIDs are refused — hand-built orgs (training) are structurally untargetable. Growing the catalog is a reviewed code change.
- Every id inlined into SQL passes a UUID gate (`assertUuids`) — psql shell-out has no bind params, so the gate is the injection guard.
- Phase 0 is entirely read-only: ledger queries, SSM param reads, a port-forward, `SELECT count(*)`.

## Design decisions

- **AWS via shell-out to `aws`** (captured JSON + long-running port-forward with readiness detection) — keeps the CLI SDK-free per the gh_214 stance; sessions land in CloudTrail as typed. `psql` shell-out likewise (unit-separator fields, `ON_ERROR_STOP`).
- Footprint map grounded in each repo's prisma schema (iam-db, programs/scheduling/sessions, ads-adm-db, coach-db), anchor + first ring, explicitly extensible.
- Postgres-first; Mongo (`directConnection=true` through SSM tunnels) is a follow-up.

## Testing

- 7 core unit tests (seed-id byte-match against iam-seed-ids canon; UUID gate; SQL shapes) + 9 command int tests (both IO seams faked): ledger summary + tier hint, discover pagination/filter/jump-host, connect candidate order + `--print-only` + tunnel request shape, org-status refusals + offline vs live resolution + projection marking.
- Full suite 1434 green; `tsc`/eslint clean; offline smoke of the built CLI derives the canonical Empty Org id.

## Live verification — DONE (dev, 2026-07-21, authed session)

- `env list`: ledger live (dev: ecs×20/routing×93; training: db×14 — the 14 training Postgres containers).
- Resolution reshaped by live findings (second commit): the researched SSM endpoint params don't exist — `env connect` now resolves from each service's **live ECS task definition** (DATABASE_URL secret or split `POSTGRES_*` shapes, both live-verified), and `.dbs-v2.local` targets route via **CloudMap → the container's own db-host instance with a 127.0.0.1 dial** (the shared jump host's SG can't reach the containers — verified hang). psql seam gained a `docker run` fallback.
- **End-to-end live footprint**: `env connect iam` + `programs` (tunnels up via db-host route) → `env org status --org emptyOrg` **live against dev**: 31 groups / 22 users / 122 memberships / 7 programs / **213 rows** of accumulated journey residue — exactly the reset target.
- Two footprint-map corrections from live runs (user_policies group-keyed; pod_assignment deferred to the Phase-1 resolver).

Phase 1 (`env org reset` with snapshot + delete-by-id-set + reseed) builds on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jxm7ZSGT58TQj8WAP1bcGf

---

## Phase 1 — `env org reset` (added; LIVE-VERIFIED on dev)

`ss env org reset --org emptyOrg --url iam=… --url programs=… [--url …] [--dry-run|--yes] [--snapshot]` surgically deletes ONE fixture org's data across the mesh's Postgres stores back to the seeded skeleton (org row + admin + seeded personas survive), so a journey-test loop can start from Empty Org, run, reset, repeat.

**Design** (built via a mine → implement → 3-way adversarial review → fix workflow; all serious findings folded in):
- **Pure core** `reset-plan.ts`: dependency-ordered id-set resolution (programIds→periods→cohorts/pods/slots/schedules/sessions, projection-side orphan unions), then per-store ordered DELETE plans (leaf stores first, iam last). Skeleton protection is IN the SQL — org row/admin/admin-membership/seeded-personas excluded by deterministic-id predicates; the `users` delete carries the multi-org rule AND an env-wide-actor rule (non-USER role or any `user_system_roles` row survive), so shared-env staff/service accounts are never swept. Every id UUID/base64url-gated before inlining.
- **Command** `reset.ts`: wipe-canon flow (dry-run enumerate → one confirm → `--yes`; hard refusals non-zero). Guards: slug-only targeting, BOTH anchors required, pre-flight identity assertion, per-store `BEGIN/COMMIT` transactions, post-verify before/after (self-blinding tables reported verify-indirect), skeleton check (broken → non-zero exit after report). `--snapshot` best-effort via the db-host-v2 orchestrator (dev-only; refused for `--env training`).

**Live verification (dev, read-only dry-run, all 6 connectable stores)** — found + fixed two bugs the offline tests couldn't:
1. Identity assertion compared `iam.users.username` against the email; the real seeded value is the admin *handle* (= catalog slug, `empty`) — iam has no email column (PII lives in iam_pii). Fixed to compare against the slug.
2. `tutoring_session.id` is a versioned opaque key `v2.<base64url>` (dot + prefix), not the plain base64url the miner assumed; the strict charset gate rejected it. Widened (still injection-safe).

With both fixed, the dry-run resolves every id-set live (groups=31, programs=7, periods=10, pods=11, slots=14, schedules=2, sessions=1) and enumerates **980 org-reachable rows** across sessions(463)/programs(212)/iam(152)/scheduling(90)/ads-adm(63), coach 0, skeleton-protected, zero errors. `deletable-users=0` — this org's 22 users are all multi-org/shared, correctly kept.

**Testing**: `reset-plan.unit.test.ts` + `env-reset.int.test.ts` (byte-exact iam transaction, identity refusals, dry-run zero-mutation, leftover/broken-skeleton paths, snapshot ladder) + `env-aws.unit.test.ts`. Full suite **1486 pass / 123 files**; tsc + eslint clean.