### PR TITLE
fix(saga-stack-cli): openfga host ports so `ss stack up --with authz` works

### DIFF
--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
@@ -102,7 +102,8 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
       // env, but FGA_ENABLED only flips 'true' when the bundle is selected —
       // absent selection here, so fail-closed defaults.
       FGA_ENABLED: 'false',
-      FGA_API_URL: 'http://localhost:8080',
+      // 8180 (the HOST port from infra/.env.defaults), NOT 8080 (in-container).
+      FGA_API_URL: 'http://localhost:8180',
       FGA_STORE_ID: '',
     });
   });

--- a/packages/node/saga-stack-cli/src/core/launch-plan.ts
+++ b/packages/node/saga-stack-cli/src/core/launch-plan.ts
@@ -177,9 +177,13 @@ export interface LaunchTokens {
    * off every default `stack up` (opt-in design decision).
    */
   FGA_ENABLED: string;
-  /** OpenFGA HTTP API — `http://localhost:8080` (single-slot only; no meshOffset
-   *  port-shifting support for openfga in this pass). Feeds both iam-api's
-   *  `FGA_API_URL` and authz-sync's `OPENFGA_API_URL`. */
+  /**
+   * OpenFGA HTTP API — `http://localhost:<openfga host port + meshOffset>`
+   * (8180 at slot 0; 8080 is the IN-CONTAINER port and is deliberately not used
+   * here). Feeds both iam-api's `FGA_API_URL` and authz-sync's
+   * `OPENFGA_API_URL`, and is slot-correct because `meshMakeArgs` exports the
+   * matching `OPENFGA_HTTP_PORT` to compose.
+   */
   OPENFGA_API_URL: string;
   /**
    * The bootstrapped OpenFGA store id, or `''` before the `fga-bootstrap` seed
@@ -633,6 +637,7 @@ export function defaultLaunchContext(inputs: LaunchContextInputs, m: Manifest = 
   const mqPort = getMesh('rabbitmq', m).port + meshOffset; // 5672
   const mongoPort = getMesh('connect-mongo', m).port + meshOffset; // 27037
   const redisPort = getMesh('redis', m).port + meshOffset; // 6379
+  const openfgaPort = getMesh('openfga', m).port + meshOffset; // 8180 (host; 8080 in-container)
 
   const recorderControlPort = inputs.recorderControlPort ?? 7890;
   const recordingsApiPort = inputs.recordingsApiPort ?? 8444;
@@ -690,7 +695,7 @@ export function defaultLaunchContext(inputs: LaunchContextInputs, m: Manifest = 
 
     // OpenFGA authz (opt-in — see LaunchTokens' FGA_ENABLED/OPENFGA_* docs)
     FGA_ENABLED: inputs.withAuthz ? 'true' : 'false',
-    OPENFGA_API_URL: 'http://localhost:8080',
+    OPENFGA_API_URL: `http://localhost:${openfgaPort}`,
     OPENFGA_STORE_ID: inputs.openfgaStoreId ?? '',
 
     // global launch env (up.sh `:-` defaults; runtime may pass ambient overrides)

--- a/packages/node/saga-stack-cli/src/core/manifest/mesh.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/mesh.ts
@@ -44,8 +44,16 @@ export const MESH: Readonly<Record<MeshId, MeshDef>> = {
   openfga: {
     id: 'openfga',
     container: 'soa-openfga-1',
-    port: 8080, // HTTP API
-    mgmtPort: 8081, // gRPC (used for the health probe, not an HTTP mgmt UI)
+    // HOST ports, and deliberately NOT 8080/8081 (the IN-CONTAINER ports).
+    // `infra/.env.defaults` pins OPENFGA_HTTP_PORT=8180 / OPENFGA_GRPC_PORT=8181
+    // to keep 8080 free on the host, and compose publishes `${OPENFGA_HTTP_PORT}:8080`.
+    // These must match that mapping: they feed the check_ports preflight, the
+    // OPENFGA_*_PORT values exported to compose by meshMakeArgs, and
+    // OPENFGA_API_URL in launch-plan. Declaring 8080 here made the CLI hand
+    // authz-sync + iam-api a URL nothing listened on, so authz-sync never went
+    // healthy on ANY slot.
+    port: 8180, // HTTP API (host) → 8080 in-container
+    mgmtPort: 8181, // gRPC (host) → 8081 in-container; health probe runs IN-container on 8081
     readinessCmd: '/usr/local/bin/grpc_health_probe -addr=:8081',
     // openfga/openfga is a distroless-style image with no `sh` — `docker exec
     // ... sh -c '<cmd>'` fails with "sh: executable file not found" before the

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/mesh.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/mesh.unit.test.ts
@@ -67,7 +67,18 @@ describe('meshMakeArgs', () => {
       'RABBITMQ_PORT=5672',
       'RABBITMQ_MGMT_PORT=15672',
       'CONNECT_MONGO_PORT=27037',
+      'OPENFGA_HTTP_PORT=8180',
+      'OPENFGA_GRPC_PORT=8181',
     ]);
+  });
+
+  it('offsets the openfga ports like every other mesh unit (slot isolation)', () => {
+    // Before this, openfga was absent from the argv, so compose fell through to
+    // infra/.env.defaults' FIXED 8180/8181 and EVERY slot published openfga on the
+    // same host ports — a collision between two slots running `--with authz`.
+    const args = meshMakeArgs(manifest, { offset: 1000 });
+    expect(args).toContain('OPENFGA_HTTP_PORT=9180');
+    expect(args).toContain('OPENFGA_GRPC_PORT=9181');
   });
 
   it('M7 slot 0 (no opts / project+offset 0) is byte-identical', () => {
@@ -85,6 +96,8 @@ describe('meshMakeArgs', () => {
       'RABBITMQ_PORT=6672',
       'RABBITMQ_MGMT_PORT=16672',
       'CONNECT_MONGO_PORT=28037',
+      'OPENFGA_HTTP_PORT=9180',
+      'OPENFGA_GRPC_PORT=9181',
     ]);
   });
 

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/preflight.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/preflight.unit.test.ts
@@ -38,8 +38,11 @@ describe('meshPortSpecs / meshOwnedContainers', () => {
       { port: 5672, name: 'rabbitmq' },
       { port: 15672, name: 'rabbitmq-mgmt' },
       { port: 27037, name: 'connect-mongo' },
-      { port: 8080, name: 'openfga' },
-      { port: 8081, name: 'openfga-mgmt' },
+      // HOST ports, matching compose's `${OPENFGA_HTTP_PORT:-8080}:8080` with
+      // infra/.env.defaults' OPENFGA_HTTP_PORT=8180. Asserting 8080/8081 here
+      // meant the preflight guarded ports nothing ever bound.
+      { port: 8180, name: 'openfga' },
+      { port: 8181, name: 'openfga-mgmt' },
     ]);
   });
 
@@ -56,8 +59,8 @@ describe('meshPortSpecs / meshOwnedContainers', () => {
       { port: 6672, name: 'rabbitmq' },
       { port: 16672, name: 'rabbitmq-mgmt' },
       { port: 28037, name: 'connect-mongo' },
-      { port: 9080, name: 'openfga' },
-      { port: 9081, name: 'openfga-mgmt' },
+      { port: 9180, name: 'openfga' },
+      { port: 9181, name: 'openfga-mgmt' },
     ]);
     // offset 0 is byte-identical to the default.
     expect(meshPortSpecs(manifest, 0)).toEqual(meshPortSpecs(manifest));

--- a/packages/node/saga-stack-cli/src/runtime/mesh.ts
+++ b/packages/node/saga-stack-cli/src/runtime/mesh.ts
@@ -156,6 +156,7 @@ export function meshMakeArgs(
   const redis = getMesh('redis', m);
   const rabbit = getMesh('rabbitmq', m);
   const mongo = getMesh('connect-mongo', m);
+  const openfga = getMesh('openfga', m);
   return [
     'up',
     ...(opts.project ? [`COMPOSE_PROJECT_NAME=${opts.project}`] : []),
@@ -166,6 +167,13 @@ export function meshMakeArgs(
     `RABBITMQ_PORT=${rabbit.port + offset}`,
     `RABBITMQ_MGMT_PORT=${(rabbit.mgmtPort ?? 15672) + offset}`,
     `CONNECT_MONGO_PORT=${mongo.port + offset}`,
+    // Exported like every other mesh port so the slot offset actually reaches
+    // compose. Omitting them let compose fall through to infra/.env.defaults'
+    // FIXED 8180/8181, which meant every slot published openfga on the SAME host
+    // ports — two slots running `--with authz` would collide, and the offset the
+    // rest of the mesh honours was silently ignored for this unit.
+    `OPENFGA_HTTP_PORT=${openfga.port + offset}`,
+    `OPENFGA_GRPC_PORT=${(openfga.mgmtPort ?? 8181) + offset}`,
   ];
 }
 


### PR DESCRIPTION
## The bug

**`ss stack up --with authz` could never succeed, on any slot** — not just slots > 0. authz-sync was handed an `OPENFGA_API_URL` nothing listened on, so it never became healthy:

```
service launch FAILED at authz-sync — it never became healthy
```

Three committed places disagreed about openfga's **host** port:

| Where | Value | |
|---|---|---|
| `infra/.env.defaults:21` | `OPENFGA_HTTP_PORT=8180` | ✅ what compose publishes |
| `core/manifest/mesh.ts:47` | `port: 8080` | ❌ what the CLI believed |
| `core/launch-plan.ts:693` | `'http://localhost:8080'` | ❌ hardcoded, independently |

`8080`/`8081` are the **in-container** ports. Compose publishes `${OPENFGA_HTTP_PORT:-8080}:8080`, and `.env.defaults` overrides the host side to `8180` to keep 8080 free.

OpenFGA itself was **always fine** — `Up (healthy)`, migrations applied (`current version 6`), answering on 8180. Only the CLI's idea of where it lived was wrong.

## The fix — three coordinated changes

1. **`mesh.ts`** — declare the real host ports (8180/8181). These feed the `check_ports` preflight, which was previously guarding ports nothing ever bound. The readiness probe is unaffected: it execs `grpc_health_probe` *in-container* on 8081.
2. **`launch-plan.ts`** — derive `OPENFGA_API_URL` from the manifest + `meshOffset` instead of hardcoding, matching how pg/redis/rabbitmq/mongo already work.
3. **`runtime/mesh.ts`** — export `OPENFGA_HTTP_PORT`/`OPENFGA_GRPC_PORT` from `meshMakeArgs`. Their absence is why the offset never reached compose: every slot fell through to `.env.defaults`' **fixed** 8180/8181, so two slots running `--with authz` would collide on the same host ports.

That third change also retires the caveat this file documented against itself:

> `OPENFGA_API_URL` — `http://localhost:8080` (**single-slot only; no meshOffset port-shifting support for openfga in this pass**)

## Verified live, not just in unit tests

On slot 0 with the built CLI, `--with authz --with dash` now reports:

```
native partial-stack up: 9 service(s) launched
launched: iam-api (already up), authz-sync, sis-api (already up), …
mesh: postgres=ready, redis=ready, rabbitmq=ready, openfga=ready
seed: OK
```

- authz-sync healthy: `curl :3111/health` → **200**
- store created, model loaded, 4 canonical tuples seeded
- `meshMakeArgs` emits `8180/8181` at slot 0 and `9180/9181` at slot 1

## Tests

`1583 passed`, typecheck clean, lint clean on changed files. Three test expectations encoded the wrong ports and were corrected (`launch-plan` `FGA_API_URL`, `preflight` port specs at offset 0 and 1000); two tests added — the openfga entries in `meshMakeArgs`, and that they take the slot offset.

> One pre-existing flake, unrelated: `env-aws.unit.test.ts > probeLocalPort` fails in a full run and passes in isolation — it binds a real local port. **Confirmed identical on unmodified `main`** (1 failed / 127 files, both before and after this change).

## Two follow-ups NOT fixed here

Both independent of the ports, and both hit while verifying:

1. **`scripts/fga` deps are never installed.** It's a standalone npm package (own `package.json` + lockfile), so the `fga-bootstrap` seed step dies with `ERR_MODULE_NOT_FOUND '@openfga/syntax-transformer'` and **silently produces no store** — the seed reports fine. Needs an `npm ci` there first; I ran it by hand to unblock. (rostering-side.)
2. **authz-sync hard-fails on an empty `OPENFGA_STORE_ID`** (`missing required env OPENFGA_STORE_ID`). So the bundle's documented *"rerun `up --with authz` once more to pick up the persisted store id"* is **mandatory, not advisory**, and the first run always surfaces as a launch failure. Worth either pre-creating the store or downgrading the first-run error.

Also noted: `ss stack status` doesn't probe authz-sync or openfga, so a working authz stack is invisible to it.