### PR TITLE
feat(saga-fga): contextual tuples + checkDetailed attribution + unavailable≠deny

### DIFF
--- a/packages/core/saga-fga/README.md
+++ b/packages/core/saga-fga/README.md
@@ -53,6 +53,16 @@ const d = await fga.checkDetailed(
 them in priority order: `['host', 'edit_grant']` makes HOST win when a caller
 is both.
 
+> **Caller obligation — keep `relations[]` exhaustive.** The array you pass must
+> be exactly the branches of the corresponding `can_*` union.
+> `checkDetailed(u, ['host', 'edit_grant'], o)` is caller-side duplication of
+> `can_edit: host or edit_grant`. If a branch is ever added to that union in the
+> model, an enumerating caller **denies access the model would allow**. The
+> drift fails closed (under-authorization, not a hole), and it is silent — so
+> when you add a branch to a `can_*` union, grep for its `checkDetailed`
+> callers. The capability catalog codegens these shapes, so branch growth is
+> anticipated.
+
 ## Contextual tuples
 
 Ephemeral objects are never materialized as stored tuples. A session id decodes

--- a/packages/core/saga-fga/README.md
+++ b/packages/core/saga-fga/README.md
@@ -25,6 +25,72 @@ await enforceFgaRelation(
 );
 ```
 
+## Attribution: `checkDetailed`
+
+Some gates must report not just *whether* access was allowed but *which* rule
+allowed it — program-hub's sessions gate derives its D19 actor (`HOST` vs
+`ADMIN`) from exactly that.
+
+An OpenFGA Check answers only `allowed`, so a union relation
+(`can_edit: host or edit_grant`) cannot say which side fired. The model
+therefore keeps the branches **separable** — an invariant recorded in the
+`session` type of `scripts/fga/prototype/unified-graph.fga` (rostering) — and
+`checkDetailed` asks each branch independently (in parallel) and reports the
+winners. No `Expand` call is involved.
+
+```ts
+const d = await fga.checkDetailed(
+  `user:${callerId}`,
+  ['host', 'edit_grant'], // attribution-priority order
+  `session:${sessionId}`,
+);
+// d.allowed → boolean
+// d.via     → 'host' | 'edit_grant' | undefined  (first branch that held)
+// d.branches→ every branch that held
+```
+
+`via` reports the **first** branch that held in the order supplied, so pass
+them in priority order: `['host', 'edit_grant']` makes HOST win when a caller
+is both.
+
+## Contextual tuples
+
+Ephemeral objects are never materialized as stored tuples. A session id decodes
+to `(date, periodId, slotId, podId)`; the *durable* facts (pod tutorship,
+program scope edges) live in the graph, while the *derived* facts — effective
+pod after SWAP/ABSENT at NOW, the per-occurrence override host after its
+live-membership gate — are resolved by the caller and ride in on the request:
+
+```ts
+await fga.checkDetailed(`user:${callerId}`, ['host', 'edit_grant'], `session:${id}`, [
+  { user: `pod:${effectivePodId}`, relation: 'pod', object: `session:${id}` },
+  { user: `user:${overrideHostId}`, relation: 'host', object: `session:${id}` },
+]);
+```
+
+Contextual-tuple relations are marked as such in the partition registry
+(ADR 0006 §3) — they are **never also stored**.
+
+## An unreachable verdict is not a denial
+
+`check` returns a bare boolean, so a swallowed failure would be
+indistinguishable from a legitimate `false` — an outage would silently present
+as "permission denied". Instead, any failure to reach a verdict (transport
+error, non-2xx, missing `OPENFGA_STORE_ID`) throws **`FgaUnavailableError`**.
+
+Keep the two apart at the call site. Masking a confirmed deny as `NOT_FOUND` is
+correct (D15); masking an outage that way is not — it surfaces as the distinct
+authz-unavailable signal (north star P5):
+
+```ts
+try {
+  await enforceFgaRelation(fga, user, 'host', object, () => notFound());
+} catch (e) {
+  if (e instanceof FgaUnavailableError) throw serviceUnavailable(); // NOT NOT_FOUND
+  throw e;
+}
+```
+
 ## Enforcement is off by default
 
 `AUTHZ_FGA_ENFORCE` must equal the exact string `true` to enable checks. While

--- a/packages/core/saga-fga/package.json
+++ b/packages/core/saga-fga/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/saga-fga",
-    "version": "0.1.0-dev.1",
+    "version": "0.1.0-dev.2",
     "private": false,
     "type": "module",
     "description": "Saga OpenFGA Tier-2 authorization gate — a thin check client + framework-agnostic enforcement helper over @openfga/sdk. Services check; they never write tuples (ADR 0005).",

--- a/packages/core/saga-fga/src/__tests__/gate.unit.test.ts
+++ b/packages/core/saga-fga/src/__tests__/gate.unit.test.ts
@@ -1,5 +1,21 @@
-import { describe, it, expect } from 'vitest';
-import { loadFgaGateConfig, enforceFgaRelation, type FgaGate } from '../index.js';
+import { describe, it, expect, vi } from 'vitest';
+import {
+  loadFgaGateConfig,
+  enforceFgaRelation,
+  createFgaGate,
+  FgaUnavailableError,
+  type FgaGate,
+} from '../index.js';
+
+const checkMock = vi.hoisted(() => vi.fn());
+vi.mock('@openfga/sdk', () => ({
+  OpenFgaClient: class {
+    check = checkMock;
+  },
+}));
+
+const gateWithStore = () =>
+  createFgaGate({ enforce: true, apiUrl: 'http://fga.test', storeId: 's1' });
 
 describe('saga-fga gate config', () => {
   it('defaults enforcement OFF', () => {
@@ -23,13 +39,16 @@ describe('saga-fga gate config', () => {
 describe('enforceFgaRelation', () => {
   it('is a no-op when the gate is disabled — never calls check', async () => {
     let called = false;
-    const gate: FgaGate = { enforce: false, async check() { called = true; return false; } };
+    const gate: Pick<FgaGate, 'enforce' | 'check'> = {
+      enforce: false,
+      async check() { called = true; return false; },
+    };
     await enforceFgaRelation(gate, 'user:a', 'host', 'session:s', () => new Error('should not throw'));
     expect(called).toBe(false);
   });
 
   it('throws makeForbidden() when the relation does not hold', async () => {
-    const gate: FgaGate = { enforce: true, async check() { return false; } };
+    const gate: Pick<FgaGate, 'enforce' | 'check'> = { enforce: true, async check() { return false; } };
     await expect(
       enforceFgaRelation(gate, 'user:a', 'host', 'session:s', () => new Error('forbidden')),
     ).rejects.toThrow('forbidden');
@@ -37,7 +56,7 @@ describe('enforceFgaRelation', () => {
 
   it('passes (resolves) when the relation holds', async () => {
     let asked: [string, string, string] | undefined;
-    const gate: FgaGate = {
+    const gate: Pick<FgaGate, 'enforce' | 'check'> = {
       enforce: true,
       async check(u, r, o) { asked = [u, r, o]; return true; },
     };
@@ -45,5 +64,91 @@ describe('enforceFgaRelation', () => {
       enforceFgaRelation(gate, 'user:a', 'host', 'session:s', () => new Error('forbidden')),
     ).resolves.toBeUndefined();
     expect(asked).toEqual(['user:a', 'host', 'session:s']);
+  });
+});
+
+describe('contextual tuples', () => {
+  it('forwards them to the client, and omits the key entirely when absent', async () => {
+    checkMock.mockReset().mockResolvedValue({ allowed: true });
+    const gate = gateWithStore();
+    const tuples = [{ user: 'pod:p1', relation: 'pod', object: 'session:s' }];
+
+    await gate.check('user:a', 'can_edit', 'session:s', tuples);
+    expect(checkMock.mock.calls[0]?.[0]).toMatchObject({ contextualTuples: tuples });
+
+    await gate.check('user:a', 'can_edit', 'session:s');
+    expect(checkMock.mock.calls[1]?.[0]).not.toHaveProperty('contextualTuples');
+
+    // An empty array is "no contextual facts", not an empty payload to send.
+    await gate.check('user:a', 'can_edit', 'session:s', []);
+    expect(checkMock.mock.calls[2]?.[0]).not.toHaveProperty('contextualTuples');
+  });
+});
+
+describe('checkDetailed attribution', () => {
+  const allowOnly = (relation: string) =>
+    checkMock.mockReset().mockImplementation(
+      (req: { relation: string }) => Promise.resolve({ allowed: req.relation === relation }),
+    );
+
+  it('reports which branch fired', async () => {
+    allowOnly('edit_grant');
+    const d = await gateWithStore().checkDetailed('user:a', ['host', 'edit_grant'], 'session:s');
+    expect(d).toEqual({ allowed: true, via: 'edit_grant', branches: ['edit_grant'] });
+  });
+
+  it('prefers the earliest branch supplied when several hold (HOST beats ADMIN)', async () => {
+    checkMock.mockReset().mockResolvedValue({ allowed: true });
+    const d = await gateWithStore().checkDetailed('user:a', ['host', 'edit_grant'], 'session:s');
+    expect(d.via).toBe('host');
+    expect(d.branches).toEqual(['host', 'edit_grant']);
+  });
+
+  it('denies with no attribution when no branch holds', async () => {
+    allowOnly('none');
+    const d = await gateWithStore().checkDetailed('user:a', ['host', 'edit_grant'], 'session:s');
+    expect(d).toEqual({ allowed: false, via: undefined, branches: [] });
+  });
+
+  it('passes contextual tuples to every branch', async () => {
+    checkMock.mockReset().mockResolvedValue({ allowed: false });
+    const tuples = [{ user: 'user:a', relation: 'host', object: 'session:s' }];
+    await gateWithStore().checkDetailed('user:a', ['host', 'edit_grant'], 'session:s', tuples);
+    expect(checkMock).toHaveBeenCalledTimes(2);
+    for (const call of checkMock.mock.calls) {
+      expect(call[0]).toMatchObject({ contextualTuples: tuples });
+    }
+  });
+});
+
+describe('an unreachable verdict is NOT a deny', () => {
+  it('surfaces a transport failure as FgaUnavailableError', async () => {
+    checkMock.mockReset().mockRejectedValue(new Error('ECONNREFUSED'));
+    await expect(gateWithStore().check('user:a', 'host', 'session:s')).rejects.toThrow(
+      FgaUnavailableError,
+    );
+  });
+
+  it('surfaces a missing store id as FgaUnavailableError, not false', async () => {
+    checkMock.mockReset();
+    const gate = createFgaGate({ enforce: true, apiUrl: 'http://fga.test' });
+    await expect(gate.check('user:a', 'host', 'session:s')).rejects.toThrow(FgaUnavailableError);
+    expect(checkMock).not.toHaveBeenCalled();
+  });
+
+  it('propagates out of checkDetailed rather than degrading to a denial', async () => {
+    checkMock.mockReset().mockRejectedValue(new Error('boom'));
+    await expect(
+      gateWithStore().checkDetailed('user:a', ['host', 'edit_grant'], 'session:s'),
+    ).rejects.toThrow(FgaUnavailableError);
+  });
+
+  it('propagates through enforceFgaRelation instead of throwing makeForbidden()', async () => {
+    checkMock.mockReset().mockRejectedValue(new Error('boom'));
+    await expect(
+      enforceFgaRelation(gateWithStore(), 'user:a', 'host', 'session:s', () =>
+        new Error('MASKED-AS-DENY'),
+      ),
+    ).rejects.toThrow(FgaUnavailableError);
   });
 });

--- a/packages/core/saga-fga/src/index.ts
+++ b/packages/core/saga-fga/src/index.ts
@@ -35,11 +35,90 @@ export function loadFgaGateConfig(
   };
 }
 
+/**
+ * A tuple supplied on the request rather than stored in the graph.
+ *
+ * Ephemeral objects (a session occurrence, whose id decodes to
+ * date/period/slot/pod) are never materialized as stored tuples. The caller
+ * resolves the derived facts locally — effective pod after SWAP/ABSENT at NOW,
+ * the per-occurrence override host after its live-membership gate — and rides
+ * them in on the check. Contextual-tuple relations are marked as such in the
+ * partition registry (ADR 0006 §3); they are never ALSO stored.
+ */
+export interface FgaContextualTuple {
+  user: string;
+  relation: string;
+  object: string;
+}
+
+/**
+ * Raised when the PDP could not reach a verdict — a transport failure,
+ * a non-2xx from OpenFGA, or missing store configuration.
+ *
+ * This exists to keep "unavailable" separable from "denied" at every call
+ * site. A confirmed deny may be masked (e.g. presented as NOT_FOUND); an
+ * error must NEVER take that path — it surfaces as the distinct
+ * authz-unavailable signal (north star P5). Because `check` returns a bare
+ * boolean, a swallowed failure would be indistinguishable from a legitimate
+ * `false` and would silently mask an outage as a permission denial.
+ */
+export class FgaUnavailableError extends Error {
+  override readonly name = 'FgaUnavailableError';
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+  }
+}
+
+/**
+ * The outcome of a `checkDetailed` call: whether access is allowed, and — when
+ * it is — which relation branch produced it.
+ */
+export interface FgaDetailedDecision {
+  allowed: boolean;
+  /**
+   * The first branch (in the order supplied) that held, or `undefined` when
+   * none did. Callers map this to their own actor vocabulary, e.g.
+   * `'host' → HOST`, `'edit_grant' → ADMIN` (D19 attribution).
+   */
+  via?: string | undefined;
+  /** Every branch that held, in the order supplied. */
+  branches: string[];
+}
+
 export interface FgaGate {
   /** Call sites skip enforcement entirely when false. */
   readonly enforce: boolean;
-  /** True iff (user, relation, object) holds in the configured store/model. */
-  check(user: string, relation: string, object: string): Promise<boolean>;
+  /**
+   * True iff (user, relation, object) holds in the configured store/model.
+   * Throws {@link FgaUnavailableError} when no verdict could be reached —
+   * never returns `false` to mean "could not tell".
+   */
+  check(
+    user: string,
+    relation: string,
+    object: string,
+    contextualTuples?: readonly FgaContextualTuple[],
+  ): Promise<boolean>;
+  /**
+   * Evaluate several relation branches on the same object and report which
+   * one(s) held.
+   *
+   * Attribution is composed from independent Checks rather than read out of a
+   * single one: an OpenFGA Check answers only `allowed`, so a union relation
+   * (`can_edit: host or edit_grant`) cannot say which side fired. The model
+   * therefore keeps the branches separable and we ask each in turn — see the
+   * invariant recorded in `unified-graph.fga`'s `session` type.
+   *
+   * Branches are evaluated in parallel; `via` reports the first one that held
+   * in the order supplied, so pass them in attribution-priority order (e.g.
+   * `['host', 'edit_grant']` — HOST wins over ADMIN when both hold).
+   */
+  checkDetailed(
+    user: string,
+    relations: readonly string[],
+    object: string,
+    contextualTuples?: readonly FgaContextualTuple[],
+  ): Promise<FgaDetailedDecision>;
 }
 
 /**
@@ -61,11 +140,44 @@ export function createFgaGate(config: FgaGateConfig = loadFgaGateConfig()): FgaG
     return client;
   };
 
+  const checkOne = async (
+    user: string,
+    relation: string,
+    object: string,
+    contextualTuples?: readonly FgaContextualTuple[],
+  ): Promise<boolean> => {
+    let res;
+    try {
+      res = await clientFor().check({
+        user,
+        relation,
+        object,
+        ...(contextualTuples?.length ? { contextualTuples: [...contextualTuples] } : {}),
+      });
+    } catch (cause) {
+      // Any failure to REACH a verdict — unconfigured store, transport error,
+      // non-2xx — is unavailability, not denial. Never collapse it to `false`.
+      throw new FgaUnavailableError(
+        `FGA check failed for ${relation} on ${object}`,
+        { cause },
+      );
+    }
+    return res.allowed === true;
+  };
+
   return {
     enforce: config.enforce,
-    async check(user, relation, object) {
-      const res = await clientFor().check({ user, relation, object });
-      return res.allowed === true;
+    check: checkOne,
+    async checkDetailed(user, relations, object, contextualTuples) {
+      const held = await Promise.all(
+        relations.map((relation) => checkOne(user, relation, object, contextualTuples)),
+      );
+      const branches = relations.filter((_, i) => held[i]);
+      return {
+        allowed: branches.length > 0,
+        via: branches[0],
+        branches,
+      };
     },
   };
 }
@@ -78,9 +190,14 @@ export function createFgaGate(config: FgaGateConfig = loadFgaGateConfig()): FgaG
  *
  *   await enforceFgaRelation(ctx.fga, `user:${userId}`, 'host', `session:${id}`,
  *     () => new TRPCError({ code: 'FORBIDDEN', message: '...' }));
+ *
+ * Two distinct failure modes propagate, and callers must keep them apart:
+ * `makeForbidden()` on a confirmed deny, and {@link FgaUnavailableError} when
+ * no verdict was reachable. Do not catch them together — masking a deny as
+ * NOT_FOUND is correct (D15), masking an outage that way is not.
  */
 export async function enforceFgaRelation(
-  gate: FgaGate,
+  gate: Pick<FgaGate, 'enforce' | 'check'>,
   user: string,
   relation: string,
   object: string,


### PR DESCRIPTION
Extends the shared Tier-2 OpenFGA gate with the three capabilities the
[sessions-gating PDP migration design](https://github.com/saga-ed/program-hub/blob/main/docs/superpowers/specs/2026-07-13-sessions-gating-pdp-migration-design.md)
requires but `0.1.0-dev.1` could not express. This is the **soa half** of building
`check`/`require` on authz-api — rostering consumes it once published.

## What and why

| Capability | Why the old API couldn't do it |
|---|---|
| `checkDetailed(user, relations[], object)` | An OpenFGA Check answers only `allowed`; a union relation (`can_edit: host or edit_grant`) can't say which side fired — but the D19 actor (HOST vs ADMIN) is derived from exactly that. |
| Contextual tuples | Ephemeral session occurrences are never materialized as stored tuples; caller-resolved derived facts (effective pod after SWAP/ABSENT, override host) must ride on the request. |
| `FgaUnavailableError` | `check` returns a bare boolean, so a swallowed failure was indistinguishable from a legitimate `false` — an outage could present as a permission denial. |

**Attribution uses parallel Checks, not `Expand`.** The model deliberately keeps
`host` and `*_grant` separable (invariant in `unified-graph.fga`'s `session`
type); we ask each branch independently. `Expand` returns an unresolved userset
tree for a single relation and cannot attribute either.

**Fail-loud is deliberate in `checkDetailed`.** One branch erroring rejects the
whole call rather than returning a partial result: the D19 actor is persisted to
`tutoringSession.cancellationActor` and emitted on `SessionLifecycleCancelledV1`,
so a partial result could write a permanently wrong authorization basis into an
immutable event stream.

## Compatibility

`check`'s 3-arg shape is unchanged (4th param optional) and `enforceFgaRelation`
now takes `Pick<FgaGate,'enforce'|'check'>` so existing doubles need not stub
`checkDetailed`. Two things *did* change — `FgaGate` gained a required
`checkDetailed`, and `check` now throws instead of returning `false` on failure.
Both are safe here because there are **zero consumers**: the package has never
been published.

## Verification

`tsc --noEmit` clean · `tsup` emits JS+DTS · **15/15 vitest pass** (3 pre-existing
+ 12 new covering tuple pass-through, attribution ordering, and error≠deny).
Contextual-tuple shape verified against the real `@openfga/sdk@0.9.6` types
(`contextualTuples` is a bare array on `check()`).

Runtime behaviour against a live store is **not** verified — `OPENFGA_STORE_ID`
isn't provisioned for authz-api yet, and enforcement stays off by default.

## ⚠️ Merging this is not enough to unblock rostering

`@saga-ed/saga-fga` has **never been published**. Consuming it requires minting
its first CodeArtifact release into the PROD-account domain (`531314149529`) —
a path that is tier-gapped for the current role. Version is bumped to
`0.1.0-dev.2`; the publish is a separate gated step.

Draft pending the publish decision.