### PR TITLE
fix(e2e): bind the project to `--project=` so Playwright's variadic flag stops swallowing the spec (#401)

### DIFF
--- a/packages/node/saga-stack-cli/src/__tests__/e2e-orchestrate-slot.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/__tests__/e2e-orchestrate-slot.unit.test.ts
@@ -245,8 +245,7 @@ describe('playwrightArgv — spec scoping (single-spawn only, never on a stage o
       'playwright',
       'test',
       '--config=playwright.config.ts',
-      '--project',
-      'chromium',
+      '--project=chromium',
       'dashboard/dashboard-authenticated.e2e.smoke.test.ts',
     ]);
   });
@@ -258,8 +257,7 @@ describe('playwrightArgv — spec scoping (single-spawn only, never on a stage o
       'playwright',
       'test',
       '--config=playwright.config.ts',
-      '--project',
-      'stage-2-program',
+      '--project=stage-2-program',
       '--no-deps',
     ]);
     expect(argv).not.toContain('dashboard/dashboard-authenticated.e2e.smoke.test.ts');
@@ -270,6 +268,42 @@ describe('playwrightArgv — spec scoping (single-spawn only, never on a stage o
       playwright: { config: 'playwright.stack.config.ts', project: 'stage-4-pods', headed: false },
     } as unknown as ResolvedFlow;
     const argv = playwrightArgv(noSpecResolved);
-    expect(argv).toEqual(['exec', 'playwright', 'test', '--config=playwright.stack.config.ts', '--project', 'stage-4-pods']);
+    expect(argv).toEqual(['exec', 'playwright', 'test', '--config=playwright.stack.config.ts', '--project=stage-4-pods']);
+  });
+
+  /**
+   * soa#401 argv-shape guard. Playwright declares `--project <name...>`
+   * VARIADIC: with the separated form (`'--project', name`) any bare token
+   * later in the argv is swallowed as a second project name and the run dies
+   * with `Project(s) "<token>" not found` before executing a single test. Two
+   * bare tokens can legitimately appear after the project: the `spec`
+   * positional, and anything the user passes through after `--`.
+   *
+   * These assert the EQUALS form is what ships, and that no separated
+   * `--project` token survives anywhere in the argv — including the case that
+   * actually broke (`@interactive` + forced `--headless` + a spec, where
+   * neither `--grep-invert` nor `--headed` is present to absorb the variadic).
+   */
+  describe('soa#401 — `--project=` equals form disarms the variadic flag', () => {
+    // No spec, no grep-invert, not headed — i.e. NOTHING optional sits between
+    // the project and whatever comes next. This is the shape that made the bug
+    // reachable, so it is the shape the guard has to cover.
+    const noFlagsResolved = {
+      playwright: { config: 'playwright.stack.config.ts', project: 'stage-4-pods', headed: false },
+    } as unknown as ResolvedFlow;
+
+    const cases: Array<[string, string[]]> = [
+      ['spec positional directly after the project', playwrightArgv(specResolved)],
+      ['user passthrough directly after the project', playwrightArgv(noFlagsResolved, ['--workers=1', 'some-filter'])],
+      ['nothing after the project', playwrightArgv(noFlagsResolved)],
+      ['stage override', playwrightArgv(specResolved, [], { project: 'stage-2-program', noDeps: true })],
+    ];
+
+    it.each(cases)('%s: no bare `--project` token, value bound with `=`', (_label, argv) => {
+      expect(argv).not.toContain('--project');
+      const flags = argv.filter((a) => a.startsWith('--project'));
+      expect(flags).toHaveLength(1);
+      expect(flags[0]).toMatch(/^--project=.+/);
+    });
   });
 });

--- a/packages/node/saga-stack-cli/src/__tests__/helpers/pw.ts
+++ b/packages/node/saga-stack-cli/src/__tests__/helpers/pw.ts
@@ -2,7 +2,7 @@
  * Playwright child-argv builder (M15-C test-harness consolidation, T5).
  *
  * Mirrors the argv assembly in e2e-orchestrate.ts (`exec playwright test
- * --config=… --project <p> [--no-deps] [--grep-invert <tag>] [--headed]`) for
+ * --config=… --project=<p> [--no-deps] [--grep-invert <tag>] [--headed]`) for
  * VARIANT exact-array assertions — the ones that differ from the golden pin
  * only in project/flags. The config is pinned to the bundled example's
  * `playwright.stack.config.ts`, which is what every hermetic suite resolves.
@@ -28,7 +28,7 @@ export interface PwArgvOptions {
 
 /** Build the expected `pnpm` args array for a spawned Playwright child. */
 export function pwArgv(opts: PwArgvOptions): string[] {
-  const argv = ['exec', 'playwright', 'test', '--config=playwright.stack.config.ts', '--project', opts.project];
+  const argv = ['exec', 'playwright', 'test', '--config=playwright.stack.config.ts', `--project=${opts.project}`];
   if (opts.noDeps) argv.push('--no-deps');
   if (opts.grepInvert !== undefined) argv.push('--grep-invert', opts.grepInvert);
   if (opts.headed) argv.push('--headed');

--- a/packages/node/saga-stack-cli/src/__tests__/helpers/seams.ts
+++ b/packages/node/saga-stack-cli/src/__tests__/helpers/seams.ts
@@ -67,7 +67,8 @@ export interface CoreSeamsOptions {
   /** Service ids whose launch reports health-down (`ok: false`). */
   launchFail?: Set<string>;
   /**
-   * Fail (exit 1) any Playwright child whose args include this token —
+   * Fail (exit 1) any Playwright child targeting this token — matched either as
+   * a bare arg (a `spec` positional) or as the `--project=` value.
    * checkpoint.int's RED-stage lever. Non-Playwright runs still exit 0.
    */
   playwrightFail?: string;
@@ -133,7 +134,10 @@ export function installCoreSeams(opts: CoreSeamsOptions): CoreSeams {
       if (
         opts.playwrightFail !== undefined &&
         spec.args.includes('playwright') &&
-        spec.args.includes(opts.playwrightFail)
+        // Match the token as a standalone arg (a `spec` positional) OR as the
+        // value of `--project=` — since soa#401 the project is bound to the flag
+        // with `=`, so a bare `includes` no longer sees a project name.
+        spec.args.some((a) => a === opts.playwrightFail || a === `--project=${opts.playwrightFail}`)
       ) {
         return { code: 1 };
       }

--- a/packages/node/saga-stack-cli/src/commands/develop/__tests__/bootstrap.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/__tests__/bootstrap.int.test.ts
@@ -101,12 +101,12 @@ function playwrightRuns(): ScriptInvocation[] {
 
 /** The phase-1 journey replay spawns (terminal project stage-5-schedule). */
 function journeyRuns(): ScriptInvocation[] {
-  return playwrightRuns().filter((r) => r.args.includes('stage-5-schedule'));
+  return playwrightRuns().filter((r) => r.args.includes('--project=stage-5-schedule'));
 }
 
 /** The headed live-session spawn (the hand-off's terminal stage). */
 function liveRun(): ScriptInvocation | undefined {
-  return playwrightRuns().find((r) => r.args.includes('interactive-connect'));
+  return playwrightRuns().find((r) => r.args.includes('--project=interactive-connect'));
 }
 
 function ledgerPath(): string {
@@ -454,7 +454,7 @@ describe('develop connect --bootstrap — prerequisite retry-once (stage-flake c
     vi.spyOn(proto as unknown as Record<string, () => unknown>, 'getRunner').mockReturnValue({
       run: async (spec: ScriptInvocation) => {
         const res = await base.run(spec);
-        if (left > 0 && spec.args.includes('playwright') && spec.args.includes('stage-5-schedule')) {
+        if (left > 0 && spec.args.includes('playwright') && spec.args.includes('--project=stage-5-schedule')) {
           left -= 1;
           return { code: 1 };
         }

--- a/packages/node/saga-stack-cli/src/commands/develop/__tests__/connect.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/__tests__/connect.int.test.ts
@@ -85,7 +85,7 @@ function playwrightRuns(): ScriptInvocation[] {
 
 /** The headed live-session spawn (the flow's terminal stage). */
 function liveRun(): ScriptInvocation | undefined {
-  return playwrightRuns().find((r) => r.args.includes('interactive-connect'));
+  return playwrightRuns().find((r) => r.args.includes('--project=interactive-connect'));
 }
 
 /** The state dir the command pointed the launcher at. */
@@ -136,7 +136,7 @@ describe('develop connect — slot awareness (slot > 0)', () => {
 
     // The prerequisite is a separate ResolvedFlow built through `schedule`; it seeds
     // the room's data, so a slot-0 prerequisite behind a slot-2 room is a split brain.
-    const prereq = playwrightRuns().find((r) => r.args.includes('stage-5-schedule'));
+    const prereq = playwrightRuns().find((r) => r.args.includes('--project=stage-5-schedule'));
     expect(prereq?.env?.PLAYWRIGHT_IAM_URL).toBe('http://localhost:5010');
   });
 
@@ -256,7 +256,7 @@ describe('develop connect — per-slot checkpoint root (the cross-slot corruptio
     // so stage-1-roster appears only here — the main run's prerequisite enters at
     // stage-5). It needs the offset ports independently of the main run: a bake driven
     // against the base iam would bake slot-0 data INTO the slot-2 checkpoint root.
-    const bake = playwrightRuns().find((r) => r.args.includes('stage-1-roster'));
+    const bake = playwrightRuns().find((r) => r.args.includes('--project=stage-1-roster'));
     expect(bake).toBeDefined();
     expect(bake?.env?.PLAYWRIGHT_IAM_URL).toBe('http://localhost:5010');
   });

--- a/packages/node/saga-stack-cli/src/commands/develop/__tests__/session-adm.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/develop/__tests__/session-adm.int.test.ts
@@ -153,12 +153,12 @@ function playwrightRuns(): ScriptInvocation[] {
 
 /** The held demo spawn (the flow's single stage). */
 function demoRun(): ScriptInvocation | undefined {
-  return playwrightRuns().find((r) => r.args.includes('connect-session-demo'));
+  return playwrightRuns().find((r) => r.args.includes('--project=connect-session-demo'));
 }
 
 /** The journey prerequisite's terminal-stage spawn (the replay's signature). */
 function prereqRun(): ScriptInvocation | undefined {
-  return playwrightRuns().find((r) => r.args.includes('stage-7-attendance'));
+  return playwrightRuns().find((r) => r.args.includes('--project=stage-7-attendance'));
 }
 
 /** The vendored browser-login.mjs child invocation (the admin hand-off). */
@@ -369,7 +369,7 @@ describe('develop session-adm — the --refresh-snapshot bake path (shared helpe
     // against the base iam would bake slot-0 data into the slot-2 checkpoint
     // root (the connect.int twin, pinned HERE because the wiring is this
     // command's own call into the shared bakePrerequisiteCheckpoints).
-    const bake = playwrightRuns().find((r) => r.args.includes('stage-1-roster'));
+    const bake = playwrightRuns().find((r) => r.args.includes('--project=stage-1-roster'));
     expect(bake).toBeDefined();
     expect(bake?.env?.PLAYWRIGHT_IAM_URL).toBe('http://localhost:5010');
 

--- a/packages/node/saga-stack-cli/src/commands/e2e/__tests__/checkpoint.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/__tests__/checkpoint.int.test.ts
@@ -125,10 +125,10 @@ describe('--snapshot-stages (bake)', () => {
     const pw = playwrightRuns();
     expect(pw).toHaveLength(2);
     // Stage 1 keeps its config deps (the stage-0-coherence gate rides along).
-    expect(pw[0]!.args).toContain('stage-1-roster');
+    expect(pw[0]!.args).toContain('--project=stage-1-roster');
     expect(pw[0]!.args).not.toContain('--no-deps');
     // Stage 2 breaks the chain — no replay of stage 1.
-    expect(pw[1]!.args).toContain('stage-2-program-creation');
+    expect(pw[1]!.args).toContain('--project=stage-2-program-creation');
     expect(pw[1]!.args).toContain('--no-deps');
 
     // The date env is computed ONCE for the whole ladder — every stage spawn
@@ -215,7 +215,7 @@ describe('--from (restore)', () => {
     // Exactly the window stage ran, chain broken.
     const pw = playwrightRuns();
     expect(pw).toHaveLength(1);
-    expect(pw[0]!.args).toContain('stage-2-program-creation');
+    expect(pw[0]!.args).toContain('--project=stage-2-program-creation');
     expect(pw[0]!.args).toContain('--no-deps');
 
     // §2.2: the child env carries ALL THREE baked dates, not today's clamp.
@@ -356,7 +356,7 @@ describe('prerequisite-via-checkpoint (M14-C)', () => {
     // Exactly ONE Playwright child (the connect room) — no journey replay spawn.
     const pw = playwrightRuns();
     expect(pw).toHaveLength(1);
-    expect(pw[0]!.args).toContain('interactive-connect');
+    expect(pw[0]!.args).toContain('--project=interactive-connect');
 
     // The PARENT spawn exports the checkpoint's baked dates (they crossed the
     // frame because the restore ran in the parent, not the recursion).
@@ -446,14 +446,14 @@ describe('e2e connect --refresh-snapshot (bake the prerequisite fresh, then rest
     // 5 bake spawns (journey stages 1..5, headless) + 1 live interactive-connect.
     expect(pw).toHaveLength(6);
     // The bake ladder: stage-1 keeps its config deps, stages 2..5 break the chain.
-    expect(pw[0]!.args).toContain('stage-1-roster');
-    expect(pw[4]!.args).toContain('stage-5-schedule');
+    expect(pw[0]!.args).toContain('--project=stage-1-roster');
+    expect(pw[4]!.args).toContain('--project=stage-5-schedule');
     expect(pw[4]!.args).not.toContain('--headed');
     // The live session is LAST, headed, and the prerequisite was RESTORED (not
     // replayed) — so there is exactly one stage-5-schedule spawn (the bake's).
-    expect(pw[5]!.args).toContain('interactive-connect');
+    expect(pw[5]!.args).toContain('--project=interactive-connect');
     expect(pw[5]!.args).toContain('--headed');
-    expect(pw.filter((r) => r.args.includes('stage-5-schedule'))).toHaveLength(1);
+    expect(pw.filter((r) => r.args.includes('--project=stage-5-schedule'))).toHaveLength(1);
 
     const out = logged.join('\n');
     expect(out).toContain('refresh-snapshot: baking journey@schedule');
@@ -665,7 +665,7 @@ describe('tunnel post-restore persona preflight (soa#327)', () => {
     expect(posts[0]!.url).toBe('https://iam.testmoniker.vms.test/trpc/auth.devLogin');
     expect(posts[0]!.opts.origin).toBe('https://iam.testmoniker.vms.test');
     expect(posts[0]!.opts.body).toContain('alex.tutor@example.org');
-    expect(playwrightRuns().some((r) => r.args.includes('interactive-connect'))).toBe(true);
+    expect(playwrightRuns().some((r) => r.args.includes('--project=interactive-connect'))).toBe(true);
   });
 
   it('poster 401: TORN checkpoint — loud error naming the persona + the recipe; no browser launches', async () => {
@@ -684,7 +684,7 @@ describe('tunnel post-restore persona preflight (soa#327)', () => {
     fakeMoniker();
     await E2eConnect.run(['--tunnel', ...ws()], config);
     expect(posts).toHaveLength(3);
-    expect(playwrightRuns().some((r) => r.args.includes('interactive-connect'))).toBe(true);
+    expect(playwrightRuns().some((r) => r.args.includes('--project=interactive-connect'))).toBe(true);
   });
 
   it('persistently unreachable iam: capped retries then the loud torn error', async () => {
@@ -730,7 +730,7 @@ describe('tunnel post-restore persona preflight (soa#327)', () => {
     installPoster([200]);
     await E2eConnect.run([...ws()], config);
     expect(posts).toHaveLength(0);
-    expect(playwrightRuns().some((r) => r.args.includes('interactive-connect'))).toBe(true);
+    expect(playwrightRuns().some((r) => r.args.includes('--project=interactive-connect'))).toBe(true);
   });
 });
 

--- a/packages/node/saga-stack-cli/src/commands/e2e/__tests__/e2e.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/__tests__/e2e.int.test.ts
@@ -110,7 +110,7 @@ describe('e2e run — --dry-run (pure planner, touches no seam)', () => {
     // purpose — do NOT rebuild it with helpers/pw.ts's pwArgv, so a drift in
     // the printed argv shape can never be masked by the builder drifting too.
     expect(text).toContain(
-      'pnpm exec playwright test --config=playwright.stack.config.ts --project stage-4-pods --grep-invert @interactive --headed',
+      'pnpm exec playwright test --config=playwright.stack.config.ts --project=stage-4-pods --grep-invert @interactive --headed',
     );
   });
 
@@ -119,14 +119,14 @@ describe('e2e run — --dry-run (pure planner, touches no seam)', () => {
     const text = logged.join('\n');
     expect(text).toContain('prerequisite: saga-dash/journey (through schedule');
     // The terminal stage IS @interactive-tagged, so the main run does NOT invert it.
-    expect(text).toContain('--project interactive-connect');
+    expect(text).toContain('--project=interactive-connect');
     expect(text).not.toMatch(/interactive-connect.*--grep-invert/);
   });
 
   it('--headless flips a foreground flow off headed', async () => {
     await E2eRun.run(['journey', '--through', '1', '--headless', '--dry-run', ...ws()], config);
     const text = logged.join('\n');
-    expect(text).toContain('--project stage-1-roster');
+    expect(text).toContain('--project=stage-1-roster');
     expect(text).not.toContain('--headed');
   });
 });
@@ -228,10 +228,10 @@ describe('e2e connect — foreground connect-session entry', () => {
     const pw = playwrightRuns();
     expect(pw).toHaveLength(2);
     // prerequisite first: journey through schedule, headless (no --headed).
-    expect(pw[0].args).toContain('stage-5-schedule');
+    expect(pw[0].args).toContain('--project=stage-5-schedule');
     expect(pw[0].args).not.toContain('--headed');
     // then the live session: interactive-connect, headed.
-    expect(pw[1].args).toContain('interactive-connect');
+    expect(pw[1].args).toContain('--project=interactive-connect');
     expect(pw[1].args).toContain('--headed');
   });
 
@@ -239,7 +239,7 @@ describe('e2e connect — foreground connect-session entry', () => {
     await E2eConnect.run(['--reuse', ...ws(), '--', '--debug'], config);
     const pw = playwrightRuns();
     expect(pw).toHaveLength(1);
-    expect(pw[0].args).toContain('interactive-connect');
+    expect(pw[0].args).toContain('--project=interactive-connect');
     expect(pw[0].args).toContain('--headed');
     // passthrough forwarded.
     expect(pw[0].args).toContain('--debug');
@@ -253,17 +253,17 @@ describe('e2e connect — foreground connect-session entry', () => {
     const pw = playwrightRuns();
     expect(pw).toHaveLength(2);
     // journey prerequisite (a separate ResolvedFlow) must NOT get FAKE_MEDIA.
-    expect(pw[0].args).toContain('stage-5-schedule');
+    expect(pw[0].args).toContain('--project=stage-5-schedule');
     expect(pw[0].env?.FAKE_MEDIA).toBeUndefined();
     // the headed live session does.
-    expect(pw[1].args).toContain('interactive-connect');
+    expect(pw[1].args).toContain('--project=interactive-connect');
     expect(pw[1].env?.FAKE_MEDIA).toBe('1');
   });
 
   it('bare (no --fake-media): interactive-connect runs with real media (no FAKE_MEDIA)', async () => {
     await E2eConnect.run([...ws()], config);
     const pw = playwrightRuns();
-    expect(pw[1].args).toContain('interactive-connect');
+    expect(pw[1].args).toContain('--project=interactive-connect');
     expect(pw[1].env?.FAKE_MEDIA).toBeUndefined();
   });
 
@@ -279,7 +279,7 @@ describe('e2e connect — foreground connect-session entry', () => {
     await E2eConnect.run(['--tunnel', '--reuse', ...ws()], config);
     // The live session's env carries the tunnel URLs — proving tunnelDomain reached the
     // executeResolvedFlow deps (and buildStackContext) for the headed interactive run.
-    const live = playwrightRuns().find((r) => r.args.includes('interactive-connect'));
+    const live = playwrightRuns().find((r) => r.args.includes('--project=interactive-connect'));
     // dash is the non-derivable rename for saga-dash; <label>.<moniker>.<VMS_BASE>.
     expect(live?.env?.PLAYWRIGHT_BASE_URL).toMatch(/^https:\/\/dash\.testmoniker\./);
     expect(live?.env?.PLAYWRIGHT_BASE_URL).not.toContain('localhost');

--- a/packages/node/saga-stack-cli/src/commands/e2e/__tests__/run.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/e2e/__tests__/run.int.test.ts
@@ -145,7 +145,7 @@ describe('e2e run — --dry-run plan (touches no seam)', () => {
     // purpose — do NOT rebuild it with helpers/pw.ts's pwArgv, so a drift in
     // the printed argv shape can never be masked by the builder drifting too.
     expect(text).toContain(
-      'pnpm exec playwright test --config=playwright.stack.config.ts --project stage-4-pods --grep-invert @interactive',
+      'pnpm exec playwright test --config=playwright.stack.config.ts --project=stage-4-pods --grep-invert @interactive',
     );
     expect(text).not.toContain('--headed');
   });
@@ -155,7 +155,7 @@ describe('e2e run — --dry-run plan (touches no seam)', () => {
     expect(runs).toEqual([]);
     const text = logged.join('\n');
     expect(text).toContain('prerequisite: saga-dash/journey (through schedule, headless)');
-    expect(text).toContain('--project interactive-connect');
+    expect(text).toContain('--project=interactive-connect');
     // The terminal stage IS @interactive — the main run must NOT --grep-invert it.
     expect(text).not.toMatch(/interactive-connect.*--grep-invert/);
   });
@@ -205,8 +205,7 @@ describe('e2e run — native orchestration (stack lane)', () => {
       'playwright',
       'test',
       '--config=playwright.stack.config.ts',
-      '--project',
-      'stage-4-pods',
+      '--project=stage-4-pods',
       '--grep-invert',
       '@interactive',
       'journey/pods.e2e.test.ts',
@@ -232,10 +231,10 @@ describe('e2e run — native orchestration (stack lane)', () => {
     const pw = playwrightRuns();
     expect(pw).toHaveLength(2);
     // 1) the prerequisite: journey through schedule, headless.
-    expect(pw[0].args).toContain('stage-5-schedule');
+    expect(pw[0].args).toContain('--project=stage-5-schedule');
     expect(pw[0].args).not.toContain('--headed');
     // 2) the live session: interactive-connect, headed, tag not inverted.
-    expect(pw[1].args).toContain('interactive-connect');
+    expect(pw[1].args).toContain('--project=interactive-connect');
     expect(pw[1].args).toContain('--headed');
     expect(pw[1].args).not.toContain('--grep-invert');
   });
@@ -401,8 +400,8 @@ describe('e2e run — --to window (Plan 13)', () => {
     const pw = playwrightRuns();
     expect(pw).toHaveLength(1);
     // the terminal project is enrollment (the last RUN stage), never pods.
-    expect(pw[0].args).toContain('stage-3-enrollment-periods');
-    expect(pw[0].args).not.toContain('stage-4-pods');
+    expect(pw[0].args).toContain('--project=stage-3-enrollment-periods');
+    expect(pw[0].args).not.toContain('--project=stage-4-pods');
   });
 
   it('--to the FIRST stage is an empty window: reset+seed baseline, ZERO Playwright', async () => {
@@ -434,7 +433,7 @@ describe('e2e run — --hold manual-testing handoff (Plan 13)', () => {
     // window ran roster only (stops before program); then the hold epilogue fired.
     const pw = playwrightRuns();
     expect(pw).toHaveLength(1);
-    expect(pw[0].args).toContain('stage-1-roster');
+    expect(pw[0].args).toContain('--project=stage-1-roster');
 
     // dev-persona jar minted at slot-0 iam, written to the state dir.
     expect(posts).toHaveLength(1);

--- a/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
+++ b/packages/node/saga-stack-cli/src/e2e-orchestrate.ts
@@ -364,9 +364,18 @@ function joinPath(root: string, sub: string): string {
 /**
  * The `pnpm exec playwright test …` argv for a resolved flow. The CLI never
  * parses the SPA's Playwright config — it passes `--config` (verbatim,
- * appDir-relative), `--project` (the terminal stage), an optional
+ * appDir-relative), `--project=` (the terminal stage), an optional
  * `--grep-invert @interactive` (pipeline runs exclude the interactive harness),
  * `--headed` (foreground flows), then any user passthrough (after `--`).
+ *
+ * `--project=<name>` uses the EQUALS form deliberately (soa#401). Playwright
+ * declares `--project <name...>` variadic, so with the separated form any bare
+ * token later in the argv — the `spec` positional below, or anything the user
+ * passes after `--` — is parsed as a SECOND project name and the run dies with
+ * `Project(s) "<that token>" not found` before a single test executes. The
+ * equals form binds the value to the flag and disarms the whole class. Do not
+ * "simplify" this back to `'--project', name`; `pwArgv` (src/__tests__/helpers/
+ * pw.ts) and the argv-shape guard in e2e-orchestrate-slot.unit.test.ts pin it.
  */
 export function playwrightArgv(
   resolved: ResolvedFlow,
@@ -384,8 +393,7 @@ export function playwrightArgv(
     'playwright',
     'test',
     `--config=${resolved.playwright.config}`,
-    '--project',
-    stage?.project ?? resolved.playwright.project,
+    `--project=${stage?.project ?? resolved.playwright.project}`,
   ];
   if (stage?.noDeps) argv.push('--no-deps');
   if (resolved.playwright.grepInvert) argv.push('--grep-invert', resolved.playwright.grepInvert);


### PR DESCRIPTION
Fixes #401.

### The bug

`playwrightArgv` emitted the project as a separate argv element:

```
exec playwright test --config=… --project interactive-connect connect-observe-qtf.e2e.test.ts
```

Playwright declares `--project <name...>` **variadic**, so it greedily consumes the following bare token as a *second project name* and the run dies before executing a single test:

```
Error: Project(s) "connect-observe-qtf.e2e.test.ts" not found.
```

Two bare tokens can legitimately follow the project: the `spec` positional, and anything the user passes after `--`. The failure only surfaced when nothing optional sat in between — which needs `@interactive` (suppresses `--grep-invert`) **and** forced `--headless` (suppresses `--headed`) **and** a single-spawn flow carrying a spec. connectv3 is the only interactive+foreground family, so it was the only thing exposed. Not a regression: this invocation never worked.

### The fix

Equals form — `--project=<name>` — which binds the value to the flag and disarms the entire class.

This is option 1 from the plan rather than the plan's recommended option 2 (reorder the spec push). Option 2 fixes the case we hit but leaves the trap live, because `passthrough` is still appended last: whenever the optional flags are absent, a user's `-- somefile.ts` lands directly after the project name and gets swallowed exactly as the spec does today. The equals form closes both, stays inside this repo, and is consistent with the `--config=` on the adjacent line.

### Guard

Added an argv-shape guard covering all four positions: spec after project, passthrough after project, nothing after project, and the stage-override path. **Verified non-vacuous** — reintroducing the separated form fails all four cases.

Note the guard suggested in the issue would not have worked as written: `expect(argv[i + 2] ?? '').toMatch(/^-/)` false-fails when `--project <name>` ends the argv (`undefined` → `''`, which doesn't match `/^-/`), and goes silently vacuous under this fix since `indexOf('--project')` returns `-1` once the token is `--project=name`. This version asserts the form directly instead.

### Test churn

Mechanical. Assertions that matched the project as a standalone argv token now match `--project=<name>` — strictly more precise, since the old form could also match a spec filename. One helper change worth a look: `installCoreSeams`'s `playwrightFail` lever now matches its token as *either* a bare arg or the `--project=` value, so the spec-positional call sites keep working.

### Verification

- Full suite green: **129 files / 1616 tests**, run three times consecutively.
- `tsc --noEmit` clean; `eslint` 0 errors (128 pre-existing `turbo/no-undeclared-env-vars` warnings in untouched files).
- Guard mutation-tested as described above.

I did **not** run the real e2e flow against a live local stack — that still hits #402 (`authz-api` missing from the manifest → HTTP 408 on every sessions read), which this PR does not address. #401 was masking #402; with this landed, #402 becomes reproducible.

Plan for both: `claude/projects/gh_401_2/source/plan.md` (#403).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYoTrzK5tj4XqLJUcqmvdA