### PR TITLE
feat(api-core): configurable jsonBodyLimit + 413 handler advertising the cap

### DIFF
--- a/packages/node/api-core/src/__tests__/express-server.int.test.ts
+++ b/packages/node/api-core/src/__tests__/express-server.int.test.ts
@@ -522,4 +522,48 @@ describe('ExpressServer (integration)', () => {
       await new Promise(resolve => setTimeout(resolve, 100));
     }
   });
+
+  it('advertises the configured limit on an oversized JSON body (413)', async () => {
+    const container = new Container();
+    const mockLogger: ILogger = {
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    };
+
+    const port = getRandomPort();
+    const config = {
+      configType: 'EXPRESS_SERVER' as const,
+      port,
+      logLevel: 'info' as const,
+      name: 'Body Limit Test',
+      jsonBodyLimit: '1kb',
+    };
+
+    container.bind('ExpressServerConfig').toConstantValue(config);
+    container.bind('ILogger').toConstantValue(mockLogger);
+    container.bind(ExpressServer).toSelf();
+
+    const server = container.get(ExpressServer);
+    await server.init(container, [InheritedParamController]);
+    server.start();
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    try {
+      const resp = await fetch(`http://localhost:${port}/inherit/echo`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ msg: 'x'.repeat(5000) }),
+      });
+      expect(resp.status).toBe(413);
+      const maxBodyBytesHeader = resp.headers.get('x-max-body-bytes');
+      expect(maxBodyBytesHeader).toMatch(/^\d+$/);
+      const data = await resp.json() as any;
+      expect(data).toEqual({ error: 'payload_too_large', maxBodyBytes: Number(maxBodyBytesHeader) });
+    } finally {
+      server.stop();
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+  });
 });

--- a/packages/node/api-core/src/express-server-schema.ts
+++ b/packages/node/api-core/src/express-server-schema.ts
@@ -28,6 +28,10 @@ export const ExpressServerSchema = z.object({
   allowedHeaders: z
     .array(z.string())
     .optional(),
+  // Max request body size for the built-in JSON parser (any `bytes`-parsable
+  // string, e.g. '5mb'). Consumers that mount their own parser first are
+  // unaffected. Defaults to '5mb' (see ExpressServer) when omitted.
+  jsonBodyLimit: z.string().optional(),
 });
 
 // Use the INPUT type, not `z.infer` (the output): this config is bound directly

--- a/packages/node/api-core/src/express-server.ts
+++ b/packages/node/api-core/src/express-server.ts
@@ -8,6 +8,7 @@ import type { ILogger } from '@saga-ed/soa-logger';
 import { useContainer, useExpressServer, getMetadataArgsStorage } from 'routing-controllers';
 import { Container } from 'inversify';
 import { SectorsController } from './sectors-controller.js';
+import { payloadTooLargeHandler } from './payload-too-large-handler.js';
 
 // Default CORS `Access-Control-Allow-Headers`: the baseline request headers
 // every Saga API accepts, plus the Datadog browser-RUM distributed-tracing
@@ -18,6 +19,10 @@ import { SectorsController } from './sectors-controller.js';
 // their ExpressServerConfig (spread `DATADOG_RUM_TRACING_HEADERS` to keep RUM
 // working). See hipponot/iac#358.
 const DEFAULT_ALLOWED_HEADERS: string[] = ['Content-Type', 'Authorization', ...DATADOG_RUM_TRACING_HEADERS];
+
+// Default max JSON request body size (express's own default is a silent
+// 100kb). Consumers override via the `jsonBodyLimit` config field.
+const DEFAULT_JSON_BODY_LIMIT = '5mb';
 
 @injectable()
 export class ExpressServer {
@@ -87,7 +92,7 @@ export class ExpressServer {
     // parsers — re-read the consumed stream and 500 every JSON POST with
     // "stream is not readable" (saga-ed/program-hub#306). Marking req._body
     // restores the 1.x contract for those route-scoped parsers too.
-    const jsonParser = express.json();
+    const jsonParser = express.json({ limit: this.config.jsonBodyLimit ?? DEFAULT_JSON_BODY_LIMIT });
     this.app.use((req: express.Request, res: express.Response, next: express.NextFunction) => {
       if (req.body !== undefined) {
         (req as { _body?: boolean })._body = true;
@@ -96,6 +101,9 @@ export class ExpressServer {
       }
       jsonParser(req, res, next);
     });
+
+    // Catch the JSON parser's oversized-body (413) error and advertise the limit.
+    this.app.use(payloadTooLargeHandler());
 
     // Ensure routing-controllers uses Inversify for controller resolution
     useContainer(container);

--- a/packages/node/api-core/src/index.ts
+++ b/packages/node/api-core/src/index.ts
@@ -2,3 +2,4 @@ export { AbstractRestController } from './abstract-rest-controller.js';
 export { AbstractTGQLController } from './abstract-tgql-controller.js';
 export { AbstractGQLController, type ResolverMap } from './abstract-gql-controller.js';
 export { type ExpressServerConfig } from './express-server-schema.js';
+export { payloadTooLargeHandler } from './payload-too-large-handler.js';

--- a/packages/node/api-core/src/payload-too-large-handler.ts
+++ b/packages/node/api-core/src/payload-too-large-handler.ts
@@ -1,0 +1,21 @@
+import type { ErrorRequestHandler } from 'express';
+
+/**
+ * Express error middleware that advertises the request body-size limit on
+ * oversized-payload rejections, so clients can right-size their batch and retry
+ * instead of failing opaquely. body-parser throws a PayloadTooLargeError with
+ * `type: 'entity.too.large'` and a numeric `limit` (the configured byte cap).
+ * Register this immediately AFTER the JSON body parser (see ExpressServer) so it
+ * catches the parser's error before any downstream framework error handler.
+ */
+export function payloadTooLargeHandler(): ErrorRequestHandler {
+  return (err, _req, res, next) => {
+    const e = err as { type?: string; status?: number; statusCode?: number; limit?: number } | null;
+    if (e && (e.type === 'entity.too.large' || e.status === 413 || e.statusCode === 413)) {
+      if (typeof e.limit === 'number') res.setHeader('X-Max-Body-Bytes', String(e.limit));
+      res.status(413).json({ error: 'payload_too_large', maxBodyBytes: e.limit ?? null });
+      return;
+    }
+    next(err);
+  };
+}


### PR DESCRIPTION
## Summary

- Makes the shared `ExpressServer`'s JSON body-size limit configurable via a new `jsonBodyLimit` field on `ExpressServerConfig` (defaults to `5mb`, replacing express's silent 100kb default).
- Adds a reusable `payloadTooLargeHandler()` (exported from `@saga-ed/soa-api-core`) that catches body-parser's `entity.too.large` / 413 error, sets an `X-Max-Body-Bytes` response header, and returns `{ error: 'payload_too_large', maxBodyBytes }` — so clients can right-size a batch and retry instead of failing opaquely.
- The handler is registered immediately after the guarded JSON-parser middleware in `ExpressServer.init()`, and before `useContainer(container)` / `useExpressServer(...)`, so it intercepts the parser's error before routing-controllers' own error handler can shadow it.
- Lands this once in the shared package rather than per-service, covering all 11 services that mount `ExpressServer`. Part of a fleet-wide convergence effort.

## Test plan

- [x] `pnpm turbo run build` for internal deps (`@saga-ed/soa-api-util`, `@saga-ed/soa-logger`) — clean
- [x] `tsc --noEmit -p packages/node/api-core/tsconfig.json` — clean (the package has no dedicated `check-types` turbo script, so this ran the real type check directly)
- [x] `pnpm turbo run test --filter=@saga-ed/soa-api-core` — 3 test files, 36/36 tests passed, including:
  - new integration test proving the 413 placement end-to-end (`jsonBodyLimit: '1kb'`, oversized POST → 413, `X-Max-Body-Bytes` header present, JSON body shape correct)
  - all pre-existing tests still green (basePath, CORS, param-inheritance patch, upstream-parser interop, and the compression test from #358)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVfaSbfi6wmLVSfr9o13r8