### PR TITLE
fix(ss): point coach-web at the SLOT's programs-api, and let it through CORS (coach#329)

### DIFF
--- a/packages/node/saga-stack-cli/src/__tests__/stack-api.int.test.ts
+++ b/packages/node/saga-stack-cli/src/__tests__/stack-api.int.test.ts
@@ -259,7 +259,9 @@ describe('StackApi.up — skips a service whose sibling repo is not cloned (warn
     runtime.repoDirExists = (dir: string) => dir !== REPO_ROOTS.COACH;
     const api = makeStackApi(manifest, runtime);
 
-    // closure(coach-web) = coach-web + coach-api (COACH, absent) + iam-api (present).
+    // closure(coach-web) = coach-web + coach-api (COACH, absent) + iam-api and
+    // programs-api (present — programs-api rides in on coach-web's `browser`
+    // edge for the Reports program filter, coach#329).
     const closure = computeClosure(manifest, ['coach-web'] as ServiceId[]);
 
     const res = await api.up(closure.services);
@@ -267,8 +269,8 @@ describe('StackApi.up — skips a service whose sibling repo is not cloned (warn
     // the run does NOT fail — the missing repo is a warning, not an error.
     expect(res.ok).toBe(true);
 
-    // only iam-api (a present repo) launched; the coach pair was skipped, not spawned.
-    expect(fakes.launches.map((s) => s.id)).toEqual(['iam-api']);
+    // only the present-repo services launched; the coach pair was skipped, not spawned.
+    expect(fakes.launches.map((s) => s.id)).toEqual(['iam-api', 'programs-api']);
 
     // both coach services are reported skipped, with the repo dir + a clear message.
     expect(res.skipped.map((s) => s.id).sort()).toEqual(['coach-api', 'coach-web']);

--- a/packages/node/saga-stack-cli/src/__tests__/stack-api.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/__tests__/stack-api.unit.test.ts
@@ -222,6 +222,7 @@ describe('StackApi.up — native partial-stack bring-up', () => {
     // base ports at slot 0: iam 3010, coach-api 6105, saga-dash 8900. No remote defaults.
     expect(contents).toContain('PUBLIC_IAM_API_URL=http://localhost:3010');
     expect(contents).toContain('PUBLIC_COACH_API_URL=http://localhost:6105');
+    expect(contents).toContain('PUBLIC_PROGRAMS_API_URL=http://localhost:3006');
     expect(contents).toContain('PUBLIC_DASHBOARD_URL=http://localhost:8900');
     expect(contents).toContain('PUBLIC_LOGIN_URL=http://localhost:3010');
     expect(contents).not.toContain('wootdev.com');
@@ -243,8 +244,10 @@ describe('StackApi.up — native partial-stack bring-up', () => {
     // slot 1 = base + 1000: iam 4010, coach-api 7105, saga-dash 9900.
     expect(contents).toContain('PUBLIC_IAM_API_URL=http://localhost:4010');
     expect(contents).toContain('PUBLIC_COACH_API_URL=http://localhost:7105');
+    expect(contents).toContain('PUBLIC_PROGRAMS_API_URL=http://localhost:4006');
     expect(contents).toContain('PUBLIC_DASHBOARD_URL=http://localhost:9900');
     expect(contents).not.toContain(':6105'); // slot 0's coach-api must not leak
+    expect(contents).not.toContain(':3006'); // …nor slot 0's programs-api
   });
 
   it('soa#300: no coach-web .env.local write when coach-web is not in the closure', async () => {

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/resolve-service-set.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/resolve-service-set.unit.test.ts
@@ -24,9 +24,11 @@ const resolve = (only: string | undefined, withB: string[] | undefined): Service
   resolveServiceSet(only, withB, throwFail);
 
 describe('resolveServiceSet — --with is sugar over --only', () => {
-  it('--with coach ⇒ closure {iam-api, coach-api, coach-web}', () => {
+  it('--with coach ⇒ closure {iam-api, coach-api, coach-web, programs-api}', () => {
+    // programs-api via coach-web's `browser` dep edge (coach#329 — the Reports
+    // program filter calls programs.list straight from the browser).
     expect(new Set(resolve(undefined, ['coach']))).toEqual(
-      new Set(['iam-api', 'coach-api', 'coach-web']),
+      new Set(['iam-api', 'coach-api', 'coach-web', 'programs-api']),
     );
   });
 

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/up-native.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/up-native.int.test.ts
@@ -276,13 +276,15 @@ describe('stack up --only — native partial-stack', () => {
       'getRepoDirCheck',
     ).mockReturnValue((dir: string) => !dir.endsWith('/coach'));
 
-    // closure(coach-web) = coach-web + coach-api (COACH, absent) + iam-api (present).
+    // closure(coach-web) = coach-web + coach-api (COACH, absent) + iam-api and
+    // programs-api (present — programs-api rides in on coach-web's `browser`
+    // edge for the Reports program filter, coach#329).
     await expect(
       StackUp.run(['--only', 'coach-web', '--seed', 'full', ...WS], config),
     ).resolves.toBeUndefined();
 
-    // only iam-api launched; the coach pair was skipped (repo not cloned).
-    expect(launches.map((s) => s.id)).toEqual(['iam-api']);
+    // only the present-repo services launched; the coach pair was skipped (repo not cloned).
+    expect(launches.map((s) => s.id)).toEqual(['iam-api', 'programs-api']);
 
     // the seed plan dropped coach-pg — NOTHING ran against the coach-db dir (which
     // would have spawn-crashed on the missing checkout with a real runner).

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/up.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/up.unit.test.ts
@@ -69,13 +69,21 @@ describe('stack up --dry-run — closure planning path', () => {
     expect(closure.mesh).toContain('connect-mongo'); // connect-api in the full set
   });
 
-  it('--with coach (dry-run) plans the {iam-api, coach-api, coach-web} closure', () => {
+  it('--with coach (dry-run) plans the {iam-api, coach-api, coach-web, programs-api} closure', () => {
     // Mirrors StackUp.run: requested = combineRequested(only, with) → computeClosure.
     const requested = combineRequested(undefined, ['coach'], fail);
     const closure = computeClosure(manifest, requested, {
       withPlayback: effectiveWithPlayback(['coach']),
     });
-    expect(new Set(closure.services)).toEqual(new Set(['iam-api', 'coach-api', 'coach-web']));
+    // programs-api rides in on coach-web's `browser` edge (coach#329): the Reports
+    // program filter fetches programs.list from the browser, so an interactive
+    // `--with coach` that omitted it would hand coach-web a dead localhost:3006.
+    expect(new Set(closure.services)).toEqual(
+      new Set(['iam-api', 'coach-api', 'coach-web', 'programs-api']),
+    );
+    // …and the closure unions programs-api's own db + broker with it.
+    expect(closure.databases).toContain('programs');
+    expect(closure.mesh).toContain('rabbitmq');
   });
 
   it('--with playback (dry-run) plans the playback closure, not the full stack', () => {

--- a/packages/node/saga-stack-cli/src/commands/stack/snapshot/__tests__/snapshot.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/snapshot/__tests__/snapshot.int.test.ts
@@ -164,7 +164,11 @@ describe('stack snapshot store — manifest-driven, all 11 pg + connectv3 mongo'
     // iam's own DBs + coach's coach_api, and nothing outside that scope.
     expect(pg).toContain('iam_local');
     expect(pg).toContain('coach_api');
-    expect(pg).not.toContain('programs');
+    // `programs` IS in scope: coach-web's `browser` edge pulls programs-api into
+    // the coach closure (coach#329), and snapshot scope follows the closure.
+    expect(pg).toContain('programs');
+    // still scoped — a service reachable from neither iam nor coach stays out.
+    expect(pg).not.toContain('scheduling');
     expect(dbsCalled('mongoDump')).toEqual([]);
   });
 

--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.overlay.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.overlay.unit.test.ts
@@ -93,12 +93,29 @@ describe('tunnel_env overlay (--tunnel)', () => {
     );
   });
 
-  it('programs/scheduling/sessions/ads-adm: CORS + JANUS_LOGIN_HOST → tunnelled iam demo', () => {
-    for (const id of ['programs-api', 'scheduling-api', 'sessions-api', 'ads-adm-api'] as const) {
+  it('scheduling/sessions/ads-adm: CORS + JANUS_LOGIN_HOST → tunnelled iam demo', () => {
+    // programs-api is NOT in this loop any more — see the test below.
+    for (const id of ['scheduling-api', 'sessions-api', 'ads-adm-api'] as const) {
       const e = envFor(id, TUN);
       expect(e.CORS_ORIGIN).toBe(`http://localhost:8900,https://dash.${TD}`);
       expect(e.JANUS_LOGIN_HOST).toBe(`iam.${TD}/demo`);
     }
+  });
+
+  it('programs-api: CORS keeps the coach origins its siblings do not have (coach#329)', () => {
+    // The overlay REPLACES CORS_ORIGIN wholesale (env last-wins, no merge), so the
+    // ${COACH_WEB_URL} the base launch.env carries has to be restated here or a
+    // --tunnel run silently regresses to dash-only and the Reports program filter
+    // fails preflight again — this time only for the remote coworker.
+    const e = envFor('programs-api', TUN);
+    expect(e.CORS_ORIGIN).toBe(
+      `http://localhost:8900,http://localhost:8800,https://dash.${TD},https://coach.${TD}`,
+    );
+    expect(e.JANUS_LOGIN_HOST).toBe(`iam.${TD}/demo`);
+    // The tunnel LABEL is `coach` (vendor/tunnel.sh "coach:8800"), NOT the
+    // manifest's tunnelSlug 'coach-web' — the latter is a host the tunnel never
+    // creates, so admitting it would allow nothing.
+    expect(e.CORS_ORIGIN).not.toContain(`coach-web.${TD}`);
   });
 
   it('connect-api: allowed origins + public URL + fleek cluster AV topology (no creds by default)', () => {
@@ -155,6 +172,18 @@ describe('tunnel_env overlay (--tunnel)', () => {
     expect(envFor('coach-web', TUN).PUBLIC_IAM_API_URL).toBe(`https://iam.${TD}`);
   });
 
+  it('coach-web: programs flips too — the Reports filter fetches programs.list DIRECT (coach#329)', () => {
+    // Same shape as the iam case above: the base manifest pins this to
+    // http://localhost:${PROGRAMS_PORT}, which a remote coworker's browser cannot
+    // reach. The tunnel LABEL is `programs` (vendor/tunnel.sh "programs:3006",
+    // tunnelSlug 'programs') — NOT `programs-api`, which is only the shape of the
+    // DEPLOYED host in coach-web's checked-in .env and a name the tunnel never
+    // creates.
+    const e = envFor('coach-web', TUN);
+    expect(e.PUBLIC_PROGRAMS_API_URL).toBe(`https://programs.${TD}`);
+    expect(e.PUBLIC_PROGRAMS_API_URL).not.toContain('programs-api.');
+  });
+
   it('coach-web: login + dashboard leave the SHARED remote hosts for this tunnel', () => {
     const e = envFor('coach-web', TUN);
     // `.env` defaults are login./dash.wootdev.com — shared remote infra. A tunnel session
@@ -208,7 +237,12 @@ describe('soa#336: tunnel-rewritten keys are covered by the adoption contract', 
   const EXEMPT = new Set(['__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS']);
   const TD = 'm1.vms.wootdev.com';
 
-  for (const id of ['iam-api', 'coach-web', 'connect-web'] as ServiceId[]) {
+  // programs-api joined this list with coach#329: once coach-web's browser calls
+  // it direct, its CORS_ORIGIN is boot-critical to a frontend exactly like
+  // iam-api's, and an adopted programs-api carrying the old allow-list is the
+  // same silent failure. Its rewrite set is {CORS_ORIGIN, JANUS_LOGIN_HOST}, and
+  // its adoptEnv guards both.
+  for (const id of ['iam-api', 'coach-web', 'connect-web', 'programs-api'] as ServiceId[]) {
     it(`${id}: adoptEnv ⊇ its tunnelOverlay() rewrite set`, () => {
       const plain = envFor(id, {});
       const tunneled = envFor(id, { tunnel: { domain: TD } });

--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.slot.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.slot.unit.test.ts
@@ -241,3 +241,46 @@ describe('rtsm-api per-slot fleet (soa#271) — browser CRDT reaches the SLOT rt
     expect(env.FLEET_CONFIG_PATH).toBe('/tmp/sds-synthetic-s2/rtsm-fleet-s2.json');
   });
 });
+
+describe('coach-web x programs-api slottability (coach#329) — the browser dials ITS slot', () => {
+  const slotCtx = (slot: number) => {
+    const p = deriveInstance({ slot });
+    return defaultLaunchContext({
+      ...baseInputs,
+      portOverrides: p.portOverrides,
+      meshOffset: p.meshOffset,
+    });
+  };
+
+  it('slot 0: PUBLIC_PROGRAMS_API_URL is the base programs-api port (byte-identity)', () => {
+    const env = resolveLaunchEnv('coach-web', 'stack', slotCtx(0));
+    expect(env.PUBLIC_PROGRAMS_API_URL).toBe('http://localhost:3006');
+    // and NOT the checked-in .env default it exists to displace.
+    expect(env.PUBLIC_PROGRAMS_API_URL).not.toContain('wootdev.com');
+  });
+
+  it('slot 2: it offsets with the slot — a slot-2 browser never dials slot 0', () => {
+    // Composed from ${PROGRAMS_PORT}, so it slots for free; a literal
+    // http://localhost:3006 would have pinned every slot's browser to slot 0's
+    // programs-api and silently read the wrong stack's programs.
+    const env = resolveLaunchEnv('coach-web', 'stack', slotCtx(2));
+    expect(env.PUBLIC_PROGRAMS_API_URL).toBe(
+      `http://localhost:${manifest.services['programs-api'].port + 2000}`,
+    );
+    for (const v of Object.values(env)) {
+      expect(v).not.toMatch(/localhost:(3006|3010|6105)\b/);
+    }
+  });
+
+  it("programs-api CORS admits the SLOT coach-web origin, not slot 0's", () => {
+    // The other half of the same bug: the URL can be right and the preflight
+    // still unlabeled. ${COACH_WEB_URL} offsets in lockstep with coach-web's own
+    // listen port (stack-api appends --port <base+offset> for frontends).
+    expect(resolveLaunchEnv('programs-api', 'stack', slotCtx(0)).CORS_ORIGIN).toBe(
+      'http://localhost:8900,http://localhost:8800',
+    );
+    expect(resolveLaunchEnv('programs-api', 'stack', slotCtx(2)).CORS_ORIGIN).toBe(
+      'http://localhost:10900,http://localhost:10800',
+    );
+  });
+});

--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
@@ -126,7 +126,10 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
       IAM_API_URL: 'http://localhost:3010',
       RABBITMQ_URL: 'amqp://rabbitmq_admin:password123@localhost:5672',
       JANUS_REQUIRED: 'false',
-      CORS_ORIGIN: 'http://localhost:8900',
+      // dash AND coach-web: coach-web's browser calls programs.list direct, and
+      // that call preflights (x-organization-id), so an unlisted origin gets a
+      // 204 with no ACAO → "Failed to fetch" (coach#329).
+      CORS_ORIGIN: 'http://localhost:8900,http://localhost:8800',
       JANUS_LOGIN_HOST: 'localhost:3010/demo',
       JWT_ISSUER: 'https://iam.wootdev.com',
     });
@@ -311,12 +314,17 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
     });
   });
 
-  it('coach-web (client-only SPA: browser calls coach-api AND iam direct)', () => {
+  it('coach-web (client-only SPA: browser calls coach-api, iam AND programs direct)', () => {
     expect(env('coach-web')).toEqual({
       PUBLIC_COACH_API_URL: 'http://localhost:6105',
       // Without this it falls back to its .env default (https://iam.wootdev.com)
       // and the local SPA talks to DEPLOYED iam.
       PUBLIC_IAM_API_URL: 'http://localhost:3010',
+      // Same, for programs-api: the .env default is
+      // https://programs-api.wootdev.com, which is what the Reports program
+      // selector was dialling cross-origin (coach#329). Composed from
+      // ${PROGRAMS_PORT} — there is no ${PROGRAMS_URL} token.
+      PUBLIC_PROGRAMS_API_URL: 'http://localhost:3006',
     });
   });
 

--- a/packages/node/saga-stack-cli/src/core/launch-plan.ts
+++ b/packages/node/saga-stack-cli/src/core/launch-plan.ts
@@ -362,6 +362,18 @@ function tunnelOverlay(service: ServiceId, tokens: LaunchTokens): Record<string,
         CORS_ORIGIN: `${dash},http://localhost:${tokens.IAM_PORT},https://dash.${td},https://iam.${td}`,
       };
     case 'programs-api':
+      // Split out from its three siblings below because programs-api is the only
+      // one of them with a SECOND browser origin: coach-web calls programs.list
+      // direct (coach#329). The overlay REPLACES CORS_ORIGIN wholesale (env
+      // last-wins over the launch env, it does not merge), so the coach origins
+      // the base value carries must be restated here or a tunnel run silently
+      // regresses to dash-only. Local coach-web is kept alongside the tunnel host
+      // for the same reason iam-api keeps ${connectWeb}: a local browser must
+      // keep working next to remote ones.
+      return {
+        CORS_ORIGIN: `${dash},${tokens.COACH_WEB_URL},https://dash.${td},https://coach.${td}`,
+        JANUS_LOGIN_HOST: `iam.${td}/demo`,
+      };
     case 'scheduling-api':
     case 'sessions-api':
     case 'ads-adm-api':
@@ -432,6 +444,15 @@ function tunnelOverlay(service: ServiceId, tokens: LaunchTokens): Record<string,
         // that would otherwise reach the remote browser verbatim → whoami fails →
         // coach-web renders the soa#300 503 "Unable to reach the sign-in service".
         PUBLIC_IAM_API_URL: `https://iam.${td}`,
+        // programs-api flips for the same reason: the Reports Program filter
+        // fetches programs.list DIRECT from the browser (coach-web
+        // `src/lib/api/programs.ts`). The base manifest pins this to the
+        // PROGRAMS_PORT localhost origin, which is unreachable from a remote
+        // coworker's machine. The tunnel LABEL is `programs`, NOT `programs-api`
+        // — vendor/tunnel.sh declares "programs:3006" and the manifest's
+        // tunnelSlug is 'programs'; a `programs-api.<domain>` host (the shape of
+        // the deployed default in coach-web's .env) is one the tunnel never creates.
+        PUBLIC_PROGRAMS_API_URL: `https://programs.${td}`,
         // Logout target and the "open dashboard" link. Not boot-critical (unlike the two
         // above), but their `.env` defaults are the SHARED remote hosts
         // (login./dash.wootdev.com) — a tunnel session must stay inside its own mesh.

--- a/packages/node/saga-stack-cli/src/core/manifest/__tests__/consistency.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/__tests__/consistency.unit.test.ts
@@ -66,7 +66,14 @@ describe('manifest consistency — every edge resolves', () => {
     expect(manifest.services['coach-api'].databases).toEqual(['coach_api']);
     expect(manifest.services['coach-web'].repo).toBe('COACH');
     // iam-api too: coach-web's browser calls auth.whoami direct (session.ts).
-    expect(manifest.services['coach-web'].dependsOn).toEqual(['coach-api', 'iam-api']);
+    // programs-api too: its browser calls programs.list direct for the Reports
+    // program filter (coach#329) — all three are `browser` edges.
+    expect(manifest.services['coach-web'].dependsOn).toEqual([
+      'coach-api',
+      'iam-api',
+      'programs-api',
+    ]);
+    expect(manifest.services['coach-web'].depKinds['programs-api']).toBe('browser');
     expect(manifest.databases['coach_api'].ownerRole).toBe('coach_api_app');
   });
 

--- a/packages/node/saga-stack-cli/src/core/manifest/services.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/services.ts
@@ -260,7 +260,18 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
         IAM_API_URL: '${IAM_URL}',
         RABBITMQ_URL: '${MESH_MQ}',
         JANUS_REQUIRED: 'false',
-        CORS_ORIGIN: '${DASH_URL}',
+        // coach-web is here for the SAME reason it is in iam-api's CORS_ORIGIN:
+        // its browser calls `programs.list` DIRECT (coach-web
+        // `src/lib/api/programs.ts`), and that call carries an
+        // `x-organization-id` header, so it PREFLIGHTS. programs-api's allow-list
+        // is `CORS_ORIGIN` + devOrigins + the https-only `*.wootdev.com` regex
+        // (api-util `buildSagaOriginAllowlist`) — nothing in it matched
+        // `http://localhost:8800`, so the OPTIONS came back 204 with NO
+        // `Access-Control-Allow-Origin` and the browser reported the same opaque
+        // "Failed to fetch" a wrong host produces (coach#329). Measured live on
+        // slot 0 before this line existed; fixing coach-web's URL alone left the
+        // symptom byte-identical.
+        CORS_ORIGIN: '${DASH_URL},${COACH_WEB_URL}',
         JANUS_LOGIN_HOST: 'localhost:${IAM_PORT}/demo',
         // Validate the SAME issuer iam-api stamps (its JWT_ISSUER). Without this
         // the rostering-client verifier falls back to the prod issuer and 401s
@@ -273,6 +284,18 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
     tunnelSlug: 'programs',
     isFrontend: false,
     optional: false,
+    // programs-api serves a BROWSER plane now (coach-web's Reports program
+    // filter), so its CORS allow-list is boot-critical to a frontend the same
+    // way iam-api's is — and it is exactly what `tunnelOverlay()` rewrites.
+    // Without a fingerprint an already-running programs-api carrying the OLD
+    // single-origin allow-list is adopted by the next `up` (healthy ⇒
+    // alreadyUp), the preflight keeps failing, and the fix looks like it
+    // shipped while nothing changed. JANUS_LOGIN_HOST is the overlay's other
+    // rewrite; guarding both is what lets programs-api join the
+    // `adoptEnv ⊇ tunnelOverlay() rewrite set` invariant test.
+    // Same one-time "stop the process and re-run" cost iam-api/saga-dash
+    // already pay for processes stamped by an older CLI.
+    adoptEnv: ['CORS_ORIGIN', 'JANUS_LOGIN_HOST'],
   },
   'scheduling-api': {
     id: 'scheduling-api',
@@ -726,11 +749,20 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
     // SvelteKit SPA — probed on the root path like saga-dash / connect-web.
     healthPath: '/',
     databases: [],
-    // Client-only SPA (ssr = false): the BROWSER calls coach-api for data and
-    // iam's auth.whoami direct for identity — so it needs both URLs, and iam
-    // must allow its origin (see iam-api's CORS_ORIGIN).
-    dependsOn: ['coach-api', 'iam-api'],
-    depKinds: { 'coach-api': 'browser', 'iam-api': 'browser' },
+    // Client-only SPA (ssr = false): the BROWSER calls coach-api for data,
+    // iam's auth.whoami direct for identity, and programs-api direct for the
+    // Reports program filter (coach#313) — so it needs all three URLs, and each
+    // must allow its origin (see those services' CORS_ORIGIN).
+    //
+    // programs-api is a real dep even though it only powers ONE control: with
+    // it absent, `stack up --with coach` / `--only coach-web` hand the browser a
+    // localhost:3006 nothing is listening on, so the Reports Program selector
+    // errors by construction. The cost is that the `coach` bundle now pulls the
+    // `programs` db + rabbitmq + the programs seed; that is the honest price of
+    // the page working. `browser` kind, so e2e FLOW closures (which list their
+    // own requiredSystems and run with followBrowserEdges:false) are unchanged.
+    dependsOn: ['coach-api', 'iam-api', 'programs-api'],
+    depKinds: { 'coach-api': 'browser', 'iam-api': 'browser', 'programs-api': 'browser' },
     mesh: [],
     launch: {
       cmd: 'pnpm dev',
@@ -739,6 +771,15 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
         // Without this, coach-web falls back to its .env default
         // (https://iam.wootdev.com) and the local SPA talks to deployed iam.
         PUBLIC_IAM_API_URL: '${IAM_URL}',
+        // Same class, third instance: without this, coach-web falls back to its
+        // .env default (https://programs-api.wootdev.com) and the local SPA's
+        // Reports Program selector fires a cross-origin call at DEPLOYED
+        // programs-api — net::ERR_FAILED, "programs.list request failed: Failed
+        // to fetch", empty selector (coach#329).
+        // No ${PROGRAMS_URL} token exists (only the port), so this composes the
+        // origin from ${PROGRAMS_PORT} — the staff-admin-api / ads-adm-api idiom
+        // below, which slot-offsets correctly where a literal would not.
+        PUBLIC_PROGRAMS_API_URL: 'http://localhost:${PROGRAMS_PORT}',
       },
     },
     seed: [],
@@ -754,22 +795,36 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
     // 2026-07-16 slot-0 incident: a plain `develop coach` adopted a leftover
     // `--tunnel` coach-web and the browser whoami dialed the dead tunnel iam →
     // the misleading soa#300 "503 — Unable to reach the sign-in service".
-    // Fingerprint the four browser-plane keys tunnelOverlay() rewrites:
-    //  - PUBLIC_COACH_API_URL / PUBLIC_IAM_API_URL (boot-critical): in the
-    //    plain launch env above AND value-flipped under --tunnel ⇒ the
+    // Fingerprint the five browser-plane keys tunnelOverlay() rewrites:
+    //  - PUBLIC_COACH_API_URL / PUBLIC_IAM_API_URL / PUBLIC_PROGRAMS_API_URL:
+    //    in the plain launch env above AND value-flipped under --tunnel ⇒ the
     //    fingerprints differ in both directions.
     //  - PUBLIC_LOGIN_URL / PUBLIC_DASHBOARD_URL: tunnel-ONLY (no plain-env
     //    entry — plain runs let them fall through to coach-web's dotfiles).
     //    The fingerprint OMITS absent keys, so plain stamps lack them while
     //    tunnel stamps carry them — present-vs-omitted still mismatches BOTH
     //    ways, the same asymmetry saga-dash's guard relies on.
-    // A mode-drifted coach-web is REFUSED loudly and relaunched with the
-    // current mode's env — refuse-or-relaunch, never adopt.
+    // PUBLIC_PROGRAMS_API_URL (coach#329) is the case that proves why the list
+    // must grow with the launch env rather than track modes: adding the var
+    // WITHOUT adding it here is a plain→plain drift the other four are provably
+    // incapable of seeing — their values are unchanged, so a coach-web vite
+    // started before the fix stamps a byte-identical contract, gets adopted, and
+    // keeps serving the `.env` default https://programs-api.wootdev.com out of a
+    // bundle no on-disk write can reach. Green stack, unchanged bug.
+    // A mode- or contract-drifted coach-web is REFUSED loudly — the launcher
+    // neither adopts nor kills it; the operator stops the process (`ss stack
+    // down` for an ss-launched one; a hand-run `pnpm dev` has no pidfile here
+    // and must be killed by hand) and re-runs, and THAT run relaunches with the
+    // current env. Every existing slot pays that once when this lands.
     adoptEnv: [
       'PUBLIC_COACH_API_URL',
       'PUBLIC_IAM_API_URL',
       'PUBLIC_LOGIN_URL',
       'PUBLIC_DASHBOARD_URL',
+      // Appended, not inserted: the first four positions of an existing stamp
+      // stay put, so the refusal message's expected-vs-recorded diff reads as
+      // "one key added" rather than a wholesale reshuffle.
+      'PUBLIC_PROGRAMS_API_URL',
     ],
   },
   'transcripts-api': {

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/coach-web-env.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/coach-web-env.unit.test.ts
@@ -37,6 +37,7 @@ function fakeFs(opts: { hasApp?: boolean } = {}): {
 const slotPorts = (offset: number): Partial<Record<ServiceId, number>> => ({
   'iam-api': 3010 + offset,
   'coach-api': 6105 + offset,
+  'programs-api': 3006 + offset,
   'saga-dash': 8900 + offset,
 });
 
@@ -81,6 +82,10 @@ describe('syncCoachWebEnvLocal', () => {
     // base ports: iam 3010, coach-api 6105, saga-dash 8900. Remote wootdev defaults gone.
     expect(env.PUBLIC_IAM_API_URL).toBe('http://localhost:3010');
     expect(env.PUBLIC_COACH_API_URL).toBe('http://localhost:6105');
+    // coach#329: the Reports program filter fetches programs.list from the
+    // browser. Redundant under `ss` (the launch env outranks this file) — this
+    // line is what makes a hand-run `pnpm dev` in the coach-web dir work.
+    expect(env.PUBLIC_PROGRAMS_API_URL).toBe('http://localhost:3006');
     expect(env.PUBLIC_DASHBOARD_URL).toBe('http://localhost:8900');
     // PUBLIC_LOGIN_URL → iam (the whoami 401 challenge login lives at iam's /demo).
     expect(env.PUBLIC_LOGIN_URL).toBe('http://localhost:3010');
@@ -97,11 +102,13 @@ describe('syncCoachWebEnvLocal', () => {
     // slot 2 = base + 2000: iam 5010, coach-api 8105, saga-dash 10900.
     expect(env.PUBLIC_IAM_API_URL).toBe('http://localhost:5010');
     expect(env.PUBLIC_COACH_API_URL).toBe('http://localhost:8105');
+    expect(env.PUBLIC_PROGRAMS_API_URL).toBe('http://localhost:5006');
     expect(env.PUBLIC_DASHBOARD_URL).toBe('http://localhost:10900');
     expect(env.PUBLIC_LOGIN_URL).toBe('http://localhost:5010');
     // base-port (slot 0) values must NOT leak through at an offset slot.
     expect(env.PUBLIC_IAM_API_URL).not.toContain(':3010');
     expect(env.PUBLIC_COACH_API_URL).not.toContain(':6105');
+    expect(env.PUBLIC_PROGRAMS_API_URL).not.toContain(':3006');
   });
 
   it('coachWebEnvLocalContents omits a PUBLIC_ var whose backing service has no resolved port', () => {

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/launcher.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/launcher.unit.test.ts
@@ -370,18 +370,21 @@ describe('makeRealLauncher.launch adopt-contract guard (soa#305)', () => {
     'PUBLIC_IAM_API_URL',
     'PUBLIC_LOGIN_URL',
     'PUBLIC_DASHBOARD_URL',
+    'PUBLIC_PROGRAMS_API_URL',
   ];
-  // Plain slot-0 launch env: only the two boot-critical keys (manifest launch.env).
+  // Plain slot-0 launch env: the three boot-critical keys (manifest launch.env).
   const COACH_PLAIN_ENV = {
     PUBLIC_COACH_API_URL: 'http://localhost:6105',
     PUBLIC_IAM_API_URL: 'http://localhost:3010',
+    PUBLIC_PROGRAMS_API_URL: 'http://localhost:3006',
   };
-  // Tunnel launch env: all four, rewritten to the public hosts (tunnelOverlay()).
+  // Tunnel launch env: all five, rewritten to the public hosts (tunnelOverlay()).
   const COACH_TUNNEL_ENV = {
     PUBLIC_COACH_API_URL: 'https://coach-api.sk.vms.wootdev.com',
     PUBLIC_IAM_API_URL: 'https://iam.sk.vms.wootdev.com',
     PUBLIC_LOGIN_URL: 'https://iam.sk.vms.wootdev.com',
     PUBLIC_DASHBOARD_URL: 'https://dash.sk.vms.wootdev.com',
+    PUBLIC_PROGRAMS_API_URL: 'https://programs.sk.vms.wootdev.com',
   };
 
   it('refuses to adopt a TUNNEL-leftover coach-web on a plain run (the 2026-07-16 slot-0 incident)', async () => {
@@ -447,6 +450,43 @@ describe('makeRealLauncher.launch adopt-contract guard (soa#305)', () => {
     });
 
     expect(res).toEqual({ id: 'coach-web', ok: true, alreadyUp: true });
+  });
+
+  it('refuses a PRE-coach#329 coach-web on a plain re-run (plain → plain, no mode change)', async () => {
+    // The regression the fifth key exists for. A vite started before
+    // PUBLIC_PROGRAMS_API_URL was injected has the .env default
+    // (https://programs-api.wootdev.com) INLINED into its bundle, and no on-disk
+    // write can reach it. Its stamp is the four-key shape below. Without
+    // PUBLIC_PROGRAMS_API_URL in adoptEnv the expected fingerprint would pick the
+    // same four keys with the same values — byte-identical — so the launcher
+    // would adopt it, `ss stack status` would read 14/14, and the browser would
+    // still dial deployed programs-api. Same mode both sides: the other four keys
+    // are provably incapable of catching this.
+    const { prober } = seqProber([true]);
+    const { spawn, calls } = fakeSpawn(1);
+    const preFixStamp = {
+      PUBLIC_COACH_API_URL: 'http://localhost:6105',
+      PUBLIC_IAM_API_URL: 'http://localhost:3010',
+    };
+    const launcher = makeRealLauncher({
+      stateDir: STATE,
+      prober,
+      spawn,
+      readContract: () => JSON.stringify(preFixStamp),
+    });
+
+    const res = await launcher.launch({
+      ...SPEC,
+      id: 'coach-web',
+      env: COACH_PLAIN_ENV,
+      adoptEnv: COACH_ADOPT,
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.alreadyUp).toBeUndefined();
+    expect(res.reason).toMatch(/contract/);
+    // Refuse, don't restart: no spawn and no kill — the operator stops it and re-runs.
+    expect(calls).toHaveLength(0);
   });
 
   it("refuses a tunnel-leftover iam-api whose JWT_ISSUER alone would MATCH (soa#336's finding A)", async () => {

--- a/packages/node/saga-stack-cli/src/runtime/coach-web-env.ts
+++ b/packages/node/saga-stack-cli/src/runtime/coach-web-env.ts
@@ -20,10 +20,11 @@
  *
  * SO WHAT THIS HOOK ACTUALLY BUYS: `PUBLIC_LOGIN_URL` + `PUBLIC_DASHBOARD_URL` — the
  * two the launch env does NOT set, whose `.env` defaults are shared REMOTE hosts.
- * `PUBLIC_IAM_API_URL` / `PUBLIC_COACH_API_URL` are also written here, but the manifest
- * sets both (`core/manifest/services.ts`, `${IAM_URL}` / `${COACH_API_URL}`) and the
- * launch env outranks this file, so those two lines are a redundant fallback rather
- * than the operative fix. Do not "fix" a URL bug by editing them alone — check whether
+ * `PUBLIC_IAM_API_URL` / `PUBLIC_COACH_API_URL` / `PUBLIC_PROGRAMS_API_URL` are also
+ * written here, but the manifest sets all three (`core/manifest/services.ts`,
+ * `${IAM_URL}` / `${COACH_API_URL}` / `http://localhost:${PROGRAMS_PORT}`) and the
+ * launch env outranks this file, so those three lines are a redundant fallback rather
+ * than the operative fix — what they buy is a hand-run `pnpm dev` in the coach-web dir. Do not "fix" a URL bug by editing them alone — check whether
  * the manifest or `tunnelOverlay()` sets the var first, because that is what wins.
  *
  * SCOPE: the local `stack` lane only. Under `--tunnel` every coach-web PUBLIC_ var is
@@ -94,16 +95,19 @@ export function coachWebEnvLocalPath(coachWebRoot: string): string {
  * port is omitted rather than emitting `localhost:undefined` (coach-web then falls
  * back to its `.env` default for that one var — never a broken URL). Trailing newline.
  *
- *   PUBLIC_IAM_API_URL   ← iam-api    (browser dials iam DIRECT for whoami)
- *   PUBLIC_COACH_API_URL ← coach-api  (the coach BFF)
- *   PUBLIC_DASHBOARD_URL ← saga-dash  (the "open dashboard" link)
- *   PUBLIC_LOGIN_URL     ← iam-api    (the whoami 401 challenge login lives at iam's /demo)
+ *   PUBLIC_IAM_API_URL      ← iam-api      (browser dials iam DIRECT for whoami)
+ *   PUBLIC_COACH_API_URL    ← coach-api    (the coach BFF)
+ *   PUBLIC_PROGRAMS_API_URL ← programs-api (browser dials programs DIRECT for the
+ *                                           Reports program filter, coach#329)
+ *   PUBLIC_DASHBOARD_URL    ← saga-dash    (the "open dashboard" link)
+ *   PUBLIC_LOGIN_URL        ← iam-api      (the whoami 401 challenge login lives at iam's /demo)
  *
  * PUBLIC_EMBED_ALLOWED_ORIGINS is deliberately LEFT ALONE — not needed for boot.
  */
 export function coachWebEnvLocalContents(stackPorts: Partial<Record<ServiceId, number>>): string {
   const iam = stackPorts['iam-api'];
   const coachApi = stackPorts['coach-api'];
+  const programs = stackPorts['programs-api'];
   const dash = stackPorts['saga-dash'];
 
   const header = [
@@ -116,6 +120,7 @@ export function coachWebEnvLocalContents(stackPorts: Partial<Record<ServiceId, n
   const vars: string[] = [];
   if (iam !== undefined) vars.push(`PUBLIC_IAM_API_URL=http://localhost:${iam}`);
   if (coachApi !== undefined) vars.push(`PUBLIC_COACH_API_URL=http://localhost:${coachApi}`);
+  if (programs !== undefined) vars.push(`PUBLIC_PROGRAMS_API_URL=http://localhost:${programs}`);
   if (dash !== undefined) vars.push(`PUBLIC_DASHBOARD_URL=http://localhost:${dash}`);
   // PUBLIC_LOGIN_URL → iam locally: the whoami 401 challenge login URL is iam's /demo.
   if (iam !== undefined) vars.push(`PUBLIC_LOGIN_URL=http://localhost:${iam}`);


### PR DESCRIPTION
Fixes the transport half of [coach#329](https://github.com/saga-ed/coach/issues/329) — *"Coach Reports: Organizations dropdown not working / not tied to new endpoints"*.

## Two bugs, one symptom

On slot 0, `/reports` shows `programs.list request failed: Failed to fetch` and an empty Program selector. Playwright capture:

```
FAILED   https://programs-api.wootdev.com/trpc/programs.list?input=… → net::ERR_FAILED
200      localhost:3010  auth.whoami · personas.getMyPermissions · users.getBulk
200      localhost:6105  /coach/v1/graphql
```

iam and coach-api are correctly slot-local. Programs is not — and **fixing the URL alone does not fix the bug.**

### 1. The URL

coach-web's `launch.env` injected only `PUBLIC_COACH_API_URL` and `PUBLIC_IAM_API_URL`, so `PUBLIC_PROGRAMS_API_URL` fell through to coach-web's checked-in `.env` (`https://programs-api.wootdev.com`) and the local SPA called deployed programs. The `PUBLIC_IAM_API_URL` line has a comment describing exactly this failure for iam; programs was simply never added.

Composed from `${PROGRAMS_PORT}` — the settled idiom (`services.ts:965`, `:426`); there is no `${PROGRAMS_URL}` token and I did not invent one. It slot-offsets for free: **:3006 @ slot 0, :4006 @ slot 1**. A literal would have pinned every slot's browser to slot 0's programs.

### 2. CORS — measured, not inferred

`programs.list` sends `x-organization-id`, so it **preflights**. Against the *running* slot-0 process, before any change could be in effect:

```
OPTIONS /trpc/programs.list   Origin: http://localhost:8800  → 204, NO Access-Control-Allow-Origin
OPTIONS /trpc/programs.list   Origin: http://localhost:8900  → 204, Access-Control-Allow-Origin: …:8900
/proc/<pid>/environ           CORS_ORIGIN=http://localhost:8900
```

So the corrected URL would have produced the identical opaque `Failed to fetch`. `CORS_ORIGIN` becomes `${DASH_URL},${COACH_WEB_URL}`, mirroring iam-api's own line — including inside `tunnelOverlay()`, which **replaces** `CORS_ORIGIN` wholesale rather than merging, so programs-api is split out of the shared four-service case there.

## Adoption — why this actually takes effect

coach-web's `PUBLIC_*` are SvelteKit `$env/static/public`, inlined at vite start; an adopted vite serves its boot-time hosts forever and no on-disk write can reach it (the soa#300 / 2026-07-16 incident).

- **coach-web `adoptEnv` gains `PUBLIC_PROGRAMS_API_URL`.** The case this catches is **plain → plain, same slot, no mode change**: a vite started before this fix has the wootdev host inlined while the other four keys are unchanged, so its stamp matched the expectation and it was adopted silently — green 14/14 stack, unchanged bug. Verified against the live slot-0 stamp.
- **programs-api had no `adoptEnv` at all**, so a running instance with the single-origin allow-list would be adopted unconditionally and the CORS fix would appear to deploy and do nothing (`launcher.ts:299` names this trap but only warns). It also joins the `adoptEnv ⊇ tunnelOverlay() rewrites` invariant loop so it cannot rot.

## Scope calls, both easy to reverse

- **`coach-web dependsOn programs-api` (`browser`)** — without it, `stack up --only coach-web` hands the SPA a dead `:3006`: same broken control, new error text. Cost stated plainly: the `coach` bundle closure gains the `programs` db + rabbitmq + seed, and `snapshot store --with coach` includes the `programs` dump. E2E flow closures are unaffected (`followBrowserEdges:false`). One line + `depKinds` to revert.
- **`PUBLIC_LOGIN_URL` / `PUBLIC_DASHBOARD_URL` untouched** — verified navigation-only in `Navbar.svelte` (a top-level redirect and an `<a href>`), so neither can produce `net::ERR_FAILED` and neither needs a CORS entry.

## Verification

- `tsc --noEmit` clean; **132 files / 1657 tests pass** (+7 new, none deleted).
- Resolved launch plan printed through the real production path (`deriveInstance` + `defaultLaunchContext` + `resolveLaunchEnv`, zero IO):

| | slot 0 | slot 1 | `--tunnel` |
|---|---|---|---|
| `PUBLIC_PROGRAMS_API_URL` | `http://localhost:3006` | `http://localhost:4006` | `https://programs.<td>` |
| programs-api `CORS_ORIGIN` | `…:8900,…:8800` | `…:9900,…:9800` | coach origins included |

- **Slot 0 was never restarted** — no `stack up`/`down`/`restart`; 14/14 before and after.

Adversarial review raised 4 findings; all 4 were refuted on inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NA3hmaQwFyvMsGotCsyRZb
