### PR TITLE
fix(ss): org-reset no longer sweeps sessions' dropped authz mirror tables

### DIFF
--- a/packages/node/saga-stack-cli/docs/env.md
+++ b/packages/node/saga-stack-cli/docs/env.md
@@ -185,9 +185,12 @@ reset with the orchestrator's `switch`/`restore` against that profile.
   re-run).
 - **Never touched anywhere**: `outbox_event`, `consumed_events`,
   `snapshot_metadata`, `audit_logs` (DB-rule append-only), sessions'
-  `projection_readiness` + `authz_persona_definition`, coach's authored
-  content + `persona_definition`, programs' `content_item`, and the whole
-  content-api database (no org-reachable column exists).
+  `projection_readiness`, coach's authored content + `persona_definition`,
+  programs' `content_item`, and the whole content-api database (no
+  org-reachable column exists). Sessions' former authz mirror tables
+  (`authz_group_membership` / `authz_group_hierarchy` /
+  `authz_persona_assignment` / `authz_persona_definition`) were dropped by
+  the authz cutover (program-hub#454) — the plan no longer references them.
 - **Known residue**: `session_alias` rows minted before their lazily-written
   session row (unreachable via sessionIds), and journey-test-added attributes
   on the org row itself (kept with the seeded ones).

--- a/packages/node/saga-stack-cli/src/core/env/__tests__/reset-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/env/__tests__/reset-plan.unit.test.ts
@@ -171,14 +171,16 @@ describe('buildResetPlan — order, skeleton predicates, empty-set skips', () =>
     expect(sql('group_auth_config')).toContain(`group_id <> '${ORG.orgId}'`);
   });
 
-  it('sessions authz mirrors keep the admin membership + org hierarchy rows', () => {
+  it('sessions store has NO authz mirror sweeps (tables dropped by program-hub#454)', () => {
     const plan = buildResetPlan(fullIds());
     const sessions = plan.find((s) => s.store === 'sessions')!;
-    const sql = (table: string): string => sessions.tables.find((t) => t.table === table)!.deleteSql!;
-    expect(sql('authz_group_membership')).toContain(`iam_row_id IS DISTINCT FROM '${ORG.adminMembershipId}'`);
-    expect(sql('authz_group_hierarchy')).toContain(`child_group_id <> '${ORG.orgId}'`);
-    expect(sql('authz_persona_assignment')).toContain(`user_id IN ('${USER}')`);
-    expect(sql('authz_persona_assignment')).toContain(`group_id <> '${ORG.orgId}'`);
+    const tables = sessions.tables.map((t) => t.table);
+    // Sweeping a dropped relation aborts the whole sessions-store transaction —
+    // the cutover deleted these tables, so the plan must not reference them.
+    expect(tables).not.toContain('authz_group_membership');
+    expect(tables).not.toContain('authz_group_hierarchy');
+    expect(tables).not.toContain('authz_persona_assignment');
+    expect(tables).not.toContain('authz_persona_definition');
   });
 
   it('every user-keyed sweep uses userDelIds (multi-org survivors keep mirrors/PII/progress)', () => {

--- a/packages/node/saga-stack-cli/src/core/env/reset-plan.ts
+++ b/packages/node/saga-stack-cli/src/core/env/reset-plan.ts
@@ -39,10 +39,10 @@
  *
  * Deliberately NEVER touched, in every store: `outbox_event`,
  * `consumed_events`, `snapshot_metadata`, `audit_logs` (DB-rule append-only),
- * sessions' `projection_readiness` + `authz_persona_definition`, coach's
- * authored-content tables + `persona_definition`, programs' `content_item`
- * (global catalog), and the whole content-api database (no org-reachable
- * column anywhere).
+ * sessions' `projection_readiness`, coach's authored-content tables +
+ * `persona_definition`, programs' `content_item` (global catalog), and the
+ * whole content-api database (no org-reachable column anywhere). Sessions'
+ * former authz mirror tables are gone entirely (program-hub#454 cutover).
  */
 
 import { assertUuids } from './footprint.js';
@@ -400,34 +400,12 @@ export const RESET_STORES: ResetStoreDef[] = [
         note: 'prisma model is named PodAssignmentOverride; the TABLE is pod_assignment_override_projection',
         where: guarded((ids) => inSet('slot_id', ids.slotIds)),
       },
-      {
-        // The admin's org membership survives in iam — its mirror survives too.
-        table: 'authz_group_membership',
-        projection: true,
-        where: guarded(
-          (ids) => `group_id IN (${lit(ids.groupIds)}) AND iam_row_id IS DISTINCT FROM '${ids.adminMembershipId}'`,
-        ),
-      },
-      {
-        // The org group row survives in iam — keep its hierarchy mirror.
-        table: 'authz_group_hierarchy',
-        projection: true,
-        where: guarded((ids) => `child_group_id IN (${lit(ids.groupIds)}) AND child_group_id <> '${ids.orgId}'`),
-      },
-      {
-        // Two sweeps in one predicate: assignments OF deleted users anywhere in
-        // the org, plus assignments scoped to dying child groups (surviving
-        // users' org-row assignments — the admin's — are kept).
-        table: 'authz_persona_assignment',
-        projection: true,
-        where: guarded((ids) => {
-          const parts: string[] = [];
-          const u = inSet('user_id', ids.userDelIds);
-          if (u !== null) parts.push(u);
-          parts.push(`(group_id IN (${lit(ids.groupIds)}) AND group_id <> '${ids.orgId}')`);
-          return parts.join(' OR ');
-        }),
-      },
+      // NOTE (authz cutover, program-hub#454): the sessions-store authz mirror
+      // tables (authz_group_membership / authz_group_hierarchy /
+      // authz_persona_assignment / authz_persona_definition) are DROPPED —
+      // sessions-api now reads authz-api's capabilities per request instead of
+      // projecting grants locally. No sweep entries for them; sweeping a
+      // dropped relation aborts the whole sessions-store transaction.
       {
         // userDelIds, NOT the raw reachable set: a multi-org user's iam row
         // survives, so its mirror must too (a deleted mirror never self-heals).
@@ -548,7 +526,7 @@ export const RESET_STORES: ResetStoreDef[] = [
         // The admin's org-row assignment mirrors the KEPT iam membership row
         // (iam_row_id = adminMembershipId) — coach projections never re-emit
         // for unchanged iam rows, so deleting it would break the admin's coach
-        // persona permanently. Same protection as sessions' authz mirrors.
+        // persona permanently.
         table: 'persona_assignment',
         projection: true,
         where: guarded((ids) => {


### PR DESCRIPTION
Rides the authz merge train: program-hub#454 DROPs the four `authz_*` mirror tables from the sessions store, and `ss env org reset` still swept three of them — a dropped relation errors the pre-count and aborts the whole sessions-store transaction, so org reset fails against any #454-migrated DB (verified gone on live slot 1).

Removes the three sweep entries + the `authz_persona_definition` never-touch note (reset-plan.ts + docs/env.md) and pins the absence in reset-plan.unit.test.ts.

Full saga-stack-cli suite (1527 tests) + typecheck run green with this change in the ss-authz-api worktree. Cherry-picked onto main because the `ss env` family (#355) postdates the #365 branch base — this PR should merge alongside (or after) #365 as part of the cutover release.

Found by the 2026-07-28 cutover adversarial gap review (deletion-completeness lens: the residual-reader sweep had never covered soa stack tooling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)