### PR TITLE
fix(ss): prod coach-api is coach-coach-api-main, not the canary

### DIFF
--- a/packages/node/saga-stack-cli/src/commands/env/__tests__/env-verify.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/env/__tests__/env-verify.int.test.ts
@@ -224,7 +224,10 @@ describe('per-env service scope (I#375)', () => {
 
   it('carries the per-env ABSOLUTE ECS name only where one is declared', () => {
     const prod = Object.fromEntries(buildEnvHealthProbes('saga.org', 'prod').map((p) => [p.id, p]));
-    expect(prod['coach-api']!.ecsServiceName).toBe('coach-coach-api-canary');
+    // No service declares an override today — coach-api used to pin
+    // `coach-coach-api-canary`, but prod-shared runs `coach-coach-api-main`.
+    expect(prod['coach-api']!.ecsServiceName).toBeUndefined();
+    expect(prod['coach-api']!.ecsService).toBe('coach-coach-api');
     // Everything else composes from the prefix — no global suffix override.
     expect(prod['iam-api']!.ecsServiceName).toBeUndefined();
     expect(prod['iam-api']!.ecsService).toBe('rostering-iam-api');
@@ -331,7 +334,7 @@ describe('env verify --ecs', () => {
     expect(text()).toContain('ECS: under-running 0/2');
   });
 
-  it('--env prod asks ECS for the right service names, canary override included', async () => {
+  it('--env prod asks ECS for the right service names — all on the -main suffix', async () => {
     const asked: string[] = [];
     const fake = {
       async json(args: string[]): Promise<unknown> {
@@ -359,10 +362,10 @@ describe('env verify --ecs', () => {
     // prod's shared mesh uses the SAME `-main` suffix as dev's…
     expect(asked).toContain('rostering-iam-api-main');
     expect(asked).toContain('qboard-connectv3-api-main');
-    // …except coach, which is the absolute override — NOT suffixed again.
-    expect(asked).toContain('coach-coach-api-canary');
-    expect(asked).not.toContain('coach-coach-api-main');
-    expect(asked).not.toContain('coach-coach-api-canary-main');
+    // …and coach is no exception: `aws ecs list-services --cluster prod-shared`
+    // lists `coach-coach-api-main` and no canary, so it composes like the rest.
+    expect(asked).toContain('coach-coach-api-main');
+    expect(asked).not.toContain('coach-coach-api-canary');
     // Services scoped out of prod are never asked about at all.
     expect(asked.some((s) => s.includes('content-api') || s.includes('ads-adm') || s.includes('transcripts'))).toBe(false);
     // Nothing in prod reads as unroutable any more — the three services that
@@ -381,7 +384,7 @@ describe('env verify --ecs', () => {
       async json(args: string[]): Promise<unknown> {
         if (args[0] === 'sts') return '531314149529';
         if (args[1] === 'describe-services') {
-          return args.includes('coach-coach-api-canary') ? null : { running: 1, desired: 1, status: 'ACTIVE', rollout: 'COMPLETED' };
+          return args.includes('coach-coach-api-main') ? null : { running: 1, desired: 1, status: 'ACTIVE', rollout: 'COMPLETED' };
         }
         return null;
       },

--- a/packages/node/saga-stack-cli/src/core/env/services.ts
+++ b/packages/node/saga-stack-cli/src/core/env/services.ts
@@ -123,11 +123,15 @@ export interface DeployedServiceDef {
   ecsService?: string;
   /**
    * Per-ENV ABSOLUTE ECS service name, keyed by env name — used INSTEAD of
-   * `<ecsService>-<identifier>` (the ECS-side mirror of `fqdnByEnv`). For the
-   * one-off that does not follow its env's suffix convention: prod's coach is
-   * `coach-coach-api-canary`, not `-main`. Overriding per service rather than
-   * per env is deliberate — prod's other six shared-mesh services DO use
-   * `-main`, so a global suffix override would break them.
+   * `<ecsService>-<identifier>` (the ECS-side mirror of `fqdnByEnv`), for a
+   * service that does not follow its env's suffix convention. Overriding per
+   * service rather than per env is deliberate: prod's shared-mesh services all
+   * use `-main`, so a global suffix override would break them.
+   *
+   * Currently unused — every known service follows the convention. Verify an
+   * override against `aws ecs list-services` before adding one; a stale pin
+   * here turns a healthy service into a hard FAIL, which is what happened to
+   * coach-api on prod.
    */
   ecsServiceByEnv?: Record<string, string>;
   note?: string;
@@ -176,8 +180,14 @@ export const DEPLOYED_SERVICES: DeployedServiceDef[] = [
     host: 'coach-api',
     healthPath: '/health',
     kind: 'api',
+    // No `ecsServiceByEnv` override: prod's coach-api follows the standard
+    // `<ecsService>-<ledgerIdentifier>` convention like every other shared-mesh
+    // service. It was previously pinned to `coach-coach-api-canary`, which was
+    // true when the canary was the only coach service on `prod-shared` and it
+    // was INACTIVE. `aws ecs list-services --cluster prod-shared` now lists
+    // `coach-coach-api-main` and no canary at all, so the override made
+    // `env verify --env prod --ecs` report a healthy service as a hard FAIL.
     ecsService: 'coach-coach-api',
-    ecsServiceByEnv: { prod: 'coach-coach-api-canary' },
   },
   { id: 'saga-dash', host: 'dash', healthPath: '/', kind: 'frontend', note: 'Amplify-hosted SPA (not an ECS service)' },
   { id: 'coach-web', host: 'coach', healthPath: '/', kind: 'frontend', note: 'Amplify-hosted SPA, not ECS (the API is coach-api)' },


### PR DESCRIPTION
Closes the loose end flagged in [coach I#342](https://github.com/saga-ed/coach/issues/342) ("the ECS service name on `prod-shared` — `coach-coach-api-main`, or a reactivated canary?").

## The problem

`ss env verify --env prod --ecs` reported coach-api as a hard FAIL — `no such ECS service in the shared clusters` — while `coach-api.saga.org/health` was serving normally. Prod read **9/10** instead of 10/10, and the one failure was the gate lying about a healthy service.

```
✗ coach-api       ECS: no such ECS service in the shared clusters
✗ verify FAILED — 1 required service(s) unhealthy (9/10 healthy).
```

## Cause

`services.ts` pinned `ecsServiceByEnv: { prod: 'coach-coach-api-canary' }`. That was true when the canary was the only coach service on `prod-shared` and it was INACTIVE. It no longer is:

```
$ aws ecs list-services --cluster prod-shared
… coach-coach-api-main …          # and no canary at all
```

This is precisely the hazard `services.ts` warns about in its own header comment — a stale entry turning the gate into a lie.

## The fix

**Dropped the override rather than editing it.** `-main` *is* prod's suffix convention — all the other shared-mesh services use it — so the one-off has no remaining reason to exist. `ecsServiceByEnv` stays as an escape hatch but is now unused, with a note to verify against AWS before adding one.

## Verification

```
$ ss env verify --env prod --ecs --profile prod_admin
  ✓ coach-api       https://coach-api.saga.org/health · ecs 1/1 task(s) running
✓ verify passed — 10/10 service(s) healthy.
```

Three tests had pinned the canary as *expected* behaviour; they now assert the `-main` name. The "HTTP fine but ECS bad" test keeps its intent, just renamed to the real service.

- `pnpm test` — 1583 passed, 14 todo, 128 files
- `pnpm check-types` — clean

## Note, not included

soa's committed `oclif.manifest.json` has drifted from its own source (missing the `e2e:connect` command), so a local `pnpm build` regenerates ~158 unrelated lines. Left out of this PR — pre-existing and separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)