### PR TITLE
feat(saga-stack-cli): add authz-api to the synthetic dev mesh

### DIFF
--- a/infra/compose/projects/saga-mesh/seed/profile-empty.sql
+++ b/infra/compose/projects/saga-mesh/seed/profile-empty.sql
@@ -19,6 +19,7 @@ CREATE USER ledger         WITH PASSWORD 'ledger';
 CREATE USER sis            WITH PASSWORD 'sis';
 CREATE USER coach_api_app  WITH PASSWORD 'dev-password-coach-api-app';
 CREATE USER authz_sync     WITH PASSWORD 'authz_sync';
+CREATE USER authz_api      WITH PASSWORD 'authz_api';
 
 -- ── Databases ───────────────────────────────────────────────────────
 -- Owner set at creation time so prisma migrate deploy can CREATE SCHEMA.
@@ -39,8 +40,12 @@ CREATE DATABASE coach_api       OWNER coach_api_app;
 -- ../../../services/openfga/compose.yml's `profiles: ["authz"]`).
 -- `openfga` stays owned by the mesh superuser — its schema is (re)created by
 -- the `openfga_migrate` one-shot job, not by app-level `CREATE SCHEMA`.
+-- `authz_api_local` is owned by authz_api so the CLI's prisma migrate deploy
+-- (R3, meshProvisioned:true) can CREATE SCHEMA — same owner-at-creation pattern
+-- as the sis_db/programs app DBs above.
 CREATE DATABASE openfga          OWNER postgres_admin;
 CREATE DATABASE authz_sync_local OWNER authz_sync;
+CREATE DATABASE authz_api_local  OWNER authz_api;
 
 -- ── Grants (belt-and-suspenders; owner already has these) ──────────
 GRANT ALL PRIVILEGES ON DATABASE iam_local     TO iam;
@@ -55,6 +60,7 @@ GRANT ALL PRIVILEGES ON DATABASE sis_db        TO sis;
 GRANT ALL PRIVILEGES ON DATABASE coach_api     TO coach_api_app;
 GRANT ALL PRIVILEGES ON DATABASE openfga          TO postgres_admin;
 GRANT ALL PRIVILEGES ON DATABASE authz_sync_local TO authz_sync;
+GRANT ALL PRIVILEGES ON DATABASE authz_api_local  TO authz_api;
 
 -- The sentinel row in _profile_meta.seeded is written by
 -- services/postgres/seed/init-and-seed.sh after this file completes.

--- a/packages/node/saga-stack-cli/README.md
+++ b/packages/node/saga-stack-cli/README.md
@@ -69,9 +69,14 @@ plus tab-completion work at every level.
 
 ### Bundles — common shapes in one word
 
-`--with dash|connect|coach|playback|qtf` expand to a set of `--only` includes (sugar over
-the closure, composable: `--with dash --with coach`). Shared across `up`/`status`/`verify`/
-`seed`/`reset`/`snapshot store`. See `ss stack bundle list`.
+`--with dash|connect|coach|playback|qtf|authz` expand to a set of `--only` includes (sugar
+over the closure, composable: `--with dash --with coach`). Shared across `up`/`status`/
+`verify`/`seed`/`reset`/`snapshot store`. See `ss stack bundle list`.
+
+`--with authz` brings up the OpenFGA authorization stack: the `openfga` mesh unit, iam-api
+with `FGA_ENABLED=true`, the `fga-bootstrap` seed (model + canonical tuples), the `authz-sync`
+RabbitMQ tuple projector, and **`authz-api`** — the PDP that serves check/require over its own
+prisma-migrated `authz_db`, hydrated from the iam.* event projection (:3200, `/health/ready`).
 
 ### Slots — multiple stacks on one box
 

--- a/packages/node/saga-stack-cli/src/core/__tests__/bundles.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/bundles.unit.test.ts
@@ -41,7 +41,7 @@ describe('bundle registry', () => {
     expect(SERVICE_BUNDLES.coach).toEqual(['coach-api', 'coach-web']);
     expect(SERVICE_BUNDLES.playback).toEqual(['transcripts-api', 'insights-api', 'chat-api']);
     expect(SERVICE_BUNDLES.qtf).toEqual([]);
-    expect(SERVICE_BUNDLES.authz).toEqual(['authz-sync']);
+    expect(SERVICE_BUNDLES.authz).toEqual(['authz-sync', 'authz-api']);
   });
 
   it('derives BUNDLE_SEED_ADDONS only for the seed-bearing bundles', () => {

--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
@@ -150,6 +150,7 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
       DATABASE_URL: 'postgresql://saga_user:password123@localhost:5432/sessions',
       IAM_API_URL: 'http://localhost:3010',
       SCHEDULING_API_URL: 'http://localhost:3008',
+      AUTHZ_API_URL: 'http://localhost:3200',
       RABBITMQ_URL: 'amqp://rabbitmq_admin:password123@localhost:5672',
       CORS_ORIGIN: 'http://localhost:8900',
       JWT_ISSUER: 'https://iam.wootdev.com',

--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
@@ -149,6 +149,7 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
       NODE_ENV: 'development',
       DATABASE_URL: 'postgresql://saga_user:password123@localhost:5432/sessions',
       IAM_API_URL: 'http://localhost:3010',
+      SCHEDULING_API_URL: 'http://localhost:3008',
       RABBITMQ_URL: 'amqp://rabbitmq_admin:password123@localhost:5672',
       CORS_ORIGIN: 'http://localhost:8900',
       JWT_ISSUER: 'https://iam.wootdev.com',

--- a/packages/node/saga-stack-cli/src/core/bundles.ts
+++ b/packages/node/saga-stack-cli/src/core/bundles.ts
@@ -63,13 +63,17 @@ export const BUNDLES: Readonly<Record<BundleName, BundleDef>> = {
     description: 'Seed-only: QTF observation-notes demo on an Ended session (no extra services).',
   },
   authz: {
-    services: ['authz-sync'],
+    services: ['authz-sync', 'authz-api'],
     seedAddOn: 'authz',
     description:
       'OpenFGA authz stack: brings up the openfga mesh unit, flips iam-api FGA_ENABLED=true, ' +
-      'runs the fga-bootstrap seed step (model + canonical tuples), and starts the authz-sync ' +
-      'RabbitMQ consumer. First run bootstraps a fresh store (FGA checks fail closed); rerun ' +
-      '`stack up --with authz` once more to pick up the persisted store id.',
+      'runs the fga-bootstrap seed step (model + canonical tuples), starts the authz-sync ' +
+      'RabbitMQ consumer, and launches authz-api (the OpenFGA PDP that serves check/require ' +
+      'over its own prisma-migrated authz_db, hydrated from the iam.* event projection). ' +
+      'First run bootstraps a fresh store (FGA checks fail closed); rerun `stack up --with ' +
+      'authz` once more to pick up the persisted store id. NB: authz-api itself reads NO ' +
+      'OPENFGA_* env — it lives in this bundle because it is the authorization PDP, not ' +
+      'because it talks to OpenFGA directly (its FGA reads go through authz-sync-projected tuples).',
   },
 };
 

--- a/packages/node/saga-stack-cli/src/core/closure.ts
+++ b/packages/node/saga-stack-cli/src/core/closure.ts
@@ -79,7 +79,7 @@ export function computeClosure(
   // every opt-in flag, which would cross-admit (e.g. `--with authz` alone must
   // not also resolve the playback trio).
   const admitsOptional = (id: ServiceId): boolean =>
-    id === 'authz-sync' ? withAuthz : withPlayback;
+    id === 'authz-sync' || id === 'authz-api' ? withAuthz : withPlayback;
 
   const inClosure = new Set<ServiceId>();
   const reasons = new Map<ServiceId, string[]>();

--- a/packages/node/saga-stack-cli/src/core/flow/types.ts
+++ b/packages/node/saga-stack-cli/src/core/flow/types.ts
@@ -39,6 +39,7 @@ const SERVICE_IDS = [
   'insights-api',
   'chat-api',
   'authz-sync',
+  'authz-api',
 ] as const;
 
 // Compile guard: every literal above must be a real ServiceId (catches typos /

--- a/packages/node/saga-stack-cli/src/core/launch-plan.ts
+++ b/packages/node/saga-stack-cli/src/core/launch-plan.ts
@@ -86,6 +86,8 @@ export interface LaunchTokens {
   REDIS_PORT: string;
   /** authz-sync port — opt-in service (`--with authz`), no up.sh precedent (new). */
   AUTHZ_SYNC_PORT: string;
+  /** authz-api port — opt-in service (`--with authz`), no up.sh precedent (new). */
+  AUTHZ_API_PORT: string;
 
   // ── lane base URLs (local/stack lane: http://localhost:<port>) ──
   /** up.sh `IAM_URL`. */
@@ -106,6 +108,10 @@ export interface LaunchTokens {
   SAGA_API_TARGET: string;
   /** up.sh `COACH_API_URL` — `http://localhost:$COACH_API_PORT` (coach-web PUBLIC_COACH_API_URL). */
   COACH_API_URL: string;
+  /** authz-api base URL — `http://localhost:${AUTHZ_API_PORT}`. Provided so a future
+   *  caller's `AUTHZ_API_URL` env can reference it (the S2S seam programs-api#403 /
+   *  program-hub's AUTHZ_API_URL will consume); no mesh app reads it yet. */
+  AUTHZ_API_URL: string;
   /** up.sh `COACH_WEB_HOST` — bare hostname for coach-api's CORS allow-list (`localhost`). */
   COACH_WEB_HOST: string;
   /** up.sh `SAGA_API_TARGET_COACH` — coach's frontend upstream-saga config (default https://staging.wootmath.com). */
@@ -155,6 +161,9 @@ export interface LaunchTokens {
   ADS_ADM_DB_URL: string;
   /** authz-sync dedup-table DB URL — `postgresql://authz_sync:authz_sync@localhost:<pg>/authz_sync_local`. */
   AUTHZ_SYNC_DB_URL: string;
+  /** authz-api prisma DB URL — `postgresql://authz_api:authz_api@localhost:<pg>/authz_api_local`
+   *  (fed to authz-api's AUTHZ_DATABASE_URL + the R3 migrate step's migrateEnvVar). */
+  AUTHZ_API_DB_URL: string;
 
   // ── misc scalars ──
   /** up.sh `RECORDING_TOKEN` — shared fleek bearer (`local-dev-token`). */
@@ -653,6 +662,7 @@ export function defaultLaunchContext(inputs: LaunchContextInputs, m: Manifest = 
     CONNECT_MONGO_PORT: String(mongoPort),
     REDIS_PORT: String(redisPort),
     AUTHZ_SYNC_PORT: String(ports['authz-sync']),
+    AUTHZ_API_PORT: String(ports['authz-api']),
 
     // lane base URLs (local/stack lane)
     IAM_URL: `http://localhost:${ports['iam-api']}`,
@@ -664,6 +674,7 @@ export function defaultLaunchContext(inputs: LaunchContextInputs, m: Manifest = 
     RTSM_URL: `http://localhost:${ports['rtsm-api']}`,
     SAGA_API_TARGET: inputs.sagaApiTarget ?? 'https://wootmath.com',
     COACH_API_URL: `http://localhost:${ports['coach-api']}`,
+    AUTHZ_API_URL: `http://localhost:${ports['authz-api']}`,
     COACH_WEB_HOST: 'localhost',
     SAGA_API_TARGET_COACH: 'https://staging.wootmath.com',
     IAM_ISSUER: 'https://iam.wootdev.com',
@@ -681,6 +692,7 @@ export function defaultLaunchContext(inputs: LaunchContextInputs, m: Manifest = 
     COACH_DB_URL: pgUrl('coach_api', pgPort, m),
     ADS_ADM_DB_URL: pgUrl('ads_adm_local', pgPort, m),
     AUTHZ_SYNC_DB_URL: pgUrl('authz_sync_local', pgPort, m),
+    AUTHZ_API_DB_URL: pgUrl('authz_api_local', pgPort, m),
 
     // misc scalars (up.sh hardcodes these verbatim)
     RECORDING_TOKEN: 'local-dev-token',

--- a/packages/node/saga-stack-cli/src/core/launch-plan.ts
+++ b/packages/node/saga-stack-cli/src/core/launch-plan.ts
@@ -92,6 +92,12 @@ export interface LaunchTokens {
   // ── lane base URLs (local/stack lane: http://localhost:<port>) ──
   /** up.sh `IAM_URL`. */
   IAM_URL: string;
+  /** scheduling-api base URL — no up.sh precedent (single-slot up.sh relied on
+   *  sessions-api's own localhost:3008 default, which is slot 0's port; a
+   *  slot>0 sessions-api needs the offset URL or every time/adhoc S2S write
+   *  dials the wrong slot — found live: sessions.time.set ECONNREFUSED :3008
+   *  on slot 1). */
+  SCHEDULING_URL: string;
   /** up.sh `DASH_URL` (saga-dash, :8900). */
   DASH_URL: string;
   /** up.sh `CONNECT_WEB_URL`. */
@@ -666,6 +672,7 @@ export function defaultLaunchContext(inputs: LaunchContextInputs, m: Manifest = 
 
     // lane base URLs (local/stack lane)
     IAM_URL: `http://localhost:${ports['iam-api']}`,
+    SCHEDULING_URL: `http://localhost:${ports['scheduling-api']}`,
     DASH_URL: `http://localhost:${ports['saga-dash']}`,
     CONNECT_WEB_URL: `http://localhost:${ports['connect-web']}`,
     COACH_WEB_URL: `http://localhost:${ports['coach-web']}`,

--- a/packages/node/saga-stack-cli/src/core/manifest/databases.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/databases.ts
@@ -220,4 +220,31 @@ export const DATABASES: Readonly<Record<DbId, DatabaseDef>> = {
     // NOT part of default mesh-up — see the `openfga` entry above.
     meshProvisioned: false,
   },
+  authz_api_local: {
+    name: 'authz_api_local',
+    engine: 'postgres',
+    // authz-api owns a PRISMA-migrated DB (@saga-ed/authz-db). Its prisma.config.ts
+    // loads AUTHZ_DATABASE_URL directly and THROWS if unset, so R3 injects it via
+    // migrateEnvVar (same shape as sis_db's SIS_DATABASE_URL). cmd `prisma migrate
+    // deploy` applies packages/node/authz-db/src/prisma/migrations.
+    migrate: {
+      dir: 'packages/node/authz-db',
+      cmd: 'prisma migrate deploy',
+      migrateEnvVar: 'AUTHZ_DATABASE_URL',
+    },
+    ownerRole: 'authz_api',
+    ownerPw: 'authz_api',
+    resettable: true,
+    resetMode: 'truncate',
+    // meshProvisioned:true UNLIKE its authz_sync/openfga bundle-siblings: the
+    // provision (R2) AND migrate (R3) runners BOTH gate on `meshProvisioned`
+    // (provision.ts:118, migrate.ts:207), so a prisma-migrated DB MUST be true or
+    // its schema is never applied (the app then breaks on first query). No
+    // always-on cost: provision/migrate/reset all iterate the CLOSURE's DBs
+    // (migrate.ts:195 `closure.has(d)`), so authz_api_local is only touched when
+    // it's in the `--with authz` closure — opt-in in practice despite `true`.
+    // profile-empty.sql creates the role+DB unconditionally on a fresh volume
+    // (cheap empty DB), mirroring the authz_sync "created unconditionally" note.
+    meshProvisioned: true,
+  },
 };

--- a/packages/node/saga-stack-cli/src/core/manifest/services.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/services.ts
@@ -838,4 +838,57 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
     isFrontend: false,
     optional: true,
   },
+  'authz-api': {
+    id: 'authz-api',
+    repo: 'ROSTERING',
+    subpath: 'apps/node/authz-api',
+    // 3200 % 1000 = 200, clear of every other manifest port's `% 1000` across
+    // slots 0..8 (nearest is rtsm-api 6210 → 210) — derive-instance's no-collision
+    // property test enumerates this, same rule that forced authz-sync off 3110.
+    port: 3200,
+    portEnvVar: 'PORT',
+    // /health/ready is the honest readiness gate the ALB uses (main.ts
+    // mountReadinessRoutes). It gates ONLY on `!!authzPrismaClient` (authz_db
+    // connected) — NOT on iam-projection catch-up — so it goes green as soon as
+    // the DB is up + migrated, without waiting on the iam.* event backfill.
+    healthPath: '/health/ready',
+    // authz_api_local is prisma-migrated (@saga-ed/authz-db) — see databases.ts.
+    // No openfga here: authz-api reads FGA facts from authz-sync-projected tuples
+    // + its own iam.* projection, and holds no OPENFGA_* config of its own.
+    databases: ['authz_api_local'],
+    // iam-api is a `url` dep only for LAUNCH ORDERING + JWKS reachability: authz-api
+    // NEVER calls iam-api live on the request path (that would be circular — it
+    // replaces personas.getMyPermissions). It validates iam-minted JWTs OFFLINE
+    // against iam's JWKS and hydrates iam facts via the iam.* RabbitMQ projection.
+    dependsOn: ['iam-api'],
+    depKinds: { 'iam-api': 'url' },
+    mesh: ['postgres', 'rabbitmq'],
+    launch: {
+      cmd: 'pnpm dev',
+      env: {
+        NODE_ENV: 'development',
+        PORT: '${AUTHZ_API_PORT}',
+        // Own prisma DB (read directly off env, bypassing the AUTHZ_ prefix — see
+        // inversify.config.ts). RABBITMQ_URL is the fleet-wide shared name.
+        AUTHZ_DATABASE_URL: '${AUTHZ_API_DB_URL}',
+        RABBITMQ_URL: '${MESH_MQ}',
+        // ---- iam-api S2S validation (env prefix IAM_ via DotenvConfigManager) ----
+        // The app's config defaults point at prod hosts / :3000 and WILL 401 every
+        // locally-minted token unless repointed at the stack iam (:3010) and the
+        // issuer iam actually mints (${IAM_ISSUER} = https://iam.wootdev.com, NOT
+        // the schema's https://iam.saga.org default). Same JWT-issuer drift class
+        // the manifest guards for programs-api's JWT_ISSUER above.
+        IAM_JWKSURL: '${IAM_URL}/.well-known/services/jwks.json',
+        IAM_USERJWKSURL: '${IAM_URL}/.well-known/jwks.json',
+        IAM_SERVICETOKENISSUER: '${IAM_ISSUER}',
+        IAM_USERTOKENISSUER: '${IAM_ISSUER}',
+      },
+    },
+    // No fixture seed of its own — iam.* projection hydrates authz_db at runtime.
+    seed: [],
+    lane: lanes(3200, 'authz-api'),
+    tunnelSlug: 'authz-api',
+    isFrontend: false,
+    optional: true,
+  },
 };

--- a/packages/node/saga-stack-cli/src/core/manifest/services.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/services.ts
@@ -259,6 +259,9 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
         // slot 0's scheduling-api, so slot>0 time/adhoc S2S writes dialed the
         // wrong slot without this (live ECONNREFUSED on slot 1).
         SCHEDULING_API_URL: '${SCHEDULING_URL}',
+        // sessions-api authz cutover: grant evaluation via authz-api
+        // capabilities (cookie-relay). Slot-offset like every other URL.
+        AUTHZ_API_URL: '${AUTHZ_API_URL}',
         RABBITMQ_URL: '${MESH_MQ}',
         CORS_ORIGIN: '${DASH_URL}',
         // Same iss iam-api stamps — see programs-api's JWT_ISSUER note.

--- a/packages/node/saga-stack-cli/src/core/manifest/services.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/services.ts
@@ -872,16 +872,20 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
         // inversify.config.ts). RABBITMQ_URL is the fleet-wide shared name.
         AUTHZ_DATABASE_URL: '${AUTHZ_API_DB_URL}',
         RABBITMQ_URL: '${MESH_MQ}',
-        // ---- iam-api S2S validation (env prefix IAM_ via DotenvConfigManager) ----
+        // ---- iam-api S2S validation ----
         // The app's config defaults point at prod hosts / :3000 and WILL 401 every
         // locally-minted token unless repointed at the stack iam (:3010) and the
         // issuer iam actually mints (${IAM_ISSUER} = https://iam.wootdev.com, NOT
         // the schema's https://iam.saga.org default). Same JWT-issuer drift class
         // the manifest guards for programs-api's JWT_ISSUER above.
-        IAM_JWKSURL: '${IAM_URL}/.well-known/services/jwks.json',
-        IAM_USERJWKSURL: '${IAM_URL}/.well-known/jwks.json',
-        IAM_SERVICETOKENISSUER: '${IAM_ISSUER}',
-        IAM_USERTOKENISSUER: '${IAM_ISSUER}',
+        // Env names: DotenvConfigManager prefixes with the schema's configType
+        // ('IAM_AUTH'), so the vars are IAM_AUTH_<FIELD> — plain IAM_<FIELD>
+        // never reaches the config and the service silently keeps its prod
+        // defaults (verified live: every cookie 401'd until the rename).
+        IAM_AUTH_JWKSURL: '${IAM_URL}/.well-known/services/jwks.json',
+        IAM_AUTH_USERJWKSURL: '${IAM_URL}/.well-known/jwks.json',
+        IAM_AUTH_SERVICETOKENISSUER: '${IAM_ISSUER}',
+        IAM_AUTH_USERTOKENISSUER: '${IAM_ISSUER}',
       },
     },
     // No fixture seed of its own — iam.* projection hydrates authz_db at runtime.

--- a/packages/node/saga-stack-cli/src/core/manifest/services.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/services.ts
@@ -890,6 +890,11 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
         IAM_AUTH_USERJWKSURL: '${IAM_URL}/.well-known/jwks.json',
         IAM_AUTH_SERVICETOKENISSUER: '${IAM_ISSUER}',
         IAM_AUTH_USERTOKENISSUER: '${IAM_ISSUER}',
+        // Browser leg (#881): authz-api's credentialed CORS allowlist covers the
+        // wildcard prod/dev hosts + localhost:8900 only — a slot>0 dash (:9900)
+        // is blocked (no ACAO echoed → browser "Failed to fetch" → dash silently
+        // runs its permission-derived fallback; found live on slot 1).
+        CORS_ORIGIN: '${DASH_URL}',
       },
     },
     // No fixture seed of its own — iam.* projection hydrates authz_db at runtime.

--- a/packages/node/saga-stack-cli/src/core/manifest/services.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/services.ts
@@ -255,6 +255,10 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
         NODE_ENV: 'development',
         DATABASE_URL: '${SESSIONS_DB_URL}',
         IAM_API_URL: '${IAM_URL}',
+        // No up.sh precedent: sessions-api's own default (localhost:3008) is
+        // slot 0's scheduling-api, so slot>0 time/adhoc S2S writes dialed the
+        // wrong slot without this (live ECONNREFUSED on slot 1).
+        SCHEDULING_API_URL: '${SCHEDULING_URL}',
         RABBITMQ_URL: '${MESH_MQ}',
         CORS_ORIGIN: '${DASH_URL}',
         // Same iss iam-api stamps — see programs-api's JWT_ISSUER note.

--- a/packages/node/saga-stack-cli/src/core/manifest/types.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/types.ts
@@ -29,7 +29,8 @@ export type ServiceId =
   | 'transcripts-api' // optional: true (--with-playback)
   | 'insights-api' //    optional: true (--with-playback)
   | 'chat-api' //        optional: true (--with-playback)
-  | 'authz-sync'; //     optional: true (--with authz) — RabbitMQ-only OpenFGA tuple projector
+  | 'authz-sync' //      optional: true (--with authz) — RabbitMQ-only OpenFGA tuple projector
+  | 'authz-api'; //      optional: true (--with authz) — OpenFGA PDP (check/require); own prisma DB, iam.* projection
 
 /** Mesh infra units, started as a single `make up PROFILE=empty`. */
 export type MeshId = 'postgres' | 'redis' | 'rabbitmq' | 'connect-mongo' | 'openfga';
@@ -75,7 +76,8 @@ export type DbId =
   | 'chat_local'
   | 'connectv3'
   | 'openfga'
-  | 'authz_sync_local';
+  | 'authz_sync_local'
+  | 'authz_api_local';
 
 /** Canonical SeedStep ids (see §4). Referenced by `ServiceDef.seed`. */
 export type SeedStepRef =

--- a/packages/node/saga-stack-cli/src/core/snapshot/__tests__/plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/snapshot/__tests__/plan.unit.test.ts
@@ -120,7 +120,7 @@ describe('storePlan — manifest-driven db set (the 6→10-pg + mongo extension)
   it('--with-playback adds the transcripts/insights/chat trio', () => {
     const plan = storePlan(manifest, { fixtureId: 'x', profile: 'roster', withPlayback: true });
     const dbs = plan.databases.map((d) => d.db);
-    expect(plan.databases.filter((d) => d.engine === 'postgres')).toHaveLength(13);
+    expect(plan.databases.filter((d) => d.engine === 'postgres')).toHaveLength(14);
     for (const pb of PLAYBACK_DBS) expect(dbs).toContain(pb);
   });
 

--- a/packages/node/saga-stack-cli/src/core/snapshot/manifest.ts
+++ b/packages/node/saga-stack-cli/src/core/snapshot/manifest.ts
@@ -50,6 +50,7 @@ const DB_IDS = [
   'connectv3',
   'openfga',
   'authz_sync_local',
+  'authz_api_local',
 ] as const;
 const _dbIdsAreDbIds: readonly DbId[] = DB_IDS;
 void _dbIdsAreDbIds;
@@ -73,6 +74,7 @@ const SERVICE_IDS = [
   'insights-api',
   'chat-api',
   'authz-sync',
+  'authz-api',
 ] as const;
 const _serviceIdsAreServiceIds: readonly ServiceId[] = SERVICE_IDS;
 void _serviceIdsAreServiceIds;

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/dash-defaults.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/dash-defaults.unit.test.ts
@@ -123,6 +123,8 @@ describe('syncDashLocalDefaults — M7 stack-lane slot config', () => {
     'sis-api': 3100 + offset,
     'content-api': 3009 + offset,
     'connect-api': 6106 + offset,
+    'connect-web': 6210 + offset,
+    'authz-api': 3200 + offset,
     'ads-adm-api': 5005 + offset,
     'transcripts-api': 6302 + offset,
   });
@@ -152,7 +154,10 @@ describe('syncDashLocalDefaults — M7 stack-lane slot config', () => {
     expect(parsed.localDefaults.iam).toEqual({ type: 'url', url: 'http://localhost:4010' });
     expect(parsed.localDefaults['program-hub']).toEqual({ type: 'url', url: 'http://localhost:4006' });
     expect(parsed.localDefaults['enrollment-api']).toEqual({ type: 'url', url: 'http://localhost:4006' });
-    expect(parsed.localDefaults.connect).toEqual({ type: 'url', url: 'http://localhost:7106' });
+    // connect = the WEB SPA origin (browser navigation target), not the API.
+    expect(parsed.localDefaults.connect).toEqual({ type: 'url', url: 'http://localhost:7210' });
+    // authz-api backs the dash affordances client (saga-dash#779).
+    expect(parsed.localDefaults['authz-api']).toEqual({ type: 'url', url: 'http://localhost:4200' });
     // ads-adm + transcripts-api MUST offset too (the browser dials them for real —
     // the split-brain BLOCKER). Base config.json ports (5005 / 6302 = slot 0) must
     // NOT leak through: slot 1 ⇒ 6005 / 7302.

--- a/packages/node/saga-stack-cli/src/runtime/dash-defaults.ts
+++ b/packages/node/saga-stack-cli/src/runtime/dash-defaults.ts
@@ -70,7 +70,12 @@ export const DASH_LOCAL_SERVICES: Readonly<Record<string, ServiceId>> = {
   'sessions-api': 'sessions-api',
   'sis-api': 'sis-api',
   'content-api': 'content-api',
-  connect: 'connect-api',
+  // Dash's `connect` service key is the connect WEB SPA origin (deployed:
+  // connect.wootdev.com; checked-in local default 6210 = connectv3 web dev) —
+  // observe/join links navigate there. Mapping it to connect-api wrote the
+  // API port into the browser-navigation key, so every slot>0 dash connect
+  // link landed on Express's "Cannot GET /" (found live on slot 1).
+  connect: 'connect-web',
   // The browser dials these two for REAL (the dash's attendance/transcripts tRPC
   // clients), so a slot's config.local.json MUST offset them too — else a slot > 0
   // dash keeps the base config.json ports (ads-adm 5005 / transcripts 6302 = SLOT
@@ -82,6 +87,11 @@ export const DASH_LOCAL_SERVICES: Readonly<Record<string, ServiceId>> = {
   // refused) instead of writing cross-slot — the corruption gate.
   'ads-adm': 'ads-adm-api',
   'transcripts-api': 'transcripts-api',
+  // saga-dash#779: the dash authz client (affordances). Without this entry a
+  // slot>0 dash falls back to the checked-in localhost:3200 (slot 0), fails
+  // the fetch, and silently runs its permission-derived fallback — i.e. the
+  // authz path is never exercised on a slot.
+  'authz-api': 'authz-api',
 };
 
 /** Inputs to the dash-defaults prelaunch hook. */


### PR DESCRIPTION
## What

Wires rostering's **authz-api** (the OpenFGA PDP serving check/require) into the `ss` synthetic dev-stack manifest, so `ss stack up --with authz` boots it alongside `authz-sync`. authz-api is a *distinct* service from authz-sync (the RabbitMQ tuple projector) — it owns a prisma-migrated `authz_db` and validates iam-minted JWTs offline.

Complements the deploy-side internal-ALB homing (rostering#871, program-hub#444) by giving authz-api a first-class seat in local dev.

## Manifest edits (the 8 registration points)

| File | Change |
|---|---|
| `manifest/types.ts` | `authz-api` → `ServiceId`, `authz_api_local` → `DbId` |
| `manifest/services.ts` | `ServiceDef`: :3200, `/health/ready`, DB `authz_api_local`, mesh postgres+rabbitmq, iam-api url dep, `optional`. **launch.env repoints the four `IAM_` S2S vars** at the stack iam + issuer (app defaults are prod/`:3000` → would 401 every locally-minted token). |
| `manifest/databases.ts` | prisma-migrated `DatabaseDef`, **`meshProvisioned: true`** — the provision *and* migrate runners both gate on it, so a prisma DB must be `true` or its schema never applies. No always-on cost (all runners iterate the *closure's* DBs, so it's only touched under `--with authz`). |
| `launch-plan.ts` | `AUTHZ_API_PORT` / `AUTHZ_API_URL` / `AUTHZ_API_DB_URL` tokens |
| `closure.ts` | admit authz-api under `withAuthz` (else `--with authz` **silently drops it** — no compile error) |
| `bundles.ts` | `authz-api` → the `authz` bundle |
| `profile-empty.sql` | `CREATE USER/DATABASE/GRANT authz_api` |
| `README.md` | document `--with authz` |

Plus the **three hardcoded mirror lists** the manifest widening invalidated (`snapshot/manifest.ts` DB_IDS+SERVICE_IDS, `flow/types.ts` SERVICE_IDS) — their subset compile-guards are blind to a *missing* member, so the gap surfaced via the exhaustiveness unit tests. Two stale assertions updated (authz bundle now = both services; whole-manifest postgres DB count 13→14).

## Integration with other services

- **Inbound (iam-api) is wired** — the `IAM_` JWKS/issuer overrides above. This is the real integration today.
- **Outbound callers (programs-api/sessions-api → authz-api): intentionally NOT wired** — no mesh app reads `AUTHZ_API_URL` yet. The `AUTHZ_API_URL` *token* is provided so the S2S seam (program-hub#403's client / `AUTHZ_API_URL`) can reference it when it lands. On slot 0, that client's `localhost:3200` default auto-finds authz-api with zero extra ss wiring; only non-zero slots would need the token threaded.
- `/health/ready` gates only on `authz_db` connectivity (not iam-projection catch-up), so it goes ready as soon as the DB is up + migrated.

## Testing

- **Port 3200 collision-clear** across slots 0..8 (`derive-instance` no-collision property test passes).
- `pnpm check-types` clean; **full suite 1418 passed / 0 failed** (118 files), incl. all three zod-enum exhaustiveness guards.

## Acceptance test — RUN 2026-07-23 (live Docker mesh)

Booted the closure on a live mesh and verified authz-api end-to-end. All authz-api-owned behavior is GREEN:

- **Closure/dry-run:** `ss stack up --with authz --dry-run` → admits authz-api, launch order `iam-api → authz-sync → authz-api`, `authz_api_local` DB + postgres/rabbitmq mesh planned. (`--only authz-api` alone yields an empty closure — confirms the `closure.ts` optional-gate works: authz-api only admitted under `--with authz`.)
- **Seed:** fresh-volume `postgres_init` runs `profile-empty.sql` and creates the `authz_api` role + `authz_api_local` DB clean (also verified by direct `psql` apply of the exact authored lines + the structurally-identical `authz_sync` sibling seeding in the same pass).
- **Migrate (ss-orchestrated, end-to-end):** the CLI's migrate runner applied `authz-db`'s `prisma migrate deploy` against `authz_api_local` via `migrateEnvVar: AUTHZ_DATABASE_URL` — 2 migrations, 8 tables materialized (`authz_decision_log`, `iam_*_projection`, `consumed_events`, `projection_readiness`).
- **Runtime GREEN** (authz-api launched **directly** — `node dist/main.js` with the env *values* ss resolves from its launch-plan tokens; ss's own launcher aborted at authz-sync before spawning authz-api, so end-to-end ss-spawn is proven only by analogy — the identical launcher path *did* spawn authz-sync to its own app-level throw):
  - `/health/ready` → **HTTP 200** `{"status":"ready","checks":{"authzDb":{"ready":true,"detail":"connected"}}}`
  - **RabbitMQ iam-projection consumer connected** — `[MQConnectionManager] READY`, `[EventConsumer:authz-api.iam-projection] started`, consuming `iam.user/group/group_membership/persona_assignment/persona_definition/persona_policies.*`.
  - **iam URLs resolved correctly** — the four `IAM_` vars resolved to the stack iam (`:3010` / `iam.wootdev.com`), **not** the prod defaults (`:3000` / `iam.saga.org`), and authz-api booted clean with no JWKS-fetch errors. Note: iam-api was not up and authz-api validates JWKS *lazily*, so no token was validated in this test — the 401-drift guard is proven by the resolved config value, not by an exercised validation path. Live JWKS validation deferred with the full-chain boot.

### ⚠️ Two gotchas surfaced by the boot (both carried below)

1. **Build-time prerequisite — `AUTHZ_DATABASE_URL` must be present for the monorepo build.** authz-db's `prisma.config.ts` *eagerly throws* if `AUTHZ_DATABASE_URL` is unset — and it fires during the **build/prep phase** (`turbo run … db:generate`), which reads rostering's repo-root `.env.local`. ss injects DB URLs into its own **migrate** step (this PR's `migrateEnvVar` — correct), but the **build phase** reads `.env.local`, which ss does not own/compose (a legacy `up.sh` artifact, now dev-local) and which currently lacks `AUTHZ_DATABASE_URL` (it has `DATABASE_URL`/`PII_DATABASE_URL`/`SIS_DATABASE_URL` only). Until the rostering fix lands, `ss stack up --with authz` needs `AUTHZ_DATABASE_URL` exported (or added to `.env.local`). **Filed rostering issue saga-ed/rostering#873** — ideal fix is that `db:generate` should not hard-require a live DB URL to build a Prisma client from schema. (Same class as sis-db's `SIS_DATABASE_URL`, which `.env.local` *does* carry.)

2. **Pre-authz Postgres volumes need a reseed.** `profile-empty.sql` only runs on a *fresh* volume (the seed is marker-guarded — "already seeded … skipping"). A dev whose `soa_postgres-data` volume predates the `authz_api` lines won't have the `authz_api_local` DB until they wipe/reseed (`ss stack cold-start`, or drop the postgres volume). Hit exactly this on a 2026-07-09 volume during acceptance.

### Orthogonal blocker (NOT this PR)

`--with authz` also launches **authz-sync** (a pre-existing bundle sibling; this PR added only authz-api). On this host authz-sync failed its first-run launch with `missing required env OPENFGA_STORE_ID` — the store-id file (`$ROSTERING/.saga-mesh/openfga-store.json`) is written by the `fga-bootstrap` seed step for the *next* run to consume, and authz-sync's build hard-throws when it's absent on the very first run. Independent of authz-api (which holds no OpenFGA config). authz-api was verified by launching it directly against the live mesh, past the authz-sync step. The full-chain `--with authz` green + sandbox/tunnel overlays remain for a stable host / a separate authz-sync-first-run fix.

**Still deferred (non-blocking):** sandbox/tunnel lane overlays (authz-api's `IAM_` JWKS/CORS won't repoint under `--sandbox`/`--tunnel`); `adoptEnv` fingerprinting for the issuer/JWKS keys.

---

## Booting `--with authz` today (workaround until rostering#873 lands)

Two host-side prerequisites, both from the acceptance run above (neither is an ss-code change):

1. **Export the build-time DB URL** (works around rostering#873):
   ```
   export AUTHZ_DATABASE_URL="postgresql://authz_api:authz_api@localhost:5432/authz_api_local"
   ```
2. **Start from a fresh Postgres volume** if yours predates the `authz_api` seed lines
   (`ss stack cold-start`, or drop `soa_postgres-data` so `profile-empty.sql` re-runs).

With those in place, `ss stack up --with authz` builds + migrates authz-api and it comes up green
(`/health/ready` 200, iam-projection consumer connected). The one caveat is the **orthogonal
authz-sync first-run `OPENFGA_STORE_ID`** blocker (above) — independent of authz-api and tracked
separately; authz-api itself is verified.
