### PR TITLE
feat(stack status): flag listeners serving code that is not on disk

### DIFF
--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -5217,6 +5217,12 @@
           "name": "program-hub",
           "type": "option"
         },
+        "provenance": {
+          "allowNo": true,
+          "description": "also check that each listener is serving the checkout ss resolves for it, and started after that checkout last moved (--no-provenance to skip). Reports problems only; --output-json carries every verdict.",
+          "name": "provenance",
+          "type": "boolean"
+        },
         "qboard": {
           "description": "override path to the qboard repo checkout",
           "hasDynamicHelp": false,

--- a/packages/node/saga-stack-cli/src/base-command.ts
+++ b/packages/node/saga-stack-cli/src/base-command.ts
@@ -90,6 +90,7 @@ import {
   makeRealBuildCleaner,
   makeRealEnvFs,
   makeRealForeignProcs,
+  makeRealProvenance,
   generateTunnelFleetConfig,
   generateSlotFleetConfig,
   resolveRepoRoot,
@@ -136,6 +137,7 @@ import type {
   BuildCleaner,
   EnvFs,
   ForeignProcs,
+  Provenance,
 } from './runtime/index.js';
 
 /**
@@ -520,6 +522,19 @@ export abstract class BaseCommand extends Command {
    */
   protected getForeignProcs(): ForeignProcs {
     return makeRealForeignProcs();
+  }
+
+  /**
+   * The listener-provenance seam — production is the only place `/proc`, `lsof
+   * -d cwd`, `ps -o lstart=` and the reflog stat run to answer "is the process
+   * answering this port still serving the code I think it is?". Complements
+   * `getForeignProcs` (which answers ownership) and posture (which answers
+   * whether the CHECKOUT is right); this one catches an owned process, in the
+   * right checkout, that predates the checkout's last HEAD movement. `stack
+   * status` uses `assess` (report-only). See `runtime/provenance`.
+   */
+  protected getProvenance(): Provenance {
+    return makeRealProvenance();
   }
 
   /**

--- a/packages/node/saga-stack-cli/src/commands/stack/status.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/status.ts
@@ -36,6 +36,7 @@ import type { RepoKey, ServiceId } from '../../core/manifest/index.js';
 import { resolveRepoRoot } from '../../runtime/index.js';
 import { repoContextFromFlags } from '../../runtime/index.js';
 import type { ScriptContext } from '../../runtime/index.js';
+import { isProvenanceProblem, type ProvenanceRow } from '../../core/provenance.js';
 
 export default class StackStatus extends BaseCommand {
   static description =
@@ -58,6 +59,12 @@ export default class StackStatus extends BaseCommand {
       options: [...BUNDLE_NAMES],
       description:
         "convenience bundle(s) to include — sugar over --only (unions the bundle's services into the closure). Repeatable/composable: --with dash --with coach. Bundles: dash, connect, coach, playback.",
+    }),
+    provenance: Flags.boolean({
+      default: true,
+      allowNo: true,
+      description:
+        'also check that each listener is serving the checkout ss resolves for it, and started after that checkout last moved (--no-provenance to skip). Reports problems only; --output-json carries every verdict.',
     }),
   };
 
@@ -103,6 +110,23 @@ export default class StackStatus extends BaseCommand {
     const down = rows.length - up;
     const healthy = down === 0; // not-cloned services do NOT count as down
 
+    // Provenance is a SEPARATE question from health: a 200 says something is
+    // answering, not that it is answering with the code on disk. Assessed only
+    // for services we actually probed, and never folded into `healthy` — see the
+    // note on the JSON payload below.
+    const provenance = flags.provenance
+      ? await this.getProvenance().assess({
+          manifest,
+          services: probe,
+          portOverrides: profile.portOverrides,
+          expectedRoots: new Map(
+            probe.map((id) => [id, resolveRepoRoot(manifest.services[id].repo, ctx)]),
+          ),
+        })
+      : [];
+    const suspect = provenance.filter((p) => isProvenanceProblem(p.verdict));
+    const byId = new Map(provenance.map((p) => [p.id, p]));
+
     if (flags['output-json']) {
       this.log(
         JSON.stringify(
@@ -114,8 +138,28 @@ export default class StackStatus extends BaseCommand {
               status: r.status ?? null,
             })),
             notCloned: notCloned.map((n) => ({ id: n.id, repo: n.repo, repoDir: n.repoDir })),
-            summary: { total: rows.length, up, down, notCloned: notCloned.length },
+            // `healthy` deliberately still means "every probed service answered".
+            // Provenance gets its OWN verdict so anything gating on `healthy`
+            // keeps its existing meaning instead of silently tightening.
+            provenance: provenance.map((p) => ({
+              id: p.id,
+              port: p.port,
+              verdict: p.verdict,
+              pid: p.pid,
+              expectedRoot: p.expectedRoot,
+              actualRoot: p.actualRoot,
+              startedAt: p.startedAtMs === null ? null : new Date(p.startedAtMs).toISOString(),
+              refMovedAt: p.refMovedAtMs === null ? null : new Date(p.refMovedAtMs).toISOString(),
+            })),
+            summary: {
+              total: rows.length,
+              up,
+              down,
+              notCloned: notCloned.length,
+              suspect: suspect.length,
+            },
             healthy,
+            provenanceOk: suspect.length === 0,
           },
           null,
           2,
@@ -127,17 +171,23 @@ export default class StackStatus extends BaseCommand {
     if (flags.porcelain) {
       for (const r of rows) this.log(`${r.id}=${r.ok ? 'up' : 'down'}`);
       for (const n of notCloned) this.log(`${n.id}=not-cloned`);
+      for (const p of suspect) this.log(`provenance.${p.id}=${p.verdict}`);
       this.log(`healthy=${healthy}`);
+      this.log(`provenanceOk=${suspect.length === 0}`);
       return;
     }
 
-    for (const r of rows) this.log(formatRow(r));
+    for (const r of rows) {
+      this.log(formatRow(r, byId.get(r.id)));
+      for (const line of provenanceDetail(byId.get(r.id))) this.log(line);
+    }
     for (const n of notCloned) {
       this.log(`⚠ ${n.id.padEnd(16)} ${n.repoDir}  (not cloned: ${n.repo} repo not present)`);
     }
     this.log(
       `${up}/${rows.length} services up${healthy ? '' : ` (${down} down)`}` +
-        (notCloned.length ? `, ${notCloned.length} not cloned` : ''),
+        (notCloned.length ? `, ${notCloned.length} not cloned` : '') +
+        (suspect.length ? ` · ⚠ ${suspect.length} serving unverified code` : ''),
     );
   }
 }
@@ -150,11 +200,58 @@ interface StatusRow {
   status?: number;
 }
 
-/** Human line: `✓ id   url   (200)` for up, `✗ id   url   (down)` for down. */
-function formatRow(r: StatusRow): string {
-  const mark = r.ok ? '✓' : '✗';
+/**
+ * Human line: `✓ id   url   (200)` for up, `✗ id   url   (down)` for down. A
+ * service that answers but whose provenance is suspect is marked `⚠` and
+ * labelled, because a bare `✓` on a process serving week-old code is exactly the
+ * false reassurance this check exists to remove.
+ */
+function formatRow(r: StatusRow, p?: ProvenanceRow): string {
+  const suspect = p !== undefined && isProvenanceProblem(p.verdict);
+  const mark = suspect ? '⚠' : r.ok ? '✓' : '✗';
   const code = r.status !== undefined ? `(${r.status})` : '(down)';
-  return `${mark} ${r.id.padEnd(16)} ${r.url}  ${code}`;
+  const label = suspect ? `  ${p.verdict === 'stale' ? 'STALE' : 'WRONG CHECKOUT'}` : '';
+  return `${mark} ${r.id.padEnd(16)} ${r.url}  ${code}${label}`;
+}
+
+/** Render `ms` as a local `YYYY-MM-DD HH:MM`, or `?` when unknown. */
+function stamp(ms: number | null): string {
+  if (ms === null) return '?';
+  const d = new Date(ms);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+/** `6d` / `3h` / `12m` — how far `earlier` precedes `later`; '' if either is unknown. */
+function gap(earlier: number | null, later: number | null): string {
+  if (earlier === null || later === null) return '';
+  const mins = Math.max(0, Math.round((later - earlier) / 60000));
+  if (mins >= 1440) return `${Math.floor(mins / 1440)}d`;
+  if (mins >= 60) return `${Math.floor(mins / 60)}h`;
+  return `${mins}m`;
+}
+
+/**
+ * The indented explanation under a suspect service. Says what is wrong, what was
+ * expected, and — for `stale` — how far behind the process is, so the operator
+ * can act without re-deriving it by hand.
+ */
+function provenanceDetail(p?: ProvenanceRow): string[] {
+  if (p === undefined || !isProvenanceProblem(p.verdict)) return [];
+  const out: string[] = [];
+  if (p.verdict === 'wrong-checkout') {
+    out.push(`    serving from  ${p.actualRoot ?? '?'}`);
+    out.push(`    expected      ${p.expectedRoot}`);
+  } else {
+    const behind = gap(p.startedAtMs, p.refMovedAtMs);
+    out.push(`    checkout      ${p.expectedRoot}`);
+    out.push(
+      `    started       ${stamp(p.startedAtMs)}  ·  HEAD moved ${stamp(p.refMovedAtMs)}` +
+        (behind ? `  (${behind} behind)` : ''),
+    );
+  }
+  out.push(`    pid ${p.pid ?? '?'} — restart this service to serve what is on disk`);
+  return out;
 }
 
 /**

--- a/packages/node/saga-stack-cli/src/core/__tests__/provenance.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/provenance.unit.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Listener-provenance classification — PURE (no /proc, no ps, no spawn, no
+ * clock). The rule under test: a listener is suspect when it is serving a
+ * DIFFERENT checkout than `ss` resolves for that service (`wrong-checkout`), or
+ * when it started BEFORE its checkout's HEAD last moved (`stale`).
+ *
+ * The `stale` case is the one that motivated the module: it is invisible to both
+ * neighbouring checks, because the process is owned and the checkout is correct.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { classifyProvenance, isProvenanceProblem, type ProcOrigin } from '../provenance.js';
+import type { PortListener } from '../foreign-procs.js';
+import type { ServiceId } from '../manifest/index.js';
+
+const COACH_WEB: ServiceId = 'coach-web';
+const IAM: ServiceId = 'iam-api';
+
+const T0 = Date.parse('2026-08-05T10:00:00Z');
+const MINUTE = 60_000;
+
+function listener(port: number, pid: number): PortListener {
+  return { port, pid, pgid: pid, command: 'node vite.js dev' };
+}
+
+function origin(pid: number, checkoutRoot: string | null, startedAtMs: number | null): ProcOrigin {
+  return { pid, checkoutRoot, startedAtMs };
+}
+
+/** One coach-web target on :8800, expected to run from /dev/coach. */
+const TARGETS = [{ id: COACH_WEB, port: 8800 }];
+const EXPECTED = new Map<ServiceId, string>([[COACH_WEB, '/dev/coach']]);
+
+function assess(
+  listeners: Map<number, PortListener>,
+  origins: Map<number, ProcOrigin>,
+  refMoved: number | null = T0 - 10 * MINUTE,
+) {
+  return classifyProvenance(
+    TARGETS,
+    listeners,
+    origins,
+    EXPECTED,
+    new Map([['/dev/coach', refMoved]]),
+  );
+}
+
+describe('classifyProvenance', () => {
+  it('is ok when the checkout matches and the process started after HEAD moved', () => {
+    const [row] = assess(
+      new Map([[8800, listener(8800, 42)]]),
+      new Map([[42, origin(42, '/dev/coach', T0)]]),
+      T0 - 10 * MINUTE,
+    );
+    expect(row?.verdict).toBe('ok');
+    expect(isProvenanceProblem('ok')).toBe(false);
+  });
+
+  it('flags STALE when the process predates the checkout’s last HEAD movement', () => {
+    // The measured 2026-08-05 case: right port, right checkout, right owner —
+    // and a process six days older than the branch it claims to serve.
+    const sixDays = 6 * 24 * 60 * MINUTE;
+    const [row] = assess(
+      new Map([[8800, listener(8800, 42)]]),
+      new Map([[42, origin(42, '/dev/coach', T0 - sixDays)]]),
+      T0,
+    );
+    expect(row?.verdict).toBe('stale');
+    expect(row?.startedAtMs).toBe(T0 - sixDays);
+    expect(row?.refMovedAtMs).toBe(T0);
+    expect(isProvenanceProblem('stale')).toBe(true);
+  });
+
+  it('flags WRONG-CHECKOUT when the listener runs from another tree', () => {
+    const [row] = assess(
+      new Map([[8800, listener(8800, 42)]]),
+      new Map([[42, origin(42, '/dev/coach/.claude/worktrees/pr332', T0)]]),
+    );
+    expect(row?.verdict).toBe('wrong-checkout');
+    expect(row?.actualRoot).toBe('/dev/coach/.claude/worktrees/pr332');
+    expect(row?.expectedRoot).toBe('/dev/coach');
+  });
+
+  it('prefers WRONG-CHECKOUT over STALE when both are true', () => {
+    const [row] = assess(
+      new Map([[8800, listener(8800, 42)]]),
+      new Map([[42, origin(42, '/dev/elsewhere', T0 - 99 * MINUTE)]]),
+      T0,
+    );
+    expect(row?.verdict).toBe('wrong-checkout');
+  });
+
+  it('reports DOWN, not a problem, when nothing is listening', () => {
+    const [row] = assess(new Map(), new Map());
+    expect(row?.verdict).toBe('down');
+    expect(row?.pid).toBeNull();
+    expect(isProvenanceProblem('down')).toBe(false);
+  });
+
+  describe('degrades to unknown rather than crying wolf', () => {
+    it('when the origin could not be read at all', () => {
+      const [row] = assess(new Map([[8800, listener(8800, 42)]]), new Map());
+      expect(row?.verdict).toBe('unknown');
+      expect(row?.pid).toBe(42);
+    });
+
+    it('when the cwd resolved to no checkout (non-Linux, or outside a repo)', () => {
+      const [row] = assess(
+        new Map([[8800, listener(8800, 42)]]),
+        new Map([[42, origin(42, null, T0)]]),
+      );
+      expect(row?.verdict).toBe('unknown');
+    });
+
+    it('when the expected root could not be resolved', () => {
+      const [row] = classifyProvenance(
+        TARGETS,
+        new Map([[8800, listener(8800, 42)]]),
+        new Map([[42, origin(42, '/dev/coach', T0)]]),
+        new Map([[COACH_WEB, '']]),
+        new Map(),
+      );
+      expect(row?.verdict).toBe('unknown');
+    });
+
+    it('when HEAD movement is unknown — the staleness leg is SKIPPED, not failed', () => {
+      const [row] = assess(
+        new Map([[8800, listener(8800, 42)]]),
+        new Map([[42, origin(42, '/dev/coach', T0 - 99 * MINUTE)]]),
+        null,
+      );
+      expect(row?.verdict).toBe('ok');
+    });
+
+    it('when the start time is unknown but the checkout is right', () => {
+      const [row] = assess(
+        new Map([[8800, listener(8800, 42)]]),
+        new Map([[42, origin(42, '/dev/coach', null)]]),
+        T0,
+      );
+      expect(row?.verdict).toBe('ok');
+    });
+  });
+
+  it('is order-preserving and returns one row per target', () => {
+    const rows = classifyProvenance(
+      [
+        { id: IAM, port: 3010 },
+        { id: COACH_WEB, port: 8800 },
+      ],
+      new Map([[3010, listener(3010, 7)]]),
+      new Map([[7, origin(7, '/dev/rostering', T0)]]),
+      new Map([
+        [IAM, '/dev/rostering'],
+        [COACH_WEB, '/dev/coach'],
+      ]),
+      new Map([
+        ['/dev/rostering', T0 - MINUTE],
+        ['/dev/coach', T0 - MINUTE],
+      ]),
+    );
+    expect(rows.map((r) => r.id)).toEqual([IAM, COACH_WEB]);
+    expect(rows.map((r) => r.verdict)).toEqual(['ok', 'down']);
+  });
+
+  it('a process started exactly when HEAD moved is not stale (strict <)', () => {
+    const [row] = assess(
+      new Map([[8800, listener(8800, 42)]]),
+      new Map([[42, origin(42, '/dev/coach', T0)]]),
+      T0,
+    );
+    expect(row?.verdict).toBe('ok');
+  });
+});

--- a/packages/node/saga-stack-cli/src/core/provenance.ts
+++ b/packages/node/saga-stack-cli/src/core/provenance.ts
@@ -1,0 +1,154 @@
+/**
+ * Listener provenance (PURE) — "is the process answering this port still serving
+ * the code I think it is?", split out so the command layer + tests reason about
+ * it with zero IO.
+ *
+ * WHY THIS EXISTS, and how it differs from its two neighbours:
+ *
+ *   core/foreign-procs   "did `ss` launch this?"        — ownership, by pgid
+ *   runtime/verify-posture  "is the CHECKOUT what I expect?" — branch/pins/drift
+ *   THIS MODULE          "is what ss launched still CURRENT?"
+ *
+ * The gap is real and was measured on 2026-08-05: slot 0's coach-web was served
+ * by a `vite` process started six days earlier, which had survived a `git
+ * checkout` of its own repo — so it answered 200 on the right port, from the
+ * right checkout, under the right pgid, while serving code that no longer existed
+ * on disk. `stack status` reported 13/13 healthy throughout. Ownership could not
+ * see it (the process was owned), posture could not see it (the checkout was
+ * correct); only the process's START TIME against the checkout's last ref
+ * movement reveals it.
+ *
+ * TWO CHECKS, and why both are needed:
+ *
+ *   wrong-checkout  the listener's checkout root != the root ss resolves for that
+ *                   service. Catches a process left over from a worktree/slot.
+ *   stale           the listener started BEFORE its checkout's HEAD last moved.
+ *                   Catches the case above, which `wrong-checkout` misses because
+ *                   the path is right and only the time is wrong.
+ *
+ * CHECKOUT ROOT, not a path prefix. A naive `cwd.startsWith(expectedRoot)` calls
+ * `~/dev/soa/.claude/worktrees/x/apps/…` a match for `~/dev/soa` — exactly
+ * backwards, since a linked worktree is a DIFFERENT checkout that happens to
+ * live inside the primary one. The IO layer resolves each cwd to its nearest
+ * `.git`-bearing ancestor and this module compares roots for EQUALITY.
+ *
+ * DEGRADES TO `unknown`, NEVER TO A FALSE ALARM. Missing `/proc`, an unreadable
+ * reflog, a process that vanished mid-probe — all yield `unknown`, which renders
+ * as a note and never as a failure. A provenance check that cries wolf gets
+ * switched off, and then it protects nothing.
+ *
+ * INVARIANT (plan hard constraint): this lives in `core/` and stays PURE — no
+ * `/proc`, no `ps`, no spawn, no clock. The host IO lives only in
+ * `runtime/provenance`.
+ */
+
+import type { ServiceId } from './manifest/index.js';
+import type { PortListener } from './foreign-procs.js';
+
+/** Where a live process came from, as resolved by the IO layer. */
+export interface ProcOrigin {
+  pid: number;
+  /**
+   * The nearest `.git`-bearing ancestor of the process's cwd — its CHECKOUT, not
+   * its cwd. `null` when it could not be determined (no `/proc`, vanished, or a
+   * cwd outside any repo).
+   */
+  checkoutRoot: string | null;
+  /** Wall-clock ms at which the process started; `null` when unreadable. */
+  startedAtMs: number | null;
+}
+
+/** What is wrong with a listener, if anything. */
+export type ProvenanceVerdict =
+  /** Listener's checkout matches and it started after the last ref movement. */
+  | 'ok'
+  /** Nothing is listening — the service is down, which `status`'s health leg reports. */
+  | 'down'
+  /** Could not determine provenance; reported as a note, never as a failure. */
+  | 'unknown'
+  /** Serving from a different checkout than the one `ss` resolves for this service. */
+  | 'wrong-checkout'
+  /** Right checkout, but the process predates that checkout's last HEAD movement. */
+  | 'stale';
+
+/** One service's provenance assessment. */
+export interface ProvenanceRow {
+  id: ServiceId;
+  port: number;
+  verdict: ProvenanceVerdict;
+  /** The listening pid, when there is one. */
+  pid: number | null;
+  /** The checkout `ss` resolves for this service's repo. */
+  expectedRoot: string;
+  /** The checkout the listener is actually running from. */
+  actualRoot: string | null;
+  startedAtMs: number | null;
+  /** When `expectedRoot`'s HEAD last moved (checkout/pull/reset). */
+  refMovedAtMs: number | null;
+}
+
+/** True iff this verdict should draw the operator's attention. */
+export function isProvenanceProblem(v: ProvenanceVerdict): boolean {
+  return v === 'wrong-checkout' || v === 'stale';
+}
+
+/**
+ * Classify every target's listener provenance. Pure and order-preserving: the
+ * targets order in, one row each out.
+ *
+ * - `listeners` maps port → its live listener (absent ⇒ `down`).
+ * - `origins` maps pid → where that process came from (absent ⇒ `unknown`).
+ * - `expectedRoots` maps service → the checkout `ss` resolves for its repo.
+ * - `refMovedAt` maps a checkout root → when its HEAD last moved (`null` ⇒ the
+ *   staleness leg is skipped for that root, not failed).
+ *
+ * Precedence is `wrong-checkout` before `stale`: if the process is running from
+ * the wrong tree entirely, when it started is a detail of a bigger problem.
+ */
+export function classifyProvenance(
+  targets: { id: ServiceId; port: number }[],
+  listeners: Map<number, PortListener>,
+  origins: Map<number, ProcOrigin>,
+  expectedRoots: Map<ServiceId, string>,
+  refMovedAt: Map<string, number | null>,
+): ProvenanceRow[] {
+  return targets.map(({ id, port }) => {
+    const expectedRoot = expectedRoots.get(id) ?? '';
+    const base: Omit<ProvenanceRow, 'verdict'> = {
+      id,
+      port,
+      expectedRoot,
+      pid: null,
+      actualRoot: null,
+      startedAtMs: null,
+      refMovedAtMs: refMovedAt.get(expectedRoot) ?? null,
+    };
+
+    const listener = listeners.get(port);
+    if (!listener) return { ...base, verdict: 'down' };
+
+    const origin = origins.get(listener.pid);
+    if (!origin || origin.checkoutRoot === null) {
+      return { ...base, verdict: 'unknown', pid: listener.pid, startedAtMs: origin?.startedAtMs ?? null };
+    }
+
+    const row: ProvenanceRow = {
+      ...base,
+      verdict: 'ok',
+      pid: listener.pid,
+      actualRoot: origin.checkoutRoot,
+      startedAtMs: origin.startedAtMs,
+    };
+
+    // An empty expectedRoot means the caller could not resolve the repo — say so
+    // rather than accusing the process of being in the wrong place.
+    if (expectedRoot === '') return { ...row, verdict: 'unknown' };
+    if (origin.checkoutRoot !== expectedRoot) return { ...row, verdict: 'wrong-checkout' };
+
+    const movedAt = row.refMovedAtMs;
+    if (movedAt !== null && origin.startedAtMs !== null && origin.startedAtMs < movedAt) {
+      return { ...row, verdict: 'stale' };
+    }
+    return row;
+  });
+}

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/provenance.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/provenance.unit.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Listener-provenance IO — the wiring, driven entirely through fakes: no
+ * sockets, no `/proc`, no `ps`, no git. Asserts that `makeRealProvenance`
+ * resolves listeners through the SHARED `ForeignIo` (so ownership and
+ * provenance can never disagree about what is listening), canonicalises the
+ * expected roots before comparing, and stats each distinct root only once.
+ *
+ * `checkoutRootOf` is covered directly, because "which checkout is this?" is the
+ * single most load-bearing decision in the module: a linked worktree's `.git` is
+ * a FILE inside the primary checkout, so a path-prefix test would call it a
+ * match when it is precisely the mismatch we are hunting.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { checkoutRootOf, makeRealProvenance, type ProvenanceIo } from '../provenance.js';
+import type { ForeignIo } from '../foreign-procs.js';
+import type { ProcOrigin } from '../../core/provenance.js';
+import { manifest } from '../../core/manifest/index.js';
+import type { ServiceId } from '../../core/manifest/index.js';
+
+const COACH_WEB: ServiceId = 'coach-web';
+const T0 = Date.parse('2026-08-05T10:00:00Z');
+
+describe('checkoutRootOf', () => {
+  it('returns the nearest ancestor holding a .git entry', () => {
+    const present = new Set(['/dev/coach/.git']);
+    expect(checkoutRootOf('/dev/coach/apps/web/coach-web', (p) => present.has(p))).toBe('/dev/coach');
+  });
+
+  it('stops at a linked WORKTREE inside the primary checkout, not at the primary', () => {
+    // A worktree's `.git` is a file, and it lives UNDER the primary checkout —
+    // the exact shape a `startsWith(expectedRoot)` test gets backwards.
+    const present = new Set([
+      '/dev/coach/.git',
+      '/dev/coach/.claude/worktrees/pr332/.git',
+    ]);
+    expect(
+      checkoutRootOf('/dev/coach/.claude/worktrees/pr332/apps/web/coach-web', (p) => present.has(p)),
+    ).toBe('/dev/coach/.claude/worktrees/pr332');
+  });
+
+  it('returns the directory itself when it is the checkout root', () => {
+    expect(checkoutRootOf('/dev/coach', (p) => p === '/dev/coach/.git')).toBe('/dev/coach');
+  });
+
+  it('returns null when no ancestor is a checkout', () => {
+    expect(checkoutRootOf('/tmp/scratch', () => false)).toBeNull();
+  });
+});
+
+/** A ForeignIo whose listeners come from a port→pid map. */
+function fakeForeignIo(listeners: Record<number, number>): ForeignIo {
+  return {
+    pidOnPort: async (port) => listeners[port] ?? null,
+    procInfo: async (pid) => ({ pgid: pid, command: 'node vite.js dev' }),
+    ownedPgids: () => [],
+    killGroup: () => true,
+  };
+}
+
+/** A ProvenanceIo whose origins come from a pid→origin map. */
+function fakeProvenanceIo(
+  origins: Record<number, ProcOrigin | null>,
+  refMoved: Record<string, number | null> = {},
+  canonical: (p: string) => string = (p) => p,
+): ProvenanceIo {
+  return {
+    procOrigin: async (pid) => origins[pid] ?? null,
+    refMovedAt: (root) => refMoved[root] ?? null,
+    canonical,
+  };
+}
+
+describe('makeRealProvenance.assess', () => {
+  const opts = {
+    manifest,
+    services: [COACH_WEB],
+    expectedRoots: new Map<ServiceId, string>([[COACH_WEB, '/dev/coach']]),
+  };
+
+  it('reports ok for a listener in the right checkout, started after HEAD moved', async () => {
+    const p = makeRealProvenance(
+      fakeProvenanceIo(
+        { 42: { pid: 42, checkoutRoot: '/dev/coach', startedAtMs: T0 } },
+        { '/dev/coach': T0 - 60_000 },
+      ),
+      fakeForeignIo({ 8800: 42 }),
+    );
+    const [row] = await p.assess(opts);
+    expect(row?.verdict).toBe('ok');
+    expect(row?.pid).toBe(42);
+    expect(row?.port).toBe(8800);
+  });
+
+  it('reports stale for an owned listener that predates the checkout', async () => {
+    const p = makeRealProvenance(
+      fakeProvenanceIo(
+        { 42: { pid: 42, checkoutRoot: '/dev/coach', startedAtMs: T0 - 6 * 86_400_000 } },
+        { '/dev/coach': T0 },
+      ),
+      fakeForeignIo({ 8800: 42 }),
+    );
+    const [row] = await p.assess(opts);
+    expect(row?.verdict).toBe('stale');
+  });
+
+  it('canonicalises the expected root before comparing it to the resolved cwd', async () => {
+    // `resolveRepoRoot` may hand back a symlinked path; the process's cwd is
+    // realpath'd. Without canonicalising the expectation these never match and
+    // every service would be reported wrong-checkout.
+    const p = makeRealProvenance(
+      fakeProvenanceIo(
+        { 42: { pid: 42, checkoutRoot: '/real/coach', startedAtMs: T0 } },
+        { '/real/coach': T0 - 60_000 },
+        (path) => (path === '/dev/coach' ? '/real/coach' : path),
+      ),
+      fakeForeignIo({ 8800: 42 }),
+    );
+    const [row] = await p.assess(opts);
+    expect(row?.verdict).toBe('ok');
+    expect(row?.expectedRoot).toBe('/real/coach');
+  });
+
+  it('treats a service with nothing listening as down, without probing its origin', async () => {
+    const io = fakeProvenanceIo({});
+    const spy = vi.spyOn(io, 'procOrigin');
+    const p = makeRealProvenance(io, fakeForeignIo({}));
+    const [row] = await p.assess(opts);
+    expect(row?.verdict).toBe('down');
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('treats a process that vanishes between probes as down', async () => {
+    const foreign: ForeignIo = { ...fakeForeignIo({ 8800: 42 }), procInfo: async () => null };
+    const p = makeRealProvenance(fakeProvenanceIo({}), foreign);
+    const [row] = await p.assess(opts);
+    expect(row?.verdict).toBe('down');
+  });
+
+  it('stats each distinct checkout root only once across services', async () => {
+    const io = fakeProvenanceIo(
+      {
+        1: { pid: 1, checkoutRoot: '/dev/coach', startedAtMs: T0 },
+        2: { pid: 2, checkoutRoot: '/dev/coach', startedAtMs: T0 },
+      },
+      { '/dev/coach': T0 - 60_000 },
+    );
+    const spy = vi.spyOn(io, 'refMovedAt');
+    const p = makeRealProvenance(io, fakeForeignIo({ 8800: 1, 6105: 2 }));
+    await p.assess({
+      manifest,
+      services: [COACH_WEB, 'coach-api' as ServiceId],
+      expectedRoots: new Map<ServiceId, string>([
+        [COACH_WEB, '/dev/coach'],
+        ['coach-api' as ServiceId, '/dev/coach'],
+      ]),
+    });
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/node/saga-stack-cli/src/runtime/index.ts
+++ b/packages/node/saga-stack-cli/src/runtime/index.ts
@@ -53,6 +53,7 @@ export * from './lock.js';
 export * from './checkpoint-store.js';
 export * from './trace-preserve.js';
 export * from './foreign-procs.js';
+export * from './provenance.js';
 export * from './fake-media.js';
 export * from './claim.js';
 export * from './cli-version.js';

--- a/packages/node/saga-stack-cli/src/runtime/provenance.ts
+++ b/packages/node/saga-stack-cli/src/runtime/provenance.ts
@@ -1,0 +1,219 @@
+/**
+ * Listener-provenance IO — the host side of `core/provenance`. Resolves where a
+ * listening process is actually running from and when it started, and when each
+ * checkout's HEAD last moved. Host/process IO lives ONLY here; `core/provenance`
+ * stays pure.
+ *
+ * Listener resolution is DELEGATED to the existing `ForeignIo` (`pidOnPort` +
+ * `procInfo`) rather than re-implemented, so both checks agree on what is
+ * listening and the cross-platform `lsof`/`ss`/`ps` handling lives in one place.
+ *
+ * Cross-platform where it can be: `procInfo` and start time go through POSIX
+ * `ps`; the cwd probe prefers Linux `/proc/<pid>/cwd` and falls back to
+ * `lsof -d cwd` (macOS). Every probe folds errors into `null`, so the check
+ * DEGRADES TO `unknown` — never to a false alarm.
+ *
+ * HEAD movement is read from the checkout's reflog file mtime
+ * (`<gitdir>/logs/HEAD`), not from the HEAD commit's own date. The two differ in
+ * the case that matters: fast-forwarding to a commit authored last week moves
+ * your working tree TODAY, and a process started yesterday is stale even though
+ * the commit predates it. `logs/HEAD` is touched exactly when HEAD moves
+ * (checkout, pull, merge, reset) and — unlike `.git/index` — is not rewritten by
+ * a plain `git status`, so it does not produce phantom staleness.
+ */
+
+import { execFile } from 'node:child_process';
+import { existsSync, readFileSync, realpathSync, statSync } from 'node:fs';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
+import {
+  classifyProvenance,
+  type ProcOrigin,
+  type ProvenanceRow,
+} from '../core/provenance.js';
+import { foreignCheckTargets, type PortListener } from '../core/foreign-procs.js';
+import type { Manifest, ServiceId } from '../core/manifest/index.js';
+import { makeRealForeignIo, type ForeignIo } from './foreign-procs.js';
+
+/** Options for {@link Provenance.assess}. */
+export interface AssessProvenanceOptions {
+  manifest: Manifest;
+  /** Service subset to check; omitted ⇒ every non-optional service. */
+  services?: ServiceId[];
+  /** A slot's offset ports (`InstanceProfile.portOverrides`); absent ⇒ base ports. */
+  portOverrides?: Partial<Record<ServiceId, number>>;
+  /** Service → the checkout `ss` resolves for its repo (`resolveRepoRoot`). */
+  expectedRoots: Map<ServiceId, string>;
+}
+
+/** The command-facing seam. `stack status` calls `assess` (report-only). */
+export interface Provenance {
+  assess(opts: AssessProvenanceOptions): Promise<ProvenanceRow[]>;
+}
+
+/** The low-level host IO, injectable so `makeRealProvenance` is unit-testable. */
+export interface ProvenanceIo {
+  /** Where `pid` is running from + when it started; `null` if it has vanished. */
+  procOrigin(pid: number): Promise<ProcOrigin | null>;
+  /** When `root`'s HEAD last moved (ms), or `null` if unreadable. */
+  refMovedAt(root: string): number | null;
+  /** Canonical form of a path, for root-vs-root equality; input on any failure. */
+  canonical(path: string): string;
+}
+
+/** Run a command, resolving its trimmed stdout (or '' on any error). NEVER throws. */
+function runCapture(command: string, args: string[]): Promise<string> {
+  return new Promise((resolve) => {
+    execFile(command, args, { encoding: 'utf8' }, (err, stdout) => {
+      resolve(err ? '' : (stdout ?? '').toString());
+    });
+  });
+}
+
+/** Canonicalise, folding any failure back to the input so comparisons still run. */
+function defaultCanonical(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return path;
+  }
+}
+
+/**
+ * The nearest ancestor of `from` (inclusive) that holds a `.git` entry — the
+ * process's CHECKOUT. A linked worktree's `.git` is a FILE, not a directory, and
+ * that is precisely the case this must catch, so presence is tested rather than
+ * directory-ness. `null` when no ancestor qualifies.
+ */
+export function checkoutRootOf(from: string, exists: (p: string) => boolean = existsSync): string | null {
+  let dir = from;
+  for (;;) {
+    if (exists(join(dir, '.git'))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+/** Resolve a checkout's git dir, following the `gitdir:` pointer of a linked worktree. */
+export function gitDirOf(root: string): string | null {
+  const dotGit = join(root, '.git');
+  try {
+    if (statSync(dotGit).isDirectory()) return dotGit;
+  } catch {
+    return null;
+  }
+  try {
+    const pointer = readFileSync(dotGit, 'utf8').trim();
+    const match = /^gitdir:\s*(.+)$/.exec(pointer);
+    const target = match?.[1]?.trim();
+    if (!target) return null;
+    return isAbsolute(target) ? target : resolve(root, target);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The production `ProvenanceIo`. `procOrigin` reads `/proc/<pid>/cwd` (Linux),
+ * falling back to `lsof -d cwd` (macOS), and takes the start time from POSIX
+ * `ps -o lstart=`; `refMovedAt` stats the checkout's reflog.
+ */
+export function makeRealProvenanceIo(): ProvenanceIo {
+  return {
+    async procOrigin(pid: number): Promise<ProcOrigin | null> {
+      let cwd: string | null = null;
+      try {
+        cwd = realpathSync(`/proc/${pid}/cwd`);
+      } catch {
+        // Not Linux, or not ours to read — try lsof's cwd descriptor.
+        const out = await runCapture('lsof', ['-a', '-p', String(pid), '-d', 'cwd', '-Fn']);
+        const line = out.split('\n').find((l) => l.startsWith('n'));
+        cwd = line ? line.slice(1).trim() || null : null;
+      }
+
+      const lstart = (await runCapture('ps', ['-o', 'lstart=', '-p', String(pid)])).trim();
+      const parsed = lstart ? Date.parse(lstart) : Number.NaN;
+      const startedAtMs = Number.isNaN(parsed) ? null : parsed;
+
+      // A pid with neither a cwd nor a start time has vanished between probes.
+      if (cwd === null && startedAtMs === null) return null;
+
+      return {
+        pid,
+        checkoutRoot: cwd === null ? null : checkoutRootOf(cwd),
+        startedAtMs,
+      };
+    },
+
+    refMovedAt(root: string): number | null {
+      const gitDir = gitDirOf(root);
+      if (gitDir === null) return null;
+      // `logs/HEAD` is touched exactly when HEAD moves. Fall back to `HEAD`
+      // itself when reflogs are disabled — it still changes on branch switches.
+      for (const candidate of [join(gitDir, 'logs', 'HEAD'), join(gitDir, 'HEAD')]) {
+        try {
+          return statSync(candidate).mtimeMs;
+        } catch {
+          /* try the next candidate */
+        }
+      }
+      return null;
+    },
+
+    canonical: defaultCanonical,
+  };
+}
+
+/**
+ * Build the command-facing seam over a `ProvenanceIo` + the shared `ForeignIo`
+ * (production IO by default). Resolves each target port's listener, that
+ * listener's origin, and each expected checkout's last HEAD movement, then runs
+ * the pure `classifyProvenance`.
+ *
+ * Probes run CONCURRENTLY across services — `status` already probes health in
+ * parallel, and a provenance pass that visibly slowed it down would get turned
+ * off.
+ */
+export function makeRealProvenance(
+  io: ProvenanceIo = makeRealProvenanceIo(),
+  foreignIo: ForeignIo = makeRealForeignIo(),
+): Provenance {
+  return {
+    async assess(opts: AssessProvenanceOptions): Promise<ProvenanceRow[]> {
+      const targets = foreignCheckTargets(opts.manifest, opts.services, opts.portOverrides);
+
+      const resolved = await Promise.all(
+        targets.map(async ({ port }) => {
+          const pid = await foreignIo.pidOnPort(port);
+          if (pid === null) return null;
+          const info = await foreignIo.procInfo(pid);
+          if (info === null) return null; // vanished mid-probe ⇒ treat as down
+          const origin = await io.procOrigin(pid);
+          return {
+            listener: { port, pid, pgid: info.pgid, command: info.command } satisfies PortListener,
+            origin,
+          };
+        }),
+      );
+
+      const listeners = new Map<number, PortListener>();
+      const origins = new Map<number, ProcOrigin>();
+      for (const entry of resolved) {
+        if (entry === null) continue;
+        listeners.set(entry.listener.port, entry.listener);
+        if (entry.origin !== null) origins.set(entry.listener.pid, entry.origin);
+      }
+
+      // Canonicalise expected roots so they compare equal to the realpath'd cwds.
+      const expectedRoots = new Map<ServiceId, string>();
+      for (const [id, root] of opts.expectedRoots) expectedRoots.set(id, io.canonical(root));
+
+      const refMovedAt = new Map<string, number | null>();
+      for (const root of new Set(expectedRoots.values())) {
+        refMovedAt.set(root, io.refMovedAt(root));
+      }
+
+      return classifyProvenance(targets, listeners, origins, expectedRoots, refMovedAt);
+    },
+  };
+}


### PR DESCRIPTION
## The problem

`stack status` asks *"is something answering this port?"* and calls that healthy. That is not the same question as *"is the thing answering serving the code I have checked out?"*

On 2026-08-05, slot 0's coach-web was served by a `vite` process **started six days earlier** that had survived a `git checkout` of its own repo. It answered 200, on the right port, from the right checkout, under the right pgid — so `status` reported `13/13 services up` while the code being served no longer existed on disk. About an hour went into debugging a bug that had already been fixed.

The two checks that already exist could not see it:

| check | why it passed |
|---|---|
| `core/foreign-procs` — ownership by pgid | the process **was** ours |
| `runtime/verify-posture` — P1–P4 branch/pins/drift | the **checkout** was correct |

Only the process's start time, against the checkout's last HEAD movement, reveals it. This adds that third question.

## What it does

Two verdicts, both reported by `stack status`:

- **`wrong-checkout`** — the listener's checkout is not the one `ss` resolves for that service
- **`stale`** — right checkout, but the process predates that checkout's last HEAD movement

```
✓ coach-api        http://localhost:6105/health  (200)
⚠ coach-web        http://localhost:8800/  (200)  STALE
    checkout      /home/skelly/dev/coach
    started       2026-08-05 10:20  ·  HEAD moved 2026-08-05 11:19  (1h behind)
    pid 1720048 — restart this service to serve what is on disk
13/14 services up · ⚠ 1 serving unverified code
```

## Two decisions worth reviewing

**Checkout roots are compared, not path prefixes.** A linked worktree's `.git` is a *file inside* the primary checkout, so `cwd.startsWith(expectedRoot)` calls a worktree process a match for the primary — exactly backwards, since that is the mismatch we are hunting. The IO layer walks up to the nearest `.git`-bearing ancestor and roots are compared for equality. Covered by a dedicated test.

**HEAD movement comes from the reflog file's mtime, not HEAD's commit date.** The two differ in the case that matters: fast-forwarding to a commit authored last week moves your tree *today*, and a process from yesterday is stale even though the commit predates it. `logs/HEAD` is touched exactly when HEAD moves and — unlike `.git/index` — is not rewritten by a plain `git status`, so it does not manufacture phantom staleness.

## Seams and invariants

- Listener resolution **delegates to the existing `ForeignIo`** (`pidOnPort` / `procInfo`) rather than re-implementing it, so ownership and provenance can never disagree about what is listening, and the `lsof`/`ss`/`ps` handling stays in one place.
- **`healthy` still means "every probed service answered."** The new signal is its own `provenanceOk`, so anything gating on `healthy` keeps its existing meaning instead of silently tightening.
- **Everything degrades to `unknown`** — missing `/proc`, unreadable reflog, a process that vanishes mid-probe. A check that cries wolf gets switched off, and then it protects nothing.
- `core/provenance.ts` stays **pure** — no `/proc`, no `ps`, no spawn, no clock. Host IO lives only in `runtime/provenance.ts`.
- Humans get exceptions (problem rows only, `⚠` replacing the misleading `✓`); `--output-json` carries a verdict for every service; `--no-provenance` skips the pass.

## Verification

Both verdicts exercised **end to end against slot 0 on real processes**, not just in tests:

- **`stale`** — bumped `~/dev/coach/.git/logs/HEAD`'s mtime, confirmed both coach services flipped to `⚠ STALE` with correct pids and a `1h behind` delta, then restored the mtime byte-identically and confirmed the status went clean again.
- **`wrong-checkout`** — via the existing `--coach` path override, which also confirmed the worktree-root logic resolves correctly rather than prefix-matching.

Also checked: `--no-provenance`, `--porcelain` (`provenanceOk=true`), and `--output-json`.

`pnpm check-types` clean · 22 new unit tests · the package's **1638 tests pass**.

⚠️ `pnpm lint` could not be run: the repo's flat config uses `no-unassigned-vars`, which needs eslint 9, and the installed eslint is 8.57.1. An untouched file (`core/foreign-procs.ts`) fails identically, so this is pre-existing and out of scope here — but worth someone's attention.

## Deliberately not in this PR

- **`stack verify` should grow this as a P5 posture check** so it can gate rather than only report. Kept out to keep the change reviewable, and because `verify`'s warn-only-then-promote pattern deserves its own decision.
- **`stack restart` did not actually kill the vite process that prompted this.** That is a real second bug — the reason the stale process existed at all — and it wants its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJ3swta9V4Y8JfaqXSQ38M
