### PR TITLE
chore(observability): bump to 0.1.0-dev.6 for the exception-capture release

### DIFF
--- a/packages/node/observability/package.json
+++ b/packages/node/observability/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/soa-observability",
-    "version": "0.1.0-dev.5",
+    "version": "0.1.0-dev.6",
     "private": false,
     "type": "module",
     "main": "dist/index.js",


### PR DESCRIPTION
Unblocks publishing the APM exception-capture work from #406.

## Why a bump PR exists at all

#406 merged `recordSpanException()` + `PiiSanitizingSpanExporter` into
`@saga-ed/soa-observability`, but never bumped the version. `0.1.0-dev.5` had
already been published from an earlier commit (`26a3cc4`, a span-noise fix that
is an ancestor of the #406 merge). So `dev.5` names two different builds, and
the copy in CodeArtifact is the **older** one — without exception capture.

Confirmed against the registry, not the repo:

```
$ aws codeartifact list-package-versions --domain saga --repository saga_js \
    --format npm --namespace saga-ed --package soa-observability
dev.1, dev.3, dev.4, dev.5   # dev.6 is free
```

`publish-codeartifact.yml` is `workflow_dispatch`-only and its `single_package`
input publishes at the *already-committed* version — so the bump must land on
`main` before the publish can be dispatched. Hence this PR rather than a direct
push (which `main`'s ruleset blocks anyway).

## Scope

One line. No in-repo package depends on `@saga-ed/soa-observability`, so
`pnpm install --lockfile-only` leaves `pnpm-lock.yaml` unchanged and the
`--frozen-lockfile` installs in the publish jobs stay green.

## After merge

1. Dispatch `publish-codeartifact.yml` with
   `single_package: packages/node/observability`.
2. Verify the **`Version and Publish Packages` job** ran — a green run is not
   proof; on the #406 merge that job was skipped.
3. Verify the artifact: `dev.6` appears in `list-package-versions`.

Consumer dep bumps (rostering, qboard, program-hub) are follow-up work, not part
of this PR. Until they land, the fleet still ships `error: {}` on OTel services.