### PR TITLE
chore(observability): bump to 0.1.0-dev.5 for span-noise fix

### DIFF
--- a/packages/node/observability/package.json
+++ b/packages/node/observability/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/soa-observability",
-    "version": "0.1.0-dev.4",
+    "version": "0.1.0-dev.5",
     "private": false,
     "type": "module",
     "main": "dist/index.js",


### PR DESCRIPTION
Version bump only — prerequisite for publishing [#377](https://github.com/saga-ed/soa/pull/377) to CodeArtifact.

The `publish-codeartifact` workflow's `single_package` mode publishes the version **already committed on main**, and main's ruleset blocks direct pushes — so the bump has to land as a PR first.

After merge: run `publish-codeartifact.yml` with `single_package=packages/node/observability`, then bump the 4 program-hub consumers off `0.1.0-dev.4`.

Ships: parentless `pg - pool.connect` / `dns` / `net` spans dropped — that pg floor alone was a flat ~44 KB/s in dev, ~65% of the dev APM ingest baseline.