### PR TITLE
chore(rabbitmq): bump to 1.4.0-dev.2 to publish the error-logging fix

### DIFF
--- a/packages/node/rabbitmq/package.json
+++ b/packages/node/rabbitmq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saga-ed/soa-rabbitmq",
-  "version": "1.4.0-dev.1",
+  "version": "1.4.0-dev.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Why

[soa#393](https://github.com/saga-ed/soa/pull/393) (`868f11a1`) landed `describeError()` — RabbitMQ connection failures no longer log as `{}` — but **left the version at `1.4.0-dev.1`**, which was **already published to CodeArtifact on 2026-07-28**, two days before that merge.

So right now `main` carries the fix and the published artifact does not. Anyone pinning `1.4.0-dev.1` keeps getting the old code.

Republishing the same version isn't an option: it either fails, or silently ships different code under a tag consumers have already resolved.

## What this does

`1.4.0-dev.1` → `1.4.0-dev.2`. Version bump only — no code change.

## Who needs it

rostering `authz-sync`, whose first prod deploy is blocked on an undiagnosable:

```
[MQConnectionManager] Error connecting to RabbitMQ: {}
```

The broker is reachable and its SG correct, so that log line is the entire remaining question. With the fix published, the next redeploy will name the actual cause (auth rejection vs DNS vs TLS) instead of `{}`.

> 🪤 **Publishing is not automatic on merge.** `publish-all-packages.yml`'s detect step uses Turborepo content hashing and reports *"No package changes detected"* when the merge-queue run already built the same tree — silently skipping the publish job. This bit the `saga-fga` release earlier in the week. **Verify the version actually lands in CodeArtifact after merge**; if it doesn't, use the `single_package` dispatch on `publish-codeartifact.yml`, which publishes the already-committed version with no further bump.