### PR TITLE
fix(stack restart): reap foreign listeners, and stop lying about the kill

### DIFF
--- a/packages/node/saga-stack-cli/src/__tests__/stack-api.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/__tests__/stack-api.unit.test.ts
@@ -12,7 +12,7 @@
  *   reset() — NATIVE (M8 R4); login() is now native at the command layer (removed here).
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { computeClosure } from '../core/closure.js';
 import { deriveInstance } from '../core/derive-instance.js';
 import { defaultLaunchContext } from '../core/launch-plan.js';
@@ -1129,5 +1129,80 @@ describe('StackApi.restart — M9 native bounce (down → vite-clear → up, no 
 
     expect(out.reaped?.find((r) => r.id === 'iam-api')?.outcome).toBe('alive');
     expect(out.down.stopped.find((s) => s.id === 'iam-api')?.stopped).toBe(false);
+  });
+
+  // B2: the group reap above only ever reaches a listener that HAS a pidfile. An
+  // orphan that lost its — a previous run, a slot remap, a crashed CLI, a hand-run
+  // `pnpm dev` — is invisible to the stopper, survives the bounce, and is then
+  // ADOPTED by up() (200 on the port ⇒ alreadyUp), so it rides through every
+  // restart serving stale code. Measured 2026-08-05 on slot 0's coach-web.
+  const ORPHAN = {
+    id: 'iam-api' as ServiceId,
+    port: 3010,
+    pid: 2703661,
+    pgid: 2703660,
+    command: 'node vite.js dev',
+  };
+
+  function fakeForeignProcs(found: typeof ORPHAN[], killed = true) {
+    const find = vi.fn(async () => found);
+    const reap = vi.fn(async (fs: typeof found) => fs.map((f) => ({ ...f, killed })));
+    return { seam: { find, reap } as unknown as Runtime['foreignProcs'], find, reap };
+  }
+
+  it('B2: reaps a FOREIGN listener that holds a stack port with no pidfile', async () => {
+    const { seam, reap } = fakeForeignProcs([ORPHAN]);
+    const { runtime } = makeRuntime({
+      serviceStopper: async () => [],
+      stateDir: '/tmp/sds-synthetic',
+      foreignProcs: seam,
+    });
+    const out = await makeStackApi(manifest, runtime).restart(['iam-api'] as ServiceId[]);
+
+    expect(reap).toHaveBeenCalledWith([ORPHAN]);
+    expect(out.reapedForeign).toEqual([{ ...ORPHAN, killed: true }]);
+  });
+
+  it('B2: surfaces a foreign SURVIVOR rather than claiming a clean bounce', async () => {
+    const { seam } = fakeForeignProcs([ORPHAN], false);
+    const { runtime } = makeRuntime({
+      serviceStopper: async () => [],
+      stateDir: '/tmp/sds-synthetic',
+      foreignProcs: seam,
+    });
+    const out = await makeStackApi(manifest, runtime).restart(['iam-api'] as ServiceId[]);
+
+    // up() will adopt it — never report this as a successful bounce.
+    expect(out.reapedForeign?.[0]?.killed).toBe(false);
+  });
+
+  it('B2: stays SLOT-SAFE — sweeps this slot’s ports against this state dir, never host-globally', async () => {
+    const { seam, find, reap } = fakeForeignProcs([]);
+    const { runtime } = makeRuntime({
+      serviceStopper: async () => [],
+      stateDir: '/tmp/sds-synthetic-s2',
+      foreignProcs: seam,
+      slot: 2,
+    });
+    const out = await makeStackApi(manifest, runtime).restart(['iam-api'] as ServiceId[]);
+
+    const arg = find.mock.calls[0]?.[0] as {
+      stateDir: string;
+      services?: ServiceId[];
+      portOverrides?: Partial<Record<ServiceId, number>>;
+    };
+    expect(arg.stateDir).toBe('/tmp/sds-synthetic-s2');
+    expect(arg.services).toEqual(['iam-api']);
+    // Slot 2's OFFSET port — a host-global sweep would have hit the base 3010.
+    expect(arg.portOverrides?.['iam-api' as ServiceId]).toBe(5010);
+    // Nothing foreign ⇒ no kills attempted at all.
+    expect(reap).not.toHaveBeenCalled();
+    expect(out.reapedForeign).toEqual([]);
+  });
+
+  it('B2: skips the sweep when no foreignProcs seam is wired (facade parity)', async () => {
+    const { runtime } = makeRuntime({ serviceStopper: async () => [], stateDir: '/tmp/x' });
+    const out = await makeStackApi(manifest, runtime).restart(['iam-api'] as ServiceId[]);
+    expect(out.reapedForeign).toBeUndefined();
   });
 });

--- a/packages/node/saga-stack-cli/src/base-command.ts
+++ b/packages/node/saga-stack-cli/src/base-command.ts
@@ -1016,6 +1016,10 @@ export abstract class BaseCommand extends Command {
         reclaimStopped: (holder) => this.reclaimStoppedPrepLock(flags, holder),
       }),
       repoDirExists: this.getRepoDirCheck(),
+      // The foreign-listener sweep native `restart` runs between its pidfile reap and
+      // the fresh bring-up: an orphan with no pidfile is invisible to the stopper, and
+      // `up` would adopt it and serve its stale code.
+      foreignProcs: this.getForeignProcs(),
       // M9: the ff-only sibling sync (up.sh `pull_repos`) + its mode, the vite-cache
       // clear (native `restart`), and best-effort Connect AV (slot-0 + connect-in-closure,
       // gated in the facade). All three no-op unless the relevant native path invokes them.

--- a/packages/node/saga-stack-cli/src/commands/stack/restart.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/restart.ts
@@ -70,6 +70,17 @@ export default class StackRestart extends BaseCommand {
         );
       }
     }
+    // Orphans the pidfile reap could not see, because they had no pidfile. Worth a
+    // line even when the kill succeeded: a process holding a stack port that `ss` did
+    // not launch is a fact the operator wants, and a survivor means the fresh `up`
+    // below will adopt stale code.
+    for (const f of outcome.reapedForeign ?? []) {
+      this.log(
+        f.killed
+          ? `⚠ reaped FOREIGN ${f.id} :${f.port} (pid ${f.pid}, pgid ${f.pgid}) — held the port with no pidfile`
+          : `⚠ FOREIGN ${f.id} :${f.port} (pid ${f.pid}) SURVIVED the reap — restart will serve stale code`,
+      );
+    }
     const up = outcome.up;
     if (up.autoPull) {
       this.log(`sibling sync (ff-only — ${up.autoPull.mode}):`);
@@ -97,6 +108,12 @@ export default class StackRestart extends BaseCommand {
       {
         native: true,
         stopped,
+        reapedForeign: (outcome.reapedForeign ?? []).map((f) => ({
+          id: f.id,
+          port: f.port,
+          pid: f.pid,
+          killed: f.killed,
+        })),
         viteCleared: outcome.vite?.removed ?? [],
         launched: up.launched.map((r) => ({ id: r.id, ok: r.ok, alreadyUp: r.alreadyUp ?? false })),
         mesh: { ok: up.mesh.ok },

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/foreign-procs-kill.int.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/foreign-procs-kill.int.test.ts
@@ -1,0 +1,62 @@
+/**
+ * `makeRealForeignIo().killGroup` against a REAL process — the one part of the
+ * foreign reap that cannot be asserted with a fake, because the bug it now
+ * guards against lives in the timing of a real SIGKILL.
+ *
+ * THE RACE: SIGKILL is asynchronous. The kernel has not necessarily torn the
+ * group down by the time the next statement runs, and a killed child that its
+ * parent has not yet reaped lingers as a ZOMBIE — which still answers signal 0
+ * without ESRCH. An immediate `!pidAlive(pid)` therefore reports a perfectly
+ * successful reap as a survivor.
+ *
+ * Measured 2026-08-05: `stack restart` reaped a foreign coach-web and printed
+ * "SURVIVED the reap — restart will serve stale code"; both pids were confirmed
+ * dead a moment later and a fresh server already held the port. A guardrail that
+ * cries wolf on every success is a guardrail that gets ignored.
+ *
+ * The spawned child is detached so it leads its own process group, which is what
+ * `killGroup(-pgid)` targets — the same shape as a launcher-spawned service.
+ */
+
+import { spawn } from 'node:child_process';
+import { describe, expect, it } from 'vitest';
+import { makeRealForeignIo } from '../foreign-procs.js';
+
+function alive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+describe('makeRealForeignIo.killGroup — real process, real SIGKILL', () => {
+  it('reports killed:true for a group it actually killed', async () => {
+    // `sleep` is POSIX-portable and does nothing but exist.
+    const child = spawn('sleep', ['30'], { detached: true, stdio: 'ignore' });
+    const pid = child.pid;
+    expect(pid).toBeDefined();
+    if (pid === undefined) return;
+
+    // Detached ⇒ the child leads its own group, so pgid === pid.
+    const killed = await makeRealForeignIo().killGroup(pid, pid);
+
+    // The assertion that regressed: BEFORE the poll was added this returned
+    // false, because the child was still an unreaped zombie at that instant.
+    expect(killed).toBe(true);
+    expect(alive(pid)).toBe(false);
+  });
+
+  it('reports killed:true for a pid that was already gone', async () => {
+    const child = spawn('sleep', ['0'], { detached: true, stdio: 'ignore' });
+    const pid = child.pid;
+    expect(pid).toBeDefined();
+    if (pid === undefined) return;
+
+    await new Promise((r) => child.on('exit', r));
+
+    // An ESRCH on the signal is not a failure — the port is free either way.
+    expect(await makeRealForeignIo().killGroup(pid, pid)).toBe(true);
+  });
+});

--- a/packages/node/saga-stack-cli/src/runtime/foreign-procs.ts
+++ b/packages/node/saga-stack-cli/src/runtime/foreign-procs.ts
@@ -62,7 +62,7 @@ export interface ForeignIo {
   /** The pids recorded in `<stateDir>/*.pid` (== ss pgid leaders); [] if none. */
   ownedPgids(stateDir: string): number[];
   /** SIGKILL a process group (negative pid), then confirm the pid is gone. */
-  killGroup(pgid: number, pid: number): boolean;
+  killGroup(pgid: number, pid: number): Promise<boolean>;
 }
 
 /** Run a command, resolving its trimmed stdout (or '' on any error). NEVER throws. */
@@ -73,6 +73,12 @@ function runCapture(command: string, args: string[]): Promise<string> {
     });
   });
 }
+
+/** Bounded wait for an async SIGKILL to land: 20 x 50ms = 1s worst case. */
+const KILL_POLL_ATTEMPTS = 20;
+const KILL_POLL_INTERVAL_MS = 50;
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
 function pidAlive(pid: number): boolean {
   try {
@@ -88,7 +94,8 @@ function pidAlive(pid: number): boolean {
  * The production `ForeignIo`. `pidOnPort` prefers `lsof -t` (terse pid list,
  * works on Linux + macOS), falling back to `ss -ltnHp` for a Linux box without
  * lsof; `procInfo` uses POSIX `ps -o pgid=,args=`; `killGroup` SIGKILLs the
- * negative pid (the whole detached tree) with a bare-pid fallback.
+ * negative pid (the whole detached tree) with a bare-pid fallback, then POLLS
+ * for the exit (SIGKILL is asynchronous — see `killGroup`).
  */
 export function makeRealForeignIo(): ForeignIo {
   return {
@@ -137,7 +144,7 @@ export function makeRealForeignIo(): ForeignIo {
       return pids;
     },
 
-    killGroup(pgid: number, pid: number): boolean {
+    async killGroup(pgid: number, pid: number): Promise<boolean> {
       try {
         process.kill(-pgid, 'SIGKILL');
       } catch {
@@ -146,6 +153,17 @@ export function makeRealForeignIo(): ForeignIo {
         } catch {
           /* already gone — treat as reaped below */
         }
+      }
+      // SIGKILL is ASYNCHRONOUS: the kernel has not necessarily torn the process
+      // down by the time this line runs, and a not-yet-reaped child lingers as a
+      // zombie that still answers signal 0 — so an immediate `!pidAlive(pid)`
+      // reports a SUCCESSFUL reap as a survivor. Measured 2026-08-05: a foreign
+      // coach-web was killed (both pids confirmed gone a moment later) and still
+      // reported `killed:false`. Poll for the exit the way `stopServices` already
+      // does, rather than trusting a single instantaneous read.
+      for (let i = 0; i < KILL_POLL_ATTEMPTS; i += 1) {
+        if (!pidAlive(pid)) return true;
+        await sleep(KILL_POLL_INTERVAL_MS);
       }
       return !pidAlive(pid);
     },
@@ -179,7 +197,9 @@ export function makeRealForeignProcs(io: ForeignIo = makeRealForeignIo()): Forei
       // pgid, the second SIGKILL to the now-dead group is a harmless ESRCH no-op
       // (folded inside killGroup), and `killed` is still checked per-pid — so no
       // dedupe is needed and every finding reports its own liveness accurately.
-      return foreign.map((f) => ({ ...f, killed: io.killGroup(f.pgid, f.pid) }));
+      return Promise.all(
+        foreign.map(async (f) => ({ ...f, killed: await io.killGroup(f.pgid, f.pid) })),
+      );
     },
   };
 }

--- a/packages/node/saga-stack-cli/src/stack-api.ts
+++ b/packages/node/saga-stack-cli/src/stack-api.ts
@@ -41,6 +41,7 @@ import type { LaunchContext } from './core/launch-plan.js';
 import { recordPlan } from './core/record-plan.js';
 import type { RecordPlan } from './core/record-plan.js';
 import { launchOrder } from './core/launch-order.js';
+import { deriveInstance } from './core/derive-instance.js';
 import { getMesh, getService, manifest as defaultManifest } from './core/manifest/index.js';
 import type { DbId, Lane, Manifest, MeshId, RepoKey, ServiceId } from './core/manifest/index.js';
 import type { HealthProbe } from './core/probe-plan.js';
@@ -84,6 +85,8 @@ import type {
   ServiceLauncher,
   PrepRepoLock,
   ServiceStopper,
+  ForeignProcs,
+  ReapedProc,
   StopResult,
   StopServiceResult,
   ViteClear,
@@ -241,6 +244,26 @@ export interface Runtime {
    * launcher writes pids under, so the restart reap targets exactly this run's servers.
    */
   stateDir?: string;
+  /**
+   * The foreign-listener seam (`core/foreign-procs`). Native `restart` uses it to reap
+   * a stack port held by a process with NO pidfile in this state dir — an orphan from
+   * an earlier run, a slot remap, a crashed CLI, or a hand-run `pnpm dev`.
+   *
+   * WHY `restart` NEEDS IT: the stopper above enumerates PIDFILES, so a listener that
+   * has lost its pidfile is invisible to it. `up()` then health-probes the port, sees a
+   * 200, and ADOPTS the survivor (`alreadyUp`) — so the orphan rides through every
+   * bounce, forever, serving whatever code it was launched with. Measured 2026-08-05:
+   * slot 0's coach-web was served by a six-day-old process across a branch change while
+   * `stack status` reported healthy. `cold-start` already reaps this; nothing short of
+   * it did.
+   *
+   * STILL SLOT-SAFE — this is NOT up.sh's host-global `pkill -f tsup` / `fuser -k`. The
+   * targets are THIS slot's ports (via `portOverrides`) and ownership is decided against
+   * THIS state dir's pidfiles, so a peer slot's servers are never candidates.
+   *
+   * Absent ⇒ `restart` skips the sweep (facade unit tests stay byte-identical).
+   */
+  foreignProcs?: ForeignProcs;
   /**
    * Best-effort Connect AV bring-up (M9 — livekit + coturn from qboard's compose). When
    * true AND slot 0 AND connect is in the closure, `up` starts AV via the Runner (parity
@@ -427,6 +450,13 @@ export interface RestartOutcome {
    * (`alive`) survivor — an under-kill that would let `up()` serve stale code.
    */
   reaped?: StopServiceResult[];
+  /**
+   * Foreign listeners on this slot's ports that were killed after the pidfile reap —
+   * orphans the stopper could not see because they had no pidfile. Present when the
+   * `foreignProcs` seam was wired; empty on a clean bounce. `killed:false` means the
+   * port is STILL held, so `up()` will adopt a stale server: the command surfaces it.
+   */
+  reapedForeign?: ReapedProc[];
   /** The vite-cache clear (absent when no viteClear seam was wired). */
   vite?: ViteClearResult;
   /**
@@ -1098,6 +1128,23 @@ export function makeStackApi(m: Manifest, runtime: Runtime): StackApi {
         down = await this.down(services);
       }
 
+      // 1b. foreign sweep — the stopper above works from PIDFILES, so a listener that
+      //     has lost its (an orphan from an earlier run, a slot remap, a crashed CLI, a
+      //     hand-run `pnpm dev`) survives it untouched. `up()` would then probe the
+      //     port, get a 200, and adopt the survivor — which is precisely how a process
+      //     rides through every bounce serving stale code. Reap it here so `up()` boots
+      //     fresh. Slot-safe: this slot's ports, this state dir's pidfiles.
+      let reapedForeign: ReapedProc[] | undefined;
+      if (runtime.foreignProcs && runtime.stateDir !== undefined) {
+        const foreign = await runtime.foreignProcs.find({
+          manifest,
+          services,
+          stateDir: runtime.stateDir,
+          portOverrides: deriveInstance({ slot: runtime.slot ?? 0 }).portOverrides,
+        });
+        reapedForeign = foreign.length > 0 ? await runtime.foreignProcs.reap(foreign) : [];
+      }
+
       // 2. vite-clear — drop the stale optimized-bundle caches (up.sh `nuke_vite`) so a
       //    dead watcher can't serve old JS. Paths are byte-faithful to up.sh; skipped
       //    when no seam is wired.
@@ -1141,7 +1188,7 @@ export function makeStackApi(m: Manifest, runtime: Runtime): StackApi {
       const relaunch =
         restorable.length > 0 ? [...new Set<ServiceId>([...services, ...restorable])] : services;
       const up = await this.up(relaunch);
-      return { down, reaped, vite, up, notRelaunched: overlayBound };
+      return { down, reaped, reapedForeign, vite, up, notRelaunched: overlayBound };
     },
 
     async reset(services: ServiceId[], opts: ResetOpts = {}): Promise<ResetOutcome> {


### PR DESCRIPTION
Follow-up to #411. That PR taught `stack status` to *notice* a listener serving code that is not on disk; this one fixes the thing that let it happen and kept it happening.

Two bugs.

## 1. `restart` could not evict the process that motivated #411

`down` / `restart` reap **by pidfile**. A listener that has *lost* its pidfile — an orphan from an earlier run, a slot remap, a crashed CLI, a hand-run `pnpm dev` — is invisible to the stopper and survives the bounce untouched. `up()` then probes the port, gets a 200, reports `alreadyUp`, and **adopts** the survivor.

So once a process loses its pidfile it rides through *every* restart, forever, serving whatever code it was launched with. `cold-start` was the only thing that could evict it, and that is a docker wipe.

**This is not the under-kill the stopper already handles.** I checked that path on a live slot 0 before touching anything — a group SIGTERM takes down the `pnpm dev` leader, `sh -c vite`, and the port-holding vite grandchild together in under 500ms:

```
t+250ms leader=alive port8800=1
t+500ms leader=dead  port8800=0
```

The hole is only ever reached by a listener with **no pidfile to reap in the first place**.

`restart` now runs the **existing** foreign sweep (`ForeignProcs.find` / `reap`, already used by `cold-start`) between its pidfile reap and the fresh bring-up. No new machinery.

**Still slot-safe** — that is the property native `restart` was deliberately careful to buy, and the sweep keeps it: targets are *this* slot's ports (via `portOverrides`) and ownership is decided against *this* state dir's pidfiles. It is not up.sh's host-global `pkill -f tsup` / `fuser -k <port>`, and it still cannot touch a peer slot. There is a test asserting exactly that at slot 2.

## 2. `killGroup` reported successful reaps as survivors

Found by running the above against a real orphan. `restart` printed:

```
⚠ FOREIGN coach-web :8800 (pid 2281712) SURVIVED the reap — restart will serve stale code
```

…while both pids were **already dead** and a fresh server held the port.

SIGKILL is asynchronous. The kernel has not necessarily torn the group down by the next statement, and a killed child whose parent has not yet reaped it lingers as a **zombie that still answers signal 0** — so the immediate `!pidAlive(pid)` read a success as a failure. `stopServices` already polls for precisely this reason; `killGroup` did not. It now polls too (20 × 50ms), which also makes `cold-start`'s reap reporting honest.

This was worth fixing rather than tolerating: the new warning is load-bearing, and a guardrail that cries wolf on every success is one that gets ignored.

## Verification

End to end on slot 0, twice — orphaned coach-web by deleting its pidfile, then bounced:

```
⚠ reaped FOREIGN coach-web :8800 (pid 2362836, pgid 2362811) — held the port with no pidfile
restart: OK
```

Old listener confirmed dead, a fresh one holding `:8800`, and its pidfile back on disk. `ss stack status --slot 0` then reports `14/14 services up` with no provenance warnings.

The new int test spawns a real detached child and asserts `killGroup` returns `true`; I confirmed it **fails** with the poll disabled, so it genuinely pins the race rather than passing by luck.

`pnpm check-types` clean · **132 test files, 1644 tests pass**.

⚠️ `pnpm lint` still cannot run — the flat config uses `no-unassigned-vars` (eslint 9) against an installed eslint 8.57.1. Pre-existing; an untouched file fails identically.

## Not in this PR

`up` still adopts a foreign listener rather than refusing it. That is arguably fine — `up` is additive, and `up-forbid-foreign` already covers the guarded services where a drifted env is dangerous — but it is the remaining path by which a stale process gets adopted, and it deserves its own decision rather than being folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJ3swta9V4Y8JfaqXSQ38M
