### PR TITLE
feat(saga-stack-cli): --fake-video/--fake-audio for stack login browser (soa#363)

### DIFF
--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -2464,7 +2464,8 @@
       "examples": [
         "<%= config.bin %> <%= command.id %>",
         "<%= config.bin %> <%= command.id %> teacher@saga.org",
-        "<%= config.bin %> <%= command.id %> --browser"
+        "<%= config.bin %> <%= command.id %> --browser",
+        "<%= config.bin %> <%= command.id %> empty@saga.org --browser --fake-video ~/clips/student.mp4"
       ],
       "flags": {
         "browser": {
@@ -2486,6 +2487,20 @@
           "multiple": false,
           "name": "dev",
           "noCacheDefault": true,
+          "type": "option"
+        },
+        "fake-audio": {
+          "description": "feed a LOCAL audio file into the --browser Chromium's fake mic. Auto-transcoded to PCM WAV via ffmpeg (a .wav file is used as-is). Overrides the audio derived from --fake-video. Requires --browser.",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "fake-audio",
+          "type": "option"
+        },
+        "fake-video": {
+          "description": "feed a LOCAL video file into the --browser Chromium's fake camera (AV flows on a box with no real device). Auto-transcoded to Y4M via ffmpeg (a .y4m file is used as-is); also derives the mic track from this file unless --fake-audio is given. Requires --browser.",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "fake-video",
           "type": "option"
         },
         "fleek": {

--- a/packages/node/saga-stack-cli/src/base-command.ts
+++ b/packages/node/saga-stack-cli/src/base-command.ts
@@ -1178,6 +1178,13 @@ export abstract class BaseCommand extends Command {
        * rejection is the CALLER's own close request — swallowed, never warned.
        */
       signal?: AbortSignal;
+      /**
+       * Extra Chromium launch flags for browser-login.mjs to spread onto its own
+       * `['--start-maximized']` (soa#363). Today this carries the fake-media capture
+       * flags (`--use-file-for-fake-video-capture=…` etc.) built by the pure
+       * `fakeMediaChromiumArgs`; passed as a JSON array via `CHROMIUM_EXTRA_ARGS`.
+       */
+      chromiumExtraArgs?: string[];
     },
   ): Promise<void> {
     const script = resolveVendorScript('browser-login.mjs');
@@ -1214,6 +1221,11 @@ export abstract class BaseCommand extends Command {
       // browser-login.mjs reads this as its playwright-resolution dir (name historical).
       SAGA_DASH_DASH: spaAppDir,
     };
+    // soa#363: extra Chromium flags (today: fake-media file capture) — browser-login.mjs
+    // JSON-parses this and spreads it onto its launch args. Omitted when empty.
+    if (ctx.chromiumExtraArgs && ctx.chromiumExtraArgs.length > 0) {
+      env.CHROMIUM_EXTRA_ARGS = JSON.stringify(ctx.chromiumExtraArgs);
+    }
     try {
       await this.runVendor(
         { cwd: spaAppDir, command: 'node', args: [script], env, signal: ctx.signal },

--- a/packages/node/saga-stack-cli/src/commands/stack/login.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/login.ts
@@ -22,12 +22,24 @@
  *   node bin/dev.js stack login                         # native headless jar (dev@saga.org)
  *   node bin/dev.js stack login teacher@saga.org        # native headless jar (persona)
  *   node bin/dev.js stack login --browser               # native jar + vendored browser-login.mjs
+ *
+ * FAKE MEDIA (`--fake-video`/`--fake-audio`, soa#363): feed a LOCAL video/audio file into
+ * the `--browser` Chromium's camera/mic (for AV flows on a box with no real devices).
+ * Chromium's file-backed fake capture reads only raw Y4M video + PCM WAV audio, so any
+ * other format (`.mp4`, …) is auto-transcoded via ffmpeg (a `.y4m`/`.wav` input is used
+ * as-is). `--fake-video foo.mp4` alone also DERIVES the mic track from the same file.
+ * Applies only with `--browser`.
+ *
+ *   node bin/dev.js stack login empty@saga.org --browser --fake-video ~/clips/student.mp4
  */
 
+import { join, resolve } from 'node:path';
 import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command.js';
 import { deriveInstance } from '../../core/derive-instance.js';
+import { fakeMediaChromiumArgs } from '../../core/fake-media.js';
 import { DEFAULT_LOGIN_USER, loginFailureHint } from '../../core/login.js';
+import { prepareFakeMedia } from '../../runtime/index.js';
 
 export default class StackLogin extends BaseCommand {
   static description =
@@ -37,6 +49,7 @@ export default class StackLogin extends BaseCommand {
     '<%= config.bin %> <%= command.id %>',
     '<%= config.bin %> <%= command.id %> teacher@saga.org',
     '<%= config.bin %> <%= command.id %> --browser',
+    '<%= config.bin %> <%= command.id %> empty@saga.org --browser --fake-video ~/clips/student.mp4',
   ];
 
   static args = {
@@ -52,6 +65,14 @@ export default class StackLogin extends BaseCommand {
       default: false,
       description:
         'ALSO open an auto-logged-in Chromium via the vendored browser-login.mjs (native headless jar + headful browser). The default mints only the native headless cookie jar.',
+    }),
+    'fake-video': Flags.string({
+      description:
+        "feed a LOCAL video file into the --browser Chromium's fake camera (AV flows on a box with no real device). Auto-transcoded to Y4M via ffmpeg (a .y4m file is used as-is); also derives the mic track from this file unless --fake-audio is given. Requires --browser.",
+    }),
+    'fake-audio': Flags.string({
+      description:
+        "feed a LOCAL audio file into the --browser Chromium's fake mic. Auto-transcoded to PCM WAV via ffmpeg (a .wav file is used as-is). Overrides the audio derived from --fake-video. Requires --browser.",
     }),
   };
 
@@ -73,6 +94,14 @@ export default class StackLogin extends BaseCommand {
     const email = args.email ?? DEFAULT_LOGIN_USER;
     const profile = deriveInstance({ slot: flags.slot });
     const stateDir = flags['state-dir'] ?? profile.stateDir;
+
+    // --fake-video/--fake-audio only reach the headful Chromium; without --browser
+    // there is nothing to feed them into (soa#363).
+    const fakeVideo = flags['fake-video'];
+    const fakeAudio = flags['fake-audio'];
+    if ((fakeVideo || fakeAudio) && !flags.browser) {
+      this.warn('--fake-video/--fake-audio apply only with --browser — ignoring (no headful browser to feed).');
+    }
 
     const res = await this.mintNativeLoginJar({ email, slot: flags.slot, stateDir });
     const { iamUrl, jarPath } = res;
@@ -118,7 +147,34 @@ export default class StackLogin extends BaseCommand {
       // byte-identical to the previous slot-0-only behaviour.
       const dashPort = profile.portOverrides['saga-dash'] ?? 8900;
       const dashUrl = process.env.LOGIN_DASH_URL || `http://localhost:${dashPort}`;
-      await this.openVendoredBrowser(flags, { email, iamUrl, stateDir, dashUrl });
+
+      // soa#363: transcode any --fake-video/--fake-audio to Chromium capture format and
+      // build the launch flags. A prep failure (missing file / ffmpeg / bad transcode) is
+      // NON-fatal — the jar is already minted, so warn and open a NORMAL browser rather
+      // than abort; the user sees exactly why the fake camera didn't engage.
+      let chromiumExtraArgs: string[] = [];
+      if (fakeVideo || fakeAudio) {
+        try {
+          const prepared = await prepareFakeMedia(
+            {
+              video: fakeVideo ? resolve(process.cwd(), fakeVideo) : undefined,
+              audio: fakeAudio ? resolve(process.cwd(), fakeAudio) : undefined,
+              outDir: join(stateDir, 'fake-av'),
+            },
+            { runner: this.getRunner(), notify: (m) => this.log(m) },
+          );
+          chromiumExtraArgs = fakeMediaChromiumArgs(prepared);
+          this.log(
+            `  fake media ready — camera${prepared.audio ? ' + mic' : ''} will play ${prepared.video ?? prepared.audio}`,
+          );
+        } catch (err) {
+          this.warn(
+            `fake media skipped — ${err instanceof Error ? err.message : String(err)} (opening the browser without it)`,
+          );
+        }
+      }
+
+      await this.openVendoredBrowser(flags, { email, iamUrl, stateDir, dashUrl, chromiumExtraArgs });
     }
   }
 }

--- a/packages/node/saga-stack-cli/src/core/__tests__/fake-media.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/fake-media.unit.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Fake-media planning (PURE) — soa#363. Cover the transcode plan (target formats,
+ * passthrough, derived-audio rules, outDir) and the Chromium flag builder.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { fakeMediaChromiumArgs, planFakeMedia } from '../fake-media.js';
+
+describe('planFakeMedia', () => {
+  it('an .mp4 video plans a Y4M transcode AND derives a WAV audio from the same file', () => {
+    const plan = planFakeMedia({ video: '/clips/student.mp4', outDir: '/state/fake-av' });
+    expect(plan.video).toMatchObject({
+      input: '/clips/student.mp4',
+      output: '/state/fake-av/student.fake-video.y4m',
+      passthrough: false,
+      derived: false,
+    });
+    expect(plan.video?.argv).toEqual([
+      '-y', '-i', '/clips/student.mp4', '-pix_fmt', 'yuv420p', '/state/fake-av/student.fake-video.y4m',
+    ]);
+    // audio derived from the SAME file (mp4 carries both), marked derived ⇒ non-fatal.
+    expect(plan.audio).toMatchObject({
+      input: '/clips/student.mp4',
+      output: '/state/fake-av/student.fake-audio.wav',
+      passthrough: false,
+      derived: true,
+    });
+    expect(plan.audio?.argv).toContain('-vn');
+    expect(plan.audio?.argv).toContain('pcm_s16le');
+  });
+
+  it('a .y4m video is passthrough (no transcode) and does NOT derive audio', () => {
+    const plan = planFakeMedia({ video: '/clips/pattern.y4m', outDir: '/o' });
+    expect(plan.video).toMatchObject({ output: '/clips/pattern.y4m', passthrough: true, argv: [] });
+    expect(plan.audio).toBeUndefined(); // a raw .y4m has no audio to derive
+  });
+
+  it('an explicit --fake-audio is NOT derived (fatal on failure) and overrides derivation', () => {
+    const plan = planFakeMedia({ video: '/v.mp4', audio: '/a.mp3', outDir: '/o' });
+    expect(plan.audio).toMatchObject({ input: '/a.mp3', output: '/o/a.fake-audio.wav', derived: false });
+  });
+
+  it('a .wav audio is passthrough', () => {
+    const plan = planFakeMedia({ audio: '/a.wav', outDir: '/o' });
+    expect(plan.audio).toMatchObject({ output: '/a.wav', passthrough: true, argv: [] });
+    expect(plan.video).toBeUndefined();
+  });
+
+  it('empty request ⇒ empty plan', () => {
+    expect(planFakeMedia({ outDir: '/o' })).toEqual({});
+  });
+});
+
+describe('fakeMediaChromiumArgs', () => {
+  it('no files ⇒ no flags', () => {
+    expect(fakeMediaChromiumArgs({})).toEqual([]);
+  });
+
+  it('video + audio ⇒ fake device + auto-accept + both file flags', () => {
+    expect(fakeMediaChromiumArgs({ video: '/o/v.y4m', audio: '/o/a.wav' })).toEqual([
+      '--use-fake-device-for-media-stream',
+      '--use-fake-ui-for-media-stream',
+      '--use-file-for-fake-video-capture=/o/v.y4m',
+      '--use-file-for-fake-audio-capture=/o/a.wav',
+    ]);
+  });
+
+  it('video only ⇒ no audio-capture flag', () => {
+    const args = fakeMediaChromiumArgs({ video: '/o/v.y4m' });
+    expect(args).toContain('--use-file-for-fake-video-capture=/o/v.y4m');
+    expect(args.some((a) => a.startsWith('--use-file-for-fake-audio-capture'))).toBe(false);
+  });
+});

--- a/packages/node/saga-stack-cli/src/core/fake-media.ts
+++ b/packages/node/saga-stack-cli/src/core/fake-media.ts
@@ -1,0 +1,107 @@
+/**
+ * Fake-media planning (PURE) — turn a user's `--fake-video`/`--fake-audio` inputs into
+ * (a) the ffmpeg transcode steps that produce Chromium-consumable capture files and
+ * (b) the Chromium launch flags that feed them. No IO here: file existence, ffmpeg
+ * execution, and caching live in `runtime/fake-media`.
+ *
+ * WHY: Chromium's fake device can play a FILE into `getUserMedia` via
+ * `--use-file-for-fake-video-capture=<Y4M>` / `--use-file-for-fake-audio-capture=<WAV>`,
+ * but ONLY those raw formats. So an `.mp4` the user hands us must be transcoded first:
+ * video → Y4M (yuv420p), audio → 16-bit PCM WAV. A file ALREADY in the target format is
+ * passed through untouched (a power user can pre-transcode and skip ffmpeg). When only a
+ * video is given, its audio track is DERIVED from the same file (an mp4 usually carries
+ * both) — a derive that fails (video-only source) is dropped, not fatal (see runtime).
+ *
+ * INVARIANT (plan hard constraint): this lives in `core/` and stays PURE — only
+ * `node:path` string ops, no `fs`/spawn. The host IO lives in `runtime/fake-media`.
+ */
+
+import { basename, extname, join } from 'node:path';
+
+/** The raw containers Chromium's file-backed fake capture requires. */
+export const VIDEO_TARGET_EXT = '.y4m';
+export const AUDIO_TARGET_EXT = '.wav';
+
+/** One transcode (or passthrough) of a single capture stream. */
+export interface FfmpegStep {
+  /** Absolute source path (the user's file). */
+  input: string;
+  /** Absolute destination under the plan's `outDir` — or `=== input` when passthrough. */
+  output: string;
+  /** ffmpeg argv AFTER `ffmpeg` (empty when passthrough — nothing to run). */
+  argv: string[];
+  /** Input is ALREADY in the target format ⇒ no transcode, use as-is. */
+  passthrough: boolean;
+  /**
+   * This AUDIO step's source is the VIDEO file (derived), not an explicit `--fake-audio`.
+   * A derived transcode that fails (the video has no audio track) is NON-fatal — drop
+   * audio, keep video; an EXPLICIT `--fake-audio` failure is fatal. Always false for video.
+   */
+  derived: boolean;
+}
+
+/** The transcodes to run for a `--fake-video`/`--fake-audio` request. */
+export interface FakeMediaPlan {
+  video?: FfmpegStep;
+  audio?: FfmpegStep;
+}
+
+/** yuv420p Y4M — the widely-supported raw form Chromium's fake VIDEO capture reads. */
+function videoArgv(input: string, output: string): string[] {
+  return ['-y', '-i', input, '-pix_fmt', 'yuv420p', output];
+}
+
+/** 16-bit PCM WAV (mono, 48 kHz) — the form Chromium's fake AUDIO capture reads. `-vn` drops video. */
+function audioArgv(input: string, output: string): string[] {
+  return ['-y', '-i', input, '-vn', '-acodec', 'pcm_s16le', '-ar', '48000', '-ac', '1', output];
+}
+
+function makeStep(
+  input: string,
+  targetExt: string,
+  outDir: string,
+  kind: 'video' | 'audio',
+  derived: boolean,
+): FfmpegStep {
+  if (extname(input).toLowerCase() === targetExt) {
+    return { input, output: input, argv: [], passthrough: true, derived };
+  }
+  const output = join(outDir, `${basename(input, extname(input))}.fake-${kind}${targetExt}`);
+  const argv = kind === 'video' ? videoArgv(input, output) : audioArgv(input, output);
+  return { input, output, argv, passthrough: false, derived };
+}
+
+/**
+ * Plan the transcodes. `video`/`audio` are ABSOLUTE paths (the command layer resolves
+ * them). Audio source = `audio` if given, else the `video` file (DERIVED) — but never a
+ * raw `.y4m` video, which carries no audio. Outputs land under `outDir`; a `.y4m`/`.wav`
+ * input is passthrough. An empty request yields an empty plan.
+ */
+export function planFakeMedia(opts: { video?: string; audio?: string; outDir: string }): FakeMediaPlan {
+  const plan: FakeMediaPlan = {};
+  if (opts.video) plan.video = makeStep(opts.video, VIDEO_TARGET_EXT, opts.outDir, 'video', false);
+
+  const explicitAudio = opts.audio;
+  const derivedAudio =
+    !explicitAudio && opts.video && extname(opts.video).toLowerCase() !== VIDEO_TARGET_EXT
+      ? opts.video
+      : undefined;
+  const audioSrc = explicitAudio ?? derivedAudio;
+  if (audioSrc) {
+    plan.audio = makeStep(audioSrc, AUDIO_TARGET_EXT, opts.outDir, 'audio', explicitAudio === undefined);
+  }
+  return plan;
+}
+
+/**
+ * The Chromium launch flags that feed the RESOLVED capture files into `getUserMedia`.
+ * Any file present ⇒ enable the fake device + auto-accept the permission prompt, then a
+ * per-stream file flag for whichever of video/audio resolved. No files ⇒ no flags.
+ */
+export function fakeMediaChromiumArgs(resolved: { video?: string; audio?: string }): string[] {
+  if (!resolved.video && !resolved.audio) return [];
+  const args = ['--use-fake-device-for-media-stream', '--use-fake-ui-for-media-stream'];
+  if (resolved.video) args.push(`--use-file-for-fake-video-capture=${resolved.video}`);
+  if (resolved.audio) args.push(`--use-file-for-fake-audio-capture=${resolved.audio}`);
+  return args;
+}

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/fake-media.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/fake-media.unit.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Fake-media IO (soa#363) — `prepareFakeMedia` over a FAKE Runner + fake stat, so no real
+ * ffmpeg/fs runs. Covers: transcode both streams, passthrough (no ffmpeg), cache reuse,
+ * derived-audio failure is non-fatal, explicit-audio failure throws, ffmpeg-missing
+ * throws an install hint, and a missing input throws.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { RunResult, Runner, ScriptInvocation } from '../exec.js';
+import { prepareFakeMedia } from '../fake-media.js';
+
+/** A Runner whose exit code per call is decided by `codeFor(spec)` (default 0). Records calls. */
+function fakeRunner(codeFor: (s: ScriptInvocation) => number | 'throw' = () => 0): {
+  runner: Runner;
+  calls: ScriptInvocation[];
+} {
+  const calls: ScriptInvocation[] = [];
+  const runner: Runner = {
+    async run(spec): Promise<RunResult> {
+      calls.push(spec);
+      const c = codeFor(spec);
+      if (c === 'throw') throw new Error('ENOENT: ffmpeg not found');
+      return { code: c };
+    },
+  };
+  return { runner, calls };
+}
+
+const NOOP = (): void => {};
+// Inputs exist (mtime 100); transcode OUTPUTS (their basenames carry `.fake-`) don't yet
+// exist (null) ⇒ every non-passthrough step actually transcodes rather than cache-hitting.
+const inputsExist = (p: string): number | null => (p.includes('.fake-') ? null : 100);
+const baseDeps = (runner: Runner, statMtime = inputsExist) => ({
+  runner,
+  statMtime,
+  ensureDir: NOOP,
+  notify: NOOP,
+});
+
+describe('prepareFakeMedia', () => {
+  it('transcodes video + derived audio, gating ffmpeg presence first, and returns the outputs', async () => {
+    const { runner, calls } = fakeRunner();
+    const out = await prepareFakeMedia(
+      { video: '/clips/s.mp4', outDir: '/state/fake-av' },
+      baseDeps(runner),
+    );
+    expect(out).toEqual({
+      video: '/state/fake-av/s.fake-video.y4m',
+      audio: '/state/fake-av/s.fake-audio.wav',
+    });
+    // ffmpeg -version presence check, then the two transcodes.
+    expect(calls.map((c) => c.args[0])).toEqual(['-version', '-y', '-y']);
+    expect(calls[1].command).toBe('ffmpeg');
+    expect(calls[1].args).toContain('/state/fake-av/s.fake-video.y4m');
+  });
+
+  it('passthrough inputs run NO ffmpeg (not even the -version presence check)', async () => {
+    const { runner, calls } = fakeRunner();
+    const out = await prepareFakeMedia(
+      { video: '/clips/p.y4m', audio: '/clips/p.wav', outDir: '/o' },
+      baseDeps(runner),
+    );
+    expect(out).toEqual({ video: '/clips/p.y4m', audio: '/clips/p.wav' });
+    expect(calls).toEqual([]); // no transcode needed ⇒ ffmpeg never invoked
+  });
+
+  it('reuses a cached output that is at least as new as its input (no ffmpeg for that step)', async () => {
+    // input mtime 100; the .y4m output mtime 200 (newer) ⇒ cache hit; audio output missing.
+    const statMtime = (p: string): number | null => {
+      if (p.endsWith('.mp4')) return 100;
+      if (p.endsWith('.y4m')) return 200; // cached, newer than input
+      return null; // audio .wav not yet produced
+    };
+    const { runner, calls } = fakeRunner();
+    const out = await prepareFakeMedia(
+      { video: '/c/s.mp4', outDir: '/o' },
+      { runner, statMtime, ensureDir: NOOP, notify: NOOP },
+    );
+    expect(out.video).toBe('/o/s.fake-video.y4m');
+    // -version + audio transcode only; the video step was a cache hit.
+    const y4mTranscode = calls.find((c) => c.args.includes('/o/s.fake-video.y4m'));
+    expect(y4mTranscode).toBeUndefined();
+    expect(calls.some((c) => c.args.includes('/o/s.fake-audio.wav'))).toBe(true);
+  });
+
+  it('a DERIVED audio transcode failure is NON-fatal — video-only result, no throw', async () => {
+    // ffmpeg -version ok; the .wav (derived audio) transcode fails (video had no audio).
+    const { runner } = fakeRunner((s) => (s.args.some((a) => a.endsWith('.wav')) ? 1 : 0));
+    const out = await prepareFakeMedia({ video: '/c/silent.mp4', outDir: '/o' }, baseDeps(runner));
+    expect(out).toEqual({ video: '/o/silent.fake-video.y4m' }); // audio dropped, video kept
+  });
+
+  it('an EXPLICIT --fake-audio transcode failure THROWS', async () => {
+    const { runner } = fakeRunner((s) => (s.args.some((a) => a.endsWith('.wav')) ? 1 : 0));
+    await expect(
+      prepareFakeMedia({ audio: '/c/bad.mp3', outDir: '/o' }, baseDeps(runner)),
+    ).rejects.toThrow(/--fake-audio/);
+  });
+
+  it('ffmpeg missing (presence check rejects) throws an install hint when a transcode is needed', async () => {
+    const { runner } = fakeRunner((s) => (s.args[0] === '-version' ? 'throw' : 0));
+    await expect(
+      prepareFakeMedia({ video: '/c/s.mp4', outDir: '/o' }, baseDeps(runner)),
+    ).rejects.toThrow(/ffmpeg is required/);
+  });
+
+  it('a missing input file throws before any ffmpeg runs', async () => {
+    const { runner, calls } = fakeRunner();
+    await expect(
+      prepareFakeMedia({ video: '/nope.mp4', outDir: '/o' }, { runner, statMtime: () => null, ensureDir: NOOP }),
+    ).rejects.toThrow(/--fake-video file not found/);
+    expect(calls).toEqual([]);
+  });
+
+  it('defaults ensureDir/notify (mkdir the outDir) — real deps path is exercised', async () => {
+    const { runner } = fakeRunner();
+    const spy = { made: '' };
+    await prepareFakeMedia(
+      { video: '/c/p.y4m', outDir: '/o' },
+      { runner, statMtime: inputsExist, ensureDir: (d) => { spy.made = d; } },
+    );
+    expect(spy.made).toBe('/o');
+  });
+});

--- a/packages/node/saga-stack-cli/src/runtime/fake-media.ts
+++ b/packages/node/saga-stack-cli/src/runtime/fake-media.ts
@@ -1,0 +1,140 @@
+/**
+ * Fake-media IO (soa#363) — execute the pure `planFakeMedia` transcodes via ffmpeg and
+ * return the resolved Chromium capture paths. The ONLY place ffmpeg runs + the fs is
+ * touched for the fake-AV feature; `core/fake-media` stays pure.
+ *
+ * Behaviours:
+ *  - PRESENCE: if any step needs a transcode, `ffmpeg -version` must succeed, else a
+ *    clear install hint is thrown. A passthrough-only plan (`.y4m`/`.wav` inputs) needs
+ *    no ffmpeg and skips the check.
+ *  - CACHE: an output at least as new as its input is reused — Y4M is large and slow to
+ *    produce, so a repeated `login` with the same clip doesn't re-transcode.
+ *  - DERIVED audio is best-effort: a failed derive (a video with no audio track) drops
+ *    audio and keeps video; an EXPLICIT `--fake-audio` failure throws.
+ *
+ * IO is behind injectable deps (Runner + stat/mkdir seams) so it is unit-tested with a
+ * fake runner and NO real ffmpeg/fs.
+ */
+
+import { mkdirSync, statSync } from 'node:fs';
+import { planFakeMedia } from '../core/fake-media.js';
+import type { FfmpegStep } from '../core/fake-media.js';
+import type { Runner } from './exec.js';
+
+/** Injectable deps of {@link prepareFakeMedia}, defaulted to real IO. */
+export interface PrepareFakeMediaDeps {
+  /** Runs ffmpeg. A spawn-level failure (ffmpeg missing) REJECTS — caught as "not found". */
+  runner: Runner;
+  /** mtimeMs of a path, or `null` if it doesn't exist. Default `fs.statSync`. */
+  statMtime?: (path: string) => number | null;
+  /** `mkdir -p` the transcode outDir. Default `fs.mkdirSync({recursive})`. */
+  ensureDir?: (dir: string) => void;
+  /** Progress-line sink (transcode notices). Default no-op. */
+  notify?: (msg: string) => void;
+}
+
+/** The resolved Chromium capture paths (a stream is absent when it had no source / was dropped). */
+export interface PreparedFakeMedia {
+  video?: string;
+  audio?: string;
+}
+
+const realStatMtime = (p: string): number | null => {
+  try {
+    return statSync(p).mtimeMs;
+  } catch {
+    return null;
+  }
+};
+
+/** Run `ffmpeg -version` once to confirm it is on PATH; throw an install hint if not. */
+async function assertFfmpeg(runner: Runner): Promise<void> {
+  try {
+    const { code } = await runner.run({ cwd: process.cwd(), command: 'ffmpeg', args: ['-version'], env: {} });
+    if (code === 0) return;
+  } catch {
+    // spawn-level failure (ENOENT) — fall through to the throw.
+  }
+  throw new Error(
+    'ffmpeg is required to transcode --fake-video/--fake-audio to Chromium capture format, but was ' +
+      'not found on PATH. Install it (macOS: `brew install ffmpeg`; Debian/Ubuntu: `sudo apt install ' +
+      'ffmpeg`), or pass an already-transcoded .y4m video / .wav audio file.',
+  );
+}
+
+/** Run one transcode step (or a no-op passthrough / cache hit). Never throws — returns the outcome. */
+async function runStep(
+  step: FfmpegStep,
+  runner: Runner,
+  statMtime: (p: string) => number | null,
+  notify: (msg: string) => void,
+): Promise<'ok' | 'failed'> {
+  if (step.passthrough) return 'ok';
+  const inM = statMtime(step.input);
+  const outM = statMtime(step.output);
+  if (outM !== null && inM !== null && outM >= inM) {
+    notify(`  · reusing transcoded ${step.output} (cache)`);
+    return 'ok';
+  }
+  notify(`  · ffmpeg ${step.input} → ${step.output}`);
+  try {
+    const { code } = await runner.run({
+      cwd: process.cwd(),
+      command: 'ffmpeg',
+      args: step.argv,
+      env: {},
+      stdio: 'inherit',
+    });
+    return code === 0 ? 'ok' : 'failed';
+  } catch {
+    return 'failed';
+  }
+}
+
+/**
+ * Transcode the `--fake-video`/`--fake-audio` inputs (absolute paths) into Chromium
+ * capture files under `outDir`, returning the resolved paths. Validates the explicit
+ * inputs exist, gates ffmpeg presence when a real transcode is needed, reuses a cached
+ * output, and tolerates a failed DERIVED audio derive (video-only source). Throws with a
+ * clear message on a missing input, missing ffmpeg, or a fatal transcode failure.
+ */
+export async function prepareFakeMedia(
+  opts: { video?: string; audio?: string; outDir: string },
+  deps: PrepareFakeMediaDeps,
+): Promise<PreparedFakeMedia> {
+  const statMtime = deps.statMtime ?? realStatMtime;
+  const ensureDir = deps.ensureDir ?? ((d: string): void => void mkdirSync(d, { recursive: true }));
+  const notify = deps.notify ?? ((): void => {});
+
+  if (opts.video && statMtime(opts.video) === null) {
+    throw new Error(`--fake-video file not found: ${opts.video}`);
+  }
+  if (opts.audio && statMtime(opts.audio) === null) {
+    throw new Error(`--fake-audio file not found: ${opts.audio}`);
+  }
+
+  const plan = planFakeMedia(opts);
+  const needsTranscode = [plan.video, plan.audio].some((s) => s && !s.passthrough);
+  if (needsTranscode) await assertFfmpeg(deps.runner);
+  ensureDir(opts.outDir);
+
+  const out: PreparedFakeMedia = {};
+  if (plan.video) {
+    if ((await runStep(plan.video, deps.runner, statMtime, notify)) === 'ok') {
+      out.video = plan.video.output;
+    } else {
+      throw new Error(`ffmpeg failed to transcode --fake-video (${plan.video.input}) — see the output above`);
+    }
+  }
+  if (plan.audio) {
+    const res = await runStep(plan.audio, deps.runner, statMtime, notify);
+    if (res === 'ok') {
+      out.audio = plan.audio.output;
+    } else if (plan.audio.derived) {
+      notify(`  ⚠ no audio track derived from ${plan.audio.input} — continuing with video only`);
+    } else {
+      throw new Error(`ffmpeg failed to transcode --fake-audio (${plan.audio.input}) — see the output above`);
+    }
+  }
+  return out;
+}

--- a/packages/node/saga-stack-cli/src/runtime/index.ts
+++ b/packages/node/saga-stack-cli/src/runtime/index.ts
@@ -54,6 +54,7 @@ export * from './lock.js';
 export * from './checkpoint-store.js';
 export * from './trace-preserve.js';
 export * from './foreign-procs.js';
+export * from './fake-media.js';
 export * from './claim.js';
 export * from './cli-version.js';
 export * from './slot-wipe.js';

--- a/packages/node/saga-stack-cli/vendor/browser-login.mjs
+++ b/packages/node/saga-stack-cli/vendor/browser-login.mjs
@@ -21,6 +21,9 @@
 //   PROFILE_DIR      persistent profile (default /tmp/sds-synthetic/browser-profile)
 //   SAGA_DASH_DASH   path to saga-dash apps/web/dash (for playwright resolution)
 //   HEADLESS=1       run headless (verification only; default headful)
+//   CHROMIUM_EXTRA_ARGS  JSON array of extra Chromium flags to spread onto the launch
+//                    args (soa#363: fake-media file capture, e.g.
+//                    --use-file-for-fake-video-capture=<abs .y4m>). Ignored if unparseable.
 //
 // Prints one sentinel line for up.sh to grep:
 //   AUTOLOGIN_OK <email> <userId> <finalUrl>
@@ -35,6 +38,13 @@ const EMAIL    = process.env.LOGIN_EMAIL || 'dev@saga.org';
 const PROFILE  = process.env.PROFILE_DIR || '/tmp/sds-synthetic/browser-profile';
 const DASH_DIR = process.env.SAGA_DASH_DASH;
 const HEADLESS = process.env.HEADLESS === '1';
+// soa#363: extra Chromium flags (fake-media file capture) built by the CLI. A malformed
+// value must never break login, so parse defensively and fall back to none.
+let EXTRA_ARGS = [];
+try {
+  const parsed = JSON.parse(process.env.CHROMIUM_EXTRA_ARGS || '[]');
+  if (Array.isArray(parsed)) EXTRA_ARGS = parsed.filter((a) => typeof a === 'string');
+} catch { /* unparseable ⇒ no extra args */ }
 
 const fail = (reason) => { console.log(`AUTOLOGIN_FAIL ${reason}`); process.exit(1); };
 
@@ -53,7 +63,7 @@ try {
   ctx = await chromium.launchPersistentContext(PROFILE, {
     headless: HEADLESS,
     viewport: null,
-    args: ['--start-maximized'],
+    args: ['--start-maximized', ...EXTRA_ARGS],
   });
 } catch (e) {
   fail(`could not launch Chromium (profile in use? missing DISPLAY?): ${e.message}`);


### PR DESCRIPTION
Closes #363.

## What

Adds `--fake-video <file>` / `--fake-audio <file>` to `ss stack login` (with `--browser`): feed a **local** clip into the headful Chromium's fake camera/mic, for AV flows (Connect) on a box with no real device.

```bash
ss stack login empty@saga.org --browser --state-dir /tmp/ss-eadmin-browser \
   --fake-video ~/clips/student.mp4        # auto → .y4m/.wav, camera + mic
```

Previously `login --browser` had **no** AV control, and the only mock-AV (`develop connect --fake-media`) just plays Chromium's synthetic **test pattern**, not a real clip.

## How

Chromium's file-backed fake capture (`--use-file-for-fake-video-capture` / `--use-file-for-fake-audio-capture`) reads only raw **Y4M** video + **PCM WAV** audio, so any other format is **auto-transcoded via ffmpeg** (a `.y4m`/`.wav` input is passthrough). `--fake-video foo.mp4` alone also **derives the mic track** from the same file; `--fake-audio` overrides it.

- **`core/fake-media.ts`** (pure, unit-tested): the transcode plan (target formats, passthrough, derived-audio rule, outDir) + `fakeMediaChromiumArgs`.
- **`runtime/fake-media.ts`**: ffmpeg execution behind an injectable `Runner` — **presence check** (clear install hint when ffmpeg is missing, skipped for passthrough), **mtime cache** (Y4M is large/slow to produce), **non-fatal derived-audio failure** (a video with no audio track keeps video). Unit-tested with a fake runner (no real ffmpeg/fs).
- **`login.ts`** resolves + transcodes, then threads the ready Chromium flags through `openVendoredBrowser` via a new `CHROMIUM_EXTRA_ARGS` env; **`browser-login.mjs`** JSON-parses + spreads them onto its launch args. A prep failure (missing file / no ffmpeg / bad transcode) is **non-fatal** — the jar is already minted, so it warns and opens a normal browser.
- `--fake-video/--fake-audio` without `--browser` → warned + ignored.

## Verification

- Unit: `core/fake-media` (plan + flags) and `runtime/fake-media` (transcode both, passthrough skips ffmpeg, cache reuse, derived-audio failure non-fatal, explicit-audio failure throws, ffmpeg-missing hint, missing-input error).
- **End-to-end**: generated a sample with ffmpeg `testsrc`, transcoded with the shipped argv, launched **headless Chromium with the shipped `fakeMediaChromiumArgs`**, and confirmed `getUserMedia({video,audio})` returns a live **320×240** video track (the clip's exact dimensions — proving it read the file, not a synthetic default) + an audio track.
- Full package suite (1434), `check-types`, `eslint` (0 errors) green. Manifest regenerated (canonical, #353) — the only churn is the two new `login` flags.

## Note on Y4M size

Y4M is uncompressed (~a few MB/sec at small sizes, much more at 720p+). The transcode is cached by mtime, and a pre-made `.y4m`/`.wav` is used as-is for users who want to control it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)