### PR TITLE
feat(saga-fga): send the OpenFGA preshared key on checks

### DIFF
--- a/packages/core/saga-fga/README.md
+++ b/packages/core/saga-fga/README.md
@@ -13,7 +13,7 @@ ADR 0005). Services only **check**.
 ```ts
 import { createFgaGate, enforceFgaRelation } from '@saga-ed/saga-fga';
 
-const fga = createFgaGate(); // from env: AUTHZ_FGA_ENFORCE, OPENFGA_API_URL, OPENFGA_STORE_ID, OPENFGA_MODEL_ID
+const fga = createFgaGate(); // from env: AUTHZ_FGA_ENFORCE, OPENFGA_API_URL, OPENFGA_STORE_ID, OPENFGA_MODEL_ID, OPENFGA_API_TOKEN
 
 // In a resolver / handler:
 await enforceFgaRelation(
@@ -116,3 +116,11 @@ checks stay authoritative until the flag flips on.
 | `OPENFGA_API_URL` | OpenFGA HTTP API | `http://localhost:8080` |
 | `OPENFGA_STORE_ID` | store id (required once enforcing) | — |
 | `OPENFGA_MODEL_ID` | authorization model id | store's latest |
+| `OPENFGA_API_TOKEN` | preshared key, sent as `Authorization: Bearer` | — (no credentials) |
+
+> **The shared dev and prod OpenFGA servers run `authn=preshared`** — the
+> `openfga-shared-<env>` task definition sets `OPENFGA_AUTHN_METHOD=preshared`.
+> Against those, `OPENFGA_API_TOKEN` is **required**: without it every call is a
+> 401, which the gate surfaces as `FgaUnavailableError`. That's the right
+> failure *direction* (never a silent deny), but the gate answers nothing. Leave
+> it unset only for a local/CI OpenFGA started with no authn.

--- a/packages/core/saga-fga/README.md
+++ b/packages/core/saga-fga/README.md
@@ -124,3 +124,14 @@ checks stay authoritative until the flag flips on.
 > 401, which the gate surfaces as `FgaUnavailableError`. That's the right
 > failure *direction* (never a silent deny), but the gate answers nothing. Leave
 > it unset only for a local/CI OpenFGA started with no authn.
+
+> 🪤 **Supply ONE key.** The server-side var is `OPENFGA_AUTHN_PRESHARED_KEYS`
+> (*plural* — OpenFGA accepts a comma-separated list). If `OPENFGA_API_TOKEN` is
+> pointed at a secret holding `key1,key2` or a JSON blob, the client sends
+> `Bearer key1,key2` and gets a 401 → `FgaUnavailableError` — a symptom
+> **identical to having no token at all**, and easily misread as "the token
+> wiring didn't land". Resolve to a single opaque key (use a `:jsonKey::`
+> selector on the secret ARN if it holds JSON).
+
+`FgaGateConfig` is secret-bearing once `apiToken` is set — never log or
+`JSON.stringify` it; enumerate the non-secret fields instead.

--- a/packages/core/saga-fga/package.json
+++ b/packages/core/saga-fga/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/saga-fga",
-    "version": "0.1.0-dev.2",
+    "version": "0.1.0-dev.3",
     "private": false,
     "type": "module",
     "description": "Saga OpenFGA Tier-2 authorization gate — a thin check client + framework-agnostic enforcement helper over @openfga/sdk. Services check; they never write tuples (ADR 0005).",

--- a/packages/core/saga-fga/src/__tests__/gate.unit.test.ts
+++ b/packages/core/saga-fga/src/__tests__/gate.unit.test.ts
@@ -8,9 +8,16 @@ import {
 } from '../index.js';
 
 const checkMock = vi.hoisted(() => vi.fn());
+// Capture constructor args so we can assert on the CLIENT CONFIG, not just on
+// calls — a token that never reaches the constructor never reaches the wire.
+const clientConfigs = vi.hoisted(() => [] as Record<string, unknown>[]);
 vi.mock('@openfga/sdk', () => ({
+  CredentialsMethod: { None: 'none', ApiToken: 'api_token', ClientCredentials: 'client_credentials' },
   OpenFgaClient: class {
     check = checkMock;
+    constructor(config: Record<string, unknown>) {
+      clientConfigs.push(config);
+    }
   },
 }));
 
@@ -33,6 +40,45 @@ describe('saga-fga gate config', () => {
     expect(c.apiUrl).toBe('http://localhost:8080');
     expect(c.storeId).toBe('s1');
     expect(c.modelId).toBe('m1');
+  });
+
+  it('reads the preshared key from OPENFGA_API_TOKEN, undefined when absent or empty', () => {
+    expect(loadFgaGateConfig({ OPENFGA_API_TOKEN: 'k1' }).apiToken).toBe('k1');
+    expect(loadFgaGateConfig({}).apiToken).toBeUndefined();
+    // An empty env var is "unset", not a token — an empty Bearer would 401.
+    expect(loadFgaGateConfig({ OPENFGA_API_TOKEN: '' }).apiToken).toBeUndefined();
+  });
+});
+
+describe('preshared-key credentials', () => {
+  // The shared dev/prod OpenFGA run authn=preshared. A gate that never puts the
+  // token on the client 401s every call — which surfaces as unavailability, not
+  // a deny, so it fails in the right DIRECTION but answers nothing.
+  it('configures ApiToken credentials on the client when a token is set', async () => {
+    clientConfigs.length = 0;
+    checkMock.mockResolvedValue({ allowed: true });
+    const gate = createFgaGate({
+      enforce: true,
+      apiUrl: 'http://fga.test',
+      storeId: 's1',
+      apiToken: 'preshared-abc',
+    });
+    await gate.check('user:u1', 'viewer', 'session:s1');
+
+    expect(clientConfigs).toHaveLength(1);
+    expect(clientConfigs[0]?.credentials).toEqual({
+      method: 'api_token',
+      config: { token: 'preshared-abc' },
+    });
+  });
+
+  it('omits credentials entirely when no token is configured', async () => {
+    clientConfigs.length = 0;
+    checkMock.mockResolvedValue({ allowed: true });
+    await gateWithStore().check('user:u1', 'viewer', 'session:s1');
+
+    expect(clientConfigs).toHaveLength(1);
+    expect(clientConfigs[0]).not.toHaveProperty('credentials');
   });
 });
 

--- a/packages/core/saga-fga/src/index.ts
+++ b/packages/core/saga-fga/src/index.ts
@@ -33,6 +33,10 @@ export interface FgaGateConfig {
    *
    * Optional so a local/CI OpenFGA started with no authn still works: when
    * unset no credentials are configured and the header is never sent.
+   *
+   * ⚠️ This makes `FgaGateConfig` SECRET-BEARING. Never `JSON.stringify` or
+   * log the config object — enumerate the non-secret fields explicitly
+   * (`enforce`/`apiUrl`/`storeId`/`modelId`) as authz-api's bootstrap does.
    */
   apiToken?: string | undefined;
 }

--- a/packages/core/saga-fga/src/index.ts
+++ b/packages/core/saga-fga/src/index.ts
@@ -1,4 +1,4 @@
-import { OpenFgaClient } from '@openfga/sdk';
+import { CredentialsMethod, OpenFgaClient } from '@openfga/sdk';
 
 /**
  * @saga-ed/saga-fga — Tier-2 (per-resource) OpenFGA authorization gate.
@@ -22,6 +22,19 @@ export interface FgaGateConfig {
   storeId?: string | undefined;
   /** Authorization model id; when unset OpenFGA uses the store's latest. */
   modelId?: string | undefined;
+  /**
+   * Preshared key sent as `Authorization: Bearer <token>` (SEC-REQ-5).
+   *
+   * Required against any OpenFGA running `authn=preshared` — which the SHARED
+   * dev and prod servers do (`OPENFGA_AUTHN_METHOD=preshared` on the
+   * `openfga-shared-<env>` task definition). Without it every call is a 401,
+   * which surfaces as `FgaUnavailableError` — correctly NOT a deny, but the
+   * gate answers nothing.
+   *
+   * Optional so a local/CI OpenFGA started with no authn still works: when
+   * unset no credentials are configured and the header is never sent.
+   */
+  apiToken?: string | undefined;
 }
 
 export function loadFgaGateConfig(
@@ -32,6 +45,7 @@ export function loadFgaGateConfig(
     apiUrl: env.OPENFGA_API_URL ?? 'http://localhost:8080',
     storeId: env.OPENFGA_STORE_ID || undefined,
     modelId: env.OPENFGA_MODEL_ID || undefined,
+    apiToken: env.OPENFGA_API_TOKEN || undefined,
   };
 }
 
@@ -136,6 +150,17 @@ export function createFgaGate(config: FgaGateConfig = loadFgaGateConfig()): FgaG
       apiUrl: config.apiUrl,
       storeId: config.storeId,
       ...(config.modelId ? { authorizationModelId: config.modelId } : {}),
+      // Omit `credentials` entirely when no token is configured — passing
+      // method `none` and passing nothing are equivalent to the SDK, but an
+      // absent key keeps "this deployment has no auth" visible in the shape.
+      ...(config.apiToken
+        ? {
+            credentials: {
+              method: CredentialsMethod.ApiToken,
+              config: { token: config.apiToken },
+            },
+          }
+        : {}),
     });
     return client;
   };


### PR DESCRIPTION
## The bug

The shared dev **and** prod OpenFGA servers run `authn=preshared`. Verified from the live task definition `openfga-shared-dev:6`:

```
OPENFGA_AUTHN_METHOD = preshared
secrets: OPENFGA_AUTHN_PRESHARED_KEYS  (openfga/dev/preshared-key)
```

But `createFgaGate` constructed the client with only `{apiUrl, storeId, authorizationModelId}` and **never passed `credentials`** — so every check from a deployed service was an unauthenticated **401**.

This failed in the right *direction*: a 401 is a non-2xx, so it became `FgaUnavailableError`, never a silent deny. But it meant the gate could not answer at all in any deployed environment.

> ⚠️ Note: the template comment in rostering's `infra/authz-api/service-template.yaml` claimed "dev OpenFGA runs authn=none". That was **wrong**, and is corrected in the companion rostering PR. The CFN template *default* is empty, but the live stack passes a real key ARN — a stored-parameter/template-default divergence.

## The fix

Optional `apiToken` on `FgaGateConfig`, read from `OPENFGA_API_TOKEN`, wired as `CredentialsMethod.ApiToken`.

Optional by design so a local/CI OpenFGA with no authn keeps working — when unset the `credentials` key is **omitted entirely** rather than sent as method `none`.

## Why the tests assert on the constructor

They pin the **client constructor config**, not just the calls. A token that never reaches the constructor never reaches the wire — which is exactly the bug that shipped, and a call-level assertion would not have caught it.

Verified non-vacuous by mutation: removing the credentials wiring fails **exactly one** test (`configures ApiToken credentials on the client when a token is set`) and nothing else. 18/18 green, `tsc --noEmit` clean.

## Review notes

design-reviewer: **SHIP**, credentials shape asserted against the real SDK types (`config: Pick<ApiTokenConfig,"token">`; `Authorization`/`Bearer` are hardcoded in the SDK). Confirmed no secret-leak path: the SDK wraps every error and does **not** copy `config.headers` into the cause chain.

Two non-blocking risks it raised are now documented in code + README:
- `FgaGateConfig` is **secret-bearing** — never `JSON.stringify`/log it.
- 🪤 The server var is `OPENFGA_AUTHN_PRESHARED_**KEYS**` (plural, comma-separated). A secret holding `key1,key2` sends `Bearer key1,key2` → 401 — a symptom **identical to having no token**, easily misread as "the fix didn't land."

## This alone changes nothing deployed

Publishing `0.1.0-dev.3` does not reach authz-api: its pin is exact (`0.1.0-dev.2`), and the live `rostering-authz-api-main` task def has `secrets: []` — no `OPENFGA_API_TOKEN`. A companion **rostering** PR bumps the pin, adds the secret, and grants the execution role access to `openfga/<env>/preshared-key-*`.

Enforcement remains **off**; this makes checks *answerable*, not binding.