### PR TITLE
fix(rum-util): fail prod builds on missing or malformed RUM credentials

### DIFF
--- a/packages/web/rum-util/README.md
+++ b/packages/web/rum-util/README.md
@@ -88,6 +88,11 @@ Per-app, per-account, region `us-west-2`:
 `application-id` or `client-token` empty to disable RUM entirely for that
 account — `initRum` returns `false` and every other call no-ops.
 
+> **Non-prod only.** A build with `RUM_ENV_DEFAULT=prod` rejects empty or
+> malformed credentials outright — see [Production builds fail
+> loud](#production-builds-fail-loud). "Leave it empty to disable" is a dev/preview
+> affordance, not a way to ship prod without RUM.
+
 Seed once out-of-band (or as a one-shot CFN/Terraform stack) — the values are
 account-scoped, not per-branch, so they live longer than any single deploy.
 

--- a/packages/web/rum-util/README.md
+++ b/packages/web/rum-util/README.md
@@ -113,11 +113,34 @@ The script:
   `loadEnv`.
 - Uses heredoc-delimited form so a multi-line SSM value can't inject extra
   entries into `$GITHUB_ENV`.
-- Tolerates `ParameterNotFound` (falls back to `RUM_ENV_DEFAULT` for the env
-  param; empties for app-id / token). Other AWS errors (`AccessDenied`,
+- Tolerates `ParameterNotFound` on non-prod (falls back to `RUM_ENV_DEFAULT` for
+  the env param; empties for app-id / token). Other AWS errors (`AccessDenied`,
   `ThrottlingException`, wrong region) fail the build loudly — an IAM
   regression should not silently ship prod without RUM.
 - Masks the client-token in CI logs via `::add-mask::`.
+
+#### Production builds fail loud
+
+When `RUM_ENV_DEFAULT=prod`, the script **fails the build** if either credential
+is empty/missing, or if either is present but malformed:
+
+| Param | Expected shape |
+|---|---|
+| `application-id` | UUID (`8-4-4-4-12` hex) |
+| `client-token` | `pub` + 32 hex chars |
+
+Non-prod builds keep warning instead — local and preview builds legitimately run
+without RUM.
+
+Presence alone is not a sufficient check. A malformed value passes an is-it-empty
+test, the build goes green, and Datadog then rejects the credential at runtime —
+prod is dark, but in a way nobody notices. This is not hypothetical: saga-dash's
+prod `client-token` was once seeded as the literal placeholder `<same as dev>`
+copied out of a runbook, and prod ran unmonitored for weeks as a result.
+
+> **Before adopting this in a repo that already deploys to prod**, confirm the
+> prod SSM params are seeded and well-formed — otherwise the next prod deploy
+> hard-fails. Reading `*/rum/*` needs AppInfra or higher; Observer is denied.
 
 ### 4. Vite config
 

--- a/packages/web/rum-util/scripts/fetch-rum-config.sh
+++ b/packages/web/rum-util/scripts/fetch-rum-config.sh
@@ -26,10 +26,16 @@
 #   VITE_DD_ENV
 #   VITE_APP_VERSION
 #
-# ParameterNotFound is tolerated — initRum() no-ops on empty applicationId, so
-# a freshly bootstrapped account that hasn't seeded SSM yet still ships. Other
-# AWS errors (AccessDenied, Throttling, wrong region) fail the build loudly so
-# an IAM regression can't silently ship prod without RUM.
+# ParameterNotFound is tolerated on NON-prod — initRum() no-ops on empty
+# applicationId, so a freshly bootstrapped account that hasn't seeded SSM yet
+# still ships. Other AWS errors (AccessDenied, Throttling, wrong region) fail
+# the build loudly so an IAM regression can't silently ship prod without RUM.
+#
+# When RUM_ENV_DEFAULT=prod the script additionally HARD-FAILS the build if
+# application-id or client-token is empty, or if either is present but
+# malformed (see the shape check below). Rationale: a green prod build that
+# ships no RUM is indistinguishable from a healthy one until someone notices
+# the dashboard is empty — which took weeks in saga-dash.
 #
 # Heredoc-delimiter form prevents a multi-line SSM value from injecting extra
 # entries into $GITHUB_ENV.
@@ -72,6 +78,27 @@ if [ -n "$TOKEN" ]; then
   echo "::add-mask::$TOKEN"
 fi
 
+# Shape-check both values before they reach the build. Presence alone is not
+# enough: a malformed value sails past an is-it-empty test, the build goes green,
+# and initRum() then calls Datadog with a credential it will reject — prod stays
+# dark in exactly the way this script is supposed to prevent, but harder to spot.
+# This is not hypothetical: saga-dash's /dash/rum/client-token was once seeded as
+# the literal placeholder "<same as dev>" copied out of a runbook.
+#
+# Datadog formats: application-id is a UUID; client tokens are "pub" + 32 hex.
+# Only enforced on prod builds — non-prod may legitimately be unset/partial.
+if [ "$RUM_ENV_DEFAULT" = "prod" ]; then
+  if [ -n "$APP_ID" ] && ! printf '%s' "$APP_ID" | grep -qiE '^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$'; then
+    echo "::error::${SSM_PREFIX}/application-id is not a valid UUID (got ${#APP_ID} chars starting '${APP_ID:0:4}'). Check the value in the production account, region ${AWS_REGION:-us-west-2}."
+    exit 1
+  fi
+  if [ -n "$TOKEN" ] && ! printf '%s' "$TOKEN" | grep -qE '^pub[0-9a-f]{32}$'; then
+    # Never echo the token itself — report only its shape.
+    echo "::error::${SSM_PREFIX}/client-token is not a valid Datadog client token (expected 'pub' + 32 hex chars, got ${#TOKEN} chars starting '${TOKEN:0:3}'). A placeholder was likely copied verbatim from a runbook."
+    exit 1
+  fi
+fi
+
 {
   echo "VITE_DD_RUM_APPLICATION_ID<<EOF_RUM"
   echo "$APP_ID"
@@ -85,6 +112,18 @@ fi
   echo "VITE_APP_VERSION=${GITHUB_SHA:0:7}"
 } >> "$GITHUB_ENV"
 
-if [ -z "$APP_ID" ]; then
-  echo "::warning::Datadog RUM not configured (${SSM_PREFIX}/application-id empty) — initRum() will no-op in this build"
+if [ -z "$APP_ID" ] || [ -z "$TOKEN" ]; then
+  # On a production build a missing application-id OR client-token means the
+  # deploy ships with no observability at all — initRum() no-ops and prod goes
+  # dark silently. That is exactly how saga-dash's prod ran unmonitored for
+  # weeks: ParameterNotFound is tolerated above, so the build stayed green.
+  # Non-prod keeps warning (local/preview builds legitimately run without RUM).
+  missing=""
+  [ -z "$APP_ID" ] && missing="${SSM_PREFIX}/application-id"
+  [ -z "$TOKEN" ] && missing="${missing:+$missing and }${SSM_PREFIX}/client-token"
+  if [ "$RUM_ENV_DEFAULT" = "prod" ]; then
+    echo "::error::Datadog RUM is not configured for a PRODUCTION build ($missing empty or missing). Seed it in the production account (region ${AWS_REGION:-us-west-2})."
+    exit 1
+  fi
+  echo "::warning::Datadog RUM not configured ($missing empty) — initRum() will no-op in this build"
 fi


### PR DESCRIPTION
Canonical half of a three-repo rollout carrying [saga-dash#807](https://github.com/saga-ed/saga-dash/pull/807)'s RUM hardening to the rest of the fleet. Sibling PRs: janus, qboard.

## Why

`fetch-rum-config.sh` tolerated an empty `application-id`/`client-token` on **every** environment — it warned and shipped. On a prod build that means the deploy goes out with no observability behind a green check. That is exactly how saga-dash's prod ran unmonitored for weeks: nobody noticed until someone looked at the dashboard and found it empty.

Presence alone is also not a sufficient check. saga-dash's prod `client-token` was once seeded as the literal placeholder `<same as dev>`, copied verbatim out of a runbook. That passes an is-it-empty test, builds green, and is only rejected later by Datadog at runtime.

## What

When `RUM_ENV_DEFAULT=prod`, hard-fail the build if either credential is empty, or if either is present but malformed:

| Param | Expected shape |
|---|---|
| `application-id` | UUID (8-4-4-4-12 hex) |
| `client-token` | `pub` + 32 hex |

Checked **before** writing `$GITHUB_ENV`. Non-prod keeps warning — local and preview builds legitimately run without RUM. The token is never echoed; errors report only its length and first 3 chars.

This file is the canonical copy that janus vendored (verified logic-identical to janus's before this change), so the same diff lands there.

## Verification

Drove the script with a stubbed `aws` across 9 cases — all pass:

- prod + valid creds → exit 0
- prod + empty app-id / empty token / `ParameterNotFound` → exit 1
- prod + `<same as dev>` placeholder token → exit 1 (the original incident)
- prod + malformed app-id → exit 1
- prod + AccessDenied → exit 1
- dev + empty creds → warn, exit 0
- dev + malformed creds → exit 0

## Note for reviewers

No prod-SSM precondition applies to *this* PR — it changes the shared script only and does not itself deploy anything. The precondition binds the two adopting PRs (janus, qboard), which state it in their own bodies.