### PR TITLE
feat(ss): stack login --browser takes --app/--url so it lands on the right SPA

### DIFF
--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -3477,9 +3477,23 @@
         "<%= config.bin %> <%= command.id %>",
         "<%= config.bin %> <%= command.id %> teacher@saga.org",
         "<%= config.bin %> <%= command.id %> --browser",
+        "<%= config.bin %> <%= command.id %> --browser --app coach-web",
+        "<%= config.bin %> <%= command.id %> --browser --url http://localhost:8800/reports?org=ist-sc",
         "<%= config.bin %> <%= command.id %> empty@saga.org --browser --fake-video ~/clips/student.mp4"
       ],
       "flags": {
+        "app": {
+          "description": "which SPA the --browser Chromium opens (default saga-dash). Also sources the Playwright cwd + clone gate from that SPA's own repo. The port is slot-aware. Requires --browser.",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "app",
+          "options": [
+            "saga-dash",
+            "connectv3",
+            "coach-web"
+          ],
+          "type": "option"
+        },
         "browser": {
           "allowNo": false,
           "description": "ALSO open an auto-logged-in Chromium via the vendored browser-login.mjs (native headless jar + headful browser). The default mints only the native headless cookie jar.",
@@ -3603,6 +3617,13 @@
           "hasDynamicHelp": false,
           "multiple": false,
           "name": "state-dir",
+          "type": "option"
+        },
+        "url": {
+          "description": "open the --browser Chromium at this exact URL (deep links welcome). Beats --app and $LOGIN_DASH_URL; leaves Playwright resolution on --app (or saga-dash), so any URL works. Requires --browser.",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "url",
           "type": "option"
         }
       },

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/login-native.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/login-native.int.test.ts
@@ -238,4 +238,103 @@ describe('stack login — native headless cookie jar', () => {
     expect(spawn?.env?.DASH_URL).toBe('https://dash.moniker.wootdev.com');
     expect(spawn?.env?.IAM_URL).toBe('http://localhost:4010');
   });
+
+  // ── --app / --url: WHICH SPA the headful browser lands on ───────────────────
+  // Until these existed, `stack login --browser` always opened saga-dash, so a
+  // Coach walkthrough handed the reader the wrong app (and saga-dash's own
+  // identity failure then reads as "login is broken" when the jar is fine).
+  it('--app coach-web opens coach-web (:8800) with the Playwright cwd off COACH, not saga-dash', async () => {
+    installPoster(OK_COOKIES);
+    installJar();
+    vi.spyOn(
+      BaseCommand.prototype as unknown as { getRepoDirCheck: () => (dir: string) => boolean },
+      'getRepoDirCheck',
+    ).mockReturnValue(() => true);
+
+    await StackLogin.run(['--browser', '--app', 'coach-web', ...WS], config);
+
+    expect(runnerCalls).toHaveLength(1);
+    const spawn = runnerCalls[0];
+    const coachApp = join(DEV_ROOT, 'coach', 'apps/web/coach-web');
+    // The SPA row drives BOTH the address and where playwright resolves from.
+    expect(spawn?.env?.DASH_URL).toBe('http://localhost:8800');
+    expect(spawn?.cwd).toBe(coachApp);
+    expect(spawn?.env?.SAGA_DASH_DASH).toBe(coachApp);
+    // iam is unaffected by the SPA choice.
+    expect(spawn?.env?.IAM_URL).toBe('http://localhost:3010');
+  });
+
+  it('--app is slot-aware: coach-web at slot 1 is :9800', async () => {
+    installPoster(OK_COOKIES);
+    installJar();
+    vi.spyOn(
+      BaseCommand.prototype as unknown as { getRepoDirCheck: () => (dir: string) => boolean },
+      'getRepoDirCheck',
+    ).mockReturnValue(() => true);
+
+    await StackLogin.run(['--browser', '--app', 'coach-web', '--slot', '1', ...WS], config);
+
+    expect(runnerCalls[0]?.env?.DASH_URL).toBe('http://localhost:9800');
+    expect(runnerCalls[0]?.env?.IAM_URL).toBe('http://localhost:4010');
+  });
+
+  it('--url wins over --app AND over $LOGIN_DASH_URL, and keeps the --app playwright cwd (deep links)', async () => {
+    process.env.LOGIN_DASH_URL = 'https://dash.moniker.wootdev.com';
+    installPoster(OK_COOKIES);
+    installJar();
+    vi.spyOn(
+      BaseCommand.prototype as unknown as { getRepoDirCheck: () => (dir: string) => boolean },
+      'getRepoDirCheck',
+    ).mockReturnValue(() => true);
+
+    await StackLogin.run(
+      ['--browser', '--app', 'coach-web', '--url', 'http://localhost:8800/reports?org=ist-sc', ...WS],
+      config,
+    );
+
+    const spawn = runnerCalls[0];
+    // An explicit flag is a deliberate act; the env var is ambient tunnel config.
+    expect(spawn?.env?.DASH_URL).toBe('http://localhost:8800/reports?org=ist-sc');
+    expect(spawn?.cwd).toBe(join(DEV_ROOT, 'coach', 'apps/web/coach-web'));
+  });
+
+  it('--url alone leaves playwright resolution on saga-dash, so ANY url works', async () => {
+    installPoster(OK_COOKIES);
+    installJar();
+    vi.spyOn(
+      BaseCommand.prototype as unknown as { getRepoDirCheck: () => (dir: string) => boolean },
+      'getRepoDirCheck',
+    ).mockReturnValue(() => true);
+
+    await StackLogin.run(['--browser', '--url', 'http://localhost:6210/', ...WS], config);
+
+    const spawn = runnerCalls[0];
+    expect(spawn?.env?.DASH_URL).toBe('http://localhost:6210/');
+    expect(spawn?.cwd).toBe(join(DEV_ROOT, 'saga-dash', 'apps', 'web', 'dash'));
+  });
+
+  it('no --app/--url is byte-identical to the previous saga-dash behaviour', async () => {
+    installPoster(OK_COOKIES);
+    installJar();
+    vi.spyOn(
+      BaseCommand.prototype as unknown as { getRepoDirCheck: () => (dir: string) => boolean },
+      'getRepoDirCheck',
+    ).mockReturnValue(() => true);
+
+    await StackLogin.run(['--browser', ...WS], config);
+
+    const spawn = runnerCalls[0];
+    expect(spawn?.env?.DASH_URL).toBe('http://localhost:8900');
+    expect(spawn?.cwd).toBe(join(DEV_ROOT, 'saga-dash', 'apps', 'web', 'dash'));
+  });
+
+  it('--app/--url without --browser warns and opens nothing (the jar is still the product)', async () => {
+    installPoster(OK_COOKIES);
+    installJar();
+
+    await StackLogin.run(['--app', 'coach-web', ...WS], config);
+
+    expect(jarWrites).toHaveLength(1); // the jar still minted
+    expect(runnerCalls).toHaveLength(0); // but no browser opened
+  });
 });

--- a/packages/node/saga-stack-cli/src/commands/stack/login.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/login.ts
@@ -39,6 +39,9 @@ import { BaseCommand } from '../../base-command.js';
 import { deriveInstance } from '../../core/derive-instance.js';
 import { fakeMediaChromiumArgs } from '../../core/fake-media.js';
 import { DEFAULT_LOGIN_USER, loginFailureHint } from '../../core/login.js';
+import { SPA_REGISTRY } from '../../core/flow/spa-registry.js';
+import type { RepoKey } from '../../core/manifest/index.js';
+import { SERVICES } from '../../core/manifest/services.js';
 import { prepareFakeMedia } from '../../runtime/index.js';
 
 export default class StackLogin extends BaseCommand {
@@ -49,6 +52,8 @@ export default class StackLogin extends BaseCommand {
     '<%= config.bin %> <%= command.id %>',
     '<%= config.bin %> <%= command.id %> teacher@saga.org',
     '<%= config.bin %> <%= command.id %> --browser',
+    '<%= config.bin %> <%= command.id %> --browser --app coach-web',
+    '<%= config.bin %> <%= command.id %> --browser --url http://localhost:8800/reports?org=ist-sc',
     '<%= config.bin %> <%= command.id %> empty@saga.org --browser --fake-video ~/clips/student.mp4',
   ];
 
@@ -65,6 +70,20 @@ export default class StackLogin extends BaseCommand {
       default: false,
       description:
         'ALSO open an auto-logged-in Chromium via the vendored browser-login.mjs (native headless jar + headful browser). The default mints only the native headless cookie jar.',
+    }),
+    // Which SPA the --browser Chromium lands on. Until now `stack login --browser`
+    // always opened saga-dash, so a Coach (or connectv3) walkthrough handed the
+    // reader the WRONG app — and saga-dash's own identity config failing then reads
+    // as "login is broken" when the jar is fine. `develop coach` already opens
+    // coach-web through the same seam; these two flags expose that to `stack login`.
+    app: Flags.string({
+      options: Object.keys(SPA_REGISTRY),
+      description:
+        'which SPA the --browser Chromium opens (default saga-dash). Also sources the Playwright cwd + clone gate from that SPA\'s own repo. The port is slot-aware. Requires --browser.',
+    }),
+    url: Flags.string({
+      description:
+        'open the --browser Chromium at this exact URL (deep links welcome). Beats --app and $LOGIN_DASH_URL; leaves Playwright resolution on --app (or saga-dash), so any URL works. Requires --browser.',
     }),
     'fake-video': Flags.string({
       description:
@@ -101,6 +120,11 @@ export default class StackLogin extends BaseCommand {
     const fakeAudio = flags['fake-audio'];
     if ((fakeVideo || fakeAudio) && !flags.browser) {
       this.warn('--fake-video/--fake-audio apply only with --browser — ignoring (no headful browser to feed).');
+    }
+    // Same shape: these only steer the headful Chromium. Warn rather than error —
+    // the jar is the command's real product and it is unaffected.
+    if ((flags.app !== undefined || flags.url !== undefined) && !flags.browser) {
+      this.warn('--app/--url apply only with --browser — ignoring (no headful browser to point anywhere).');
     }
 
     const res = await this.mintNativeLoginJar({ email, slot: flags.slot, stateDir });
@@ -145,8 +169,23 @@ export default class StackLogin extends BaseCommand {
       // stateDir (⇒ PROFILE_DIR) are already slot-aware; the per-slot stateDir gives a
       // distinct persistent profile per slot. At slot 0 dashPort is 8900, so this is
       // byte-identical to the previous slot-0-only behaviour.
-      const dashPort = profile.portOverrides['saga-dash'] ?? 8900;
-      const dashUrl = process.env.LOGIN_DASH_URL || `http://localhost:${dashPort}`;
+      // --app selects the SPA row (its `system` is the manifest service that owns
+      // the port, and its repo drives the Playwright cwd); --url overrides the
+      // address outright. Default stays saga-dash, so an unflagged invocation is
+      // byte-identical to the previous behaviour.
+      const spaRow = flags.app === undefined ? undefined : SPA_REGISTRY[flags.app];
+      const spaSystem = spaRow?.system ?? 'saga-dash';
+      const spaPort = profile.portOverrides[spaSystem] ?? SERVICES[spaSystem]?.port ?? 8900;
+      // Explicit --url beats $LOGIN_DASH_URL (a flag is a deliberate act; the env
+      // var is ambient tunnel config), which still beats the derived port.
+      const dashUrl = flags.url || process.env.LOGIN_DASH_URL || `http://localhost:${spaPort}`;
+      const spa =
+        spaRow === undefined
+          ? undefined
+          : // `SpaDescriptor.repoEnvVar` is a plain string in the flow schema; the
+            // registry rows are curated and match RepoKey. Same cast `develop coach`
+            // makes at its own openVendoredBrowser call site.
+            { repoEnvVar: spaRow.repoEnvVar as RepoKey, appDir: spaRow.appDir, port: spaPort };
 
       // soa#363: transcode any --fake-video/--fake-audio to Chromium capture format and
       // build the launch flags. A prep failure (missing file / ffmpeg / bad transcode) is
@@ -174,7 +213,7 @@ export default class StackLogin extends BaseCommand {
         }
       }
 
-      await this.openVendoredBrowser(flags, { email, iamUrl, stateDir, dashUrl, chromiumExtraArgs });
+      await this.openVendoredBrowser(flags, { email, iamUrl, stateDir, dashUrl, spa, chromiumExtraArgs });
     }
   }
 }


### PR DESCRIPTION
## Problem

`ss stack login --browser` always opened **saga-dash**. There was no way to say "land me somewhere else," so any non-dash walkthrough hands the reader the wrong application.

Found while walking the Coach synthetic-dev guide: step 4 says `--browser` opens "an auto-logged-in Chromium," and it does — on `localhost:8900`, saga-dash, which then rendered *"We're having trouble signing you in — we can't reach the identity service."* The session was completely fine (iam-api up, correct `Access-Control-Allow-Origin` for `:8900`, the minted jar authorizes coach-web on `:8800` immediately). But the reader's honest conclusion is "login is broken," and the actual app they wanted was one port away.

## The machinery already existed

This is wiring, not a feature:

- `BaseCommand.openVendoredBrowser` already accepts `dashUrl` **and** an `spa` descriptor.
- `SPA_REGISTRY` already has a `coach-web` row (and `connectv3`).
- `develop coach` already deep-links a headed browser into coach-web through exactly this seam.

`stack login` just never passed either one — it hardcoded `portOverrides['saga-dash'] ?? 8900`.

## Change

```
--app <saga-dash|connectv3|coach-web>   pick the SPA
--url <url>                             open this exact address
```

- **`--app`** resolves the slot-aware port from the manifest (`coach-web` → 8800, `--slot 1` → 9800) **and** sources the Playwright cwd + clone gate from that SPA's own repo — the part `--url` alone cannot do.
- **`--url`** takes an exact address, deep links included, and deliberately leaves Playwright resolution alone so it works for any URL, including apps with no registry row.
- Precedence: `--url` > `$LOGIN_DASH_URL` > `--app` port > saga-dash. An explicit flag beats ambient tunnel config.
- Neither flag ⇒ **byte-identical** to previous behaviour (pinned by its own test).
- `--app`/`--url` without `--browser` warns rather than errors, matching `--fake-video`: the cookie jar is the command's real product and is unaffected.

## Verification

- `pnpm exec vitest run` — **1650 tests / 132 files pass**, including 6 new cases: coach-web routing, slot-awareness (`:9800` at slot 1), `--url` beating both `--app` and the env var while keeping the `--app` playwright cwd, `--url` alone staying on saga-dash for playwright, the no-flag byte-identical pin, and the warn-not-error path.
- `tsc --noEmit` clean; `oclif.manifest.json` regenerated via `pnpm build` (it is tracked, so a stale one would ship wrong `--help`).
- **Live against slot 0:**
  ```
  ss stack login demo-dadmin@saga.org --slot 0 --browser --app coach-web \
     --url 'http://localhost:8800/reports?org=ist-sc'
  → AUTOLOGIN_OK demo-dadmin@saga.org 0ebae718-…-a90b47e183b6 http://localhost:8800/reports?org=ist-sc
  ```

## Follow-on

Coach's `concierge login --browser` delegates straight to this command, so it can now pass `--app coach-web` and stop sending Coach readers to the dashboard. That is a coach-repo change, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NA3hmaQwFyvMsGotCsyRZb
