### PR TITLE
feat(health): report build identity (colour, sha, env) from /health

### DIFF
--- a/packages/node/health/package.json
+++ b/packages/node/health/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/soa-health",
-    "version": "0.1.0-dev.2",
+    "version": "0.1.0-dev.3",
     "private": false,
     "type": "module",
     "main": "dist/index.js",

--- a/packages/node/health/src/__tests__/health.unit.test.ts
+++ b/packages/node/health/src/__tests__/health.unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { mountHealthRoutes, type HealthRouter } from '../health.js';
+import { mountHealthRoutes, buildIdentity, type HealthRouter } from '../health.js';
 
 /**
  * Captures the route handlers a service would register, so we can invoke them
@@ -73,12 +73,13 @@ describe('mountHealthRoutes', () => {
     expect(body.dependencies.postgres.latencyMs).toBeUndefined();
   });
 
-  // dev.1 -> dev.2 superset guard: adding mountReadinessRoutes must NOT alter
-  // the existing two-arg mountHealthRoutes contract. program-hub is exact-pinned
-  // to dev.1 and must see byte-identical /health + /health/details output, so a
-  // future repin to dev.2 is a no-op. (timestamp is the only non-deterministic
-  // field; asserted by shape, the rest by exact value.)
-  it('dev.1 superset: the two-arg mountHealthRoutes output is unchanged', async () => {
+  // Superset guard, updated for build identity. The original form asserted an
+  // EXACT top-level key set so a repin was a byte-identical no-op. Build
+  // identity intentionally adds keys, so the invariant is now narrower but still
+  // load-bearing: with NO deploy env set (local, tests, any undeployed run) the
+  // body must be byte-identical to the pre-identity contract. Consumers pinned
+  // to an older version therefore see no change until they actually deploy.
+  it('superset: with no deploy env, the output is unchanged from the pre-identity contract', async () => {
     const { app, call, paths } = fakeApp();
     mountHealthRoutes(app, { serviceName: 'Programs API', pingDb: async () => undefined });
     expect(paths().sort()).toEqual(['/health', '/health/details']);
@@ -90,7 +91,97 @@ describe('mountHealthRoutes', () => {
     expect(details.service).toBe('Programs API');
     expect(typeof details.timestamp).toBe('string');
     expect((details.dependencies as { postgres: { status: string } }).postgres.status).toBe('healthy');
-    // exact key set — no new top-level fields leaked into the dev.1 body
     expect(Object.keys(details).sort()).toEqual(['dependencies', 'service', 'status', 'timestamp']);
+  });
+});
+
+describe('buildIdentity', () => {
+  it('parses the colour out of the comma-joined OTEL attribute string', () => {
+    expect(
+      buildIdentity({
+        OTEL_RESOURCE_ATTRIBUTES:
+          'deployment.environment=prod,deployment.environment.name=prod,deployment.identifier=blue',
+      }).colour,
+    ).toBe('blue');
+  });
+
+  it('reads version, environment and deploy time from their own vars', () => {
+    expect(
+      buildIdentity({
+        DD_VERSION: '3b436235b8ecd8eb395396e938690985b48ef554',
+        EXEC_ENV: 'prod',
+        DEPLOYMENT_DATETIME: '2026-07-31T01:08:45Z',
+      }),
+    ).toEqual({
+      version: '3b436235b8ecd8eb395396e938690985b48ef554',
+      environment: 'prod',
+      deployedAt: '2026-07-31T01:08:45Z',
+    });
+  });
+
+  // The whole point of D10: blue and green must be distinguishable. Same image,
+  // same env — only the colour differs, which is exactly the live prod shape.
+  it('distinguishes two colours running the identical image', () => {
+    const base = { DD_VERSION: 'abc123', EXEC_ENV: 'prod' };
+    const blue = buildIdentity({
+      ...base,
+      OTEL_RESOURCE_ATTRIBUTES: 'deployment.environment=prod,deployment.identifier=blue',
+    });
+    const green = buildIdentity({
+      ...base,
+      OTEL_RESOURCE_ATTRIBUTES: 'deployment.environment=prod,deployment.identifier=green',
+    });
+    expect(blue.colour).toBe('blue');
+    expect(green.colour).toBe('green');
+    expect(blue).not.toEqual(green);
+  });
+
+  it('omits absent fields rather than emitting undefined or a placeholder', () => {
+    expect(buildIdentity({})).toEqual({});
+    expect(Object.keys(buildIdentity({ DD_VERSION: 'abc' }))).toEqual(['version']);
+  });
+
+  it('tolerates a malformed or identifier-free OTEL string', () => {
+    expect(buildIdentity({ OTEL_RESOURCE_ATTRIBUTES: '' }).colour).toBeUndefined();
+    expect(buildIdentity({ OTEL_RESOURCE_ATTRIBUTES: 'novalue' }).colour).toBeUndefined();
+    expect(buildIdentity({ OTEL_RESOURCE_ATTRIBUTES: 'deployment.identifier=' }).colour).toBeUndefined();
+    expect(
+      buildIdentity({ OTEL_RESOURCE_ATTRIBUTES: 'deployment.environment=prod' }).colour,
+    ).toBeUndefined();
+  });
+
+  // deployment.environment.name CONTAINS "deployment.environment" as a prefix;
+  // a substring match would return the wrong value for the wrong key.
+  it('matches the identifier key exactly, not by prefix', () => {
+    expect(
+      buildIdentity({
+        OTEL_RESOURCE_ATTRIBUTES: 'deployment.identifier.suffix=wrong,deployment.identifier=right',
+      }).colour,
+    ).toBe('right');
+  });
+
+  it('surfaces identity on both routes when the deploy env is present', async () => {
+    const { app, call } = fakeApp();
+    const env = {
+      DD_VERSION: 'abc123',
+      EXEC_ENV: 'prod',
+      OTEL_RESOURCE_ATTRIBUTES: 'deployment.identifier=green',
+    };
+    vi.stubGlobal('process', { env });
+    try {
+      mountHealthRoutes(app, { serviceName: 'Programs API', pingDb: async () => undefined });
+      expect(await call('/health')).toEqual({
+        status: 'ok',
+        service: 'Programs API',
+        colour: 'green',
+        version: 'abc123',
+        environment: 'prod',
+      });
+      const details = (await call('/health/details')) as Record<string, unknown>;
+      expect(details.colour).toBe('green');
+      expect(details.version).toBe('abc123');
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 });

--- a/packages/node/health/src/health.ts
+++ b/packages/node/health/src/health.ts
@@ -6,6 +6,13 @@
  * dependency readiness probe (typically Postgres). Typed structurally (no
  * express import) so the helper has no framework dependency — any object with
  * `get(path, handler)` works.
+ *
+ * Both routes also report the running task's build identity (colour, git SHA,
+ * environment, deploy time) when the environment supplies it. Without that a
+ * response cannot say WHICH build or blue/green colour answered, so a
+ * header-pinned smoke test against a non-serving colour cannot prove it reached
+ * that colour: an unmatched preview header falls through to the live rule and
+ * returns an equally healthy 200.
  */
 
 export interface HealthResponse {
@@ -26,9 +33,76 @@ export interface MountHealthOptions {
   pingDb: () => Promise<unknown>;
 }
 
+/**
+ * Environment bag, typed structurally so this package keeps its zero-dependency
+ * shape (no `@types/node` at the type level, matching the framework-free router
+ * typing above).
+ */
+export type EnvLike = Record<string, string | undefined>;
+
+/** Build/deploy identity of the running task, as far as the environment reveals it. */
+export interface BuildIdentity {
+  /** Blue/green colour slot (`blue` | `green` | `main`), or undefined outside a deployed task. */
+  colour?: string;
+  /** Git SHA of the running image. */
+  version?: string;
+  /** Deployment environment, e.g. `dev` | `prod`. */
+  environment?: string;
+  /** ISO timestamp stamped at deploy time. */
+  deployedAt?: string;
+}
+
+/**
+ * Read the colour slot out of `OTEL_RESOURCE_ATTRIBUTES`.
+ *
+ * The colour is NOT its own env var — infra threads the CFN `Identifier`
+ * parameter into the comma-joined OTEL attribute string as
+ * `deployment.identifier=<colour>`. Parsing it here means every already-deployed
+ * task reports its colour with no task-definition change; a dedicated
+ * `DEPLOY_COLOR` var would require redeploying every service first.
+ */
+function readColour(env: EnvLike): string | undefined {
+  for (const pair of env.OTEL_RESOURCE_ATTRIBUTES?.split(',') ?? []) {
+    const eq = pair.indexOf('=');
+    if (eq === -1) continue;
+    if (pair.slice(0, eq).trim() !== 'deployment.identifier') continue;
+    const value = pair.slice(eq + 1).trim();
+    if (value) return value;
+  }
+  return undefined;
+}
+
+/**
+ * The ambient process environment, resolved without a static `process`
+ * reference so the package stays runtime-agnostic (and importable somewhere
+ * `process` is absent). Returns an empty bag when there is none.
+ */
+function ambientEnv(): EnvLike {
+  const proc = (globalThis as { process?: { env?: EnvLike } }).process;
+  return proc?.env ?? {};
+}
+
+/**
+ * Build identity from the ambient environment. Every field is optional: locally
+ * and in tests none of these are set, and `/health` must never fail because a
+ * deploy-time variable is missing. Absent fields are omitted from the response
+ * rather than emitted as `undefined`/`"unknown"`, so a caller can distinguish
+ * "not reported" from a real value.
+ */
+export function buildIdentity(env: EnvLike = ambientEnv()): BuildIdentity {
+  const identity: BuildIdentity = {};
+  const colour = readColour(env);
+  if (colour) identity.colour = colour;
+  // DD_VERSION is the image tag, which CI sets to the git SHA.
+  if (env.DD_VERSION) identity.version = env.DD_VERSION;
+  if (env.EXEC_ENV) identity.environment = env.EXEC_ENV;
+  if (env.DEPLOYMENT_DATETIME) identity.deployedAt = env.DEPLOYMENT_DATETIME;
+  return identity;
+}
+
 export function mountHealthRoutes(app: HealthRouter, opts: MountHealthOptions): void {
   app.get('/health', (_req, res) => {
-    res.json({ status: 'ok', service: opts.serviceName });
+    res.json({ status: 'ok', service: opts.serviceName, ...buildIdentity() });
   });
 
   app.get('/health/details', async (_req, res) => {
@@ -44,6 +118,7 @@ export function mountHealthRoutes(app: HealthRouter, opts: MountHealthOptions): 
     res.json({
       status: allHealthy ? 'healthy' : 'unhealthy',
       service: opts.serviceName,
+      ...buildIdentity(),
       timestamp: new Date().toISOString(),
       dependencies,
     });

--- a/packages/node/health/src/index.ts
+++ b/packages/node/health/src/index.ts
@@ -1,8 +1,11 @@
 export {
     mountHealthRoutes,
+    buildIdentity,
     type HealthRouter,
     type HealthResponse,
     type MountHealthOptions,
+    type BuildIdentity,
+    type EnvLike,
 } from './health.js';
 
 export {


### PR DESCRIPTION
Closes fleet gap **D10**: `/health` could not say *which* build or blue/green colour answered.

## Why

Blue/green smoke-testing needs to prove a header-pinned request reached the **non-serving**
colour. It currently cannot: an unmatched `x-saga-preview-*` header falls through to the live
rule and returns an equally healthy `200`, so a cookie-value typo is indistinguishable from a
real colour pin.

The other candidate discriminator — ALB access logs (`target:port`) — turns out to be dead in
prod: `prod-app-stack-lb` reports `access_logs.s3.enabled=true` but has written nothing to
`saga-lb-access-logs-prod` since **2026-01-05**. So `/health` is the remaining path.

## What

`/health` and `/health/details` now include build identity when the environment supplies it:

```json
{"status":"ok","service":"Programs API","colour":"blue","version":"3b436235…","environment":"prod"}
```

**No infra change is required** — the identity is already present in every running task:

| Field | Source |
|---|---|
| `version` | `DD_VERSION` (the image tag, which CI sets to the git SHA) |
| `colour` | parsed from `OTEL_RESOURCE_ATTRIBUTES` → `deployment.identifier=<colour>` |
| `environment` | `EXEC_ENV` |
| `deployedAt` | `DEPLOYMENT_DATETIME` |

The colour is not its own env var — infra threads the CFN `Identifier` parameter into the
comma-joined OTEL string. Parsing that (rather than adding a `DEPLOY_COLOR` var) means
**already-deployed tasks report their colour with no redeploy**.

## Compatibility

Every field is optional and absent fields are **omitted** (not `undefined`/`"unknown"`), so
`/health` can never fail because a deploy-time var is missing, and callers can distinguish
"not reported" from a real value.

The existing dev.1 superset guard is **kept and narrowed**, not deleted: with **no** deploy env
set (local, tests, any undeployed run) the body is byte-identical to the previous contract — so
consumers pinned to an older version see no change until they actually deploy.

## Verification

- 19/19 tests pass (health 5 → 12); typecheck and `tsup` build clean.
- Built output exercised against the **real prod env strings** from
  `program-hub-programs-api-{blue,green}:1`: both colours run the identical image
  `3b436235…` and are still correctly distinguished.
- Edge cases covered: empty/malformed OTEL string, missing `deployment.identifier`, and
  exact-key matching (`deployment.environment.name` contains `deployment.environment` as a
  prefix, so a substring match would return the wrong value).

Version bumped `0.1.0-dev.2` → `0.1.0-dev.3` (publish uses the version already committed on
`main`).

https://claude.ai/code/session_01UpHHYSEjfaP1gpMLodFCZ4