### PR TITLE
release(api-core): 2.0.0 → 2.1.0

### DIFF
--- a/packages/node/api-core/package.json
+++ b/packages/node/api-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saga-ed/soa-api-core",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": false,
   "type": "module",
   "main": "dist/rest-controller.js",


### PR DESCRIPTION
Version-only bump so api-core can be published with the changes already on `main`.

## Why

api-core **2.0.0 was published 2026-07-02**, and two additive commits have landed since — but the version was never bumped. So `main` and the published artifact **share a version number while differing in content**, and the newer code is unreachable to consumers.

| Commit | Change |
|---|---|
| `dcb9d09` | configurable `jsonBodyLimit` + `payloadTooLargeHandler` (**new public export**) |
| `c4e7145` | gzip response compression in `ExpressServer` |

Both are additive — one new export, no removals or signature changes — so this is a **minor** bump.

## Diff

One line. Every in-repo consumer resolves api-core via `workspace:*` or `>=1.1.3`, so nothing else needs updating.

## Unblocks

saga-ed/student-data-system#336 wants to delete ~85 LOC of duplicated 413 handler across 5 services in favor of `payloadTooLargeHandler()`. That work is currently blocked: the symbol exists on `main` but in **no published version**, so bumping SDS to 2.0.0 delivers nothing. See saga-ed/student-data-system#339 for the analysis.

## After merge

Dispatch **Publish to AWS CodeArtifact & GitHub Packages** with `single_package=packages/node/api-core` to publish the committed 2.1.0.