### PR TITLE
perf(observability): drop parentless pg pool + dns/net churn spans

### DIFF
--- a/packages/node/observability/src/tracing.ts
+++ b/packages/node/observability/src/tracing.ts
@@ -68,9 +68,27 @@ export function initTracing(
         // to the backend trace. fs is excluded — noisy and rarely actionable.
         // RuntimeNodeInstrumentation feeds DD APM's Runtime Metrics panel
         // (heap, event-loop lag, GC).
+        //
+        // dns + net are excluded for the same reason as fs: they emit a span per
+        // socket/lookup (tcp.connect, dns.lookup, tls.connect) that describes
+        // transport plumbing, not application work. The useful latency is already
+        // on the parent HTTP/pg span that triggered the connection.
+        //
+        // pg uses requireParentSpan so it only emits inside an existing trace.
+        // Connection-pool churn happens on background reconnects with no active
+        // parent, which produced a standing ~44 KB/s of `pg - pool.connect` spans
+        // in dev — ~65% of the whole dev APM ingest baseline, and the largest
+        // single contributor to the APM per-host density monitor firing
+        // (2026-07-28). Query + connect spans raised inside a real request or
+        // amqplib consumer still have a parent, so they are unaffected; only the
+        // parentless churn is dropped. See instrumentation-pg's
+        // shouldSkipInstrumentation(), which gates POOL_CONNECT/CONNECT/query.
         instrumentations: [
             getNodeAutoInstrumentations({
                 '@opentelemetry/instrumentation-fs': { enabled: false },
+                '@opentelemetry/instrumentation-dns': { enabled: false },
+                '@opentelemetry/instrumentation-net': { enabled: false },
+                '@opentelemetry/instrumentation-pg': { requireParentSpan: true },
             }),
             new RuntimeNodeInstrumentation(),
         ],


### PR DESCRIPTION
## Why

The APM per-host ingest density monitor (DD [307922923](https://app.datadoghq.com/monitors/307922923)) fired **warn 16:27:43Z (111.98)** → **alert 16:28:43Z (131.41)** → recovered 16:34:43Z on 2026-07-28. First and only firing in 14 days.

**It was a numerator event, not a host scale-down.** At the monitor's own `last_5m` resolution the ratio hit **136.2** while `apm_hosts` was flat at **10** (and rose to 12 during recovery).

> ⚠️ Querying the composed ratio at 1h rollup peaks at only ~64 and hides the firing entirely — reproduce monitor evaluations at the monitor's own window.

`env:dev` is ~95% of all fleet APM ingest (prod ~1.3 KB/s, production ~3.9 KB/s are flat). Dev baseline ~60–70 KB/s spiked to 370–411 KB/s.

## Why the existing guardrail didn't catch it

These services export via **OTLP to the agent's 4318 endpoint**, not dd-trace. OTLP traces bypass the trace-agent's head-based sampler, so `DD_APM_TARGET_TPS=10` (live on the dev daemon) **does not bind** to this traffic, and the OTel SDK defaults to **100% sampling**. All dev ingest is tagged `ingestion_reason:probabilistic` — `auto`, the agent sampler's tag, is absent entirely. That absence is the discriminator.

## What was actually burning the budget

Measured in dev over 7 days:

| resource | volume | note |
|---|---|---|
| `pg - pool.connect` | **flat ~44 KB/s for 7 days** | ~**65%** of the entire dev APM baseline |
| `dns.lookup` / `tcp.connect` / `tls.connect` | ~8 KB/s | transport plumbing |

The `pg` floor is chronic, not a spike artifact — it holds ~44 KB/s continuously and only rose to ~115–123 KB/s during the event along with everything else.

## The change

```ts
getNodeAutoInstrumentations({
    '@opentelemetry/instrumentation-fs':  { enabled: false },   // pre-existing
    '@opentelemetry/instrumentation-dns': { enabled: false },   // new
    '@opentelemetry/instrumentation-net': { enabled: false },   // new
    '@opentelemetry/instrumentation-pg':  { requireParentSpan: true }, // new
})
```

- **dns + net** excluded for the same reason `fs` already was: a span per socket/lookup describing plumbing, whose useful latency is already on the parent HTTP/pg span.
- **pg `requireParentSpan`** — verified against `instrumentation-pg@0.50.0` source: `shouldSkipInstrumentation()` gates `POOL_CONNECT` (instrumentation.js:327), `CONNECT` (:108), and query spans (:152), and skips **only when there is no active parent span**. Background pool reconnects are parentless → dropped. Connects/queries inside a real request or amqplib consumer keep their parent → **unaffected**.
- **HTTP/Express deliberately untouched** — the server-entry span carries the inbound W3C traceparent that links RUM sessions to backend traces.

## Verification

- `check-types` clean, `build` succeeds, **29/29 tests pass**, `lint` 0 errors (19 pre-existing env-var warnings on untouched lines).

## Follow-ups (not in this PR)

1. **Config drift** — the dev daemon runs `dev-datadog-agent-daemon` **rev 12** carrying `DD_APM_TARGET_TPS` / `ERROR_TPS` / `FILTER_TAGS_REJECT` that do **not** exist in the template on `iac` main; they live only on unmerged draft [hipponot/iac#610](https://github.com/hipponot/iac/pull/610). A `sam deploy` from main silently wipes them. (Limited impact, since they're inert for OTLP traffic anyway.)
2. **Monitor fragility** — `avg(last_5m)` over a denominator that swings 5→14 hosts within a week is ~3x sensitive to dev scale events alone. Worth widening the window and/or scoping dev vs prod separately.