### PR TITLE
Reap the tunnel's grandchild + fail fast on a busy local port (soa#370)

### DIFF
--- a/packages/node/saga-stack-cli/src/commands/env/connect.ts
+++ b/packages/node/saga-stack-cli/src/commands/env/connect.ts
@@ -171,10 +171,19 @@ export default class EnvConnect extends BaseCommand {
     }
 
     // ── route: under the 'db-host-cloudmap' style a `.<namespace>` target
-    // tunnels via the container's OWN host instance with a 127.0.0.1 dial (the
-    // shared jump host's SG cannot reach the containers — task-SG allowlists).
+    // tunnels via the container's OWN host instance with a 127.0.0.1 dial.
     // Everything else — including EVERY 'rds-endpoint' target, which has no
-    // namespace and no SG problem — dials from the shared jump host. ──
+    // namespace — dials from the shared jump host.
+    //
+    // This detour is not load-bearing. It used to be justified here with "the
+    // shared jump host's SG cannot reach the containers — task-SG allowlists",
+    // which soa#370 disproved against live dev: the container publishes on
+    // 0.0.0.0 (docker-proxy) and dev-db-host-v2-sg admits 5432-5499 from the
+    // whole 10.3.0.0/16 VPC CIDR, so the jump host reaches these containers
+    // directly. The branch survives only because collapsing it is a ROUTING
+    // change (it would also delete discoverDbHostInstance and its
+    // container-moved-hosts failure mode) and does not belong in a bugfix —
+    // tracked separately. Do not re-derive the old claim from this code. ──
     let ssmTarget: string;
     let dialHost: string;
     let dialPort = target.port;

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/env-aws.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/env-aws.unit.test.ts
@@ -6,10 +6,12 @@
  */
 
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:net';
+import type { Server } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { awsArgs, lambdaInvokeArgs, makeRealEnvAws, portForwardArgs } from '../env-aws.js';
+import { awsArgs, lambdaInvokeArgs, makeRealEnvAws, portForwardArgs, probeLocalPort } from '../env-aws.js';
 
 describe('awsArgs — profile/region threading', () => {
   it('appends --profile and --region only when given', () => {
@@ -122,4 +124,61 @@ describe('portForward — a timed-out session is killed, never orphaned', () => 
       rmSync(dir, { recursive: true, force: true });
     }
   });
+});
+
+/**
+ * soa#370 — a local port held by an EARLIER process (one that predates the
+ * reaping fix, a SIGKILLed run, a concurrent `ss env connect`, a stray local
+ * postgres) must be named as the cause immediately. Reaping cannot free such a
+ * port, and without the preflight the run burns the full readiness deadline and
+ * then blames the SSM route — the misdiagnosis soa#370 was filed on.
+ */
+describe('portForward — a local port already in use is diagnosed, not blamed on the route', () => {
+  const listenOn = (): Promise<{ server: Server; port: number }> =>
+    new Promise((resolve) => {
+      const server = createServer();
+      server.listen(0, '127.0.0.1', () => {
+        resolve({ server, port: (server.address() as { port: number }).port });
+      });
+    });
+
+  it('probeLocalPort reports the errno for a bound port and undefined for a free one', async () => {
+    const { server, port } = await listenOn();
+    try {
+      expect(await probeLocalPort(port)).toBe('EADDRINUSE');
+    } finally {
+      await new Promise((r) => server.close(r));
+    }
+    // Same port, now released.
+    expect(await probeLocalPort(port)).toBeUndefined();
+  });
+
+  it('fails fast naming the port — not the document/target — and reaps the child', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ss-env-aws-stub-'));
+    const stub = join(dir, 'aws');
+    writeFileSync(stub, '#!/bin/sh\nsleep 60\n', { mode: 0o755 });
+    const realPath = process.env.PATH;
+    process.env.PATH = `${dir}:${realPath ?? ''}`;
+    const { server, port } = await listenOn();
+    try {
+      const handle = makeRealEnvAws().portForward({
+        target: 'i-0abc',
+        host: 'coach-api-runtime.dbs-v2.local',
+        remotePort: 5445,
+        localPort: port,
+        region: 'us-west-2',
+        // Generous vs. the probe: if the deadline is what rejects, the
+        // preflight did not do its job and this test must fail.
+        readyTimeoutMs: 10_000,
+      });
+      await expect(handle.ready).rejects.toThrow(/already in use \(EADDRINUSE\)/);
+      await expect(handle.ready).rejects.toThrow(/NOT a routing problem/);
+      await expect(handle.ready).rejects.not.toThrow(/not ready after/);
+      expect(await handle.exited).not.toBeUndefined();
+    } finally {
+      await new Promise((r) => server.close(r));
+      process.env.PATH = realPath;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 15_000);
 });

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/env-aws.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/env-aws.unit.test.ts
@@ -5,13 +5,23 @@
  * IO is exercised through the command int tests' fakes.
  */
 
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { createServer } from 'node:net';
 import type { Server } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { awsArgs, lambdaInvokeArgs, makeRealEnvAws, portForwardArgs, probeLocalPort } from '../env-aws.js';
+
+/** A port nothing is listening on: bind :0, read what the kernel gave us, release it. */
+const freePort = (): Promise<number> =>
+  new Promise((resolve) => {
+    const s = createServer();
+    s.listen(0, '127.0.0.1', () => {
+      const { port } = s.address() as { port: number };
+      s.close(() => resolve(port));
+    });
+  });
 
 describe('awsArgs — profile/region threading', () => {
   it('appends --profile and --region only when given', () => {
@@ -108,7 +118,11 @@ describe('portForward — a timed-out session is killed, never orphaned', () => 
         target: 'i-0abc',
         host: 'db.dbs-v2.local',
         remotePort: 5440,
-        localPort: 15432,
+        // Must be a port nothing holds, or the local-bind preflight below
+        // rejects first and this stops exercising the DEADLINE path. A
+        // hardcoded 15432 made that environment-dependent: a stray tunnel from
+        // an earlier run is exactly what soa#370 is about.
+        localPort: await freePort(),
         region: 'us-west-2',
         readyTimeoutMs: 250,
       });
@@ -124,6 +138,67 @@ describe('portForward — a timed-out session is killed, never orphaned', () => 
       rmSync(dir, { recursive: true, force: true });
     }
   });
+});
+
+/**
+ * soa#370 — the port holder is the GRANDCHILD, so teardown must reach it.
+ * `aws ssm start-session` only launches `session-manager-plugin`, and that is
+ * what binds the local port. Killing the `aws` child alone leaves the plugin
+ * reparented to init, still holding the port: confirmed live against dev, where
+ * a COMPLETED concierge reset stranded a plugin on 127.0.0.1:15432 and broke
+ * the very next run. The stub models that shape — a launcher whose background
+ * child outlives it.
+ */
+describe('portForward — teardown reaps the grandchild, not just the launcher', () => {
+  const alive = (pid: number): boolean => {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  it('stop() kills the process the launcher spawned', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ss-env-aws-stub-'));
+    const stub = join(dir, 'aws');
+    const gcPidFile = join(dir, 'grandchild.pid');
+    // Launcher shape: spawn a long-lived child, record it, then wait — exactly
+    // how `aws` sits in front of session-manager-plugin.
+    writeFileSync(stub, `#!/bin/sh\nsleep 60 &\necho $! > ${gcPidFile}\nwait\n`, { mode: 0o755 });
+    const realPath = process.env.PATH;
+    process.env.PATH = `${dir}:${realPath ?? ''}`;
+    try {
+      const handle = makeRealEnvAws().portForward({
+        target: 'i-0abc',
+        host: 'db.dbs-v2.local',
+        remotePort: 5440,
+        localPort: await freePort(),
+        region: 'us-west-2',
+        readyTimeoutMs: 5_000,
+      });
+      // Let the stub record its background child.
+      let gcPid: number | undefined;
+      for (let i = 0; i < 50 && gcPid === undefined; i++) {
+        await new Promise((r) => setTimeout(r, 20));
+        try {
+          gcPid = Number(readFileSync(gcPidFile, 'utf8').trim());
+        } catch {
+          /* not written yet */
+        }
+      }
+      expect(gcPid).toBeTypeOf('number');
+      expect(alive(gcPid!)).toBe(true);
+      handle.stop();
+      await handle.exited;
+      await new Promise((r) => setTimeout(r, 150));
+      // The whole group must be gone — this is what frees the local port.
+      expect(alive(gcPid!)).toBe(false);
+    } finally {
+      process.env.PATH = realPath;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 15_000);
 });
 
 /**

--- a/packages/node/saga-stack-cli/src/runtime/env-aws.ts
+++ b/packages/node/saga-stack-cli/src/runtime/env-aws.ts
@@ -155,6 +155,36 @@ const READY_TIMEOUT_MS = 30_000;
  * race costs nothing — the session-manager-plugin then fails its own bind and
  * the early-exit path reports that instead.
  */
+/**
+ * Tear down a port-forward session — the whole process GROUP, not just `aws`
+ * (soa#370).
+ *
+ * `aws ssm start-session` is a launcher: it execs `session-manager-plugin`, and
+ * THAT grandchild is what binds the local port. SIGTERM to the `aws` child kills
+ * the launcher only; the plugin is reparented to init and keeps the port held
+ * forever. Confirmed live against dev — a completed `coach-concierge reset`
+ * left `session-manager-plugin` (PPID 4056) still listening on 127.0.0.1:15432,
+ * which is why the very next reset failed. Since concierge pins dev to 15432,
+ * that made every run after the first fail, matching the "reads work, every
+ * write fails" report exactly.
+ *
+ * Spawning `detached` makes the child a group leader, so a negative pid signals
+ * the launcher and the plugin together. Falls back to the plain child kill if
+ * the group is already gone (ESRCH) or the platform refuses the negative pid.
+ */
+function killGroup(child: ChildProcess, signal: NodeJS.Signals = 'SIGTERM'): void {
+  if (child.pid === undefined) return;
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // Already reaped — nothing left to signal.
+    }
+  }
+}
+
 export function probeLocalPort(port: number): Promise<string | undefined> {
   return new Promise((resolve) => {
     const probe = createServer();
@@ -213,8 +243,12 @@ export function makeRealEnvAws(): EnvAws {
     },
 
     portForward(req): PortForwardHandle {
+      // `detached` puts the session in its OWN process group so teardown can
+      // signal the GROUP (see killGroup). Without it we can only reach `aws`
+      // itself, which is not the process holding the port (soa#370).
       const child: ChildProcess = spawn('aws', portForwardArgs(req), {
         stdio: ['ignore', 'pipe', 'pipe'],
+        detached: true,
       });
       let output = '';
       const readyTimeoutMs = req.readyTimeoutMs ?? READY_TIMEOUT_MS;
@@ -225,12 +259,12 @@ export function makeRealEnvAws(): EnvAws {
         // A session that never signals READY must be REAPED, not abandoned
         // (soa#370). `aws ssm start-session` keeps running after we give up —
         // and the session-manager-plugin under it holds the local port — so an
-        // un-killed child silently poisons that port for every later run. The
+        // un-killed session silently poisons that port for every later run. The
         // next attempt then times out too and orphans another, which is how one
         // transient failure turned into "the tunnel is permanently broken".
         const fail = (err: Error): void => {
           clearTimeout(timer);
-          child.kill('SIGTERM');
+          killGroup(child);
           reject(err);
         };
         const timer = setTimeout(() => {
@@ -282,7 +316,7 @@ export function makeRealEnvAws(): EnvAws {
         ready,
         exited,
         stop: () => {
-          child.kill('SIGTERM');
+          killGroup(child);
         },
       };
     },

--- a/packages/node/saga-stack-cli/src/runtime/env-aws.ts
+++ b/packages/node/saga-stack-cli/src/runtime/env-aws.ts
@@ -22,6 +22,7 @@
 import { spawn } from 'node:child_process';
 import type { ChildProcess } from 'node:child_process';
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { createServer } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -133,6 +134,36 @@ export function lambdaInvokeArgs(req: LambdaInvokeRequest, outfile: string): str
 const READY_MARKER = 'Waiting for connections';
 const READY_TIMEOUT_MS = 30_000;
 
+/**
+ * Is the tunnel's LOCAL end already taken? Resolves the errno when 127.0.0.1
+ * `port` cannot be bound, undefined when it is free (soa#370).
+ *
+ * Reaping our own timed-out children stops this CLI from creating new orphans,
+ * but it cannot free a port some EARLIER process is still holding — a run that
+ * predates the reaping fix, one killed with SIGKILL, a second concurrent
+ * `ss env connect`, or an unrelated local postgres. Without this probe every
+ * one of those spends the full 30s readiness deadline and then reports a
+ * message naming the SSM document, target and remote endpoint — i.e. it
+ * describes the ROUTE, which is exactly the wrong layer. That is the misread
+ * that cost soa#370 a day of investigation, and the reaping fix alone does not
+ * prevent a repeat.
+ *
+ * Deliberately advisory, not a lock: it races the spawn below rather than
+ * gating it, so `portForward` keeps its synchronous handle (and a real `pid`).
+ * A bind test takes ~1ms while the plugin needs a round trip to AWS before it
+ * touches the port, so the probe always settles first in practice. Losing the
+ * race costs nothing — the session-manager-plugin then fails its own bind and
+ * the early-exit path reports that instead.
+ */
+export function probeLocalPort(port: number): Promise<string | undefined> {
+  return new Promise((resolve) => {
+    const probe = createServer();
+    probe.once('error', (err: NodeJS.ErrnoException) => resolve(err.code ?? 'EADDRINUSE'));
+    probe.once('listening', () => probe.close(() => resolve(undefined)));
+    probe.listen(port, '127.0.0.1');
+  });
+}
+
 export function makeRealEnvAws(): EnvAws {
   return {
     async json(args, opts): Promise<unknown> {
@@ -215,6 +246,21 @@ export function makeRealEnvAws(): EnvAws {
             ),
           );
         }, readyTimeoutMs);
+        // Name the LOCAL bind as the cause the moment we can prove it, and say
+        // outright that the route was never dialled — otherwise the deadline
+        // message above (document + target + remote endpoint) reads as a
+        // routing failure and sends the next reader to the wrong layer.
+        void probeLocalPort(req.localPort).then((errno) => {
+          if (errno === undefined) return;
+          fail(
+            new Error(
+              `local port :${req.localPort} is already in use (${errno}) — the tunnel cannot bind it. ` +
+                `The route ${req.target} → ${req.host}:${req.remotePort} was never attempted, so this is NOT a routing problem. ` +
+                `An earlier tunnel may still hold the port: check \`pgrep -af session-manager-plugin\` and kill any stragglers, ` +
+                `or rerun with --local-port <other>.`,
+            ),
+          );
+        });
         const scan = (chunk: Buffer): void => {
           output += chunk.toString();
           if (output.includes(READY_MARKER)) {


### PR DESCRIPTION
Follow-on to PR#378 for I#370. **Verified end-to-end against live dev**: `coach-concierge reset 1 --target dev --execute` now works, twice in a row.

## The defect that actually blocked concierge

`aws ssm start-session` is only a **launcher** — it execs `session-manager-plugin`, and *that grandchild* binds the local port. SIGTERM to the `aws` child (Ctrl-C, concierge's `close()`, or PR#378's own reaping) kills the launcher alone; the plugin is reparented to init and holds the port **forever**.

Observed live, twice: a **successful** `concierge reset --execute` left `session-manager-plugin` (PPID 4056) listening on `127.0.0.1:15432`, so the *next* reset failed. Concierge pins dev to 15432 — which is why every run after the first failed, and why the report reads "reads work, every write fails". Each hand-rolled tunnel used a fresh port, so it never hit this. **The route was never involved.**

Fix: spawn `detached` so the session is its own process group, and signal the **group** on every teardown path.

## Second change: fail fast on a busy local port

PR#378 stopped this CLI creating *new* orphans but could not free a port an **earlier** process holds. Those runs burned the full 30s deadline and then printed a message naming the SSM document, target and remote endpoint — describing the **route**, the wrong layer, and exactly the misread I#370 was filed on.

`probeLocalPort()` now bind-tests `127.0.0.1:<port>` and fails immediately, stating the route was never attempted. Advisory, not a gate: it races the spawn so `portForward` keeps its synchronous handle and real `pid`. Against live dev this turned a 30s misleading failure into a **4s** accurate one.

## Also

Corrects the comment guarding the `.dbs-v2.local` loopback branch in `connect.ts` ("the shared jump host's SG cannot reach the containers — task-SG allowlists"), which I#370 disproved against live dev. Collapsing that branch is a routing change and deliberately stays out of this bugfix.

Stops the pre-existing timeout test hardcoding 15432 — with the preflight, a stray tunnel there made it assert the wrong rejection. It now uses an ephemeral port.

## On I#370's stated diagnosis

Both "suggested fixes" were **already true before the issue was filed** (verified at `4079d53`): `env-aws.ts` used `AWS-StartPortForwardingSessionToRemoteHost`, and `resolveJumpHost()` already filtered `PingStatus == Online`. The ASG-churn bug the issue predicts on a second run is real *as a symptom*, but its cause is the orphaned grandchild, not a cached instance id.

## Verification

| Check | Result |
|---|---|
| `pnpm test` | 1583 passed (128 files) |
| `check-types` / `lint` | clean / 0 errors |
| `concierge reset --execute` x2 back-to-back | both `reset complete`, no orphan left |
| dev post-state | `modules=38  states={"LOCKED":37,"UNLOCKED":1}  completed=0` |
| `module_answer` orphans | `0` |

Both new tests are non-vacuous — reverting each fix flips them red (`expected true to be false`; and the rejection reverts to `port-forward not ready after 10s: AWS-StartPortForwardingSessionToRemoteHost via i-0abc ...`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RBCbkJhSMAyi9kaC3NpAc
