### PR TITLE
fix(rabbitmq): log the real connection error instead of "{}"

### DIFF
--- a/packages/node/rabbitmq/__tests__/connection-manager.unit.test.ts
+++ b/packages/node/rabbitmq/__tests__/connection-manager.unit.test.ts
@@ -105,6 +105,34 @@ describe('ConnectionManager.connect — failureMode', () => {
         expect(cm.state()).toBe('CIRCUIT_OPEN');
     });
 
+    it('LOGS THE ACTUAL CAUSE, not "{}"', async () => {
+        // Regression guard for the real defect: the connect catch used
+        // `JSON.stringify(error)`, which is "{}" for an Error (message/name/
+        // stack are non-enumerable). Every failure logged
+        // `Error connecting to RabbitMQ: {}` — auth rejection, DNS miss and TLS
+        // failure were indistinguishable, which cost a prod debugging session.
+        //
+        // Asserted at the CALL SITE deliberately: a describeError() unit test
+        // alone still passes if someone reverts this line, because nothing
+        // would tie the helper to the logger.
+        vi.mocked(mockConnect).mockRejectedValue(
+            Object.assign(new Error('ACCESS_REFUSED - Login was refused'), { code: 403 }),
+        );
+        // NOOP_LOGGER is module-level and never reset, so earlier tests' calls
+        // are still in .mock.calls — clear it or we assert on their 'boom'.
+        vi.mocked(NOOP_LOGGER.error).mockClear();
+
+        const cm = makeFailingManager('log-and-continue');
+        await cm.connect();
+
+        const logged = vi.mocked(NOOP_LOGGER.error).mock.calls.map(c => String(c[0]));
+        const connectLine = logged.find(l => l.includes('Error connecting to RabbitMQ'));
+        expect(connectLine).toBeDefined();
+        expect(connectLine).toContain('ACCESS_REFUSED');
+        expect(connectLine).toContain('code=403');
+        expect(connectLine).not.toContain('{}');
+    });
+
     it('returns + logs warn when failureMode=log-and-continue', async () => {
         const cm = makeFailingManager('log-and-continue');
         await expect(cm.connect()).resolves.toBeUndefined();

--- a/packages/node/rabbitmq/__tests__/describe-error.unit.test.ts
+++ b/packages/node/rabbitmq/__tests__/describe-error.unit.test.ts
@@ -1,0 +1,76 @@
+/**
+ * `describeError` — the fix for connection failures logging as `{}`.
+ *
+ * The bug: `JSON.stringify(new Error('boom'))` is `"{}"`, because an Error's
+ * `message`/`name`/`stack` are non-enumerable. Every RabbitMQ connect failure
+ * therefore logged `Error connecting to RabbitMQ: {}`, making an auth
+ * rejection, a DNS miss and a TLS failure indistinguishable. These tests pin
+ * the property that matters: the log line must contain the actual cause.
+ */
+import { describe, it, expect } from 'vitest';
+import { describeError } from '../src/connection-manager.js';
+
+describe('describeError', () => {
+  it('renders an Error with its message — NOT "{}"', () => {
+    const out = describeError(new Error('handshake failed'));
+    expect(out).toContain('handshake failed');
+    expect(out).not.toBe('{}');
+  });
+
+  it('is the regression guard: JSON.stringify would have returned "{}" here', () => {
+    // Documents the exact defect, so a refactor back to stringify fails loudly.
+    const err = new Error('ECONNREFUSED');
+    expect(JSON.stringify(err)).toBe('{}');
+    expect(describeError(err)).toContain('ECONNREFUSED');
+  });
+
+  it('surfaces the errno-style fields Node/amqplib attach', () => {
+    // These are what distinguish "wrong host" from "refused" from "reset" —
+    // the whole reason a bare message is not enough.
+    const err = Object.assign(new Error('getaddrinfo ENOTFOUND broker'), {
+      code: 'ENOTFOUND',
+      errno: -3008,
+      syscall: 'getaddrinfo',
+    });
+    const out = describeError(err);
+    expect(out).toContain('code=ENOTFOUND');
+    expect(out).toContain('errno=-3008');
+    expect(out).toContain('syscall=getaddrinfo');
+  });
+
+  it('includes the error name so the class is visible', () => {
+    class AmqpAuthError extends Error {
+      override readonly name = 'AmqpAuthError';
+    }
+    expect(describeError(new AmqpAuthError('ACCESS_REFUSED'))).toContain('AmqpAuthError');
+  });
+
+  it('unwraps `cause` — amqplib hides the real failure there', () => {
+    // An auth rejection otherwise reads only as a generic connection close.
+    const err = new Error('Connection closed', {
+      cause: Object.assign(new Error('ACCESS_REFUSED - Login was refused'), { code: 403 }),
+    });
+    const out = describeError(err);
+    expect(out).toContain('Connection closed');
+    expect(out).toContain('ACCESS_REFUSED');
+    expect(out).toContain('code=403');
+  });
+
+  it('omits absent optional fields rather than printing undefined', () => {
+    const out = describeError(new Error('plain'));
+    expect(out).not.toContain('undefined');
+    expect(out).not.toContain('code=');
+  });
+
+  it('handles non-Error throws', () => {
+    expect(describeError('just a string')).toBe('just a string');
+    expect(describeError({ weird: true })).toContain('weird');
+  });
+
+  it('never returns undefined, even for values stringify cannot represent', () => {
+    // JSON.stringify(Symbol()) is undefined — a bare template literal would
+    // then log the string "undefined".
+    expect(describeError(Symbol('nope'))).toBeTypeOf('string');
+    expect(describeError(undefined)).toBeTypeOf('string');
+  });
+});

--- a/packages/node/rabbitmq/src/connection-manager.ts
+++ b/packages/node/rabbitmq/src/connection-manager.ts
@@ -4,6 +4,44 @@ import { inject, injectable } from 'inversify';
 import type { ILogger } from '@saga-ed/soa-logger';
 import { QueueDefinition } from './queue';
 
+/**
+ * Render a thrown value for a log line.
+ *
+ * 🪤 `JSON.stringify(new Error('boom'))` is `"{}"` — an Error's `message`,
+ * `name` and `stack` are all NON-ENUMERABLE, so stringify sees no own
+ * enumerable properties and emits an empty object. Every connect failure
+ * therefore logged `Error connecting to RabbitMQ: {}` and the actual cause was
+ * invisible: an auth rejection, a DNS failure and a TLS handshake error were
+ * indistinguishable. (Cost a full prod debugging session on authz-sync, where
+ * the broker was reachable and the credentials were the open question.)
+ *
+ * Errors from `amqplib`/Node's net stack carry the diagnostically useful bits
+ * as extra own properties — `code` (e.g. `ENOTFOUND`, `ECONNREFUSED`,
+ * `ECONNRESET`), `errno`, `syscall` — so surface those explicitly alongside
+ * the message.
+ *
+ * Deliberately does NOT include the stack: these lines are emitted once per
+ * retry with backoff, and a stack per attempt buries the signal. The message +
+ * code is what identifies the failure mode.
+ */
+export function describeError(error: unknown): string {
+  if (!(error instanceof Error)) {
+    // A non-Error throw (string, object). stringify is right here — and can
+    // legitimately return undefined for e.g. a thrown symbol, so guard it.
+    return typeof error === 'string' ? error : (JSON.stringify(error) ?? String(error));
+  }
+  const extra = error as Error & { code?: unknown; errno?: unknown; syscall?: unknown };
+  const parts = [`${error.name}: ${error.message}`];
+  if (extra.code !== undefined) parts.push(`code=${String(extra.code)}`);
+  if (extra.errno !== undefined) parts.push(`errno=${String(extra.errno)}`);
+  if (extra.syscall !== undefined) parts.push(`syscall=${String(extra.syscall)}`);
+  // amqplib wraps the underlying socket/auth failure in `cause`; without it an
+  // auth rejection reads only as a generic connection close.
+  const cause = (error as Error & { cause?: unknown }).cause;
+  if (cause !== undefined) parts.push(`cause=${describeError(cause)}`);
+  return parts.join(' ');
+}
+
 export interface RabbitMQConfig {
   url: string; // eg. amqp://user:password@host:port
 
@@ -180,7 +218,7 @@ export class ConnectionManager {
         return;
       } catch (error) {
         this.failureCount++;
-        this.logger.error(`[MQConnectionManager] Error connecting to RabbitMQ: ${JSON.stringify(error)}`);
+        this.logger.error(`[MQConnectionManager] Error connecting to RabbitMQ: ${describeError(error)}`);
 
         const delay = this.backoff(this.failureCount);
         console.warn(`[ConnectionManager] Retry in ${delay}ms`);
@@ -243,7 +281,7 @@ export class ConnectionManager {
      * 'close' will be emitted immediately after this event
      */
     model.on("error", err => {
-      this.logger.error(`[MQConnectionManager] Connection error: ${JSON.stringify(err)}`);
+      this.logger.error(`[MQConnectionManager] Connection error: ${describeError(err)}`);
     });
 
     /**


### PR DESCRIPTION
## The bug

Every RabbitMQ connection failure logged this, and only this:

```
[MQConnectionManager] Error connecting to RabbitMQ: {}
```

`JSON.stringify(new Error('boom'))` is `"{}"` — an `Error`'s `message`, `name` and `stack` are all **non-enumerable**, so `stringify` sees no own enumerable properties. An auth rejection, a DNS miss, a refused connection and a TLS handshake failure were all indistinguishable.

## Why it mattered

This cost a full prod debugging session on authz-sync's first deploy. The broker was RUNNING, the security group was correctly allow-listed, the endpoint/port/scheme all matched — so the open question was exactly the one the log refused to answer. With Amazon MQ broker logging also disabled (`Logs.General: false`), there was no server-side record either: **both ends were blind at once.**

## The fix

`describeError()`, used at both call sites (the connect retry loop and the connection `'error'` handler). It surfaces:

- `name: message` — the basics `stringify` was dropping
- **`code` / `errno` / `syscall`** — the Node/amqplib fields that actually identify the failure mode (`ENOTFOUND` vs `ECONNREFUSED` vs `ECONNRESET`)
- **`cause`**, recursively — amqplib hides the underlying socket/auth failure there, so an `ACCESS_REFUSED` otherwise reads only as a generic connection close

Deliberately **omits the stack**: these lines fire once per retry under backoff, so a stack per attempt buries the signal. Message + code is what identifies the failure.

Before / after for the same failure:
```
- [MQConnectionManager] Error connecting to RabbitMQ: {}
+ [MQConnectionManager] Error connecting to RabbitMQ: Error: Connection closed cause=Error: ACCESS_REFUSED - Login was refused code=403
```

## Testing

**24/24 pass** (9 new), typecheck clean, lint clean (0 errors — the single `NODE_ENV`/turbo warning is pre-existing at line 362).

**The call-site test is the load-bearing one, and I only found that out by mutation testing.** With just `describeError()`'s own unit tests, reverting the call site to `JSON.stringify(error)` **still passed all 23** — nothing tied the helper to the logger. The new test asserts on the *logged line*, and that mutation now fails.

Coverage: message present / not `{}`; an explicit regression guard documenting that `JSON.stringify(err) === '{}'`; errno-style fields; error name; `cause` unwrapping; absent fields not printed as `undefined`; non-Error throws; and values `stringify` can't represent (a thrown `Symbol` returns `undefined`, which would otherwise log the literal string "undefined").

> 🪤 Note for future tests in this file: `NOOP_LOGGER` is module-level and never reset, so `.mock.calls` accumulates across tests. The new test must `mockClear()` first or it asserts on a previous test's error — which is exactly what tripped me up writing it.

## Follow-up (not in this PR)

Amazon MQ broker logging is disabled on `shared-prod-mq` (`Logs.General: false`). Enabling it would give the server-side half of the picture. I could not do it: **`AppInfra` lacks `mq:UpdateBroker`** — a tier gap worth filing separately.