### PR TITLE
feat(authz-model): resolve session hosting through pod + persona grant spine

### DIFF
--- a/packages/core/saga-authz-model/README.md
+++ b/packages/core/saga-authz-model/README.md
@@ -70,6 +70,10 @@ district-agnostic, and one flip changes every holder fleet-wide.
   write **no** pod tuple and no direct `host` tuples; otherwise the default pod.
   ⚠️ The sessionId encodes the **default** podId and the override row is keyed on
   it independent of any SWAP — resolve the pod, never parse it out of the id.
+- **`pod.parent`** is a two-hop lookup, not a column: a pod carries `periodId`/`cohortId`
+  and the program comes via `PeriodProjection.programId` (non-null, but soft-deletable
+  via `deletedAt`). Re-resolve it when `Pod.rotation` changes re-point `PodAssignment` —
+  a missing `pod.parent` tuple silently denies `can_create_session`.
 - **`pod.tutor`** comes from `pod_tutor_projection` (1:N, **interval-modeled**), not
   programs-api's `PodTutor` table (1:1 — using it silently loses multi-tutor pods).
   FGA tuples are at-now, so the writer must re-run on interval boundaries (a timer,

--- a/packages/core/saga-authz-model/README.md
+++ b/packages/core/saga-authz-model/README.md
@@ -23,9 +23,74 @@ Once an FGA store is deployed:
 3. Services adopt `check`/`list-objects` resource-by-resource alongside their existing RBAC checks.
 4. RBAC is removed once parity is proven.
 
+## Session hosting (pod / persona / pgrant)
+
+A tutor attaches to a **pod**, not to a session — program-hub's `tutoring_session`
+table has no owner column at all. So session hosting resolves *through* the pod:
+
+```
+session.host      = [user] or tutor from pod      # relationship branch
+session.edit_grant = edit_non_hosted from parent  # delegation branch
+session.can_edit   = host or edit_grant
+```
+
+The two branches stay **separable relations on purpose**: `checkDetailed(user,
+['host','edit_grant'], session)` attributes D19 actor `HOST` vs `ADMIN`, which is
+what program-hub stamps into `cancellationActor`. Never collapse them into one
+OR'd relation — attribution is lost and the audit column goes wrong.
+
+Delegation is a **group-scoped persona capability**, never a direct grant:
+
+```
+persona.grants_* ─→ pgrant (subject AND grants_*) ─→ group ─→ program.grant_group ─→ session.edit_grant
+```
+
+`persona` is a first-class type *because* `authz_persona_definition.permissions[]`
+is mutable — revoking a capability is one tuple on the persona object, rather than
+a fleet-wide rewrite of every derived assignment tuple.
+
+⚠️ Two invariants in that chain are load-bearing, and both are pinned by tests:
+
+- **`pgrant`'s `and` must never become `or`.** `persona.grants_*` is a `[user:*]`
+  public wildcard, so the union form confers the capability on *every user in the
+  store*. The intersection with `subject` is the only thing binding it to that
+  assignment's user.
+- **The spine is FLAT — no group ancestor cascade.** program-hub enumerates
+  `programGrantGroupIds` (org group + school groups) and does a flat `groupId IN
+  (...)` test, explicitly "not a hierarchy crawl". A `from parent_group` edge would
+  grant edits that `callerHoldsGrant` denies.
+
+Writing `persona.grants_*` is the highest-privilege tuple write in this model —
+district-agnostic, and one flip changes every holder fleet-wide.
+
+### Notes for whoever writes the tuples (not written today)
+
+- **`session.pod` is the EFFECTIVE pod**, resolved from
+  `pod_assignment_override(slotId, date)`: `SWAP` → the swapped-in pod; `ABSENT` →
+  write **no** pod tuple and no direct `host` tuples; otherwise the default pod.
+  ⚠️ The sessionId encodes the **default** podId and the override row is keyed on
+  it independent of any SWAP — resolve the pod, never parse it out of the id.
+- **`pod.tutor`** comes from `pod_tutor_projection` (1:N, **interval-modeled**), not
+  programs-api's `PodTutor` table (1:1 — using it silently loses multi-tutor pods).
+  FGA tuples are at-now, so the writer must re-run on interval boundaries (a timer,
+  not only an event handler).
+- **The direct `[user]` branch of `host`** is the per-occurrence override host
+  (`session_instance_override.hostIds`). It is *additive* — it never revokes the base
+  tutor. Gate it on live period membership **and retract on whole-user deactivation**,
+  because `period_membership` does not close on deactivation.
+- `ABSENT` suppresses only the **host** branch; a grant holder still passes `can_edit`,
+  matching sessions-api checking `holdsGrant` outside its effective-pod guard.
+
 ## Editing the model
 
 1. Open a PR editing `model.fga` and `src/types.ts` in lockstep.
-2. The unit test asserts they agree — CI will fail if you forget one.
-3. Backwards-incompatible changes (renaming a relation, removing a type) require a coordinated rollout plan in the PR description.
-4. Additive changes (new types, new relations) can land normally.
+2. The unit test asserts they agree — CI will fail if you forget one. Relations are
+   checked too, via the `FGA_RELATIONS` runtime mirror: adding a relation to the DSL
+   without mirroring it (or vice versa) fails the build.
+3. Backwards-incompatible changes (renaming a relation, removing a type) require a
+   coordinated rollout plan in the PR description.
+4. Additive changes (new types, new relations) can land normally. **Widening an
+   existing relation's union** (e.g. `host: [user]` → `host: [user] or tutor from pod`)
+   is *monotonic* — existing tuples stay valid and checks only broaden — so it lands
+   the same way; but state the intended blast radius, since computed relations that
+   consume it (`viewer`, `can_join`, `whiteboard.editor`, `room.can_join`) widen too.

--- a/packages/core/saga-authz-model/model.fga
+++ b/packages/core/saga-authz-model/model.fga
@@ -36,11 +36,26 @@ type user
 
 # A group of users. Used for sections, cohorts, ad-hoc rosters.
 # Membership is tenant-scoped via `parent`.
+#
+# `pgrant` + the capability relations carry the delegation spine (see the
+# persona/pgrant types below).
+#
+# NO ancestor cascade here — deliberately. program-hub resolves grant scope as a
+# FLAT two-source enumeration (`programGrantGroupIds` = organizationId + the
+# program's schoolGroupIds) and then a flat `groupId IN (...)` membership test;
+# `resolved-membership.service.ts` calls it "a bounded membership pick (not a
+# hierarchy crawl)", and `authz_group_hierarchy` has no runtime reader in the
+# authorization path. A `from parent_group` cascade here would grant edit rights
+# that `callerHoldsGrant` denies. `program.grant_group` (below) mirrors the real
+# flat enumeration instead.
 type group
   relations
     define parent: [tenant]
     define member: [user]
     define admin: [user] or admin from parent
+    define pgrant: [pgrant]
+    define edit_non_hosted: edit_non_hosted from pgrant
+    define observe: observe from pgrant
 
 # A role assignment carrier. Roles are per-tenant; a user assigned a role
 # inherits the role's permissions on the resources the role grants.
@@ -48,6 +63,66 @@ type role
   relations
     define parent: [tenant]
     define holder: [user, group#member]
+
+# ---------------------------------------------------------------------------
+# Delegation spine (persona -> pgrant -> group -> program)
+# ---------------------------------------------------------------------------
+#
+# Session write delegation is NOT a program relation. program-hub resolves it
+# as a GROUP-scoped persona capability:
+#
+#   callerHoldsGrant -> holdsPermissionOnPeriod(periodId) -> program
+#     -> programGrantGroupIds(programId)
+#          = program_projection.organizationId  (the district/org group)
+#          + N program_school_mapping_projection.schoolGroupId
+#     -> a LIVE authz_persona_assignment in one of those groups
+#     -> authz_persona_definition.permissions[]
+#
+# `persona` is a first-class TYPE (rather than baking the permission set into
+# the projected tuples) precisely BECAUSE `authz_persona_definition.permissions`
+# is MUTABLE: editing one persona's permissions would otherwise invalidate
+# every derived tuple fleet-wide. Here it is one tuple on the persona object.
+#
+# Permission strings these mirror (sessions-api):
+#   edit_non_hosted -> 'sessions:edit_non_hosted_sessions'
+#   observe         -> 'sessions:observe_sessions'
+
+# TENANT-CONTAINMENT EXEMPTION: `persona` and `pgrant` deliberately have NO
+# `parent: [tenant]` edge, unlike the resource types above. A persona is a
+# fleet-wide DEFINITION (not tenant-owned), and a pgrant is scoped by the group
+# it hangs off — containment comes from the `group.pgrant` edge, so the
+# projector, not the model, is what keeps grants inside a tenant.
+#
+# A persona definition. The `grants_*` relations use the [user:*] public
+# wildcard: the persona either confers the capability on its holders, or it
+# does not. Written from authz_persona_definition.permissions[].
+#
+# ⚠️ Writing `persona.grants_*` is the highest-privilege tuple write in this
+# model — it is district-agnostic by virtue of [user:*], and flipping one tuple
+# changes the capability for EVERY holder fleet-wide. `saga_platform`'s
+# `can_admin_personas` is the staff capability that corresponds to it; the tuple
+# writer must treat these writes as privileged.
+type persona
+  relations
+    define grants_edit_non_hosted: [user:*]
+    define grants_observe: [user:*]
+
+# A persona ASSIGNMENT carrier — ONE OBJECT PER `authz_persona_assignment` ROW
+# (key on the assignment row id, NEVER on `(user, persona)`: one object reused
+# across groups would leak a grant between groups/tenants). It binds a subject
+# to a persona within a group.
+#
+# ⚠️ The `and` here is load-bearing and MUST NOT become `or`. `grants_*` is a
+# [user:*] public wildcard, so the union form would confer the capability on
+# EVERY user in the store — cascading pgrant -> group -> program -> session
+# .can_edit and pod.can_create_session. The intersection with `subject` is the
+# only thing binding the capability to this assignment's user.
+type pgrant
+  relations
+    define subject: [user]
+    define persona: [persona]
+    define edit_non_hosted: subject and grants_edit_non_hosted from persona
+    define observe: subject and grants_observe from persona
 
 # ---------------------------------------------------------------------------
 # Resource types
@@ -74,6 +149,14 @@ type program
     define admin: [user, group#member, role#holder] or owner or admin from parent
     define editor: [user, group#member, role#holder] or admin
     define viewer: [user, group#member, role#holder] or editor
+    # A program's grant groups are its district group AND its school groups —
+    # edges to the SAME group objects the capability relations run on. Mirrors
+    # `programGrantGroupIds` = program_projection.organizationId +
+    # program_school_mapping_projection.schoolGroupId[]. FLAT by construction:
+    # the projector writes one edge per grant group, no ancestor walk.
+    define grant_group: [group]
+    define edit_non_hosted: edit_non_hosted from grant_group
+    define observe: observe from grant_group
 
 # An enrollment links a user to a program/cohort.
 # Used by program-hub's enrollment-tree read path.
@@ -85,14 +168,70 @@ type enrollment
     define tutor: [user]
     define viewer: [user, group#member, role#holder] or admin from program or editor from program or student or tutor
 
+# A pod — the level a TUTOR is actually attached at. A session has no owner
+# column of its own (program-hub's `tutoring_session` has no hostId/ownerId),
+# so session hosting resolves THROUGH the pod.
+#
+# `tutor` is written by a projector from program-hub's `pod_tutor_projection`
+# (1:N, INTERVAL-modeled: valid_from/valid_until queried at an `asOf`). FGA
+# tuples are at-now, so the projector writes only rows live NOW and must
+# re-run on interval boundaries — a timer, not only an event handler.
+#
+# PROJECTOR NOTE: read `pod_tutor_projection` (1:N), NOT programs-api's
+# `PodTutor` table (1:1, podId as PK) — the latter silently loses multi-tutor
+# pods.
+#
+# `can_create_session` is the AD-HOC create gate: an ad-hoc create has no
+# session object yet, so it cannot be a session-level check. Mirrors
+# sessions-api `assertCanCreateAdhoc` ("host of podId OR an edit grant").
+type pod
+  relations
+    # Projector-derived edge: a Pod row carries periodId/cohortId, not a
+    # programId — the program resolves via period -> PeriodProjection.programId.
+    # Pod.rotation changes re-point PodAssignment, so this edge is MUTABLE.
+    define parent: [program]
+    define tutor: [user]
+    define can_create_session: tutor or edit_non_hosted from parent
+
 # A scheduled session (a tutoring session, a class meeting). Lives under
 # a program; participants get session-level permissions.
+#
+# HOSTING (see the `pod` type above): `host` is the RELATIONSHIP branch and
+# `edit_grant`/`observe_grant` are the DELEGATION branch. They stay SEPARABLE
+# relations on purpose so `checkDetailed` can attribute D19 actor HOST vs
+# ADMIN (`cancellationActor`); never collapse them into one OR'd relation.
+#
+# The `pod` edge is the EFFECTIVE pod for the occurrence, resolved by the
+# projector from `pod_assignment_override(slotId, date)`:
+#   SWAP   -> write the swapped-in effectivePodId
+#   ABSENT -> write NO pod tuple AND no direct `host` tuples ("an ABSENT
+#             effective pod admits no host at all")
+#   DEFAULT/no row -> the session's default pod
+# FOOTGUN: the sessionId encodes the DEFAULT podId and the override row is
+# keyed on it "independent of any SWAP" — a projector that parses podId out
+# of the sessionId writes the WRONG pod on every SWAP. Resolve it, don't
+# parse it.
+#
+# The direct `[user]` branch of `host` is the per-occurrence override host
+# (`session_instance_override.hostIds` + `hostOverridden`). It is ADDITIVE —
+# it never revokes the base pod tutor. The projector must gate it on the
+# user's LIVE period membership AND retract on whole-user deactivation,
+# because `period_membership` does NOT close on deactivation.
+#
+# Note ABSENT suppresses only the HOST branch: a grant holder still passes
+# `can_edit` via `edit_grant`, matching sessions-api checking `holdsGrant`
+# outside its effective-pod guard.
 type session
   relations
     define parent: [program]
-    define host: [user]
+    define pod: [pod]
+    define host: [user] or tutor from pod
     define participant: [user, group#member]
     define observer: [user, group#member, role#holder]
+    define edit_grant: edit_non_hosted from parent
+    define observe_grant: observe from parent
+    define can_edit: host or edit_grant
+    define can_observe: host or observe_grant
     define viewer: host or participant or observer or admin from parent
     define can_join: host or participant or admin from parent
 

--- a/packages/core/saga-authz-model/src/__tests__/model-fga.unit.test.ts
+++ b/packages/core/saga-authz-model/src/__tests__/model-fga.unit.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { transformer } from '@openfga/syntax-transformer';
 import { describe, expect, it } from 'vitest';
-import { FGA_TYPES } from '../types.js';
+import { FGA_RELATIONS, FGA_TYPES } from '../types.js';
 
 /**
  * Verify that every type declared in src/types.ts is present in model.fga.
@@ -55,6 +55,148 @@ describe('model.fga is a valid OpenFGA model', () => {
     it('compiles to schema 1.1', () => {
         const json = transformer.transformDSLToJSONObject(modelText);
         expect(json.schema_version).toBe('1.1');
+    });
+});
+
+/**
+ * RELATION-level drift guard. The type-set check above only compares type
+ * NAMES, so adding a relation to model.fga without updating src/types.ts used
+ * to pass CI silently. This closes that gap: every type's relation set in the
+ * DSL must equal FGA_RELATIONS exactly, in both directions.
+ */
+describe('model.fga ↔ FGA_RELATIONS (relation-level drift)', () => {
+    const json = transformer.transformDSLToJSONObject(modelText);
+    const byType = Object.fromEntries(
+        json.type_definitions.map((t) => [t.type, t]),
+    );
+
+    it.each(FGA_TYPES)('declares exactly the mirrored relations on %s', (type) => {
+        const inDsl = Object.keys(byType[type]?.relations ?? {}).sort();
+        const mirrored = [...FGA_RELATIONS[type]].sort();
+        expect(inDsl).toEqual(mirrored);
+    });
+});
+
+/**
+ * Session/pod hosting invariants. These encode decisions that are expensive to
+ * rediscover and easy to break with a well-meaning edit; each maps to a real
+ * program-hub behaviour in apps/node/sessions-api.
+ */
+describe('session hosting model', () => {
+    const json = transformer.transformDSLToJSONObject(modelText);
+    const byType = Object.fromEntries(
+        json.type_definitions.map((t) => [t.type, t]),
+    );
+
+    it('resolves host through the pod (tutors attach at the pod level)', () => {
+        // `tutoring_session` has no owner column; hosting resolves via the pod.
+        expect(JSON.stringify(byType.session.relations.host)).toContain('pod');
+        expect(byType.pod.relations).toHaveProperty('tutor');
+    });
+
+    it('keeps host and edit_grant SEPARABLE for D19 attribution', () => {
+        // checkDetailed(['host','edit_grant']) attributes actor HOST vs ADMIN
+        // (cancellationActor). Collapsing these into one relation destroys it.
+        // Asserted in BOTH directions: folding either into the other is fatal.
+        expect(byType.session.relations).toHaveProperty('host');
+        expect(byType.session.relations).toHaveProperty('edit_grant');
+        expect(JSON.stringify(byType.session.relations.host)).not.toContain(
+            'edit_grant',
+        );
+        // NB: assert on relation NAMES, not a substring — `edit_non_hosted`
+        // legitimately contains the substring "host".
+        const grantRefs = JSON.stringify(
+            byType.session.relations.edit_grant,
+        ).match(/"relation":"([^"]+)"/g);
+        expect(grantRefs).not.toContain('"relation":"host"');
+    });
+
+    it('gates ad-hoc create on the POD, not the session', () => {
+        // An ad-hoc create has no session object yet, so the gate cannot live
+        // on `session`. Mirrors sessions-api assertCanCreateAdhoc.
+        expect(byType.pod.relations).toHaveProperty('can_create_session');
+    });
+
+    it('routes edit_grant through the program grant-group spine, not a direct grant', () => {
+        // Grants are group-scoped persona capabilities; a direct [user] grant
+        // here would bypass persona revocation.
+        expect(JSON.stringify(byType.session.relations.edit_grant)).toContain(
+            'edit_non_hosted',
+        );
+        expect(JSON.stringify(byType.program.relations.edit_non_hosted)).toContain(
+            'grant_group',
+        );
+        expect(JSON.stringify(byType.pgrant.relations.edit_non_hosted)).toContain(
+            'grants_edit_non_hosted',
+        );
+    });
+
+    /**
+     * SEC-CRIT: `persona.grants_*` is a [user:*] PUBLIC WILDCARD, so pgrant's
+     * capability relations MUST be an intersection with `subject`. Flipping the
+     * `and` to `or` is a one-character fleet-wide authorization bypass — every
+     * user in the store would gain the capability, cascading pgrant -> group ->
+     * program -> session.can_edit / pod.can_create_session.
+     *
+     * A substring assertion cannot catch this (`subject or grants_x from persona`
+     * contains the same tokens), so assert the STRUCTURE.
+     */
+    it.each(['edit_non_hosted', 'observe'] as const)(
+        'pgrant.%s is an INTERSECTION with subject, never a union',
+        (rel) => {
+            const def = byType.pgrant.relations[rel];
+            expect(def).toHaveProperty('intersection');
+            expect(def).not.toHaveProperty('union');
+
+            const children = def.intersection?.child ?? [];
+            // One side must be the `subject` computed userset — that is what
+            // binds the [user:*] capability to THIS assignment's user.
+            expect(
+                children.some(
+                    (c) => c.computedUserset?.relation === 'subject',
+                ),
+            ).toBe(true);
+            // The other must resolve the grant through the persona object.
+            expect(
+                children.some(
+                    (c) =>
+                        c.tupleToUserset?.tupleset?.relation === 'persona' &&
+                        c.tupleToUserset?.computedUserset?.relation ===
+                            `grants_${rel}`,
+                ),
+            ).toBe(true);
+        },
+    );
+
+    /**
+     * The delegation spine must stay FLAT. program-hub resolves grant scope as
+     * `programGrantGroupIds` (organizationId + schoolGroupIds) and a flat
+     * `groupId IN (...)` test — explicitly "not a hierarchy crawl". A group->group
+     * ancestor cascade here would grant edits that `callerHoldsGrant` denies.
+     */
+    it('has no group ancestor cascade on the capability relations', () => {
+        const groupRels = byType.group.relations ?? {};
+        expect(groupRels).not.toHaveProperty('parent_group');
+        // group.edit_non_hosted/observe must resolve ONLY through pgrant —
+        // every tupleset they traverse must be the `pgrant` edge.
+        for (const rel of ['edit_non_hosted', 'observe'] as const) {
+            const serialized = JSON.stringify(groupRels[rel]);
+            expect(serialized).toContain('pgrant');
+            const tuplesets = [
+                ...serialized.matchAll(/"tupleset":\{"relation":"([^"]+)"\}/g),
+            ].map((m) => m[1]);
+            expect(tuplesets.length).toBeGreaterThan(0);
+            expect([...new Set(tuplesets)]).toEqual(['pgrant']);
+        }
+    });
+
+    it('leaves edit_grant OUTSIDE the pod path (ABSENT still admits grants)', () => {
+        // An ABSENT effective pod admits no HOST, but a grant holder still
+        // passes can_edit — matching sessions-api checking holdsGrant outside
+        // its `if (effectivePod != null)` guard.
+        expect(JSON.stringify(byType.session.relations.edit_grant)).not.toContain(
+            'pod',
+        );
     });
 });
 

--- a/packages/core/saga-authz-model/src/types.ts
+++ b/packages/core/saga-authz-model/src/types.ts
@@ -10,11 +10,16 @@ export const FGA_TYPES = [
     'user',
     'group',
     'role',
+    // Delegation spine — persona capabilities cascade group -> program and
+    // feed session `edit_grant`/`observe_grant`.
+    'persona',
+    'pgrant',
     // Resources
     'school',
     'cohort',
     'program',
     'enrollment',
+    'pod',
     'session',
     'room',
     'whiteboard',
@@ -32,17 +37,39 @@ export type FgaType = (typeof FGA_TYPES)[number];
 export interface FgaRelationsByType {
     tenant: 'admin' | 'member' | 'support';
     user: never;
-    group: 'parent' | 'member' | 'admin';
+    group:
+        | 'parent'
+        | 'member'
+        | 'admin'
+        | 'pgrant'
+        | 'edit_non_hosted'
+        | 'observe';
     role: 'parent' | 'holder';
+    persona: 'grants_edit_non_hosted' | 'grants_observe';
+    pgrant: 'subject' | 'persona' | 'edit_non_hosted' | 'observe';
     school: 'parent' | 'admin' | 'editor' | 'viewer';
     cohort: 'parent' | 'admin' | 'editor' | 'viewer';
-    program: 'parent' | 'owner' | 'admin' | 'editor' | 'viewer';
+    program:
+        | 'parent'
+        | 'owner'
+        | 'admin'
+        | 'editor'
+        | 'viewer'
+        | 'grant_group'
+        | 'edit_non_hosted'
+        | 'observe';
     enrollment: 'parent' | 'program' | 'student' | 'tutor' | 'viewer';
+    pod: 'parent' | 'tutor' | 'can_create_session';
     session:
         | 'parent'
+        | 'pod'
         | 'host'
         | 'participant'
         | 'observer'
+        | 'edit_grant'
+        | 'observe_grant'
+        | 'can_edit'
+        | 'can_observe'
         | 'viewer'
         | 'can_join';
     room: 'parent' | 'session' | 'member' | 'moderator' | 'can_join';
@@ -69,3 +96,70 @@ export interface FgaRelationsByType {
 }
 
 export type FgaRelation<T extends FgaType> = FgaRelationsByType[T];
+
+/**
+ * Runtime mirror of {@link FgaRelationsByType}. `FgaRelationsByType` is a
+ * type-only interface, so nothing can compare it against model.fga at run
+ * time — this constant is what the CI drift test diffs against the DSL.
+ *
+ * The `satisfies` clause below ties the two together: if you add a relation
+ * here that is not in the interface (or use the wrong type name), the build
+ * fails. If you add one to model.fga but not here, the drift test fails.
+ * Keep all three in lockstep.
+ */
+export const FGA_RELATIONS = {
+    tenant: ['admin', 'member', 'support'],
+    user: [],
+    group: ['parent', 'member', 'admin', 'pgrant', 'edit_non_hosted', 'observe'],
+    role: ['parent', 'holder'],
+    persona: ['grants_edit_non_hosted', 'grants_observe'],
+    pgrant: ['subject', 'persona', 'edit_non_hosted', 'observe'],
+    school: ['parent', 'admin', 'editor', 'viewer'],
+    cohort: ['parent', 'admin', 'editor', 'viewer'],
+    program: [
+        'parent',
+        'owner',
+        'admin',
+        'editor',
+        'viewer',
+        'grant_group',
+        'edit_non_hosted',
+        'observe',
+    ],
+    enrollment: ['parent', 'program', 'student', 'tutor', 'viewer'],
+    pod: ['parent', 'tutor', 'can_create_session'],
+    session: [
+        'parent',
+        'pod',
+        'host',
+        'participant',
+        'observer',
+        'edit_grant',
+        'observe_grant',
+        'can_edit',
+        'can_observe',
+        'viewer',
+        'can_join',
+    ],
+    room: ['parent', 'session', 'member', 'moderator', 'can_join'],
+    whiteboard: ['parent', 'editor', 'viewer'],
+    saga_platform: [
+        'super_admin',
+        'support',
+        'org_admin',
+        'can_impersonate',
+        'can_create_org',
+        'can_admin_personas',
+        'can_manage_staff',
+    ],
+    staff_org: [
+        'platform',
+        'staff_admin',
+        'can_view',
+        'can_edit',
+        'can_delete',
+        'can_force_clever_sync',
+    ],
+} as const satisfies {
+    [T in FgaType]: readonly FgaRelationsByType[T][];
+};


### PR DESCRIPTION
## Why

A tutor attaches to a **pod**, not to a session — program-hub's `tutoring_session` table has no owner column at all (`hostId`/`ownerId`/`createdBy` do not exist). Host is resolved transitively:

```
TutoringSession.podId
  → resolveEffectivePod(slotId, date, podId)   # pod_assignment_override: SWAP / ABSENT / DEFAULT
  → getPodTutors(effectivePodId, asOf)          # pod_tutor_projection, interval-modeled
  ∪ callerIsOverrideHost(...)                   # session_instance_override.hostIds, ADDITIVE
```

The shipped model couldn't express that: `session` had `host: [user]` with no pod concept, and no `can_edit` at all. This adds the types that make a real `can_edit` check expressible.

## What

- **new `pod` type** — `tutor` + `can_create_session`. The ad-hoc create gate *cannot* live on `session` (no session object exists yet at create time); it mirrors sessions-api `assertCanCreateAdhoc` ("host of podId OR an edit grant").
- **new `persona` / `pgrant` delegation spine**, plus `group.pgrant` and `program.grant_group`. Grants are **group-scoped persona capabilities**, not a program relation: `programGrantGroupIds` = `program_projection.organizationId` + the program's `schoolGroupId`s. `persona` is a first-class type *because* `authz_persona_definition.permissions[]` is mutable — revocation is one tuple on the persona object rather than a fleet-wide rewrite of every derived assignment tuple.
- **`session`** — adds `pod`, `edit_grant`, `observe_grant`, `can_edit`, `can_observe`; widens `host` to `[user] or tutor from pod`.

`host` (relationship) and `edit_grant` (delegation) stay **separable relations on purpose** so `checkDetailed(user, ['host','edit_grant'], session)` can attribute D19 actor `HOST` vs `ADMIN` — that's what program-hub stamps into `cancellationActor`. Collapsing them into one OR'd relation would silently corrupt the audit column.

Merged into the shipped `session` block rather than adopting rostering's prototype shape: `parent: [program]` is kept (`whiteboard.parent`/`room.can_join` resolve through it) and no existing relation is dropped.

## Verification

Not just "tests pass" — the semantics were exercised against a real store:

- **18 semantic checks vs a dockerized OpenFGA**: host resolution through the pod, D19 attribution (a grant holder is *not* a host), ABSENT admitting no host but **still** admitting grant holders, the ad-hoc pod gate, and persona revocation taking effect via a single tuple.
- **Monotonicity proven against `origin/main`**: every pre-existing tuple still writes, and no previously-allowed check became denied. The one modified relation (`host`) is widened, not redefined.
- **Over-grant probe**: with a `[user:*]` persona tuple live, a user holding no pgrant is denied everywhere — the intersection binds the wildcard to its subject.
- **Mutation-tested guards**: introducing each defect fails the suite — `and`→`or` on pgrant, reintroducing a group ancestor cascade, and folding `host` into `edit_grant`.
- 56/56 vitest, `tsc --noEmit` clean, eslint clean.

## Test hardening

The existing drift guard only compared type **names**, so adding a relation to `model.fga` without mirroring it in `src/types.ts` passed CI silently. This adds a `FGA_RELATIONS` runtime mirror (tied to the type-only interface via `satisfies`) and a relation-level drift test, plus structural guards on the invariants that are one edit away from an authorization bypass.

> ⚠️ Note for reviewers: substring assertions are unsafe in this file — `edit_non_hosted` contains the substring `"host"`. The tests assert on relation names/structure.

## Deliberately flat

No group→group ancestor cascade. program-hub does a two-source enumeration then a flat `groupId IN (...)` test — `resolved-membership.service.ts` calls it *"a bounded membership pick (not a hierarchy crawl)"* — and `authz_group_hierarchy` has no runtime reader in the authorization path. A cascade here would grant edits that `callerHoldsGrant` denies. (An earlier revision of this branch had one; it was removed after checking the source.)

## Scope / sequencing

**Model only — there is no tuple writer in this PR.** `session.host` was verified declared-but-unused fleet-wide (the only writer, rostering `authz-sync/src/fga-sync.ts`, writes `group#member` / `saga_platform` / `staff_org` and no resource-side tuples), so nothing collides and the ABSENT rule retracts nothing another writer owns.

Two things to decide **before** any deploy, neither blocking this PR:

1. 🔴 **Phase ordering.** `fleet_authz_strategy.md` §6 sequences session-edit as **Phase 4**, behind a **Phase 3 pilot on rtsm `room.can_join`** — and §9 still lists that pilot choice as open. Building the projector would either run ahead of that plan or make session-edit the pilot instead.
2. 📌 **Model-id cutover.** Services don't pin `OPENFGA_MODEL_ID` today, so unset means OpenFGA serves the store's *latest* model — pushing a new model id is effectively a live cutover for every caller.

Per the package README this is an additive change and can land normally; ADR 0005's "reviewed by the auth working group" is the stricter reading if you'd rather route it there.

https://claude.ai/code/session_01LhvKXmUWkwTqJkk1G2nnqL