### PR TITLE
feat(infra-compose): restore-time schemaRev compatibility gate (off/warn/enforce)

### DIFF
--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@saga-ed/infra-compose",
-    "version": "1.3.3",
+    "version": "1.6.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@saga-ed/infra-compose",
-            "version": "1.3.3",
+            "version": "1.6.0",
             "dependencies": {
                 "bson": "^6.10.4",
                 "express": "^4.22.1",

--- a/infra/package.json
+++ b/infra/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/infra-compose",
-    "version": "1.5.1",
+    "version": "1.6.0",
     "description": "Composable Docker service templates for Saga platform local development",
     "bin": {
         "infra-compose": "bin/infra-compose"

--- a/infra/src/ec2/ec2-router.js
+++ b/infra/src/ec2/ec2-router.js
@@ -14,10 +14,19 @@ import { generate_compose } from './compose-generator.js';
 import { allocate_port, register_port, release_port, get_allocated_ports } from './ports.js';
 import { create_volume, attach_and_mount, cleanup_volume, get_instance_metadata } from './volumes.js';
 import { register, deregister } from './cloudmap.js';
-import { snapshot_db, download_profile_seed, seed_after_start, list_s3_profiles, read_profile_registry, write_active_profile } from './profiles.js';
+import { snapshot_db, download_profile_seed, seed_after_start, list_s3_profiles, read_profile_registry, write_active_profile, check_schema_rev_gate } from './profiles.js';
 
 const SEEDS_BASE = '/mnt/seeds';
 const SEED_BUCKET = process.env.SEED_BUCKET || 'saga-db-seeds-dev';
+
+// v1 refuse-loudly gate (default OFF). 'off' never gates; 'warn' logs the
+// verdict and always proceeds; 'enforce' refuses on no-sidecar/ahead/behind.
+// Read live (not cached at module load) so it can be toggled without a
+// restart in tests and, if ever needed, via a config reload. See profiles.js
+// check_schema_rev_gate and services/switchboard/docs/snapshot-schema-versioning.md.
+function schema_gate_mode() {
+    return process.env.SNAPSHOT_SCHEMA_GATE || 'off';
+}
 
 function sync_seeds(name) {
     const seeds_dir = resolve(SEEDS_BASE, name);
@@ -743,6 +752,47 @@ export function create_ec2_router(config = {}) {
             const project_dir = resolve(projects_dir, name);
             if (!existsSync(project_dir)) {
                 return res.status(404).json({ ok: false, error: `Project ${name} not found` });
+            }
+
+            // Schema-rev compatibility gate — postgres only (see profiles.js
+            // check_schema_rev_gate). Runs BEFORE anything is stopped/wiped so an
+            // enforce-mode refusal never touches the live container. Every
+            // evaluation (including proceed cases) is logged as one structured
+            // line carrying the same fields the response would carry on refusal.
+            if (entry.engine === 'postgres') {
+                const config_before = get_compose_config(projects_dir, name, entry.engine);
+                const db_name_before = get_db_name(projects_dir, name, entry.engine);
+                const container_before = spawnSync('docker', ['compose', 'ps', '--format', '{{.Name}}'], {
+                    cwd: project_dir, encoding: 'utf8', stdio: 'pipe',
+                }).stdout.trim().split('\n')[0] || name;
+
+                const gate = check_schema_rev_gate({
+                    name,
+                    profile,
+                    bucket: SEED_BUCKET,
+                    source_name: seedFrom,
+                    mode: schema_gate_mode(),
+                    container: container_before,
+                    db_name: db_name_before,
+                    db_user: config_before.user,
+                });
+
+                console.log(
+                    `schema-gate: ${action} ${name} profile=${profile} verdict=${gate.verdict} ` +
+                    `snapshotSchemaRev=${gate.snapshotSchemaRev} dbSchemaRev=${gate.dbSchemaRev} ` +
+                    `gateMode=${gate.gateMode} refuse=${gate.refuse} — ${gate.message}`,
+                );
+
+                if (gate.refuse) {
+                    return res.status(409).json({
+                        ok: false,
+                        error: gate.message,
+                        verdict: gate.verdict,
+                        snapshotSchemaRev: gate.snapshotSchemaRev,
+                        dbSchemaRev: gate.dbSchemaRev,
+                        gateMode: gate.gateMode,
+                    });
+                }
             }
 
             // Stop container

--- a/infra/src/ec2/ec2-router.js
+++ b/infra/src/ec2/ec2-router.js
@@ -755,11 +755,16 @@ export function create_ec2_router(config = {}) {
             }
 
             // Schema-rev compatibility gate — postgres only (see profiles.js
-            // check_schema_rev_gate). Runs BEFORE anything is stopped/wiped so an
-            // enforce-mode refusal never touches the live container. Every
-            // evaluation (including proceed cases) is logged as one structured
-            // line carrying the same fields the response would carry on refusal.
-            if (entry.engine === 'postgres') {
+            // check_schema_rev_gate). `off` (the default) skips evaluation
+            // entirely: no S3 sidecar fetch, no docker calls, no added latency
+            // or failure surface while the gate is disabled — shadow visibility
+            // is what `warn` is for. In warn/enforce the gate runs BEFORE
+            // anything is stopped/wiped so an enforce-mode refusal never
+            // touches the live container. Every evaluation (including proceed
+            // cases) is logged as one structured line carrying the same fields
+            // the response would carry on refusal.
+            const gate_mode = schema_gate_mode();
+            if (entry.engine === 'postgres' && gate_mode !== 'off') {
                 const config_before = get_compose_config(projects_dir, name, entry.engine);
                 const db_name_before = get_db_name(projects_dir, name, entry.engine);
                 const container_before = spawnSync('docker', ['compose', 'ps', '--format', '{{.Name}}'], {
@@ -771,7 +776,7 @@ export function create_ec2_router(config = {}) {
                     profile,
                     bucket: SEED_BUCKET,
                     source_name: seedFrom,
-                    mode: schema_gate_mode(),
+                    mode: gate_mode,
                     container: container_before,
                     db_name: db_name_before,
                     db_user: config_before.user,

--- a/infra/src/ec2/profiles.js
+++ b/infra/src/ec2/profiles.js
@@ -326,16 +326,19 @@ export function check_schema_rev_gate({ name, profile, bucket, source_name, mode
     const object_stem = at ? `profile-${base_profile}-v${at[2]}` : `profile-${base_profile}`;
     const meta_s3_path = `s3://${bucket}/${src}/${object_stem}.meta.json`;
 
-    // Fetch the sidecar to a scratch path; a non-zero exit (key missing, or any
-    // other S3 error) is read as "no sidecar" — the gate degrades safely rather
-    // than throwing, matching the spec's "Missing sidecar" verdict.
-    const meta_tmp = `/tmp/schema-gate-${name}-${process.pid}.meta.json`;
-    const dl = spawnSync('aws', ['s3', 'cp', meta_s3_path, meta_tmp], { encoding: 'utf8', stdio: 'pipe' });
+    // Fetch the sidecar straight to stdout (`aws s3 cp <src> -`) rather than a
+    // /tmp scratch file: this runs in a long-lived server process (stable
+    // pid), so a per-call tmp file would never get cleaned up and would
+    // accumulate one per distinct db name forever. A non-zero exit (key
+    // missing, or any other S3 error) is read as "no sidecar" — the gate
+    // degrades safely rather than throwing, matching the spec's "Missing
+    // sidecar" verdict.
+    const dl = spawnSync('aws', ['s3', 'cp', meta_s3_path, '-'], { encoding: 'utf8', stdio: 'pipe' });
 
     let sidecar_schema_rev = null;
     if (dl.status === 0) {
         try {
-            const meta = JSON.parse(readFileSync(meta_tmp, 'utf8'));
+            const meta = JSON.parse(dl.stdout);
             sidecar_schema_rev = meta.schemaRev ?? null; // null schemaRev in sidecar -> treated like no-sidecar below
         } catch {
             sidecar_schema_rev = null;

--- a/infra/src/ec2/profiles.js
+++ b/infra/src/ec2/profiles.js
@@ -283,6 +283,131 @@ export function seed_after_start({ container, engine, seeds_dir, profile, db_use
     }
 }
 
+// --- Schema-rev compatibility gate (restore/switch, postgres only) ---
+//
+// Compares a snapshot's sidecar `schemaRev` (its migration state at capture
+// time) against the CURRENT DB's live migration head (read fresh via
+// extract_prisma_rev, BEFORE the caller wipes/reloads it) — see
+// services/switchboard/docs/snapshot-schema-versioning.md in the microservices
+// repo. This uses the live DB as the app-expectation proxy rather than a
+// separate `db-requirements.yaml` declaration (still future-work per the spec's
+// "Open questions"), so the gate is self-contained and needs no new plumbing.
+//
+// v1 scope (spec: "v1 ships hard-fail-on-any-drift; auto-heal stays OFF until
+// the destructive gate exists"): this NEVER runs `migrate deploy`. Any drift
+// (ahead OR behind) is a refuse-in-enforce condition. No auto-heal, no one-shot
+// ECS task, no destructive-migration detection — those remain future work.
+export const SCHEMA_GATE_VERDICTS = Object.freeze({
+    CLEAN: 'clean',
+    NO_SIDECAR: 'no-sidecar',
+    UNVERIFIED_FRESH_DB: 'unverified-fresh-db',
+    AHEAD: 'ahead',
+    BEHIND: 'behind',
+});
+
+/**
+ * Evaluate the schemaRev compatibility gate for a restore/switch onto
+ * `profile` (optionally version-pinned `@vN`, optionally sourced from another
+ * DB's prefix via `source_name`/seedFrom — same S3 resolution as the dump).
+ *
+ * Returns `{ verdict, snapshotSchemaRev, dbSchemaRev, refuse, message }`.
+ * `refuse` reflects what `mode` dictates the caller should do; the verdict
+ * itself is mode-independent (same classification regardless of off/warn/
+ * enforce — only the action taken on it differs).
+ *
+ * Postgres-only: callers must skip this entirely for mongo/mysql (mirrors the
+ * sidecar-write gate in snapshot_db — there is no schemaRev to compare for
+ * engines with no Prisma migration history).
+ */
+export function check_schema_rev_gate({ name, profile, bucket, source_name, mode, container, db_name, db_user }) {
+    const src = source_name || name;
+    const at = profile.match(/^(.+)@v(\d+)$/);
+    const base_profile = at ? at[1] : profile;
+    const object_stem = at ? `profile-${base_profile}-v${at[2]}` : `profile-${base_profile}`;
+    const meta_s3_path = `s3://${bucket}/${src}/${object_stem}.meta.json`;
+
+    // Fetch the sidecar to a scratch path; a non-zero exit (key missing, or any
+    // other S3 error) is read as "no sidecar" — the gate degrades safely rather
+    // than throwing, matching the spec's "Missing sidecar" verdict.
+    const meta_tmp = `/tmp/schema-gate-${name}-${process.pid}.meta.json`;
+    const dl = spawnSync('aws', ['s3', 'cp', meta_s3_path, meta_tmp], { encoding: 'utf8', stdio: 'pipe' });
+
+    let sidecar_schema_rev = null;
+    if (dl.status === 0) {
+        try {
+            const meta = JSON.parse(readFileSync(meta_tmp, 'utf8'));
+            sidecar_schema_rev = meta.schemaRev ?? null; // null schemaRev in sidecar -> treated like no-sidecar below
+        } catch {
+            sidecar_schema_rev = null;
+        }
+    }
+
+    const db_schema_rev = extract_prisma_rev({ container, db_name, db_user });
+
+    // extract_prisma_rev collapses two very different situations to the same
+    // null: a genuinely fresh DB with zero applied migrations (expected,
+    // benign — the app runs its own migrate deploy after this restore), and
+    // the container being unreachable/stopped so the exec never even ran
+    // (extract_prisma_rev never throws, so this degrades the same way). Both
+    // proceed identically in every mode — refusing here would break routine
+    // provisioning onto a not-yet-started container — but a warn-soak
+    // operator reading logs needs to tell them apart, so probe reachability
+    // separately just for the log message; it does not change `refuse`.
+    const container_reachable = db_schema_rev !== null
+        || spawnSync('docker', ['inspect', '--format', '{{.State.Running}}', container], { encoding: 'utf8', stdio: 'pipe' }).stdout.trim() === 'true';
+
+    const base = { snapshotSchemaRev: sidecar_schema_rev, dbSchemaRev: db_schema_rev, gateMode: mode };
+
+    if (sidecar_schema_rev === null) {
+        return {
+            ...base,
+            verdict: SCHEMA_GATE_VERDICTS.NO_SIDECAR,
+            refuse: mode === 'enforce',
+            message: `no schema sidecar found at ${meta_s3_path} (or schemaRev is null) — cannot verify compatibility`,
+        };
+    }
+
+    // Fresh provision: _prisma_migrations absent/empty on the CURRENT db means
+    // there's nothing to compare against yet (the app boots and runs its own
+    // `migrate deploy` after this restore). Comparison is impossible, not
+    // failed — proceed in every mode (enforce still required a sidecar to
+    // exist, which it does at this point).
+    if (db_schema_rev === null) {
+        const cause = container_reachable
+            ? 'current DB has no applied migrations yet (fresh provision)'
+            : `current DB container (${container}) is unreachable/stopped — head could not be read`;
+        return {
+            ...base,
+            verdict: SCHEMA_GATE_VERDICTS.UNVERIFIED_FRESH_DB,
+            refuse: false,
+            message: `${cause} — proceeding with snapshot schemaRev ${sidecar_schema_rev}, comparison deferred to the app's own migrate deploy`,
+        };
+    }
+
+    if (sidecar_schema_rev === db_schema_rev) {
+        return { ...base, verdict: SCHEMA_GATE_VERDICTS.CLEAN, refuse: false, message: `snapshot schemaRev matches DB head (${db_schema_rev})` };
+    }
+
+    // Prisma migration names are timestamp-prefixed and the history is linear
+    // (see snapshot-schema-versioning.md "version token MUST be the latest
+    // migration name") — a plain lexical compare orders them correctly.
+    if (sidecar_schema_rev > db_schema_rev) {
+        return {
+            ...base,
+            verdict: SCHEMA_GATE_VERDICTS.AHEAD,
+            refuse: mode === 'enforce',
+            message: `snapshot schemaRev ${sidecar_schema_rev} is ahead of DB head ${db_schema_rev} — rollback not supported; use a snapshot at or behind the app schema`,
+        };
+    }
+
+    return {
+        ...base,
+        verdict: SCHEMA_GATE_VERDICTS.BEHIND,
+        refuse: mode === 'enforce',
+        message: `snapshot schemaRev ${sidecar_schema_rev} is behind DB head ${db_schema_rev} and auto-heal is not enabled — re-snapshot canonical to advance the baseline (see snapshot-schema-versioning.md Flow B)`,
+    };
+}
+
 // --- Download profile seed from S3 ---
 
 export function download_profile_seed({ name, profile, engine, bucket, seeds_base, source_name }) {

--- a/infra/test/unit/ec2-router-schema-gate.unit.test.js
+++ b/infra/test/unit/ec2-router-schema-gate.unit.test.js
@@ -24,7 +24,7 @@ let sidecarCpResult = { status: 0, stdout: '', stderr: '' };
 let revQueryResult = { status: 0, stdout: '20260603120000_add_session_index\n', stderr: '' };
 
 function isSidecarCp(cmd, args) {
-    return cmd === 'aws' && args[0] === 's3' && args[1] === 'cp' && args[2].endsWith('.meta.json');
+    return cmd === 'aws' && args[0] === 's3' && args[1] === 'cp' && args[3] === '-';
 }
 function isRevQuery(cmd, args) {
     return cmd === 'docker' && args[0] === 'exec' && args.includes('psql')
@@ -53,31 +53,14 @@ vi.mock('child_process', () => ({
     spawn: vi.fn(),
 }));
 
-let sidecarFileContent = null;
-vi.mock('fs', async (importOriginal) => {
-    const actual = await importOriginal();
-    return {
-        ...actual,
-        readFileSync: vi.fn((path, ...rest) => {
-            if (typeof path === 'string' && path.includes('schema-gate-') && path.endsWith('.meta.json')) {
-                if (sidecarFileContent === null) throw new Error('ENOENT (test stub)');
-                return sidecarFileContent;
-            }
-            return actual.readFileSync(path, ...rest);
-        }),
-    };
-});
-
 import { create_ec2_router } from '../../src/ec2/ec2-router.js';
 import { download_profile_seed } from '../../src/ec2/profiles.js';
 
 function setSidecar(schemaRev) {
-    sidecarCpResult = { status: 0, stdout: '', stderr: '' };
-    sidecarFileContent = JSON.stringify({ schemaRev });
+    sidecarCpResult = { status: 0, stdout: JSON.stringify({ schemaRev }), stderr: '' };
 }
 function setNoSidecar() {
     sidecarCpResult = { status: 1, stdout: '', stderr: 'NoSuchKey' };
-    sidecarFileContent = null;
 }
 function setDbHead(rev) {
     revQueryResult = rev === null

--- a/infra/test/unit/ec2-router-schema-gate.unit.test.js
+++ b/infra/test/unit/ec2-router-schema-gate.unit.test.js
@@ -1,0 +1,308 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import http from 'http';
+import express from 'express';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+
+// Mock everything the restore/switch path touches downstream of the gate —
+// this test is only about whether the gate runs, refuses correctly per mode,
+// and never fires for non-postgres engines. Real download/seed/compose
+// mechanics are covered by profiles-seedfrom.unit.test.js and friends.
+vi.mock('../../src/ec2/profiles.js', async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+        ...actual,
+        download_profile_seed: vi.fn(() => '/tmp/fake-seeds'),
+        seed_after_start: vi.fn(),
+        write_active_profile: vi.fn(),
+    };
+});
+
+const spawnSync_calls = [];
+let sidecarCpResult = { status: 0, stdout: '', stderr: '' };
+let revQueryResult = { status: 0, stdout: '20260603120000_add_session_index\n', stderr: '' };
+
+function isSidecarCp(cmd, args) {
+    return cmd === 'aws' && args[0] === 's3' && args[1] === 'cp' && args[2].endsWith('.meta.json');
+}
+function isRevQuery(cmd, args) {
+    return cmd === 'docker' && args[0] === 'exec' && args.includes('psql')
+        && args.some((a) => typeof a === 'string' && a.includes('_prisma_migrations'));
+}
+
+vi.mock('child_process', () => ({
+    spawnSync: vi.fn((cmd, args) => {
+        spawnSync_calls.push([cmd, args]);
+        if (isSidecarCp(cmd, args)) return sidecarCpResult;
+        if (isRevQuery(cmd, args)) return revQueryResult;
+        if (cmd === 'docker' && args[0] === 'compose' && args.includes('ps')) {
+            return { status: 0, stdout: 'sbx-db-1\n', stderr: '' };
+        }
+        if (cmd === 'docker' && args[0] === 'inspect' && args.includes('{{.State.Running}}')) {
+            // Container is up in every scenario this file exercises; the
+            // running-vs-fresh distinction itself is covered at the
+            // check_schema_rev_gate unit level (profiles-schema-gate test).
+            return { status: 0, stdout: 'true\n', stderr: '' };
+        }
+        if (cmd === 'docker' && (args.includes('down') || args.includes('up'))) {
+            return { status: 0, stdout: '', stderr: '' };
+        }
+        return { status: 0, stdout: '', stderr: '' };
+    }),
+    spawn: vi.fn(),
+}));
+
+let sidecarFileContent = null;
+vi.mock('fs', async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+        ...actual,
+        readFileSync: vi.fn((path, ...rest) => {
+            if (typeof path === 'string' && path.includes('schema-gate-') && path.endsWith('.meta.json')) {
+                if (sidecarFileContent === null) throw new Error('ENOENT (test stub)');
+                return sidecarFileContent;
+            }
+            return actual.readFileSync(path, ...rest);
+        }),
+    };
+});
+
+import { create_ec2_router } from '../../src/ec2/ec2-router.js';
+import { download_profile_seed } from '../../src/ec2/profiles.js';
+
+function setSidecar(schemaRev) {
+    sidecarCpResult = { status: 0, stdout: '', stderr: '' };
+    sidecarFileContent = JSON.stringify({ schemaRev });
+}
+function setNoSidecar() {
+    sidecarCpResult = { status: 1, stdout: '', stderr: 'NoSuchKey' };
+    sidecarFileContent = null;
+}
+function setDbHead(rev) {
+    revQueryResult = rev === null
+        ? { status: 1, stdout: '', stderr: 'relation "_prisma_migrations" does not exist' }
+        : { status: 0, stdout: `${rev}\n`, stderr: '' };
+}
+
+function create_test_server(router_options) {
+    const app = express();
+    app.use('/infra', create_ec2_router(router_options));
+    const server = http.createServer(app);
+    return new Promise((res) => {
+        server.listen(0, '127.0.0.1', () => {
+            const { port } = server.address();
+            res({
+                server,
+                base_url: `http://127.0.0.1:${port}/infra`,
+                close: () => new Promise((r) => server.close(r)),
+            });
+        });
+    });
+}
+
+async function api(base_url, method, path, body) {
+    const opts = { method, headers: { 'Content-Type': 'application/json' } };
+    if (body) opts.body = JSON.stringify(body);
+    const resp = await fetch(`${base_url}${path}`, opts);
+    return { status: resp.status, data: await resp.json() };
+}
+
+describe('POST /dbs/:name/restore — schemaRev compatibility gate', () => {
+    let projects_dir;
+    let data_dir;
+    let registry_path;
+    let test_server;
+    const name = 'programs-api-sbx';
+
+    beforeEach(async () => {
+        vi.clearAllMocks();
+        spawnSync_calls.length = 0;
+        setSidecar('20260603120000_add_session_index');
+        setDbHead('20260603120000_add_session_index');
+
+        projects_dir = mkdtempSync(join(tmpdir(), 'ec2-router-gate-projects-'));
+        data_dir = mkdtempSync(join(tmpdir(), 'ec2-router-gate-data-'));
+        registry_path = join(data_dir, 'ports.json');
+
+        mkdirSync(resolve(projects_dir, name), { recursive: true });
+        writeFileSync(
+            resolve(projects_dir, name, 'docker-compose.yml'),
+            'services:\n  db:\n    environment:\n      POSTGRES_DB: "programs"\n      POSTGRES_USER: "postgres_admin"\n',
+        );
+        writeFileSync(registry_path, JSON.stringify({ [name]: { engine: 'postgres', port: 5440 } }));
+
+        test_server = await create_test_server({ projects_dir, data_dir, registry_path });
+    });
+
+    afterEach(async () => {
+        await test_server.close();
+        rmSync(projects_dir, { recursive: true, force: true });
+        rmSync(data_dir, { recursive: true, force: true });
+    });
+
+    it('default mode (off): proceeds and never 409s even on an ahead sidecar', async () => {
+        setSidecar('20260701000000_later_migration');
+        const { status, data } = await api(test_server.base_url, 'POST', `/dbs/${name}/restore`, { profile: 'canonical' });
+        expect(status).toBe(200);
+        expect(data.ok).toBe(true);
+        expect(download_profile_seed).toHaveBeenCalled();
+    });
+
+    it('enforce: 409s with structured body on a missing sidecar, and never calls download_profile_seed', async () => {
+        process.env.SNAPSHOT_SCHEMA_GATE = 'enforce';
+        try {
+            setNoSidecar();
+            const gated_server = await create_test_server({ projects_dir, data_dir, registry_path });
+            try {
+                const { status, data } = await api(gated_server.base_url, 'POST', `/dbs/${name}/restore`, { profile: 'canonical' });
+                expect(status).toBe(409);
+                expect(data).toMatchObject({
+                    ok: false,
+                    verdict: 'no-sidecar',
+                    snapshotSchemaRev: null,
+                    gateMode: 'enforce',
+                });
+                expect(data.error).toMatch(/no schema sidecar/);
+                expect(download_profile_seed).not.toHaveBeenCalled();
+            } finally {
+                await gated_server.close();
+            }
+        } finally {
+            delete process.env.SNAPSHOT_SCHEMA_GATE;
+        }
+    });
+
+    it('enforce: 409s on an ahead sidecar with the rollback-not-supported message', async () => {
+        process.env.SNAPSHOT_SCHEMA_GATE = 'enforce';
+        try {
+            setSidecar('20260701000000_later_migration');
+            const gated_server = await create_test_server({ projects_dir, data_dir, registry_path });
+            try {
+                const { status, data } = await api(gated_server.base_url, 'POST', `/dbs/${name}/restore`, { profile: 'canonical' });
+                expect(status).toBe(409);
+                expect(data.verdict).toBe('ahead');
+                expect(data.error).toMatch(/rollback not supported/);
+                expect(download_profile_seed).not.toHaveBeenCalled();
+            } finally {
+                await gated_server.close();
+            }
+        } finally {
+            delete process.env.SNAPSHOT_SCHEMA_GATE;
+        }
+    });
+
+    it('enforce: 409s on a behind sidecar (no auto-heal in v1)', async () => {
+        process.env.SNAPSHOT_SCHEMA_GATE = 'enforce';
+        try {
+            setSidecar('20260101000000_old_migration');
+            const gated_server = await create_test_server({ projects_dir, data_dir, registry_path });
+            try {
+                const { status, data } = await api(gated_server.base_url, 'POST', `/dbs/${name}/restore`, { profile: 'canonical' });
+                expect(status).toBe(409);
+                expect(data.verdict).toBe('behind');
+                expect(data.error).toMatch(/auto-heal is not enabled/);
+                expect(download_profile_seed).not.toHaveBeenCalled();
+            } finally {
+                await gated_server.close();
+            }
+        } finally {
+            delete process.env.SNAPSHOT_SCHEMA_GATE;
+        }
+    });
+
+    it('enforce: proceeds on a clean match', async () => {
+        process.env.SNAPSHOT_SCHEMA_GATE = 'enforce';
+        try {
+            const gated_server = await create_test_server({ projects_dir, data_dir, registry_path });
+            try {
+                const { status, data } = await api(gated_server.base_url, 'POST', `/dbs/${name}/restore`, { profile: 'canonical' });
+                expect(status).toBe(200);
+                expect(data.ok).toBe(true);
+                expect(download_profile_seed).toHaveBeenCalled();
+            } finally {
+                await gated_server.close();
+            }
+        } finally {
+            delete process.env.SNAPSHOT_SCHEMA_GATE;
+        }
+    });
+
+    it('enforce: proceeds on a fresh DB with no applied migrations (comparison deferred)', async () => {
+        process.env.SNAPSHOT_SCHEMA_GATE = 'enforce';
+        try {
+            setDbHead(null);
+            const gated_server = await create_test_server({ projects_dir, data_dir, registry_path });
+            try {
+                const { status, data } = await api(gated_server.base_url, 'POST', `/dbs/${name}/restore`, { profile: 'canonical' });
+                expect(status).toBe(200);
+                expect(data.ok).toBe(true);
+                expect(download_profile_seed).toHaveBeenCalled();
+            } finally {
+                await gated_server.close();
+            }
+        } finally {
+            delete process.env.SNAPSHOT_SCHEMA_GATE;
+        }
+    });
+
+    it('warn: logs but proceeds even with no sidecar', async () => {
+        process.env.SNAPSHOT_SCHEMA_GATE = 'warn';
+        try {
+            setNoSidecar();
+            const gated_server = await create_test_server({ projects_dir, data_dir, registry_path });
+            try {
+                const { status, data } = await api(gated_server.base_url, 'POST', `/dbs/${name}/restore`, { profile: 'canonical' });
+                expect(status).toBe(200);
+                expect(data.ok).toBe(true);
+                expect(download_profile_seed).toHaveBeenCalled();
+            } finally {
+                await gated_server.close();
+            }
+        } finally {
+            delete process.env.SNAPSHOT_SCHEMA_GATE;
+        }
+    });
+
+    it('/switch shares the same gate as /restore (same choke point)', async () => {
+        process.env.SNAPSHOT_SCHEMA_GATE = 'enforce';
+        try {
+            setNoSidecar();
+            const gated_server = await create_test_server({ projects_dir, data_dir, registry_path });
+            try {
+                const { status, data } = await api(gated_server.base_url, 'POST', `/dbs/${name}/switch`, { profile: 'canonical' });
+                expect(status).toBe(409);
+                expect(data.verdict).toBe('no-sidecar');
+            } finally {
+                await gated_server.close();
+            }
+        } finally {
+            delete process.env.SNAPSHOT_SCHEMA_GATE;
+        }
+    });
+
+    it('mongo/mysql: gate never runs, no rev query, no sidecar fetch, even in enforce', async () => {
+        process.env.SNAPSHOT_SCHEMA_GATE = 'enforce';
+        try {
+            const mongo_name = 'sessions-sbx';
+            mkdirSync(resolve(projects_dir, mongo_name), { recursive: true });
+            writeFileSync(resolve(projects_dir, mongo_name, 'docker-compose.yml'), 'services:\n  db:\n');
+            const mongo_registry_path = join(data_dir, 'mongo-ports.json');
+            writeFileSync(mongo_registry_path, JSON.stringify({ [mongo_name]: { engine: 'mongo', port: 27017 } }));
+
+            const gated_server = await create_test_server({ projects_dir, data_dir, registry_path: mongo_registry_path });
+            try {
+                spawnSync_calls.length = 0;
+                const { status, data } = await api(gated_server.base_url, 'POST', `/dbs/${mongo_name}/restore`, { profile: 'canonical' });
+                expect(status).toBe(200);
+                expect(data.ok).toBe(true);
+                expect(spawnSync_calls.some(([cmd, args]) => isSidecarCp(cmd, args))).toBe(false);
+                expect(spawnSync_calls.some(([cmd, args]) => isRevQuery(cmd, args))).toBe(false);
+            } finally {
+                await gated_server.close();
+            }
+        } finally {
+            delete process.env.SNAPSHOT_SCHEMA_GATE;
+        }
+    });
+});

--- a/infra/test/unit/ec2-router-schema-gate.unit.test.js
+++ b/infra/test/unit/ec2-router-schema-gate.unit.test.js
@@ -124,12 +124,14 @@ describe('POST /dbs/:name/restore — schemaRev compatibility gate', () => {
         rmSync(data_dir, { recursive: true, force: true });
     });
 
-    it('default mode (off): proceeds and never 409s even on an ahead sidecar', async () => {
+    it('default mode (off): skips gate evaluation entirely — no sidecar fetch, proceeds', async () => {
         setSidecar('20260701000000_later_migration');
         const { status, data } = await api(test_server.base_url, 'POST', `/dbs/${name}/restore`, { profile: 'canonical' });
         expect(status).toBe(200);
         expect(data.ok).toBe(true);
         expect(download_profile_seed).toHaveBeenCalled();
+        // off = disabled, not shadow mode: the sidecar must never even be fetched
+        expect(spawnSync_calls.some(([cmd, args]) => isSidecarCp(cmd, args))).toBe(false);
     });
 
     it('enforce: 409s with structured body on a missing sidecar, and never calls download_profile_seed', async () => {

--- a/infra/test/unit/profiles-schema-gate.unit.test.js
+++ b/infra/test/unit/profiles-schema-gate.unit.test.js
@@ -1,13 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// Two spawnSync surfaces to stub: the sidecar `aws s3 cp` download, and the
-// `_prisma_migrations` rev query (docker exec psql) against the CURRENT db.
+// Two spawnSync surfaces to stub: the sidecar `aws s3 cp <src> -` download
+// (piped straight to stdout, no /tmp file — see check_schema_rev_gate), and
+// the `_prisma_migrations` rev query (docker exec psql) against the CURRENT db.
 const spawnSync_calls = [];
 let sidecarCpResult = { status: 0, stdout: '', stderr: '' };
 let revQueryResult = { status: 0, stdout: '20260603120000_add_session_index\n', stderr: '' };
 
 function isSidecarCp(cmd, args) {
-    return cmd === 'aws' && args[0] === 's3' && args[1] === 'cp' && args[2].endsWith('.meta.json');
+    return cmd === 'aws' && args[0] === 's3' && args[1] === 'cp' && args[3] === '-';
 }
 function isRevQuery(cmd, args) {
     return cmd === 'docker' && args[0] === 'exec' && args.includes('psql')
@@ -30,22 +31,6 @@ vi.mock('child_process', () => ({
     spawn: vi.fn(),
 }));
 
-// The gate reads the downloaded sidecar back off disk via readFileSync.
-let sidecarFileContent = null;
-vi.mock('fs', async (importOriginal) => {
-    const actual = await importOriginal();
-    return {
-        ...actual,
-        readFileSync: vi.fn((path, ...rest) => {
-            if (typeof path === 'string' && path.includes('schema-gate-') && path.endsWith('.meta.json')) {
-                if (sidecarFileContent === null) throw new Error('ENOENT (test stub)');
-                return sidecarFileContent;
-            }
-            return actual.readFileSync(path, ...rest);
-        }),
-    };
-});
-
 import { check_schema_rev_gate, SCHEMA_GATE_VERDICTS } from '../../src/ec2/profiles.js';
 
 const BASE = {
@@ -59,12 +44,10 @@ const BASE = {
 };
 
 function setSidecar(schemaRev) {
-    sidecarCpResult = { status: 0, stdout: '', stderr: '' };
-    sidecarFileContent = JSON.stringify({ schemaRev });
+    sidecarCpResult = { status: 0, stdout: JSON.stringify({ schemaRev }), stderr: '' };
 }
 function setNoSidecar() {
     sidecarCpResult = { status: 1, stdout: '', stderr: 'NoSuchKey' };
-    sidecarFileContent = null;
 }
 function setDbHead(rev) {
     revQueryResult = rev === null

--- a/infra/test/unit/profiles-schema-gate.unit.test.js
+++ b/infra/test/unit/profiles-schema-gate.unit.test.js
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Two spawnSync surfaces to stub: the sidecar `aws s3 cp` download, and the
+// `_prisma_migrations` rev query (docker exec psql) against the CURRENT db.
+const spawnSync_calls = [];
+let sidecarCpResult = { status: 0, stdout: '', stderr: '' };
+let revQueryResult = { status: 0, stdout: '20260603120000_add_session_index\n', stderr: '' };
+
+function isSidecarCp(cmd, args) {
+    return cmd === 'aws' && args[0] === 's3' && args[1] === 'cp' && args[2].endsWith('.meta.json');
+}
+function isRevQuery(cmd, args) {
+    return cmd === 'docker' && args[0] === 'exec' && args.includes('psql')
+        && args.some((a) => typeof a === 'string' && a.includes('_prisma_migrations'));
+}
+function isInspectRunning(cmd, args) {
+    return cmd === 'docker' && args[0] === 'inspect' && args.includes('{{.State.Running}}');
+}
+
+let containerRunning = true;
+
+vi.mock('child_process', () => ({
+    spawnSync: vi.fn((cmd, args) => {
+        spawnSync_calls.push([cmd, args]);
+        if (isSidecarCp(cmd, args)) return sidecarCpResult;
+        if (isRevQuery(cmd, args)) return revQueryResult;
+        if (isInspectRunning(cmd, args)) return { status: 0, stdout: containerRunning ? 'true\n' : 'false\n', stderr: '' };
+        return { status: 0, stdout: '', stderr: '' };
+    }),
+    spawn: vi.fn(),
+}));
+
+// The gate reads the downloaded sidecar back off disk via readFileSync.
+let sidecarFileContent = null;
+vi.mock('fs', async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+        ...actual,
+        readFileSync: vi.fn((path, ...rest) => {
+            if (typeof path === 'string' && path.includes('schema-gate-') && path.endsWith('.meta.json')) {
+                if (sidecarFileContent === null) throw new Error('ENOENT (test stub)');
+                return sidecarFileContent;
+            }
+            return actual.readFileSync(path, ...rest);
+        }),
+    };
+});
+
+import { check_schema_rev_gate, SCHEMA_GATE_VERDICTS } from '../../src/ec2/profiles.js';
+
+const BASE = {
+    name: 'programs-api-sbx',
+    profile: 'canonical',
+    bucket: 'seeds-bkt',
+    mode: 'enforce',
+    container: 'sbx-db-1',
+    db_name: 'programs',
+    db_user: 'postgres_admin',
+};
+
+function setSidecar(schemaRev) {
+    sidecarCpResult = { status: 0, stdout: '', stderr: '' };
+    sidecarFileContent = JSON.stringify({ schemaRev });
+}
+function setNoSidecar() {
+    sidecarCpResult = { status: 1, stdout: '', stderr: 'NoSuchKey' };
+    sidecarFileContent = null;
+}
+function setDbHead(rev) {
+    revQueryResult = rev === null
+        ? { status: 1, stdout: '', stderr: 'relation "_prisma_migrations" does not exist' }
+        : { status: 0, stdout: `${rev}\n`, stderr: '' };
+}
+
+describe('check_schema_rev_gate', () => {
+    beforeEach(() => {
+        spawnSync_calls.length = 0;
+        containerRunning = true;
+        setSidecar('20260603120000_add_session_index');
+        setDbHead('20260603120000_add_session_index');
+    });
+
+    it('verdict=clean when sidecar schemaRev matches the current DB head', () => {
+        const gate = check_schema_rev_gate({ ...BASE });
+        expect(gate.verdict).toBe(SCHEMA_GATE_VERDICTS.CLEAN);
+        expect(gate.refuse).toBe(false);
+        expect(gate.snapshotSchemaRev).toBe('20260603120000_add_session_index');
+        expect(gate.dbSchemaRev).toBe('20260603120000_add_session_index');
+    });
+
+    it('verdict=ahead + refuses in enforce when sidecar is ahead of DB head', () => {
+        setSidecar('20260701000000_later_migration');
+        setDbHead('20260603120000_add_session_index');
+        const gate = check_schema_rev_gate({ ...BASE, mode: 'enforce' });
+        expect(gate.verdict).toBe(SCHEMA_GATE_VERDICTS.AHEAD);
+        expect(gate.refuse).toBe(true);
+        expect(gate.message).toMatch(/ahead of DB head/);
+        expect(gate.message).toMatch(/rollback not supported/);
+    });
+
+    it('verdict=behind + refuses in enforce when sidecar is behind DB head', () => {
+        setSidecar('20260101000000_old_migration');
+        setDbHead('20260603120000_add_session_index');
+        const gate = check_schema_rev_gate({ ...BASE, mode: 'enforce' });
+        expect(gate.verdict).toBe(SCHEMA_GATE_VERDICTS.BEHIND);
+        expect(gate.refuse).toBe(true);
+        expect(gate.message).toMatch(/behind DB head/);
+        expect(gate.message).toMatch(/auto-heal is not enabled/);
+    });
+
+    it('verdict=no-sidecar + refuses in enforce when the sidecar is missing', () => {
+        setNoSidecar();
+        const gate = check_schema_rev_gate({ ...BASE, mode: 'enforce' });
+        expect(gate.verdict).toBe(SCHEMA_GATE_VERDICTS.NO_SIDECAR);
+        expect(gate.refuse).toBe(true);
+        expect(gate.snapshotSchemaRev).toBeNull();
+    });
+
+    it('treats a null schemaRev inside an otherwise-present sidecar like no-sidecar', () => {
+        setSidecar(null);
+        const gate = check_schema_rev_gate({ ...BASE, mode: 'enforce' });
+        expect(gate.verdict).toBe(SCHEMA_GATE_VERDICTS.NO_SIDECAR);
+        expect(gate.refuse).toBe(true);
+    });
+
+    it('verdict=unverified-fresh-db and always proceeds when the current DB has no applied migrations', () => {
+        setDbHead(null);
+        const gate = check_schema_rev_gate({ ...BASE, mode: 'enforce' });
+        expect(gate.verdict).toBe(SCHEMA_GATE_VERDICTS.UNVERIFIED_FRESH_DB);
+        expect(gate.refuse).toBe(false);
+        expect(gate.dbSchemaRev).toBeNull();
+        expect(gate.message).toMatch(/fresh provision/);
+    });
+
+    it('same unverified-fresh-db verdict/proceed behavior, but a distinct log message, when the container is unreachable rather than genuinely fresh', () => {
+        setDbHead(null);
+        containerRunning = false;
+        const gate = check_schema_rev_gate({ ...BASE, mode: 'enforce' });
+        expect(gate.verdict).toBe(SCHEMA_GATE_VERDICTS.UNVERIFIED_FRESH_DB);
+        expect(gate.refuse).toBe(false);
+        expect(gate.message).toMatch(/unreachable\/stopped/);
+        expect(gate.message).not.toMatch(/fresh provision/);
+    });
+
+    it('mode=off never refuses, regardless of verdict', () => {
+        setSidecar('20260701000000_later_migration'); // ahead
+        setDbHead('20260603120000_add_session_index');
+        const gate = check_schema_rev_gate({ ...BASE, mode: 'off' });
+        expect(gate.verdict).toBe(SCHEMA_GATE_VERDICTS.AHEAD);
+        expect(gate.refuse).toBe(false);
+    });
+
+    it('mode=warn logs the verdict but never refuses', () => {
+        setNoSidecar();
+        const gate = check_schema_rev_gate({ ...BASE, mode: 'warn' });
+        expect(gate.verdict).toBe(SCHEMA_GATE_VERDICTS.NO_SIDECAR);
+        expect(gate.refuse).toBe(false);
+    });
+
+    it('resolves the versioned sidecar object when profile carries an @vN pin', () => {
+        check_schema_rev_gate({ ...BASE, profile: 'canonical@v2' });
+        const cp = spawnSync_calls.find(([cmd, args]) => isSidecarCp(cmd, args));
+        expect(cp[1][2]).toBe('s3://seeds-bkt/programs-api-sbx/profile-canonical-v2.meta.json');
+    });
+
+    it('reads the sidecar from the seedFrom source prefix, same resolution as the dump', () => {
+        check_schema_rev_gate({ ...BASE, source_name: 'programs-api-canonical' });
+        const cp = spawnSync_calls.find(([cmd, args]) => isSidecarCp(cmd, args));
+        expect(cp[1][2]).toBe('s3://seeds-bkt/programs-api-canonical/profile-canonical.meta.json');
+    });
+});


### PR DESCRIPTION
## Summary

v1 "refuse-loudly" gate from the snapshot/schema-versioning design (see
`services/switchboard/docs/snapshot-schema-versioning.md` in
`hipponot/microservices`). Before a restore/switch wipes and reloads a
postgres DB, compares the snapshot's `.meta.json` sidecar `schemaRev`
(captured since infra-compose 1.5.x) against the CURRENT DB's live
migration head — read via the existing `extract_prisma_rev()`, **before**
anything is stopped or wiped.

Gate mode: env var **`SNAPSHOT_SCHEMA_GATE`** (`off` | `warn` | `enforce`),
default **`off`**. This PR does not flip it anywhere.

## Gate matrix

| Verdict | Condition | `off` | `warn` | `enforce` |
|---|---|---|---|---|
| `clean` | sidecar rev == DB head | proceed | proceed | proceed |
| `unverified-fresh-db` | DB head unreadable (fresh provision, or container down) | proceed | proceed | proceed (sidecar still required to exist) |
| `no-sidecar` | sidecar missing, or `schemaRev` is `null` | proceed | proceed (log) | **409 refuse** |
| `ahead` | sidecar rev > DB head | proceed | proceed (log) | **409 refuse** — rollback not supported |
| `behind` | sidecar rev < DB head | proceed | proceed (log) | **409 refuse** — no auto-heal in v1 |

Refusals are a non-2xx JSON body:
```json
{"ok": false, "error": "<message>", "verdict": "<verdict>", "snapshotSchemaRev": "...", "dbSchemaRev": "...", "gateMode": "enforce"}
```
Every evaluation, including proceed cases, logs one structured line with
the same fields — this is what a warn-mode soak reads.

## What this deliberately does NOT do (v1 scope, per spec)

The spec is explicit: **"v1 ships hard-fail-on-any-drift; auto-heal stays
OFF until the destructive gate exists."** This PR does not:
- run `prisma migrate deploy` (no auto-heal)
- build the one-shot ECS migration task
- detect destructive migrations

Both `ahead` and `behind` hard-refuse in enforce mode — there is no
"safe to auto-advance" path yet.

## Scope notes

- Postgres only. Mongo/mysql restores skip the gate entirely (mirrors the
  sidecar-write gate in `snapshot_db`) — verified by test, no rev query or
  sidecar fetch fires for those engines even in `enforce`.
- Shared choke point: `/restore` and `/switch` both go through
  `handle_switch` in `ec2-router.js`, so both get the same gate.
- A stopped/unreachable container is read the same as a genuinely fresh
  DB for `refuse` purposes (both must proceed — refusing here would break
  routine provisioning), but logs a distinct message so warn-soak reads
  don't conflate the two.
- `seedFrom` / version-pinned (`@vN`) restores resolve the sidecar the
  same way `download_profile_seed` resolves the dump (source-prefix
  override, versioned object stem).

## Version

`@saga-ed/infra-compose` 1.5.1 → **1.6.0**, matching the existing bump
convention (separate `chore` commit).

## Rollout plan (for the orchestrator to review, not part of this PR)

1. Publish 1.6.0 to CodeArtifact.
2. Bump `InfraComposeVersion` in the db-host-v2 ASG launch template (iac)
   — noted as a follow-up in the iac PR, not done here.
3. Run `warn` mode in dev for a soak period, reading the structured log
   lines above for false positives (especially `unverified-fresh-db` vs
   genuine drift).
4. Flip to `enforce` — gated on a design-reviewer sign-off per the
   orchestrator's process for irreversible-adjacent gates.

## Test plan

- [x] `npx vitest run` — 127/127 passing (20 new: 11 gate-logic unit tests
      in `profiles-schema-gate.unit.test.js`, 9 router-level tests in
      `ec2-router-schema-gate.unit.test.js`)
- [x] `npx eslint .` — clean
- [x] `npm run typecheck` — clean
- [x] Mongo/mysql skip verified (no rev query, no sidecar fetch, even in enforce)
- [x] Off/warn/enforce mode matrix covered, including the no-sidecar,
      ahead, behind, clean, and fresh-db-proceed cases