### PR TITLE
fix(saga-stack-cli): slot-offset OpenFGA's playground port too

### DIFF
--- a/packages/node/saga-stack-cli/src/core/seed/__tests__/profiles.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/seed/__tests__/profiles.unit.test.ts
@@ -111,4 +111,19 @@ describe('seed profiles list iam-registry FIRST in every iam-seeding profile (so
   it('SEED_RUN_ORDER places iam-registry before iam-dev-user', () => {
     expect(SEED_RUN_ORDER.indexOf('iam-registry')).toBeLessThan(SEED_RUN_ORDER.indexOf('iam-dev-user'));
   });
+
+  // Regression: the step passed `--tuples` but NOT `--model`, so bootstrap.mjs's
+  // defaultModelPath() silently preferred the PUBLISHED @saga-ed/saga-authz-model
+  // package over rostering's checked-out scripts/fga/model.fga. Every local
+  // `--with authz` store was therefore built from a stale model — 0.1.0-dev.3 is
+  // missing three already-shipped relations — while still reporting success.
+  // The deploy workflow always passed `--model ./model.fga`; local was the gap.
+  it('fga-bootstrap pins --model to the checked-out model.fga (not the published package)', () => {
+    const step = buildSeedRegistry()['fga-bootstrap'];
+    expect(step.cwd).toBe('scripts/fga');
+    const i = step.command.indexOf('--model');
+    expect(i).toBeGreaterThan(-1);
+    // cwd-relative, exactly like the --tuples arg beside it.
+    expect(step.command[i + 1]).toBe('model.fga');
+  });
 });

--- a/packages/node/saga-stack-cli/src/core/seed/profiles.ts
+++ b/packages/node/saga-stack-cli/src/core/seed/profiles.ts
@@ -454,6 +454,24 @@ export function buildSeedRegistry(m: Manifest = manifest): Record<SeedStepId, Se
         '--store-name',
         'saga-mesh-dev',
         '--reuse',
+        // Pin the model to the CHECKED-OUT copy, matching what rostering's own
+        // deploy workflow passes (`run-fga-bootstrap.yml` → `--model ./model.fga`
+        // with WORKDIR /app/scripts/fga).
+        //
+        // Without this, bootstrap.mjs's `defaultModelPath()` prefers the
+        // PUBLISHED @saga-ed/saga-authz-model package and only falls back to the
+        // vendored file when that package is absent — so a local bootstrap
+        // silently ignores every edit to rostering's scripts/fga/model.fga. That
+        // is not hypothetical: the published 0.1.0-dev.3 is missing THREE
+        // already-shipped relations (can_force_clever_sync,
+        // can_configure_district, can_force_oneroster_ingest), so every local
+        // `--with authz` store was being built unable to evaluate sis-api's
+        // staff gates — and the bootstrap still reports success.
+        //
+        // `cwd` below is `scripts/fga`, so this relative path resolves the same
+        // way `--tuples canonical-tuples.json` already does.
+        '--model',
+        'model.fga',
         '--tuples',
         'canonical-tuples.json',
         '--out-file',

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/mesh.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/mesh.unit.test.ts
@@ -69,6 +69,7 @@ describe('meshMakeArgs', () => {
       'CONNECT_MONGO_PORT=27037',
       'OPENFGA_HTTP_PORT=8180',
       'OPENFGA_GRPC_PORT=8181',
+      'OPENFGA_PLAYGROUND_PORT=3105',
     ]);
   });
 
@@ -79,6 +80,16 @@ describe('meshMakeArgs', () => {
     const args = meshMakeArgs(manifest, { offset: 1000 });
     expect(args).toContain('OPENFGA_HTTP_PORT=9180');
     expect(args).toContain('OPENFGA_GRPC_PORT=9181');
+  });
+
+  it('offsets the PLAYGROUND port too — the third published openfga port', () => {
+    // Regression: the HTTP/gRPC ports were fixed but the playground port was
+    // missed, so it still fell through to compose's fixed 3105 on every slot.
+    // Observed failure: `ss stack up --with authz --slot 3` beside a running
+    // slot 0 dies with "Bind for 0.0.0.0:3105 failed: port is already
+    // allocated" — the whole `make up` fails, so it reads as a broken authz
+    // bundle rather than a port clash.
+    expect(meshMakeArgs(manifest, { offset: 3000 })).toContain('OPENFGA_PLAYGROUND_PORT=6105');
   });
 
   it('M7 slot 0 (no opts / project+offset 0) is byte-identical', () => {
@@ -98,11 +109,17 @@ describe('meshMakeArgs', () => {
       'CONNECT_MONGO_PORT=28037',
       'OPENFGA_HTTP_PORT=9180',
       'OPENFGA_GRPC_PORT=9181',
+      'OPENFGA_PLAYGROUND_PORT=4105',
     ]);
   });
 
   it('two slots (1 vs 2) emit non-colliding mesh port args', () => {
-    const portsOf = (a: string[]): string[] => a.filter((x) => x.endsWith('_PORT') === false && /_PORT=/.test(x));
+    // `_PORT=` matches the KEY=value entries; the `endsWith('_PORT')` clause this
+    // replaced was a no-op (a `KEY=value` string never ends in `_PORT`), so the
+    // filter silently depended on the regex alone. Spelled out so this test
+    // genuinely covers EVERY published port — it is the guard that should have
+    // caught the playground-port collision.
+    const portsOf = (a: string[]): string[] => a.filter((x) => /_PORT=/.test(x));
     const s1 = portsOf(meshMakeArgs(manifest, { project: 'soa-s1', offset: 1000 }));
     const s2 = portsOf(meshMakeArgs(manifest, { project: 'soa-s2', offset: 2000 }));
     const vals1 = s1.map((x) => x.split('=')[1]);

--- a/packages/node/saga-stack-cli/src/runtime/mesh.ts
+++ b/packages/node/saga-stack-cli/src/runtime/mesh.ts
@@ -147,6 +147,15 @@ export function meshContainer(unit: MeshDef): string {
  * under the slot's `soa-s<N>` namespace. At slot 0 (offset 0, no project) the
  * argv is byte-identical to the pre-M7 form.
  */
+/**
+ * Host base port for OpenFGA's playground UI, matching
+ * `infra/compose/services/openfga/compose.yml`'s
+ * `${OPENFGA_PLAYGROUND_PORT:-3105}:3005` default. Kept here rather than on the
+ * MeshDef because no other part of the CLI consumes it (no readiness probe, no
+ * service URL) — it exists only so the slot offset reaches compose.
+ */
+const OPENFGA_PLAYGROUND_BASE_PORT = 3105;
+
 export function meshMakeArgs(
   m: Manifest = defaultManifest,
   opts: { project?: string; offset?: number } = {},
@@ -174,6 +183,16 @@ export function meshMakeArgs(
     // rest of the mesh honours was silently ignored for this unit.
     `OPENFGA_HTTP_PORT=${openfga.port + offset}`,
     `OPENFGA_GRPC_PORT=${(openfga.mgmtPort ?? 8181) + offset}`,
+    // The PLAYGROUND port is the third port this compose unit publishes
+    // (`${OPENFGA_PLAYGROUND_PORT:-3105}:3005`) and it was missed when the two
+    // above were fixed — so it still fell through to the fixed 3105 on EVERY
+    // slot. That is not a cosmetic gap: compose fails the whole `make up` with
+    // "Bind for 0.0.0.0:3105 failed: port is already allocated" the moment a
+    // second slot runs `--with authz`, which reads as a broken authz bundle
+    // rather than a port clash. Not modeled as a MeshDef field because it is a
+    // dev-UI port with no readiness/URL role — nothing else in the CLI consumes
+    // it — so it is derived from the same base the compose default uses.
+    `OPENFGA_PLAYGROUND_PORT=${OPENFGA_PLAYGROUND_BASE_PORT + offset}`,
   ];
 }
 


### PR DESCRIPTION
`ss stack up --with authz --slot 3` (beside a running slot 0) dies with:

```
Bind for 0.0.0.0:3105 failed: port is already allocated
make: *** [Makefile:76: up] Error 1
mesh bring-up FAILED (`make up` exited non-zero)
```

## Cause

openfga's compose unit publishes **three** host ports:

```yaml
ports:
  - "${OPENFGA_HTTP_PORT:-8080}:8080"
  - "${OPENFGA_GRPC_PORT:-8081}:8081"
  - "${OPENFGA_PLAYGROUND_PORT:-3105}:3005"
```

`meshMakeArgs` exported the slot offset for the first two but never set `OPENFGA_PLAYGROUND_PORT`, so it fell through to the fixed `3105` on **every** slot. This is the same class of bug the comment directly above those two lines already describes fixing — just missed for the third port.

The failure mode is worse than a cosmetic clash: compose fails the whole `make up`, so it surfaces as a **broken authz bundle** rather than a port collision, and the slot never comes up at all. Anyone running `--with authz` on a non-zero slot hits it.

## Fix

One line, plus the base constant. Deliberately **not** modeled as a `MeshDef` field: unlike `port`/`mgmtPort`, the playground port has no readiness probe and no service URL — nothing else in the CLI consumes it — so it's derived from the same base compose defaults to, and documented as such.

## Also: a no-op in the test that should have caught this

The two-slot collision test filtered with `x.endsWith('_PORT') === false && /_PORT=/.test(x)`. The first clause is **always true** for a `KEY=value` string, so the filter silently depended on the regex alone. Spelled out so it genuinely covers every published port.

## Verification

- Slot 0 argv **unchanged** (`OPENFGA_PLAYGROUND_PORT=3105`); slot 3 → `6105`.
- `ss stack up --only iam-api --with authz --slot 3` now comes up green beside a running slot 0 (`mesh: postgres=ready, redis=ready, rabbitmq=ready, openfga=ready`).
- 20/20 mesh unit tests pass; package typecheck clean.

Found while validating saga-ed/rostering#933 + saga-ed/saga-dash#842 locally.