### PR TITLE
feat(saga-stack-cli): `--with staff-admin` — stand up the staff-admin console locally

### DIFF
--- a/packages/node/saga-stack-cli/README.md
+++ b/packages/node/saga-stack-cli/README.md
@@ -76,7 +76,12 @@ includes (sugar over the closure, composable: `--with dash --with coach`). Share
 #### `--with staff-admin` — the staff-admin console
 
 Brings up saga-dash's **second** app: the staff-only SvelteKit SPA (`:8910`) plus its own
-Express BFF (`:3000`), and the iam/programs/sis closure they read.
+Express BFF (`:3011`), and the iam/programs/sis closure they read.
+
+The BFF runs on **3011, not the app's own default of 3000** — `stack down`'s orphan reap
+group-kills whatever sits on the manifest's port band, and claiming `:3000` would put every
+unrelated Next/Rails dev server on the box in a SIGKILL path. The launcher injects the port
+via `PORT`, so no repo change is needed.
 
 ```bash
 ss stack up --with staff-admin   # → iam-api, sis-api, programs-api, staff-admin-bff, staff-admin-console

--- a/packages/node/saga-stack-cli/README.md
+++ b/packages/node/saga-stack-cli/README.md
@@ -101,11 +101,10 @@ Two things are expected to be missing, and are upstream gaps rather than wiring 
 Districts/Roster start empty — the seed creates personas and permissions but no district
 groups; create one from the console's Districts page.
 
-⚠️ **Slot-0 only.** `staff-admin-console`'s port is baked into `vite.config.ts` + its dev
-script and vite ignores `$PORT`, so at `--slot N` the SPA keeps `:8910` (the same
-pre-existing limitation as `saga-dash`'s `:8900`). Its BFF *does* slot, and the SPA's proxy
-target follows it, so a slot >0 console still reads its own slot's data — it just can't run
-concurrently with slot 0's console.
+Both slot normally under `--slot N`: the BFF takes its offset port via `PORT`, and the SPA
+rides the same `--port <base+offset>` argv append every `isFrontend` service uses (vite
+ignores `$PORT`, but honours the last `--port`). The SPA's proxy target follows its own
+slot's BFF, so concurrent consoles never mix stacks.
 
 ### Slots — multiple stacks on one box
 

--- a/packages/node/saga-stack-cli/README.md
+++ b/packages/node/saga-stack-cli/README.md
@@ -69,9 +69,43 @@ plus tab-completion work at every level.
 
 ### Bundles — common shapes in one word
 
-`--with dash|connect|coach|playback|qtf` expand to a set of `--only` includes (sugar over
-the closure, composable: `--with dash --with coach`). Shared across `up`/`status`/`verify`/
-`seed`/`reset`/`snapshot store`. See `ss stack bundle list`.
+`--with dash|connect|coach|playback|qtf|authz|staff-admin` expand to a set of `--only`
+includes (sugar over the closure, composable: `--with dash --with coach`). Shared across
+`up`/`status`/`verify`/`seed`/`reset`/`snapshot store`. See `ss stack bundle list`.
+
+#### `--with staff-admin` — the staff-admin console
+
+Brings up saga-dash's **second** app: the staff-only SvelteKit SPA (`:8910`) plus its own
+Express BFF (`:3000`), and the iam/programs/sis closure they read.
+
+```bash
+ss stack up --with staff-admin   # → iam-api, sis-api, programs-api, staff-admin-bff, staff-admin-console
+ss stack login                   # the console reads THIS operator cookie
+open http://localhost:8910
+```
+
+Permissions, Personas, Policies, Templates and Roster all read (and write) live stack data —
+persona permission edits persist, because iam-api's `enforceIamAdmin` and CSRF gates are
+both no-ops locally (janus verification off, `SECURITY_ENFORCECSRF` unset). Don't infer
+deployed behavior from that: deployed, both enforce.
+
+Two things are expected to be missing, and are upstream gaps rather than wiring faults:
+
+- **Impersonate is hidden.** `canImpersonate` comes from iam-api's `staffAdmin.myCapabilities`,
+  which fails closed; the synthetic seed mints no `staff:*` claims (those are janus/JumpCloud
+  group-derived, never seeded).
+- **The COACH pages 401**, even with `coach-api` up: its `staffProcedure` locally verifies a
+  `janus_session`, which the `JANUS_REQUIRED=false` local bypass never mints. `coach-api` is
+  deliberately NOT in this bundle for that reason.
+
+Districts/Roster start empty — the seed creates personas and permissions but no district
+groups; create one from the console's Districts page.
+
+⚠️ **Slot-0 only.** `staff-admin-console`'s port is baked into `vite.config.ts` + its dev
+script and vite ignores `$PORT`, so at `--slot N` the SPA keeps `:8910` (the same
+pre-existing limitation as `saga-dash`'s `:8900`). Its BFF *does* slot, and the SPA's proxy
+target follows it, so a slot >0 console still reads its own slot's data — it just can't run
+concurrently with slot 0's console.
 
 ### Slots — multiple stacks on one box
 

--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -3929,7 +3929,8 @@
             "coach",
             "playback",
             "qtf",
-            "authz"
+            "authz",
+            "staff-admin"
           ],
           "type": "option"
         }
@@ -4240,7 +4241,8 @@
             "coach",
             "playback",
             "qtf",
-            "authz"
+            "authz",
+            "staff-admin"
           ],
           "type": "option"
         }
@@ -4988,7 +4990,8 @@
             "coach",
             "playback",
             "qtf",
-            "authz"
+            "authz",
+            "staff-admin"
           ],
           "type": "option"
         }
@@ -5289,7 +5292,8 @@
             "coach",
             "playback",
             "qtf",
-            "authz"
+            "authz",
+            "staff-admin"
           ],
           "type": "option"
         }
@@ -5682,7 +5686,8 @@
             "coach",
             "playback",
             "qtf",
-            "authz"
+            "authz",
+            "staff-admin"
           ],
           "type": "option"
         },
@@ -5877,7 +5882,8 @@
             "coach",
             "playback",
             "qtf",
-            "authz"
+            "authz",
+            "staff-admin"
           ],
           "type": "option"
         }

--- a/packages/node/saga-stack-cli/src/commands/stack/reset.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/reset.ts
@@ -19,7 +19,12 @@
 
 import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command.js';
-import { BUNDLE_NAMES, effectiveWithAuthz, effectiveWithPlayback } from '../../core/bundles.js';
+import {
+  BUNDLE_NAMES,
+  effectiveWithAuthz,
+  effectiveWithPlayback,
+  effectiveWithStaffAdmin,
+} from '../../core/bundles.js';
 import { computeClosure } from '../../core/closure.js';
 import { deriveInstance } from '../../core/derive-instance.js';
 import { manifest } from '../../core/manifest/index.js';
@@ -64,6 +69,7 @@ export default class StackReset extends BaseCommand {
     const { flags } = await this.parse(StackReset);
     const withPlayback = effectiveWithPlayback(flags.with);
     const withAuthz = effectiveWithAuthz(flags.with);
+    const withStaffAdmin = effectiveWithStaffAdmin(flags.with);
 
     const profile = deriveInstance({ slot: flags.slot });
     const api = makeStackApi(manifest, this.buildNativeRuntime(flags, profile));
@@ -75,9 +81,11 @@ export default class StackReset extends BaseCommand {
       .filter((s) => !s.optional)
       .map((s) => s.id);
     const excluded = new Set(profile.excludedServices);
-    const services = computeClosure(manifest, requested, { withPlayback, withAuthz }).services.filter(
-      (id) => !excluded.has(id),
-    );
+    const services = computeClosure(manifest, requested, {
+      withPlayback,
+      withAuthz,
+      withStaffAdmin,
+    }).services.filter((id) => !excluded.has(id));
 
     const res = await api.reset(services, { withPlayback, withAuthz });
 

--- a/packages/node/saga-stack-cli/src/commands/stack/reset.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/reset.ts
@@ -19,12 +19,7 @@
 
 import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command.js';
-import {
-  BUNDLE_NAMES,
-  effectiveWithAuthz,
-  effectiveWithPlayback,
-  effectiveWithStaffAdmin,
-} from '../../core/bundles.js';
+import { BUNDLE_NAMES, closureOptsFor } from '../../core/bundles.js';
 import { computeClosure } from '../../core/closure.js';
 import { deriveInstance } from '../../core/derive-instance.js';
 import { manifest } from '../../core/manifest/index.js';
@@ -67,9 +62,7 @@ export default class StackReset extends BaseCommand {
 
   async run(): Promise<void> {
     const { flags } = await this.parse(StackReset);
-    const withPlayback = effectiveWithPlayback(flags.with);
-    const withAuthz = effectiveWithAuthz(flags.with);
-    const withStaffAdmin = effectiveWithStaffAdmin(flags.with);
+    const closureOpts = closureOptsFor(flags.with);
 
     const profile = deriveInstance({ slot: flags.slot });
     const api = makeStackApi(manifest, this.buildNativeRuntime(flags, profile));
@@ -81,13 +74,11 @@ export default class StackReset extends BaseCommand {
       .filter((s) => !s.optional)
       .map((s) => s.id);
     const excluded = new Set(profile.excludedServices);
-    const services = computeClosure(manifest, requested, {
-      withPlayback,
-      withAuthz,
-      withStaffAdmin,
-    }).services.filter((id) => !excluded.has(id));
+    const services = computeClosure(manifest, requested, closureOpts).services.filter(
+      (id) => !excluded.has(id),
+    );
 
-    const res = await api.reset(services, { withPlayback, withAuthz });
+    const res = await api.reset(services, closureOpts);
 
     const truncated = res.native?.dbs.filter((d) => d.action === 'truncated').map((d) => d.db) ?? [];
     const migrateReset = res.native?.dbs.filter((d) => d.action === 'migrate-reset').map((d) => d.db) ?? [];

--- a/packages/node/saga-stack-cli/src/commands/stack/restart.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/restart.ts
@@ -76,6 +76,17 @@ export default class StackRestart extends BaseCommand {
     }
     if (up.av) this.log(up.av.message);
     for (const s of up.skipped) this.log(`⚠ ${s.message}`);
+    // Overlay-bound optionals were stopped by the reap but deliberately not
+    // relaunched (restart builds no overlay — relaunching would misconfigure
+    // them). Say so loudly: a silent drop here is what makes an operator think
+    // authz is still live after a bounce.
+    for (const id of outcome.notRelaunched ?? []) {
+      this.log(
+        `⚠ ${id} was stopped but NOT relaunched — it needs its overlay. Re-run: ss stack up --with ${
+          id === 'authz-sync' ? 'authz' : id
+        }`,
+      );
+    }
 
     this.emit(
       flags,

--- a/packages/node/saga-stack-cli/src/commands/stack/restart.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/restart.ts
@@ -18,6 +18,7 @@
 
 import { BaseCommand } from '../../base-command.js';
 import type { NativeRuntimeFlags } from '../../base-command.js';
+import { bundleForService } from '../../core/bundles.js';
 import { computeClosure } from '../../core/closure.js';
 import { deriveInstance } from '../../core/derive-instance.js';
 import type { InstanceProfile } from '../../core/derive-instance.js';
@@ -81,10 +82,13 @@ export default class StackRestart extends BaseCommand {
     // them). Say so loudly: a silent drop here is what makes an operator think
     // authz is still live after a bounce.
     for (const id of outcome.notRelaunched ?? []) {
+      // Print the BUNDLE name, not the service id — `--with authz-sync` is not a
+      // valid bundle. Derived from the registry so a second overlay-bound service
+      // cannot silently start printing an uninvokable command.
+      const bundle = bundleForService(id);
       this.log(
-        `⚠ ${id} was stopped but NOT relaunched — it needs its overlay. Re-run: ss stack up --with ${
-          id === 'authz-sync' ? 'authz' : id
-        }`,
+        `⚠ ${id} was stopped but NOT relaunched — it needs its overlay.` +
+          (bundle ? ` Re-run: ss stack up --with ${bundle}` : ''),
       );
     }
 

--- a/packages/node/saga-stack-cli/src/commands/stack/seed.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/seed.ts
@@ -33,6 +33,7 @@ import {
   combineRequested,
   effectiveWithAuthz,
   effectiveWithPlayback,
+  effectiveWithStaffAdmin,
   seedAddOnsFor,
 } from '../../core/bundles.js';
 import { computeClosure } from '../../core/closure.js';
@@ -138,6 +139,7 @@ export default class StackSeed extends BaseCommand {
     // the services are assumed already up.
     const withPlayback = effectiveWithPlayback(flags.with);
     const withAuthz = effectiveWithAuthz(flags.with);
+    const withStaffAdmin = effectiveWithStaffAdmin(flags.with);
     const fullNonOptional = (Object.values(manifest.services) as { id: ServiceId; optional: boolean }[])
       .filter((s) => !s.optional)
       .map((s) => s.id);
@@ -148,7 +150,11 @@ export default class StackSeed extends BaseCommand {
     // subtract them from the active set exactly like `reset` does, so their
     // seed steps degrade to service-inactive skips instead of failing.
     const excluded = new Set(instance.excludedServices);
-    const closureServices = computeClosure(manifest, requested, { withPlayback, withAuthz }).services;
+    const closureServices = computeClosure(manifest, requested, {
+      withPlayback,
+      withAuthz,
+      withStaffAdmin,
+    }).services;
     const active = new Set(closureServices.filter((id) => !excluded.has(id)));
     const droppedForSlot = closureServices.filter((id) => excluded.has(id));
     if (droppedForSlot.length > 0) {

--- a/packages/node/saga-stack-cli/src/commands/stack/seed.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/seed.ts
@@ -30,10 +30,8 @@ import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command.js';
 import {
   BUNDLE_NAMES,
+  closureOptsFor,
   combineRequested,
-  effectiveWithAuthz,
-  effectiveWithPlayback,
-  effectiveWithStaffAdmin,
   seedAddOnsFor,
 } from '../../core/bundles.js';
 import { computeClosure } from '../../core/closure.js';
@@ -137,9 +135,6 @@ export default class StackSeed extends BaseCommand {
     // playback trio (transcripts/insights/chat) so their add-on seed steps compose
     // instead of being dropped as service-inactive. There is no prep/mesh/launch —
     // the services are assumed already up.
-    const withPlayback = effectiveWithPlayback(flags.with);
-    const withAuthz = effectiveWithAuthz(flags.with);
-    const withStaffAdmin = effectiveWithStaffAdmin(flags.with);
     const fullNonOptional = (Object.values(manifest.services) as { id: ServiceId; optional: boolean }[])
       .filter((s) => !s.optional)
       .map((s) => s.id);
@@ -150,11 +145,7 @@ export default class StackSeed extends BaseCommand {
     // subtract them from the active set exactly like `reset` does, so their
     // seed steps degrade to service-inactive skips instead of failing.
     const excluded = new Set(instance.excludedServices);
-    const closureServices = computeClosure(manifest, requested, {
-      withPlayback,
-      withAuthz,
-      withStaffAdmin,
-    }).services;
+    const closureServices = computeClosure(manifest, requested, closureOptsFor(flags.with)).services;
     const active = new Set(closureServices.filter((id) => !excluded.has(id)));
     const droppedForSlot = closureServices.filter((id) => excluded.has(id));
     if (droppedForSlot.length > 0) {

--- a/packages/node/saga-stack-cli/src/commands/stack/snapshot/restore.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/snapshot/restore.ts
@@ -30,6 +30,7 @@ import { join } from 'node:path';
 import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../../base-command.js';
 import { deriveInstance } from '../../../core/derive-instance.js';
+import { closureOptsForIds } from '../../../core/bundles.js';
 import { computeClosure } from '../../../core/closure.js';
 import { manifest } from '../../../core/manifest/index.js';
 import type { DbId, ServiceId } from '../../../core/manifest/index.js';
@@ -213,7 +214,12 @@ export function scopeSnapshot(
     fail(`unknown service id(s): ${unknown.join(', ')}\nknown: ${[...known].join(', ')}`);
   }
 
-  const dbSet = new Set<DbId>(computeClosure(manifest, requested, { withPlayback: true }).databases);
+  // `scopeSnapshot` only has the requested service ids (`restore` carries no `--with`
+  // flag — only `--only`), so derive the opt-in flags from the ids themselves rather
+  // than hardcoding `withPlayback: true`: that hardcode is exactly the bug this fixes
+  // — `--only staff-admin-*` needs `withStaffAdmin`, not `withPlayback`, and resolved
+  // an EMPTY closure (silent "no database present in snapshot" failure) without it.
+  const dbSet = new Set<DbId>(computeClosure(manifest, requested, closureOptsForIds(requested)).databases);
   const databases = snapshot.databases.filter((d) => dbSet.has(d.db));
   if (databases.length === 0) {
     fail(

--- a/packages/node/saga-stack-cli/src/commands/stack/snapshot/store.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/snapshot/store.ts
@@ -23,8 +23,14 @@ import { join } from 'node:path';
 import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../../base-command.js';
 import { deriveInstance } from '../../../core/derive-instance.js';
-import { BUNDLE_NAMES, combineRequested, effectiveWithAuthz, effectiveWithPlayback } from '../../../core/bundles.js';
-import { computeClosure } from '../../../core/closure.js';
+import {
+  BUNDLE_NAMES,
+  combineRequested,
+  effectiveWithAuthz,
+  effectiveWithPlayback,
+  effectiveWithStaffAdmin,
+} from '../../../core/bundles.js';
+import { computeClosure, type ClosureOpts } from '../../../core/closure.js';
 import { manifest } from '../../../core/manifest/index.js';
 import type { DbId, ServiceId } from '../../../core/manifest/index.js';
 import { storePlan, CURRENT_SNAPSHOT_SCHEMA_VERSION } from '../../../core/snapshot/index.js';
@@ -113,13 +119,13 @@ export default class SnapshotStore extends BaseCommand {
     // degrades gracefully rather than dumping absent playback DBs.
     const withPlayback = effectiveWithPlayback(flags.with);
     const withAuthz = effectiveWithAuthz(flags.with);
+    const withStaffAdmin = effectiveWithStaffAdmin(flags.with);
     const excluded = new Set<ServiceId>(instance.excludedServices);
     let only: DbId[] | undefined;
     if (flags.only) {
       only = closureDatabases(
         combineRequested(flags.only, flags.with, (m) => this.error(m)),
-        withPlayback,
-        withAuthz,
+        { withPlayback, withAuthz, withStaffAdmin },
         (m) => this.error(m),
       );
     } else if (instance.slot > 0) {
@@ -128,9 +134,11 @@ export default class SnapshotStore extends BaseCommand {
         .map((s) => s.id);
       const bundleServices = combineRequested(undefined, flags.with, (m) => this.error(m));
       const requested = [...new Set<ServiceId>([...fullNonOptional, ...bundleServices])];
-      const kept = computeClosure(manifest, requested, { withPlayback, withAuthz }).services.filter(
-        (id) => !excluded.has(id),
-      );
+      const kept = computeClosure(manifest, requested, {
+        withPlayback,
+        withAuthz,
+        withStaffAdmin,
+      }).services.filter((id) => !excluded.has(id));
       only = [...new Set<DbId>(kept.flatMap((id) => manifest.services[id].databases))];
     }
 
@@ -215,13 +223,18 @@ export default class SnapshotStore extends BaseCommand {
  * Resolve a requested service set (`--only <svc,…>` ∪ `--with <bundle>` services,
  * already combined by `combineRequested`) to its closure's DB set (`DbId[]`).
  * Mirrors `status`'s `resolveServiceSet`: unknown ids fail with a friendly oclif
- * error. `withPlayback`/`withAuthz` keep their respective optional services in
- * the closure.
+ * error.
+ *
+ * Takes the opt-in flags as a ClosureOpts-shaped OBJECT rather than positionals:
+ * every `optional:true` service needs its OWN flag (see `admitsOptional`), and a
+ * missing positional silently yields an EMPTY db list here — which `storePlan`
+ * then honours as "dump exactly these", writing a zero-database snapshot that
+ * exits 0. Spreading one object keeps a new optional service from re-opening
+ * that hole.
  */
 export function closureDatabases(
   requested: ServiceId[],
-  withPlayback: boolean,
-  withAuthz: boolean,
+  opts: Pick<ClosureOpts, 'withPlayback' | 'withAuthz' | 'withStaffAdmin'>,
   fail: (msg: string) => never,
 ): DbId[] {
   const known = new Set(Object.keys(manifest.services));
@@ -230,5 +243,5 @@ export function closureDatabases(
     fail(`unknown service id(s): ${unknown.join(', ')}\nknown: ${[...known].join(', ')}`);
   }
 
-  return computeClosure(manifest, requested, { withPlayback, withAuthz }).databases;
+  return computeClosure(manifest, requested, opts).databases;
 }

--- a/packages/node/saga-stack-cli/src/commands/stack/snapshot/store.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/snapshot/store.ts
@@ -23,13 +23,7 @@ import { join } from 'node:path';
 import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../../base-command.js';
 import { deriveInstance } from '../../../core/derive-instance.js';
-import {
-  BUNDLE_NAMES,
-  combineRequested,
-  effectiveWithAuthz,
-  effectiveWithPlayback,
-  effectiveWithStaffAdmin,
-} from '../../../core/bundles.js';
+import { BUNDLE_NAMES, closureOptsFor, combineRequested } from '../../../core/bundles.js';
 import { computeClosure, type ClosureOpts } from '../../../core/closure.js';
 import { manifest } from '../../../core/manifest/index.js';
 import type { DbId, ServiceId } from '../../../core/manifest/index.js';
@@ -117,15 +111,13 @@ export default class SnapshotStore extends BaseCommand {
     // an excluded service back in (a dependency edge from a non-excluded service
     // into an excluded one), and it applies AFTER the --with union so `--with playback --slot N`
     // degrades gracefully rather than dumping absent playback DBs.
-    const withPlayback = effectiveWithPlayback(flags.with);
-    const withAuthz = effectiveWithAuthz(flags.with);
-    const withStaffAdmin = effectiveWithStaffAdmin(flags.with);
+    const closureOpts = closureOptsFor(flags.with);
     const excluded = new Set<ServiceId>(instance.excludedServices);
     let only: DbId[] | undefined;
     if (flags.only) {
       only = closureDatabases(
         combineRequested(flags.only, flags.with, (m) => this.error(m)),
-        { withPlayback, withAuthz, withStaffAdmin },
+        closureOpts,
         (m) => this.error(m),
       );
     } else if (instance.slot > 0) {
@@ -134,11 +126,9 @@ export default class SnapshotStore extends BaseCommand {
         .map((s) => s.id);
       const bundleServices = combineRequested(undefined, flags.with, (m) => this.error(m));
       const requested = [...new Set<ServiceId>([...fullNonOptional, ...bundleServices])];
-      const kept = computeClosure(manifest, requested, {
-        withPlayback,
-        withAuthz,
-        withStaffAdmin,
-      }).services.filter((id) => !excluded.has(id));
+      const kept = computeClosure(manifest, requested, closureOpts).services.filter(
+        (id) => !excluded.has(id),
+      );
       only = [...new Set<DbId>(kept.flatMap((id) => manifest.services[id].databases))];
     }
 
@@ -146,8 +136,8 @@ export default class SnapshotStore extends BaseCommand {
       fixtureId,
       profile: flags.profile,
       only,
-      withPlayback,
-      withAuthz,
+      withPlayback: closureOpts.withPlayback,
+      withAuthz: closureOpts.withAuthz,
     });
 
     const io = this.getSnapshotIO();
@@ -225,16 +215,19 @@ export default class SnapshotStore extends BaseCommand {
  * Mirrors `status`'s `resolveServiceSet`: unknown ids fail with a friendly oclif
  * error.
  *
- * Takes the opt-in flags as a ClosureOpts-shaped OBJECT rather than positionals:
+ * Takes the opt-in flags as a `Required<…>` OBJECT rather than positionals:
  * every `optional:true` service needs its OWN flag (see `admitsOptional`), and a
- * missing positional silently yields an EMPTY db list here — which `storePlan`
- * then honours as "dump exactly these", writing a zero-database snapshot that
- * exits 0. Spreading one object keeps a new optional service from re-opening
- * that hole.
+ * missing flag silently yields an EMPTY db list here — which `storePlan` then
+ * honours as "dump exactly these", writing a zero-database snapshot that exits 0.
+ *
+ * `Required` is load-bearing: every `ClosureOpts` field is declared `?:`, so a
+ * bare `Pick` would leave them all optional and `closureDatabases(ids, {}, fail)`
+ * would typecheck — re-opening the exact hole this signature exists to close.
+ * Callers should pass `closureOptsFor(flags.with)` rather than hand-building it.
  */
 export function closureDatabases(
   requested: ServiceId[],
-  opts: Pick<ClosureOpts, 'withPlayback' | 'withAuthz' | 'withStaffAdmin'>,
+  opts: Required<Pick<ClosureOpts, 'withPlayback' | 'withAuthz' | 'withStaffAdmin'>>,
   fail: (msg: string) => never,
 ): DbId[] {
   const known = new Set(Object.keys(manifest.services));

--- a/packages/node/saga-stack-cli/src/commands/stack/snapshot/store.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/snapshot/store.ts
@@ -24,7 +24,8 @@ import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../../base-command.js';
 import { deriveInstance } from '../../../core/derive-instance.js';
 import { BUNDLE_NAMES, closureOptsFor, combineRequested } from '../../../core/bundles.js';
-import { computeClosure, type ClosureOpts } from '../../../core/closure.js';
+import type { ResolvedClosureOpts } from '../../../core/bundles.js';
+import { computeClosure } from '../../../core/closure.js';
 import { manifest } from '../../../core/manifest/index.js';
 import type { DbId, ServiceId } from '../../../core/manifest/index.js';
 import { storePlan, CURRENT_SNAPSHOT_SCHEMA_VERSION } from '../../../core/snapshot/index.js';
@@ -227,7 +228,7 @@ export default class SnapshotStore extends BaseCommand {
  */
 export function closureDatabases(
   requested: ServiceId[],
-  opts: Required<Pick<ClosureOpts, 'withPlayback' | 'withAuthz' | 'withStaffAdmin'>>,
+  opts: ResolvedClosureOpts,
   fail: (msg: string) => never,
 ): DbId[] {
   const known = new Set(Object.keys(manifest.services));

--- a/packages/node/saga-stack-cli/src/commands/stack/status.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/status.ts
@@ -27,13 +27,7 @@
 
 import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command.js';
-import {
-  BUNDLE_NAMES,
-  combineRequested,
-  effectiveWithAuthz,
-  effectiveWithPlayback,
-  effectiveWithStaffAdmin,
-} from '../../core/bundles.js';
+import { BUNDLE_NAMES, closureOptsFor, combineRequested } from '../../core/bundles.js';
 import { computeClosure } from '../../core/closure.js';
 import { deriveInstance } from '../../core/derive-instance.js';
 import { healthProbes } from '../../core/probe-plan.js';
@@ -192,11 +186,7 @@ export function resolveServiceSet(
     fail(`unknown service id(s): ${unknown.join(', ')}\nknown: ${[...known].join(', ')}`);
   }
 
-  return computeClosure(manifest, requested, {
-    withPlayback: effectiveWithPlayback(withBundles),
-    withAuthz: effectiveWithAuthz(withBundles),
-    withStaffAdmin: effectiveWithStaffAdmin(withBundles),
-  }).services;
+  return computeClosure(manifest, requested, closureOptsFor(withBundles)).services;
 }
 
 /** A service excluded from the health pass because its sibling repo isn't cloned. */

--- a/packages/node/saga-stack-cli/src/commands/stack/status.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/status.ts
@@ -32,6 +32,7 @@ import {
   combineRequested,
   effectiveWithAuthz,
   effectiveWithPlayback,
+  effectiveWithStaffAdmin,
 } from '../../core/bundles.js';
 import { computeClosure } from '../../core/closure.js';
 import { deriveInstance } from '../../core/derive-instance.js';
@@ -194,6 +195,7 @@ export function resolveServiceSet(
   return computeClosure(manifest, requested, {
     withPlayback: effectiveWithPlayback(withBundles),
     withAuthz: effectiveWithAuthz(withBundles),
+    withStaffAdmin: effectiveWithStaffAdmin(withBundles),
   }).services;
 }
 

--- a/packages/node/saga-stack-cli/src/commands/stack/up.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/up.ts
@@ -44,6 +44,7 @@ import {
   combineRequested,
   effectiveWithAuthz,
   effectiveWithPlayback,
+  effectiveWithStaffAdmin,
   seedAddOnsFor,
 } from '../../core/bundles.js';
 import { computeClosure } from '../../core/closure.js';
@@ -194,11 +195,14 @@ export default class StackUp extends BaseCommand {
     // Workspace files carry no authz axis (mirrors playback's `ws.playback`, but
     // `--with authz` is a `--only`/`--with` concept only, not modeled in workspace JSON).
     const withAuthz = ws ? false : effectiveWithAuthz(flags.with);
+    // Same shape as `withAuthz` — `--with staff-admin` is a `--only`/`--with` concept
+    // only, not modeled in workspace JSON.
+    const withStaffAdmin = ws ? false : effectiveWithStaffAdmin(flags.with);
 
     // ── --dry-run (M0/M4): planner only. Compute the SAME sandbox/workspace prune the
     // launch path applies (BLOCKER-1) so the dry-run reflects what actually launches. ──
     if (flags['dry-run']) {
-      this.runDryRun(flags, requested, isOnly, withPlayback, withAuthz, {
+      this.runDryRun(flags, requested, isOnly, withPlayback, withAuthz, withStaffAdmin, {
         sandboxHybrid: flags.sandbox !== undefined,
         sandboxServices: ws ? new Set(ws.sandboxServices) : undefined,
         sandboxName: ws?.iamSandbox ?? flags.sandbox,
@@ -249,7 +253,7 @@ export default class StackUp extends BaseCommand {
     //    deps the closure pulled in — iam-api et al. live at the cloud sandbox).
     //  - `--workspace`: subtract EVERY mode:sandbox service id (`ws.sandboxServices`).
     const overlays = await this.resolveOverlays(flags, sandboxName, withAuthz);
-    await this.runNative(flags, requested, withPlayback, withAuthz, overlays, {
+    await this.runNative(flags, requested, withPlayback, withAuthz, withStaffAdmin, overlays, {
       sandboxHybrid: flags.sandbox !== undefined,
       sandboxServices: ws ? new Set(ws.sandboxServices) : undefined,
       sandboxName,
@@ -369,6 +373,7 @@ export default class StackUp extends BaseCommand {
     isOnly: boolean,
     withPlayback: boolean,
     withAuthz: boolean,
+    withStaffAdmin: boolean,
     prune: LaunchPrune = {},
   ): void {
     const resolvedRequest: ServiceId[] = isOnly
@@ -383,7 +388,7 @@ export default class StackUp extends BaseCommand {
       this.error(`unknown service id(s): ${unknown.join(', ')}\nknown: ${[...known].join(', ')}`);
     }
 
-    const closure = computeClosure(manifest, resolvedRequest, { withPlayback, withAuthz });
+    const closure = computeClosure(manifest, resolvedRequest, { withPlayback, withAuthz, withStaffAdmin });
 
     // M7: at slot > 0 the bring-up would EXCLUDE the literal-port services; surface
     // that in the preview so the dry-run matches what a real `--slot N` up launches.
@@ -466,6 +471,7 @@ export default class StackUp extends BaseCommand {
     requested: ServiceId[],
     withPlayback: boolean,
     withAuthz: boolean,
+    withStaffAdmin: boolean,
     overlays: NativeOverlays = {},
     prune: LaunchPrune = {},
   ): Promise<void> {
@@ -489,7 +495,7 @@ export default class StackUp extends BaseCommand {
     // THIS slot's rtsm, not slot 0's) is generated in `buildRuntime`, the seam BOTH
     // `stack up` and `e2e run` share; it need not be repeated here.
 
-    const fullClosure = computeClosure(manifest, requested, { withPlayback, withAuthz });
+    const fullClosure = computeClosure(manifest, requested, { withPlayback, withAuthz, withStaffAdmin });
 
     // Exclude the still-un-slottable services from a slot > 0 bring-up: only the
     // literal-port playback trio (transcripts/insights/chat) carries literal cross-slot

--- a/packages/node/saga-stack-cli/src/commands/stack/up.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/up.ts
@@ -195,9 +195,11 @@ export default class StackUp extends BaseCommand {
     // Workspace files carry no authz axis (mirrors playback's `ws.playback`, but
     // `--with authz` is a `--only`/`--with` concept only, not modeled in workspace JSON).
     const withAuthz = ws ? false : effectiveWithAuthz(flags.with);
-    // Same shape as `withAuthz` — `--with staff-admin` is a `--only`/`--with` concept
-    // only, not modeled in workspace JSON.
-    const withStaffAdmin = ws ? false : effectiveWithStaffAdmin(flags.with);
+    // Unlike `withAuthz`, workspaces DO model this: a workspace names services
+    // directly, so `ws.staffAdmin` (derived from the run set, exactly like
+    // `ws.playback`) is how a workspace asks for the console. Hard-coding false
+    // here would drop the pair and report a successful `up` that never started it.
+    const withStaffAdmin = ws ? ws.staffAdmin : effectiveWithStaffAdmin(flags.with);
 
     // ── --dry-run (M0/M4): planner only. Compute the SAME sandbox/workspace prune the
     // launch path applies (BLOCKER-1) so the dry-run reflects what actually launches. ──

--- a/packages/node/saga-stack-cli/src/commands/stack/up.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/up.ts
@@ -46,8 +46,8 @@ import {
   combineRequested,
   seedAddOnsFor,
 } from '../../core/bundles.js';
+import type { ResolvedClosureOpts } from '../../core/bundles.js';
 import { computeClosure } from '../../core/closure.js';
-import type { ClosureOpts } from '../../core/closure.js';
 import { deriveInstance, slotExcludedServices } from '../../core/derive-instance.js';
 import type { InstanceProfile } from '../../core/derive-instance.js';
 import * as flagMap from '../../core/flag-map.js';
@@ -193,13 +193,13 @@ export default class StackUp extends BaseCommand {
     let isOnly = requested.length > 0 || ws !== undefined;
     // When a workspace is set, its flags come from the run set — a workspace
     // names services DIRECTLY, so naming e.g. `authz-sync` is the workspace's way
-    // of asking for it, NOT from flags.with. `closureOptsForIds(ws.runSet)` derives
-    // all three the SAME way `WorkspaceSelection.playback`/`.authz`/`.staffAdmin`
-    // do (id-family membership) — using it here (rather than reading those fields)
-    // means a future bundle only needs a registry edit in bundles.ts, not a second
-    // hand-listed derivation here. Hard-coding withAuthz to false previously
-    // dropped a workspace-named `authz-sync` silently.
-    const closureOpts: Required<Pick<ClosureOpts, 'withPlayback' | 'withAuthz' | 'withStaffAdmin'>> =
+    // of asking for it, NOT from flags.with. `closureOptsForIds` derives every
+    // flag from the BUNDLES-backed id sets, so a future bundle needs only a
+    // registry edit in bundles.ts rather than a hand-listed derivation here (which
+    // is why `parseWorkspace` exposes no per-family booleans of its own).
+    // Hard-coding withAuthz to false previously dropped a workspace-named
+    // `authz-sync` silently.
+    const closureOpts: ResolvedClosureOpts =
       ws ? closureOptsForIds(ws.runSet) : closureOptsFor(flags.with);
     const { withAuthz } = closureOpts;
 
@@ -375,7 +375,7 @@ export default class StackUp extends BaseCommand {
     flags: DryRunFlags,
     requested: ServiceId[],
     isOnly: boolean,
-    closureOpts: Required<Pick<ClosureOpts, 'withPlayback' | 'withAuthz' | 'withStaffAdmin'>>,
+    closureOpts: ResolvedClosureOpts,
     prune: LaunchPrune = {},
   ): void {
     const resolvedRequest: ServiceId[] = isOnly
@@ -471,7 +471,7 @@ export default class StackUp extends BaseCommand {
   private async runNative(
     flags: NativeFlags,
     requested: ServiceId[],
-    closureOpts: Required<Pick<ClosureOpts, 'withPlayback' | 'withAuthz' | 'withStaffAdmin'>>,
+    closureOpts: ResolvedClosureOpts,
     overlays: NativeOverlays = {},
     prune: LaunchPrune = {},
   ): Promise<void> {

--- a/packages/node/saga-stack-cli/src/commands/stack/up.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/up.ts
@@ -41,13 +41,13 @@ import { BaseCommand } from '../../base-command.js';
 import type { NativeOverlays, WorkspaceFlags } from '../../base-command.js';
 import {
   BUNDLE_NAMES,
+  closureOptsFor,
+  closureOptsForIds,
   combineRequested,
-  effectiveWithAuthz,
-  effectiveWithPlayback,
-  effectiveWithStaffAdmin,
   seedAddOnsFor,
 } from '../../core/bundles.js';
 import { computeClosure } from '../../core/closure.js';
+import type { ClosureOpts } from '../../core/closure.js';
 import { deriveInstance, slotExcludedServices } from '../../core/derive-instance.js';
 import type { InstanceProfile } from '../../core/derive-instance.js';
 import * as flagMap from '../../core/flag-map.js';
@@ -191,20 +191,22 @@ export default class StackUp extends BaseCommand {
       ? ws.runSet
       : combineRequested(flags.only, flags.with, (m) => this.error(m));
     let isOnly = requested.length > 0 || ws !== undefined;
-    const withPlayback = ws ? ws.playback : effectiveWithPlayback(flags.with);
-    // Workspace files carry no authz axis (mirrors playback's `ws.playback`, but
-    // `--with authz` is a `--only`/`--with` concept only, not modeled in workspace JSON).
-    const withAuthz = ws ? false : effectiveWithAuthz(flags.with);
-    // Unlike `withAuthz`, workspaces DO model this: a workspace names services
-    // directly, so `ws.staffAdmin` (derived from the run set, exactly like
-    // `ws.playback`) is how a workspace asks for the console. Hard-coding false
-    // here would drop the pair and report a successful `up` that never started it.
-    const withStaffAdmin = ws ? ws.staffAdmin : effectiveWithStaffAdmin(flags.with);
+    // When a workspace is set, its flags come from the run set — a workspace
+    // names services DIRECTLY, so naming e.g. `authz-sync` is the workspace's way
+    // of asking for it, NOT from flags.with. `closureOptsForIds(ws.runSet)` derives
+    // all three the SAME way `WorkspaceSelection.playback`/`.authz`/`.staffAdmin`
+    // do (id-family membership) — using it here (rather than reading those fields)
+    // means a future bundle only needs a registry edit in bundles.ts, not a second
+    // hand-listed derivation here. Hard-coding withAuthz to false previously
+    // dropped a workspace-named `authz-sync` silently.
+    const closureOpts: Required<Pick<ClosureOpts, 'withPlayback' | 'withAuthz' | 'withStaffAdmin'>> =
+      ws ? closureOptsForIds(ws.runSet) : closureOptsFor(flags.with);
+    const { withAuthz } = closureOpts;
 
     // ── --dry-run (M0/M4): planner only. Compute the SAME sandbox/workspace prune the
     // launch path applies (BLOCKER-1) so the dry-run reflects what actually launches. ──
     if (flags['dry-run']) {
-      this.runDryRun(flags, requested, isOnly, withPlayback, withAuthz, withStaffAdmin, {
+      this.runDryRun(flags, requested, isOnly, closureOpts, {
         sandboxHybrid: flags.sandbox !== undefined,
         sandboxServices: ws ? new Set(ws.sandboxServices) : undefined,
         sandboxName: ws?.iamSandbox ?? flags.sandbox,
@@ -255,7 +257,7 @@ export default class StackUp extends BaseCommand {
     //    deps the closure pulled in — iam-api et al. live at the cloud sandbox).
     //  - `--workspace`: subtract EVERY mode:sandbox service id (`ws.sandboxServices`).
     const overlays = await this.resolveOverlays(flags, sandboxName, withAuthz);
-    await this.runNative(flags, requested, withPlayback, withAuthz, withStaffAdmin, overlays, {
+    await this.runNative(flags, requested, closureOpts, overlays, {
       sandboxHybrid: flags.sandbox !== undefined,
       sandboxServices: ws ? new Set(ws.sandboxServices) : undefined,
       sandboxName,
@@ -373,9 +375,7 @@ export default class StackUp extends BaseCommand {
     flags: DryRunFlags,
     requested: ServiceId[],
     isOnly: boolean,
-    withPlayback: boolean,
-    withAuthz: boolean,
-    withStaffAdmin: boolean,
+    closureOpts: Required<Pick<ClosureOpts, 'withPlayback' | 'withAuthz' | 'withStaffAdmin'>>,
     prune: LaunchPrune = {},
   ): void {
     const resolvedRequest: ServiceId[] = isOnly
@@ -390,7 +390,7 @@ export default class StackUp extends BaseCommand {
       this.error(`unknown service id(s): ${unknown.join(', ')}\nknown: ${[...known].join(', ')}`);
     }
 
-    const closure = computeClosure(manifest, resolvedRequest, { withPlayback, withAuthz, withStaffAdmin });
+    const closure = computeClosure(manifest, resolvedRequest, closureOpts);
 
     // M7: at slot > 0 the bring-up would EXCLUDE the literal-port services; surface
     // that in the preview so the dry-run matches what a real `--slot N` up launches.
@@ -471,12 +471,11 @@ export default class StackUp extends BaseCommand {
   private async runNative(
     flags: NativeFlags,
     requested: ServiceId[],
-    withPlayback: boolean,
-    withAuthz: boolean,
-    withStaffAdmin: boolean,
+    closureOpts: Required<Pick<ClosureOpts, 'withPlayback' | 'withAuthz' | 'withStaffAdmin'>>,
     overlays: NativeOverlays = {},
     prune: LaunchPrune = {},
   ): Promise<void> {
+    const { withPlayback, withAuthz } = closureOpts;
     const known = new Set(Object.keys(manifest.services));
     const unknown = requested.filter((s) => !known.has(s));
     if (unknown.length > 0) {
@@ -497,7 +496,7 @@ export default class StackUp extends BaseCommand {
     // THIS slot's rtsm, not slot 0's) is generated in `buildRuntime`, the seam BOTH
     // `stack up` and `e2e run` share; it need not be repeated here.
 
-    const fullClosure = computeClosure(manifest, requested, { withPlayback, withAuthz, withStaffAdmin });
+    const fullClosure = computeClosure(manifest, requested, closureOpts);
 
     // Exclude the still-un-slottable services from a slot > 0 bring-up: only the
     // literal-port playback trio (transcripts/insights/chat) carries literal cross-slot

--- a/packages/node/saga-stack-cli/src/core/__tests__/bundles.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/bundles.unit.test.ts
@@ -25,8 +25,16 @@ const throwFail = (msg: string): never => {
 };
 
 describe('bundle registry', () => {
-  it('exposes the six bundle names in registry order', () => {
-    expect(BUNDLE_NAMES).toEqual(['dash', 'connect', 'coach', 'playback', 'qtf', 'authz']);
+  it('exposes the seven bundle names in registry order', () => {
+    expect(BUNDLE_NAMES).toEqual([
+      'dash',
+      'connect',
+      'coach',
+      'playback',
+      'qtf',
+      'authz',
+      'staff-admin',
+    ]);
   });
 
   it('every bundle carries a non-empty description', () => {
@@ -42,6 +50,8 @@ describe('bundle registry', () => {
     expect(SERVICE_BUNDLES.playback).toEqual(['transcripts-api', 'insights-api', 'chat-api']);
     expect(SERVICE_BUNDLES.qtf).toEqual([]);
     expect(SERVICE_BUNDLES.authz).toEqual(['authz-sync']);
+    // BFF before SPA: the console's vite proxy is useless without it.
+    expect(SERVICE_BUNDLES['staff-admin']).toEqual(['staff-admin-bff', 'staff-admin-console']);
   });
 
   it('derives BUNDLE_SEED_ADDONS only for the seed-bearing bundles', () => {

--- a/packages/node/saga-stack-cli/src/core/__tests__/bundles.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/bundles.unit.test.ts
@@ -9,10 +9,14 @@
 
 import { describe, expect, it, vi } from 'vitest';
 import {
+  AUTHZ_IDS,
   BUNDLES,
   BUNDLE_NAMES,
   BUNDLE_SEED_ADDONS,
+  PLAYBACK_IDS,
   SERVICE_BUNDLES,
+  STAFF_ADMIN_IDS,
+  bundleForService,
   combineRequested,
   effectiveWithPlayback,
   expandBundles,
@@ -150,6 +154,30 @@ describe('effectiveWithPlayback', () => {
     expect(effectiveWithPlayback(['qtf'])).toBe(false);
     expect(effectiveWithPlayback([])).toBe(false);
     expect(effectiveWithPlayback(undefined)).toBe(false);
+  });
+});
+
+describe('bundleForService', () => {
+  it('maps a service id back to the bundle that contributes it', () => {
+    // The id and the bundle name deliberately DIFFER here — this is the case a
+    // hand-rolled `id === 'authz-sync' ? 'authz' : id` ternary got right by luck
+    // and every other overlay-bound service would have got wrong.
+    expect(bundleForService('authz-sync')).toBe('authz');
+    expect(bundleForService('staff-admin-bff')).toBe('staff-admin');
+    expect(bundleForService('staff-admin-console')).toBe('staff-admin');
+    expect(bundleForService('coach-api')).toBe('coach');
+  });
+
+  it('undefined for a service no bundle contributes', () => {
+    expect(bundleForService('sessions-api')).toBeUndefined();
+  });
+
+  it('every bundle name it returns is invokable as `--with <name>`', () => {
+    for (const id of [...AUTHZ_IDS, ...STAFF_ADMIN_IDS, ...PLAYBACK_IDS]) {
+      const name = bundleForService(id);
+      expect(name).toBeDefined();
+      expect(BUNDLE_NAMES).toContain(name);
+    }
   });
 });
 

--- a/packages/node/saga-stack-cli/src/core/__tests__/workspace.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/workspace.unit.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { closureOptsForIds } from '../bundles.js';
 import { parseWorkspace } from '../workspace.js';
 
 describe('parseWorkspace — mode mapping → run-set / iam-sandbox / playback', () => {
@@ -76,24 +77,25 @@ describe('parseWorkspace — mode mapping → run-set / iam-sandbox / playback',
     expect(sel.playback).toBe(true);
   });
 
-  it('a staff-admin service in the run-set flips staffAdmin on', () => {
-    // Same derivation as `playback` above: a workspace names services DIRECTLY,
-    // so naming the console IS the ask. `up --workspace` previously hard-coded
-    // this false, so the closure dropped the pair and reported a successful
-    // bring-up while the console never started.
+  it('a workspace run-set naming staff-admin admits the pair into the closure', () => {
+    // A workspace names services DIRECTLY, so naming the console IS the ask.
+    // `up --workspace` derives the opt-in flags from the run-set via
+    // `closureOptsForIds` (it previously hard-coded withAuthz false, dropping a
+    // workspace-named service while reporting a successful bring-up), so assert
+    // the derivation `up.ts` actually performs rather than a parse-time field.
     const sel = parseWorkspace({
       version: '1',
       services: { 'staff-admin-console': { mode: 'local-source' } },
     });
-    expect(sel.staffAdmin).toBe(true);
+    expect(closureOptsForIds(sel.runSet).withStaffAdmin).toBe(true);
   });
 
-  it('leaves staffAdmin off when no staff-admin service is named', () => {
+  it('leaves the staff-admin flag off when no staff-admin service is named', () => {
     const sel = parseWorkspace({
       version: '1',
       services: { 'iam-api': { mode: 'local-source' } },
     });
-    expect(sel.staffAdmin).toBe(false);
+    expect(closureOptsForIds(sel.runSet).withStaffAdmin).toBe(false);
   });
 
   it('records per-service dbProfiles for local-source services', () => {

--- a/packages/node/saga-stack-cli/src/core/__tests__/workspace.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/workspace.unit.test.ts
@@ -76,6 +76,26 @@ describe('parseWorkspace — mode mapping → run-set / iam-sandbox / playback',
     expect(sel.playback).toBe(true);
   });
 
+  it('a staff-admin service in the run-set flips staffAdmin on', () => {
+    // Same derivation as `playback` above: a workspace names services DIRECTLY,
+    // so naming the console IS the ask. `up --workspace` previously hard-coded
+    // this false, so the closure dropped the pair and reported a successful
+    // bring-up while the console never started.
+    const sel = parseWorkspace({
+      version: '1',
+      services: { 'staff-admin-console': { mode: 'local-source' } },
+    });
+    expect(sel.staffAdmin).toBe(true);
+  });
+
+  it('leaves staffAdmin off when no staff-admin service is named', () => {
+    const sel = parseWorkspace({
+      version: '1',
+      services: { 'iam-api': { mode: 'local-source' } },
+    });
+    expect(sel.staffAdmin).toBe(false);
+  });
+
   it('records per-service dbProfiles for local-source services', () => {
     const sel = parseWorkspace({
       version: '1',

--- a/packages/node/saga-stack-cli/src/core/bundles.ts
+++ b/packages/node/saga-stack-cli/src/core/bundles.ts
@@ -200,6 +200,19 @@ export function effectiveWithStaffAdmin(withBundles: string[] | undefined): bool
 }
 
 /**
+ * The `optional:true` service ids each opt-in flag admits, derived from the
+ * bundle registry so they cannot drift from `BUNDLES`.
+ *
+ * Consumers that must map an optional id BACK to its flag (flow resolution,
+ * workspace run-sets) use these instead of hand-listing ids — every optional
+ * service needs its OWN flag (see `admitsOptional`), and a stale hand-list is
+ * exactly how one gets silently dropped into an empty closure.
+ */
+export const PLAYBACK_IDS: readonly ServiceId[] = BUNDLES.playback.services;
+export const AUTHZ_IDS: readonly ServiceId[] = BUNDLES.authz.services;
+export const STAFF_ADMIN_IDS: readonly ServiceId[] = BUNDLES['staff-admin'].services;
+
+/**
  * The ordered, deduped seed add-ons the `--with` features contribute (via
  * `BUNDLE_SEED_ADDONS`): `--with playback` ⇒ `['playback']`, `--with qtf` ⇒
  * `['qtf']`, `--with playback --with qtf` ⇒ both. Service-only features

--- a/packages/node/saga-stack-cli/src/core/bundles.ts
+++ b/packages/node/saga-stack-cli/src/core/bundles.ts
@@ -82,7 +82,7 @@ export const BUNDLES: Readonly<Record<BundleName, BundleDef>> = {
   'staff-admin': {
     services: ['staff-admin-bff', 'staff-admin-console'],
     description:
-      'Staff-admin console: the staff-only SPA (:8910) + its own BFF (:3000), plus the ' +
+      'Staff-admin console: the staff-only SPA (:8910) + its own BFF (:3011), plus the ' +
       'iam/programs/sis closure they read. Log in with `ss stack login` — the console ' +
       'reads that operator cookie. Impersonate is HIDDEN (the synthetic seed mints no ' +
       'staff:* claims) and the COACH pages 401 (coach-api verifies a janus_session).',
@@ -214,6 +214,20 @@ export const AUTHZ_IDS: readonly ServiceId[] = BUNDLES.authz.services;
 export const STAFF_ADMIN_IDS: readonly ServiceId[] = BUNDLES['staff-admin'].services;
 
 /**
+ * The fully-resolved opt-in flags for every `optional:true` family — one field
+ * per flag, none omittable.
+ *
+ * `Required` is load-bearing: every `ClosureOpts` field is declared `?:`, so a
+ * bare `Pick` would leave them all optional and a caller could pass `{}` — which
+ * typechecks and then silently resolves an EMPTY closure (exit 0, no error). The
+ * alias exists so adding a fourth family is ONE edit here rather than a hand-sweep
+ * of every signature that spells the shape out.
+ */
+export type ResolvedClosureOpts = Required<
+  Pick<ClosureOpts, 'withPlayback' | 'withAuthz' | 'withStaffAdmin'>
+>;
+
+/**
  * Every optional-service opt-in flag, derived from one `--with` list.
  *
  * THE point of this helper: each `optional:true` family needs its OWN flag, and
@@ -227,7 +241,7 @@ export const STAFF_ADMIN_IDS: readonly ServiceId[] = BUNDLES['staff-admin'].serv
  */
 export function closureOptsFor(
   withBundles: string[] | undefined,
-): Required<Pick<ClosureOpts, 'withPlayback' | 'withAuthz' | 'withStaffAdmin'>> {
+): ResolvedClosureOpts {
   return {
     withPlayback: effectiveWithPlayback(withBundles),
     withAuthz: effectiveWithAuthz(withBundles),
@@ -243,13 +257,27 @@ export function closureOptsFor(
  */
 export function closureOptsForIds(
   ids: readonly ServiceId[],
-): Required<Pick<ClosureOpts, 'withPlayback' | 'withAuthz' | 'withStaffAdmin'>> {
+): ResolvedClosureOpts {
   const has = (family: readonly ServiceId[]): boolean => ids.some((id) => family.includes(id));
   return {
     withPlayback: has(PLAYBACK_IDS),
     withAuthz: has(AUTHZ_IDS),
     withStaffAdmin: has(STAFF_ADMIN_IDS),
   };
+}
+
+/**
+ * The `--with` bundle name that contributes a given service id, or `undefined`
+ * when no bundle does.
+ *
+ * For "re-run `ss stack up --with <X>`" advice: the bundle name and the service
+ * id are NOT interchangeable (`authz-sync` lives in the `authz` bundle, and the
+ * staff-admin pair in `staff-admin`), so a message that prints the id is telling
+ * the operator to run a command that fails on an unknown bundle. Derived from
+ * `BUNDLES` in registry order, so it cannot drift as families are added. PURE.
+ */
+export function bundleForService(id: ServiceId): BundleName | undefined {
+  return BUNDLE_NAMES.find((name) => BUNDLES[name].services.includes(id));
 }
 
 /**

--- a/packages/node/saga-stack-cli/src/core/bundles.ts
+++ b/packages/node/saga-stack-cli/src/core/bundles.ts
@@ -14,6 +14,7 @@
  * PURE: this module carries zero IO.
  */
 
+import type { ClosureOpts } from './closure.js';
 import type { ServiceId } from './manifest/index.js';
 
 /** The named features a `--with` value may select (services, a seed add-on, or both). */
@@ -211,6 +212,45 @@ export function effectiveWithStaffAdmin(withBundles: string[] | undefined): bool
 export const PLAYBACK_IDS: readonly ServiceId[] = BUNDLES.playback.services;
 export const AUTHZ_IDS: readonly ServiceId[] = BUNDLES.authz.services;
 export const STAFF_ADMIN_IDS: readonly ServiceId[] = BUNDLES['staff-admin'].services;
+
+/**
+ * Every optional-service opt-in flag, derived from one `--with` list.
+ *
+ * THE point of this helper: each `optional:true` family needs its OWN flag, and
+ * every flag defaults to FALSE — so a `computeClosure` caller that forgets one
+ * silently resolves an EMPTY closure (exit 0, no error, no compiler help). That
+ * failure has now been shipped three times (snapshot store, snapshot restore,
+ * flow resolution). Deriving all flags in ONE place means adding a bundle is a
+ * single edit here rather than a hand-sweep of every call site.
+ *
+ * Returns a `Required<…>` shape so a caller cannot partially spread it. PURE.
+ */
+export function closureOptsFor(
+  withBundles: string[] | undefined,
+): Required<Pick<ClosureOpts, 'withPlayback' | 'withAuthz' | 'withStaffAdmin'>> {
+  return {
+    withPlayback: effectiveWithPlayback(withBundles),
+    withAuthz: effectiveWithAuthz(withBundles),
+    withStaffAdmin: effectiveWithStaffAdmin(withBundles),
+  };
+}
+
+/**
+ * The opt-in flags implied by a set of service ids already known to be wanted
+ * (a workspace run-set, a flow's `requiredSystems`) — the id→flag direction of
+ * `closureOptsFor`. Derived from the same `BUNDLES`-backed id sets, so it cannot
+ * drift. PURE.
+ */
+export function closureOptsForIds(
+  ids: readonly ServiceId[],
+): Required<Pick<ClosureOpts, 'withPlayback' | 'withAuthz' | 'withStaffAdmin'>> {
+  const has = (family: readonly ServiceId[]): boolean => ids.some((id) => family.includes(id));
+  return {
+    withPlayback: has(PLAYBACK_IDS),
+    withAuthz: has(AUTHZ_IDS),
+    withStaffAdmin: has(STAFF_ADMIN_IDS),
+  };
+}
 
 /**
  * The ordered, deduped seed add-ons the `--with` features contribute (via

--- a/packages/node/saga-stack-cli/src/core/bundles.ts
+++ b/packages/node/saga-stack-cli/src/core/bundles.ts
@@ -17,7 +17,14 @@
 import type { ServiceId } from './manifest/index.js';
 
 /** The named features a `--with` value may select (services, a seed add-on, or both). */
-export type BundleName = 'dash' | 'connect' | 'coach' | 'playback' | 'qtf' | 'authz';
+export type BundleName =
+  | 'dash'
+  | 'connect'
+  | 'coach'
+  | 'playback'
+  | 'qtf'
+  | 'authz'
+  | 'staff-admin';
 
 /** A seed add-on a bundle may layer onto the composed seed plan. */
 export type BundleSeedAddOn = 'playback' | 'qtf' | 'authz';
@@ -70,6 +77,14 @@ export const BUNDLES: Readonly<Record<BundleName, BundleDef>> = {
       'runs the fga-bootstrap seed step (model + canonical tuples), and starts the authz-sync ' +
       'RabbitMQ consumer. First run bootstraps a fresh store (FGA checks fail closed); rerun ' +
       '`stack up --with authz` once more to pick up the persisted store id.',
+  },
+  'staff-admin': {
+    services: ['staff-admin-bff', 'staff-admin-console'],
+    description:
+      'Staff-admin console: the staff-only SPA (:8910) + its own BFF (:3000), plus the ' +
+      'iam/programs/sis closure they read. Log in with `ss stack login` — the console ' +
+      'reads that operator cookie. Impersonate is HIDDEN (the synthetic seed mints no ' +
+      'staff:* claims) and the COACH pages 401 (coach-api verifies a janus_session).',
   },
 };
 
@@ -171,6 +186,17 @@ export function effectiveWithPlayback(withBundles: string[] | undefined): boolea
  */
 export function effectiveWithAuthz(withBundles: string[] | undefined): boolean {
   return (withBundles ?? []).includes('authz');
+}
+
+/**
+ * Whether the closure should keep the `optional:true` staff-admin pair
+ * (`staff-admin-bff` + `staff-admin-console`): true iff the `staff-admin`
+ * bundle was requested via `--with`. Same shape as `effectiveWithAuthz` —
+ * `computeClosure` drops both unless this is set, keeping the operator console
+ * out of every default `stack up`. PURE.
+ */
+export function effectiveWithStaffAdmin(withBundles: string[] | undefined): boolean {
+  return (withBundles ?? []).includes('staff-admin');
 }
 
 /**

--- a/packages/node/saga-stack-cli/src/core/closure.ts
+++ b/packages/node/saga-stack-cli/src/core/closure.ts
@@ -81,10 +81,31 @@ export function computeClosure(
   // Each optional service is admitted by its OWN flag — never a blanket OR of
   // every opt-in flag, which would cross-admit (e.g. `--with authz` alone must
   // not also resolve the playback trio).
+  //
+  // EXHAUSTIVE BY CONSTRUCTION: there is deliberately no `return withPlayback`
+  // fallthrough. That default is what silently handed every unmapped optional id
+  // the playback flag — so a newly-added optional service resolved an EMPTY
+  // closure (exit 0, no error) until someone noticed. An unmapped id now THROWS,
+  // which surfaces at the first test that touches it rather than in the field.
+  // `bundles.ts` cannot be imported here (it imports this module's types), so the
+  // map is local; `optional-families.unit.test.ts` asserts it matches BUNDLES.
   const admitsOptional = (id: ServiceId): boolean => {
-    if (id === 'authz-sync') return withAuthz;
-    if (id === 'staff-admin-bff' || id === 'staff-admin-console') return withStaffAdmin;
-    return withPlayback;
+    switch (id) {
+      case 'transcripts-api':
+      case 'insights-api':
+      case 'chat-api':
+        return withPlayback;
+      case 'authz-sync':
+        return withAuthz;
+      case 'staff-admin-bff':
+      case 'staff-admin-console':
+        return withStaffAdmin;
+      default:
+        throw new Error(
+          `closure: optional service '${id}' has no opt-in flag — add it to admitsOptional ` +
+            `(and to a BUNDLES entry), or it will silently resolve an empty closure.`,
+        );
+    }
   };
 
   const inClosure = new Set<ServiceId>();

--- a/packages/node/saga-stack-cli/src/core/closure.ts
+++ b/packages/node/saga-stack-cli/src/core/closure.ts
@@ -47,6 +47,8 @@ export interface ClosureOpts {
   withPlayback?: boolean;
   /** Keep the `optional:true` `authz-sync` service. */
   withAuthz?: boolean;
+  /** Keep the `optional:true` staff-admin console pair (SPA + its BFF). */
+  withStaffAdmin?: boolean;
   /**
    * Whether to traverse `depKind: 'browser'` edges (default `true`).
    *
@@ -73,13 +75,17 @@ export function computeClosure(
 ): Closure {
   const withPlayback = opts.withPlayback ?? false;
   const withAuthz = opts.withAuthz ?? false;
+  const withStaffAdmin = opts.withStaffAdmin ?? false;
   const followBrowserEdges = opts.followBrowserEdges ?? true;
 
   // Each optional service is admitted by its OWN flag — never a blanket OR of
   // every opt-in flag, which would cross-admit (e.g. `--with authz` alone must
   // not also resolve the playback trio).
-  const admitsOptional = (id: ServiceId): boolean =>
-    id === 'authz-sync' ? withAuthz : withPlayback;
+  const admitsOptional = (id: ServiceId): boolean => {
+    if (id === 'authz-sync') return withAuthz;
+    if (id === 'staff-admin-bff' || id === 'staff-admin-console') return withStaffAdmin;
+    return withPlayback;
+  };
 
   const inClosure = new Set<ServiceId>();
   const reasons = new Map<ServiceId, string[]>();

--- a/packages/node/saga-stack-cli/src/core/closure.ts
+++ b/packages/node/saga-stack-cli/src/core/closure.ts
@@ -28,6 +28,7 @@
  * would wrongly resolve transcripts-api), so the gate dispatches per service id.
  */
 
+import { AUTHZ_IDS, PLAYBACK_IDS, STAFF_ADMIN_IDS } from './bundles.js';
 import { launchOrder } from './launch-order.js';
 import type { DbId, Manifest, MeshId, ServiceId } from './manifest/index.js';
 
@@ -82,30 +83,24 @@ export function computeClosure(
   // every opt-in flag, which would cross-admit (e.g. `--with authz` alone must
   // not also resolve the playback trio).
   //
+  // The id→family sets come from `bundles.ts` (derived from BUNDLES) rather than
+  // being hand-listed here, so adding a family is a registry edit only. Importing
+  // bundles.ts is safe: its only dependency on this module is `import type
+  // { ClosureOpts }`, which is erased at compile time — there is no runtime cycle.
+  //
   // EXHAUSTIVE BY CONSTRUCTION: there is deliberately no `return withPlayback`
   // fallthrough. That default is what silently handed every unmapped optional id
   // the playback flag — so a newly-added optional service resolved an EMPTY
   // closure (exit 0, no error) until someone noticed. An unmapped id now THROWS,
   // which surfaces at the first test that touches it rather than in the field.
-  // `bundles.ts` cannot be imported here (it imports this module's types), so the
-  // map is local; `optional-families.unit.test.ts` asserts it matches BUNDLES.
   const admitsOptional = (id: ServiceId): boolean => {
-    switch (id) {
-      case 'transcripts-api':
-      case 'insights-api':
-      case 'chat-api':
-        return withPlayback;
-      case 'authz-sync':
-        return withAuthz;
-      case 'staff-admin-bff':
-      case 'staff-admin-console':
-        return withStaffAdmin;
-      default:
-        throw new Error(
-          `closure: optional service '${id}' has no opt-in flag — add it to admitsOptional ` +
-            `(and to a BUNDLES entry), or it will silently resolve an empty closure.`,
-        );
-    }
+    if (PLAYBACK_IDS.includes(id)) return withPlayback;
+    if (AUTHZ_IDS.includes(id)) return withAuthz;
+    if (STAFF_ADMIN_IDS.includes(id)) return withStaffAdmin;
+    throw new Error(
+      `closure: optional service '${id}' has no opt-in flag — add it to a BUNDLES entry ` +
+        `(and its *_IDS export), or it will silently resolve an empty closure.`,
+    );
   };
 
   const inClosure = new Set<ServiceId>();

--- a/packages/node/saga-stack-cli/src/core/flow/resolve.ts
+++ b/packages/node/saga-stack-cli/src/core/flow/resolve.ts
@@ -24,6 +24,7 @@
  * only shapes the orchestration inputs.
  */
 
+import { AUTHZ_IDS, PLAYBACK_IDS, STAFF_ADMIN_IDS } from '../bundles.js';
 import { computeClosure } from '../closure.js';
 import type { Closure } from '../closure.js';
 import { getService, manifest as defaultManifest } from '../manifest/index.js';
@@ -289,16 +290,29 @@ export function resolveFlow(
   const requiredSystems = unionRequiredSystems(stages, manifest.spa);
   const seedSelection = effectiveSeed(flow, terminal);
 
-  // Admit playback services into the closure iff a selected stage requires one
-  // (optional in the manifest) or the seed layers the playback add-on.
-  const requiresOptional = requiredSystems.some((id) => getService(id, sm).optional);
+  // Admit optional services into the closure iff a selected stage requires one
+  // (optional in the manifest) or the seed layers the matching add-on.
+  //
+  // Dispatch PER FAMILY, mirroring `admitsOptional` in closure.ts: each optional
+  // service has its OWN opt-in flag, so a blanket `requiresOptional → withPlayback`
+  // silently drops every non-playback optional a flow names (an empty closure,
+  // whose stages then fail against a service that was never launched — pointing
+  // at the browser rather than at the gate that dropped it).
+  const requiresOptional = (ids: readonly ServiceId[]): boolean =>
+    requiredSystems.some((id) => getService(id, sm).optional && ids.includes(id));
   const withPlayback =
-    opts.withPlayback ?? (requiresOptional || (seedSelection?.addOns?.includes('playback') ?? false));
+    opts.withPlayback ??
+    (requiresOptional(PLAYBACK_IDS) || (seedSelection?.addOns?.includes('playback') ?? false));
+  const withStaffAdmin = requiresOptional(STAFF_ADMIN_IDS);
+  const withAuthz =
+    requiresOptional(AUTHZ_IDS) || (seedSelection?.addOns?.includes('authz') ?? false);
   // followBrowserEdges:false — a flow's requiredSystems explicitly list the
   // backends its stages touch; we must NOT auto-expand the SPA's browser deps
   // (which would drag in every backend and defeat the N-of-M payoff, §5.2).
   const closure = computeClosure(sm, requiredSystems, {
     withPlayback,
+    withAuthz,
+    withStaffAdmin,
     followBrowserEdges: false,
   });
 

--- a/packages/node/saga-stack-cli/src/core/flow/resolve.ts
+++ b/packages/node/saga-stack-cli/src/core/flow/resolve.ts
@@ -24,10 +24,10 @@
  * only shapes the orchestration inputs.
  */
 
-import { AUTHZ_IDS, PLAYBACK_IDS, STAFF_ADMIN_IDS } from '../bundles.js';
+import { closureOptsForIds } from '../bundles.js';
 import { computeClosure } from '../closure.js';
 import type { Closure } from '../closure.js';
-import { getService, manifest as defaultManifest } from '../manifest/index.js';
+import { manifest as defaultManifest } from '../manifest/index.js';
 import type { Lane, Manifest, ServiceId } from '../manifest/index.js';
 import type { SeedSelection } from '../seed/index.js';
 import type { FlowDef, FlowManifest, SpaDescriptor, StageDef } from './types.js';
@@ -298,14 +298,20 @@ export function resolveFlow(
   // silently drops every non-playback optional a flow names (an empty closure,
   // whose stages then fail against a service that was never launched — pointing
   // at the browser rather than at the gate that dropped it).
-  const requiresOptional = (ids: readonly ServiceId[]): boolean =>
-    requiredSystems.some((id) => getService(id, sm).optional && ids.includes(id));
+  // `closureOptsForIds` is the shared id→flag mapping (derived from BUNDLES), so
+  // this cannot drift from `admitsOptional` as families are added.
+  const implied = closureOptsForIds(requiredSystems);
   const withPlayback =
     opts.withPlayback ??
-    (requiresOptional(PLAYBACK_IDS) || (seedSelection?.addOns?.includes('playback') ?? false));
-  const withStaffAdmin = requiresOptional(STAFF_ADMIN_IDS);
-  const withAuthz =
-    requiresOptional(AUTHZ_IDS) || (seedSelection?.addOns?.includes('authz') ?? false);
+    (implied.withPlayback || (seedSelection?.addOns?.includes('playback') ?? false));
+  const withStaffAdmin = implied.withStaffAdmin;
+  // ⚠️ authz stays SEED-DRIVEN ONLY, deliberately NOT `implied.withAuthz`. The
+  // flow/e2e path builds no authz overlay, so admitting authz-sync purely because
+  // a flow names it would launch it with an empty OPENFGA_STORE_ID against an
+  // iam-api running FGA_ENABLED=false — misconfigured, but reported as up (the
+  // same trap `restart` avoids via OVERLAY_BOUND_SERVICES). A flow that genuinely
+  // needs authz must come up under `stack up --with authz` first.
+  const withAuthz = seedSelection?.addOns?.includes('authz') ?? false;
   // followBrowserEdges:false — a flow's requiredSystems explicitly list the
   // backends its stages touch; we must NOT auto-expand the SPA's browser deps
   // (which would drag in every backend and defeat the N-of-M payoff, §5.2).

--- a/packages/node/saga-stack-cli/src/core/flow/types.ts
+++ b/packages/node/saga-stack-cli/src/core/flow/types.ts
@@ -39,6 +39,8 @@ const SERVICE_IDS = [
   'insights-api',
   'chat-api',
   'authz-sync',
+  'staff-admin-bff',
+  'staff-admin-console',
 ] as const;
 
 // Compile guard: every literal above must be a real ServiceId (catches typos /

--- a/packages/node/saga-stack-cli/src/core/launch-plan.ts
+++ b/packages/node/saga-stack-cli/src/core/launch-plan.ts
@@ -75,7 +75,7 @@ export interface LaunchTokens {
   /** coach-web port — up.sh `COACH_WEB_PORT` (8800). */
   COACH_WEB_PORT: string;
   /**
-   * staff-admin-console BFF port (3000) — the SPA's vite `/api` proxy target
+   * staff-admin-console BFF port (3011) — the SPA's vite `/api` proxy target
    * (`BFF_URL`). Needed because the SPA's own listen port cannot slot (vite
    * ignores $PORT) but its proxy target CAN, so a slot > 0 console still talks
    * to ITS slot's BFF instead of slot 0's.

--- a/packages/node/saga-stack-cli/src/core/launch-plan.ts
+++ b/packages/node/saga-stack-cli/src/core/launch-plan.ts
@@ -74,6 +74,13 @@ export interface LaunchTokens {
   COACH_API_PORT: string;
   /** coach-web port — up.sh `COACH_WEB_PORT` (8800). */
   COACH_WEB_PORT: string;
+  /**
+   * staff-admin-console BFF port (3000) — the SPA's vite `/api` proxy target
+   * (`BFF_URL`). Needed because the SPA's own listen port cannot slot (vite
+   * ignores $PORT) but its proxy target CAN, so a slot > 0 console still talks
+   * to ITS slot's BFF instead of slot 0's.
+   */
+  STAFF_ADMIN_BFF_PORT: string;
   /** connect-mongo mesh port — up.sh `CONNECT_MONGO_PORT` (27037; coach-api's MONGO_PORT). */
   CONNECT_MONGO_PORT: string;
   /**
@@ -655,6 +662,7 @@ export function defaultLaunchContext(inputs: LaunchContextInputs, m: Manifest = 
     RECORDINGS_API_PORT: String(recordingsApiPort),
     COACH_API_PORT: String(ports['coach-api']),
     COACH_WEB_PORT: String(ports['coach-web']),
+    STAFF_ADMIN_BFF_PORT: String(ports['staff-admin-bff']),
     CONNECT_MONGO_PORT: String(mongoPort),
     REDIS_PORT: String(redisPort),
     AUTHZ_SYNC_PORT: String(ports['authz-sync']),

--- a/packages/node/saga-stack-cli/src/core/manifest/__tests__/staff-admin.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/__tests__/staff-admin.unit.test.ts
@@ -8,6 +8,8 @@
  */
 import { describe, expect, it } from 'vitest';
 
+import { closureDatabases } from '../../../commands/stack/snapshot/store.js';
+import { AUTHZ_IDS, PLAYBACK_IDS, STAFF_ADMIN_IDS } from '../../bundles.js';
 import { computeClosure } from '../../closure.js';
 import { manifest } from '../index.js';
 
@@ -43,11 +45,13 @@ describe('staff-admin manifest entries', () => {
   });
 
   it('routes the SPA proxy at its OWN slot BFF', () => {
-    // The SPA's listen port cannot slot (vite ignores $PORT; the port is baked
-    // into vite.config.ts + the dev script), but its proxy target CAN — so a
-    // slot > 0 console must not silently read slot 0's BFF.
+    // A slot > 0 console must not silently read slot 0's BFF — that would mix
+    // two stacks' data behind one console.
     expect(spa.launch.env.BFF_URL).toBe('http://localhost:${STAFF_ADMIN_BFF_PORT}');
+    // vite ignores $PORT (hence null), but the SPA still slots: `isFrontend`
+    // services get `--port <base+offset>` appended to argv by stack-api.
     expect(spa.portEnvVar).toBeNull();
+    expect(spa.isFrontend).toBe(true);
   });
 
   it('brings the BFF up before the SPA that proxies to it', () => {
@@ -94,5 +98,48 @@ describe('staff-admin closure admission', () => {
     );
     const c = computeClosure(manifest, all as never, {});
     for (const id of ids) expect(c.services).not.toContain(id);
+  });
+});
+
+describe('optional-service id sets (derived from BUNDLES)', () => {
+  it('maps each opt-in flag to its own bundle services', () => {
+    // Consumers that map an optional id BACK to its flag (flow resolution,
+    // workspace run-sets) read these instead of hand-listing ids, so they
+    // cannot drift from the bundle registry.
+    expect(STAFF_ADMIN_IDS).toEqual(['staff-admin-bff', 'staff-admin-console']);
+    expect(AUTHZ_IDS).toEqual(['authz-sync']);
+    expect(PLAYBACK_IDS).toEqual(['transcripts-api', 'insights-api', 'chat-api']);
+  });
+
+  it('every optional manifest service belongs to exactly one opt-in set', () => {
+    // The gap this whole class of bug came from: an optional service with no
+    // flag mapping silently resolves to an EMPTY closure at every caller.
+    const mapped = new Set<string>([...PLAYBACK_IDS, ...AUTHZ_IDS, ...STAFF_ADMIN_IDS]);
+    const optional = Object.values(manifest.services)
+      .filter((s) => s.optional)
+      .map((s) => s.id);
+    for (const id of optional) expect(mapped.has(id)).toBe(true);
+  });
+});
+
+describe('snapshot store — closureDatabases', () => {
+  const fail = (m: string): never => {
+    throw new Error(m);
+  };
+
+  it('resolves the staff-admin closure DBs when the flag is set', () => {
+    // Regression: this call site omitted `withStaffAdmin`, so the ids resolved
+    // to an EMPTY db list — and `storePlan` honours a defined-but-empty `only`
+    // as "dump exactly these", writing a zero-database snapshot that exits 0.
+    // The pair owns no DBs itself; the upstreams it pulls in do.
+    const dbs = closureDatabases([...STAFF_ADMIN_IDS], { withStaffAdmin: true }, fail);
+    expect(dbs).not.toEqual([]);
+    expect(dbs).toContain('iam_local');
+  });
+
+  it('still fails loudly on an unknown service id', () => {
+    expect(() => closureDatabases(['nope' as never], { withStaffAdmin: true }, fail)).toThrow(
+      /unknown service id/,
+    );
   });
 });

--- a/packages/node/saga-stack-cli/src/core/manifest/__tests__/staff-admin.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/__tests__/staff-admin.unit.test.ts
@@ -9,7 +9,13 @@
 import { describe, expect, it } from 'vitest';
 
 import { closureDatabases } from '../../../commands/stack/snapshot/store.js';
-import { AUTHZ_IDS, PLAYBACK_IDS, STAFF_ADMIN_IDS } from '../../bundles.js';
+import {
+  AUTHZ_IDS,
+  PLAYBACK_IDS,
+  STAFF_ADMIN_IDS,
+  closureOptsFor,
+  closureOptsForIds,
+} from '../../bundles.js';
 import { computeClosure } from '../../closure.js';
 import { manifest } from '../index.js';
 
@@ -57,6 +63,29 @@ describe('staff-admin manifest entries', () => {
   it('brings the BFF up before the SPA that proxies to it', () => {
     expect(spa.dependsOn).toContain('staff-admin-bff');
     expect(bff.dependsOn).toEqual(['iam-api', 'programs-api', 'sis-api']);
+  });
+
+  it('keeps the BFF off the contested :3000', () => {
+    // `deriveInstance` builds portOverrides over EVERY service (optional too),
+    // and `stack down`'s orphan reap group-kills whatever sits on the resulting
+    // band — for every user, including those who never pass --with staff-admin.
+    // On :3000 that means SIGKILLing a stray Next/Rails dev server.
+    expect(bff.port).not.toBe(3000);
+    expect(bff.port).toBe(3011);
+    expect(bff.lane.stack).toBe('http://localhost:3011');
+  });
+
+  it('makes the SPA→BFF edge survive followBrowserEdges:false', () => {
+    // A 'browser' edge is skipped in flow/e2e closures, which would resolve the
+    // SPA WITHOUT its only upstream — every page then fails at the /api proxy.
+    expect(spa.depKinds['staff-admin-bff']).toBe('url');
+  });
+
+  it('fingerprints BOTH processes against adoption of a stray dev server', () => {
+    // Both sides of the proxy can be mis-adopted: a `dev:mock` BFF serves fixture
+    // data, and a stray vite never receives BFF_URL (so it proxies to :3000).
+    expect(bff.adoptEnv).toContain('IAM_API_URL');
+    expect(spa.adoptEnv).toContain('BFF_URL');
   });
 });
 
@@ -122,6 +151,64 @@ describe('optional-service id sets (derived from BUNDLES)', () => {
   });
 });
 
+describe('closureOptsFor / closureOptsForIds', () => {
+  it('derives every flag from one --with list', () => {
+    expect(closureOptsFor(['staff-admin'])).toEqual({
+      withPlayback: false,
+      withAuthz: false,
+      withStaffAdmin: true,
+    });
+    expect(closureOptsFor(undefined)).toEqual({
+      withPlayback: false,
+      withAuthz: false,
+      withStaffAdmin: false,
+    });
+  });
+
+  it('derives the same flags from wanted ids (workspace run-set / flow systems)', () => {
+    expect(closureOptsForIds(['staff-admin-console'])).toEqual({
+      withPlayback: false,
+      withAuthz: false,
+      withStaffAdmin: true,
+    });
+    expect(closureOptsForIds(['iam-api'])).toEqual({
+      withPlayback: false,
+      withAuthz: false,
+      withStaffAdmin: false,
+    });
+  });
+
+  it('never cross-admits between families', () => {
+    expect(closureOptsFor(['authz']).withStaffAdmin).toBe(false);
+    expect(closureOptsFor(['playback']).withAuthz).toBe(false);
+    expect(closureOptsFor(['staff-admin']).withPlayback).toBe(false);
+  });
+});
+
+describe('admitsOptional is exhaustive', () => {
+  it('throws on an optional id with no opt-in flag rather than silently dropping it', () => {
+    // The whole bug class: an unmapped optional id used to inherit `withPlayback`
+    // and resolve an EMPTY closure with exit 0. It must now fail loudly.
+    const fake = {
+      ...manifest,
+      services: {
+        ...manifest.services,
+        'ghost-api': { ...manifest.services['iam-api'], id: 'ghost-api', optional: true },
+      },
+    } as unknown as typeof manifest;
+    expect(() => computeClosure(fake, ['ghost-api'] as never, {})).toThrow(/no opt-in flag/);
+  });
+
+  it('still admits every real optional family from its own flag', () => {
+    expect(computeClosure(manifest, ['authz-sync'], { withAuthz: true }).services).toEqual([
+      'authz-sync',
+    ]);
+    expect(computeClosure(manifest, ['chat-api'], { withPlayback: true }).services).toContain(
+      'chat-api',
+    );
+  });
+});
+
 describe('snapshot store — closureDatabases', () => {
   const fail = (m: string): never => {
     throw new Error(m);
@@ -132,13 +219,13 @@ describe('snapshot store — closureDatabases', () => {
     // to an EMPTY db list — and `storePlan` honours a defined-but-empty `only`
     // as "dump exactly these", writing a zero-database snapshot that exits 0.
     // The pair owns no DBs itself; the upstreams it pulls in do.
-    const dbs = closureDatabases([...STAFF_ADMIN_IDS], { withStaffAdmin: true }, fail);
+    const dbs = closureDatabases([...STAFF_ADMIN_IDS], closureOptsFor(['staff-admin']), fail);
     expect(dbs).not.toEqual([]);
     expect(dbs).toContain('iam_local');
   });
 
   it('still fails loudly on an unknown service id', () => {
-    expect(() => closureDatabases(['nope' as never], { withStaffAdmin: true }, fail)).toThrow(
+    expect(() => closureDatabases(['nope' as never], closureOptsFor(['staff-admin']), fail)).toThrow(
       /unknown service id/,
     );
   });

--- a/packages/node/saga-stack-cli/src/core/manifest/__tests__/staff-admin.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/__tests__/staff-admin.unit.test.ts
@@ -1,0 +1,98 @@
+/**
+ * staff-admin-console manifest guards.
+ *
+ * The console is saga-dash's SECOND app — a staff-only SPA plus its own BFF —
+ * and the two entries encode three facts that are easy to regress and expensive
+ * to debug, because each fails as a plausible-looking 200/404 rather than a
+ * crash. Each gets a test here.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { computeClosure } from '../../closure.js';
+import { manifest } from '../index.js';
+
+const bff = manifest.services['staff-admin-bff'];
+const spa = manifest.services['staff-admin-console'];
+
+describe('staff-admin manifest entries', () => {
+  it('keeps both out of the default closure (optional)', () => {
+    // A bare `ss stack up` must stay byte-identical: this is an operator
+    // console, reached only via `--with staff-admin` / `--only`.
+    expect(bff.optional).toBe(true);
+    expect(spa.optional).toBe(true);
+  });
+
+  it('points the BFF at BARE upstream origins, never a /trpc suffix', () => {
+    // 🪤 The BFF's tRPC clients append `/trpc` themselves (iam-client.ts et al),
+    // unlike ads-adm-api whose manifest entry uses `${IAM_URL}/trpc`. Copying
+    // that form here doubles the segment and 404s in a way that reads like a
+    // broken feature rather than a config error.
+    expect(bff.launch.env.IAM_API_URL).toBe('${IAM_URL}');
+    expect(bff.launch.env.PROGRAMS_API_URL).toBe('http://localhost:${PROGRAMS_PORT}');
+    expect(bff.launch.env.SIS_API_URL).toBe('http://localhost:${SIS_PORT}');
+    for (const [key, value] of Object.entries(bff.launch.env)) {
+      expect(`${key}=${value}`).not.toMatch(/\/trpc$/);
+    }
+  });
+
+  it('fingerprints IAM_API_URL so a `dev:mock` BFF is never adopted', () => {
+    // The app's documented local path (`pnpm dev:mock`) pins IAM_API_URL at the
+    // e2e mock (127.0.0.1:4610). Adopting such a process serves FIXTURE data
+    // from a console claiming to be on the ss stack — 200s all the way down.
+    expect(bff.adoptEnv).toContain('IAM_API_URL');
+  });
+
+  it('routes the SPA proxy at its OWN slot BFF', () => {
+    // The SPA's listen port cannot slot (vite ignores $PORT; the port is baked
+    // into vite.config.ts + the dev script), but its proxy target CAN — so a
+    // slot > 0 console must not silently read slot 0's BFF.
+    expect(spa.launch.env.BFF_URL).toBe('http://localhost:${STAFF_ADMIN_BFF_PORT}');
+    expect(spa.portEnvVar).toBeNull();
+  });
+
+  it('brings the BFF up before the SPA that proxies to it', () => {
+    expect(spa.dependsOn).toContain('staff-admin-bff');
+    expect(bff.dependsOn).toEqual(['iam-api', 'programs-api', 'sis-api']);
+  });
+});
+
+describe('staff-admin closure admission', () => {
+  const ids = ['staff-admin-bff', 'staff-admin-console'] as const;
+
+  it('resolves the pair + its upstream closure under withStaffAdmin', () => {
+    const c = computeClosure(manifest, [...ids], { withStaffAdmin: true });
+    // The whole point of the bundle: one flag, and the upstreams the console
+    // reads come along automatically.
+    expect(c.services).toEqual([
+      'iam-api',
+      'sis-api',
+      'programs-api',
+      'staff-admin-bff',
+      'staff-admin-console',
+    ]);
+  });
+
+  it('DROPS the pair without the flag (each optional service needs its own)', () => {
+    // Regression: `admitsOptional` fell through to `withPlayback` for unknown
+    // optional ids, so `--with staff-admin` silently resolved ZERO services
+    // while every test still passed.
+    expect(computeClosure(manifest, [...ids], {}).services).toEqual([]);
+    expect(computeClosure(manifest, [...ids], { withPlayback: true }).services).toEqual([]);
+    expect(computeClosure(manifest, [...ids], { withAuthz: true }).services).toEqual([]);
+  });
+
+  it('is not cross-admitted by, and does not cross-admit, other optionals', () => {
+    const c = computeClosure(manifest, ['authz-sync', ...ids], {
+      withStaffAdmin: true,
+    });
+    expect(c.services).not.toContain('authz-sync');
+  });
+
+  it('stays out of the default full-stack closure', () => {
+    const all = Object.keys(manifest.services).filter(
+      (id) => !manifest.services[id as keyof typeof manifest.services].optional,
+    );
+    const c = computeClosure(manifest, all as never, {});
+    for (const id of ids) expect(c.services).not.toContain(id);
+  });
+});

--- a/packages/node/saga-stack-cli/src/core/manifest/services.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/services.ts
@@ -850,10 +850,19 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
     id: 'staff-admin-bff',
     repo: 'SAGA_DASH',
     subpath: 'apps/web/staff-admin-console/backend',
-    port: 3000,
+    // 3011, NOT the app's own default of 3000 — same reason content-api runs on
+    // 3009 instead of its default. :3000 is the most contested port on a dev box
+    // (every default Next/Express/Rails app), and `deriveInstance` builds
+    // `portOverrides` over EVERY manifest service including optional ones, so
+    // `stack down`'s orphan reap (`reapScanServices`) would group-kill whatever
+    // sits on :3000 for EVERY user — including people who never pass
+    // `--with staff-admin`. Registering an unrelated dev server's port into a
+    // SIGKILL band is not a cost this opt-in bundle gets to impose.
+    port: 3011,
     // `pnpm dev` = `JANUS_REQUIRED=false tsx watch src/local.ts`, so the janus
     // (JumpCloud) perimeter bypass rides along for free — a local operator has
-    // no janus_session to present. src/local.ts reads `PORT`.
+    // no janus_session to present. src/local.ts reads `PORT`, so the launcher
+    // injects 3011 (and the slot offset) rather than the app's baked default.
     portEnvVar: 'PORT',
     healthPath: '/health/ready',
     databases: [],
@@ -883,7 +892,7 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
       },
     },
     seed: [],
-    lane: lanes(3000, 'staff-admin-api'),
+    lane: lanes(3011, 'staff-admin-api'),
     tunnelSlug: 'staff-admin-api',
     isFrontend: false,
     optional: true,
@@ -912,9 +921,15 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
     healthPath: '/',
     databases: [],
     dependsOn: ['staff-admin-bff'],
-    // The browser calls the BFF (same-origin via vite's /api proxy), so the SPA
-    // needs it merely reachable — the `browser` kind, like saga-dash's deps.
-    depKinds: { 'staff-admin-bff': 'browser' },
+    // 'url', NOT 'browser' — deliberately unlike saga-dash's deps. A `browser`
+    // edge is skipped under `followBrowserEdges:false` (flow/e2e closures), which
+    // would resolve a closure containing the SPA and NOT its BFF: every page then
+    // fails at the /api proxy with connection errors that read as a broken test
+    // rather than a missing service. And the distinction a `browser` edge encodes
+    // — "the SPA MAY call this backend from SOME page" — does not apply here: the
+    // console has exactly ONE upstream and cannot render a single page without
+    // it, so it is a hard dependency in every closure.
+    depKinds: { 'staff-admin-bff': 'url' },
     mesh: [],
     launch: {
       cmd: 'pnpm dev',
@@ -931,5 +946,14 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
     tunnelSlug: 'staff-admin',
     isFrontend: true,
     optional: true,
+    // Same soa#305 guard as the BFF, for the same reason on the other side of the
+    // proxy. `healthPath: '/'` means a bare `pnpm dev` vite left running in the
+    // app dir answers 200, and an unguarded launcher ADOPTS it — never applying
+    // BFF_URL, so the console's /api proxy falls back to vite.config.ts's
+    // `http://localhost:3000` default and the browser reads whatever happens to
+    // be on 3000 instead of this stack's BFF. Fingerprinting the key refuses that
+    // process instead (one-time "stop and re-run"), which is precisely the
+    // mixed-stack condition BFF_URL exists to prevent.
+    adoptEnv: ['BFF_URL'],
   },
 };

--- a/packages/node/saga-stack-cli/src/core/manifest/services.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/services.ts
@@ -900,15 +900,14 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
     repo: 'SAGA_DASH',
     subpath: 'apps/web/staff-admin-console',
     port: 8910,
-    // ⚠️ SLOT-0 ONLY, and deliberately so. The dev script is
-    // `vite dev --port 8910` and vite.config.ts hardcodes `server.port: 8910`;
-    // vite does NOT read $PORT (verified: with PORT=8913 set it still took the
-    // config's 8910, then auto-incremented to 8911 when that was busy). So
-    // `portEnvVar` cannot steer it and at --slot N this entry keeps its base
-    // port. This is the SAME pre-existing limitation as saga-dash (:8900,
-    // `vite dev --port 8900`, portEnvVar: null) — not a new regression.
-    // Fixing it properly is a saga-dash-side change (make the dev script and
-    // `server.port` env-driven), i.e. a second PR in a second repo.
+    // `null` because vite does NOT read $PORT — the dev script is
+    // `vite dev --port 8910` and vite.config.ts hardcodes `server.port: 8910`
+    // (verified: with PORT=8913 set it still took the config's 8910, then
+    // auto-incremented to 8911 when that was busy). It still SLOTS: like every
+    // `isFrontend` service, stack-api appends `--port <base+offset>` to the
+    // launch argv at slot > 0 and vite/cac honours the LAST `--port`. Same seam
+    // saga-dash (:8900, portEnvVar: null, isFrontend: true) rides — so do NOT
+    // add this to SLOT_EXCLUDED_SERVICES.
     portEnvVar: null,
     healthPath: '/',
     databases: [],
@@ -921,9 +920,9 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
       cmd: 'pnpm dev',
       env: {
         // vite.config.ts's proxy target is `process.env.BFF_URL ??
-        // 'http://localhost:3000'`, so this IS slot-correct even though the
-        // SPA's own listen port is not: at slot > 0 the SPA still reaches ITS
-        // slot's BFF rather than silently proxying to slot 0's.
+        // 'http://localhost:3000'`, so the proxy target slots too: at slot > 0
+        // the SPA reaches ITS slot's BFF rather than silently proxying to
+        // slot 0's (which would mix two stacks' data behind one console).
         BFF_URL: 'http://localhost:${STAFF_ADMIN_BFF_PORT}',
       },
     },

--- a/packages/node/saga-stack-cli/src/core/manifest/services.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/services.ts
@@ -838,4 +838,99 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
     isFrontend: false,
     optional: true,
   },
+  // ── staff-admin console (saga-dash's SECOND app) ────────────────────────
+  // A staff-only SPA + its OWN Express/Lambda BFF. Modeled as TWO entries, the
+  // coach-web/coach-api precedent — `ServiceDef` is one id → one launch.cmd →
+  // one port, so a single entry cannot start both processes. `--with
+  // staff-admin` brings the pair up together (bundles.ts).
+  //
+  // Both are `optional: true`: this is an operator console, not part of the
+  // default closure, so a bare `ss stack up` is byte-identical to before.
+  'staff-admin-bff': {
+    id: 'staff-admin-bff',
+    repo: 'SAGA_DASH',
+    subpath: 'apps/web/staff-admin-console/backend',
+    port: 3000,
+    // `pnpm dev` = `JANUS_REQUIRED=false tsx watch src/local.ts`, so the janus
+    // (JumpCloud) perimeter bypass rides along for free — a local operator has
+    // no janus_session to present. src/local.ts reads `PORT`.
+    portEnvVar: 'PORT',
+    healthPath: '/health/ready',
+    databases: [],
+    dependsOn: ['iam-api', 'programs-api', 'sis-api'],
+    // All plain URL reads — the BFF proxies the operator's forwarded cookie to
+    // each. No S2S: access rides on the `iam_session` `ss stack login` mints.
+    depKinds: { 'iam-api': 'url', 'programs-api': 'url', 'sis-api': 'url' },
+    mesh: [],
+    launch: {
+      cmd: 'pnpm dev',
+      env: {
+        // 🪤 BARE ORIGINS — NOT `${IAM_URL}/trpc`. The BFF's tRPC clients append
+        // `/trpc` themselves (iam-client.ts, programs-client.ts, sis-client.ts),
+        // so ads-adm-api's `${IAM_URL}/trpc` form would double the segment and
+        // 404 in a way that reads like a broken feature.
+        //
+        // Also note the BFF's built-in IAM_API_URL default is localhost:3000 —
+        // its OWN port — so leaving this unset makes it proxy to itself.
+        IAM_API_URL: '${IAM_URL}',
+        // No PROGRAMS_URL / SIS_URL tokens exist (only the ports), so these
+        // compose the origin from the port tokens and slot correctly.
+        PROGRAMS_API_URL: 'http://localhost:${PROGRAMS_PORT}',
+        SIS_API_URL: 'http://localhost:${SIS_PORT}',
+        // Impersonation hands off to the local dash. Slot-correct via the token
+        // rather than the BFF's own localhost:8900 default.
+        IMPERSONATION_MOCK_DASH_ORIGIN: '${DASH_URL}',
+      },
+    },
+    seed: [],
+    lane: lanes(3000, 'staff-admin-api'),
+    tunnelSlug: 'staff-admin-api',
+    isFrontend: false,
+    optional: true,
+    // soa#305 adoption guard. The DOCUMENTED local path for this app is
+    // `pnpm dev:mock`, which pins IAM_API_URL at the e2e mock (127.0.0.1:4610).
+    // Without this fingerprint the launcher adopts such a process and the
+    // console then serves MOCK FIXTURE data while claiming to be on the ss
+    // stack — 200s all the way down, which is exactly how it misleads. Refuse
+    // it loudly instead (one-time "stop and re-run" for a pre-existing process).
+    adoptEnv: ['IAM_API_URL'],
+  },
+  'staff-admin-console': {
+    id: 'staff-admin-console',
+    repo: 'SAGA_DASH',
+    subpath: 'apps/web/staff-admin-console',
+    port: 8910,
+    // ⚠️ SLOT-0 ONLY, and deliberately so. The dev script is
+    // `vite dev --port 8910` and vite.config.ts hardcodes `server.port: 8910`;
+    // vite does NOT read $PORT (verified: with PORT=8913 set it still took the
+    // config's 8910, then auto-incremented to 8911 when that was busy). So
+    // `portEnvVar` cannot steer it and at --slot N this entry keeps its base
+    // port. This is the SAME pre-existing limitation as saga-dash (:8900,
+    // `vite dev --port 8900`, portEnvVar: null) — not a new regression.
+    // Fixing it properly is a saga-dash-side change (make the dev script and
+    // `server.port` env-driven), i.e. a second PR in a second repo.
+    portEnvVar: null,
+    healthPath: '/',
+    databases: [],
+    dependsOn: ['staff-admin-bff'],
+    // The browser calls the BFF (same-origin via vite's /api proxy), so the SPA
+    // needs it merely reachable — the `browser` kind, like saga-dash's deps.
+    depKinds: { 'staff-admin-bff': 'browser' },
+    mesh: [],
+    launch: {
+      cmd: 'pnpm dev',
+      env: {
+        // vite.config.ts's proxy target is `process.env.BFF_URL ??
+        // 'http://localhost:3000'`, so this IS slot-correct even though the
+        // SPA's own listen port is not: at slot > 0 the SPA still reaches ITS
+        // slot's BFF rather than silently proxying to slot 0's.
+        BFF_URL: 'http://localhost:${STAFF_ADMIN_BFF_PORT}',
+      },
+    },
+    seed: [],
+    lane: lanes(8910, 'staff-admin'),
+    tunnelSlug: 'staff-admin',
+    isFrontend: true,
+    optional: true,
+  },
 };

--- a/packages/node/saga-stack-cli/src/core/manifest/types.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/types.ts
@@ -29,7 +29,9 @@ export type ServiceId =
   | 'transcripts-api' // optional: true (--with-playback)
   | 'insights-api' //    optional: true (--with-playback)
   | 'chat-api' //        optional: true (--with-playback)
-  | 'authz-sync'; //     optional: true (--with authz) — RabbitMQ-only OpenFGA tuple projector
+  | 'authz-sync' //      optional: true (--with authz) — RabbitMQ-only OpenFGA tuple projector
+  | 'staff-admin-bff' //     optional: true (--with staff-admin) — the console's own Express BFF
+  | 'staff-admin-console'; // optional: true (--with staff-admin) — staff-only SvelteKit SPA (:8910)
 
 /** Mesh infra units, started as a single `make up PROFILE=empty`. */
 export type MeshId = 'postgres' | 'redis' | 'rabbitmq' | 'connect-mongo' | 'openfga';

--- a/packages/node/saga-stack-cli/src/core/snapshot/manifest.ts
+++ b/packages/node/saga-stack-cli/src/core/snapshot/manifest.ts
@@ -73,6 +73,8 @@ const SERVICE_IDS = [
   'insights-api',
   'chat-api',
   'authz-sync',
+  'staff-admin-bff',
+  'staff-admin-console',
 ] as const;
 const _serviceIdsAreServiceIds: readonly ServiceId[] = SERVICE_IDS;
 void _serviceIdsAreServiceIds;

--- a/packages/node/saga-stack-cli/src/core/workspace.ts
+++ b/packages/node/saga-stack-cli/src/core/workspace.ts
@@ -18,7 +18,7 @@
  *  - version != "1" warns (proceeds); missing/empty `.services` throws.
  */
 
-import { AUTHZ_IDS, STAFF_ADMIN_IDS } from './bundles.js';
+import { PLAYBACK_IDS } from './bundles.js';
 import type { ServiceId } from './manifest/index.js';
 
 /** One service entry in a workspace manifest. */
@@ -49,28 +49,11 @@ export interface WorkspaceSelection {
   sandboxServices: ServiceId[];
   /** True iff any playback API (insights/transcripts/chat) is in the run set (up.sh `DO_PLAYBACK`). */
   playback: boolean;
-  /**
-   * True iff `authz-sync` is in the run set. Same derivation as `playback`: a
-   * workspace names services DIRECTLY, so naming `authz-sync` is the workspace's
-   * way of asking for it — without this the closure's `withAuthz` gate drops the
-   * service and `up --workspace` reports success while authz-sync never starts.
-   */
-  authz: boolean;
-  /**
-   * True iff either staff-admin service is in the run set. Same derivation as
-   * `playback`: a workspace names services DIRECTLY, so naming the console is
-   * the workspace's way of asking for it — without this the closure's
-   * `withStaffAdmin` gate drops the pair and `up --workspace` reports success
-   * while the console never starts.
-   */
-  staffAdmin: boolean;
   /** Per-service DB-restore profiles (up.sh `SVC_DBPROFILE`) for local-source services. */
   dbProfiles: Record<string, string>;
   /** Non-fatal notes (recorded-but-unwired sandbox deps, version mismatch). */
   warnings: string[];
 }
-
-const PLAYBACK_APIS = new Set<ServiceId>(['insights-api', 'transcripts-api', 'chat-api']);
 
 /**
  * Parse an already-`JSON.parse`d workspace manifest into a `WorkspaceSelection`.
@@ -151,9 +134,12 @@ export function parseWorkspace(manifest: WorkspaceManifest): WorkspaceSelection 
     );
   }
 
-  const playback = runSet.some((s) => PLAYBACK_APIS.has(s));
-  const authz = runSet.some((s) => AUTHZ_IDS.includes(s));
-  const staffAdmin = runSet.some((s) => STAFF_ADMIN_IDS.includes(s));
+  // Registry-derived (bundles.ts) rather than a local hand-list, so it cannot
+  // drift from BUNDLES. Only `playback` is surfaced: it has a real consumer (the
+  // `DO_PLAYBACK` launch token). The other optional families are derived where
+  // they are USED, via `closureOptsForIds(ws.runSet)` in `up.ts` — one derivation
+  // on the same registry, rather than a second set of fields to keep in sync.
+  const playback = runSet.some((s) => PLAYBACK_IDS.includes(s));
 
-  return { runSet, iamSandbox, sandboxServices, playback, authz, staffAdmin, dbProfiles, warnings };
+  return { runSet, iamSandbox, sandboxServices, playback, dbProfiles, warnings };
 }

--- a/packages/node/saga-stack-cli/src/core/workspace.ts
+++ b/packages/node/saga-stack-cli/src/core/workspace.ts
@@ -18,7 +18,7 @@
  *  - version != "1" warns (proceeds); missing/empty `.services` throws.
  */
 
-import { STAFF_ADMIN_IDS } from './bundles.js';
+import { AUTHZ_IDS, STAFF_ADMIN_IDS } from './bundles.js';
 import type { ServiceId } from './manifest/index.js';
 
 /** One service entry in a workspace manifest. */
@@ -49,6 +49,13 @@ export interface WorkspaceSelection {
   sandboxServices: ServiceId[];
   /** True iff any playback API (insights/transcripts/chat) is in the run set (up.sh `DO_PLAYBACK`). */
   playback: boolean;
+  /**
+   * True iff `authz-sync` is in the run set. Same derivation as `playback`: a
+   * workspace names services DIRECTLY, so naming `authz-sync` is the workspace's
+   * way of asking for it — without this the closure's `withAuthz` gate drops the
+   * service and `up --workspace` reports success while authz-sync never starts.
+   */
+  authz: boolean;
   /**
    * True iff either staff-admin service is in the run set. Same derivation as
    * `playback`: a workspace names services DIRECTLY, so naming the console is
@@ -145,7 +152,8 @@ export function parseWorkspace(manifest: WorkspaceManifest): WorkspaceSelection 
   }
 
   const playback = runSet.some((s) => PLAYBACK_APIS.has(s));
+  const authz = runSet.some((s) => AUTHZ_IDS.includes(s));
   const staffAdmin = runSet.some((s) => STAFF_ADMIN_IDS.includes(s));
 
-  return { runSet, iamSandbox, sandboxServices, playback, staffAdmin, dbProfiles, warnings };
+  return { runSet, iamSandbox, sandboxServices, playback, authz, staffAdmin, dbProfiles, warnings };
 }

--- a/packages/node/saga-stack-cli/src/core/workspace.ts
+++ b/packages/node/saga-stack-cli/src/core/workspace.ts
@@ -18,6 +18,7 @@
  *  - version != "1" warns (proceeds); missing/empty `.services` throws.
  */
 
+import { STAFF_ADMIN_IDS } from './bundles.js';
 import type { ServiceId } from './manifest/index.js';
 
 /** One service entry in a workspace manifest. */
@@ -48,6 +49,14 @@ export interface WorkspaceSelection {
   sandboxServices: ServiceId[];
   /** True iff any playback API (insights/transcripts/chat) is in the run set (up.sh `DO_PLAYBACK`). */
   playback: boolean;
+  /**
+   * True iff either staff-admin service is in the run set. Same derivation as
+   * `playback`: a workspace names services DIRECTLY, so naming the console is
+   * the workspace's way of asking for it — without this the closure's
+   * `withStaffAdmin` gate drops the pair and `up --workspace` reports success
+   * while the console never starts.
+   */
+  staffAdmin: boolean;
   /** Per-service DB-restore profiles (up.sh `SVC_DBPROFILE`) for local-source services. */
   dbProfiles: Record<string, string>;
   /** Non-fatal notes (recorded-but-unwired sandbox deps, version mismatch). */
@@ -136,6 +145,7 @@ export function parseWorkspace(manifest: WorkspaceManifest): WorkspaceSelection 
   }
 
   const playback = runSet.some((s) => PLAYBACK_APIS.has(s));
+  const staffAdmin = runSet.some((s) => STAFF_ADMIN_IDS.includes(s));
 
-  return { runSet, iamSandbox, sandboxServices, playback, dbProfiles, warnings };
+  return { runSet, iamSandbox, sandboxServices, playback, staffAdmin, dbProfiles, warnings };
 }

--- a/packages/node/saga-stack-cli/src/stack-api.ts
+++ b/packages/node/saga-stack-cli/src/stack-api.ts
@@ -429,6 +429,15 @@ export interface RestartOutcome {
   reaped?: StopServiceResult[];
   /** The vite-cache clear (absent when no viteClear seam was wired). */
   vite?: ViteClearResult;
+  /**
+   * Optional services that were reaped but deliberately NOT relaunched, because
+   * their correct launch env depends on an overlay `restart` does not build
+   * (`authz-sync` needs `--with authz`'s FGA_ENABLED + OPENFGA_STORE_ID).
+   * Relaunching them here would start them MISCONFIGURED while reporting
+   * success; the command surfaces this list so the operator re-`up`s them
+   * explicitly. Empty on a normal bounce.
+   */
+  notRelaunched?: ServiceId[];
   /** The fresh bring-up (mesh + prep + launch + auto-pull + AV). */
   up: UpResult;
 }
@@ -446,6 +455,20 @@ export interface StackApi {
 // ── helpers (pure) ───────────────────────────────────────────────────────────
 
 /** Matches a `${NAME}` token (uppercase / digits / underscore). */
+/**
+ * Optional services whose CORRECT launch env depends on an overlay that only
+ * `up` builds — so a context without that overlay would start them
+ * misconfigured rather than not at all.
+ *
+ * `authz-sync` is the case today: without `--with authz`'s overlay the tokens
+ * resolve to `FGA_ENABLED='false'` and an EMPTY `OPENFGA_STORE_ID`, i.e. a
+ * consumer projecting tuples into nowhere while iam-api runs with FGA off.
+ * `restart` uses this to leave such a service visibly down instead of silently
+ * wrong. The staff-admin pair is deliberately NOT here — its launch env is
+ * fully token-resolved with no overlay, so it restores cleanly.
+ */
+const OVERLAY_BOUND_SERVICES = new Set<ServiceId>(['authz-sync']);
+
 const TOKEN_RE = /\$\{([A-Z0-9_]+)\}/g;
 
 /** Expand every `${NAME}` in `value` from `tokens`; throws on an unset token. */
@@ -1098,20 +1121,27 @@ export function makeStackApi(m: Manifest, runtime: Runtime): StackApi {
       //    browser tab just dies with connection-refused). Reaped ids are what was
       //    actually running, so this restores exactly the previous shape — and it is
       //    generic, so it covers `authz-sync` and any future optional too.
-      const optionalIds = new Set<string>(
-        (Object.values(manifest.services) as { id: ServiceId; optional: boolean }[])
-          .filter((s) => s.optional)
-          .map((s) => s.id),
-      );
+      //
+      //    ⚠️ OVERLAY-FREE OPTIONALS ONLY. `restart` builds its runtime with NO
+      //    overlays (`buildNativeRuntime(flags, profile)`, `overlays = {}`), so
+      //    `launchContext` here carries `withAuthz: undefined` /
+      //    `openfgaStoreId: undefined` ⇒ tokens `FGA_ENABLED='false'` and
+      //    `OPENFGA_STORE_ID=''`. Relaunching an overlay-DEPENDENT service under
+      //    that context is WORSE than leaving it down: authz-sync would come back
+      //    projecting tuples into an empty store id while iam-api runs with FGA
+      //    off, and the operator — told "restart: OK, relaunched authz-sync" —
+      //    would believe authz is live. Down is at least visibly down. So those
+      //    are reported as needing an explicit re-`up` instead.
+      const defs = manifest.services as Record<string, { id: ServiceId; optional: boolean }>;
       const reapedOptional = (reaped ?? [])
         .map((r) => r.id)
-        .filter((id): id is ServiceId => optionalIds.has(id));
+        .filter((id): id is ServiceId => defs[id]?.optional === true);
+      const restorable = reapedOptional.filter((id) => !OVERLAY_BOUND_SERVICES.has(id));
+      const overlayBound = reapedOptional.filter((id) => OVERLAY_BOUND_SERVICES.has(id));
       const relaunch =
-        reapedOptional.length > 0
-          ? [...new Set<ServiceId>([...services, ...reapedOptional])]
-          : services;
+        restorable.length > 0 ? [...new Set<ServiceId>([...services, ...restorable])] : services;
       const up = await this.up(relaunch);
-      return { down, reaped, vite, up };
+      return { down, reaped, vite, up, notRelaunched: overlayBound };
     },
 
     async reset(services: ServiceId[], opts: ResetOpts = {}): Promise<ResetOutcome> {

--- a/packages/node/saga-stack-cli/src/stack-api.ts
+++ b/packages/node/saga-stack-cli/src/stack-api.ts
@@ -1088,7 +1088,29 @@ export function makeStackApi(m: Manifest, runtime: Runtime): StackApi {
 
       // 3. up — the SAME native bring-up (mesh + prep + launch + auto-pull + AV). NO
       //    reset (restart never truncates data); the caller passes only the closure.
-      const up = await this.up(services);
+      //
+      //    RESTORE THE OPTIONALS WE JUST REAPED. The caller's closure is built from
+      //    NON-OPTIONAL services (restart takes no `--with`, so it cannot know which
+      //    opt-ins were used at `up` time), but step 1's reap is dir-scoped and stops
+      //    EVERY pidfile — including `--with`-launched optional services. Without this
+      //    union a bounce silently DELETES them: `up --with staff-admin` then `restart`
+      //    left the console and its BFF dead while reporting a successful restart (the
+      //    browser tab just dies with connection-refused). Reaped ids are what was
+      //    actually running, so this restores exactly the previous shape — and it is
+      //    generic, so it covers `authz-sync` and any future optional too.
+      const optionalIds = new Set<string>(
+        (Object.values(manifest.services) as { id: ServiceId; optional: boolean }[])
+          .filter((s) => s.optional)
+          .map((s) => s.id),
+      );
+      const reapedOptional = (reaped ?? [])
+        .map((r) => r.id)
+        .filter((id): id is ServiceId => optionalIds.has(id));
+      const relaunch =
+        reapedOptional.length > 0
+          ? [...new Set<ServiceId>([...services, ...reapedOptional])]
+          : services;
+      const up = await this.up(relaunch);
       return { down, reaped, vite, up };
     },
 


### PR DESCRIPTION
Stand up saga-dash's **second** app — the staff-only SvelteKit SPA (`:8910`) plus its own Express BFF (`:3000`) — from one flag, instead of hand-exporting five env vars across three terminals.

```bash
ss stack up --with staff-admin   # → iam-api, sis-api, programs-api, staff-admin-bff, staff-admin-console
ss stack login                   # the console reads THIS operator cookie
open http://localhost:8910
```

Permissions, Personas, Policies, Templates and Roster all read **and write** live stack data — persona permission edits persist.

## Design

**Two manifest entries, not one** (the coach-web/coach-api precedent). `ServiceDef` is one id → one `launch.cmd` → one port, so a single entry cannot start both processes. There is no two-process precedent in the manifest.

**Both `optional: true`.** A bare `ss stack up` is unchanged — the default closure is still exactly the same 13 services, verified by dry-run and by the untouched `toHaveLength(13)` assertions.

Three details worth review attention:

1. **Bare upstream origins, not `${IAM_URL}/trpc`.** The BFF's tRPC clients append `/trpc` themselves (`iam-client.ts` et al), unlike `ads-adm-api` whose entry uses the `/trpc` form. Copying that here doubles the segment and 404s in a way that reads like a broken feature. Pinned by a test.
2. **`adoptEnv: ['IAM_API_URL']` on the BFF.** The app's documented local path (`pnpm dev:mock`) pins that var at the e2e mock, and adopting such a process serves **fixture** data from a console claiming to be on the ss stack — 200s all the way down. Refuse it loudly instead (soa#305 pattern).
3. **The SPA is slot-0 only.** Its port is baked into `vite.config.ts` + the dev script, and vite ignores `$PORT` (verified empirically: with `PORT=8913` it still took the config's 8910). Same pre-existing limitation as `saga-dash`'s `:8900` — not a new regression. Its BFF *does* slot, and the SPA's proxy target (`BFF_URL`) follows it, so a slot >0 console never silently reads slot 0's data. A proper fix is a saga-dash-side change (env-drive the dev script + `server.port`), i.e. a second PR in a second repo.

## Bug found and fixed along the way

`admitsOptional` fell through to `withPlayback` for any unknown optional id, so the new pair resolved to **zero** services while the entire suite still passed. Added `withStaffAdmin` (its own opt-in flag, per the existing no-cross-admit rule) and a regression test pinning the empty-closure case.

## Verification

- `--with staff-admin` resolves `iam-api → sis-api → programs-api → staff-admin-bff → staff-admin-console`
- `ss stack status --with staff-admin` → **5/5 services up**
- BFF targets `localhost:3010` (the ss stack, **not** the mock's `127.0.0.1:4610`) and serves **56 permissions / 36 personas** as the seeded dev user
- Default `stack up` closure unchanged (13 services); `--with authz` still isolated
- **129 test files / 1595 tests pass**, including 9 new staff-admin guards

## Known gaps — upstream, not wiring

- **Impersonate is hidden.** `canImpersonate` comes from iam-api's `staffAdmin.myCapabilities`, which fails closed; the synthetic seed mints no `staff:*` claims (janus/JumpCloud group-derived, never seeded).
- **COACH pages 401**, even with `coach-api` up: its `staffProcedure` locally verifies a `janus_session` that the `JANUS_REQUIRED=false` bypass never mints. `coach-api` is therefore deliberately **not** in this bundle.
- **Districts/Roster start empty** — the seed creates personas and permissions but no district groups; create one from the console's Districts page.

Seeding a staff-permissioned persona and a district group are real follow-ups, but out of scope for "make standing it up a flag."

⚠️ Local writes succeed without CSRF or `iam-admin` because iam-api's `enforceIamAdmin` short-circuits when janus verification is off and `SECURITY_ENFORCECSRF` is unset. That's by design in the synthetic mesh — **don't infer deployed behavior from it**; deployed, both gates enforce.