### PR TITLE
model: occurrence layer + view/lifecycle capabilities atop #369

### DIFF
--- a/packages/core/saga-authz-model/README.md
+++ b/packages/core/saga-authz-model/README.md
@@ -65,11 +65,16 @@ district-agnostic, and one flip changes every holder fleet-wide.
 
 ### Notes for whoever writes the tuples (not written today)
 
-- **`session.pod` is the EFFECTIVE pod**, resolved from
-  `pod_assignment_override(slotId, date)`: `SWAP` → the swapped-in pod; `ABSENT` →
-  write **no** pod tuple and no direct `host` tuples; otherwise the default pod.
+- **`session.pod` is the DEFAULT (series) pod — stable across days.** This
+  SUPERSEDES the earlier "effective pod" guidance, which predated the
+  occurrence layer: per-day `pod_assignment_override(slotId, date)`
+  SWAP/ABSENT resolution is written on that day's `session_instance`
+  (`override_pod` + the `pod_overridden` marker; a marker with no
+  `override_pod` is an ABSENT day). Never rewrite `session.pod` per-day —
+  `session_instance.base_host`/`base_member` resolve through it, so a per-day
+  rewrite corrupts every other day's resolution.
   ⚠️ The sessionId encodes the **default** podId and the override row is keyed on
-  it independent of any SWAP — resolve the pod, never parse it out of the id.
+  it independent of any SWAP — resolve the override pod, never parse it out of the id.
 - **`pod.parent`** is a two-hop lookup, not a column: a pod carries `periodId`/`cohortId`
   and the program comes via `PeriodProjection.programId` (non-null, but soft-deletable
   via `deletedAt`). Re-resolve it when `Pod.rotation` changes re-point `PodAssignment` —
@@ -78,18 +83,23 @@ district-agnostic, and one flip changes every holder fleet-wide.
   programs-api's `PodTutor` table (1:1 — using it silently loses multi-tutor pods).
   FGA tuples are at-now, so the writer must re-run on interval boundaries (a timer,
   not only an event handler).
-- **The direct `[user]` branch of `host`** is the per-occurrence override host
-  (`session_instance_override.hostIds`). It is *additive* — it never revokes the base
-  tutor. Gate it on live period membership **and retract on whole-user deactivation**,
-  because `period_membership` does not close on deactivation.
-- `ABSENT` suppresses only the **host** branch; a grant holder still passes `can_edit`,
-  matching sessions-api checking `holdsGrant` outside its effective-pod guard.
+- **Per-occurrence override hosts** (`session_instance_override.hostIds`) are
+  written on the day's `session_instance.override_host` (additive — never
+  revokes the base tutor); `session.host`'s direct `[user]` branch is reserved
+  for rare series-level explicit hosts. Gate override hosts on live period
+  membership **and retract on whole-user deactivation**, because
+  `period_membership` does not close on deactivation.
+- An ABSENT day suppresses the base pod entirely (marker, no `override_pod`);
+  only explicitly authored `override_host`/`added_participant` admit anyone —
+  and a grant holder still passes `can_edit` via the grant arm, matching
+  sessions-api checking `holdsGrant` outside its effective-pod guard.
 
 ## The occurrence layer (`session_instance`)
 
 A `session_instance` is a **dated occurrence** of a repeating session — the layer
 program-hub's per-day facts live at (`pod_assignment_override` SWAP/ABSENT,
-`session_instance_override.hostIds`, participant deltas). Instances are **lazy**:
+`session_instance_override.hostIds`, participant ADDITIONS — removals ride the
+pod-swap path by disposition, no per-user negative tuples). Instances are **lazy**:
 an object carries tuples only when a per-day fact was *authored*; default days
 resolve straight through the `session` edge, so there is no per-day tuple fan-out.
 

--- a/packages/core/saga-authz-model/README.md
+++ b/packages/core/saga-authz-model/README.md
@@ -85,6 +85,56 @@ district-agnostic, and one flip changes every holder fleet-wide.
 - `ABSENT` suppresses only the **host** branch; a grant holder still passes `can_edit`,
   matching sessions-api checking `holdsGrant` outside its effective-pod guard.
 
+## The occurrence layer (`session_instance`)
+
+A `session_instance` is a **dated occurrence** of a repeating session — the layer
+program-hub's per-day facts live at (`pod_assignment_override` SWAP/ABSENT,
+`session_instance_override.hostIds`, participant deltas). Instances are **lazy**:
+an object carries tuples only when a per-day fact was *authored*; default days
+resolve straight through the `session` edge, so there is no per-day tuple fan-out.
+
+```
+base_host = host from session but not pod_overridden   # marker removes the base arm
+host      = override_host or tutor from override_pod or base_host
+member    = added_participant or member from override_pod or base_member
+```
+
+- **Override REPLACES, never unions.** The `pod_overridden: [user:*]` wildcard
+  marker suppresses the base arm; `override_pod` supplies the swap-day pod (pods
+  carry rosters via `pod.member`, so swap-day membership comes with it). ⚠️ The
+  marker and `override_pod` MUST be written in the **same authoring action** —
+  they are one fact. A marker alone is an ABSENT day; an `override_pod` alone
+  would silently union base ∪ swapped pods.
+- **`override_host` / `added_participant` are additive** — they never revoke the
+  resolved base, matching `session_instance_override.hostIds` semantics.
+- **Grants pass through the `session` edge only** — an overridden or ABSENT day
+  still admits grant holders, and the D19 arm separability (HOST vs ADMIN
+  attribution) holds at the instance level too. The gates mirror the session's
+  arm structure: `can_edit`/`can_observe`/`can_view`/`can_lifecycle`.
+
+These semantics have runnable-evidence backing: rostering's prototype slice
+(`scripts/fga/prototype/session-instance-slice.fga.yaml`, landed in
+[rostering#883](https://github.com/saga-ed/rostering/pull/883)) exercises the
+same shapes against a real store via `fga model test` — swap-day replacement,
+added-participant days, grant-vs-host separability, see-all reads — 8/8 green.
+This package pins the structure with transformer-based tests (no store harness
+ships in this repo).
+
+## View / lifecycle capabilities
+
+Two more capabilities ride the same persona → pgrant → group →
+`program.grant_group` spine, in the same shape as `edit_non_hosted`/`observe`:
+
+| Capability | Permission string (sessions-api) | Session gate |
+|---|---|---|
+| `view_non_member` | `sessions:view_non_member_sessions` (see-all reads) | `can_view = host or participant or view_grant` |
+| `lifecycle_non_hosted` | `sessions:lifecycle_non_hosted_sessions` (start/end/cancel takeover) | `can_lifecycle = host or lifecycle_grant` |
+
+Both inherit the spine's invariants (the `pgrant` intersection, the flat
+no-cascade rule) and stay separable from `host` for D19 attribution. The legacy
+`viewer`/`can_join` relations are untouched — `can_view` is the new
+vocabulary-aligned gate, not a replacement.
+
 ## Editing the model
 
 1. Open a PR editing `model.fga` and `src/types.ts` in lockstep.

--- a/packages/core/saga-authz-model/model.fga
+++ b/packages/core/saga-authz-model/model.fga
@@ -220,32 +220,37 @@ type pod
 # relations on purpose so `checkDetailed` can attribute D19 actor HOST vs
 # ADMIN (`cancellationActor`); never collapse them into one OR'd relation.
 #
-# The `pod` edge is the EFFECTIVE pod for the occurrence, resolved by the
-# projector from `pod_assignment_override(slotId, date)`:
-#   SWAP   -> write the swapped-in effectivePodId
-#   ABSENT -> write NO pod tuple AND no direct `host` tuples ("an ABSENT
-#             effective pod admits no host at all")
-#   DEFAULT/no row -> the session's default pod
-# FOOTGUN: the sessionId encodes the DEFAULT podId and the override row is
-# keyed on it "independent of any SWAP" — a projector that parses podId out
-# of the sessionId writes the WRONG pod on every SWAP. Resolve it, don't
-# parse it.
-#
-# The direct `[user]` branch of `host` is the per-occurrence override host
-# (`session_instance_override.hostIds` + `hostOverridden`). It is ADDITIVE —
-# it never revokes the base pod tutor. The projector must gate it on the
-# user's LIVE period membership AND retract on whole-user deactivation,
-# because `period_membership` does NOT close on deactivation.
-#
-# Note ABSENT suppresses only the HOST branch: a grant holder still passes
-# `can_edit` via `edit_grant`, matching sessions-api checking `holdsGrant`
-# outside its effective-pod guard.
+# TUPLE-WRITER CONTRACT — SUPERSEDES the pre-instance-layer guidance that
+# previously lived here (which wrote per-day facts onto this series-level
+# object): `session` is the SERIES.
+#   - `pod` = the session's DEFAULT pod, stable across days. NEVER rewrite
+#     it per-day: `session_instance.base_host`/`base_member` resolve through
+#     it, so a per-day rewrite corrupts every OTHER day's resolution.
+#   - Per-day facts — `pod_assignment_override(slotId, date)` SWAP/ABSENT
+#     resolution, `session_instance_override.hostIds`, participant
+#     additions — are written on that day's `session_instance`, never here.
+#   - The direct `[user]` branch of `host` is for series-level explicit
+#     hosts only (rare; additive). Per-day override hosts go on the
+#     instance's `override_host`.
+# FOOTGUN (still applies, now at the instance): the sessionId encodes the
+# DEFAULT podId and the override row is keyed on it "independent of any
+# SWAP" — a writer that parses podId out of the sessionId writes the WRONG
+# `override_pod` on every SWAP. Resolve it, don't parse it.
+# Liveness caveats apply wherever host facts are written: gate override
+# hosts on LIVE period membership and retract on whole-user deactivation
+# (`period_membership` does NOT close on deactivation).
 type session
   relations
     define parent: [program]
     define pod: [pod]
     define host: [user] or tutor from pod
     define participant: [user, group#member]
+    # `member` is the resolved pod roster (ingest: programs.pod_membership.*
+    # -> pod.member) — the event-fed membership source the instance layer
+    # resolves through. `participant` is the legacy direct-assignment
+    # relation (no event writer today); it stays honored by viewer/can_join
+    # and by can_view.
+    define member: member from pod
     define observer: [user, group#member, role#holder]
     define edit_grant: edit_non_hosted from parent
     define observe_grant: observe from parent
@@ -253,16 +258,18 @@ type session
     define lifecycle_grant: lifecycle_non_hosted from parent
     define can_edit: host or edit_grant
     define can_observe: host or observe_grant
-    define can_view: host or participant or view_grant
+    define can_view: host or participant or member or view_grant
     define can_lifecycle: host or lifecycle_grant
     define viewer: host or participant or observer or admin from parent
     define can_join: host or participant or admin from parent
 
 # A DATED OCCURRENCE of a repeating session — the layer where program-hub's
 # per-day facts live (`pod_assignment_override` SWAP/ABSENT resolution,
-# `session_instance_override.hostIds`, participant deltas). The repeating
+# `session_instance_override.hostIds`, participant ADDITIONS). The repeating
 # `session` above answers "who is attached to this series"; the instance
-# answers "who is host/member ON THIS DAY".
+# answers "who is host/member ON THIS DAY". Per-day REMOVALS are not
+# expressible as per-user negative tuples by design — they ride the
+# pod-swap path (disposition 2026-07-27).
 #
 # Instances are LAZY: an object exists (and carries tuples) only when
 # instance-specific facts were AUTHORED for that date — a pod-swap override,
@@ -274,8 +281,9 @@ type session
 #   base_host = host from session BUT NOT pod_overridden
 # ⚠️ The marker and `override_pod` MUST be written in the SAME authoring
 # action (they represent one fact — "this day's pod is different"). A marker
-# without an override_pod is an ABSENT day (no host at all — mirrors the
-# session-level ABSENT rule); an override_pod without the marker would
+# without an `override_pod` is an ABSENT day: the base pod is suppressed
+# entirely and only explicitly authored `override_host`/`added_participant`
+# facts admit anyone (grants still pass through); an override_pod without the marker would
 # silently UNION the swapped-in pod with the base one, which is exactly the
 # wrong-pod footgun the session comment warns about.
 #
@@ -293,6 +301,12 @@ type session
 # TENANT-CONTAINMENT NOTE: like `room.session`, containment resolves through
 # the `session` edge (session -> parent program -> tenant); the instance has
 # no `parent` edge of its own.
+#
+# JOIN PATH: the instance defines `can_join` below, but `room.can_join` and
+# the `whiteboard` relations still resolve through the SERIES session today —
+# wiring the realtime types to instances is DEFERRED (like the period hop)
+# until the connect surface adopts the PDP. Consequence to own explicitly:
+# on a swap day the room gate still admits the base pod until that lands.
 type session_instance
   relations
     define session: [session]
@@ -307,7 +321,7 @@ type session_instance
     # session either way.
     define base_host: host from session but not pod_overridden
     define host: override_host or tutor from override_pod or base_host
-    define base_member: participant from session but not pod_overridden
+    define base_member: member from session but not pod_overridden
     define member: added_participant or member from override_pod or base_member
     define edit_grant: edit_grant from session
     define observe_grant: observe_grant from session
@@ -318,6 +332,9 @@ type session_instance
     define can_observe: host or observe_grant
     define can_view: host or member or view_grant
     define can_lifecycle: host or lifecycle_grant
+    # v1 vocabulary join gate (observe grant admits observers). The legacy
+    # series-level `can_join` keeps its `admin from parent` arm untouched.
+    define can_join: host or member or observe_grant
 
 # A real-time room (rtsm). Tenant-scoped via parent. Used to lock down
 # socket joins; the `can_join` relation is what `RoomManager.joinRoom`

--- a/packages/core/saga-authz-model/model.fga
+++ b/packages/core/saga-authz-model/model.fga
@@ -56,6 +56,8 @@ type group
     define pgrant: [pgrant]
     define edit_non_hosted: edit_non_hosted from pgrant
     define observe: observe from pgrant
+    define view_non_member: view_non_member from pgrant
+    define lifecycle_non_hosted: lifecycle_non_hosted from pgrant
 
 # A role assignment carrier. Roles are per-tenant; a user assigned a role
 # inherits the role's permissions on the resources the role grants.
@@ -84,8 +86,11 @@ type role
 # every derived tuple fleet-wide. Here it is one tuple on the persona object.
 #
 # Permission strings these mirror (sessions-api):
-#   edit_non_hosted -> 'sessions:edit_non_hosted_sessions'
-#   observe         -> 'sessions:observe_sessions'
+#   edit_non_hosted      -> 'sessions:edit_non_hosted_sessions'
+#   observe              -> 'sessions:observe_sessions'
+#   view_non_member      -> 'sessions:view_non_member_sessions' (see-all reads)
+#   lifecycle_non_hosted -> 'sessions:lifecycle_non_hosted_sessions'
+#                           (start/end/cancel takeover)
 
 # TENANT-CONTAINMENT EXEMPTION: `persona` and `pgrant` deliberately have NO
 # `parent: [tenant]` edge, unlike the resource types above. A persona is a
@@ -106,6 +111,8 @@ type persona
   relations
     define grants_edit_non_hosted: [user:*]
     define grants_observe: [user:*]
+    define grants_view_non_member: [user:*]
+    define grants_lifecycle_non_hosted: [user:*]
 
 # A persona ASSIGNMENT carrier — ONE OBJECT PER `authz_persona_assignment` ROW
 # (key on the assignment row id, NEVER on `(user, persona)`: one object reused
@@ -123,6 +130,8 @@ type pgrant
     define persona: [persona]
     define edit_non_hosted: subject and grants_edit_non_hosted from persona
     define observe: subject and grants_observe from persona
+    define view_non_member: subject and grants_view_non_member from persona
+    define lifecycle_non_hosted: subject and grants_lifecycle_non_hosted from persona
 
 # ---------------------------------------------------------------------------
 # Resource types
@@ -157,6 +166,8 @@ type program
     define grant_group: [group]
     define edit_non_hosted: edit_non_hosted from grant_group
     define observe: observe from grant_group
+    define view_non_member: view_non_member from grant_group
+    define lifecycle_non_hosted: lifecycle_non_hosted from grant_group
 
 # An enrollment links a user to a program/cohort.
 # Used by program-hub's enrollment-tree read path.
@@ -191,13 +202,21 @@ type pod
     # Pod.rotation changes re-point PodAssignment, so this edge is MUTABLE.
     define parent: [program]
     define tutor: [user]
+    # Student roster of the pod — pods carry rosters, so a SWAP day's
+    # membership resolves through the swapped-in pod
+    # (session_instance.override_pod below). Written from the RESOLVED
+    # pod-membership facts (programs-api's engine already applies the
+    # program inclusion/exclusion filters; the projector ingests
+    # conclusions, never the rules).
+    define member: [user]
     define can_create_session: tutor or edit_non_hosted from parent
 
 # A scheduled session (a tutoring session, a class meeting). Lives under
 # a program; participants get session-level permissions.
 #
 # HOSTING (see the `pod` type above): `host` is the RELATIONSHIP branch and
-# `edit_grant`/`observe_grant` are the DELEGATION branch. They stay SEPARABLE
+# the `*_grant` relations (`edit_grant`/`observe_grant`/`view_grant`/
+# `lifecycle_grant`) are the DELEGATION branch. They stay SEPARABLE
 # relations on purpose so `checkDetailed` can attribute D19 actor HOST vs
 # ADMIN (`cancellationActor`); never collapse them into one OR'd relation.
 #
@@ -230,10 +249,75 @@ type session
     define observer: [user, group#member, role#holder]
     define edit_grant: edit_non_hosted from parent
     define observe_grant: observe from parent
+    define view_grant: view_non_member from parent
+    define lifecycle_grant: lifecycle_non_hosted from parent
     define can_edit: host or edit_grant
     define can_observe: host or observe_grant
+    define can_view: host or participant or view_grant
+    define can_lifecycle: host or lifecycle_grant
     define viewer: host or participant or observer or admin from parent
     define can_join: host or participant or admin from parent
+
+# A DATED OCCURRENCE of a repeating session — the layer where program-hub's
+# per-day facts live (`pod_assignment_override` SWAP/ABSENT resolution,
+# `session_instance_override.hostIds`, participant deltas). The repeating
+# `session` above answers "who is attached to this series"; the instance
+# answers "who is host/member ON THIS DAY".
+#
+# Instances are LAZY: an object exists (and carries tuples) only when
+# instance-specific facts were AUTHORED for that date — a pod-swap override,
+# an occurrence host, or a participant delta. Default days resolve straight
+# through the `session` edge; no per-day fan-out of tuples.
+#
+# OVERRIDE **REPLACES** — it never unions with the base pod. The
+# `pod_overridden: [user:*]` wildcard marker is what removes the base arm:
+#   base_host = host from session BUT NOT pod_overridden
+# ⚠️ The marker and `override_pod` MUST be written in the SAME authoring
+# action (they represent one fact — "this day's pod is different"). A marker
+# without an override_pod is an ABSENT day (no host at all — mirrors the
+# session-level ABSENT rule); an override_pod without the marker would
+# silently UNION the swapped-in pod with the base one, which is exactly the
+# wrong-pod footgun the session comment warns about.
+#
+# `override_host` and `added_participant` are ADDITIVE per-occurrence facts —
+# they never revoke the resolved base (matching
+# `session_instance_override.hostIds` being additive). Same projector
+# liveness caveats as the session-level override-host note above.
+#
+# The `*_grant` relations pass through the `session` edge ONLY — never
+# through `override_pod` — so an overridden (or ABSENT) day still admits
+# grant holders, and `checkDetailed` D19 attribution (HOST vs ADMIN) keeps
+# working at the instance level. Arms stay separable here for the same
+# reason they do on `session`.
+#
+# TENANT-CONTAINMENT NOTE: like `room.session`, containment resolves through
+# the `session` edge (session -> parent program -> tenant); the instance has
+# no `parent` edge of its own.
+type session_instance
+  relations
+    define session: [session]
+    # Authored instance facts (durable rows). `pod_overridden` is the
+    # wildcard marker written in the SAME authoring action as `override_pod`.
+    define override_pod: [pod]
+    define override_host: [user]
+    define added_participant: [user]
+    define pod_overridden: [user:*]
+    # Resolution: instance-authored facts first; else the repeating session's
+    # (suppressed entirely on an overridden day); grants pass through the
+    # session either way.
+    define base_host: host from session but not pod_overridden
+    define host: override_host or tutor from override_pod or base_host
+    define base_member: participant from session but not pod_overridden
+    define member: added_participant or member from override_pod or base_member
+    define edit_grant: edit_grant from session
+    define observe_grant: observe_grant from session
+    define view_grant: view_grant from session
+    define lifecycle_grant: lifecycle_grant from session
+    # Composite gates (enforce form) — same arm structure as `session`.
+    define can_edit: host or edit_grant
+    define can_observe: host or observe_grant
+    define can_view: host or member or view_grant
+    define can_lifecycle: host or lifecycle_grant
 
 # A real-time room (rtsm). Tenant-scoped via parent. Used to lock down
 # socket joins; the `can_join` relation is what `RoomManager.joinRoom`

--- a/packages/core/saga-authz-model/package.json
+++ b/packages/core/saga-authz-model/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/saga-authz-model",
-    "version": "0.1.0-dev.3",
+    "version": "0.1.0-dev.4",
     "private": false,
     "type": "module",
     "description": "Saga's OpenFGA authorization model (.fga DSL) and tuple-key helpers. Source of truth for ReBAC types and relations.",

--- a/packages/core/saga-authz-model/src/__tests__/model-fga.unit.test.ts
+++ b/packages/core/saga-authz-model/src/__tests__/model-fga.unit.test.ts
@@ -141,7 +141,12 @@ describe('session hosting model', () => {
      * A substring assertion cannot catch this (`subject or grants_x from persona`
      * contains the same tokens), so assert the STRUCTURE.
      */
-    it.each(['edit_non_hosted', 'observe'] as const)(
+    it.each([
+        'edit_non_hosted',
+        'observe',
+        'view_non_member',
+        'lifecycle_non_hosted',
+    ] as const)(
         'pgrant.%s is an INTERSECTION with subject, never a union',
         (rel) => {
             const def = byType.pgrant.relations[rel];
@@ -177,9 +182,14 @@ describe('session hosting model', () => {
     it('has no group ancestor cascade on the capability relations', () => {
         const groupRels = byType.group.relations ?? {};
         expect(groupRels).not.toHaveProperty('parent_group');
-        // group.edit_non_hosted/observe must resolve ONLY through pgrant —
+        // group's capability relations must resolve ONLY through pgrant —
         // every tupleset they traverse must be the `pgrant` edge.
-        for (const rel of ['edit_non_hosted', 'observe'] as const) {
+        for (const rel of [
+            'edit_non_hosted',
+            'observe',
+            'view_non_member',
+            'lifecycle_non_hosted',
+        ] as const) {
             const serialized = JSON.stringify(groupRels[rel]);
             expect(serialized).toContain('pgrant');
             const tuplesets = [
@@ -197,6 +207,283 @@ describe('session hosting model', () => {
         expect(JSON.stringify(byType.session.relations.edit_grant)).not.toContain(
             'pod',
         );
+    });
+});
+
+/**
+ * View / lifecycle capabilities. Same delegation spine as edit/observe —
+ * persona -> pgrant -> group -> program(grant_group) -> session — mirroring
+ * sessions-api's 'sessions:view_non_member_sessions' (see-all reads) and
+ * 'sessions:lifecycle_non_hosted_sessions' (start/end/cancel takeover).
+ */
+describe('view / lifecycle capability spine', () => {
+    const json = transformer.transformDSLToJSONObject(modelText);
+    const byType = Object.fromEntries(
+        json.type_definitions.map((t) => [t.type, t]),
+    );
+
+    it.each([
+        ['view_grant', 'view_non_member', 'grants_view_non_member'],
+        [
+            'lifecycle_grant',
+            'lifecycle_non_hosted',
+            'grants_lifecycle_non_hosted',
+        ],
+    ] as const)(
+        'routes session.%s through the program grant-group spine',
+        (grantRel, capRel, personaRel) => {
+            // Grants are group-scoped persona capabilities; a direct [user]
+            // grant here would bypass persona revocation.
+            expect(
+                JSON.stringify(byType.session.relations[grantRel]),
+            ).toContain(capRel);
+            expect(
+                JSON.stringify(byType.program.relations[capRel]),
+            ).toContain('grant_group');
+            expect(
+                JSON.stringify(byType.pgrant.relations[capRel]),
+            ).toContain(personaRel);
+        },
+    );
+
+    it('gates can_view on host OR participant OR view_grant', () => {
+        const arms = (
+            JSON.stringify(byType.session.relations.can_view).match(
+                /"relation":"([^"]+)"/g,
+            ) ?? []
+        ).sort();
+        expect(arms).toEqual([
+            '"relation":"host"',
+            '"relation":"participant"',
+            '"relation":"view_grant"',
+        ]);
+    });
+
+    it('gates can_lifecycle on host OR lifecycle_grant', () => {
+        const arms = (
+            JSON.stringify(byType.session.relations.can_lifecycle).match(
+                /"relation":"([^"]+)"/g,
+            ) ?? []
+        ).sort();
+        expect(arms).toEqual([
+            '"relation":"host"',
+            '"relation":"lifecycle_grant"',
+        ]);
+    });
+
+    it('keeps host and lifecycle_grant SEPARABLE (D19 attribution)', () => {
+        // Lifecycle takeover must attribute HOST vs ADMIN just like edit —
+        // checkDetailed(['host','lifecycle_grant']). Same rule as edit_grant.
+        // NB: relation-NAME matching, never substrings ("lifecycle_non_hosted"
+        // contains "host").
+        expect(JSON.stringify(byType.session.relations.host)).not.toContain(
+            'lifecycle_grant',
+        );
+        const grantRefs = JSON.stringify(
+            byType.session.relations.lifecycle_grant,
+        ).match(/"relation":"([^"]+)"/g);
+        expect(grantRefs).not.toContain('"relation":"host"');
+    });
+
+    it.each(['view_grant', 'lifecycle_grant'] as const)(
+        'leaves session.%s OUTSIDE the pod path (ABSENT still admits grants)',
+        (rel) => {
+            expect(
+                JSON.stringify(byType.session.relations[rel]),
+            ).not.toContain('pod');
+        },
+    );
+
+    it.each(['viewer', 'can_join'] as const)(
+        'leaves legacy session.%s untouched by the new grants (additive change)',
+        (rel) => {
+            const serialized = JSON.stringify(byType.session.relations[rel]);
+            expect(serialized).not.toContain('view_grant');
+            expect(serialized).not.toContain('lifecycle_grant');
+        },
+    );
+});
+
+/**
+ * The occurrence layer. A `session_instance` is a dated occurrence of a
+ * repeating session; it exists (and carries tuples) only when per-day facts
+ * were authored — a pod-swap override, an occurrence host, or a participant
+ * delta. The invariants here mirror program-hub's host-resolution semantics
+ * (pod_assignment_override SWAP/ABSENT + additive session_instance_override)
+ * and were exercised against a real store in rostering's runnable prototype
+ * (scripts/fga/prototype/session-instance-slice.fga.yaml, rostering#883).
+ */
+describe('session occurrence layer (session_instance)', () => {
+    const json = transformer.transformDSLToJSONObject(modelText);
+    const byType = Object.fromEntries(
+        json.type_definitions.map((t) => [t.type, t]),
+    );
+    const instance = byType.session_instance;
+
+    it('declares the instance with its session edge and authored facts', () => {
+        expect(instance).toBeDefined();
+        for (const rel of [
+            'session',
+            'override_pod',
+            'override_host',
+            'added_participant',
+            'pod_overridden',
+        ]) {
+            expect(instance.relations).toHaveProperty(rel);
+        }
+    });
+
+    it('types pod_overridden as the [user:*] public wildcard marker', () => {
+        const restrictions =
+            instance.metadata?.relations?.pod_overridden
+                ?.directly_related_user_types ?? [];
+        expect(
+            restrictions.some(
+                (r) => r.type === 'user' && r.wildcard !== undefined,
+            ),
+        ).toBe(true);
+    });
+
+    /**
+     * Override REPLACES — the marker is what removes the base arm. Assert
+     * the STRUCTURE: `base_host` must be a difference whose base resolves
+     * `host` through the `session` edge and whose subtrahend is the
+     * `pod_overridden` marker. A well-meaning rewrite to a plain union
+     * (`host from session or tutor from override_pod`) would silently turn
+     * every SWAP day into base-pod ∪ swapped-pod — the exact wrong-pod
+     * footgun the session-level comment warns about.
+     */
+    it.each([
+        ['base_host', 'host'],
+        ['base_member', 'participant'],
+    ] as const)(
+        '%s subtracts the pod_overridden marker from the session\'s %s',
+        (baseRel, sessionRel) => {
+            const def = instance.relations[baseRel];
+            expect(def).toHaveProperty('difference');
+            expect(def).not.toHaveProperty('union');
+            expect(
+                def.difference?.base?.tupleToUserset?.tupleset?.relation,
+            ).toBe('session');
+            expect(
+                def.difference?.base?.tupleToUserset?.computedUserset
+                    ?.relation,
+            ).toBe(sessionRel);
+            expect(
+                def.difference?.subtract?.computedUserset?.relation,
+            ).toBe('pod_overridden');
+        },
+    );
+
+    it('resolves host as override_host or override_pod tutor or base_host', () => {
+        const children = instance.relations.host?.union?.child ?? [];
+        expect(
+            children.some(
+                (c) => c.computedUserset?.relation === 'override_host',
+            ),
+        ).toBe(true);
+        expect(
+            children.some(
+                (c) =>
+                    c.tupleToUserset?.tupleset?.relation === 'override_pod' &&
+                    c.tupleToUserset?.computedUserset?.relation === 'tutor',
+            ),
+        ).toBe(true);
+        expect(
+            children.some((c) => c.computedUserset?.relation === 'base_host'),
+        ).toBe(true);
+        // The base pod must ONLY be reachable through base_host (which the
+        // marker suppresses) — never via a direct `host from session` arm.
+        expect(
+            children.some(
+                (c) => c.tupleToUserset?.tupleset?.relation === 'session',
+            ),
+        ).toBe(false);
+    });
+
+    it('resolves member with the same override/delta mechanics', () => {
+        const children = instance.relations.member?.union?.child ?? [];
+        expect(
+            children.some(
+                (c) => c.computedUserset?.relation === 'added_participant',
+            ),
+        ).toBe(true);
+        expect(
+            children.some(
+                (c) =>
+                    c.tupleToUserset?.tupleset?.relation === 'override_pod' &&
+                    c.tupleToUserset?.computedUserset?.relation === 'member',
+            ),
+        ).toBe(true);
+        expect(
+            children.some(
+                (c) => c.computedUserset?.relation === 'base_member',
+            ),
+        ).toBe(true);
+        expect(
+            children.some(
+                (c) => c.tupleToUserset?.tupleset?.relation === 'session',
+            ),
+        ).toBe(false);
+    });
+
+    it.each([
+        'edit_grant',
+        'observe_grant',
+        'view_grant',
+        'lifecycle_grant',
+    ] as const)(
+        'passes %s through the session edge ONLY (override day still admits grants)',
+        (rel) => {
+            // Grants never route through override_pod, so a SWAP (or ABSENT)
+            // day cannot suppress a grant holder — the instance-level twin of
+            // the session-level "ABSENT still admits grants" rule.
+            const serialized = JSON.stringify(instance.relations[rel]);
+            const tuplesets = [
+                ...serialized.matchAll(/"tupleset":\{"relation":"([^"]+)"\}/g),
+            ].map((m) => m[1]);
+            expect(tuplesets.length).toBeGreaterThan(0);
+            expect([...new Set(tuplesets)]).toEqual(['session']);
+        },
+    );
+
+    /**
+     * D19 separability, instance level. The gates mirror the session's arm
+     * structure exactly, and the relationship/delegation branches stay
+     * separable so checkDetailed can attribute HOST vs ADMIN on a dated
+     * occurrence too. NB: relation-NAME matching, never substrings.
+     */
+    it.each([
+        ['can_edit', ['host', 'edit_grant']],
+        ['can_observe', ['host', 'observe_grant']],
+        ['can_view', ['host', 'member', 'view_grant']],
+        ['can_lifecycle', ['host', 'lifecycle_grant']],
+    ] as const)(
+        'gates %s on exactly the separable arms %j',
+        (gate, expected) => {
+            const arms = (
+                JSON.stringify(instance.relations[gate]).match(
+                    /"relation":"([^"]+)"/g,
+                ) ?? []
+            ).sort();
+            expect(arms).toEqual(
+                [...expected].sort().map((r) => `"relation":"${r}"`),
+            );
+        },
+    );
+
+    it('keeps host clear of every grant arm', () => {
+        const hostRefs = JSON.stringify(instance.relations.host).match(
+            /"relation":"([^"]+)"/g,
+        );
+        for (const grant of [
+            'edit_grant',
+            'observe_grant',
+            'view_grant',
+            'lifecycle_grant',
+        ]) {
+            expect(hostRefs).not.toContain(`"relation":"${grant}"`);
+        }
     });
 });
 

--- a/packages/core/saga-authz-model/src/__tests__/model-fga.unit.test.ts
+++ b/packages/core/saga-authz-model/src/__tests__/model-fga.unit.test.ts
@@ -246,7 +246,7 @@ describe('view / lifecycle capability spine', () => {
         },
     );
 
-    it('gates can_view on host OR participant OR view_grant', () => {
+    it('gates can_view on host OR participant OR member OR view_grant', () => {
         const arms = (
             JSON.stringify(byType.session.relations.can_view).match(
                 /"relation":"([^"]+)"/g,
@@ -254,9 +254,18 @@ describe('view / lifecycle capability spine', () => {
         ).sort();
         expect(arms).toEqual([
             '"relation":"host"',
+            '"relation":"member"',
             '"relation":"participant"',
             '"relation":"view_grant"',
         ]);
+    });
+
+    it('session.member is the pod-derived roster (ingest-fed source)', () => {
+        // programs.pod_membership.* -> pod.member -> session.member. The
+        // legacy `participant` relation stays direct-assignment and separate.
+        const def = byType.session.relations.member;
+        expect(def.tupleToUserset?.tupleset?.relation).toBe('pod');
+        expect(def.tupleToUserset?.computedUserset?.relation).toBe('member');
     });
 
     it('gates can_lifecycle on host OR lifecycle_grant', () => {
@@ -355,7 +364,7 @@ describe('session occurrence layer (session_instance)', () => {
      */
     it.each([
         ['base_host', 'host'],
-        ['base_member', 'participant'],
+        ['base_member', 'member'],
     ] as const)(
         '%s subtracts the pod_overridden marker from the session\'s %s',
         (baseRel, sessionRel) => {
@@ -539,4 +548,44 @@ describe('staff control-plane namespace (SEC-CRIT-2)', () => {
         expect(serialized).not.toMatch(/"relation"\s*:\s*"parent"/);
         expect(byType.staff_org.relations).not.toHaveProperty('parent');
     });
+});
+
+describe('review-driven guards (2026-07-28)', () => {
+    const json = transformer.transformDSLToJSONObject(modelText);
+    const byType = Object.fromEntries(
+        json.type_definitions.map((t) => [t.type, t]),
+    );
+    const instance = byType.session_instance;
+
+    it('session_instance.can_join follows the v1 vocabulary (host OR member OR observe_grant)', () => {
+        const arms = (
+            JSON.stringify(instance.relations.can_join).match(
+                /"relation":"([^"]+)"/g,
+            ) ?? []
+        ).sort();
+        expect(arms).toEqual([
+            '"relation":"host"',
+            '"relation":"member"',
+            '"relation":"observe_grant"',
+        ]);
+    });
+
+    // D19 separability extended to ALL four grants at both levels: no can_*
+    // gate may inline pgrant/persona machinery — the grant arm must stay a
+    // named *_grant relation so checkDetailed can attribute HOST vs ADMIN.
+    it.each([
+        ['session', 'can_view', 'view_grant'],
+        ['session', 'can_lifecycle', 'lifecycle_grant'],
+        ['session_instance', 'can_view', 'view_grant'],
+        ['session_instance', 'can_lifecycle', 'lifecycle_grant'],
+        ['session_instance', 'can_join', 'observe_grant'],
+    ] as const)(
+        '%s.%s keeps its grant arm as the named %s relation',
+        (typeName, gate, grantRel) => {
+            const text = JSON.stringify(byType[typeName].relations[gate]);
+            expect(text).toContain(`"relation":"${grantRel}"`);
+            expect(text).not.toContain('pgrant');
+            expect(text).not.toContain('grants_');
+        },
+    );
 });

--- a/packages/core/saga-authz-model/src/types.ts
+++ b/packages/core/saga-authz-model/src/types.ts
@@ -21,6 +21,10 @@ export const FGA_TYPES = [
     'enrollment',
     'pod',
     'session',
+    // Dated occurrence of a repeating session — lazy; carries tuples only
+    // when per-day facts (pod swap, occurrence host, participant delta)
+    // were authored.
+    'session_instance',
     'room',
     'whiteboard',
     // Staff control-plane (namespace: staff) — distinct from the resource
@@ -43,10 +47,22 @@ export interface FgaRelationsByType {
         | 'admin'
         | 'pgrant'
         | 'edit_non_hosted'
-        | 'observe';
+        | 'observe'
+        | 'view_non_member'
+        | 'lifecycle_non_hosted';
     role: 'parent' | 'holder';
-    persona: 'grants_edit_non_hosted' | 'grants_observe';
-    pgrant: 'subject' | 'persona' | 'edit_non_hosted' | 'observe';
+    persona:
+        | 'grants_edit_non_hosted'
+        | 'grants_observe'
+        | 'grants_view_non_member'
+        | 'grants_lifecycle_non_hosted';
+    pgrant:
+        | 'subject'
+        | 'persona'
+        | 'edit_non_hosted'
+        | 'observe'
+        | 'view_non_member'
+        | 'lifecycle_non_hosted';
     school: 'parent' | 'admin' | 'editor' | 'viewer';
     cohort: 'parent' | 'admin' | 'editor' | 'viewer';
     program:
@@ -57,9 +73,11 @@ export interface FgaRelationsByType {
         | 'viewer'
         | 'grant_group'
         | 'edit_non_hosted'
-        | 'observe';
+        | 'observe'
+        | 'view_non_member'
+        | 'lifecycle_non_hosted';
     enrollment: 'parent' | 'program' | 'student' | 'tutor' | 'viewer';
-    pod: 'parent' | 'tutor' | 'can_create_session';
+    pod: 'parent' | 'tutor' | 'member' | 'can_create_session';
     session:
         | 'parent'
         | 'pod'
@@ -68,10 +86,32 @@ export interface FgaRelationsByType {
         | 'observer'
         | 'edit_grant'
         | 'observe_grant'
+        | 'view_grant'
+        | 'lifecycle_grant'
         | 'can_edit'
         | 'can_observe'
+        | 'can_view'
+        | 'can_lifecycle'
         | 'viewer'
         | 'can_join';
+    session_instance:
+        | 'session'
+        | 'override_pod'
+        | 'override_host'
+        | 'added_participant'
+        | 'pod_overridden'
+        | 'base_host'
+        | 'host'
+        | 'base_member'
+        | 'member'
+        | 'edit_grant'
+        | 'observe_grant'
+        | 'view_grant'
+        | 'lifecycle_grant'
+        | 'can_edit'
+        | 'can_observe'
+        | 'can_view'
+        | 'can_lifecycle';
     room: 'parent' | 'session' | 'member' | 'moderator' | 'can_join';
     whiteboard: 'parent' | 'editor' | 'viewer';
     // Staff control-plane. `saga_platform` carries the role grants
@@ -110,10 +150,31 @@ export type FgaRelation<T extends FgaType> = FgaRelationsByType[T];
 export const FGA_RELATIONS = {
     tenant: ['admin', 'member', 'support'],
     user: [],
-    group: ['parent', 'member', 'admin', 'pgrant', 'edit_non_hosted', 'observe'],
+    group: [
+        'parent',
+        'member',
+        'admin',
+        'pgrant',
+        'edit_non_hosted',
+        'observe',
+        'view_non_member',
+        'lifecycle_non_hosted',
+    ],
     role: ['parent', 'holder'],
-    persona: ['grants_edit_non_hosted', 'grants_observe'],
-    pgrant: ['subject', 'persona', 'edit_non_hosted', 'observe'],
+    persona: [
+        'grants_edit_non_hosted',
+        'grants_observe',
+        'grants_view_non_member',
+        'grants_lifecycle_non_hosted',
+    ],
+    pgrant: [
+        'subject',
+        'persona',
+        'edit_non_hosted',
+        'observe',
+        'view_non_member',
+        'lifecycle_non_hosted',
+    ],
     school: ['parent', 'admin', 'editor', 'viewer'],
     cohort: ['parent', 'admin', 'editor', 'viewer'],
     program: [
@@ -125,9 +186,11 @@ export const FGA_RELATIONS = {
         'grant_group',
         'edit_non_hosted',
         'observe',
+        'view_non_member',
+        'lifecycle_non_hosted',
     ],
     enrollment: ['parent', 'program', 'student', 'tutor', 'viewer'],
-    pod: ['parent', 'tutor', 'can_create_session'],
+    pod: ['parent', 'tutor', 'member', 'can_create_session'],
     session: [
         'parent',
         'pod',
@@ -136,10 +199,33 @@ export const FGA_RELATIONS = {
         'observer',
         'edit_grant',
         'observe_grant',
+        'view_grant',
+        'lifecycle_grant',
         'can_edit',
         'can_observe',
+        'can_view',
+        'can_lifecycle',
         'viewer',
         'can_join',
+    ],
+    session_instance: [
+        'session',
+        'override_pod',
+        'override_host',
+        'added_participant',
+        'pod_overridden',
+        'base_host',
+        'host',
+        'base_member',
+        'member',
+        'edit_grant',
+        'observe_grant',
+        'view_grant',
+        'lifecycle_grant',
+        'can_edit',
+        'can_observe',
+        'can_view',
+        'can_lifecycle',
     ],
     room: ['parent', 'session', 'member', 'moderator', 'can_join'],
     whiteboard: ['parent', 'editor', 'viewer'],

--- a/packages/core/saga-authz-model/src/types.ts
+++ b/packages/core/saga-authz-model/src/types.ts
@@ -83,6 +83,7 @@ export interface FgaRelationsByType {
         | 'pod'
         | 'host'
         | 'participant'
+        | 'member'
         | 'observer'
         | 'edit_grant'
         | 'observe_grant'
@@ -111,7 +112,8 @@ export interface FgaRelationsByType {
         | 'can_edit'
         | 'can_observe'
         | 'can_view'
-        | 'can_lifecycle';
+        | 'can_lifecycle'
+        | 'can_join';
     room: 'parent' | 'session' | 'member' | 'moderator' | 'can_join';
     whiteboard: 'parent' | 'editor' | 'viewer';
     // Staff control-plane. `saga_platform` carries the role grants
@@ -196,6 +198,7 @@ export const FGA_RELATIONS = {
         'pod',
         'host',
         'participant',
+        'member',
         'observer',
         'edit_grant',
         'observe_grant',
@@ -226,6 +229,7 @@ export const FGA_RELATIONS = {
         'can_observe',
         'can_view',
         'can_lifecycle',
+        'can_join',
     ],
     room: ['parent', 'session', 'member', 'moderator', 'can_join'],
     whiteboard: ['parent', 'editor', 'viewer'],


### PR DESCRIPTION
## What this is

A **PR into #369's branch**, not into main — concrete diffs for the next model layer, offered for reconciliation: **approve it, edit it in place, or cherry-pick the pieces you want** into `authz-session-pod-model`. Nothing here lands unless you take it.

Everything is **strictly additive** by #369's own monotonicity bar: no existing relation is modified, every pre-existing tuple still writes, and no previously-allowed check becomes denied. The relation-level drift guard pins this — the diff only ever appends.

## What's added

**1. `pod.member: [user]`** — pods carry rosters (written from the *resolved* pod-membership facts; programs-api's engine owns the inclusion/exclusion rules, the projector ingests conclusions). This is what makes swap-day membership expressible.

**2. `session_instance`** — the dated-occurrence layer #369's own host-resolution write-up describes (effective pod after SWAP/ABSENT, plus the additive `session_instance_override` facts) but the model couldn't yet express:

```
base_host = host from session but not pod_overridden   # marker removes the base arm
host      = override_host or tutor from override_pod or base_host
member    = added_participant or member from override_pod or base_member
```

- **Lazy** — an instance carries tuples only when a per-day fact was *authored* (pod swap, occurrence host, participant delta). Default days resolve through the `session` edge; no per-day fan-out.
- **Override REPLACES, never unions** — the `pod_overridden: [user:*]` marker suppresses the base arm; marker + `override_pod` are written in the same authoring action (one fact). A marker alone is an ABSENT day, mirroring your session-level ABSENT rule. A structural test forbids any direct `host from session` arm inside `host`, so the base pod is only reachable through the suppressible `base_host`.
- **Grants pass through the `session` edge only** — an overridden or ABSENT day still admits grant holders (the instance-level twin of your "ABSENT suppresses only the HOST branch" rule), and the gates mirror the session's **separable arm structure**, so D19 `checkDetailed` HOST-vs-ADMIN attribution works on a dated occurrence too. Not collapsed, per the cancellationActor invariant.

**3. `view_non_member` / `lifecycle_non_hosted`** — two more capabilities on your existing persona → pgrant → group → `program.grant_group` spine, exactly in its shape (intersection in `pgrant`, flat traversal, one relation per hop):

| Capability | Permission string | Gate |
|---|---|---|
| `view_non_member` | `sessions:view_non_member_sessions` (see-all reads) | `can_view = host or participant/member or view_grant` |
| `lifecycle_non_hosted` | `sessions:lifecycle_non_hosted_sessions` (start/end/cancel takeover) | `can_lifecycle = host or lifecycle_grant` |

## What's deliberately preserved

- **Your naming, not the prototype's** — `program.grant_group` (not `scope`), your persona/pgrant relation names, `parent: [program]` on session.
- **FLAT** — no group→group cascade. The no-cascade structural guard now covers all four capability relations; the rostering prototype's `from parent` cascade was *not* carried over.
- **Every legacy relation untouched** — `parent`, `viewer`, `can_join`, `participant`, `observer`, `can_edit`, `can_observe` are byte-identical. `can_view` is the new vocabulary-aligned gate alongside `viewer`, not a replacement.
- **Arm separability** — `host` and every `*_grant` stay separable relations at both levels (D19/cancellationActor).

## Deliberately deferred: the period hop

The rostering prototype inserts a `period` type (session → period → program). **Not added here.** Today's live gate resolves `holdsPermissionOnPeriod(periodId)` by immediately hopping period → program before the grant lookup, so under the current flat semantics `session.parent: [program]` is semantically equivalent — the projector just does the period→program resolution it already must do for `pod.parent`. A `period` type earns its place when **period-scoped grants** land (then it's one added `pgrant` edge on `period`, and introducing the type then is itself additive). Adding it now would churn your `session` block for zero checkable difference.

## Verification

- **84/84 vitest** (up from 56/56 on the base branch), `tsc --noEmit` clean, eslint clean, tsup build clean.
- **Mutation-checked**: dropping the marker subtraction, unioning the base arm into `host`, and `and`→`or` on the new pgrant relations each fail exactly one named test.
- **No store harness ships in this repo**, so the new tests are transformer-structural only — stated plainly. The store-exercised twin is rostering's runnable prototype slice (`scripts/fga/prototype/session-instance-slice.fga.yaml`, landed in rostering#883): the same shapes 8/8 green under `fga model test`, covering swap-day-replaces-base (base tutor is NOT host on the swap day), the added-participant day, lifecycle-grant-vs-host separability, and view-grant see-all. If you'd rather see those semantics pinned in-repo, a dockerized harness is a natural follow-up — kept out of this diff to stay model-only like #369.

## Links

- Base: #369 (this PR targets `authz-session-pod-model`)
- Runnable-evidence twin: [rostering#883](https://github.com/saga-ed/rostering/pull/883)
- Consumer: [rostering#887](https://github.com/saga-ed/rostering/pull/887) — authz-api's tier-2 `check`/`require` consumes these relation names as opaque strings, so the names chosen here are the contract surface
- Action vocabulary: [saga-dash `docs/authz-migration-scoping.md` § Session-action vocabulary](https://github.com/saga-ed/saga-dash/blob/main/docs/authz-migration-scoping.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Review pass (multi-lens + adversarial scoring, 2026-07-28)

A structured review over the combined #369+#373 diff produced 30 scored findings; the ones landing on this PR are **fixed in the latest commit**:

- **Superseded the stale tuple-writer contract** — the pre-instance-layer guidance on `session` (write per-day SWAP/ABSENT/hostIds onto the series object) is rewritten: `session.pod` = the DEFAULT pod, stable; per-day facts live on `session_instance`. Following the old text would have corrupted every other day's resolution through `base_host`/`base_member`.
- **Added `session_instance.can_join`** (host ∨ member ∨ observe_grant — the prototype twin's shape) and **documented the realtime deferral**: `room`/`whiteboard` still resolve through the series session; on a swap day the room gate admits the base pod until the connect surface adopts the PDP.
- **Re-homed the instance roster source**: `session.member = member from pod` (the ingest-fed `programs.pod_membership.*` source); `base_member` subtracts the marker from it. Legacy `participant` untouched; `session.can_view` gains the member arm.
- **Honesty fixes**: participant *additions* only (removals ride the pod-swap path by disposition); ABSENT-day wording corrected (authored `override_host`/`added_participant` still admit).
- **Version bumped to `0.1.0-dev.4`** (the #166 in-PR precedent — dev.3 is already published).
- **Guards extended**: can_join arm shape, pod-derived member source, D19 separability across all four grants at both levels. 91/91.

### Findings that belong to #369 / the rollout (report-only, for Seth)

1. **The #166/#296 rollout chain is unaddressed for the combined change** [scored 82]: after merge → publish `saga-authz-model@0.1.0-dev.4` → re-pin `rostering/scripts/fga/package.json` → refresh rostering's vendored `scripts/fga/model.fga` (currently 13 pre-#369 types) → re-bootstrap stores. **rostering#887 (check/require) is already merged**, so until this chain runs, any enabled check on the new relations hits a store that cannot contain them.
2. Relation drift guard covers 2 of 3 directions (interface-only phantom relations escape CI); `FgaRelationsByType` could be derived from `FGA_RELATIONS` to collapse the triple-lockstep [60].
3. `persona`/`pgrant` carry no tenant-containment path — worth an explicit ADR-0005 exemption note [50].
4. The pre-existing direct `observer` relation is orphaned by the new `can_observe`/`can_view` gates — vocabulary question: fold into `observe_grant` or document as a distinct authored fact [55].
