### PR TITLE
fix(saga-stack-cli): harden cold-start against silent build/env breakage (soa#359)

### DIFF
--- a/packages/node/saga-stack-cli/src/commands/stack/cold-start.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/cold-start.ts
@@ -326,6 +326,18 @@ export default class StackColdStart extends BaseCommand {
       if (scaffolded.length > 0 && !dry) {
         this.log(`✓ scaffolded ${scaffolded.length} .env file(s) — REVIEW their values before the tutorial`);
       }
+      // soa#359: an EXISTING .env/.env.local that predates a template gaining a new required
+      // var is silently stale — surface it here (an unset required var can fail that repo's
+      // build, e.g. rostering AUTHZ_DATABASE_URL → authz-db, and read as an "unhealthy" launch).
+      const stale = result.results.filter((r) => r.missingKeys.length > 0);
+      if (stale.length > 0) {
+        this.log(
+          `⚠ ${stale.length} existing .env file(s) are MISSING key(s) declared in .env.example — add them (set your own values):`,
+        );
+        for (const r of stale) {
+          this.log(`    ${r.repo}/${r.relPath}: ${r.missingKeys.join(', ')}`);
+        }
+      }
       // NOTE: this only covers repos that SHIP a .env.example. Any service whose .env is
       // gitignored with no template must still be created by hand (see cold-start.md).
     });

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/env-ensure.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/env-ensure.unit.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { classifyEnv, ensureEnv, shouldPrune } from '../env-ensure.js';
+import { classifyEnv, ensureEnv, parseEnvKeys, shouldPrune } from '../env-ensure.js';
 import type { EnvFs } from '../env-ensure.js';
 import type { EnsureRepo } from '../ensure-repos.js';
 
@@ -29,6 +29,11 @@ describe('pure helpers', () => {
     expect(shouldPrune('dist')).toBe(true);
     expect(shouldPrune('apps')).toBe(false);
   });
+  it('parseEnvKeys: extracts KEY names, ignoring comments/blanks/export prefix; null ⇒ []', () => {
+    expect(parseEnvKeys('A=1\n# c\n\nexport B=2\n  C = 3\nnot a line\n')).toEqual(['A', 'B', 'C']);
+    expect(parseEnvKeys(null)).toEqual([]);
+    expect(parseEnvKeys('')).toEqual([]);
+  });
 });
 
 /** A fake EnvFs over an in-memory tree. `dirsChildren` maps a dir → its entries. */
@@ -36,6 +41,7 @@ function makeFakeEnvFs(
   files: Set<string>,
   dirsChildren: Record<string, { name: string; isDir: boolean }[]>,
   copies: Array<[string, string]>,
+  contents: Record<string, string> = {},
 ): EnvFs {
   return {
     list: (dir) => dirsChildren[dir] ?? [],
@@ -44,6 +50,7 @@ function makeFakeEnvFs(
       copies.push([from, to]);
       files.add(to); // reflect the write so a later check sees it
     },
+    read: (p) => contents[p] ?? null,
   };
 }
 
@@ -117,5 +124,62 @@ describe('ensureEnv — fake-fs discovery + scaffold', () => {
     const res = ensureEnv([repo('ghost')], { fs: makeFakeEnvFs(files, {}, copies) });
     expect(res.results).toEqual([]);
     expect(copies).toEqual([]);
+  });
+});
+
+describe('ensureEnv — soa#359 key reconcile', () => {
+  /** A repo root holding `.env.example` + whatever root files are listed. */
+  const rootTree = (
+    rootFiles: string[],
+  ): { files: Set<string>; children: Record<string, { name: string; isDir: boolean }[]> } => ({
+    files: new Set<string>(['/dev/rostering/.git', '/dev/rostering/.env.example', ...rootFiles]),
+    children: {
+      '/dev/rostering': [
+        { name: '.git', isDir: false },
+        { name: '.env.example', isDir: false },
+        ...rootFiles.map((f) => ({ name: f.split('/').pop() as string, isDir: false })),
+      ],
+    },
+  });
+
+  it('a PRESENT .env missing an example key (also absent from .env.local) is flagged, never copied', () => {
+    const { files, children } = rootTree(['/dev/rostering/.env', '/dev/rostering/.env.local']);
+    const copies: Array<[string, string]> = [];
+    const res = ensureEnv([repo('rostering')], {
+      fs: makeFakeEnvFs(files, children, copies, {
+        '/dev/rostering/.env.example': 'DATABASE_URL=x\nAUTHZ_DATABASE_URL=y\n',
+        '/dev/rostering/.env': 'DATABASE_URL=real\n',
+        '/dev/rostering/.env.local': 'REDIS_URL=r\n',
+      }),
+    });
+    const root = res.results.find((r) => r.relPath === '.env');
+    expect(root?.action).toBe('present');
+    expect(root?.missingKeys).toEqual(['AUTHZ_DATABASE_URL']);
+    expect(root?.message).toContain('AUTHZ_DATABASE_URL');
+    expect(copies).toEqual([]); // reported, never appended/overwritten
+  });
+
+  it('a key provided by .env.local (not .env) is NOT flagged — union of sources', () => {
+    const { files, children } = rootTree(['/dev/rostering/.env', '/dev/rostering/.env.local']);
+    const res = ensureEnv([repo('rostering')], {
+      fs: makeFakeEnvFs(files, children, [], {
+        '/dev/rostering/.env.example': 'AUTHZ_DATABASE_URL=y\n',
+        '/dev/rostering/.env': '# nothing here\n',
+        '/dev/rostering/.env.local': 'AUTHZ_DATABASE_URL=mine\n',
+      }),
+    });
+    expect(res.results.find((r) => r.relPath === '.env')?.missingKeys).toEqual([]);
+  });
+
+  it('a freshly SCAFFOLDED .env is never key-checked (it is a verbatim copy of the template)', () => {
+    const { files, children } = rootTree([]); // no .env yet ⇒ scaffold
+    const res = ensureEnv([repo('rostering')], {
+      fs: makeFakeEnvFs(files, children, [], {
+        '/dev/rostering/.env.example': 'AUTHZ_DATABASE_URL=y\n',
+      }),
+    });
+    const root = res.results.find((r) => r.relPath === '.env');
+    expect(root?.action).toBe('scaffolded');
+    expect(root?.missingKeys).toEqual([]);
   });
 });

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/prep.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/prep.unit.test.ts
@@ -264,6 +264,22 @@ describe('prepClosure — closure-scoped install/build/db:generate (R1)', () => 
     expect(FATAL_BUILD_REPOS.has('COACH')).toBe(true);
   });
 
+  it('soa#359: a ROSTERING build failure is FATAL — iam-api imports @saga-ed/iam-db from dist/ at launch', async () => {
+    // Regression for the "iam-api never became healthy" mystery: a swallowed rostering
+    // build failure must ABORT with the real build error, not launch a broken stack.
+    const { runner } = runnerFailingWhen((s) => s.cwd === '/dev/rostering' && s.args[0] === 'build');
+    const res = await prepClosure({
+      services: ['iam-api'] as ServiceId[],
+      dbs: [] as DbId[],
+      repoRoots: REPO_ROOTS,
+      runner,
+      isFresh: NEVER_FRESH,
+    });
+    expect(res.ok).toBe(false);
+    expect(res.failed).toMatchObject({ repo: 'ROSTERING', kind: 'build' });
+    expect(FATAL_BUILD_REPOS.has('ROSTERING')).toBe(true);
+  });
+
   it('FLIP 4: a 401 install failure triggers `pnpm co:login` + ONE retry, then proceeds', async () => {
     // install #1 answers a CodeArtifact 401 (unauthorized), co:login succeeds, install
     // #2 (the retry) succeeds → the pass proceeds to build.
@@ -476,7 +492,7 @@ describe('prepClosure — soa#260 build-failure repair escalation', () => {
     };
     const stamped: string[] = [];
     const res = await prepClosure({
-      services: ['iam-api'] as ServiceId[], // ROSTERING — non-fatal build
+      services: ['iam-api'] as ServiceId[], // ROSTERING (soa#359 fatal), but repair heals before the fatal check
       dbs: [] as DbId[],
       repoRoots: REPO_ROOTS,
       runner,
@@ -493,12 +509,12 @@ describe('prepClosure — soa#260 build-failure repair escalation', () => {
     expect(res.steps.map((s) => s.kind)).toEqual(['install', 'build', 'repair', 'install', 'build']);
   });
 
-  it('a build failure with NO repairable signature ⇒ normal non-fatal warning, no wipe, not stamped', async () => {
+  it('a build failure with NO repairable signature ⇒ the repo\'s normal handling (FATAL for ROSTERING), no wipe, not stamped', async () => {
     const { runner } = runnerFailingWhen((s) => s.args[0] === 'build');
     const stamped: string[] = [];
     let asked = 0;
     const res = await prepClosure({
-      services: ['iam-api'] as ServiceId[],
+      services: ['iam-api'] as ServiceId[], // ROSTERING — FATAL build (soa#359)
       dbs: [] as DbId[],
       repoRoots: REPO_ROOTS,
       runner,
@@ -509,9 +525,12 @@ describe('prepClosure — soa#260 build-failure repair escalation', () => {
         return false; // no corruption signature ⇒ do not escalate
       },
     });
-    expect(res.ok).toBe(true);
+    // soa#359: ROSTERING build is fatal, so the un-repairable failure ABORTS the pass
+    // (surfaced via `failed`, not a warning) instead of silently continuing to launch.
+    expect(res.ok).toBe(false);
+    expect(res.failed).toMatchObject({ repo: 'ROSTERING', kind: 'build' });
     expect(asked).toBe(1); // consulted once, found nothing repairable
-    expect(res.warnings.map((w) => w.kind)).toEqual(['build']); // normal non-fatal warning
+    expect(res.warnings).toHaveLength(0); // fatal abort ⇒ no non-fatal warning
     expect(stamped).not.toContain('/dev/rostering'); // failed build ⇒ no stamp
     expect(res.steps.filter((s) => s.kind === 'repair')).toHaveLength(0); // no wipe
     expect(res.steps.filter((s) => s.kind === 'install')).toHaveLength(1); // no reinstall

--- a/packages/node/saga-stack-cli/src/runtime/env-ensure.ts
+++ b/packages/node/saga-stack-cli/src/runtime/env-ensure.ts
@@ -13,20 +13,37 @@
  * defaults the team commits), it does not invent secrets. A repo that needs a `.env` but ships no
  * example is reported as `missing-no-template` — an action item, not a silent pass.
  *
+ * soa#359 — KEY RECONCILE: scaffolding only fires when the `.env` is ABSENT, so an EXISTING
+ * `.env`/`.env.local` that predates a template gaining a new required var goes silently stale —
+ * the break behind "iam-api never became healthy" (rostering's `.env.local` lacked
+ * `AUTHZ_DATABASE_URL`, so authz-db's `prisma generate` threw and the whole rostering build
+ * died). So for a PRESENT `.env`, this ALSO reports the `.env.example` keys missing from the
+ * repo's `ENV_KEY_SOURCES` (`missingExampleKeys`) as an action item. It REPORTS, never appends:
+ * a template's value can be wrong for a given box (e.g. a port that differs from the local mesh).
+ *
  * Discovery is a PRUNED recursive walk (skips `node_modules`/`.git`/build output — the noise that
  * would otherwise surface a dependency's own `.env.example`); the copy is `.env.example` → `.env`.
- * The action classifier (`classifyEnv`) + the prune predicate (`shouldPrune`) are PURE and
- * unit-tested; the walk + copy live behind the injectable `EnvFs` seam. IO stays in
- * `src/runtime/**`.
+ * The pure helpers (`classifyEnv`, `shouldPrune`, `parseEnvKeys`) are unit-tested; the walk, copy,
+ * and read live behind the injectable `EnvFs` seam. IO stays in `src/runtime/**`.
  */
 
-import { copyFileSync, existsSync, readdirSync } from 'node:fs';
+import { copyFileSync, existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import type { EnsureRepo } from './ensure-repos.js';
 
 /** The template filename a repo ships and the runtime file it seeds. */
 export const ENV_EXAMPLE = '.env.example';
 export const ENV_TARGET = '.env';
+
+/**
+ * The env files a repo's dotenv chain actually reads (besides the vars the CLI injects).
+ * A key declared in `.env.example` counts as "provided" if it appears in ANY of these —
+ * `.env.local` overrides `.env` in dotenv precedence, so either satisfies the key. This
+ * is the union heuristic behind the soa#359 reconcile check (`missingExampleKeys`); it
+ * can't model a tool that reads ONLY `.env.local`, but it never false-flags a key that
+ * a checkout does provide somewhere.
+ */
+export const ENV_KEY_SOURCES = ['.env', '.env.local'] as const;
 
 /** Dir names the discovery walk NEVER descends into (noise / not source). */
 export const ENV_WALK_PRUNE = new Set([
@@ -58,6 +75,23 @@ export function classifyEnv(input: { exampleExists: boolean; targetExists: boole
   return input.exampleExists ? 'scaffolded' : 'missing-no-template';
 }
 
+/**
+ * PURE: the variable names assigned in a dotenv-style file — one `KEY=value` per line,
+ * `#` comments and blank lines ignored, an optional `export ` prefix allowed. Values are
+ * irrelevant to the reconcile check, so they're discarded. `null`/empty ⇒ no keys.
+ */
+export function parseEnvKeys(content: string | null): string[] {
+  if (!content) return [];
+  const keys: string[] = [];
+  for (const raw of content.split('\n')) {
+    const line = raw.trim();
+    if (line === '' || line.startsWith('#')) continue;
+    const name = /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=/.exec(line)?.[1];
+    if (name) keys.push(name);
+  }
+  return keys;
+}
+
 /** One `.env` outcome (for the command's report + JSON). */
 export interface EnvEnsureResult {
   /** The repo dir name. */
@@ -65,6 +99,12 @@ export interface EnvEnsureResult {
   /** The `.env` path, repo-relative (e.g. `apps/node/iam-api/.env`). */
   relPath: string;
   action: EnvAction;
+  /**
+   * Keys declared in this dir's `.env.example` but absent from every `ENV_KEY_SOURCES`
+   * file (soa#359). Non-empty ⇒ an existing `.env`/`.env.local` predates a template that
+   * added a required var — the silent break behind "iam-api never became healthy".
+   */
+  missingKeys: string[];
   /** A ready-to-print human line. */
   message: string;
 }
@@ -76,6 +116,8 @@ export interface EnvFs {
   exists(path: string): boolean;
   /** Copy `.env.example` → `.env` (never called when the target exists). */
   copy(from: string, to: string): void;
+  /** Read a file's text, or `null` if missing/unreadable (for the key-reconcile check). */
+  read(path: string): string | null;
 }
 
 /** The seams + inputs `ensureEnv` drives. */
@@ -114,14 +156,22 @@ export function ensureEnv(repos: EnsureRepo[], deps: EnsureEnvDeps): EnsureEnvRe
       const action = classifyEnv({ exampleExists: true, targetExists: fs.exists(target) });
       if (action === 'scaffolded' && !deps.dryRun) fs.copy(example, target);
 
+      // soa#359: only a PRE-EXISTING env can be stale — a fresh scaffold is a verbatim
+      // copy of the template, so it has every example key by construction.
+      const missingKeys = action === 'present' ? missingExampleKeys(dir, example, fs) : [];
       const relPath = relative(repo.path, target);
       results.push({
         repo: repo.name,
         relPath,
         action,
-        message: envMessage(action, relPath, deps.dryRun ?? false),
+        missingKeys,
+        message: envMessage(action, relPath, deps.dryRun ?? false, missingKeys),
       });
-      notify(`  ${envSymbol(action)} ${repo.name}/${relPath}${action === 'scaffolded' && deps.dryRun ? ' (would copy)' : ''}`);
+      notify(
+        `  ${envSymbol(action, missingKeys)} ${repo.name}/${relPath}` +
+          (action === 'scaffolded' && deps.dryRun ? ' (would copy)' : '') +
+          (missingKeys.length > 0 ? ` — missing key(s): ${missingKeys.join(', ')}` : ''),
+      );
     }
   }
   return { ok: results.every((r) => r.action !== 'missing-no-template'), results };
@@ -152,11 +202,30 @@ function discoverTemplateDirs(repoRoot: string, fs: EnvFs): string[] {
   return found.sort();
 }
 
+/**
+ * soa#359: the `.env.example` keys in `dir` that no `ENV_KEY_SOURCES` file provides.
+ * Reads the template plus each present `.env`/`.env.local` through the `EnvFs.read` seam
+ * and returns example keys missing from their union. An example with no parseable keys
+ * (or an unreadable one) yields `[]` — a warning, never an invented key.
+ */
+function missingExampleKeys(dir: string, example: string, fs: EnvFs): string[] {
+  const exampleKeys = parseEnvKeys(fs.read(example));
+  if (exampleKeys.length === 0) return [];
+  const have = new Set<string>();
+  for (const name of ENV_KEY_SOURCES) {
+    const p = join(dir, name);
+    if (fs.exists(p)) for (const k of parseEnvKeys(fs.read(p))) have.add(k);
+  }
+  return exampleKeys.filter((k) => !have.has(k));
+}
+
 /** The human line for one env outcome. */
-function envMessage(action: EnvAction, relPath: string, dryRun: boolean): string {
+function envMessage(action: EnvAction, relPath: string, dryRun: boolean, missingKeys: string[]): string {
   switch (action) {
     case 'present':
-      return `${relPath} present`;
+      return missingKeys.length > 0
+        ? `${relPath} present but MISSING key(s) from ${ENV_EXAMPLE}: ${missingKeys.join(', ')} — add them (set your own values)`
+        : `${relPath} present`;
     case 'scaffolded':
       return dryRun
         ? `${relPath} MISSING — would copy from ${ENV_EXAMPLE} (review the values)`
@@ -166,8 +235,9 @@ function envMessage(action: EnvAction, relPath: string, dryRun: boolean): string
   }
 }
 
-/** The status glyph for an env action. */
-function envSymbol(action: EnvAction): string {
+/** The status glyph for an env action (a present file MISSING template keys warns). */
+function envSymbol(action: EnvAction, missingKeys: string[]): string {
+  if (action === 'present' && missingKeys.length > 0) return '⚠';
   switch (action) {
     case 'present':
       return '·';
@@ -198,6 +268,13 @@ export function makeRealEnvFs(): EnvFs {
       // The template's dir always exists (it holds `from`), so a plain copy suffices; "never
       // overwrite" is enforced by the caller (copy is only invoked for a MISSING target).
       copyFileSync(from, to);
+    },
+    read(path: string): string | null {
+      try {
+        return readFileSync(path, 'utf8');
+      } catch {
+        return null;
+      }
     },
   };
 }

--- a/packages/node/saga-stack-cli/src/runtime/prep.ts
+++ b/packages/node/saga-stack-cli/src/runtime/prep.ts
@@ -29,11 +29,12 @@
  *     distinction isn't expressible from the manifest yet (see the report).
  *   - FATAL MAP (MAJOR-C): up.sh's `build_step` defaults NON-fatal (warn+continue)
  *     and is fatal only for QBOARD/RTSM/COACH (their services import workspace
- *     `dist/` at launch); ROSTERING/PROGRAM_HUB/SDS builds
- *     and ALL `db:generate` (`|| true`) are NON-fatal. R1
- *     mirrors this: a non-fatal build/db:generate failure is recorded as a WARNING
- *     and the pass continues; only a FATAL_BUILD_REPOS build (or any `pnpm install`,
- *     which up.sh's `pnpm_install` also aborts on) stops the pass.
+ *     `dist/` at launch); PROGRAM_HUB/SDS builds and ALL `db:generate` (`|| true`)
+ *     are NON-fatal. soa#359 ADDS ROSTERING to the fatal set (iam-api imports
+ *     `@saga-ed/iam-db` from `dist/` at launch — a deliberate divergence from up.sh;
+ *     see FATAL_BUILD_REPOS). R1 mirrors this: a non-fatal build/db:generate failure
+ *     is recorded as a WARNING and the pass continues; only a FATAL_BUILD_REPOS build
+ *     (or any `pnpm install`, which up.sh's `pnpm_install` also aborts on) stops the pass.
  *   - Repos are ordered by up.sh's canonical prep order for determinism.
  *
  * `--skip-prep` (up.sh `SKIP_PREP=1`): short-circuits R1 ONLY (this pass). Unlike
@@ -76,8 +77,21 @@ export const INSTALL_ONLY_REPOS: ReadonlySet<RepoKey> = new Set<RepoKey>(['SAGA_
  * import workspace `dist/` at launch, so an unbuilt tree is a guaranteed crash
  * (up.sh: `build_step … 1`). Every other repo's build is
  * NON-fatal (warn + continue), matching up.sh's default `build_step`.
+ *
+ * ROSTERING (soa#359): iam-api imports `@saga-ed/iam-db` (and `iam-pii-db`) from
+ * their built `dist/` at launch, so a failed rostering build lands exactly the
+ * "iam-api never became healthy" crash this set exists to prevent. It was NON-fatal
+ * only because the classification is a stale port of up.sh's — from before iam-api
+ * depended on a workspace `*-db` package. Swallowed, a rostering build failure
+ * surfaces as a mystery launch failure instead of the real build error.
+ * (PROGRAM_HUB/SDS may warrant the same by the same criterion — see soa#359.)
  */
-export const FATAL_BUILD_REPOS: ReadonlySet<RepoKey> = new Set<RepoKey>(['QBOARD', 'RTSM', 'COACH']);
+export const FATAL_BUILD_REPOS: ReadonlySet<RepoKey> = new Set<RepoKey>([
+  'ROSTERING',
+  'QBOARD',
+  'RTSM',
+  'COACH',
+]);
 
 /** up.sh's canonical prep order. Non-built repos (SOA/FLEEK) omitted. */
 const PREP_REPO_ORDER: readonly RepoKey[] = [


### PR DESCRIPTION
Fixes #359.

## The failure

`ss stack cold-start` died with a misleading message:

```
service launch FAILED at iam-api — it never became healthy
```

The real cause was two layers deep, and cold-start hid it:

1. **A missing env key breaks the rostering build.** `rostering/.env.example` gained `AUTHZ_DATABASE_URL` when `authz-db` landed, but pre-existing `.env.local` files never got the key. `authz-db/prisma.config.ts` throws without it (even for `prisma generate`, which never connects to a DB), so `db:generate` fails; since turbo's `build` depends on `db:generate` and turbo (no `--continue`) stops scheduling after a failure, **iam-db never builds** → its `dist/` is absent → iam-api crashes importing `@saga-ed/iam-db/dist/index.js`.
2. **`ss` swallowed it.** `FATAL_BUILD_REPOS = {QBOARD, RTSM, COACH}` — a **ROSTERING** build failure was NON-fatal, so prep logged a warning and cold-start launched anyway. Confirmed via the soa#256 prep-stamp: rostering had **no stamp** while every other repo did → `buildFailed` was swallowed.

## Changes

**`prep.ts` — make ROSTERING build-fatal.** iam-api imports a workspace `*-db` package from `dist/` at launch, so a failed rostering build is a guaranteed launch crash. It aborts at the build step with the real error instead of a downstream mystery. (up.sh's non-fatal classification predated iam-api depending on a workspace `*-db` package. PROGRAM_HUB/SDS are candidates by the same criterion — noted for follow-up.)

**`env-ensure.ts` — reconcile `.env` KEYS, not just presence.** Scaffolding only fired when a `.env` was *absent*, so an existing `.env`/`.env.local` that predates a template gaining a new required var went silently stale. The ensure-.env step now also reports `.env.example` keys missing from the repo's `.env`/`.env.local` (`ENV_KEY_SOURCES`) as an action item in cold-start's output. **Reports, never appends** — a template's value can be wrong for a given box (the example's `authz_local` is on port 5434; local mesh is 5432).

## Verification

- ✅ Root cause reproduced and fixed: with `AUTHZ_DATABASE_URL` set, `authz-db`/`iam-db` build clean; `ss stack up` then brought the stack up (iam-api `/health` → 200).
- ✅ New/updated unit tests: ROSTERING-fatal-build regression; repair-escalation expectation flipped to fatal; `parseEnvKeys`; reconcile (present-missing-key, union-of-sources, scaffold-skips).
- ✅ Full package suite (1423 passed), `check-types`, and `eslint` all green.

## Workaround (for anyone hitting this before merge)

Add `AUTHZ_DATABASE_URL=postgresql://iam:iam@localhost:5432/authz_local` to `rostering/.env.local`, rebuild rostering, `ss stack up`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)