### PR TITLE
feat(stack): land #402 on main — authz-api onboarding + projection backfill (re-lands PR #405)

### DIFF
--- a/infra/compose/projects/saga-mesh/seed/profile-empty.sql
+++ b/infra/compose/projects/saga-mesh/seed/profile-empty.sql
@@ -19,6 +19,7 @@ CREATE USER ledger         WITH PASSWORD 'ledger';
 CREATE USER sis            WITH PASSWORD 'sis';
 CREATE USER coach_api_app  WITH PASSWORD 'dev-password-coach-api-app';
 CREATE USER authz_sync     WITH PASSWORD 'authz_sync';
+CREATE USER authz          WITH PASSWORD 'authz';
 
 -- ── Databases ───────────────────────────────────────────────────────
 -- Owner set at creation time so prisma migrate deploy can CREATE SCHEMA.
@@ -32,6 +33,12 @@ CREATE DATABASE ads_adm_local   OWNER ads_adm;
 CREATE DATABASE ledger_local    OWNER ledger;
 CREATE DATABASE sis_db          OWNER sis;
 CREATE DATABASE coach_api       OWNER coach_api_app;
+
+-- rostering authz-api (soa#402). NOT the `--with authz` opt-in below: that
+-- bundle is the OpenFGA stack (openfga + authz-sync), a different subsystem
+-- that merely shares the prefix. authz-api is the tRPC capabilities service
+-- sessions-api hard-requires on every read, so its DB is unconditional.
+CREATE DATABASE authz_local     OWNER authz;
 
 -- Opt-in (rostering `authz` bundle, `--with authz`): created unconditionally
 -- here like every other app DB above (a few KB, harmless if unused), but only
@@ -53,6 +60,7 @@ GRANT ALL PRIVILEGES ON DATABASE ads_adm_local TO ads_adm;
 GRANT ALL PRIVILEGES ON DATABASE ledger_local  TO ledger;
 GRANT ALL PRIVILEGES ON DATABASE sis_db        TO sis;
 GRANT ALL PRIVILEGES ON DATABASE coach_api     TO coach_api_app;
+GRANT ALL PRIVILEGES ON DATABASE authz_local   TO authz;
 GRANT ALL PRIVILEGES ON DATABASE openfga          TO postgres_admin;
 GRANT ALL PRIVILEGES ON DATABASE authz_sync_local TO authz_sync;
 

--- a/packages/node/saga-stack-cli/src/__tests__/stack-api.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/__tests__/stack-api.unit.test.ts
@@ -161,6 +161,7 @@ describe('StackApi.up — native partial-stack bring-up', () => {
     // launch order is the topo flatten: iam-api → programs-api → scheduling-api → sessions-api.
     expect(fakes.launches.map((s) => s.id)).toEqual([
       'iam-api',
+      'authz-api', // soa#402
       'programs-api',
       'scheduling-api',
       'sessions-api',

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/resolve-service-set.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/resolve-service-set.unit.test.ts
@@ -57,7 +57,7 @@ describe('resolveServiceSet — --with is sugar over --only', () => {
 
   it('empty (no --only, no --with) ⇒ every NON-optional service (no playback)', () => {
     const ids = resolve(undefined, undefined);
-    expect(ids).toHaveLength(13); // 10 core + rtsm-api + coach-api/coach-web
+    expect(ids).toHaveLength(14); // 10 core + rtsm-api + coach-api/coach-web + authz-api (soa#402)
     expect(ids).not.toContain('transcripts-api');
   });
 

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/status-verify.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/status-verify.int.test.ts
@@ -199,7 +199,7 @@ describe('stack status — native, manifest-derived, read-only', () => {
   it('probes every non-optional service INCLUDING content-api :3009 (the closed gap)', async () => {
     await StackStatus.run([...WS], config);
     expect(probed).toContain(CONTENT_URL);
-    expect(probed).toHaveLength(13); // 10 core + rtsm-api + coach-api/coach-web; no playback
+    expect(probed).toHaveLength(14); // 10 core + rtsm-api + coach-api/coach-web + authz-api (soa#402); no playback
   });
 
   it('--only scopes the probes to the dependency closure', async () => {
@@ -233,7 +233,7 @@ describe('stack status — native, manifest-derived, read-only', () => {
 
   it('--with qtf is seed-only ⇒ no service scope ⇒ probes the full non-optional stack', async () => {
     await StackStatus.run(['--with', 'qtf', ...WS], config);
-    expect(probed).toHaveLength(13);
+    expect(probed).toHaveLength(14);
   });
 
   it('NEVER exits non-zero even when services are down (read-only)', async () => {
@@ -241,7 +241,7 @@ describe('stack status — native, manifest-derived, read-only', () => {
     await expect(StackStatus.run([...WS, '--output-json'], config)).resolves.toBeUndefined();
     const json = JSON.parse(out.join(''));
     expect(json.healthy).toBe(false);
-    expect(json.summary).toMatchObject({ total: 13, down: 2 });
+    expect(json.summary).toMatchObject({ total: 14, down: 2 });
   });
 
   it('porcelain emits one key=value per service plus healthy=', async () => {
@@ -475,14 +475,14 @@ describe('stack verify --slot N — backend + saga-dash/coach gate on offset por
       expect(url).toContain(`:${manifest.services[id].port + 1000}`);
     }
 
-    // the full non-optional set is slottable now: all 13 are probed.
-    expect(probed).toHaveLength(13);
+    // the full non-optional set is slottable now: all 14 are probed.
+    expect(probed).toHaveLength(14);
   });
 
   it('slot 0 verify is byte-identical: probes every non-optional service on base ports', async () => {
     await StackVerify.run([...WS], config);
     expect(probed).toContain(DASH_URL); // frontends gated at slot 0
-    expect(probed).toHaveLength(13);
+    expect(probed).toHaveLength(14);
   });
 });
 

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/up-native.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/up-native.int.test.ts
@@ -187,6 +187,7 @@ describe('stack up --only — native partial-stack', () => {
     // launched the full closure in topo order — NOT via up.sh.
     expect(launches.map((s) => s.id)).toEqual([
       'iam-api',
+      'authz-api', // soa#402
       'programs-api',
       'scheduling-api',
       'sessions-api',

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/up.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/up.unit.test.ts
@@ -41,6 +41,7 @@ describe('stack up --dry-run — closure planning path', () => {
 
     expect(closure.services).toEqual([
       'iam-api',
+      'authz-api', // soa#402 — transitive through sessions-api
       'programs-api',
       'scheduling-api',
       'sessions-api',
@@ -51,6 +52,7 @@ describe('stack up --dry-run — closure planning path', () => {
       'programs',
       'scheduling',
       'sessions',
+      'authz_local', // soa#402
     ]);
     expect(closure.mesh).toEqual(['postgres', 'redis', 'rabbitmq']); // redis via iam-api
   });
@@ -60,8 +62,9 @@ describe('stack up --dry-run — closure planning path', () => {
       .filter((s) => !s.optional)
       .map((s) => s.id);
     const closure = computeClosure(manifest, fullRequest);
-    // 13 non-optional services (10 core + rtsm-api + coach-api/coach-web); no playback.
-    expect(closure.services).toHaveLength(13);
+    // 14 non-optional services (10 core + rtsm-api + coach-api/coach-web + authz-api,
+    // soa#402); no playback.
+    expect(closure.services).toHaveLength(14);
     expect(closure.services).not.toContain('transcripts-api');
     expect(closure.mesh).toContain('connect-mongo'); // connect-api in the full set
   });

--- a/packages/node/saga-stack-cli/src/commands/stack/snapshot/__tests__/snapshot.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/snapshot/__tests__/snapshot.int.test.ts
@@ -84,11 +84,11 @@ afterEach(() => {
   delete process.env.SEED_PROFILE;
 });
 
-describe('stack snapshot store — manifest-driven, all 10 pg + connectv3 mongo', () => {
-  it('dumps every non-playback DB (10 pg + connectv3 mongo) by default', async () => {
+describe('stack snapshot store — manifest-driven, all 11 pg + connectv3 mongo', () => {
+  it('dumps every non-playback DB (11 pg + connectv3 mongo) by default', async () => {
     await SnapshotStore.run(['--fixture-id', 'demo'], config);
     const pg = dbsCalled('pgDump');
-    expect(pg).toHaveLength(10);
+    expect(pg).toHaveLength(11); // +authz_local (soa#402)
     expect(pg).toContain('coach_api'); // the coach progress store (mesh app DB #10)
     expect(pg).toContain('ledger_local'); // the 7th-9th DBs mesh-fixture missed
     expect(pg).toContain('content');
@@ -171,7 +171,7 @@ describe('stack snapshot store — manifest-driven, all 10 pg + connectv3 mongo'
   it('writes a zod-valid manifest with profile + per-DB sizes', async () => {
     await SnapshotStore.run(['--fixture-id', 'demo', '--profile', 'full', '--output-json'], config);
     const json = JSON.parse(out.join(''));
-    expect(json).toMatchObject({ fixtureId: 'demo', profile: 'full', databases: 11 });
+    expect(json).toMatchObject({ fixtureId: 'demo', profile: 'full', databases: 12 });
     expect(json.totalBytes).toBeGreaterThan(0);
     // manifest.json exists and parses
     expect(statSync(join(snapDir(), 'demo', 'manifest.json')).size).toBeGreaterThan(0);
@@ -193,7 +193,7 @@ describe('stack snapshot restore — restore-as-owner + guards', () => {
   it('restores every DB AS its owner, mongo too, then flushes redis', async () => {
     await store();
     await SnapshotRestore.run(['demo'], config);
-    expect(dbsCalled('pgRestore')).toHaveLength(10);
+    expect(dbsCalled('pgRestore')).toHaveLength(11); // +authz_local (soa#402)
     const ledger = ioCalls.find((c) => c.op === 'pgRestore' && c.db === 'ledger_local');
     expect(ledger?.ownerRole).toBe('ledger');
     expect(dbsCalled('mongoRestore')).toEqual(['connectv3']);
@@ -297,14 +297,14 @@ describe('stack snapshot list / validate / delete', () => {
     await SnapshotValidate.run(['demo', '--output-json'], config);
     const json = JSON.parse(out.join(''));
     expect(json.ok).toBe(true);
-    expect(json.checks).toBe(11);
+    expect(json.checks).toBe(12);
   });
 
   it('validate --deep runs pg_restore --list on each pg dump', async () => {
     await SnapshotStore.run(['--fixture-id', 'demo'], config);
     ioCalls.length = 0;
     await SnapshotValidate.run(['demo', '--deep'], config);
-    expect(ioCalls.filter((c) => c.op === 'pgRestoreList')).toHaveLength(10); // pg dumps only
+    expect(ioCalls.filter((c) => c.op === 'pgRestoreList')).toHaveLength(11); // pg dumps only (+authz_local, soa#402)
   });
 
   it('validate FAILS (exit 1) when a dump file is corrupt under --deep', async () => {

--- a/packages/node/saga-stack-cli/src/core/__tests__/closure.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/closure.unit.test.ts
@@ -21,9 +21,12 @@ import type { ServiceId } from '../manifest/index.js';
 describe('computeClosure — {scheduling-api, sessions-api}', () => {
   const closure = computeClosure(manifest, ['scheduling-api', 'sessions-api']);
 
-  it('pulls in iam-api + programs-api, topo-ordered', () => {
+  it('pulls in iam-api + programs-api + authz-api, topo-ordered', () => {
     expect(closure.services).toEqual([
       'iam-api',
+      // soa#402: a hard `url` dep of sessions-api, so the transitive closure
+      // pulls it into every set containing sessions-api.
+      'authz-api',
       'programs-api',
       'scheduling-api',
       'sessions-api',
@@ -37,6 +40,7 @@ describe('computeClosure — {scheduling-api, sessions-api}', () => {
       'programs',
       'scheduling',
       'sessions',
+      'authz_local', // soa#402 — last in manifest declaration order
     ]);
   });
 
@@ -62,12 +66,14 @@ describe('computeClosure — {scheduling-api, sessions-api}', () => {
 describe('computeClosure — saga-dash', () => {
   const closure = computeClosure(manifest, ['saga-dash']);
 
-  it('resolves to 8 services (NOT the full stack)', () => {
-    expect(closure.services).toHaveLength(8);
+  it('resolves to 9 services (NOT the full stack)', () => {
+    expect(closure.services).toHaveLength(9);
     expect(new Set(closure.services)).toEqual(
       new Set<ServiceId>([
         'iam-api',
         'sis-api',
+        // soa#402 — reached transitively through sessions-api.
+        'authz-api',
         'programs-api',
         'scheduling-api',
         'sessions-api',

--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
@@ -153,6 +153,8 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
       RABBITMQ_URL: 'amqp://rabbitmq_admin:password123@localhost:5672',
       CORS_ORIGIN: 'http://localhost:8900',
       JWT_ISSUER: 'https://iam.wootdev.com',
+      // soa#402 — tokenized, never authz-api's literal :3200 default.
+      AUTHZ_API_URL: 'http://localhost:3200',
     });
   });
 
@@ -334,6 +336,7 @@ describe('launchPlan — ordered native specs for a closure', () => {
   it('orders the closure by launchOrder (deps first)', () => {
     expect(plan.map((s) => s.id)).toEqual([
       'iam-api',
+      'authz-api', // soa#402
       'programs-api',
       'scheduling-api',
       'sessions-api',

--- a/packages/node/saga-stack-cli/src/core/__tests__/probe-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/probe-plan.unit.test.ts
@@ -39,8 +39,9 @@ describe('healthProbes — manifest-derived probe list', () => {
   it('default set = every NON-optional service, in manifest declaration order', () => {
     const probes = healthProbes(manifest);
     const ids = probes.map((p) => p.id);
-    // 13 non-optional (10 core + rtsm-api + coach-api/coach-web); the 3 playback APIs are excluded.
-    expect(ids).toHaveLength(13);
+    // 14 non-optional (10 core + rtsm-api + coach-api/coach-web + authz-api, soa#402);
+    // the 3 playback APIs are excluded.
+    expect(ids).toHaveLength(14);
     expect(ids).not.toContain('transcripts-api');
     expect(ids).not.toContain('insights-api');
     expect(ids).not.toContain('chat-api');

--- a/packages/node/saga-stack-cli/src/core/flow/__tests__/connectv3.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/flow/__tests__/connectv3.unit.test.ts
@@ -144,6 +144,7 @@ describe('connectv3 connect-smoke — resolves through the SAME resolveFlow/clos
         'iam-api',
         'programs-api',
         'scheduling-api',
+        'authz-api', // soa#402 — sessions-api's hard authz dep
       ]),
     );
   });

--- a/packages/node/saga-stack-cli/src/core/flow/__tests__/resolve.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/flow/__tests__/resolve.unit.test.ts
@@ -49,6 +49,8 @@ const sorted = (xs: readonly string[]): string[] => [...xs].sort();
 const JOURNEY_FULL_CLOSURE = sorted([
   'iam-api',
   'sis-api',
+  'authz-api', // soa#402 — sessions-api's hard authz dep
+
   'programs-api',
   'scheduling-api',
   'sessions-api',
@@ -127,7 +129,7 @@ describe('resolveFlow — journey (full, default)', () => {
     expect(r.closure.services).not.toContain('content-api');
   });
 
-  it('closure is the full-journey backend set (7 services, NOT content-api)', () => {
+  it('closure is the full-journey backend set (8 services, NOT content-api)', () => {
     expect(sorted(r.closure.services)).toEqual(JOURNEY_FULL_CLOSURE);
   });
 });

--- a/packages/node/saga-stack-cli/src/core/flow/types.ts
+++ b/packages/node/saga-stack-cli/src/core/flow/types.ts
@@ -24,6 +24,7 @@ import type { SeedSelection } from '../seed/index.js';
 const SERVICE_IDS = [
   'iam-api',
   'sis-api',
+  'authz-api',
   'programs-api',
   'scheduling-api',
   'sessions-api',

--- a/packages/node/saga-stack-cli/src/core/launch-plan.ts
+++ b/packages/node/saga-stack-cli/src/core/launch-plan.ts
@@ -51,6 +51,10 @@ export interface LaunchTokens {
   IAM_PORT: string;
   /** sis-api port — up.sh `SIS_PORT` (3100). */
   SIS_PORT: string;
+  /** authz-api port (3200) — sessions-api's `AUTHZ_API_URL` (soa#402). authz-api's
+   *  own default is a LITERAL `:3200`, so without this token a slot > 0 sessions-api
+   *  would dial slot 0's authz-api — the exact cross-slot braid this file prevents. */
+  AUTHZ_PORT: string;
   /** sessions-api port (3007) — ads-adm-api's SESSIONS_API_CLIENT_BASEURL (was a
    *  literal `:3007` in up.sh; tokenized for M13 ads-adm slottability). */
   SESSIONS_PORT: string;
@@ -146,6 +150,8 @@ export interface LaunchTokens {
   IAM_PII_DB_URL: string;
   /** up.sh `SIS_DB_URL`. */
   SIS_DB_URL: string;
+  /** authz-api DB URL — `postgresql://authz:authz@localhost:<pg>/authz_local` (soa#402). */
+  AUTHZ_DB_URL: string;
   /** up.sh `PROGRAMS_DB_URL`. */
   PROGRAMS_DB_URL: string;
   /** up.sh `SCHEDULING_DB_URL`. */
@@ -653,6 +659,7 @@ export function defaultLaunchContext(inputs: LaunchContextInputs, m: Manifest = 
     // ports (string form)
     IAM_PORT: String(ports['iam-api']),
     SIS_PORT: String(ports['sis-api']),
+    AUTHZ_PORT: String(ports['authz-api']),
     SESSIONS_PORT: String(ports['sessions-api']),
     PROGRAMS_PORT: String(ports['programs-api']),
     CONTENT_PORT: String(ports['content-api']),
@@ -687,6 +694,7 @@ export function defaultLaunchContext(inputs: LaunchContextInputs, m: Manifest = 
     IAM_DB_URL: pgUrl('iam_local', pgPort, m),
     IAM_PII_DB_URL: pgUrl('iam_pii_local', pgPort, m),
     SIS_DB_URL: pgUrl('sis_db', pgPort, m),
+    AUTHZ_DB_URL: pgUrl('authz_local', pgPort, m),
     PROGRAMS_DB_URL: pgUrl('programs', pgPort, m),
     SCHEDULING_DB_URL: pgUrl('scheduling', pgPort, m),
     SESSIONS_DB_URL: pgUrl('sessions', pgPort, m),

--- a/packages/node/saga-stack-cli/src/core/manifest/databases.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/databases.ts
@@ -220,4 +220,23 @@ export const DATABASES: Readonly<Record<DbId, DatabaseDef>> = {
     // NOT part of default mesh-up — see the `openfga` entry above.
     meshProvisioned: false,
   },
+  authz_local: {
+    name: 'authz_local',
+    engine: 'postgres',
+    // @saga-ed/authz-db owns the schema (decision log + the local iam.* event
+    // projection tables). Same shape as sis_db: prisma.config.ts reads
+    // AUTHZ_DATABASE_URL directly (and throws if unset), so the migrate step
+    // must inject THAT var, not DATABASE_URL.
+    migrate: { dir: 'packages/node/authz-db', cmd: 'db:deploy', migrateEnvVar: 'AUTHZ_DATABASE_URL' },
+    ownerRole: 'authz',
+    ownerPw: 'authz',
+    resettable: true,
+    resetMode: 'truncate',
+    // UNCONDITIONAL, unlike the two entries above: authz-api is a hard
+    // dependency of sessions-api (soa#402), not part of the `--with authz`
+    // OpenFGA opt-in that merely shares the prefix. `meshProvisioned:true` also
+    // means runtime/provision.ts's R2 pass creates the role + DB idempotently
+    // on PRE-EXISTING mesh volumes, whose profile-empty.sql predates this entry.
+    meshProvisioned: true,
+  },
 };

--- a/packages/node/saga-stack-cli/src/core/manifest/services.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/services.ts
@@ -235,7 +235,7 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
         IAM_AUTH_USERTOKENISSUER: '${IAM_ISSUER}',
       },
     },
-    seed: [],
+    seed: ['authz-projection-backfill'],
     lane: lanes(3200, 'authz'),
     tunnelSlug: 'authz',
     isFrontend: false,

--- a/packages/node/saga-stack-cli/src/core/manifest/services.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/services.ts
@@ -173,6 +173,74 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
     isFrontend: false,
     optional: false,
   },
+  /**
+   * rostering authz-api — the tRPC capabilities/values service (soa#402).
+   *
+   * NOT `authz-sync`: that is the OpenFGA tuple projector behind `--with authz`
+   * (core/bundles.ts), a different subsystem that only shares the prefix. This
+   * one is a HARD dependency of sessions-api — since program-hub#454 (2026-07-28)
+   * sessions-api's read pipeline calls it on every request with no bypass flag,
+   * so an absent authz-api means SERVICE_UNAVAILABLE → tRPC TIMEOUT → HTTP 408
+   * on every sessions read, on a stack whose health checks all report green.
+   * Hence `optional: false`.
+   *
+   * ENV DERIVATION (from authz-api's config/schemas.ts + inversify.config.ts —
+   * nothing invented; the audit diffs resolved env against what the app reads):
+   *  - `AUTHZ_DATABASE_URL` / `RABBITMQ_URL` are read STRAIGHT off process.env,
+   *    deliberately bypassing DotenvConfigManager's `AUTHZ_` prefixing, because
+   *    they are fleet-wide names shared with authz-db's prisma.config.ts and
+   *    every other event consumer.
+   *  - The `IAM_AUTH_*` block is DotenvConfigManager-prefixed
+   *    (`configType.toUpperCase() + '_' + FIELDNAME`, no inner underscores).
+   *    Every one of these has a default, and EVERY default is wrong here:
+   *      · the JWKS defaults point at `localhost:3000`, but this stack runs
+   *        iam-api on ${IAM_PORT} (3010 at slot 0) — wrong even at slot 0, and
+   *        cross-slot at slot > 0.
+   *      · `userTokenIssuer` defaults to `https://iam.saga.org` while local
+   *        iam-api stamps `${IAM_ISSUER}` (https://iam.wootdev.com). That exact
+   *        mismatch is what made coach-api 401 every locally-minted session —
+   *        see the IAM_ISSUER note in core/launch-plan.ts.
+   *    sessions-api reaches authz-api by relaying the caller's `iam_session`
+   *    cookie (authz-api's `cookieOrServiceProcedure`), so the USER token leg is
+   *    the one on the critical path; the SERVICE leg is pinned alongside it so
+   *    the two can't drift.
+   *  - `audience` is left at its default: iam-api and authz-api already agree on
+   *    `saga-platform`.
+   */
+  'authz-api': {
+    id: 'authz-api',
+    repo: 'ROSTERING',
+    subpath: 'apps/node/authz-api',
+    port: 3200,
+    portEnvVar: 'PORT',
+    healthPath: '/health',
+    databases: ['authz_local'],
+    // iam-api is BOTH an s2s edge (authz-api fetches its JWKS to verify the
+    // relayed cookie) and an event source (the iam.* projection over rabbitmq
+    // fills authz_local's projection tables). Declared `s2s` because that is the
+    // synchronous, request-path coupling; the async edge is covered by `mesh`.
+    dependsOn: ['iam-api'],
+    depKinds: { 'iam-api': 's2s' },
+    mesh: ['postgres', 'rabbitmq'],
+    launch: {
+      cmd: 'pnpm dev',
+      env: {
+        NODE_ENV: 'development',
+        PORT: '${AUTHZ_PORT}',
+        AUTHZ_DATABASE_URL: '${AUTHZ_DB_URL}',
+        RABBITMQ_URL: '${MESH_MQ}',
+        IAM_AUTH_JWKSURL: '${IAM_URL}/.well-known/services/jwks.json',
+        IAM_AUTH_USERJWKSURL: '${IAM_URL}/.well-known/jwks.json',
+        IAM_AUTH_SERVICETOKENISSUER: '${IAM_ISSUER}',
+        IAM_AUTH_USERTOKENISSUER: '${IAM_ISSUER}',
+      },
+    },
+    seed: [],
+    lane: lanes(3200, 'authz'),
+    tunnelSlug: 'authz',
+    isFrontend: false,
+    optional: false,
+  },
   'programs-api': {
     id: 'programs-api',
     repo: 'PROGRAM_HUB',
@@ -245,9 +313,17 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
     portEnvVar: 'PORT',
     healthPath: '/health',
     databases: ['sessions'],
-    dependsOn: ['iam-api', 'programs-api', 'scheduling-api'],
+    dependsOn: ['iam-api', 'programs-api', 'scheduling-api', 'authz-api'],
     // iam-api is a required url dep; programs/scheduling are event (projections converge async).
-    depKinds: { 'iam-api': 'url', 'programs-api': 'event', 'scheduling-api': 'event' },
+    // authz-api is a HARD url dep (soa#402): SessionsAuthzGate calls it on every
+    // read with no bypass. Because the closure is transitive, this one edge pulls
+    // authz-api into EVERY flow that contains sessions-api — no per-flow edits.
+    depKinds: {
+      'iam-api': 'url',
+      'programs-api': 'event',
+      'scheduling-api': 'event',
+      'authz-api': 'url',
+    },
     mesh: ['postgres', 'rabbitmq'],
     launch: {
       cmd: 'pnpm dev',
@@ -259,6 +335,10 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
         CORS_ORIGIN: '${DASH_URL}',
         // Same iss iam-api stamps — see programs-api's JWT_ISSUER note.
         JWT_ISSUER: '${IAM_ISSUER}',
+        // soa#402. authz-api's client default is a LITERAL http://localhost:3200,
+        // so at slot > 0 an unset var would dial SLOT 0's authz-api — the
+        // cross-slot braid this manifest exists to prevent.
+        AUTHZ_API_URL: 'http://localhost:${AUTHZ_PORT}',
       },
     },
     // qtf-demo runs `db:seed:qtf-demo` against the sessions DB (up.sh seed_qtf_demo); add-on, online.

--- a/packages/node/saga-stack-cli/src/core/manifest/types.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/types.ts
@@ -15,6 +15,7 @@
 export type ServiceId =
   | 'iam-api'
   | 'sis-api'
+  | 'authz-api' //      rostering authz capabilities service (:3200) — hard dep of sessions-api (soa#402)
   | 'programs-api'
   | 'scheduling-api'
   | 'sessions-api'
@@ -77,7 +78,8 @@ export type DbId =
   | 'chat_local'
   | 'connectv3'
   | 'openfga'
-  | 'authz_sync_local';
+  | 'authz_sync_local'
+  | 'authz_local';
 
 /** Canonical SeedStep ids (see §4). Referenced by `ServiceDef.seed`. */
 export type SeedStepRef =

--- a/packages/node/saga-stack-cli/src/core/manifest/types.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/types.ts
@@ -85,6 +85,7 @@ export type DbId =
 export type SeedStepRef =
   | 'iam-dev-user'
   | 'iam'
+  | 'authz-projection-backfill'
   | 'sessions'
   | 'qtf-demo'
   | 'programs'

--- a/packages/node/saga-stack-cli/src/core/seed/__tests__/compose-seed-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/seed/__tests__/compose-seed-plan.unit.test.ts
@@ -35,14 +35,14 @@ describe('composeSeedPlan — gate 1: partial-stack drop', () => {
     // service-inactive (coach-api owns two full-profile steps now — dedupe the services).
     const dropped = plan.skipped.filter((s) => s.reason === 'service-inactive');
     expect([...new Set(dropped.map((s) => s.service))].sort()).toEqual(
-      ['coach-api', 'content-api', 'programs-api', 'scheduling-api', 'sessions-api'].sort(),
+      ['authz-api', 'coach-api', 'content-api', 'programs-api', 'scheduling-api', 'sessions-api'].sort(),
     );
   });
 });
 
 describe('composeSeedPlan — gate 2: snapshot-skip (service granularity)', () => {
-  const sel: SeedSelection = { profile: 'roster' }; // iam-registry, iam-dev-user, iam, sessions
-  const active = set('iam-api', 'sessions-api');
+  const sel: SeedSelection = { profile: 'roster' }; // iam-registry, iam-dev-user, iam, authz-projection-backfill, sessions
+  const active = set('iam-api', 'sessions-api', 'authz-api');
 
   it('drops a fully-restored service\'s steps; keeps the rest', () => {
     const plan = composeSeedPlan(sel, active, set('iam-api'));
@@ -57,6 +57,8 @@ describe('composeSeedPlan — gate 2: snapshot-skip (service granularity)', () =
   it('keeps all steps when nothing is restored', () => {
     const plan = composeSeedPlan(sel, active, set());
     expect(ids(plan.offline)).toEqual(['iam-registry', 'iam-dev-user', 'iam', 'sessions']);
+    // soa#402: online — needs iam-api + authz-api up to relay/consume iam.* events.
+    expect(ids(plan.online)).toEqual(['authz-projection-backfill']);
     expect(plan.skipped).toEqual([]);
   });
 
@@ -75,7 +77,15 @@ describe('composeSeedPlan — gate 2: snapshot-skip (service granularity)', () =
     // Coach is single-store now — mongo is retired — so fga-bootstrap is the
     // remaining `databases: []` step and carries the case.)
     const sel: SeedSelection = { profile: 'full', addOns: ['authz'] };
-    const active = set('iam-api', 'sessions-api', 'programs-api', 'scheduling-api', 'content-api', 'coach-api');
+    const active = set(
+      'iam-api',
+      'sessions-api',
+      'programs-api',
+      'scheduling-api',
+      'content-api',
+      'coach-api',
+      'authz-api',
+    );
     const plan = composeSeedPlan(sel, active, set('iam-api', 'coach-api'));
 
     // fga-bootstrap (databases: []) survives despite iam-api ∈ restored...
@@ -95,7 +105,15 @@ describe('composeSeedPlan — gate 2: snapshot-skip (service granularity)', () =
 describe('composeSeedPlan — gate 3: offline / online partition', () => {
   it('partitions survivors by requiresServiceUp, in canonical run order', () => {
     const sel: SeedSelection = { profile: 'full', addOns: ['qtf'] };
-    const active = set('iam-api', 'sessions-api', 'programs-api', 'scheduling-api', 'content-api', 'coach-api');
+    const active = set(
+      'iam-api',
+      'sessions-api',
+      'programs-api',
+      'scheduling-api',
+      'content-api',
+      'coach-api',
+      'authz-api',
+    );
     const plan = composeSeedPlan(sel, active, set());
 
     // qtf-demo (requires sessions-api) + content (requires content-api) defer online;
@@ -111,7 +129,9 @@ describe('composeSeedPlan — gate 3: offline / online partition', () => {
       'scheduling',
       'coach-pg',
     ]);
-    expect(ids(plan.online)).toEqual(['qtf-demo', 'content']);
+    // soa#402: the backfill leads the online set — it must warm authz-api's
+    // projection before qtf-demo's reads traverse sessions-api's authz gate.
+    expect(ids(plan.online)).toEqual(['authz-projection-backfill', 'qtf-demo', 'content']);
     expect(plan.skipped).toEqual([]);
   });
 });
@@ -170,8 +190,9 @@ describe('composeSeedPlan — selection refinements', () => {
 
   it('exclude drops a step by id without recording a skip note', () => {
     const sel: SeedSelection = { profile: 'roster', exclude: ['sessions'] };
-    const plan = composeSeedPlan(sel, set('iam-api', 'sessions-api'), set());
+    const plan = composeSeedPlan(sel, set('iam-api', 'sessions-api', 'authz-api'), set());
     expect(ids(plan.offline)).toEqual(['iam-registry', 'iam-dev-user', 'iam']);
+    expect(ids(plan.online)).toEqual(['authz-projection-backfill']);
     expect(plan.skipped).toEqual([]); // excluded ≠ skipped (never requested)
   });
 });

--- a/packages/node/saga-stack-cli/src/core/seed/profiles.ts
+++ b/packages/node/saga-stack-cli/src/core/seed/profiles.ts
@@ -20,6 +20,7 @@ export type SeedStepId =
   | 'iam-registry' //         soa#253: iam seed:registry (Permission/Policy catalog) — MUST precede iam-dev-user
   | 'iam-dev-user'
   | 'iam'
+  | 'authz-projection-backfill' // soa#402: warm authz-api's iam projection (offline iam seed emits no events)
   | 'sessions'
   | 'qtf-demo'
   | 'programs'
@@ -38,11 +39,21 @@ export type SeedStepId =
 export const PROFILE_STEPS: Readonly<Record<SeedProfile, readonly SeedStepId[]>> = {
   // soa#253: `iam-registry` FIRST — the Permission/Policy catalog that iam-dev-user's
   // dev-admin grant depends on (registry-gated view_rosters_tab/view_sessions_tab).
-  roster: ['iam-registry', 'iam-dev-user', 'iam', 'sessions'],
+  roster: ['iam-registry', 'iam-dev-user', 'iam', 'authz-projection-backfill', 'sessions'],
   // coach is SINGLE-STORE now: mongo is retired (curriculum reads come from
   // Postgres content_release), so `coach-mongo` is gone and `coach-pg` — which
   // also seeds the group_track_map projection — is the whole coach seed.
-  full: ['iam-registry', 'iam-dev-user', 'iam', 'sessions', 'programs', 'scheduling', 'content', 'coach-pg'],
+  full: [
+    'iam-registry',
+    'iam-dev-user',
+    'iam',
+    'authz-projection-backfill',
+    'sessions',
+    'programs',
+    'scheduling',
+    'content',
+    'coach-pg',
+  ],
 };
 
 /** Add-on → the seed-step ids it contributes (plan §4.1). */
@@ -81,6 +92,9 @@ export const SEED_RUN_ORDER: readonly SeedStepId[] = [
   'iam-registry',
   'iam-dev-user',
   'iam',
+  // soa#402: must follow 'iam' (it re-emits what that seed wrote) and precede
+  // every online step whose reads traverse sessions-api's authz gate (qtf-demo).
+  'authz-projection-backfill',
   'sessions',
   'qtf-demo',
   'programs',
@@ -315,6 +329,45 @@ export function buildSeedRegistry(m: Manifest = manifest): Record<SeedStepId, Se
       command: ['pnpm', 'db:seed'],
       env: inlineDatabaseUrl(getDb('sessions', m)),
       requiresServiceUp: [],
+      failureMode: 'fatal',
+    },
+    /**
+     * soa#402 — warm authz-api's `iam.*` projection.
+     *
+     * WHY THIS EXISTS: the stack's iam seeding is OFFLINE (direct DB writes), so
+     * it never publishes `iam.*` events. authz-api's projection consumer therefore
+     * never hydrates, `projection_readiness` stays empty, and it fails closed with
+     * `SERVICE_UNAVAILABLE` ("iam-projection is not yet warm") on every capabilities
+     * call — which sessions-api maps to tRPC TIMEOUT → HTTP 408 on EVERY sessions
+     * read. Onboarding authz-api into the manifest is necessary but NOT sufficient
+     * without this step; verified on a live slot, where the identical
+     * `sessions.dayList` went 408 → 200 once the projection warmed.
+     *
+     * Re-drives iam's normal event path (`writeOutbox` + the running OutboxRelay)
+     * rather than a bulk-hydrate API — iam-api's own script, whose docstring names
+     * authz-api's projection as its motivating consumer. Every `iam.*` consumer
+     * upserts on the wire id, so re-running is idempotent, just noisy. The script's
+     * "run off-peak" warning is about deployed environments with live traffic; a
+     * local slot has no peak.
+     *
+     * ONLINE and needs BOTH services: iam-api runs the relay that ships the rows,
+     * authz-api must be consuming to project them. `cwd` is iam-api's (the script
+     * lives there) — same ROSTERING repo root as the owning service. DATABASE_URL
+     * points at iam_local: the script only writes iam's outbox.
+     */
+    'authz-projection-backfill': {
+      id: 'authz-projection-backfill',
+      // Owned by authz-api: the step exists to hydrate ITS read model, so it drops
+      // out with authz-api on a partial stack and is snapshot-skipped when authz-api
+      // was restored (a restored projection is already warm).
+      service: 'authz-api',
+      databases: ['authz_local'],
+      cwd: getService('iam-api', m).subpath,
+      command: ['npx', 'tsx', 'src/scripts/backfill-outbox-reemit.ts'],
+      env: inlineDatabaseUrl(getDb('iam_local', m)),
+      requiresServiceUp: ['iam-api', 'authz-api'],
+      // fatal: without a warm projection every sessions read 408s, so a silent
+      // failure here reproduces exactly the bug soa#402 is about.
       failureMode: 'fatal',
     },
     // QTF + observation-notes demo on an Ended session. Add-on, online: only

--- a/packages/node/saga-stack-cli/src/core/snapshot/__tests__/plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/snapshot/__tests__/plan.unit.test.ts
@@ -39,6 +39,7 @@ const PG_APP_DBS: DbId[] = [
   'sis_db',
   'ads_adm_local',
   'ledger_local',
+  'authz_local', // soa#402
 ];
 const PLAYBACK_DBS: DbId[] = ['transcripts_local', 'insights_local', 'chat_local'];
 
@@ -80,13 +81,13 @@ function knownMigrations(snap: SnapshotManifest): LocalMigrations {
   return out as LocalMigrations;
 }
 
-describe('storePlan — manifest-driven db set (the 6→10-pg + mongo extension)', () => {
-  it('defaults to all 10 pg app DBs + connectv3 mongo, excluding playback', () => {
+describe('storePlan — manifest-driven db set (the 6→11-pg + mongo extension)', () => {
+  it('defaults to all 11 pg app DBs + connectv3 mongo, excluding playback', () => {
     const plan = storePlan(manifest, { fixtureId: 'x', profile: 'roster' });
     const pg = plan.databases.filter((d) => d.engine === 'postgres').map((d) => d.db);
     const mongo = plan.databases.filter((d) => d.engine === 'mongo').map((d) => d.db);
 
-    expect(pg).toHaveLength(10);
+    expect(pg).toHaveLength(11);
     expect(new Set(pg)).toEqual(new Set(PG_APP_DBS));
     expect(mongo).toEqual(['connectv3']);
     // The DBs mesh-fixture-cli's stale 6-DB list missed:
@@ -120,7 +121,7 @@ describe('storePlan — manifest-driven db set (the 6→10-pg + mongo extension)
   it('--with-playback adds the transcripts/insights/chat trio', () => {
     const plan = storePlan(manifest, { fixtureId: 'x', profile: 'roster', withPlayback: true });
     const dbs = plan.databases.map((d) => d.db);
-    expect(plan.databases.filter((d) => d.engine === 'postgres')).toHaveLength(13);
+    expect(plan.databases.filter((d) => d.engine === 'postgres')).toHaveLength(14);
     for (const pb of PLAYBACK_DBS) expect(dbs).toContain(pb);
   });
 

--- a/packages/node/saga-stack-cli/src/core/snapshot/manifest.ts
+++ b/packages/node/saga-stack-cli/src/core/snapshot/manifest.ts
@@ -50,6 +50,7 @@ const DB_IDS = [
   'connectv3',
   'openfga',
   'authz_sync_local',
+  'authz_local',
 ] as const;
 const _dbIdsAreDbIds: readonly DbId[] = DB_IDS;
 void _dbIdsAreDbIds;
@@ -58,6 +59,7 @@ void _dbIdsAreDbIds;
 const SERVICE_IDS = [
   'iam-api',
   'sis-api',
+  'authz-api',
   'programs-api',
   'scheduling-api',
   'sessions-api',


### PR DESCRIPTION
**Re-lands PR #405, which never reached main.** #405's base was `gh_401_project_equals` (stacked on #404); it was merged into that base at 17:39:36 — 21s *after* #404 had already merged the base into main (17:39:15). GitHub shows #405 as MERGED, but its content landed on an already-consumed branch: `authz-api` appears zero times in main's manifest today. This PR is the same two commits, targeted at main.

Content (see #405 for full detail and live slot-2 verification):
- `authz-api` as a non-optional ServiceDef + hard `url` dep of sessions-api (fixes the HTTP-408-on-every-sessions-read of #402)
- `authz-projection-backfill` online seed step (approved: local has no peak) so `stack up` warms authz-api's iam projection automatically
- End-to-end verified: saga-dash journey 18/18, connectv3/connect-observe-qtf 2/2, authz decision log live

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYoTrzK5tj4XqLJUcqmvdA