### PR TITLE
feat(observability): attach exception data to spans on error

### DIFF
--- a/packages/node/observability/src/error-middleware.ts
+++ b/packages/node/observability/src/error-middleware.ts
@@ -1,18 +1,24 @@
 import type { ErrorRequestHandler } from 'express';
 import type { ILogger } from '@saga-ed/soa-logger';
+import { recordSpanException } from './record-exception.js';
 
 /**
  * Express error middleware that routes `next(err)` calls through the
- * structured logger instead of falling back to `finalhandler` / console.error.
+ * structured logger instead of falling back to `finalhandler` / console.error,
+ * and attaches the exception to the active span so the trace carries
+ * `error.type` / `error.message` / `error.stack`.
  *
  * Without this, errors from any route's `next(err)` (snapshot endpoints,
  * /metrics, enrollment-readiness) get serialized to raw stderr, bypassing
- * the Pino JSON pipeline and any centralized log aggregation.
+ * the Pino JSON pipeline and any centralized log aggregation — and the
+ * corresponding span reaches Datadog flagged as an error but empty, since
+ * OTel derives the error flag from the status code alone.
  *
  * Register AFTER all routes via `app.use(structuredErrorMiddleware(logger))`.
  */
 export function structuredErrorMiddleware(logger: ILogger): ErrorRequestHandler {
     return (err, req, res, _next) => {
+        recordSpanException(err);
         logger.error(
             `unhandled error on ${req.method} ${req.originalUrl}`,
             err instanceof Error ? err : new Error(String(err)),

--- a/packages/node/observability/src/error-middleware.ts
+++ b/packages/node/observability/src/error-middleware.ts
@@ -18,14 +18,37 @@ import { recordSpanException } from './record-exception.js';
  */
 export function structuredErrorMiddleware(logger: ILogger): ErrorRequestHandler {
     return (err, req, res, _next) => {
-        recordSpanException(err);
-        logger.error(
-            `unhandled error on ${req.method} ${req.originalUrl}`,
-            err instanceof Error ? err : new Error(String(err)),
-        );
+        // Everything before the response is best-effort. A throw here would be
+        // a throw from inside an error handler, which Express hands to
+        // `finalhandler` — the client would get a raw stack trace instead of
+        // the opaque 500 below, and the error would never reach the log
+        // pipeline. `String(err)` alone can throw, for a null-prototype object
+        // or a poisoned `toString`, so the coercion must be guarded too.
+        try {
+            recordSpanException(err);
+            logger.error(
+                `unhandled error on ${req.method} ${req.originalUrl}`,
+                toError(err),
+            );
+        } catch {
+            // Nothing safe left to log with — the logger or the value itself is
+            // the thing that failed. Still send the response below.
+        }
+
         if (res.headersSent) {
             return;
         }
         res.status(500).json({ error: 'internal server error' });
     };
+}
+
+function toError(err: unknown): Error {
+    if (err instanceof Error) {
+        return err;
+    }
+    try {
+        return new Error(String(err));
+    } catch {
+        return new Error('unstringifiable thrown value');
+    }
 }

--- a/packages/node/observability/src/index.ts
+++ b/packages/node/observability/src/index.ts
@@ -13,6 +13,7 @@ export {
     type OutboxMetrics,
 } from './metrics.js';
 export { structuredErrorMiddleware } from './error-middleware.js';
+export { recordSpanException } from './record-exception.js';
 export {
     PiiSanitizingSpanExporter,
     sanitizeUrl,

--- a/packages/node/observability/src/index.ts
+++ b/packages/node/observability/src/index.ts
@@ -17,6 +17,7 @@ export { recordSpanException } from './record-exception.js';
 export {
     PiiSanitizingSpanExporter,
     sanitizeUrl,
+    sanitizeText,
     setSanitizerWarnSink,
     resetSanitizerWarnSink,
 } from './span-sanitizer.js';

--- a/packages/node/observability/src/record-exception.test.ts
+++ b/packages/node/observability/src/record-exception.test.ts
@@ -162,6 +162,58 @@ describe('recordSpanException PII scrubbing', () => {
             'database connection pool exhausted',
         );
     });
+
+    // A standalone slash in prose must not be treated as a path — over-matching
+    // here would redact ordinary error text into uselessness.
+    it.each([
+        'timeout after 30s / retrying',
+        'config value / missing',
+        'read/write conflict',
+        'rate limit 5/second exceeded',
+    ])('leaves prose containing a slash untouched: %s', (message) => {
+        const span = fakeSpan();
+
+        recordSpanException(new Error(message), span);
+
+        expect(recordedError(span).message).toBe(message);
+    });
+
+    // The stack is the whole point of the fix — templatizing its frames into
+    // ':id' soup would trade one unusable field for another.
+    it('keeps stack frames readable', () => {
+        const span = fakeSpan();
+        const err = new Error('boom');
+        err.stack = [
+            'Error: boom',
+            '    at handler (/app/apps/node/programs-api/dist/main.js:12:5)',
+            '    at next (/app/node_modules/express/lib/router/index.js:280:10)',
+        ].join('\n');
+
+        recordSpanException(err, span);
+
+        const recorded = recordedError(span);
+        expect(recorded.stack).toContain('programs-api/dist/main.js');
+        expect(recorded.stack).toContain('express/lib/router/index.js');
+        expect(recorded.stack).not.toContain(':id');
+    });
+
+    it('scrubs identifiers embedded in stack frames', () => {
+        const span = fakeSpan();
+        const err = new Error('boom');
+        err.stack = 'Error: boom\n    at load (/students/12345/grades:1:1)';
+
+        recordSpanException(err, span);
+
+        expect(recordedError(span).stack).not.toContain('12345');
+    });
+
+    it('records a real Error instance, not a plain object', () => {
+        const span = fakeSpan();
+
+        recordSpanException(new Error('failed for a@b.com'), span);
+
+        expect(recordedError(span)).toBeInstanceOf(Error);
+    });
 });
 
 describe('structuredErrorMiddleware', () => {

--- a/packages/node/observability/src/record-exception.test.ts
+++ b/packages/node/observability/src/record-exception.test.ts
@@ -317,18 +317,31 @@ describe('recordSpanException PII scrubbing', () => {
         expect(recordedError(span).message).not.toContain(leaked);
     });
 
+    // The npm scope redacts to `:id` — there is no exemption for it, because
+    // every attempt to carve one out leaked a `/@handle` route (see the note in
+    // span-sanitizer.ts). What must survive is enough of the frame to LOCATE
+    // the code: the unscoped package name, the path, and the filename.
     it.each([
-        '/app/node_modules/@saga-ed/soa-observability/dist/index.js',
-        '/app/node_modules/@opentelemetry/api/build/src/trace.js',
-    ])('keeps the scoped package name in %s', (frame) => {
+        [
+            '/app/node_modules/@saga-ed/soa-observability/dist/index.js',
+            ['node_modules', 'soa-observability', 'index.js'],
+        ],
+        [
+            '/app/node_modules/@opentelemetry/api/build/src/trace.js',
+            ['node_modules', 'api', 'trace.js'],
+        ],
+    ])('keeps the frame diagnosable in %s', (frame, mustSurvive) => {
         const span = fakeSpan();
         const err = new Error('boom');
         err.stack = `Error: boom\n    at handler (${frame}:1:1)`;
 
         recordSpanException(err, span);
 
-        const scope = frame.split('/')[3];
-        expect(recordedError(span).stack).toContain(scope);
+        const stack = recordedError(span).stack;
+        for (const part of mustSurvive) {
+            expect(stack).toContain(part);
+        }
+        expect(stack).toContain(':id'); // the scope itself is redacted
     });
 
     // Scrubbing runs synchronously on the Express error path and the input is

--- a/packages/node/observability/src/record-exception.test.ts
+++ b/packages/node/observability/src/record-exception.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { SpanStatusCode, trace, type Span } from '@opentelemetry/api';
+import { recordSpanException } from './record-exception.js';
+import { structuredErrorMiddleware } from './error-middleware.js';
+
+type SpyingSpan = Span & {
+    recordException: ReturnType<typeof vi.fn>;
+    setStatus: ReturnType<typeof vi.fn>;
+};
+
+function fakeSpan(): SpyingSpan {
+    return {
+        recordException: vi.fn(),
+        setStatus: vi.fn(),
+    } as unknown as SpyingSpan;
+}
+
+/**
+ * Stub the active span rather than using `context.with`: no ContextManager is
+ * registered in unit tests (that is the SDK's job at runtime), so the real
+ * context API would return undefined and the assertion would be vacuous.
+ */
+function withActiveSpan(span: Span | undefined) {
+    return vi.spyOn(trace, 'getActiveSpan').mockReturnValue(span);
+}
+
+function recordedError(span: SpyingSpan): Error {
+    return span.recordException.mock.calls[0]![0] as Error;
+}
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('recordSpanException', () => {
+    it('records the exception and sets ERROR status', () => {
+        const span = fakeSpan();
+
+        recordSpanException(new TypeError('kaboom'), span);
+
+        expect(span.recordException).toHaveBeenCalledTimes(1);
+        const recorded = recordedError(span);
+        expect(recorded.name).toBe('TypeError');
+        expect(recorded.message).toBe('kaboom');
+        expect(recorded.stack).toContain('TypeError: kaboom');
+
+        expect(span.setStatus).toHaveBeenCalledWith({
+            code: SpanStatusCode.ERROR,
+            message: 'kaboom',
+        });
+    });
+
+    it('wraps non-Error throws so type/message/stack still land', () => {
+        const span = fakeSpan();
+
+        recordSpanException('just a string', span);
+
+        const recorded = recordedError(span);
+        expect(recorded.message).toBe('just a string');
+        expect(recorded.stack).toBeDefined();
+    });
+
+    it('no-ops when no span is active and none is passed', () => {
+        withActiveSpan(undefined);
+
+        expect(() => recordSpanException(new Error('nope'))).not.toThrow();
+    });
+
+    it('falls back to the active span when none is passed', () => {
+        const span = fakeSpan();
+        withActiveSpan(span);
+
+        recordSpanException(new Error('from active span'));
+
+        expect(span.recordException).toHaveBeenCalledTimes(1);
+    });
+
+    it('prefers an explicitly passed span over the active one', () => {
+        const active = fakeSpan();
+        const explicit = fakeSpan();
+        withActiveSpan(active);
+
+        recordSpanException(new Error('boom'), explicit);
+
+        expect(explicit.recordException).toHaveBeenCalledTimes(1);
+        expect(active.recordException).not.toHaveBeenCalled();
+    });
+
+    it('never throws if the span implementation throws', () => {
+        const span = {
+            recordException: vi.fn(() => {
+                throw new Error('span is dead');
+            }),
+            setStatus: vi.fn(),
+        } as unknown as Span;
+
+        expect(() => recordSpanException(new Error('boom'), span)).not.toThrow();
+    });
+
+    it('does not mutate the caller-supplied Error', () => {
+        const span = fakeSpan();
+        const err = new Error('failed for a@b.com');
+
+        recordSpanException(err, span);
+
+        expect(err.message).toBe('failed for a@b.com');
+    });
+});
+
+describe('recordSpanException PII scrubbing', () => {
+    // Exception messages/stacks bypass PiiSanitizingSpanExporter, which only
+    // rewrites URL-shaped span attributes — so scrubbing has to happen here.
+    it('redacts bare emails in the message', () => {
+        const span = fakeSpan();
+
+        recordSpanException(new Error('no user for a@b.com'), span);
+
+        const recorded = recordedError(span);
+        expect(recorded.message).toBe('no user for :email');
+    });
+
+    it('templatizes identifiers in paths', () => {
+        const span = fakeSpan();
+
+        recordSpanException(new Error('GET /students/12345/grades failed'), span);
+
+        const recorded = recordedError(span);
+        expect(recorded.message).toContain('/students/:id/grades');
+        expect(recorded.message).not.toContain('12345');
+    });
+
+    it('strips query strings from absolute URLs', () => {
+        const span = fakeSpan();
+
+        recordSpanException(
+            new Error('upstream https://iam.saga.org/auth?email=a@b.com failed'),
+            span,
+        );
+
+        const recorded = recordedError(span);
+        expect(recorded.message).not.toContain('email=');
+        expect(recorded.message).toContain('https://iam.saga.org/auth');
+    });
+
+    it('scrubs the status message too, not just the exception', () => {
+        const span = fakeSpan();
+
+        recordSpanException(new Error('lookup failed for a@b.com'), span);
+
+        expect(span.setStatus).toHaveBeenCalledWith({
+            code: SpanStatusCode.ERROR,
+            message: 'lookup failed for :email',
+        });
+    });
+
+    it('leaves ordinary prose untouched', () => {
+        const span = fakeSpan();
+
+        recordSpanException(new Error('database connection pool exhausted'), span);
+
+        expect(recordedError(span).message).toBe(
+            'database connection pool exhausted',
+        );
+    });
+});
+
+describe('structuredErrorMiddleware', () => {
+    function harness() {
+        const errorSpy = vi.fn();
+        const logger = { error: errorSpy } as never;
+        const res = {
+            headersSent: false,
+            status: vi.fn().mockReturnThis(),
+            json: vi.fn().mockReturnThis(),
+        };
+        const req = { method: 'GET', originalUrl: '/trpc/pods.list' };
+        const next = vi.fn() as never;
+        return { logger, errorSpy, res, req, next };
+    }
+
+    it('records the exception on the active span', () => {
+        const span = fakeSpan();
+        withActiveSpan(span);
+        const { logger, res, req, next } = harness();
+
+        structuredErrorMiddleware(logger)(
+            new Error('handler blew up'),
+            req as never,
+            res as never,
+            next,
+        );
+
+        expect(span.recordException).toHaveBeenCalledTimes(1);
+        expect(span.setStatus).toHaveBeenCalledWith(
+            expect.objectContaining({ code: SpanStatusCode.ERROR }),
+        );
+    });
+
+    it('still logs and responds 500 when no span is active', () => {
+        withActiveSpan(undefined);
+        const { logger, errorSpy, res, req, next } = harness();
+
+        structuredErrorMiddleware(logger)(
+            new Error('boom'),
+            req as never,
+            res as never,
+            next,
+        );
+
+        expect(errorSpy).toHaveBeenCalledTimes(1);
+        expect(res.status).toHaveBeenCalledWith(500);
+        expect(res.json).toHaveBeenCalledWith({ error: 'internal server error' });
+    });
+
+    it('does not write a response when headers were already sent', () => {
+        withActiveSpan(fakeSpan());
+        const { logger, res, req, next } = harness();
+        res.headersSent = true;
+
+        structuredErrorMiddleware(logger)(
+            new Error('boom'),
+            req as never,
+            res as never,
+            next,
+        );
+
+        expect(res.status).not.toHaveBeenCalled();
+    });
+});

--- a/packages/node/observability/src/record-exception.test.ts
+++ b/packages/node/observability/src/record-exception.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { SpanStatusCode, trace, type Span } from '@opentelemetry/api';
 import { recordSpanException } from './record-exception.js';
 import { structuredErrorMiddleware } from './error-middleware.js';
+import {
+    setSanitizerWarnSink,
+    resetSanitizerWarnSink,
+} from './span-sanitizer.js';
 
 type SpyingSpan = Span & {
     recordException: ReturnType<typeof vi.fn>;
@@ -30,6 +34,7 @@ function recordedError(span: SpyingSpan): Error {
 
 afterEach(() => {
     vi.restoreAllMocks();
+    resetSanitizerWarnSink();
 });
 
 describe('recordSpanException', () => {
@@ -95,6 +100,80 @@ describe('recordSpanException', () => {
         } as unknown as Span;
 
         expect(() => recordSpanException(new Error('boom'), span)).not.toThrow();
+    });
+
+    // The throwing-span test above only exercises code INSIDE the try. These
+    // cover the coercion, which sat above it and was the actual gap.
+    it.each([
+        ['null-prototype object', () => Object.create(null) as unknown],
+        [
+            'poisoned toString',
+            () =>
+                ({
+                    toString() {
+                        throw new Error('nope');
+                    },
+                }) as unknown,
+        ],
+        [
+            'throwing Symbol.toPrimitive',
+            () =>
+                ({
+                    [Symbol.toPrimitive]() {
+                        throw new Error('nope');
+                    },
+                }) as unknown,
+        ],
+        ['symbol', () => Symbol('sym') as unknown],
+    ])('never throws when coercing a %s', (_label, make) => {
+        const span = fakeSpan();
+
+        expect(() => recordSpanException(make(), span)).not.toThrow();
+    });
+
+    it('reports a swallowed failure instead of failing silently', () => {
+        const warn = vi.fn();
+        setSanitizerWarnSink(warn);
+        const span = {
+            recordException: vi.fn(() => {
+                throw new Error('span is dead');
+            }),
+            setStatus: vi.fn(),
+        } as unknown as Span;
+
+        recordSpanException(new Error('boom'), span);
+
+        expect(warn).toHaveBeenCalledTimes(1);
+    });
+
+    it('preserves `code` on the sanitized clone so exception.type survives', () => {
+        // The SDK reads exception.code BEFORE exception.name for exception.type,
+        // so losing it collapses ECONNREFUSED to a generic "Error" — and only
+        // when the message happened to contain PII, splitting one failure into
+        // two Error Tracking groups.
+        const span = fakeSpan();
+        const err = Object.assign(
+            new Error('connect ECONNREFUSED 10.0.1.5:5432 for a@b.com'),
+            { code: 'ECONNREFUSED' },
+        );
+
+        recordSpanException(err, span);
+
+        const recorded = recordedError(span) as Error & { code?: string };
+        expect(recorded.message).toContain(':email');
+        expect(recorded.code).toBe('ECONNREFUSED');
+    });
+
+    it('preserves `cause` on the sanitized clone', () => {
+        const span = fakeSpan();
+        const cause = new Error('root cause');
+        const err = new Error('wrapper for a@b.com', { cause });
+
+        recordSpanException(err, span);
+
+        expect((recordedError(span) as Error & { cause?: unknown }).cause).toBe(
+            cause,
+        );
     });
 
     it('does not mutate the caller-supplied Error', () => {
@@ -213,6 +292,58 @@ describe('recordSpanException PII scrubbing', () => {
         recordSpanException(new Error('failed for a@b.com'), span);
 
         expect(recordedError(span)).toBeInstanceOf(Error);
+    });
+
+    // sanitizeUrl's identifier tests are anchored (^\d+$), so an id that
+    // absorbed trailing punctuation into its segment silently fails them.
+    it.each([
+        ['sentence-final period', 'failed to load /students/12345.', '12345'],
+        [
+            'comma after an absolute URL',
+            'upstream https://iam.saga.org/students/12345, retrying',
+            '12345',
+        ],
+        ['bare-path query string', 'GET /students?studentId=12345 failed', '12345'],
+        [
+            'query string with an SSN',
+            'POST /api/lookup?ssn=123-45-6789 rejected',
+            '123-45-6789',
+        ],
+    ])('redacts an id despite %s', (_label, message, leaked) => {
+        const span = fakeSpan();
+
+        recordSpanException(new Error(message), span);
+
+        expect(recordedError(span).message).not.toContain(leaked);
+    });
+
+    it.each([
+        '/app/node_modules/@saga-ed/soa-observability/dist/index.js',
+        '/app/node_modules/@opentelemetry/api/build/src/trace.js',
+    ])('keeps the scoped package name in %s', (frame) => {
+        const span = fakeSpan();
+        const err = new Error('boom');
+        err.stack = `Error: boom\n    at handler (${frame}:1:1)`;
+
+        recordSpanException(err, span);
+
+        const scope = frame.split('/')[3];
+        expect(recordedError(span).stack).toContain(scope);
+    });
+
+    // Scrubbing runs synchronously on the Express error path and the input is
+    // attacker-influenceable, so its cost must stay bounded. Before the length
+    // cap this exact shape blocked the event loop for ~8s.
+    it('scrubs a pathological 64KB message in bounded time', () => {
+        const span = fakeSpan();
+        const hostile = 'Cannot GET user@' + '/api/' + 'a.'.repeat(30000);
+
+        const started = performance.now();
+        recordSpanException(new Error(hostile), span);
+        const elapsed = performance.now() - started;
+
+        expect(elapsed).toBeLessThan(1000);
+        expect(recordedError(span).message).toContain('truncated');
     });
 });
 

--- a/packages/node/observability/src/record-exception.test.ts
+++ b/packages/node/observability/src/record-exception.test.ts
@@ -395,6 +395,57 @@ describe('structuredErrorMiddleware', () => {
         expect(res.json).toHaveBeenCalledWith({ error: 'internal server error' });
     });
 
+    // A throw from inside an error handler goes to Express's finalhandler,
+    // which sends a raw stack trace to the client and loses the log entry.
+    it.each([
+        ['null-prototype object', () => Object.create(null) as unknown],
+        [
+            'poisoned toString',
+            () =>
+                ({
+                    toString() {
+                        throw new Error('nope');
+                    },
+                }) as unknown,
+        ],
+    ])('still responds 500 when the thrown value is a %s', (_label, make) => {
+        withActiveSpan(undefined);
+        const { logger, res, req, next } = harness();
+
+        expect(() =>
+            structuredErrorMiddleware(logger)(
+                make(),
+                req as never,
+                res as never,
+                next,
+            ),
+        ).not.toThrow();
+
+        expect(res.status).toHaveBeenCalledWith(500);
+        expect(res.json).toHaveBeenCalledWith({ error: 'internal server error' });
+    });
+
+    it('still responds 500 when the logger itself throws', () => {
+        withActiveSpan(undefined);
+        const { res, req, next } = harness();
+        const logger = {
+            error: () => {
+                throw new Error('logger is down');
+            },
+        } as never;
+
+        expect(() =>
+            structuredErrorMiddleware(logger)(
+                new Error('boom'),
+                req as never,
+                res as never,
+                next,
+            ),
+        ).not.toThrow();
+
+        expect(res.status).toHaveBeenCalledWith(500);
+    });
+
     it('does not write a response when headers were already sent', () => {
         withActiveSpan(fakeSpan());
         const { logger, res, req, next } = harness();

--- a/packages/node/observability/src/record-exception.ts
+++ b/packages/node/observability/src/record-exception.ts
@@ -1,5 +1,5 @@
 import { SpanStatusCode, trace, type Span } from '@opentelemetry/api';
-import { sanitizeUrl } from './span-sanitizer.js';
+import { sanitizeText, warnSanitizeFailure } from './span-sanitizer.js';
 
 /**
  * Attach exception data to a span so Datadog can populate `error.type`,
@@ -17,7 +17,12 @@ import { sanitizeUrl } from './span-sanitizer.js';
  * A span processor cannot substitute for calling this at the throw site: by
  * export time the Error object is out of scope, so the stack is unrecoverable.
  *
- * Safe to call when tracing is disabled or no span is active — it no-ops.
+ * PII is scrubbed here as defence in depth, but the authoritative scrub is at
+ * the exporter (`PiiSanitizingSpanExporter`), which also covers exception
+ * events recorded by the auto-instrumentations — see `sanitizeText`.
+ *
+ * Safe to call with any thrown value, when tracing is disabled, or when no span
+ * is active — it no-ops and never throws.
  */
 export function recordSpanException(err: unknown, span?: Span): void {
     const target = span ?? trace.getActiveSpan();
@@ -25,37 +30,47 @@ export function recordSpanException(err: unknown, span?: Span): void {
         return;
     }
 
-    const error = err instanceof Error ? err : new Error(String(err));
-
     try {
-        target.recordException(sanitizeException(error));
-        target.setStatus({
-            code: SpanStatusCode.ERROR,
-            message: sanitizeMessage(error.message),
-        });
-    } catch {
-        // Never let telemetry break the error path that is already failing —
-        // this runs inside error middleware, so a throw here would replace a
-        // real 500 with an opaque one and lose the original error.
+        // Coercion is INSIDE the try: `String(err)` throws for a null-prototype
+        // object or a poisoned `toString`/`Symbol.toPrimitive`, and callers drop
+        // this into arbitrary catch blocks on the strength of the never-throw
+        // contract above.
+        const error = err instanceof Error ? err : new Error(String(err));
+        const { exception, message } = sanitizeException(error);
+
+        target.recordException(exception);
+        target.setStatus({ code: SpanStatusCode.ERROR, message });
+    } catch (cause) {
+        // Fail OPEN: the request is already failing, and a throw here would
+        // replace a real 500 with an opaque one. But surface it (throttled) —
+        // silently swallowing would let a regression revert every service to
+        // `error: {}` with a green test suite and no signal.
+        warnSanitizeFailure(
+            '[record-exception] failed to record exception on span',
+            cause,
+        );
     }
 }
 
+interface SanitizedException {
+    /** Scrubbed stand-in passed to `recordException`. */
+    exception: Error;
+    /** Scrubbed message, reused for `setStatus` so the text is scrubbed once. */
+    message: string;
+}
+
 /**
- * Exception messages and stacks bypass `PiiSanitizingSpanExporter` entirely —
- * it only rewrites URL-shaped span *attributes*, not the exception event's
- * payload. Errors routinely interpolate the offending value ("no user for
- * a@b.com", "GET /students/12345 failed"), so scrub before recording rather
- * than shipping student data to Datadog verbatim.
+ * Build a scrubbed stand-in for the caller's Error.
  *
- * Returns a shallow stand-in rather than mutating the caller's Error: the same
- * object is typically also logged and rethrown, and must reach those unchanged.
+ * Returns a stand-in rather than mutating the caller's Error: the same object
+ * is typically also logged and rethrown, and must reach those unchanged.
  */
-function sanitizeException(error: Error): Error {
-    const message = sanitizeMessage(error.message);
-    const stack = error.stack ? sanitizeMessage(error.stack) : undefined;
+function sanitizeException(error: Error): SanitizedException {
+    const message = sanitizeText(error.message);
+    const stack = error.stack ? sanitizeText(error.stack) : undefined;
 
     if (message === error.message && stack === error.stack) {
-        return error;
+        return { exception: error, message };
     }
 
     // A real Error, not a {name, message, stack} literal: recordException takes
@@ -64,20 +79,21 @@ function sanitizeException(error: Error): Error {
     const sanitized = new Error(message);
     sanitized.name = error.name;
     sanitized.stack = stack;
-    return sanitized;
+
+    // `code` and `cause` must survive the clone. The SDK reads `exception.code`
+    // BEFORE `exception.name` when deriving `exception.type`, so dropping it
+    // would collapse e.g. ECONNREFUSED to a generic "Error" — and only on the
+    // clone path, splitting one failure into two Error Tracking groups
+    // depending on whether the message happened to contain PII.
+    copyOwn(error, sanitized, 'code');
+    copyOwn(error, sanitized, 'cause');
+
+    return { exception: sanitized, message };
 }
 
-// URL-ish runs inside free text. Deliberately narrow: over-matching would
-// redact the message into uselessness, and the goal is removing the obvious
-// identifier vector, not proving the text PII-free. The path branch requires a
-// non-empty first segment so a standalone slash in prose ("30s / retrying") is
-// never a match.
-const URL_IN_TEXT =
-    /\bhttps?:\/\/\S+|(?<![\w/])\/[A-Za-z0-9_\-.%@]+(?:\/[A-Za-z0-9_\-.%@]*)*/g;
-const BARE_EMAIL = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g;
-
-function sanitizeMessage(text: string): string {
-    return text
-        .replace(URL_IN_TEXT, (match) => sanitizeUrl(match))
-        .replace(BARE_EMAIL, ':email');
+function copyOwn(from: Error, to: Error, key: 'code' | 'cause'): void {
+    const value = (from as unknown as Record<string, unknown>)[key];
+    if (value !== undefined) {
+        (to as unknown as Record<string, unknown>)[key] = value;
+    }
 }

--- a/packages/node/observability/src/record-exception.ts
+++ b/packages/node/observability/src/record-exception.ts
@@ -46,6 +46,7 @@ export function recordSpanException(err: unknown, span?: Span): void {
         // silently swallowing would let a regression revert every service to
         // `error: {}` with a green test suite and no signal.
         warnSanitizeFailure(
+            'record-exception',
             '[record-exception] failed to record exception on span',
             cause,
         );

--- a/packages/node/observability/src/record-exception.ts
+++ b/packages/node/observability/src/record-exception.ts
@@ -1,0 +1,75 @@
+import { SpanStatusCode, trace, type Span } from '@opentelemetry/api';
+import { sanitizeUrl } from './span-sanitizer.js';
+
+/**
+ * Attach exception data to a span so Datadog can populate `error.type`,
+ * `error.message`, and `error.stack`.
+ *
+ * WHY THIS EXISTS: the Node auto-instrumentations set a span's status to
+ * `Error` from a non-2xx HTTP status code, but they never synthesize an
+ * `exception` span event — that is an explicit application responsibility.
+ * Datadog sources the three `error.*` fields *only* from that event, so an
+ * OTel-instrumented service that never calls `recordException` ships error
+ * spans carrying `error: {}` — flagged as failing, with nothing to debug from
+ * and nothing for Error Tracking to group on. (dd-trace does this attachment
+ * automatically, which is why natively-instrumented services never needed it.)
+ *
+ * A span processor cannot substitute for calling this at the throw site: by
+ * export time the Error object is out of scope, so the stack is unrecoverable.
+ *
+ * Safe to call when tracing is disabled or no span is active — it no-ops.
+ */
+export function recordSpanException(err: unknown, span?: Span): void {
+    const target = span ?? trace.getActiveSpan();
+    if (!target) {
+        return;
+    }
+
+    const error = err instanceof Error ? err : new Error(String(err));
+
+    try {
+        target.recordException(sanitizeException(error));
+        target.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: sanitizeMessage(error.message),
+        });
+    } catch {
+        // Never let telemetry break the error path that is already failing —
+        // this runs inside error middleware, so a throw here would replace a
+        // real 500 with an opaque one and lose the original error.
+    }
+}
+
+/**
+ * Exception messages and stacks bypass `PiiSanitizingSpanExporter` entirely —
+ * it only rewrites URL-shaped span *attributes*, not the exception event's
+ * payload. Errors routinely interpolate the offending value ("no user for
+ * a@b.com", "GET /students/12345 failed"), so scrub before recording rather
+ * than shipping student data to Datadog verbatim.
+ *
+ * Returns a shallow stand-in rather than mutating the caller's Error: the same
+ * object is typically also logged and rethrown, and must reach those unchanged.
+ */
+function sanitizeException(error: Error): Error {
+    const message = sanitizeMessage(error.message);
+    const stack = error.stack ? sanitizeMessage(error.stack) : undefined;
+
+    if (message === error.message && stack === error.stack) {
+        return error;
+    }
+
+    // recordException reads only name/message/stack.
+    return { name: error.name, message, stack } as Error;
+}
+
+// URL-ish runs inside free text. Deliberately narrow: over-matching would
+// redact the message into uselessness, and the goal is removing the obvious
+// identifier vector, not proving the text PII-free.
+const URL_IN_TEXT = /\bhttps?:\/\/\S+|(?<![\w/])\/[A-Za-z0-9_\-./%@]*/g;
+const BARE_EMAIL = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g;
+
+function sanitizeMessage(text: string): string {
+    return text
+        .replace(URL_IN_TEXT, (match) => sanitizeUrl(match))
+        .replace(BARE_EMAIL, ':email');
+}

--- a/packages/node/observability/src/record-exception.ts
+++ b/packages/node/observability/src/record-exception.ts
@@ -58,14 +58,22 @@ function sanitizeException(error: Error): Error {
         return error;
     }
 
-    // recordException reads only name/message/stack.
-    return { name: error.name, message, stack } as Error;
+    // A real Error, not a {name, message, stack} literal: recordException takes
+    // an `Exception` and implementations are free to branch on `instanceof
+    // Error`. A plain object could be silently dropped by a future SDK version.
+    const sanitized = new Error(message);
+    sanitized.name = error.name;
+    sanitized.stack = stack;
+    return sanitized;
 }
 
 // URL-ish runs inside free text. Deliberately narrow: over-matching would
 // redact the message into uselessness, and the goal is removing the obvious
-// identifier vector, not proving the text PII-free.
-const URL_IN_TEXT = /\bhttps?:\/\/\S+|(?<![\w/])\/[A-Za-z0-9_\-./%@]*/g;
+// identifier vector, not proving the text PII-free. The path branch requires a
+// non-empty first segment so a standalone slash in prose ("30s / retrying") is
+// never a match.
+const URL_IN_TEXT =
+    /\bhttps?:\/\/\S+|(?<![\w/])\/[A-Za-z0-9_\-.%@]+(?:\/[A-Za-z0-9_\-.%@]*)*/g;
 const BARE_EMAIL = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g;
 
 function sanitizeMessage(text: string): string {

--- a/packages/node/observability/src/span-sanitizer.test.ts
+++ b/packages/node/observability/src/span-sanitizer.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import {
     sanitizeUrl,
+    sanitizeText,
     PiiSanitizingSpanExporter,
     setSanitizerWarnSink,
     resetSanitizerWarnSink,
@@ -55,12 +56,102 @@ describe('sanitizeUrl', () => {
     });
 });
 
+describe('sanitizeText', () => {
+    it.each([
+        ['no user for a@b.com', 'no user for :email'],
+        ['deep sub a@b.co.uk here', 'deep sub :email here'],
+        ['GET /students/12345/grades failed', 'GET /students/:id/grades failed'],
+        ['failed to load /students/12345.', 'failed to load /students/:id.'],
+        ['GET /students?studentId=12345 failed', 'GET /students failed'],
+    ])('scrubs %s', (input, expected) => {
+        expect(sanitizeText(input)).toBe(expected);
+    });
+
+    // Over-matching would redact ordinary error text into uselessness.
+    it.each([
+        'timeout after 30s / retrying',
+        'read/write conflict',
+        'rate limit 5/second exceeded',
+        'database connection pool exhausted',
+    ])('leaves prose untouched: %s', (text) => {
+        expect(sanitizeText(text)).toBe(text);
+    });
+
+    it('keeps scoped npm package names readable in stack frames', () => {
+        expect(
+            sanitizeText('at f (/app/node_modules/@saga-ed/soa-observability/x.js)'),
+        ).toContain('@saga-ed');
+    });
+
+    it('caps pathological input instead of scanning it all', () => {
+        const hostile = 'x@' + 'a.'.repeat(30000);
+
+        const started = performance.now();
+        const out = sanitizeText(hostile);
+
+        expect(performance.now() - started).toBeLessThan(1000);
+        expect(out).toContain('truncated');
+    });
+});
+
 describe('PiiSanitizingSpanExporter', () => {
-    function fakeSpan(attributes: Record<string, unknown>) {
-        return { attributes } as unknown as Parameters<
+    function fakeSpan(
+        attributes: Record<string, unknown>,
+        events: { name: string; attributes?: Record<string, unknown> }[] = [],
+    ) {
+        return { attributes, events } as unknown as Parameters<
             PiiSanitizingSpanExporter['export']
         >[0][number];
     }
+
+    function exportSpan(span: ReturnType<typeof fakeSpan>) {
+        const inner = {
+            export: (_spans: unknown, cb: (r: unknown) => void) => cb({ code: 0 }),
+            shutdown: () => Promise.resolve(),
+        };
+        new PiiSanitizingSpanExporter(inner as never).export([span], () => {});
+        return span as unknown as {
+            events: { attributes?: Record<string, unknown> }[];
+        };
+    }
+
+    // The auto-instrumentations record exceptions themselves — express calls
+    // recordException on the RAW error for every layer span — so scrubbing only
+    // at our own call site leaves the verbatim value on a sibling span in the
+    // same trace. This is the boundary that makes the guarantee hold.
+    it('scrubs PII from exception events recorded by instrumentations', () => {
+        const span = fakeSpan({}, [
+            {
+                name: 'exception',
+                attributes: {
+                    'exception.type': 'Error',
+                    'exception.message': 'no user for a@b.com',
+                    'exception.stacktrace':
+                        'Error: no user for a@b.com\n    at load (/students/12345/grades:1:1)',
+                },
+            },
+        ]);
+
+        const attrs = exportSpan(span).events[0]!.attributes!;
+
+        expect(attrs['exception.message']).toBe('no user for :email');
+        expect(attrs['exception.stacktrace']).not.toContain('a@b.com');
+        expect(attrs['exception.stacktrace']).not.toContain('12345');
+        expect(attrs['exception.type']).toBe('Error');
+    });
+
+    it('leaves non-exception events and spans without events alone', () => {
+        const span = fakeSpan({}, [
+            { name: 'custom', attributes: { detail: 'no user for a@b.com' } },
+        ]);
+
+        const attrs = exportSpan(span).events[0]!.attributes!;
+
+        expect(attrs.detail).toBe('no user for a@b.com');
+        expect(() =>
+            exportSpan({ attributes: {} } as ReturnType<typeof fakeSpan>),
+        ).not.toThrow();
+    });
 
     it('sanitizes url attrs + drops url.query, delegates to inner', () => {
         const seen: { attrs: Record<string, unknown> }[] = [];

--- a/packages/node/observability/src/span-sanitizer.test.ts
+++ b/packages/node/observability/src/span-sanitizer.test.ts
@@ -162,12 +162,34 @@ describe('sanitizeText', () => {
     );
 
     // Credentials in an authority reach free text too — a driver echoes the
-    // connection string into its error message.
+    // connection string into its error message. The HOST must survive: it is
+    // operational data, and it is why path-shaped tokens are routed to
+    // `sanitizeUrl` before the email pass.
     it.each([
-        ['at http://alice@saga.org/profile', 'alice@saga.org'],
-        ['connect failed: postgres://admin:s3cret@db.internal:5432/main', 's3cret'],
-    ])('redacts userinfo echoed into free text: %s', (input, leaked) => {
-        expect(sanitizeText(input)).not.toContain(leaked);
+        [
+            'at http://alice@saga.org/profile',
+            'at http://:userinfo@saga.org/profile',
+        ],
+        [
+            'connect failed: postgres://admin:s3cret@db.internal:5432/main',
+            'connect failed: postgres://:userinfo@db.internal:5432/main',
+        ],
+    ])('redacts userinfo echoed into free text: %s', (input, expected) => {
+        expect(sanitizeText(input)).toBe(expected);
+    });
+
+    // An address packed into a larger token by a NON-whitespace delimiter. A
+    // driver echoing SQL or a query parameter into its message is exactly the
+    // vector this package creates, and enumerating delimiters one at a time is
+    // what kept this leaking — the split is now the complement of the address
+    // alphabet.
+    it.each([
+        ["insert failed: email='a@b.com'", "insert failed: email=':email'"],
+        ['no recipient for to=a@b.com', 'no recipient for to=:email'],
+        ['user=a@b.com id=42', 'user=:email id=42'],
+        ['json {"email":"a@b.com"}', 'json {"email":":email"}'],
+    ])('redacts an address packed by a non-label delimiter: %s', (input, expected) => {
+        expect(sanitizeText(input)).toBe(expected);
     });
 
     // Encoding must never decide exposure — in a path segment or in prose.

--- a/packages/node/observability/src/span-sanitizer.test.ts
+++ b/packages/node/observability/src/span-sanitizer.test.ts
@@ -69,11 +69,13 @@ describe('sanitizeUrl', () => {
         );
     });
 
-    it('exempts npm scopes only in stack context', () => {
-        const frame = '/app/node_modules/@saga-ed/pkg/index.js';
-
-        expect(sanitizeUrl(frame, 'stack')).toContain('@saga-ed');
-        expect(sanitizeUrl(frame)).toContain(':id');
+    // There is NO npm-scope exemption: the scope is `@`-bearing, so it redacts
+    // like any other identifier. Three attempts to exempt it each leaked a
+    // `/@handle` route one step to the side — see the note in span-sanitizer.ts.
+    it('redacts an npm scope like any other @-bearing segment', () => {
+        expect(sanitizeUrl('/app/node_modules/@saga-ed/pkg/index.js')).toBe(
+            '/app/node_modules/:id/pkg/index.js',
+        );
     });
 
     it('redacts an id fused to a file extension', () => {
@@ -102,22 +104,41 @@ describe('sanitizeText', () => {
         expect(sanitizeText(text)).toBe(text);
     });
 
-    it('keeps scoped npm package names readable in stack frames', () => {
-        expect(
-            sanitizeText('at f (/app/node_modules/@saga-ed/soa-observability/x.js)'),
-        ).toContain('@saga-ed');
+    // The scope redacts (no exemption), but the frame must stay DIAGNOSABLE:
+    // path structure and filename survive, so the frame still locates the code.
+    // That is the guarantee we actually make, and the price of closing the
+    // /@handle class for good.
+    it('keeps stack frames diagnosable while redacting the scope', () => {
+        const out = sanitizeText(
+            'at f (/app/node_modules/@saga-ed/soa-observability/x.js)',
+        );
+
+        expect(out).toBe('at f (/app/node_modules/:id/soa-observability/x.js)');
     });
 
-    // The npm-scope exemption is keyed on provenance, not shape. A router
-    // echoes the request path into its message ("Cannot GET /@bob"), so a
-    // shape-only rule handed free text the stack-context exemption and
-    // un-redacted a handle that `sanitizeUrl` redacts correctly.
+    // A router echoes the request path into its message ("Cannot GET /@bob"),
+    // so free text is attacker-influenceable. Any marker used to prove a token
+    // is a code location can therefore be supplied BY the request — which is
+    // why there is no provenance gate. The last three entries are the spoof
+    // attempts that killed the gated design.
     it.each([
         ['Cannot GET /@bob', 'Cannot GET /:id'],
         ['Cannot GET /@bob/posts', 'Cannot GET /:id/posts'],
+        ['Cannot GET /files/node_modules/@bob', 'Cannot GET /files/node_modules/:id'],
+        ['Cannot GET /node_modules/@bob', 'Cannot GET /node_modules/:id'],
+        ['Error: file:///@bob', 'Error: file:///:id'],
     ])('redacts @handle echoed into free text: %s', (input, expected) => {
         expect(sanitizeText(input)).toBe(expected);
     });
+
+    // `mailto:a@b.com` fails the anchored whole-token test (the scheme breaks
+    // the anchor) and is not path-shaped (no slash), so it shipped verbatim.
+    it.each(['mailto:a@b.com', 'MAILTO:a@b.com', '<mailto:a@b.com>'])(
+        'redacts an address behind a URI scheme: %s',
+        (input) => {
+            expect(sanitizeText(input)).not.toContain('a@b.com');
+        },
+    );
 
     // Encoding must never decide exposure — in a path segment or in prose.
     it('treats literal and percent-encoded handles identically in text', () => {

--- a/packages/node/observability/src/span-sanitizer.test.ts
+++ b/packages/node/observability/src/span-sanitizer.test.ts
@@ -81,6 +81,27 @@ describe('sanitizeUrl', () => {
     it('redacts an id fused to a file extension', () => {
         expect(sanitizeUrl('/exports/98765.csv')).toBe('/exports/:id');
     });
+
+    // The authority was split off as an opaque prefix and never examined, so
+    // userinfo shipped verbatim — an address, or a password on a connection
+    // string that reaches `http.url`.
+    it.each([
+        ['http://a@b.com/x', 'http://:userinfo@b.com/x'],
+        ['https://user:pw@host.com/path', 'https://:userinfo@host.com/path'],
+        [
+            'postgres://admin:s3cret@db.internal:5432/main',
+            'postgres://:userinfo@db.internal:5432/main',
+        ],
+        ['https://alice%40saga.org@host.com/p', 'https://:userinfo@host.com/p'],
+    ])('redacts userinfo in %s', (input, expected) => {
+        expect(sanitizeUrl(input)).toBe(expected);
+    });
+
+    // The host is operational data, not user data — it must survive, or the
+    // attribute stops telling you which service was called.
+    it('leaves an authority without userinfo untouched', () => {
+        expect(sanitizeUrl('https://host.com/path')).toBe('https://host.com/path');
+    });
 });
 
 describe('sanitizeText', () => {
@@ -139,6 +160,15 @@ describe('sanitizeText', () => {
             expect(sanitizeText(input)).not.toContain('a@b.com');
         },
     );
+
+    // Credentials in an authority reach free text too — a driver echoes the
+    // connection string into its error message.
+    it.each([
+        ['at http://alice@saga.org/profile', 'alice@saga.org'],
+        ['connect failed: postgres://admin:s3cret@db.internal:5432/main', 's3cret'],
+    ])('redacts userinfo echoed into free text: %s', (input, leaked) => {
+        expect(sanitizeText(input)).not.toContain(leaked);
+    });
 
     // Encoding must never decide exposure — in a path segment or in prose.
     it('treats literal and percent-encoded handles identically in text', () => {

--- a/packages/node/observability/src/span-sanitizer.test.ts
+++ b/packages/node/observability/src/span-sanitizer.test.ts
@@ -8,6 +8,8 @@ import {
 } from './span-sanitizer.js';
 import { resolveResourceAttributes } from './tracing.js';
 import { recordSpanException } from './record-exception.js';
+import type { SpanExporter, ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import { ExportResultCode, type ExportResult } from '@opentelemetry/core';
 
 describe('sanitizeUrl', () => {
     it('strips query strings', () => {
@@ -486,6 +488,71 @@ describe('PiiSanitizingSpanExporter', () => {
             expect.stringContaining('span attribute sanitization failed'),
             expect.anything(),
         );
+    });
+});
+
+describe('PiiSanitizingSpanExporter degradation granularity', () => {
+    const noopInner = {
+        export: () => {},
+        shutdown: async () => {},
+    } as unknown as SpanExporter;
+
+    // The degrade-safe contract was per SPAN, which is too coarse to hold the
+    // PII guarantee: one unwritable entry aborted the shared loop and shipped
+    // every remaining entry verbatim.
+    it('a frozen event does not skip a later event on the same span', () => {
+        const later: Record<string, unknown> = {
+            'exception.message': 'y for c@d.com',
+        };
+        const span = {
+            attributes: {},
+            events: [
+                { attributes: Object.freeze({ 'exception.message': 'x' }) },
+                { attributes: later },
+            ],
+        } as unknown as ReadableSpan;
+
+        new PiiSanitizingSpanExporter(noopInner).export([span], () => {});
+
+        expect(later['exception.message']).toBe('y for :email');
+    });
+
+    it('an unwritable attribute does not skip a later key on the same span', () => {
+        const attrs: Record<string, unknown> = { 'url.path': '/students/42' };
+        Object.defineProperty(attrs, 'http.url', {
+            value: 'https://h.com/students/1',
+            writable: false,
+            configurable: false,
+            enumerable: true,
+        });
+        const span = { attributes: attrs, events: [] } as unknown as ReadableSpan;
+
+        new PiiSanitizingSpanExporter(noopInner).export([span], () => {});
+
+        expect(attrs['url.path']).toBe('/students/:id');
+    });
+
+    // BatchSpanProcessor wraps export() in a promise that settles ONLY via
+    // resultCallback, so a synchronous throw would leave it pending forever and
+    // wedge every later flush behind the in-flight guard.
+    it('reports a failed result when the inner exporter throws synchronously', () => {
+        const throwingInner = {
+            export: () => {
+                throw new Error('boom');
+            },
+            shutdown: async () => {},
+        } as unknown as SpanExporter;
+        const results: ExportResult[] = [];
+
+        expect(() =>
+            new PiiSanitizingSpanExporter(throwingInner).export(
+                [{ attributes: {}, events: [] } as unknown as ReadableSpan],
+                (r) => results.push(r),
+            ),
+        ).not.toThrow();
+
+        expect(results).toHaveLength(1);
+        expect(results[0]!.code).toBe(ExportResultCode.FAILED);
     });
 });
 

--- a/packages/node/observability/src/span-sanitizer.test.ts
+++ b/packages/node/observability/src/span-sanitizer.test.ts
@@ -485,7 +485,7 @@ describe('PiiSanitizingSpanExporter', () => {
         // The failure is surfaced on the FIRST occurrence (count 0).
         expect(warn).toHaveBeenCalledTimes(1);
         expect(warn).toHaveBeenCalledWith(
-            expect.stringContaining('span attribute sanitization failed'),
+            expect.stringContaining('span attributes could not be sanitized'),
             expect.anything(),
         );
     });

--- a/packages/node/observability/src/span-sanitizer.test.ts
+++ b/packages/node/observability/src/span-sanitizer.test.ts
@@ -108,6 +108,43 @@ describe('sanitizeText', () => {
         ).toContain('@saga-ed');
     });
 
+    // The npm-scope exemption is keyed on provenance, not shape. A router
+    // echoes the request path into its message ("Cannot GET /@bob"), so a
+    // shape-only rule handed free text the stack-context exemption and
+    // un-redacted a handle that `sanitizeUrl` redacts correctly.
+    it.each([
+        ['Cannot GET /@bob', 'Cannot GET /:id'],
+        ['Cannot GET /@bob/posts', 'Cannot GET /:id/posts'],
+    ])('redacts @handle echoed into free text: %s', (input, expected) => {
+        expect(sanitizeText(input)).toBe(expected);
+    });
+
+    // Encoding must never decide exposure — in a path segment or in prose.
+    it('treats literal and percent-encoded handles identically in text', () => {
+        expect(sanitizeText('Cannot GET /@bob')).toBe(
+            sanitizeText('Cannot GET /%40bob'),
+        );
+    });
+
+    it('redacts a percent-encoded address in prose', () => {
+        expect(sanitizeText('encoded a%40b.com in prose')).toBe(
+            'encoded :email in prose',
+        );
+    });
+
+    // A recipient list is ONE whitespace token, so the anchored whole-token
+    // test matched neither address. The comma-SPACE form always worked, which
+    // is what let the packed forms hide: the delimiter decided exposure.
+    it.each([
+        'failed for a@b.com;c@d.com',
+        'failed for a@b.com,c@d.com',
+        'failed for a@b.com, c@d.com',
+    ])('redacts every address in a packed list: %s', (input) => {
+        const out = sanitizeText(input);
+        expect(out).not.toContain('a@b.com');
+        expect(out).not.toContain('c@d.com');
+    });
+
     // Schemes are matched generically, not from a list. `file://` is the normal
     // frame shape in an ESM service, so a fixed `https?` list silently exempted
     // every stack this package exists to scrub.
@@ -139,6 +176,13 @@ describe('sanitizeText', () => {
     // allowed 1000ms and passed at ~220ms of quadratic work, so it would have
     // stayed green through a 3x regression. Doubling the input must not
     // meaningfully more than double the time.
+    //
+    // The bound is deliberately loose. This is a wall-clock measurement in a
+    // package every layer depends on, run under CI parallelism where a GC
+    // pause or a descheduled core lands entirely inside one of two short
+    // samples — a tight ratio would flake fleet-wide without catching anything
+    // extra. Quadratic behaviour on a 2x input shows up at ~4x and grows with
+    // size, so a regression still fails this; only the noise band widens.
     it('scans in linear time, not quadratically', () => {
         const scan = (kib: number) => {
             const input = 'a.'.repeat(kib * 512); // dotted run, no '@' at all
@@ -148,10 +192,10 @@ describe('sanitizeText', () => {
         };
 
         scan(8); // warm up, so JIT compilation is not attributed to the first size
-        const small = Math.max(scan(8), 0.05);
+        const small = Math.max(scan(8), 0.5);
         const large = scan(16);
 
-        expect(large / small).toBeLessThan(2.6);
+        expect(large / small).toBeLessThan(3.5);
     });
 
     it('caps retained output at the truncation limit', () => {

--- a/packages/node/observability/src/span-sanitizer.test.ts
+++ b/packages/node/observability/src/span-sanitizer.test.ts
@@ -7,6 +7,7 @@ import {
     resetSanitizerWarnSink,
 } from './span-sanitizer.js';
 import { resolveResourceAttributes } from './tracing.js';
+import { recordSpanException } from './record-exception.js';
 
 describe('sanitizeUrl', () => {
     it('strips query strings', () => {
@@ -54,6 +55,30 @@ describe('sanitizeUrl', () => {
         expect(sanitizeUrl('/')).toBe('/');
         expect(sanitizeUrl('http://host')).toBe('http://host');
     });
+
+    // The npm-scope exemption is only correct for code locations. Applied to a
+    // request URL it un-redacts a user handle, and worse, does so only for the
+    // literal form — making PII exposure depend on client encoding.
+    it('redacts @handle segments in request URLs', () => {
+        expect(sanitizeUrl('/@johndoe/profile')).toBe('/:id/profile');
+    });
+
+    it('treats literal and percent-encoded handles identically', () => {
+        expect(sanitizeUrl('/@johndoe/profile')).toBe(
+            sanitizeUrl('/%40johndoe/profile'),
+        );
+    });
+
+    it('exempts npm scopes only in stack context', () => {
+        const frame = '/app/node_modules/@saga-ed/pkg/index.js';
+
+        expect(sanitizeUrl(frame, 'stack')).toContain('@saga-ed');
+        expect(sanitizeUrl(frame)).toContain(':id');
+    });
+
+    it('redacts an id fused to a file extension', () => {
+        expect(sanitizeUrl('/exports/98765.csv')).toBe('/exports/:id');
+    });
 });
 
 describe('sanitizeText', () => {
@@ -83,14 +108,57 @@ describe('sanitizeText', () => {
         ).toContain('@saga-ed');
     });
 
-    it('caps pathological input instead of scanning it all', () => {
-        const hostile = 'x@' + 'a.'.repeat(30000);
+    // Schemes are matched generically, not from a list. `file://` is the normal
+    // frame shape in an ESM service, so a fixed `https?` list silently exempted
+    // every stack this package exists to scrub.
+    it.each([
+        ['file:///app/src/students/12345/x.js:1:1', '12345'],
+        ['prisma://db/students/12345', '12345'],
+        ['prefix/students/12345 tail', '12345'],
+        ['/students/12345.json failed', '12345'],
+        ['/exports/98765.csv', '98765'],
+    ])('redacts the id in %s', (input, leaked) => {
+        expect(sanitizeText(input)).not.toContain(leaked);
+    });
 
-        const started = performance.now();
-        const out = sanitizeText(hostile);
+    // Truncating before scrubbing removes the trailing context the anchored
+    // rules need, so a value at the boundary stops matching and ships partly
+    // intact — the cap must bound what is retained, not what is examined.
+    it.each([
+        ['email', 'p'.repeat(16374) + 'alice@saga.org', 'alice@saga'],
+        [
+            'UUID',
+            'q'.repeat(16350) + '/u/550e8400-e29b-41d4-a716-446655440000',
+            '550e8400-e29b-41',
+        ],
+    ])('redacts a %s straddling the truncation cap', (_label, input, leaked) => {
+        expect(sanitizeText(input)).not.toContain(leaked);
+    });
 
-        expect(performance.now() - started).toBeLessThan(1000);
+    // Assert the GROWTH RATE, not a wall-clock threshold. The previous test
+    // allowed 1000ms and passed at ~220ms of quadratic work, so it would have
+    // stayed green through a 3x regression. Doubling the input must not
+    // meaningfully more than double the time.
+    it('scans in linear time, not quadratically', () => {
+        const scan = (kib: number) => {
+            const input = 'a.'.repeat(kib * 512); // dotted run, no '@' at all
+            const started = performance.now();
+            sanitizeText(input);
+            return performance.now() - started;
+        };
+
+        scan(8); // warm up, so JIT compilation is not attributed to the first size
+        const small = Math.max(scan(8), 0.05);
+        const large = scan(16);
+
+        expect(large / small).toBeLessThan(2.6);
+    });
+
+    it('caps retained output at the truncation limit', () => {
+        const out = sanitizeText('x'.repeat(20000));
+
         expect(out).toContain('truncated');
+        expect(out.length).toBeLessThan(20000);
     });
 });
 
@@ -138,6 +206,64 @@ describe('PiiSanitizingSpanExporter', () => {
         expect(attrs['exception.stacktrace']).not.toContain('a@b.com');
         expect(attrs['exception.stacktrace']).not.toContain('12345');
         expect(attrs['exception.type']).toBe('Error');
+    });
+
+    // A throw in the attribute rewrite must not take the event scrub with it —
+    // the exception event is the higher-PII payload, recorded from the RAW
+    // error by instrumentations this package never touches.
+    it('still scrubs exception events when attribute sanitization throws', () => {
+        setSanitizerWarnSink(vi.fn());
+        const span = {
+            attributes: Object.freeze({ 'http.url': 'http://x/students/42?q=1' }),
+            events: [
+                {
+                    name: 'exception',
+                    attributes: { 'exception.message': 'no user for a@b.com' },
+                },
+            ],
+        } as never;
+
+        const inner = {
+            export: (_s: unknown, cb: (r: unknown) => void) => cb({ code: 0 }),
+            shutdown: () => Promise.resolve(),
+        };
+        expect(() =>
+            new PiiSanitizingSpanExporter(inner as never).export([span], () => {}),
+        ).not.toThrow();
+
+        const events = (span as unknown as { events: { attributes: Record<string, unknown> }[] })
+            .events;
+        expect(events[0]!.attributes['exception.message']).toBe('no user for :email');
+    });
+
+    it('throttles each failure channel independently', () => {
+        const warn = vi.fn();
+        setSanitizerWarnSink(warn);
+        const inner = {
+            export: (_s: unknown, cb: (r: unknown) => void) => cb({ code: 0 }),
+            shutdown: () => Promise.resolve(),
+        };
+        const exporter = new PiiSanitizingSpanExporter(inner as never);
+
+        // Drive many attribute failures so a shared counter would move well past
+        // the throttle boundary.
+        for (let i = 0; i < 50; i++) {
+            exporter.export(
+                [{ attributes: Object.freeze({ 'http.url': '/x/1' }), events: [] } as never],
+                () => {},
+            );
+        }
+        const afterAttributes = warn.mock.calls.length;
+
+        // A first failure in a DIFFERENT channel must still warn immediately.
+        recordSpanException(new Error('boom'), {
+            recordException: () => {
+                throw new Error('span is dead');
+            },
+            setStatus: () => {},
+        } as never);
+
+        expect(warn.mock.calls.length).toBe(afterAttributes + 1);
     });
 
     it('leaves non-exception events and spans without events alone', () => {
@@ -240,7 +366,7 @@ describe('PiiSanitizingSpanExporter', () => {
         // The failure is surfaced on the FIRST occurrence (count 0).
         expect(warn).toHaveBeenCalledTimes(1);
         expect(warn).toHaveBeenCalledWith(
-            expect.stringContaining('span sanitization failed'),
+            expect.stringContaining('span attribute sanitization failed'),
             expect.anything(),
         );
     });

--- a/packages/node/observability/src/span-sanitizer.ts
+++ b/packages/node/observability/src/span-sanitizer.ts
@@ -1,6 +1,6 @@
 import { diag, type Attributes } from '@opentelemetry/api';
 import type { SpanExporter, ReadableSpan } from '@opentelemetry/sdk-trace-base';
-import type { ExportResult } from '@opentelemetry/core';
+import { ExportResultCode, type ExportResult } from '@opentelemetry/core';
 
 /**
  * PII span sanitizer.
@@ -339,18 +339,45 @@ export function sanitizeUrl(value: string): string {
     return prefix + sanitizedPath;
 }
 
+// PER-ENTRY ISOLATION. The degrade-safe contract is per SPAN at the export
+// loop, but that granularity is too coarse to hold the PII guarantee: a single
+// non-writable key (a frozen attributes object, a getter-backed value) threw
+// out of the shared loop and skipped EVERY REMAINING KEY on that span. The
+// entries are independent, so one unwritable one must cost only itself.
+//
+// Isolating them must not make them SILENT, though: the first failure still has
+// to reach the throttled sink, or a read-only-attributes regression disables
+// sanitization fleet-wide with no signal. So the first error is captured and
+// rethrown once the remaining entries have been processed — the caller's
+// existing per-span catch reports it at its normal cadence, and later entries
+// no longer pay for an earlier one.
 function sanitizeAttributes(attributes: Attributes): void {
+    let firstError: unknown;
+    const record = (err: unknown) => {
+        if (firstError === undefined) firstError = err;
+    };
+
     for (const key of DROP_ATTR_KEYS) {
-        if (key in attributes) delete attributes[key];
-    }
-    for (const key of URL_ATTR_KEYS) {
-        const val = attributes[key];
-        // Only string-valued URL attrs are rewritten; numeric/boolean/array
-        // attribute values (e.g. http.status_code) are left untouched.
-        if (typeof val === 'string') {
-            attributes[key] = sanitizeUrl(val);
+        try {
+            if (key in attributes) delete attributes[key];
+        } catch (err) {
+            record(err);
         }
     }
+    for (const key of URL_ATTR_KEYS) {
+        try {
+            const val = attributes[key];
+            // Only string-valued URL attrs are rewritten; numeric/boolean/array
+            // attribute values (e.g. http.status_code) are left untouched.
+            if (typeof val === 'string') {
+                attributes[key] = sanitizeUrl(val);
+            }
+        } catch (err) {
+            record(err);
+        }
+    }
+
+    if (firstError !== undefined) throw firstError;
 }
 
 // Free-text attributes on an `exception` span event. Scrubbing these at the
@@ -369,15 +396,28 @@ function sanitizeEvents(span: ReadableSpan): void {
     // path against spans from any SDK version — a missing array must degrade to
     // "nothing to scrub", not throw and skip attribute sanitization too.
     if (!Array.isArray(span.events)) return;
+
+    let firstError: unknown;
     for (const event of span.events) {
         if (!event.attributes) continue;
         for (const key of EXCEPTION_TEXT_ATTR_KEYS) {
-            const val = event.attributes[key];
-            if (typeof val === 'string') {
-                event.attributes[key] = sanitizeText(val);
+            // Per-KEY, per-EVENT isolation — see `sanitizeAttributes`. A frozen
+            // event[0] used to abort the loop and ship event[1]'s message
+            // verbatim, which is the highest-PII payload on the span (the
+            // instrumentations record it from the RAW error). The first error
+            // is rethrown after the loop so the failure still reaches the sink.
+            try {
+                const val = event.attributes[key];
+                if (typeof val === 'string') {
+                    event.attributes[key] = sanitizeText(val);
+                }
+            } catch (err) {
+                if (firstError === undefined) firstError = err;
             }
         }
     }
+
+    if (firstError !== undefined) throw firstError;
 }
 
 // Detectability of a persistent sanitize failure must NOT depend on whether a
@@ -430,12 +470,17 @@ const SANITIZE_WARN_EVERY = 1000;
  * that was supposed to be guaranteed. "First occurrence always fires" is only
  * true if each source counts its own.
  */
-type WarnChannel = 'attributes' | 'events' | 'record-exception';
+type WarnChannel =
+    | 'attributes'
+    | 'events'
+    | 'record-exception'
+    | 'inner-export';
 
 const failureCounts: Record<WarnChannel, number> = {
     attributes: 0,
     events: 0,
     'record-exception': 0,
+    'inner-export': 0,
 };
 
 /**
@@ -501,7 +546,27 @@ export class PiiSanitizingSpanExporter implements SpanExporter {
                 );
             }
         }
-        this.inner.export(spans, resultCallback);
+        // A synchronous throw out of the inner exporter must still produce a
+        // RESULT. `BatchSpanProcessor` wraps this call in a promise that only
+        // settles via `resultCallback`, so letting the throw escape leaves that
+        // promise pending forever: the batch is never retried, never dropped,
+        // and the processor's in-flight-export guard blocks every subsequent
+        // flush — tracing stops for the life of the process. Reporting a failed
+        // result instead keeps the wrapper transparent, since a well-behaved
+        // exporter signals failure exactly this way.
+        try {
+            this.inner.export(spans, resultCallback);
+        } catch (err) {
+            warnSanitizeFailure(
+                'inner-export',
+                '[pii-sanitizer] inner exporter threw synchronously; reporting export failure',
+                err,
+            );
+            resultCallback({
+                code: ExportResultCode.FAILED,
+                error: err instanceof Error ? err : new Error(String(err)),
+            });
+        }
     }
 
     shutdown(): Promise<void> {

--- a/packages/node/observability/src/span-sanitizer.ts
+++ b/packages/node/observability/src/span-sanitizer.ts
@@ -57,13 +57,89 @@ const LONG_TOKEN_SEGMENT = /^[A-Za-z0-9_-]{20,}$/; // hex/base64-ish opaque ids
 // percent-encoded, so matching only the literal `@` would leak encoded emails.
 const EMAIL_SEGMENT = /@|%40/i;
 
+// A scoped npm package (`@saga-ed/soa-observability`) is a path segment
+// containing `@`, so the email rule would redact it — erasing the package name
+// from every stack frame in this monorepo's traces, degrading the very field
+// `recordSpanException` exists to populate. A scope is `@name` with no dot and
+// no second `@`, which no email can satisfy.
+const NPM_SCOPE_SEGMENT = /^@[A-Za-z0-9_-]+$/;
+
 function looksLikeIdentifier(segment: string): boolean {
+    if (NPM_SCOPE_SEGMENT.test(segment)) {
+        return false;
+    }
     return (
         NUMERIC_SEGMENT.test(segment) ||
         UUID_SEGMENT.test(segment) ||
         EMAIL_SEGMENT.test(segment) ||
         LONG_TOKEN_SEGMENT.test(segment)
     );
+}
+
+/**
+ * Longest message/stack scrubbed before truncation.
+ *
+ * Scrubbing runs synchronously on the Express error path, so its cost is
+ * request-blocking and the input is attacker-influenceable (frameworks echo the
+ * request path into the message). A hard cap makes the work bounded regardless
+ * of regex behaviour on pathological input. 16 KiB comfortably holds a deep
+ * Node stack; beyond that a marker is appended so truncation is never silent.
+ */
+const MAX_SCRUB_LENGTH = 16 * 1024;
+const TRUNCATION_MARKER = '… [truncated by pii-sanitizer]';
+
+// Identifier-ish runs inside free text. Deliberately narrow: over-matching
+// would redact the message into uselessness, and the goal is removing the
+// obvious identifier vector, not proving the text PII-free.
+//
+// The path branch requires a non-empty first segment, so a standalone slash in
+// prose ("30s / retrying") never matches. It also consumes an optional query
+// string so `sanitizeUrl` can drop it — without this a bare path carries
+// `?studentId=12345` straight through, since only the absolute-URL branch's
+// `\S+` would otherwise swallow a `?`.
+const PATH_CHARS = String.raw`[A-Za-z0-9_\-.%@~]`;
+// The absolute-URL branch excludes `,` `;` and quotes/brackets outright: unlike
+// `.` and `:` they never appear inside a real URL, so letting `\S+` swallow
+// them would fold prose punctuation into the final path segment and defeat
+// sanitizeUrl's anchored identifier tests.
+const URL_CHARS = String.raw`[^\s,;'"\]}>]`;
+const URL_IN_TEXT = new RegExp(
+    String.raw`\bhttps?://${URL_CHARS}+|(?<![\w/])/${PATH_CHARS}+(?:/${PATH_CHARS}*)*(?:\?\S*)?`,
+    'g',
+);
+
+// Trailing sentence punctuation must not be absorbed into the match: a segment
+// captured as "12345." fails the anchored ^\d+$ identifier test and the id then
+// ships verbatim. Stripped before sanitizing, re-appended after.
+const TRAILING_PUNCTUATION = /[.,;:!?)\]}'"]+$/;
+
+// Domain part is split into dot-free labels so there is exactly one way to
+// match — `[A-Za-z0-9.-]+` followed by `\.` lets `.` belong to either side,
+// giving overlapping split points and quadratic scanning under the `g` flag.
+const BARE_EMAIL =
+    /[A-Za-z0-9._%+-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*\.[A-Za-z]{2,}/g;
+
+/**
+ * Scrub PII out of free-form text (an exception message or stack trace).
+ *
+ * Unlike `sanitizeUrl`, which receives a whole attribute value, this extracts
+ * URL/path-shaped runs from arbitrary prose and sanitizes each in place.
+ */
+export function sanitizeText(text: string): string {
+    const truncated =
+        text.length > MAX_SCRUB_LENGTH
+            ? text.slice(0, MAX_SCRUB_LENGTH) + TRUNCATION_MARKER
+            : text;
+
+    return truncated
+        .replace(URL_IN_TEXT, (match) => {
+            const punctuation = TRAILING_PUNCTUATION.exec(match)?.[0] ?? '';
+            const trimmed = punctuation
+                ? match.slice(0, -punctuation.length)
+                : match;
+            return sanitizeUrl(trimmed) + punctuation;
+        })
+        .replace(BARE_EMAIL, ':email');
 }
 
 /**
@@ -111,6 +187,33 @@ function sanitizeAttributes(attributes: Attributes): void {
     }
 }
 
+// Free-text attributes on an `exception` span event. Scrubbing these at the
+// exporter is what makes the guarantee hold fleet-wide: the auto-instrumentations
+// record exceptions themselves (@opentelemetry/instrumentation-express calls
+// recordException on the RAW error for every express.* layer span), so scrubbing
+// only at our own call site would leave the verbatim value on a sibling span in
+// the same trace. Applies to every span, however the event was produced.
+const EXCEPTION_TEXT_ATTR_KEYS = [
+    'exception.message',
+    'exception.stacktrace',
+] as const;
+
+function sanitizeEvents(span: ReadableSpan): void {
+    // `events` is non-optional on ReadableSpan, but this runs on the export hot
+    // path against spans from any SDK version — a missing array must degrade to
+    // "nothing to scrub", not throw and skip attribute sanitization too.
+    if (!Array.isArray(span.events)) return;
+    for (const event of span.events) {
+        if (!event.attributes) continue;
+        for (const key of EXCEPTION_TEXT_ATTR_KEYS) {
+            const val = event.attributes[key];
+            if (typeof val === 'string') {
+                event.attributes[key] = sanitizeText(val);
+            }
+        }
+    }
+}
+
 // Detectability of a persistent sanitize failure must NOT depend on whether a
 // service wired an OTel diag logger. The global `diag` defaults to a no-op with
 // NO console fallback (verified against @opentelemetry/api), so a bare
@@ -153,6 +256,18 @@ const SANITIZE_WARN_EVERY = 1000;
 let sanitizeFailureCount = 0;
 
 /**
+ * Report a swallowed sanitize/telemetry failure through the throttled sink.
+ *
+ * Shared so every degrade-safe catch in this package stays detectable through
+ * one channel and one throttle, rather than each re-inventing (or omitting) it.
+ */
+export function warnSanitizeFailure(message: string, err: unknown): void {
+    if (sanitizeFailureCount++ % SANITIZE_WARN_EVERY === 0) {
+        warnSink(message, err);
+    }
+}
+
+/**
  * Wraps a SpanExporter, sanitizing PII out of span attributes before delegating
  * to the inner exporter. See module doc for the degrade-safe contract.
  */
@@ -170,6 +285,7 @@ export class PiiSanitizingSpanExporter implements SpanExporter {
                 // object, so in-place rewrite works. If a future impl makes it
                 // truly read-only the assignment throws → caught below.
                 sanitizeAttributes(span.attributes);
+                sanitizeEvents(span);
             } catch (err) {
                 // Fail OPEN: leave this span untouched rather than dropping it
                 // or aborting the whole batch. Never rethrow. But surface a

--- a/packages/node/observability/src/span-sanitizer.ts
+++ b/packages/node/observability/src/span-sanitizer.ts
@@ -57,29 +57,25 @@ const LONG_TOKEN_SEGMENT = /^[A-Za-z0-9_-]{20,}$/; // hex/base64-ish opaque ids
 // percent-encoded, so matching only the literal `@` would leak encoded emails.
 const EMAIL_SEGMENT = /@|%40/i;
 
-// A scoped npm package (`@saga-ed/soa-observability`) is a path segment
-// containing `@`, so the email rule would redact it — erasing the package name
-// from every stack frame in this monorepo's traces, degrading the very field
-// `recordSpanException` exists to populate. A scope is `@name` with no dot and
-// no second `@`, which no email can satisfy.
-const NPM_SCOPE_SEGMENT = /^@[A-Za-z0-9_-]+$/;
-
-/**
- * Where a path came from. The npm-scope exemption is only ever correct for
- * code locations: applying it to request URLs would un-redact a `/@handle`
- * route, which is user data and was previously redacted by the email rule.
- * Encoding must not decide PII exposure — `/@bob` and `/%40bob` have to behave
- * identically on a request URL.
- *
- * A token inside free text has no inherent context, so it is classified by
- * POSITIVE evidence that it names a code location (see `pathContextOf`) and
- * treated as a request URL otherwise. Shape alone cannot make that call: this
- * is the third defect of the form "something `@`-shaped escaped redaction",
- * and each previous attempt to narrow the scope pattern left a neighbouring
- * leak (`/@bob` when the rule required no dot, `/@bob/posts` if it required
- * `@scope/name`). Provenance is the boundary that closes the class.
- */
-type PathContext = 'url' | 'stack';
+// NO NPM-SCOPE EXEMPTION — deliberately, after three attempts.
+//
+// A scoped package (`@saga-ed/soa-observability`) is an `@`-bearing path
+// segment, so the email rule redacts the scope to `:id`. An exemption for it
+// was tried three times and each revision leaked a `/@handle` route one step to
+// the side of the last: first when the rule required no dot, then for
+// `/@bob/posts` under an `@scope/name` rule, and finally — after the exemption
+// was gated on "does this token look like a code location" — for any request
+// path containing the literal `node_modules/` or a `file://` prefix. That last
+// attempt is the one that settles it: this text is ATTACKER-INFLUENCEABLE
+// (routers echo the request path into the message), so any marker used to
+// prove provenance can simply be included in the request. Shape cannot
+// establish provenance.
+//
+// The cost is one token per frame: `/app/node_modules/@saga-ed/pkg/index.js`
+// ships as `/app/node_modules/:id/pkg/index.js` — the package name, path, and
+// filename all survive, so the frame stays diagnosable. Unscoped packages are
+// untouched. That is a cheap price for closing a leak class that reopened
+// three times.
 
 // An id fused to a file extension ("12345.json") fails every anchored test
 // below, because `.` sits outside their character classes. Test the stem
@@ -87,28 +83,14 @@ type PathContext = 'url' | 'stack';
 // extension is structure, the stem is the identifier.
 const FILE_EXTENSION = /\.[A-Za-z0-9]{1,8}$/;
 
-function looksLikeIdentifier(
-    segment: string,
-    context: PathContext = 'url',
-): boolean {
-    if (context === 'stack' && NPM_SCOPE_SEGMENT.test(segment)) {
-        return false;
-    }
+function looksLikeIdentifier(segment: string): boolean {
     if (matchesIdentifierRule(segment)) {
         return true;
     }
 
-    // Retry without a trailing extension, but never let the stem's `@` trigger
-    // the email rule — "user@corp.com" would otherwise be caught here anyway by
-    // the full-segment test above, and a scoped package must not match via its
-    // stem either.
+    // Retry without a trailing extension, so an id fused to one still redacts.
     const stem = segment.replace(FILE_EXTENSION, '');
-    return (
-        stem !== segment &&
-        stem !== '' &&
-        !(context === 'stack' && NPM_SCOPE_SEGMENT.test(stem)) &&
-        matchesIdentifierRule(stem)
-    );
+    return stem !== segment && stem !== '' && matchesIdentifierRule(stem);
 }
 
 function matchesIdentifierRule(segment: string): boolean {
@@ -163,8 +145,11 @@ const HAS_SCHEME = /^[a-z][a-z0-9+.-]*:\/\//i;
  * labels did not help, because the local part has the same shape.
  *
  * Tokens are already whitespace-delimited, and an email cannot contain
- * whitespace, so per-token anchoring loses nothing and makes the work linear:
- * each token is examined once, and only if it contains an `@` at all.
+ * whitespace, so anchoring makes the work linear: each piece is examined once,
+ * and only if it could hold an address at all. Anchoring alone would miss the
+ * forms whitespace does not separate, so `redactEmails` splits a token on
+ * `,`/`;` and `isBareEmail` retries without a `scheme:` prefix — both keep
+ * every test anchored rather than reintroducing a scanning pattern.
  */
 const EMAIL_LABEL = String.raw`[A-Za-z0-9_%+-]+`;
 const BARE_EMAIL_TOKEN = new RegExp(
@@ -207,7 +192,7 @@ function sanitizeToken(token: string): string {
     if (!isPathShaped(core)) {
         return token;
     }
-    return lead + sanitizeUrl(core, pathContextOf(core)) + trail;
+    return lead + sanitizeUrl(core) + trail;
 }
 
 /**
@@ -241,7 +226,7 @@ function redactEmails(core: string): string | null {
         // two as equivalent for path segments; free text has to agree, or an
         // encoded address in prose survives while its literal form is redacted.
         const decoded = piece.replace(PERCENT_ENCODED_AT, '@');
-        if (!BARE_EMAIL_TOKEN.test(decoded)) {
+        if (!isBareEmail(decoded)) {
             return piece;
         }
         redactedAny = true;
@@ -251,24 +236,28 @@ function redactEmails(core: string): string | null {
     return redactedAny ? pieces.join('') : null;
 }
 
+/**
+ * Anchored email test, retried once without a URI scheme prefix.
+ *
+ * `mailto:a@b.com` is the shape that motivated the retry: the prefix breaks the
+ * anchor so the address test fails, and it is not path-shaped either (no
+ * slash), so the token was returned verbatim — an address shipped in the
+ * clear. Stripping only a leading `scheme:` keeps each test anchored, which is
+ * the property that makes the scan linear.
+ */
+function isBareEmail(piece: string): boolean {
+    if (BARE_EMAIL_TOKEN.test(piece)) {
+        return true;
+    }
+    const withoutScheme = piece.replace(URI_SCHEME_PREFIX, '');
+    return withoutScheme !== piece && BARE_EMAIL_TOKEN.test(withoutScheme);
+}
+
 // Capturing, so `split` keeps the separators and the token rejoins verbatim.
 const EMAIL_LIST_SEPARATOR = /([,;]+)/;
 const PERCENT_ENCODED_AT = /%40/gi;
-
-/**
- * Classify a free-text token by POSITIVE evidence that it names a code
- * location. Anything else — including a bare `/@bob` echoed out of a router's
- * "Cannot GET" message — is treated as a request URL, so the npm-scope
- * exemption can never un-redact user data. Erring toward `'url'` costs at most
- * an over-redacted stack frame; erring toward `'stack'` ships PII.
- */
-function pathContextOf(token: string): PathContext {
-    return FILE_SCHEME.test(token) || token.includes('node_modules/')
-        ? 'stack'
-        : 'url';
-}
-
-const FILE_SCHEME = /^file:\/\//i;
+// `mailto:`, `MAILTO:` — a scheme with no `//`, so HAS_SCHEME does not match it.
+const URI_SCHEME_PREFIX = /^[a-z][a-z0-9+.-]*:/i;
 
 function isPathShaped(token: string): boolean {
     if (HAS_SCHEME.test(token)) return true;
@@ -293,7 +282,7 @@ const SIMPLE_RATIO = /^\d+\/[A-Za-z0-9]*$/;
  * tRPC method names (`/trpc/auth.getProvidersByEmail`) are method *names*, not
  * data, and are NOT identifier-shaped → preserved.
  */
-export function sanitizeUrl(value: string, context: PathContext = 'url'): string {
+export function sanitizeUrl(value: string): string {
     // Split scheme://host from the path so we only rewrite the path portion.
     // `file:///app/x` has an empty host, so the host part must be optional —
     // requiring `[^/]+` here is what made ESM stack frames fall through.
@@ -314,7 +303,7 @@ export function sanitizeUrl(value: string, context: PathContext = 'url'): string
 
     const sanitizedPath = rest
         .split('/')
-        .map((seg) => (looksLikeIdentifier(seg, context) ? ':id' : seg))
+        .map((seg) => (looksLikeIdentifier(seg) ? ':id' : seg))
         .join('/');
 
     return prefix + sanitizedPath;

--- a/packages/node/observability/src/span-sanitizer.ts
+++ b/packages/node/observability/src/span-sanitizer.ts
@@ -259,6 +259,26 @@ const PERCENT_ENCODED_AT = /%40/gi;
 // `mailto:`, `MAILTO:` — a scheme with no `//`, so HAS_SCHEME does not match it.
 const URI_SCHEME_PREFIX = /^[a-z][a-z0-9+.-]*:/i;
 
+/**
+ * Redact the userinfo component of an authority (`user:pw@host` → `:userinfo@host`).
+ *
+ * Everything before the `@` in an authority is a credential, and it was shipping
+ * VERBATIM: `sanitizeUrl` split `scheme://host` off as an opaque prefix and only
+ * ever rewrote the path, so nothing examined the authority. That leaked an
+ * address on `http://alice@saga.org/p` and, worse, a password on a connection
+ * string — `postgres://admin:s3cret@db.internal:5432/main` reached `http.url`
+ * with the secret intact.
+ *
+ * The host is deliberately KEPT: it is the operational half of the attribute
+ * (which service was called) and carries no user data. Only the credential is
+ * replaced, and the last `@` is the delimiter — an unencoded `@` may appear
+ * inside the userinfo itself.
+ */
+function redactUserinfo(authority: string): string {
+    const at = authority.lastIndexOf('@');
+    return at === -1 ? authority : ':userinfo' + authority.slice(at);
+}
+
 function isPathShaped(token: string): boolean {
     if (HAS_SCHEME.test(token)) return true;
 
@@ -289,10 +309,10 @@ export function sanitizeUrl(value: string): string {
     let prefix = '';
     let rest = value;
 
-    const schemeMatch = /^([a-z][a-z0-9+.-]*:\/\/[^/]*)(\/.*)?$/i.exec(value);
+    const schemeMatch = /^([a-z][a-z0-9+.-]*:\/\/)([^/]*)(\/.*)?$/i.exec(value);
     if (schemeMatch && schemeMatch[1] !== undefined) {
-        prefix = schemeMatch[1];
-        rest = schemeMatch[2] ?? '';
+        prefix = schemeMatch[1] + redactUserinfo(schemeMatch[2] ?? '');
+        rest = schemeMatch[3] ?? '';
     }
 
     // Drop query string + fragment.

--- a/packages/node/observability/src/span-sanitizer.ts
+++ b/packages/node/observability/src/span-sanitizer.ts
@@ -70,6 +70,14 @@ const NPM_SCOPE_SEGMENT = /^@[A-Za-z0-9_-]+$/;
  * route, which is user data and was previously redacted by the email rule.
  * Encoding must not decide PII exposure — `/@bob` and `/%40bob` have to behave
  * identically on a request URL.
+ *
+ * A token inside free text has no inherent context, so it is classified by
+ * POSITIVE evidence that it names a code location (see `pathContextOf`) and
+ * treated as a request URL otherwise. Shape alone cannot make that call: this
+ * is the third defect of the form "something `@`-shaped escaped redaction",
+ * and each previous attempt to narrow the scope pattern left a neighbouring
+ * leak (`/@bob` when the rule required no dot, `/@bob/posts` if it required
+ * `@scope/name`). Provenance is the boundary that closes the class.
  */
 type PathContext = 'url' | 'stack';
 
@@ -192,16 +200,75 @@ function sanitizeToken(token: string): string {
     if (core === '') {
         return token;
     }
-    // `indexOf` first: the anchored email test only runs on tokens that could
-    // possibly be one, so prose never pays for it.
-    if (core.indexOf('@') !== -1 && BARE_EMAIL_TOKEN.test(core)) {
-        return lead + ':email' + trail;
+    const emailRedacted = redactEmails(core);
+    if (emailRedacted !== null) {
+        return lead + emailRedacted + trail;
     }
     if (!isPathShaped(core)) {
         return token;
     }
-    return lead + sanitizeUrl(core, 'stack') + trail;
+    return lead + sanitizeUrl(core, pathContextOf(core)) + trail;
 }
+
+/**
+ * Redact every address in an email-shaped token, or `null` if it holds none.
+ *
+ * Whitespace is not the only delimiter that packs addresses together: a
+ * recipient list serializes as `a@b.com;c@d.com` or `a@b.com,c@d.com`, which is
+ * ONE whitespace token, matches the anchored whole-token pattern at neither
+ * address, is not path-shaped, and so shipped both verbatim. The comma-SPACE
+ * form did redact, so the split is what hid this — the delimiter, not the
+ * shape, decided exposure.
+ *
+ * Splitting on those two separators keeps each piece anchored (the property
+ * that makes the scan linear — see `BARE_EMAIL_TOKEN`) while covering the
+ * packed forms. Rejoining with the original separators preserves the text for
+ * the non-email pieces of a mixed token.
+ */
+function redactEmails(core: string): string | null {
+    // `indexOf` first: the anchored tests only run on tokens that could
+    // possibly hold an address, so prose never pays for them. NB: probe for
+    // `%40` with a substring search, not `PERCENT_ENCODED_AT` — that regex is
+    // `g`-flagged for the replace below, and a `g` regex carries `lastIndex`
+    // across `.test()` calls.
+    if (core.indexOf('@') === -1 && !core.toLowerCase().includes('%40')) {
+        return null;
+    }
+
+    let redactedAny = false;
+    const pieces = core.split(EMAIL_LIST_SEPARATOR).map((piece) => {
+        // `%40` is the percent-encoded `@`. `EMAIL_SEGMENT` already treats the
+        // two as equivalent for path segments; free text has to agree, or an
+        // encoded address in prose survives while its literal form is redacted.
+        const decoded = piece.replace(PERCENT_ENCODED_AT, '@');
+        if (!BARE_EMAIL_TOKEN.test(decoded)) {
+            return piece;
+        }
+        redactedAny = true;
+        return ':email';
+    });
+
+    return redactedAny ? pieces.join('') : null;
+}
+
+// Capturing, so `split` keeps the separators and the token rejoins verbatim.
+const EMAIL_LIST_SEPARATOR = /([,;]+)/;
+const PERCENT_ENCODED_AT = /%40/gi;
+
+/**
+ * Classify a free-text token by POSITIVE evidence that it names a code
+ * location. Anything else — including a bare `/@bob` echoed out of a router's
+ * "Cannot GET" message — is treated as a request URL, so the npm-scope
+ * exemption can never un-redact user data. Erring toward `'url'` costs at most
+ * an over-redacted stack frame; erring toward `'stack'` ships PII.
+ */
+function pathContextOf(token: string): PathContext {
+    return FILE_SCHEME.test(token) || token.includes('node_modules/')
+        ? 'stack'
+        : 'url';
+}
+
+const FILE_SCHEME = /^file:\/\//i;
 
 function isPathShaped(token: string): boolean {
     if (HAS_SCHEME.test(token)) return true;

--- a/packages/node/observability/src/span-sanitizer.ts
+++ b/packages/node/observability/src/span-sanitizer.ts
@@ -185,30 +185,38 @@ function sanitizeToken(token: string): string {
     if (core === '') {
         return token;
     }
+    // ORDER MATTERS: path-shaped tokens go to `sanitizeUrl` FIRST. A URL can
+    // carry an address in its authority (`http://alice@saga.org/p`), and
+    // `sanitizeUrl` redacts just the credential while keeping the host — which
+    // is operational data worth keeping. Running the email pass first would
+    // match the whole `alice@saga.org` piece and destroy the host with it.
+    if (isPathShaped(core)) {
+        return lead + sanitizeUrl(core) + trail;
+    }
     const emailRedacted = redactEmails(core);
     if (emailRedacted !== null) {
         return lead + emailRedacted + trail;
     }
-    if (!isPathShaped(core)) {
-        return token;
-    }
-    return lead + sanitizeUrl(core) + trail;
+    return token;
 }
 
 /**
  * Redact every address in an email-shaped token, or `null` if it holds none.
  *
- * Whitespace is not the only delimiter that packs addresses together: a
- * recipient list serializes as `a@b.com;c@d.com` or `a@b.com,c@d.com`, which is
- * ONE whitespace token, matches the anchored whole-token pattern at neither
- * address, is not path-shaped, and so shipped both verbatim. The comma-SPACE
- * form did redact, so the split is what hid this — the delimiter, not the
- * shape, decided exposure.
+ * Whitespace is not the only delimiter that packs an address into a larger
+ * token, and enumerating the delimiters one at a time is what kept this leaking
+ * — first `a@b.com;c@d.com` (a recipient list), then `email='a@b.com'` and
+ * `to=a@b.com` (a driver echoing SQL or a query parameter into its message,
+ * which is precisely the exception-message vector this package creates).
  *
- * Splitting on those two separators keeps each piece anchored (the property
- * that makes the scan linear — see `BARE_EMAIL_TOKEN`) while covering the
- * packed forms. Rejoining with the original separators preserves the text for
- * the non-email pieces of a mixed token.
+ * So the split is defined by the COMPLEMENT of what an address can contain:
+ * anything outside `EMAIL_LABEL` plus `@` and `.` is a delimiter. That is a
+ * closed rule rather than a list to extend on the next report — a character
+ * that cannot appear in an address cannot be hiding one.
+ *
+ * Each piece stays anchored, which is the property that makes the scan linear
+ * (see `BARE_EMAIL_TOKEN`), and the separators are preserved by the capturing
+ * split so a mixed token rejoins with its non-address text intact.
  */
 function redactEmails(core: string): string | null {
     // `indexOf` first: the anchored tests only run on tokens that could
@@ -254,7 +262,9 @@ function isBareEmail(piece: string): boolean {
 }
 
 // Capturing, so `split` keeps the separators and the token rejoins verbatim.
-const EMAIL_LIST_SEPARATOR = /([,;]+)/;
+// The class is the complement of the address alphabet (`EMAIL_LABEL` + `@.`),
+// so it needs no extension when a new packing shape turns up.
+const EMAIL_LIST_SEPARATOR = /([^A-Za-z0-9_%+\-@.]+)/;
 const PERCENT_ENCODED_AT = /%40/gi;
 // `mailto:`, `MAILTO:` — a scheme with no `//`, so HAS_SCHEME does not match it.
 const URI_SCHEME_PREFIX = /^[a-z][a-z0-9+.-]*:/i;

--- a/packages/node/observability/src/span-sanitizer.ts
+++ b/packages/node/observability/src/span-sanitizer.ts
@@ -64,10 +64,46 @@ const EMAIL_SEGMENT = /@|%40/i;
 // no second `@`, which no email can satisfy.
 const NPM_SCOPE_SEGMENT = /^@[A-Za-z0-9_-]+$/;
 
-function looksLikeIdentifier(segment: string): boolean {
-    if (NPM_SCOPE_SEGMENT.test(segment)) {
+/**
+ * Where a path came from. The npm-scope exemption is only ever correct for
+ * code locations: applying it to request URLs would un-redact a `/@handle`
+ * route, which is user data and was previously redacted by the email rule.
+ * Encoding must not decide PII exposure — `/@bob` and `/%40bob` have to behave
+ * identically on a request URL.
+ */
+type PathContext = 'url' | 'stack';
+
+// An id fused to a file extension ("12345.json") fails every anchored test
+// below, because `.` sits outside their character classes. Test the stem
+// separately so `/exports/98765.csv` redacts like `/exports/98765` — the
+// extension is structure, the stem is the identifier.
+const FILE_EXTENSION = /\.[A-Za-z0-9]{1,8}$/;
+
+function looksLikeIdentifier(
+    segment: string,
+    context: PathContext = 'url',
+): boolean {
+    if (context === 'stack' && NPM_SCOPE_SEGMENT.test(segment)) {
         return false;
     }
+    if (matchesIdentifierRule(segment)) {
+        return true;
+    }
+
+    // Retry without a trailing extension, but never let the stem's `@` trigger
+    // the email rule — "user@corp.com" would otherwise be caught here anyway by
+    // the full-segment test above, and a scoped package must not match via its
+    // stem either.
+    const stem = segment.replace(FILE_EXTENSION, '');
+    return (
+        stem !== segment &&
+        stem !== '' &&
+        !(context === 'stack' && NPM_SCOPE_SEGMENT.test(stem)) &&
+        matchesIdentifierRule(stem)
+    );
+}
+
+function matchesIdentifierRule(segment: string): boolean {
     return (
         NUMERIC_SEGMENT.test(segment) ||
         UUID_SEGMENT.test(segment) ||
@@ -88,59 +124,101 @@ function looksLikeIdentifier(segment: string): boolean {
 const MAX_SCRUB_LENGTH = 16 * 1024;
 const TRUNCATION_MARKER = '… [truncated by pii-sanitizer]';
 
-// Identifier-ish runs inside free text. Deliberately narrow: over-matching
-// would redact the message into uselessness, and the goal is removing the
-// obvious identifier vector, not proving the text PII-free.
-//
-// The path branch requires a non-empty first segment, so a standalone slash in
-// prose ("30s / retrying") never matches. It also consumes an optional query
-// string so `sanitizeUrl` can drop it — without this a bare path carries
-// `?studentId=12345` straight through, since only the absolute-URL branch's
-// `\S+` would otherwise swallow a `?`.
-const PATH_CHARS = String.raw`[A-Za-z0-9_\-.%@~]`;
-// The absolute-URL branch excludes `,` `;` and quotes/brackets outright: unlike
-// `.` and `:` they never appear inside a real URL, so letting `\S+` swallow
-// them would fold prose punctuation into the final path segment and defeat
-// sanitizeUrl's anchored identifier tests.
-const URL_CHARS = String.raw`[^\s,;'"\]}>]`;
-const URL_IN_TEXT = new RegExp(
-    String.raw`\bhttps?://${URL_CHARS}+|(?<![\w/])/${PATH_CHARS}+(?:/${PATH_CHARS}*)*(?:\?\S*)?`,
-    'g',
+/**
+ * Free text is tokenized on whitespace rather than matched with one big
+ * pattern. Earlier revisions accreted a `\bhttps?://` branch, a `(?<![\w/])`
+ * lookbehind and a trailing-punctuation strip, and each addition left a gap a
+ * step to the side of the last one: `file:///` frames (the normal shape in an
+ * ESM service) matched no branch, and `baseUrl/students/12345` was skipped
+ * because a word character preceded the slash. Splitting first means every
+ * token is considered exactly once, whatever scheme or prefix it carries.
+ */
+const WHITESPACE_RUN = /(\s+)/;
+
+// Punctuation that can wrap or follow a path in prose but never belongs to it.
+// Stripped from both ends before sanitizing and restored after, so an id never
+// stays fused to a bracket or sentence period.
+const LEADING_PUNCTUATION = /^[('"[{<]+/;
+const TRAILING_PUNCTUATION = /[.,;:!?)\]}'">]+$/;
+
+// A token is path-shaped if it carries a scheme (`file:///…`, `https://…`,
+// `prisma://…`) or contains a slash at all. Scheme-agnostic by design: matching
+// a fixed list is what let `file://` through.
+const HAS_SCHEME = /^[a-z][a-z0-9+.-]*:\/\//i;
+
+/**
+ * Anchored, so it is applied to a single token rather than scanned across free
+ * text. Running a `g`-flagged email pattern over prose is what went quadratic:
+ * on a long dotted run (`a.a.a.…`) with no `@` anywhere, the engine matches the
+ * dotted labels, fails at `@`, then backtracks through every split point — and
+ * repeats that from every start offset. Splitting the domain into dot-free
+ * labels did not help, because the local part has the same shape.
+ *
+ * Tokens are already whitespace-delimited, and an email cannot contain
+ * whitespace, so per-token anchoring loses nothing and makes the work linear:
+ * each token is examined once, and only if it contains an `@` at all.
+ */
+const EMAIL_LABEL = String.raw`[A-Za-z0-9_%+-]+`;
+const BARE_EMAIL_TOKEN = new RegExp(
+    String.raw`^${EMAIL_LABEL}(?:\.${EMAIL_LABEL})*@${EMAIL_LABEL}(?:\.${EMAIL_LABEL})*\.[A-Za-z]{2,}$`,
 );
-
-// Trailing sentence punctuation must not be absorbed into the match: a segment
-// captured as "12345." fails the anchored ^\d+$ identifier test and the id then
-// ships verbatim. Stripped before sanitizing, re-appended after.
-const TRAILING_PUNCTUATION = /[.,;:!?)\]}'"]+$/;
-
-// Domain part is split into dot-free labels so there is exactly one way to
-// match — `[A-Za-z0-9.-]+` followed by `\.` lets `.` belong to either side,
-// giving overlapping split points and quadratic scanning under the `g` flag.
-const BARE_EMAIL =
-    /[A-Za-z0-9._%+-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*\.[A-Za-z]{2,}/g;
 
 /**
  * Scrub PII out of free-form text (an exception message or stack trace).
  *
- * Unlike `sanitizeUrl`, which receives a whole attribute value, this extracts
- * URL/path-shaped runs from arbitrary prose and sanitizes each in place.
+ * Unlike `sanitizeUrl`, which receives a whole attribute value, this works on
+ * arbitrary prose: it sanitizes each path-shaped token in place and redacts
+ * bare email addresses anywhere in the text.
  */
 export function sanitizeText(text: string): string {
-    const truncated =
-        text.length > MAX_SCRUB_LENGTH
-            ? text.slice(0, MAX_SCRUB_LENGTH) + TRUNCATION_MARKER
-            : text;
+    // Scrub BEFORE truncating. Truncating first cuts the trailing context every
+    // anchored rule needs — an email loses its TLD, a UUID its final group — so
+    // the value stops matching and ships half-redacted. The cap then applies to
+    // already-scrubbed text, bounding what is retained rather than what is
+    // examined; the linear scanners above are what bound the work.
+    const scrubbed = text.split(WHITESPACE_RUN).map(sanitizeToken).join('');
 
-    return truncated
-        .replace(URL_IN_TEXT, (match) => {
-            const punctuation = TRAILING_PUNCTUATION.exec(match)?.[0] ?? '';
-            const trimmed = punctuation
-                ? match.slice(0, -punctuation.length)
-                : match;
-            return sanitizeUrl(trimmed) + punctuation;
-        })
-        .replace(BARE_EMAIL, ':email');
+    return scrubbed.length > MAX_SCRUB_LENGTH
+        ? scrubbed.slice(0, MAX_SCRUB_LENGTH) + TRUNCATION_MARKER
+        : scrubbed;
 }
+
+function sanitizeToken(token: string): string {
+    const lead = LEADING_PUNCTUATION.exec(token)?.[0] ?? '';
+    const withoutLead = token.slice(lead.length);
+    const trail = TRAILING_PUNCTUATION.exec(withoutLead)?.[0] ?? '';
+    const core = trail ? withoutLead.slice(0, -trail.length) : withoutLead;
+
+    if (core === '') {
+        return token;
+    }
+    // `indexOf` first: the anchored email test only runs on tokens that could
+    // possibly be one, so prose never pays for it.
+    if (core.indexOf('@') !== -1 && BARE_EMAIL_TOKEN.test(core)) {
+        return lead + ':email' + trail;
+    }
+    if (!isPathShaped(core)) {
+        return token;
+    }
+    return lead + sanitizeUrl(core, 'stack') + trail;
+}
+
+function isPathShaped(token: string): boolean {
+    if (HAS_SCHEME.test(token)) return true;
+
+    // A path must START at a slash (`/students/12345`) or contain one with a
+    // non-numeric side (`baseUrl/students/12345`, `dist/main.js`). Treating any
+    // slash as a path turns a ratio in prose — "rate limit 5/second" — into
+    // `:id/second`, redacting text that was never an identifier.
+    const slash = token.indexOf('/');
+    if (slash === -1) return false;
+    if (token.startsWith('/')) return token.length > 1;
+    return !SIMPLE_RATIO.test(token);
+}
+
+// `5/second`, `1/2`, `3/10s` — a bare number over a short word or number. These
+// are quantities in prose, not paths.
+const SIMPLE_RATIO = /^\d+\/[A-Za-z0-9]*$/;
 
 /**
  * Sanitize a URL/path string: drop the query string entirely and templatize
@@ -148,13 +226,15 @@ export function sanitizeText(text: string): string {
  * tRPC method names (`/trpc/auth.getProvidersByEmail`) are method *names*, not
  * data, and are NOT identifier-shaped → preserved.
  */
-export function sanitizeUrl(value: string): string {
+export function sanitizeUrl(value: string, context: PathContext = 'url'): string {
     // Split scheme://host from the path so we only rewrite the path portion.
+    // `file:///app/x` has an empty host, so the host part must be optional —
+    // requiring `[^/]+` here is what made ESM stack frames fall through.
     let prefix = '';
     let rest = value;
 
-    const schemeMatch = /^([a-z][a-z0-9+.-]*:\/\/[^/]+)(\/.*)?$/i.exec(value);
-    if (schemeMatch && schemeMatch[1]) {
+    const schemeMatch = /^([a-z][a-z0-9+.-]*:\/\/[^/]*)(\/.*)?$/i.exec(value);
+    if (schemeMatch && schemeMatch[1] !== undefined) {
         prefix = schemeMatch[1];
         rest = schemeMatch[2] ?? '';
     }
@@ -167,7 +247,7 @@ export function sanitizeUrl(value: string): string {
 
     const sanitizedPath = rest
         .split('/')
-        .map((seg) => (looksLikeIdentifier(seg) ? ':id' : seg))
+        .map((seg) => (looksLikeIdentifier(seg, context) ? ':id' : seg))
         .join('/');
 
     return prefix + sanitizedPath;
@@ -240,10 +320,12 @@ export function setSanitizerWarnSink(sink: WarnSink): void {
     warnSink = sink;
 }
 
-/** Restore the default failure-warning sink + reset the throttle (test seam). */
+/** Restore the default failure-warning sink + reset every throttle (test seam). */
 export function resetSanitizerWarnSink(): void {
     warnSink = defaultWarnSink;
-    sanitizeFailureCount = 0;
+    for (const channel of Object.keys(failureCounts) as WarnChannel[]) {
+        failureCounts[channel] = 0;
+    }
 }
 
 // `export()` is a hot path, so a persistent sanitize failure (e.g. a future
@@ -253,16 +335,35 @@ export function resetSanitizerWarnSink(): void {
 // without becoming a log storm. NOTE: count-based, so cadence scales with span
 // volume — acceptable here because the first occurrence always fires.
 const SANITIZE_WARN_EVERY = 1000;
-let sanitizeFailureCount = 0;
+
+/**
+ * Independent failure sources. Counters are PER CHANNEL: sharing one would let
+ * a high-volume failure (attribute rewrite, at span-export rate) advance the
+ * count past the point where an unrelated first failure in another channel
+ * lands on a multiple of the throttle — silently swallowing the one warning
+ * that was supposed to be guaranteed. "First occurrence always fires" is only
+ * true if each source counts its own.
+ */
+type WarnChannel = 'attributes' | 'events' | 'record-exception';
+
+const failureCounts: Record<WarnChannel, number> = {
+    attributes: 0,
+    events: 0,
+    'record-exception': 0,
+};
 
 /**
  * Report a swallowed sanitize/telemetry failure through the throttled sink.
  *
  * Shared so every degrade-safe catch in this package stays detectable through
- * one channel and one throttle, rather than each re-inventing (or omitting) it.
+ * one sink, while each channel keeps its own throttle.
  */
-export function warnSanitizeFailure(message: string, err: unknown): void {
-    if (sanitizeFailureCount++ % SANITIZE_WARN_EVERY === 0) {
+export function warnSanitizeFailure(
+    channel: WarnChannel,
+    message: string,
+    err: unknown,
+): void {
+    if (failureCounts[channel]++ % SANITIZE_WARN_EVERY === 0) {
         warnSink(message, err);
     }
 }
@@ -278,6 +379,12 @@ export class PiiSanitizingSpanExporter implements SpanExporter {
         spans: ReadableSpan[],
         resultCallback: (result: ExportResult) => void,
     ): void {
+        // Attributes and events are sanitized under SEPARATE try blocks. Sharing
+        // one meant a throw in the attribute rewrite (which the class doc
+        // anticipates, if a future SDK makes `attributes` truly read-only)
+        // skipped event scrubbing entirely — and the exception event is the
+        // higher-PII payload, since instrumentations record it from the RAW
+        // error. Each failure must degrade only its own half.
         for (const span of spans) {
             try {
                 // `span.attributes` is declared `readonly` on ReadableSpan, but
@@ -285,19 +392,27 @@ export class PiiSanitizingSpanExporter implements SpanExporter {
                 // object, so in-place rewrite works. If a future impl makes it
                 // truly read-only the assignment throws → caught below.
                 sanitizeAttributes(span.attributes);
-                sanitizeEvents(span);
             } catch (err) {
                 // Fail OPEN: leave this span untouched rather than dropping it
                 // or aborting the whole batch. Never rethrow. But surface a
                 // persistent failure (throttled) — a silent swallow would let a
                 // read-only-attributes regression disable PII sanitization
                 // fleet-wide with no signal.
-                if (sanitizeFailureCount++ % SANITIZE_WARN_EVERY === 0) {
-                    warnSink(
-                        '[pii-sanitizer] span sanitization failed; shipping span unmodified',
-                        err,
-                    );
-                }
+                warnSanitizeFailure(
+                    'attributes',
+                    '[pii-sanitizer] span attribute sanitization failed; shipping span unmodified',
+                    err,
+                );
+            }
+
+            try {
+                sanitizeEvents(span);
+            } catch (err) {
+                warnSanitizeFailure(
+                    'events',
+                    '[pii-sanitizer] span event sanitization failed; shipping events unmodified',
+                    err,
+                );
             }
         }
         this.inner.export(spans, resultCallback);

--- a/packages/node/observability/src/span-sanitizer.ts
+++ b/packages/node/observability/src/span-sanitizer.ts
@@ -29,11 +29,16 @@ import { ExportResultCode, type ExportResult } from '@opentelemetry/core';
  * caught per the degrade-safe contract below, with a throttled diag warning.)
  *
  * DEGRADE-SAFE CONTRACT (fleet blast radius): sanitization must NEVER throw and
- * NEVER drop a span. Any error while rewriting one span is swallowed and that
- * span is passed through unmodified — we fail OPEN (ship a span that may retain
- * a path) rather than closed (lose the telemetry entirely). The alternative —
- * an exception escaping into the BatchSpanProcessor's export loop — would take
- * down tracing for the whole service.
+ * NEVER drop a span. We fail OPEN (ship a value that may retain a path) rather
+ * than closed (lose the telemetry entirely), because an exception escaping into
+ * the BatchSpanProcessor's export loop would take down tracing for the whole
+ * service.
+ *
+ * Failing open is scoped as NARROWLY as the failure: an unwritable entry costs
+ * only that entry, not its siblings, not the span, and not the batch (see the
+ * layering note on `export`). Swallowing is never silent — the first failure in
+ * each channel reaches a throttled sink, so a regression that disables
+ * sanitization is detectable rather than invisible.
  */
 
 // URL-ish attribute keys whose string values get path-segment sanitization.
@@ -510,12 +515,22 @@ export class PiiSanitizingSpanExporter implements SpanExporter {
         spans: ReadableSpan[],
         resultCallback: (result: ExportResult) => void,
     ): void {
-        // Attributes and events are sanitized under SEPARATE try blocks. Sharing
-        // one meant a throw in the attribute rewrite (which the class doc
-        // anticipates, if a future SDK makes `attributes` truly read-only)
-        // skipped event scrubbing entirely — and the exception event is the
-        // higher-PII payload, since instrumentations record it from the RAW
-        // error. Each failure must degrade only its own half.
+        // DEGRADATION IS LAYERED, and each layer exists for a different reason:
+        //
+        //   per ENTRY (inside the helpers) — one unwritable attribute or event
+        //     costs only itself; every other entry on the span is still
+        //     scrubbed. Coarser granularity meant a single frozen entry shipped
+        //     all the rest verbatim.
+        //   per HALF (the two try blocks here) — attributes and events fail
+        //     independently, so a read-only `attributes` object cannot skip
+        //     event scrubbing. Events are the higher-PII payload, since the
+        //     instrumentations record them from the RAW error.
+        //   per SPAN (this loop) — a failure never aborts the batch.
+        //
+        // The helpers rethrow their FIRST error after finishing the remaining
+        // entries, which is what lets isolation coexist with detectability: the
+        // catches below still fire once per affected span, at the sink's normal
+        // throttled cadence.
         for (const span of spans) {
             try {
                 // `span.attributes` is declared `readonly` on ReadableSpan, but
@@ -524,14 +539,14 @@ export class PiiSanitizingSpanExporter implements SpanExporter {
                 // truly read-only the assignment throws → caught below.
                 sanitizeAttributes(span.attributes);
             } catch (err) {
-                // Fail OPEN: leave this span untouched rather than dropping it
-                // or aborting the whole batch. Never rethrow. But surface a
-                // persistent failure (throttled) — a silent swallow would let a
-                // read-only-attributes regression disable PII sanitization
-                // fleet-wide with no signal.
+                // Fail OPEN: ship the span rather than dropping it or aborting
+                // the batch. Never rethrow. But surface a persistent failure
+                // (throttled) — a silent swallow would let a read-only-
+                // attributes regression disable PII sanitization fleet-wide
+                // with no signal.
                 warnSanitizeFailure(
                     'attributes',
-                    '[pii-sanitizer] span attribute sanitization failed; shipping span unmodified',
+                    '[pii-sanitizer] one or more span attributes could not be sanitized; shipping them unmodified',
                     err,
                 );
             }
@@ -541,7 +556,7 @@ export class PiiSanitizingSpanExporter implements SpanExporter {
             } catch (err) {
                 warnSanitizeFailure(
                     'events',
-                    '[pii-sanitizer] span event sanitization failed; shipping events unmodified',
+                    '[pii-sanitizer] one or more span events could not be sanitized; shipping them unmodified',
                     err,
                 );
             }


### PR DESCRIPTION
## Problem

OTel-instrumented services ship error spans with `error: {}` — flagged as failing, carrying no message, type, or stack.

Evidence from prod (`programs-api`, HTTP 500 on `GET /trpc/pods.availableTutors.list`):

```yaml
otel.status_code: Error          # OTel set status from the 500
telemetry.sdk.name: opentelemetry
http.status_code: "500"
error: {}                        # <-- nothing to debug from
status: error
```

The auto-instrumentations set span status to `Error` from the status code, but Datadog sources `error.type` / `error.message` / `error.stack` **only** from an `exception` span event — and nothing was creating one. Error Tracking needs type + message to group, so these services form no issues at all.

## Scope of the gap

Error spans in 24h, and how many carry a stack:

| Service | error spans | with `@error.stack` | SDK |
|---|---:|---:|---|
| connectv3-api | 18,277 | **0** | opentelemetry |
| programs-api | 15,018 | **0** | opentelemetry |
| content-api | 3,310 | **0** | opentelemetry |
| sessions-api | 3,308 | **0** | opentelemetry |
| sis-api | 538 | **0** | opentelemetry |
| ads-adm-api / scheduling-api / authz-api / iam-api | 70 | **0** | opentelemetry |
| rabbitmq-bridge | 8,550 | **8,552** ✅ | datadog_lambda |
| xlr8_ars / wm_api / wm_web | 86 | **68** ✅ | dd-trace |

The correlation is exact: every OTel service → 0 stacks; every dd-trace service → stacks land. dd-trace attaches exception data itself, which is why this only shows on the OTel side. **Not a Datadog-side or OTLP-mapper problem.**

Fleet-wide, `recordException` had exactly two call sites (`event-outbox/relay.ts`, `event-consumer/consumer.ts`), neither in an HTTP request path.

## Change

- Add `recordSpanException(err, span?)` — attaches the exception to the active span and sets `SpanStatusCode.ERROR`. No-ops when tracing is off or no span is active; never throws (it runs on an already-failing path).
- Call it from `structuredErrorMiddleware`, so **every service already using the shared middleware is covered without a per-service change**.

A span processor cannot substitute for calling this at the throw site: by export time the Error is out of scope and the stack is unrecoverable.

### PII

Exception messages and stacks bypass `PiiSanitizingSpanExporter`, which only rewrites URL-shaped span *attributes*. Errors routinely interpolate the offending value (`no user for a@b.com`, `GET /students/12345 failed`), so messages and stacks are scrubbed through the existing `sanitizeUrl` before recording. The caller's `Error` is never mutated — the same object is typically logged and rethrown.

Scrubbing is deliberately narrow: stack frames must stay readable, or the fix trades one unusable field for another. Tests pin both directions (frames survive; embedded ids don't).

## Verification

- 51/51 tests pass in `packages/node/observability` (22 in the new file)
- `check-types` clean; `lint` 0 errors
- ESM + DTS build green

⚠️ **Pre-existing, unrelated:** the root `pnpm test` has 9 failing tests / ~26 failing files on `origin/main` (verified by stashing this branch and re-running). None are in `observability`.

## Follow-up (not in this PR)

tRPC-layer throws may not reach Express middleware. Each service's `errorFormatter` should also call `recordSpanException` — that part is N separate edits, since no shared tRPC factory is actually in use. Full scoping doc lives outside the repo.