### PR TITLE
fix(saga-stack-cli): keep fake-media ffmpeg off the terminal (backgrounded login froze) — follow-up to #364

### DIFF
--- a/packages/node/saga-stack-cli/docs/cheatsheet.md
+++ b/packages/node/saga-stack-cli/docs/cheatsheet.md
@@ -152,6 +152,7 @@ ss stack overlay apply --prs 165 saga-dash   # overlay in-flight PR(s) onto name
 ss stack overlay reset saga-dash             # drop the overlay, back to main
 ss stack login teacher@saga.org              # mint a persona cookie jar (defaults to dev@saga.org)
 ss stack login --browser                     # …also open an auto-logged-in Chromium
+ss stack login --browser --fake-video clip.mp4  # …feed a local clip to its fake camera/mic (auto-transcodes)
 ss stack tunnel                              # share the running stack
 ```
 

--- a/packages/node/saga-stack-cli/docs/faq.md
+++ b/packages/node/saga-stack-cli/docs/faq.md
@@ -152,6 +152,29 @@ Currently seeded flow viewers:
 District, which `dev@saga.org` already carries; `--hold` opens that browser
 for you.)
 
+## Can I feed a local video file to the login browser's camera/mic?
+
+Yes — `--fake-video <file>` (and `--fake-audio <file>`) on `ss stack login
+--browser` play a **local** clip into the headful Chromium's fake camera/mic, for
+AV flows (Connect) on a box with no real device:
+
+```bash
+ss stack login empty@saga.org --browser --state-dir /tmp/ss-eadmin-browser \
+   --fake-video ~/clips/student.mp4
+```
+
+- **Auto-transcode.** Chromium's file-backed capture reads only raw **Y4M** video +
+  **PCM WAV** audio, so any other format (`.mp4`, …) is transcoded via `ffmpeg`
+  (needs `ffmpeg` on PATH). A `.y4m`/`.wav` file is used as-is. `--fake-video foo.mp4`
+  alone also **derives the mic** from the same file; `--fake-audio` overrides it.
+- **Size caveat.** Y4M is uncompressed — a minute of 720p is hundreds of MB. The
+  transcode is cached by mtime (under `<state-dir>/fake-av/`), so a repeat run with
+  the same clip is instant; for big/long clips, pre-make a small `.y4m` and pass that.
+- **Requires `--browser`** (there's nothing to feed otherwise) and applies per
+  `--state-dir`, so each browser instance gets its own clip.
+- Distinct from `ss develop connect --fake-media`, which plays Chromium's built-in
+  **synthetic** test pattern (a moving pattern + beep), not your file.
+
 ## How do I pull the latest main into slot 0 and the worktree slots?
 
 ```bash

--- a/packages/node/saga-stack-cli/src/core/__tests__/fake-media.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/fake-media.unit.test.ts
@@ -16,7 +16,7 @@ describe('planFakeMedia', () => {
       derived: false,
     });
     expect(plan.video?.argv).toEqual([
-      '-y', '-i', '/clips/student.mp4', '-pix_fmt', 'yuv420p', '/state/fake-av/student.fake-video.y4m',
+      '-nostdin', '-y', '-i', '/clips/student.mp4', '-pix_fmt', 'yuv420p', '/state/fake-av/student.fake-video.y4m',
     ]);
     // audio derived from the SAME file (mp4 carries both), marked derived ⇒ non-fatal.
     expect(plan.audio).toMatchObject({
@@ -27,6 +27,9 @@ describe('planFakeMedia', () => {
     });
     expect(plan.audio?.argv).toContain('-vn');
     expect(plan.audio?.argv).toContain('pcm_s16le');
+    // -nostdin so a backgrounded transcode can't SIGTTIN-freeze on ffmpeg's stdin read.
+    expect(plan.video?.argv[0]).toBe('-nostdin');
+    expect(plan.audio?.argv[0]).toBe('-nostdin');
   });
 
   it('a .y4m video is passthrough (no transcode) and does NOT derive audio', () => {

--- a/packages/node/saga-stack-cli/src/core/fake-media.ts
+++ b/packages/node/saga-stack-cli/src/core/fake-media.ts
@@ -46,14 +46,20 @@ export interface FakeMediaPlan {
   audio?: FfmpegStep;
 }
 
+// `-nostdin` (soa#363): ffmpeg reads stdin for interactive control ('q' to quit). With
+// inherited terminal stdin a BACKGROUNDED `ss stack login` would take SIGTTIN on that read
+// and STOP (the transcode "freezes", so the browser never launches). `-nostdin` makes
+// ffmpeg never touch stdin — the runtime ALSO routes stdin from /dev/null (belt-and-suspenders).
+const FFMPEG_NOSTDIN = '-nostdin';
+
 /** yuv420p Y4M — the widely-supported raw form Chromium's fake VIDEO capture reads. */
 function videoArgv(input: string, output: string): string[] {
-  return ['-y', '-i', input, '-pix_fmt', 'yuv420p', output];
+  return [FFMPEG_NOSTDIN, '-y', '-i', input, '-pix_fmt', 'yuv420p', output];
 }
 
 /** 16-bit PCM WAV (mono, 48 kHz) — the form Chromium's fake AUDIO capture reads. `-vn` drops video. */
 function audioArgv(input: string, output: string): string[] {
-  return ['-y', '-i', input, '-vn', '-acodec', 'pcm_s16le', '-ar', '48000', '-ac', '1', output];
+  return [FFMPEG_NOSTDIN, '-y', '-i', input, '-vn', '-acodec', 'pcm_s16le', '-ar', '48000', '-ac', '1', output];
 }
 
 function makeStep(

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/fake-media.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/fake-media.unit.test.ts
@@ -48,10 +48,12 @@ describe('prepareFakeMedia', () => {
       video: '/state/fake-av/s.fake-video.y4m',
       audio: '/state/fake-av/s.fake-audio.wav',
     });
-    // ffmpeg -version presence check, then the two transcodes.
-    expect(calls.map((c) => c.args[0])).toEqual(['-version', '-y', '-y']);
+    // ffmpeg -version presence check, then the two transcodes (each `-nostdin …`).
+    expect(calls.map((c) => c.args[0])).toEqual(['-version', '-nostdin', '-nostdin']);
     expect(calls[1].command).toBe('ffmpeg');
     expect(calls[1].args).toContain('/state/fake-av/s.fake-video.y4m');
+    // BACKGROUND-SAFE: every ffmpeg run routes stdin from /dev/null (no SIGTTIN freeze).
+    expect(calls.every((c) => c.stdinFile === '/dev/null')).toBe(true);
   });
 
   it('passthrough inputs run NO ffmpeg (not even the -version presence check)', async () => {

--- a/packages/node/saga-stack-cli/src/runtime/fake-media.ts
+++ b/packages/node/saga-stack-cli/src/runtime/fake-media.ts
@@ -11,6 +11,10 @@
  *    produce, so a repeated `login` with the same clip doesn't re-transcode.
  *  - DERIVED audio is best-effort: a failed derive (a video with no audio track) drops
  *    audio and keeps video; an EXPLICIT `--fake-audio` failure throws.
+ *  - BACKGROUND-SAFE: every ffmpeg run routes stdin from /dev/null (`stdinFile`), so a
+ *    backgrounded `ss stack login --fake-video` can't take SIGTTIN on ffmpeg's stdin read
+ *    and STOP (`-nostdin` in the argv is the matching belt-and-suspenders). Without this
+ *    the transcode freezes and the browser never launches.
  *
  * IO is behind injectable deps (Runner + stat/mkdir seams) so it is unit-tested with a
  * fake runner and NO real ffmpeg/fs.
@@ -47,10 +51,22 @@ const realStatMtime = (p: string): number | null => {
   }
 };
 
+/**
+ * `/dev/null` stdin for every ffmpeg run: a backgrounded transcode must never read the
+ * controlling terminal (SIGTTIN → STOP → frozen transcode → no browser). See module header.
+ */
+const NULL_STDIN = '/dev/null';
+
 /** Run `ffmpeg -version` once to confirm it is on PATH; throw an install hint if not. */
 async function assertFfmpeg(runner: Runner): Promise<void> {
   try {
-    const { code } = await runner.run({ cwd: process.cwd(), command: 'ffmpeg', args: ['-version'], env: {} });
+    const { code } = await runner.run({
+      cwd: process.cwd(),
+      command: 'ffmpeg',
+      args: ['-version'],
+      env: {},
+      stdinFile: NULL_STDIN,
+    });
     if (code === 0) return;
   } catch {
     // spawn-level failure (ENOENT) — fall through to the throw.
@@ -83,7 +99,9 @@ async function runStep(
       command: 'ffmpeg',
       args: step.argv,
       env: {},
-      stdio: 'inherit',
+      // stdout/stderr inherit (progress visible); stdin from /dev/null so a backgrounded
+      // run can't SIGTTIN-freeze on ffmpeg's interactive stdin read (soa#363).
+      stdinFile: NULL_STDIN,
     });
     return code === 0 ? 'ok' : 'failed';
   } catch {


### PR DESCRIPTION
Follow-up to #364 (soa#363) — the fake-media transcode landed there, but this freeze fix was cut as a separate commit after the PR merged, so it needs its own PR.

## Bug

A **backgrounded** `ss stack login --fake-video …` froze mid-transcode and the browser never launched. ffmpeg's interactive mode calls `tcsetattr()` to put the controlling terminal into raw mode for keystroke capture; from a **background process group** that raises **SIGTTOU**, which STOPS ffmpeg. `prepareFakeMedia` then awaits an ffmpeg that never exits.

## Fix

Two independently-sufficient guards so ffmpeg never touches the terminal:
- `-nostdin` in the ffmpeg argv (`core/fake-media.ts`) — ffmpeg skips interactive terminal setup entirely.
- Route every ffmpeg run's stdin from `/dev/null` (`runtime/fake-media.ts`, via the Runner's `stdinFile`) — ffmpeg sees a non-tty and skips the setup regardless.

stdout/stderr still inherit, so transcode progress stays visible.

## Verification

- Reproduced the exact freeze in a background-process-group PTY: **BEFORE** ffmpeg is STOPPED by a terminal-access signal; **AFTER (`-nostdin`)** it completes exit 0.
- Confirmed working by the reporter on their real setup (backgrounded login now launches the browser).
- Unit tests updated: `core` asserts `-nostdin` leads the argv; `runtime` asserts every ffmpeg run sets `stdinFile: /dev/null`. Full package suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)