### PR TITLE
feat(saga-fga): add batchCheck as the fleet's authorization-filtered-list primitive

### DIFF
--- a/packages/core/saga-fga/README.md
+++ b/packages/core/saga-fga/README.md
@@ -4,6 +4,17 @@ Tier-2 (per-resource) OpenFGA authorization gate for Saga services — a thin
 `check` client over [`@openfga/sdk`](https://www.npmjs.com/package/@openfga/sdk)
 plus an enforcement flag and a framework-agnostic helper.
 
+Two query shapes, and the choice matters:
+
+| Need | Use |
+|---|---|
+| Enforce on one object | `check` / `enforceFgaRelation` |
+| Attribute *which* rule allowed it | `checkDetailed` |
+| Return only the items a user may see | [`batchCheck`](#filtered-lists-batchcheck-not-listobjects) |
+
+Enumeration (`ListObjects`) is intentionally **absent** — see
+[why](#filtered-lists-batchcheck-not-listobjects).
+
 Pairs with [`@saga-ed/saga-authz-model`](../saga-authz-model) (the `.fga` model +
 typed tuple-key builders) and the sync worker (which owns tuple **writes** —
 ADR 0005). Services only **check**.
@@ -62,6 +73,57 @@ is both.
 > when you add a branch to a `can_*` union, grep for its `checkDetailed`
 > callers. The capability catalog codegens these shapes, so branch growth is
 > anticipated.
+
+## Filtered lists: `batchCheck` (not `ListObjects`)
+
+When an endpoint must return only the items a user may see, **fetch the candidate
+records from your own datastore, then ask about them**:
+
+```ts
+const districts = await db.districts.findMany({ where: { status: 'ACTIVE' } });
+const verdicts = await fga.batchCheck(
+  districts.map((d) => ({ user: `user:${actorId}`, relation: 'can_view', object: `staff_org:${d.id}` })),
+);
+const visible = districts.filter(
+  (d) => verdicts.get(fgaBatchKey(`user:${actorId}`, 'can_view', `staff_org:${d.id}`)),
+);
+```
+
+Use `fgaBatchKey(user, relation, object)` for lookups — don't format the key by
+hand. Requests are auto-chunked (50 per batch, 10 batches in parallel), so >50
+items is allowed, but each chunk is a round trip: bound the candidate set rather
+than passing an unbounded page.
+
+**This package deliberately does not expose OpenFGA's `ListObjects`**, for two
+measured reasons:
+
+1. **It cannot report truncation.** `ListObjectsResponse` is `{ objects: string[] }`
+   — no continuation token, no truncation flag. The operation is bounded
+   server-side by a max-results cap and a deadline, so a **capped** list and a
+   **complete** list are the same response. Silently under-reporting a list is an
+   authorization *correctness* bug (items the user may see never render, with no
+   error), not a performance nit.
+2. **Result count is not the cost driver.** Measured on rostering's prototype
+   (`scripts/fga/prototype/latency.md`): p50 **28ms for ~421 objects** vs **73ms
+   for one** — latency tracks graph-search shape, not result size. So "the set is
+   small" is not a safety argument. And list-objects is **cache-immune**, while
+   `check` goes ~23ms → ~1.4ms warm; every sub-check in a `batchCheck` is
+   check-cache-eligible.
+
+If a caller genuinely needs the id set *before* touching its own datastore, that
+belongs behind the PDP's own API with an explicit `truncated` contract — not
+here, where the shape invites silent under-reporting.
+
+> **A per-item failure is not a deny.** If any item comes back carrying an
+> `error`, or the response omits a requested item, `batchCheck` throws
+> `FgaUnavailableError` rather than reporting that item `false` — same contract as
+> `check` (see below). A successfully returned map always holds exactly one entry
+> per distinct question asked.
+
+Pagination note: authorization filtering and pagination don't compose at the app
+layer — filter-after-fetch yields nondeterministic page sizes and no reliable
+total. If you need stable pagination, counts, or sort, the decision has to live
+in your datastore (a projection join), not in a post-filter.
 
 ## Contextual tuples
 

--- a/packages/core/saga-fga/package.json
+++ b/packages/core/saga-fga/package.json
@@ -1,9 +1,9 @@
 {
     "name": "@saga-ed/saga-fga",
-    "version": "0.1.0-dev.3",
+    "version": "0.1.0-dev.4",
     "private": false,
     "type": "module",
-    "description": "Saga OpenFGA Tier-2 authorization gate — a thin check client + framework-agnostic enforcement helper over @openfga/sdk. Services check; they never write tuples (ADR 0005).",
+    "description": "Saga OpenFGA Tier-2 authorization gate — check, batchCheck (authorization-filtered lists) + framework-agnostic enforcement helper over @openfga/sdk. Services check; they never write tuples (ADR 0005).",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "exports": {

--- a/packages/core/saga-fga/src/__tests__/gate.unit.test.ts
+++ b/packages/core/saga-fga/src/__tests__/gate.unit.test.ts
@@ -3,11 +3,13 @@ import {
   loadFgaGateConfig,
   enforceFgaRelation,
   createFgaGate,
+  fgaBatchKey,
   FgaUnavailableError,
   type FgaGate,
 } from '../index.js';
 
 const checkMock = vi.hoisted(() => vi.fn());
+const batchCheckMock = vi.hoisted(() => vi.fn());
 // Capture constructor args so we can assert on the CLIENT CONFIG, not just on
 // calls — a token that never reaches the constructor never reaches the wire.
 const clientConfigs = vi.hoisted(() => [] as Record<string, unknown>[]);
@@ -15,11 +17,25 @@ vi.mock('@openfga/sdk', () => ({
   CredentialsMethod: { None: 'none', ApiToken: 'api_token', ClientCredentials: 'client_credentials' },
   OpenFgaClient: class {
     check = checkMock;
+    batchCheck = batchCheckMock;
     constructor(config: Record<string, unknown>) {
       clientConfigs.push(config);
     }
   },
 }));
+
+/** Echo back an `allowed` verdict per requested item, in request order. */
+const respondAllowing = (allow: (item: { object: string; relation: string }) => boolean) =>
+  batchCheckMock.mockReset().mockImplementation(
+    (body: { checks: { user: string; relation: string; object: string; correlationId: string }[] }) =>
+      Promise.resolve({
+        result: body.checks.map((c) => ({
+          allowed: allow(c),
+          request: c,
+          correlationId: c.correlationId,
+        })),
+      }),
+  );
 
 const gateWithStore = () =>
   createFgaGate({ enforce: true, apiUrl: 'http://fga.test', storeId: 's1' });
@@ -164,6 +180,133 @@ describe('checkDetailed attribution', () => {
     for (const call of checkMock.mock.calls) {
       expect(call[0]).toMatchObject({ contextualTuples: tuples });
     }
+  });
+});
+
+describe('batchCheck — the authorization-filtered-list primitive', () => {
+  const districts = ['staff_org:d1', 'staff_org:d2', 'staff_org:d3'];
+  const asChecks = (objects: string[]) =>
+    objects.map((object) => ({ user: 'user:a', relation: 'can_view', object }));
+
+  it('returns one verdict per item, keyed by fgaBatchKey', async () => {
+    respondAllowing((c) => c.object !== 'staff_org:d2');
+    const verdicts = await gateWithStore().batchCheck(asChecks(districts));
+
+    expect(verdicts.size).toBe(3);
+    expect(verdicts.get(fgaBatchKey('user:a', 'can_view', 'staff_org:d1'))).toBe(true);
+    expect(verdicts.get(fgaBatchKey('user:a', 'can_view', 'staff_org:d2'))).toBe(false);
+    expect(verdicts.get(fgaBatchKey('user:a', 'can_view', 'staff_org:d3'))).toBe(true);
+  });
+
+  it('short-circuits an empty request without touching the client', async () => {
+    batchCheckMock.mockReset();
+    await expect(gateWithStore().batchCheck([])).resolves.toEqual(new Map());
+    expect(batchCheckMock).not.toHaveBeenCalled();
+  });
+
+  it('sends wire correlation ids OpenFGA will accept (≤36 chars, [A-Za-z0-9-])', async () => {
+    // The natural key `user:<uuid>|can_view|staff_org:<uuid>` violates BOTH the
+    // charset and the length cap, so it can never be the wire id.
+    respondAllowing(() => true);
+    const uuid = '11111111-2222-3333-4444-555555555555';
+    await gateWithStore().batchCheck([
+      { user: `user:${uuid}`, relation: 'can_view', object: `staff_org:${uuid}` },
+    ]);
+
+    const sent = batchCheckMock.mock.calls[0]?.[0] as {
+      checks: { correlationId: string }[];
+    };
+    for (const c of sent.checks) {
+      expect(c.correlationId).toMatch(/^[A-Za-z0-9-]{1,36}$/);
+    }
+  });
+
+  it('correlates by correlationId, not response order', async () => {
+    // A server that answers out of order must not shuffle the verdicts.
+    batchCheckMock.mockReset().mockImplementation(
+      (body: { checks: { relation: string; object: string; correlationId: string }[] }) =>
+        Promise.resolve({
+          result: [...body.checks]
+            .reverse()
+            .map((c) => ({
+              allowed: c.object === 'staff_org:d1',
+              request: c,
+              correlationId: c.correlationId,
+            })),
+        }),
+    );
+    const verdicts = await gateWithStore().batchCheck(asChecks(districts));
+
+    expect(verdicts.get(fgaBatchKey('user:a', 'can_view', 'staff_org:d1'))).toBe(true);
+    expect(verdicts.get(fgaBatchKey('user:a', 'can_view', 'staff_org:d3'))).toBe(false);
+  });
+
+  it('passes >50 items through in one call and lets the SDK chunk them', async () => {
+    respondAllowing(() => true);
+    const many = asChecks(Array.from({ length: 120 }, (_, i) => `staff_org:d${i}`));
+    const verdicts = await gateWithStore().batchCheck(many);
+
+    expect(verdicts.size).toBe(120);
+    // Chunking is the SDK's job (maxBatchSize 50) — we must not pre-split, or we
+    // lose its parallelism control.
+    expect(batchCheckMock).toHaveBeenCalledTimes(1);
+    expect((batchCheckMock.mock.calls[0]?.[0] as { checks: unknown[] }).checks).toHaveLength(120);
+  });
+
+  it('collapses duplicate questions to a single entry', async () => {
+    respondAllowing(() => true);
+    const verdicts = await gateWithStore().batchCheck(asChecks(['staff_org:d1', 'staff_org:d1']));
+    expect(verdicts.size).toBe(1);
+  });
+});
+
+describe('batchCheck — a per-item failure is NOT a deny', () => {
+  const one = [{ user: 'user:a', relation: 'can_view', object: 'staff_org:d1' }];
+
+  it('throws when any item carries an error, rather than reporting it false', async () => {
+    // The whole reason this method belongs in this package: a silent `false` here
+    // would hide an outage as a permission denial on a list surface.
+    batchCheckMock.mockReset().mockResolvedValue({
+      result: [
+        {
+          allowed: false,
+          request: { user: 'user:a', relation: 'can_view', object: 'staff_org:d1' },
+          correlationId: 'c0',
+          error: { input_error: 'validation_error', message: 'boom' },
+        },
+      ],
+    });
+    await expect(gateWithStore().batchCheck(one)).rejects.toThrow(FgaUnavailableError);
+  });
+
+  it('throws when the response omits a requested item', async () => {
+    batchCheckMock.mockReset().mockResolvedValue({ result: [] });
+    await expect(gateWithStore().batchCheck(one)).rejects.toThrow(FgaUnavailableError);
+  });
+
+  it('throws on an unrecognized correlationId rather than guessing', async () => {
+    batchCheckMock.mockReset().mockResolvedValue({
+      result: [
+        {
+          allowed: true,
+          request: { user: 'user:a', relation: 'can_view', object: 'staff_org:d1' },
+          correlationId: 'not-ours',
+        },
+      ],
+    });
+    await expect(gateWithStore().batchCheck(one)).rejects.toThrow(FgaUnavailableError);
+  });
+
+  it('surfaces a transport failure as FgaUnavailableError', async () => {
+    batchCheckMock.mockReset().mockRejectedValue(new Error('ECONNREFUSED'));
+    await expect(gateWithStore().batchCheck(one)).rejects.toThrow(FgaUnavailableError);
+  });
+
+  it('surfaces a missing store id without reaching the client', async () => {
+    batchCheckMock.mockReset();
+    const gate = createFgaGate({ enforce: true, apiUrl: 'http://fga.test' });
+    await expect(gate.batchCheck(one)).rejects.toThrow(FgaUnavailableError);
+    expect(batchCheckMock).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/core/saga-fga/src/index.ts
+++ b/packages/core/saga-fga/src/index.ts
@@ -8,6 +8,17 @@ import { CredentialsMethod, OpenFgaClient } from '@openfga/sdk';
  * "can user X do action A on object R?" — they NEVER write tuples (ADR 0005);
  * writes flow through the sync worker.
  *
+ * Two query shapes, and the choice matters:
+ *   - `check`/`checkDetailed` — one object. Enforcement.
+ *   - `batchCheck` — many objects. **Authorization-filtered lists**: fetch the
+ *     candidates, then ask about them. Deliberately NOT `ListObjects`, which
+ *     cannot report truncation (see `batchCheck`'s doc comment).
+ *
+ * Enumeration (`ListObjects`) is intentionally absent. If a caller ever truly
+ * needs the id set before touching its own datastore, that belongs behind the
+ * PDP's own API with an explicit `truncated` contract — not here, where the
+ * shape invites silent under-reporting.
+ *
  * Enforcement is OFF by default (`AUTHZ_FGA_ENFORCE !== 'true'`) so adopting
  * the gate is non-breaking: existing service-level checks remain authoritative
  * until the flag is flipped on.
@@ -88,6 +99,43 @@ export class FgaUnavailableError extends Error {
 }
 
 /**
+ * One (user, relation, object) question in a {@link FgaGate.batchCheck} call.
+ *
+ * Deliberately the same shape as {@link FgaContextualTuple} but a distinct type:
+ * a contextual tuple is an ASSERTED fact riding in on a request, this is a
+ * QUESTION being asked. Conflating them reads badly at call sites.
+ */
+export interface FgaBatchCheckItem {
+  user: string;
+  relation: string;
+  object: string;
+}
+
+/**
+ * The verdicts from a {@link FgaGate.batchCheck} call, keyed by
+ * `${user}|${relation}|${object}` — the natural identity of the question.
+ *
+ * Use {@link fgaBatchKey} to build a lookup key rather than formatting it by
+ * hand. Absence of a key means NO VERDICT was reached for that item, never
+ * "denied" — but `batchCheck` throws rather than returning a partial map, so a
+ * successfully returned map always holds exactly one entry per requested item
+ * (duplicates in the request collapse to one entry).
+ */
+export type FgaBatchCheckResult = ReadonlyMap<string, boolean>;
+
+/**
+ * The lookup key for a {@link FgaBatchCheckResult} entry.
+ *
+ * NOT the wire `correlation_id`: OpenFGA restricts that to letters, numbers and
+ * hyphens with length ≤ 36 (`BatchCheckItem.correlation_id`), which a
+ * `user:<uuid>`/`staff_org:<uuid>` triple violates on both counts. The wire ids
+ * are therefore opaque generated indices, mapped back to these keys internally.
+ */
+export function fgaBatchKey(user: string, relation: string, object: string): string {
+  return `${user}|${relation}|${object}`;
+}
+
+/**
  * The outcome of a `checkDetailed` call: whether access is allowed, and — when
  * it is — which relation branch produced it.
  */
@@ -137,6 +185,32 @@ export interface FgaGate {
     object: string,
     contextualTuples?: readonly FgaContextualTuple[],
   ): Promise<FgaDetailedDecision>;
+  /**
+   * Evaluate many independent (user, relation, object) questions in one call.
+   *
+   * **This is the fleet's primitive for authorization-FILTERED LISTS** — fetch
+   * the candidate records, then ask about them. Prefer it over OpenFGA's
+   * `ListObjects` for that job, for two measured reasons:
+   *
+   * 1. `ListObjectsResponse` is `{ objects: string[] }` — no continuation token,
+   *    no truncation flag. It is bounded server-side by a max-results cap and a
+   *    deadline, so a CAPPED list and a COMPLETE list are the same response.
+   *    Silent under-reporting of a list is an authorization CORRECTNESS bug
+   *    (items the user may see never render, with no error), not a perf nit.
+   * 2. Result count is not the cost driver: measured p50 was 28ms for ~421
+   *    objects vs **73ms for one** — latency tracks graph-search shape. And
+   *    list-objects is cache-immune, while `check` goes ~23ms → ~1.4ms warm.
+   *    Every sub-check here is check-cache-eligible.
+   *
+   * Requests are auto-chunked (50 per batch, 10 batches in parallel), so a
+   * caller may pass more than 50 items — but each chunk is a round trip, so
+   * bound the candidate set rather than passing an unbounded page.
+   *
+   * Throws {@link FgaUnavailableError} if ANY item failed to reach a verdict —
+   * per-item errors are never collapsed to `false`, matching `check`. Returns a
+   * map keyed by {@link fgaBatchKey}; duplicate questions collapse to one entry.
+   */
+  batchCheck(checks: readonly FgaBatchCheckItem[]): Promise<FgaBatchCheckResult>;
 }
 
 /**
@@ -194,9 +268,68 @@ export function createFgaGate(config: FgaGateConfig = loadFgaGateConfig()): FgaG
     return res.allowed === true;
   };
 
+  const batchCheck = async (
+    checks: readonly FgaBatchCheckItem[],
+  ): Promise<FgaBatchCheckResult> => {
+    const verdicts = new Map<string, boolean>();
+    if (checks.length === 0) return verdicts;
+
+    // Wire correlation ids are opaque indices: OpenFGA caps correlation_id at 36
+    // chars of [A-Za-z0-9-], which our `user:<uuid>`/`<type>:<uuid>` triples blow
+    // past. Map them back to natural keys ourselves.
+    const keyByCorrelationId = new Map<string, string>();
+    const items = checks.map((c, i) => {
+      const correlationId = `c${i}`;
+      keyByCorrelationId.set(correlationId, fgaBatchKey(c.user, c.relation, c.object));
+      return { user: c.user, relation: c.relation, object: c.object, correlationId };
+    });
+
+    let res;
+    try {
+      res = await clientFor().batchCheck({ checks: items });
+    } catch (cause) {
+      throw new FgaUnavailableError(
+        `FGA batchCheck failed for ${checks.length} item(s)`,
+        { cause },
+      );
+    }
+
+    for (const single of res.result) {
+      // A per-item `error` means this question reached no verdict. Surfacing it
+      // as `allowed: false` would be a silent deny — the exact failure mode
+      // `check`'s contract exists to prevent.
+      if (single.error) {
+        throw new FgaUnavailableError(
+          `FGA batchCheck item failed for ${single.request.relation} on ${single.request.object}`,
+          { cause: single.error },
+        );
+      }
+      const key = keyByCorrelationId.get(single.correlationId);
+      // An unrecognized correlation id means we cannot attribute this verdict to
+      // a question we asked; treating it as anything would be a guess.
+      if (key === undefined) {
+        throw new FgaUnavailableError(
+          `FGA batchCheck returned an unrecognized correlationId: ${single.correlationId}`,
+        );
+      }
+      verdicts.set(key, single.allowed === true);
+    }
+
+    // Every question must come back answered. A short response is unavailability,
+    // not a set of denials.
+    const expected = new Set(keyByCorrelationId.values());
+    if (verdicts.size !== expected.size) {
+      throw new FgaUnavailableError(
+        `FGA batchCheck returned ${verdicts.size} verdict(s) for ${expected.size} distinct item(s)`,
+      );
+    }
+    return verdicts;
+  };
+
   return {
     enforce: config.enforce,
     check: checkOne,
+    batchCheck,
     async checkDetailed(user, relations, object, contextualTuples) {
       const held = await Promise.all(
         relations.map((relation) => checkOne(user, relation, object, contextualTuples)),


### PR DESCRIPTION
## Why

Authorization-filtered list endpoints — "return only the items this user may see" — had **no primitive** in this package. `FgaGate` exposed only `check`/`checkDetailed`, both single-object.

This is Phase 1 of consolidating `staff_org` authz reads into authz-api (the PDP). The first consumer is the staff-admin district list, which today calls OpenFGA `ListObjects` directly from iam-api — the fleet's only enumeration call.

## Why NOT `ListObjects`

An earlier draft of the plan proposed adding `listObjects` here. That was **reversed after adversarial review**, on two verified findings:

**1. It cannot report truncation.** `ListObjectsResponse` is `{ objects: string[] }` (`@openfga/sdk@0.9.6/dist/apiModel.d.ts:832-838`) — no continuation token, no truncation flag, no total. Contrast `ReadResponse`, which *does* carry one. The operation is bounded server-side by a max-results cap and a deadline, so **a capped list and a complete list are the same wire response.** Silently under-reporting a list is an authorization **correctness** bug — items the user may see never render, with no error — not a performance nit.

**2. Result count is not the cost driver.** From rostering's own benchmark (`scripts/fga/prototype/latency.md:39-40`):

| Operation | p50 |
|---|---|
| list-objects — ~421 objects | 28.0 ms |
| list-objects — **1** object | **73.1 ms** |

One object is 2.6× slower than 421 — latency tracks graph-search shape, not result size. So "the set is small, it's fine" is not a safety argument, and any cardinality-based threshold would be unfounded. list-objects is also **cache-immune** (`~28/~75ms` cached), while `check` goes 23ms → **1.4ms** warm.

`batchCheck` fans questions out through the batch-check endpoint (auto-chunked 50/batch, 10 parallel), so **every sub-check is check-cache-eligible**.

## The contract this preserves

This package's stated rule is that an unreachable verdict is *never* a deny (`checkOne`: "Never collapse it to `false`"). `batchCheck` can honor it because `ClientBatchCheckSingleResponse` carries a per-item `error?: CheckError` plus a `correlationId`. So:

- per-item `error` → **throws** `FgaUnavailableError`
- response omits a requested item → **throws**
- unrecognized `correlationId` → **throws** (never guesses attribution)

That is exactly what `ListObjects`' shape cannot express, and the reason `batchCheck` belongs in the shared package while enumeration does not. Enumeration, if ever needed, belongs behind the PDP's own API with an explicit `truncated` contract.

## Implementation note

Results are keyed by `fgaBatchKey(user, relation, object)`. Wire correlation ids are **opaque indices** (`c0`, `c1`, …) because OpenFGA caps `correlation_id` at 36 chars of `[A-Za-z0-9-]` (`apiModel.d.ts:175`) — a `user:<uuid>`/`<type>:<uuid>` triple violates both the charset and the length, so the natural key can never be the wire id.

## Testing

`29/29 pass` (13 new), typecheck clean, lint clean, `tsup` build exports all four new symbols.

New coverage: one-verdict-per-item; empty request short-circuits without touching the client; wire ids satisfy OpenFGA's charset/length rule; **correlation survives an out-of-order response**; >50 items pass through in one call (SDK chunks, we don't pre-split); duplicates collapse; and each of the four failure modes throws rather than denying.

**Mutation-tested:** deleting the per-item-error throw fails exactly one test, so that assertion has teeth.

## Versioning

`0.1.0-dev.3` → `0.1.0-dev.4`. **Must be published to CodeArtifact before** the authz-api consumer PR, which pins this exactly (`authz-api/package.json:32`).

> Note: I could not run `pnpm install` in a fresh worktree — my current credentials are dev-account Observer and lack `codeartifact:GetAuthorizationToken` on the prod-account domain. Verified against the main checkout's installed deps instead. **Publishing needs someone with CodeArtifact write.**