### PR TITLE
fix(ss): prod's coach-api/connect-api/connect-web are routed, not unverifiable

### DIFF
--- a/packages/node/saga-stack-cli/src/commands/env/__tests__/env-verify.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/env/__tests__/env-verify.int.test.ts
@@ -13,6 +13,7 @@ import { Config } from '@oclif/core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { BaseCommand } from '../../../base-command.js';
 import { buildEnvHealthProbes, classifyEcsState, classifyProbeBody } from '../../../core/env/index.js';
+import type { DeployedServiceDef } from '../../../core/env/index.js';
 import type { EnvPsql, HealthProber, ProbeResult } from '../../../runtime/index.js';
 import EnvVerify from '../verify.js';
 
@@ -161,39 +162,64 @@ describe('per-env service scope (I#375)', () => {
     expect(dev['transcripts-api']!.optional).toBe(true);
   });
 
-  it('keeps DEPLOYED-but-unrouted prod services, reporting them as no-public-route', () => {
-    // coach-api and connect-api run on prod-shared but publish no DNS record.
-    // Dropping them would hide a real prod outage, so they stay in the list
-    // with url null and are judged by --ecs.
+  it('gives EVERY prod service an HTTP route — no stale no-public-route entries', () => {
+    // Regression for the three services recorded as unrouted in prod that were
+    // in fact routed the whole time (Seth, 2026-07-29). A stale "no public
+    // route" is not a harmless omission: coach-api/connect-api FAILED the gate
+    // outright, so `verify --env prod` was red on a healthy fleet.
     const prod = Object.fromEntries(buildEnvHealthProbes('saga.org', 'prod').map((p) => [p.id, p]));
-    expect(prod['coach-api']!.url).toBeNull();
-    expect(prod['connect-api']!.url).toBeNull();
-    // …while both keep a real HTTP route in dev/training.
+    expect(prod['coach-api']!.url).toBe('https://coach-api.saga.org/health');
+    expect(prod['connect-api']!.url).toBe('https://connectv3-api.saga.org/connectv3/v1/health');
+    // Prod has a custom domain (connectv3., NOT connect.); dev/training do not.
+    expect(prod['connect-web']!.url).toBe('https://connectv3.saga.org/');
+    // Nothing in prod is unroutable or un-gated any more.
+    for (const p of buildEnvHealthProbes('saga.org', 'prod')) {
+      expect(p.url, `${p.id} has no prod URL`).not.toBeNull();
+      expect(p.optional, `${p.id} is un-gated in prod`).toBe(false);
+    }
+    // …while dev/training keep their own distinct hosts.
     const dev = Object.fromEntries(buildEnvHealthProbes('wootdev.com', 'dev').map((p) => [p.id, p.url]));
     expect(dev['coach-api']).toBe('https://coach-api.wootdev.com/health');
     expect(dev['connect-api']).toBe('https://connectv3-api.wootdev.com/connectv3/v1/health');
+    expect(dev['connect-web']).toBe('https://dev.d2ezd4i8b4uexc.amplifyapp.com/');
+  });
+
+  it('reports a DEPLOYED-but-unrouted service instead of dropping it (noPublicRouteEnvs)', () => {
+    // No live service needs this today, so it is pinned against a fixture: the
+    // mechanism must keep working for the next host that loses its DNS record.
+    // Dropping such a service (via `envs`) would hide a real outage — it stays
+    // listed with url null, still REQUIRED, judged by --ecs.
+    const svc: DeployedServiceDef[] = [
+      { id: 'x-api', host: 'x-api', noPublicRouteEnvs: ['prod'], healthPath: '/health', kind: 'api', ecsService: 'x' },
+    ];
+    const prod = buildEnvHealthProbes('saga.org', 'prod', svc)[0]!;
+    expect(prod.url).toBeNull();
+    expect(prod.optional).toBe(false);
+    expect(prod.ecsService).toBe('x');
+    expect(buildEnvHealthProbes('wootdev.com', 'dev', svc)[0]!.url).toBe('https://x-api.wootdev.com/health');
   });
 
   it('un-gates a service ONLY in the env where it has no signal at all (optionalEnvs)', () => {
-    // connect-web is Amplify-hosted: no prod branch is known AND an Amplify app
-    // has no ECS service, so neither the HTTP pass nor `--ecs` can ever judge it
-    // on prod. Left required it would make `verify --env prod` permanently red
-    // on a healthy fleet, which is how a gate gets ignored.
-    const prod = Object.fromEntries(buildEnvHealthProbes('saga.org', 'prod').map((p) => [p.id, p]));
-    expect(prod['connect-web']!.url).toBeNull();
-    expect(prod['connect-web']!.optional).toBe(true);
-    expect(prod['connect-web']!.ecsService).toBeUndefined();
-    expect(prod['connect-web']!.ecsServiceName).toBeUndefined();
-    // The contrast: coach-api/connect-api are unrouted in prod too, but `--ecs`
-    // CAN judge them — so they stay REQUIRED and a real outage still fails.
-    expect(prod['coach-api']!.optional).toBe(false);
-    expect(prod['connect-api']!.optional).toBe(false);
-    // …and un-gating prod must not touch the envs where connect-web IS checkable.
-    const dev = Object.fromEntries(buildEnvHealthProbes('wootdev.com', 'dev').map((p) => [p.id, p]));
-    const training = Object.fromEntries(buildEnvHealthProbes('saga-training.org', 'training').map((p) => [p.id, p]));
-    expect(dev['connect-web']!.optional).toBe(false);
-    expect(dev['connect-web']!.url).toBe('https://dev.d2ezd4i8b4uexc.amplifyapp.com/');
-    expect(training['connect-web']!.optional).toBe(false);
+    // Also fixture-pinned now that prod's connect-web is checkable. The rule:
+    // un-gating one env must never weaken the envs where the service IS
+    // verifiable, or a real outage there passes silently.
+    const svc: DeployedServiceDef[] = [
+      {
+        id: 'x-web',
+        fqdnByEnv: { dev: 'dev.example.amplifyapp.com' },
+        optionalEnvs: ['prod'],
+        healthPath: '/',
+        kind: 'frontend',
+      },
+    ];
+    const prod = buildEnvHealthProbes('saga.org', 'prod', svc)[0]!;
+    expect(prod.url).toBeNull();
+    expect(prod.optional).toBe(true);
+    expect(prod.ecsService).toBeUndefined();
+    expect(prod.ecsServiceName).toBeUndefined();
+    const dev = buildEnvHealthProbes('wootdev.com', 'dev', svc)[0]!;
+    expect(dev.optional).toBe(false);
+    expect(dev.url).toBe('https://dev.example.amplifyapp.com/');
   });
 
   it('carries the per-env ABSOLUTE ECS name only where one is declared', () => {
@@ -339,16 +365,18 @@ describe('env verify --ecs', () => {
     expect(asked).not.toContain('coach-coach-api-canary-main');
     // Services scoped out of prod are never asked about at all.
     expect(asked.some((s) => s.includes('content-api') || s.includes('ads-adm') || s.includes('transcripts'))).toBe(false);
-    // The two unrouted-but-running services go green on the ECS pass alone.
-    expect(text()).toMatch(/coach-api\s+no public route/);
-    // connect-web has NO signal in prod (no branch, no ECS service) — it is
-    // reported as unverifiable, marked optional, and never asked about on ECS.
-    expect(text()).toMatch(/connect-web\s+no public route.*\(optional\)/);
+    // Nothing in prod reads as unroutable any more — the three services that
+    // once did are probed over HTTP like the rest.
+    expect(text()).not.toContain('no public route');
+    expect(probed).toContain('https://coach-api.saga.org/health');
+    expect(probed).toContain('https://connectv3-api.saga.org/connectv3/v1/health');
+    expect(probed).toContain('https://connectv3.saga.org/');
+    // connect-web is an Amplify SPA — HTTP is its only signal, never ECS.
     expect(asked.some((s) => s.includes('connect-web'))).toBe(false);
     expect(text()).toContain('verify passed');
   });
 
-  it('--env prod does NOT green an unrouted service whose ECS is bad', async () => {
+  it('--env prod does NOT green a service whose HTTP is fine but whose ECS is bad', async () => {
     const fake = {
       async json(args: string[]): Promise<unknown> {
         if (args[0] === 'sts') return '531314149529';
@@ -366,19 +394,23 @@ describe('env verify --ecs', () => {
     };
     vi.spyOn(BaseCommand.prototype as unknown as { getEnvAws: () => unknown }, 'getEnvAws').mockReturnValue(fake);
 
+    // A healthy /health cannot cover for a missing ECS service: the platform
+    // pass is the truth HTTP cannot see (stale target behind a dead service).
     await expect(EnvVerify.run(['--env', 'prod', '--ecs'], config)).rejects.toThrow(/env verify FAILED.*coach-api/s);
     expect(text()).toContain('no such ECS service');
-    // coach-api is the ONLY failure — the un-gated connect-web must not pad it.
     expect(text()).toContain('1 required service(s) unhealthy');
   });
 
-  it('--env prod WITHOUT --ecs leaves the unrouted services unverifiable, never green', async () => {
-    await expect(EnvVerify.run(['--env', 'prod'], config)).rejects.toThrow(/env verify FAILED.*coach-api/s);
-    expect(text()).toContain('no public route (not HTTP-verifiable)');
-    // No prod host was ever probed for them (nothing to probe).
-    expect(probed.some((u) => u.includes('coach-api.saga.org'))).toBe(false);
-    expect(probed.some((u) => u.includes('connectv3-api.saga.org'))).toBe(false);
-    // …but the routed prod services WERE probed on the plain apex.
+  it('--env prod passes on HTTP alone — every prod service is routed', async () => {
+    // The bug this replaces: coach-api/connect-api carried a stale "no public
+    // route", so a plain `ss env verify --env prod` FAILED on a healthy fleet
+    // and could only be worked around with --tolerate.
+    await expect(EnvVerify.run(['--env', 'prod'], config)).resolves.toBeUndefined();
+    expect(text()).not.toContain('no public route');
+    expect(probed).toContain('https://coach-api.saga.org/health');
+    expect(probed).toContain('https://connectv3-api.saga.org/connectv3/v1/health');
+    expect(probed).toContain('https://connectv3.saga.org/');
+    // …alongside the services that were already probed on the plain apex.
     expect(probed).toContain('https://iam.saga.org/health');
   });
 

--- a/packages/node/saga-stack-cli/src/core/env/services.ts
+++ b/packages/node/saga-stack-cli/src/core/env/services.ts
@@ -23,12 +23,19 @@
  *
  * A service with no `host` cannot be verified over HTTP — it is reported as
  * such (never silently green). Where an ECS service exists, the `--ecs`
- * platform check is the substitute signal: `coach-api` / `connect-api` in prod
- * run on prod-shared but publish no DNS record (I#375), and `--ecs` greens
- * them. Where NO signal exists at all — an Amplify SPA in an env whose branch
- * is not known (`connect-web` on prod) — there is nothing to check, so the
- * service is reported unverifiable and declared `optionalEnvs` for that env:
- * a gate that can never go green is a gate that gets ignored.
+ * platform check is the substitute signal. Where NO signal exists at all,
+ * there is nothing to check, so the service is reported unverifiable and
+ * declared `optionalEnvs` for that env: a gate that can never go green is a
+ * gate that gets ignored.
+ *
+ * As of 2026-07-29 NO service is in either bucket on prod. `coach-api`,
+ * `connect-api` and `connect-web` were all recorded here as unrouted in prod
+ * (I#375); all three are in fact routed and healthy — coach-api.saga.org,
+ * connectv3-api.saga.org and connectv3.saga.org — so the entire prod fleet is
+ * HTTP-verifiable. That is the standing hazard of this file: a host that gains
+ * (or loses) a public route turns the gate into a lie in one direction or the
+ * other, and a stale "no public route" reads as a hard FAIL on a healthy
+ * fleet. Entries are confirmed live, never inferred from an older run.
  *
  * The list is ONE global fleet, so the set differs per env in three declared
  * ways (I#375): `envs` scopes a service OUT of an env it is not deployed to at
@@ -158,14 +165,15 @@ export const DEPLOYED_SERVICES: DeployedServiceDef[] = [
     note: 'also answers on ads-adm.<domain> (sds#288 multi-host ALB rule)',
   },
   {
-    // DEPLOYED to prod (`coach-coach-api-canary` on prod-shared) but with no
-    // public DNS — coach-api.saga.org NXDOMAINs even though the prod ALB
-    // carries a host-header rule for it. HTTP-unverifiable there, so `--ecs`
-    // is the only signal; it must NOT be scoped out, or a real prod outage
-    // would go unreported.
+    // Routed in EVERY env, prod included: coach-api.saga.org/health answers
+    // {"status":"healthy","service":"Coach API"} (live 2026-07-29). The earlier
+    // `noPublicRouteEnvs: ['prod']` recorded an NXDOMAIN that is no longer true
+    // — prod now publishes real A records — and it made the gate report a
+    // healthy service as unverifiable. `/coach/v1/*` is the AUTHENTICATED API
+    // surface (401 {"realms":["iam"]} unauthenticated); `/health` is the
+    // unauthenticated probe and the only path this gate may use.
     id: 'coach-api',
     host: 'coach-api',
-    noPublicRouteEnvs: ['prod'],
     healthPath: '/health',
     kind: 'api',
     ecsService: 'coach-coach-api',
@@ -175,13 +183,14 @@ export const DEPLOYED_SERVICES: DeployedServiceDef[] = [
   { id: 'coach-web', host: 'coach', healthPath: '/', kind: 'frontend', note: 'Amplify-hosted SPA, not ECS (the API is coach-api)' },
   {
     // Host is connectv3-api.<domain> (NOT connect-api/connect) — confirmed from
-    // the ALB host-header rules and live on both envs. Its body carries no
-    // `service` key: {"status":"ok","mongo":"ok"}.
-    // Prod runs it (`qboard-connectv3-api-main` on prod-shared) but publishes
-    // no DNS record for it — ECS-only there, same reading as coach-api.
+    // the ALB host-header rules and live on EVERY env, prod included: the prod
+    // host resolves and /connectv3/v1/health answers {"status":"ok","mongo":"ok"}
+    // (live 2026-07-29). Its body carries no `service` key.
+    // The former `noPublicRouteEnvs: ['prod']` recorded a stale NXDOMAIN.
+    // NOTE health lives UNDER the /connectv3/v1 prefix — bare /health is the
+    // authenticated app surface (401 NEEDS_IAM), not a probe.
     id: 'connect-api',
     host: 'connectv3-api',
-    noPublicRouteEnvs: ['prod'],
     healthPath: '/connectv3/v1/health',
     kind: 'api',
     ecsService: 'qboard-connectv3-api',
@@ -237,28 +246,28 @@ export const DEPLOYED_SERVICES: DeployedServiceDef[] = [
     note: 'livekit recorder (fleek/OPS.md:93); shared fleet — dev+training only; prod has its own fleet',
   },
   {
-    // The connectv3 SPA is on Amplify with NO custom domain (unlike dash/coach),
-    // which is why connect.<domain> hits the shared-ALB default. Its real home is
-    // <branch>.<app-id>.amplifyapp.com — app `connectv3` = d2ezd4i8b4uexc, with a
-    // branch per env (qboard/CLAUDE.md documents the shape).
+    // The connectv3 SPA is on Amplify. On dev/training it has NO custom domain
+    // (which is why connect.<domain> hits the shared-ALB default) and lives at
+    // <branch>.<app-id>.amplifyapp.com — app `connectv3` = d2ezd4i8b4uexc, with
+    // a branch per env (qboard/CLAUDE.md documents the shape).
     //
-    // PROD: no branch of that app is established for prod, and an Amplify app
-    // has no ECS service, so `--ecs` cannot stand in for HTTP the way it does
-    // for coach-api/connect-api. With NO signal available in either direction,
-    // gating on it would make `verify --env prod` permanently red on a healthy
-    // fleet — hence `optionalEnvs: ['prod']`: still probed, still reported as
-    // unverifiable, never silently green, but not a false red either. Declare
-    // the prod branch in `fqdnByEnv` (or an `ecsService`, if it ever gets one)
-    // and delete the entry — that is the fix, not a `--tolerate` habit.
+    // PROD DOES have a custom domain: connectv3.saga.org (CloudFront, serving
+    // the "Saga Connect" document — live 2026-07-29). Note it is connectv3.,
+    // NOT connect. — connect.saga.org NXDOMAINs. That domain is the prod signal
+    // this entry previously lacked, so the `optionalEnvs: ['prod']` un-gate is
+    // gone: prod is now checkable and therefore gated like every other env.
+    // Per-env hosts stay in `fqdnByEnv` because the three envs genuinely differ
+    // (a custom domain here, Amplify branch URLs there) — an env with no entry
+    // still resolves to null rather than a guessed host.
     id: 'connect-web',
     fqdnByEnv: {
       dev: 'dev.d2ezd4i8b4uexc.amplifyapp.com',
       training: 'training.d2ezd4i8b4uexc.amplifyapp.com',
+      prod: 'connectv3.saga.org',
     },
-    optionalEnvs: ['prod'],
     healthPath: '/',
     kind: 'frontend',
-    note: 'Amplify app connectv3 (d2ezd4i8b4uexc), branch per env; no custom domain — no prod branch known, so prod is unverifiable (reported, not gated)',
+    note: 'Amplify app connectv3 (d2ezd4i8b4uexc); prod on the connectv3.saga.org custom domain, dev/training on per-branch Amplify URLs',
   },
   {
     // RTSM runs on its OWN geo-distributed cluster, not the shared ECS/ALB:


### PR DESCRIPTION
## Problem

`ss env verify --env prod` FAILED on a healthy fleet:

```
  ✗ coach-api       no public route (not HTTP-verifiable)
  ✗ connect-api     no public route (not HTTP-verifiable)
  ○ connect-web     no public route (not HTTP-verifiable) (optional)
✗ verify FAILED — 2 required service(s) unhealthy (7/10 healthy).
```

Three services carried a stale "no public route" claim recorded when their prod hosts NXDOMAINed (I#375). All three publish real DNS today, so the gate was red on a green fleet and could only be passed with `--tolerate` — exactly the habit the gate's own comments warn against.

Seth flagged coach-api and connect-api; connect-web turned out to be the same defect and is fixed here too.

## What was actually wrong

The health **paths** were already correct — only the prod **routing facts** were wrong. Confirmed live 2026-07-29:

| service | prod URL | response |
|---|---|---|
| coach-api | `https://coach-api.saga.org/health` | `{"status":"healthy","service":"Coach API"}` |
| connect-api | `https://connectv3-api.saga.org/connectv3/v1/health` | `{"status":"ok","mongo":"ok"}` |
| connect-web | `https://connectv3.saga.org/` | Saga Connect HTML document |

So the change is: drop `noPublicRouteEnvs: ['prod']` from the two APIs, and give connect-web its prod custom domain — `connectv3.`, **not** `connect.`, which NXDOMAINs — dropping its `optionalEnvs: ['prod']` un-gate now that prod has a real signal. Nothing in prod is unroutable or un-gated any more.

⚠️ The 200s in the Slack report (`/coach/v1/graphql`, `/connectv3/v1/my-sessions`) are **authenticated** surfaces — both 401 unauthenticated. The unauthenticated health paths above are what the gate may use.

## Result

```
▶ env verify — prod (*.saga.org; health judged by response body)
  ✓ coach-api       https://coach-api.saga.org/health
  ✓ connect-api     https://connectv3-api.saga.org/connectv3/v1/health
  ✓ connect-web     https://connectv3.saga.org/
✓ verify passed — 10/10 service(s) healthy.
```

## Testing

- `tsc --noEmit` clean; full package suite **1580 passed**.
- Live `env verify` against **prod (10/10 green)**, plus dev and training to confirm no regression.
- `noPublicRouteEnvs` / `optionalEnvs` still work and stay covered — re-pinned against fixtures instead of live services, so the mechanisms survive for the next host that loses a route rather than being deleted with the stale data.

## Out of scope (pre-existing, untouched)

- dev `connect-web` 404s at `dev.d2ezd4i8b4uexc.amplifyapp.com` — that URL is unchanged by this PR; the dev Amplify branch looks gone.
- `fleek` / `fleek-recorder` unreachable on dev+training — TLS cert name mismatch on `chi-1.fleek.wootdev.com`.
- `pnpm lint` cannot start in this checkout (eslint 8.57 vs. a config referencing `no-unassigned-vars`); pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M46zkfarDRZuAXSj22ZdVB