### PR TITLE
feat(ss): add `stack profile` — attach-mode CPU profiling for a running service

### DIFF
--- a/packages/node/saga-stack-cli/README.md
+++ b/packages/node/saga-stack-cli/README.md
@@ -14,7 +14,8 @@ you have to reverse-engineer.
 > path (up → status → verify → e2e → down) with the real output of each command, linking out
 > to per-feature docs ([sub-stacks](./docs/sub-stacks-and-bundles.md) · [slots](./docs/slots.md) ·
 > [verify](./docs/verify.md) · [snapshots](./docs/snapshots.md) · [e2e](./docs/e2e.md) ·
-> [develop](./docs/develop.md) · [tunnel](./docs/tunnel.md) · [hydrate](./docs/hydrate.md) · [integration](./docs/integration.md)).
+> [develop](./docs/develop.md) · [tunnel](./docs/tunnel.md) · [hydrate](./docs/hydrate.md) ·
+> [integration](./docs/integration.md) · [instrumentation](./docs/instrumentation.md)).
 
 ```bash
 ss stack up --only scheduling-api,sessions-api   # boot just those + their deps
@@ -61,6 +62,7 @@ plus tab-completion work at every level.
 | **`tunnel`** | Expose the local stack via the vms rendezvous (share your stack). |
 | **`bootstrap`** | One-command stand-up on `main` (ensure repos → up → verify). |
 | **`login`** / **`restart`** | Log in a persona / cleanly bounce the stack (no data wipe). |
+| **`profile`** | CPU-profile a *running* service by attaching to it (SIGUSR1 + CDP) — writes a `.cpuprofile` for Chrome DevTools / VS Code. Nothing is restarted or injected at launch. → [instrumentation](./docs/instrumentation.md) |
 
 ### Dependency-aware sub-stacks (N-of-M)
 

--- a/packages/node/saga-stack-cli/docs/cheatsheet.md
+++ b/packages/node/saga-stack-cli/docs/cheatsheet.md
@@ -75,6 +75,17 @@ ss stack down --mesh                 # also stop postgres/redis/rabbitmq/mongo (
 ss stack down --slot 1               # stop a specific slot   (--set <name> for a set)
 ```
 
+## Profiling a running service
+
+```bash
+ss stack profile iam-api             # 15s CPU profile → .cpuprofile (Chrome DevTools / VS Code)
+ss stack profile sessions-api --duration 30s   # drive load while it samples
+ss stack profile coach-api --out /tmp/coach.cpuprofile
+```
+
+Attaches to the live process (SIGUSR1 + CDP) — nothing is restarted or injected at
+launch. One service at a time per slot; backends only. → [instrumentation](./instrumentation.md)
+
 ## Clean slate & baselines (slot-0 only)
 
 ```bash
@@ -176,6 +187,7 @@ defined set; `ss stack status --slot N` probes one slot.
 
 [sub-stacks](./sub-stacks-and-bundles.md) · [slots](./slots.md) · [worktree-sets](./worktree-sets.md) ·
 [verify](./verify.md) · [snapshots](./snapshots.md) · [e2e](./e2e.md) · [e2e-flows](./e2e-flows.md) ·
-[integration](./integration.md) · [cold-start](./cold-start.md) · [faq](./faq.md)
+[integration](./integration.md) · [cold-start](./cold-start.md) ·
+[instrumentation](./instrumentation.md) · [faq](./faq.md)
 </content>
 </invoke>

--- a/packages/node/saga-stack-cli/docs/instrumentation.md
+++ b/packages/node/saga-stack-cli/docs/instrumentation.md
@@ -1,0 +1,121 @@
+# Instrumentation — CPU profiling a running service
+
+← [Getting started](./getting-started.md)
+
+```bash
+ss stack profile iam-api                 # 15s CPU profile of a running iam-api
+ss stack profile sessions-api --duration 30s
+ss stack profile coach-api --out /tmp/coach.cpuprofile
+```
+
+Writes a `.cpuprofile` you can open directly in **Chrome DevTools** (Performance →
+Load profile) or **VS Code**. Nothing is installed, nothing is restarted, and the
+service keeps serving traffic throughout.
+
+Drive load while it samples — a profile of an idle service is all `(idle)`:
+
+```bash
+ss stack profile iam-api --duration 20s &
+# …exercise the app, run an e2e flow, click around…
+```
+
+## How it works (and why it works this way)
+
+`profile` **attaches** to the already-running service. It does not inject anything
+at launch:
+
+1. resolve the pid **listening** on the service's port (`lsof`, the same
+   `pidOnPort` the orphan-reaper uses);
+2. `SIGUSR1` that pid — Node opens its V8 inspector on demand;
+3. drive the Chrome DevTools Protocol (`Profiler.enable/start/stop`) and write the
+   profile the target hands back.
+
+The artifact arrives **over the wire while the process is alive**, so it does not
+depend on a clean shutdown.
+
+### Why not `--cpu-prof` or `--inspect` at launch?
+
+Both were tried and neither works, for the same underlying reason: **the app is
+never a direct child of `pnpm dev`.** 14 backends nest it inside tsup's quoted
+`--onSuccess` string and 2 inside a `tsx watch` fork, so the real process sits four
+levels below the pid `ss` records:
+
+```
+node pnpm dev                                   ← ss records THIS pid
+ └─ sh -c tsup --watch --onSuccess "…"
+     └─ node tsup/cli-default.js
+         └─ /bin/sh -c cp … && node dist/main.js
+             └─ node dist/main.js                ← the actual service
+```
+
+| Attempt | What happens |
+| --- | --- |
+| `NODE_OPTIONS="--cpu-prof"` | Every child inherits it. One run produced **53 profiles — 23 prisma, 17 pnpm, 5 tsup, 0 for the service.** `--cpu-prof` also only flushes on a clean exit, and `ss stack down` group-SIGKILLs, so the service writes nothing. |
+| `pnpm dev --inspect` (argv) | **Crashes the service** — the flag reaches tsup, whose bundled `cac` rejects unknown options: `CACError: Unknown option --inspect`. |
+| `NODE_OPTIONS="--inspect"` | Inherited tree-wide; the pnpm wrapper binds the port first and you attach to the package manager. |
+
+Attach mode sidesteps all of it, and leaves the launch env **byte-identical** to a
+stack without profiling.
+
+## One service at a time, per slot
+
+`SIGUSR1` always opens the inspector on Node's default port and gives no way to
+choose another, so within a slot only one service can be profiled at a time. The
+port carries the slot offset (`9229 + slot*1000`), so parallel slots don't
+interfere.
+
+If the port is already held, `profile` **refuses**:
+
+```
+Error: iam-api: inspector port 9229 is already in use. SIGUSR1 cannot choose a
+port, so the service would fail to open its inspector SILENTLY and this profile
+would attach to the wrong process.
+```
+
+That refusal is the point. Without it the service's failure to bind is invisible
+except as `Starting inspector on 127.0.0.1:9229 failed: address already in use` in
+its own log, while the profiler happily samples whatever *did* own the port.
+
+A service's inspector stays open once signalled, so a second `profile` of the same
+service in the same stack hits this. `ss stack down` clears it.
+
+## Reading the result
+
+`profile` reports whether the capture actually contains the service's own frames:
+
+```
+captured 5665 samples → /tmp/sds-synthetic/iam-api-2026-08-05T20-30-30-279Z.cpuprofile
+  contains frames from the service's own code.
+```
+
+If it says `WARNING: no frames from <service>'s own dist`, the service was idle —
+the artifact is valid but uninformative. Re-run while driving traffic. This check
+exists because a wrapper-only profile (the `--cpu-prof` failure above) looks
+perfectly healthy until you open it.
+
+## Gotchas
+
+- **Frontends aren't profilable.** `saga-dash`, `coach-web`, `connect-web` and
+  `staff-admin-console` run a Vite dev server under `pnpm dev`; profiling it would
+  measure the bundler. They're rejected at the argument layer.
+- **A rebuild invalidates the pid.** tsup re-spawns `node dist/main.js` on every
+  file save, so a profile started before a rebuild is attached to a dead process.
+  Re-run after the rebuild settles.
+- **`--out` is not slot-aware.** The default path lives under the slot's state dir;
+  an explicit `--out` is used verbatim.
+
+## Flags
+
+| Flag | Meaning |
+| --- | --- |
+| `--duration` | how long to sample (`500ms`, `30s`, `2m`; default `15s`) |
+| `--out` | artifact path (default `<state-dir>/<service>-<timestamp>.cpuprofile`) |
+| `--slot N` | profile the service in slot N (inspector port offsets with it) |
+| `--output-json` / `--porcelain` | machine-readable result |
+
+---
+
+## Peer docs
+
+[getting-started](./getting-started.md) · [slots](./slots.md) · [verify](./verify.md) ·
+[e2e](./e2e.md) · [faq](./faq.md)

--- a/packages/node/saga-stack-cli/docs/instrumentation.md
+++ b/packages/node/saga-stack-cli/docs/instrumentation.md
@@ -57,17 +57,20 @@ node pnpm dev                                   ← ss records THIS pid
 Attach mode sidesteps all of it, and leaves the launch env **byte-identical** to a
 stack without profiling.
 
-## One service at a time, per slot
+## One service at a time, machine-wide
 
-`SIGUSR1` always opens the inspector on Node's default port and gives no way to
-choose another, so within a slot only one service can hold it. The port carries the
-slot offset (`9229 + slot*1000`), so parallel slots don't interfere.
+`SIGUSR1` always opens the inspector on Node's default port (9229) and gives no way
+to choose another. Nothing injects `--inspect-port` — that's the whole point of
+attach mode — so the port takes **no slot offset**: slot 2's inspector lands on 9229
+exactly like slot 0's. Only one profile can be in flight on the machine at a time.
+
+`--slot` still selects *which* service to profile; it just doesn't move the
+inspector port.
 
 Profiling the **same** service repeatedly is fine: Node leaves the inspector open
 after the client disconnects, so subsequent runs re-attach to it.
 
-Profiling a **different** service in that slot is refused while the first holds the
-port:
+Profiling a **different** service is refused while the first holds the port:
 
 ```
 Error: coach-api: inspector port 9229 is held by pid 4242, not by the service.
@@ -75,10 +78,12 @@ SIGUSR1 cannot choose a port, so the service could not open its own inspector an
 this profile would attach to the wrong process.
 ```
 
-That refusal is the point. Without it the service's failure to bind is invisible
-except as `Starting inspector on 127.0.0.1:9229 failed: address already in use` in
-its own log, while the profiler happily samples whatever *did* own the port. To
-profile another service, use a different `--slot`, or `ss stack down` first.
+That refusal is the point. `inspector.open()` on a taken port does **not** throw —
+it logs `Starting inspector on 127.0.0.1:9229 failed: address already in use` to the
+service's own log and returns, leaving the service running with no inspector while
+the profiler samples whatever *did* own the port. The capture re-checks the port's
+owner after signalling for the same reason. Wait for the in-flight profile to
+finish, or `ss stack down` first.
 
 `profile` also refuses when the process holding the service's port isn't Node —
 SIGUSR1 has no handler there, so signalling it would **kill** the process rather
@@ -115,7 +120,7 @@ perfectly healthy until you open it.
 | --- | --- |
 | `--duration` | how long to sample (`500ms`, `30s`, `2m`; default `15s`) |
 | `--out` | artifact path (default `<state-dir>/<service>-<timestamp>.cpuprofile`) |
-| `--slot N` | profile the service in slot N (inspector port offsets with it) |
+| `--slot N` | profile the service in slot N (the inspector port stays 9229) |
 | `--output-json` / `--porcelain` | machine-readable result |
 
 ---

--- a/packages/node/saga-stack-cli/docs/instrumentation.md
+++ b/packages/node/saga-stack-cli/docs/instrumentation.md
@@ -60,24 +60,29 @@ stack without profiling.
 ## One service at a time, per slot
 
 `SIGUSR1` always opens the inspector on Node's default port and gives no way to
-choose another, so within a slot only one service can be profiled at a time. The
-port carries the slot offset (`9229 + slot*1000`), so parallel slots don't
-interfere.
+choose another, so within a slot only one service can hold it. The port carries the
+slot offset (`9229 + slot*1000`), so parallel slots don't interfere.
 
-If the port is already held, `profile` **refuses**:
+Profiling the **same** service repeatedly is fine: Node leaves the inspector open
+after the client disconnects, so subsequent runs re-attach to it.
+
+Profiling a **different** service in that slot is refused while the first holds the
+port:
 
 ```
-Error: iam-api: inspector port 9229 is already in use. SIGUSR1 cannot choose a
-port, so the service would fail to open its inspector SILENTLY and this profile
-would attach to the wrong process.
+Error: coach-api: inspector port 9229 is held by pid 4242, not by the service.
+SIGUSR1 cannot choose a port, so the service could not open its own inspector and
+this profile would attach to the wrong process.
 ```
 
 That refusal is the point. Without it the service's failure to bind is invisible
 except as `Starting inspector on 127.0.0.1:9229 failed: address already in use` in
-its own log, while the profiler happily samples whatever *did* own the port.
+its own log, while the profiler happily samples whatever *did* own the port. To
+profile another service, use a different `--slot`, or `ss stack down` first.
 
-A service's inspector stays open once signalled, so a second `profile` of the same
-service in the same stack hits this. `ss stack down` clears it.
+`profile` also refuses when the process holding the service's port isn't Node —
+SIGUSR1 has no handler there, so signalling it would **kill** the process rather
+than open an inspector.
 
 ## Reading the result
 
@@ -88,7 +93,7 @@ captured 5665 samples → /tmp/sds-synthetic/iam-api-2026-08-05T20-30-30-279Z.cp
   contains frames from the service's own code.
 ```
 
-If it says `WARNING: no frames from <service>'s own dist`, the service was idle —
+If it says `WARNING: no frames from <service>'s own code`, the service was idle —
 the artifact is valid but uninformative. Re-run while driving traffic. This check
 exists because a wrapper-only profile (the `--cpu-prof` failure above) looks
 perfectly healthy until you open it.

--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -4026,6 +4026,179 @@
       "slotClaimWritten": false,
       "strict": false
     },
+    "stack:profile": {
+      "aliases": [],
+      "args": {
+        "service": {
+          "description": "service to profile (a backend; frontends run a Vite dev server and are not profilable)",
+          "name": "service",
+          "options": [
+            "iam-api",
+            "sis-api",
+            "authz-api",
+            "programs-api",
+            "scheduling-api",
+            "sessions-api",
+            "content-api",
+            "ads-adm-api",
+            "connect-api",
+            "rtsm-api",
+            "coach-api",
+            "transcripts-api",
+            "insights-api",
+            "chat-api",
+            "authz-sync",
+            "staff-admin-bff"
+          ],
+          "required": true
+        }
+      },
+      "description": "Capture a CPU profile from a running service by attaching to it (SIGUSR1 + Chrome DevTools Protocol). Writes a .cpuprofile openable in Chrome DevTools or VS Code. Does not restart or modify the service.",
+      "enableJsonFlag": false,
+      "examples": [
+        "<%= config.bin %> <%= command.id %> iam-api",
+        "<%= config.bin %> <%= command.id %> sessions-api --duration 30s",
+        "<%= config.bin %> <%= command.id %> coach-api --out /tmp/coach.cpuprofile",
+        "<%= config.bin %> <%= command.id %> iam-api --slot 2 --output-json"
+      ],
+      "flags": {
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "coach",
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "dev",
+          "noCacheDefault": true,
+          "type": "option"
+        },
+        "duration": {
+          "default": "15s",
+          "description": "how long to sample for (e.g. 500ms, 30s, 2m); default 15s",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "duration",
+          "type": "option"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "fleek",
+          "type": "option"
+        },
+        "out": {
+          "description": "artifact path; defaults to <state-dir>/<service>-<timestamp>.cpuprofile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "out",
+          "type": "option"
+        },
+        "output-json": {
+          "allowNo": false,
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "type": "boolean"
+        },
+        "porcelain": {
+          "allowNo": false,
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "type": "boolean"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "program-hub",
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "qboard",
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "rostering",
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "rtsm",
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "saga-dash",
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "sds",
+          "type": "option"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "set",
+          "type": "option"
+        },
+        "slot": {
+          "default": 0,
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "slot",
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "soa",
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "state-dir",
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "stack:profile",
+      "isESM": true,
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "relativePath": [
+        "dist",
+        "commands",
+        "stack",
+        "profile.js"
+      ],
+      "slotClaimWritten": false,
+      "strict": true
+    },
     "stack:reset": {
       "aliases": [],
       "args": {},

--- a/packages/node/saga-stack-cli/src/commands/stack/profile.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/profile.ts
@@ -1,24 +1,17 @@
 /**
  * `ss stack profile <service>` — capture a CPU profile from a RUNNING service.
  *
- * ATTACH MODE, and why it has to be. The app process is never a direct child of
- * `pnpm dev`: 14 backends nest it inside tsup's quoted `--onSuccess` string and 2
- * inside a `tsx watch` supervisor fork, so the real `node dist/main.js` sits 4
- * levels below the pid `ss` records. Nothing injected at launch reaches it —
- * `--inspect` as argv is rejected outright by tsup's cac, and via NODE_OPTIONS the
- * pnpm wrapper binds the port first. So this command touches the launch path not at
- * all: it finds the process that is actually LISTENING, opens its inspector with
- * SIGUSR1, and pulls the profile over CDP while the process runs.
- *
- * `stack up` presets each backend's inspector PORT (`--inspect-port`, which leaves
- * the inspector closed) so the attach is unambiguous and slot-isolated — see
- * `core/inspector.ts`.
+ * ATTACH MODE. The app is never a direct child of `pnpm dev` (backends nest it
+ * inside tsup's quoted `--onSuccess` or a `tsx watch` fork), so nothing injected
+ * at launch reaches it. This command leaves the launch path alone: find the
+ * LISTENING process, open its inspector with SIGUSR1, pull the profile over CDP.
+ * Port selection and its constraints: `core/inspector.ts`.
  */
 
 import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command.js';
 import { deriveInstance } from '../../core/derive-instance.js';
-import { inspectorPort } from '../../core/inspector.js';
+import { assertInspectorBandFree, inspectorPort, profilableServices } from '../../core/inspector.js';
 import { manifest } from '../../core/manifest/index.js';
 import type { ServiceId } from '../../core/manifest/index.js';
 import {
@@ -48,9 +41,7 @@ export default class StackProfile extends BaseCommand {
     service: Args.string({
       description: 'service to profile (a backend; frontends run a Vite dev server and are not profilable)',
       required: true,
-      options: (Object.keys(manifest.services) as ServiceId[]).filter(
-        (id) => !manifest.services[id].isFrontend,
-      ),
+      options: profilableServices(),
     }),
   };
 
@@ -81,13 +72,16 @@ export default class StackProfile extends BaseCommand {
       this.error(`--duration ${flags.duration} is not a duration (try 500ms, 30s, 2m)`);
     }
 
+    // Fail loudly if a service has since been banded onto an inspector port —
+    // otherwise the collision surfaces only as a profile of the wrong service.
+    assertInspectorBandFree();
+
     const io: ForeignIo = makeRealForeignIo();
     const servicePort = profile.portOverrides[service] ?? manifest.services[service].port;
     const plan = await this.buildPlan(service, profile.slot, servicePort, stateDir, io);
 
     if (!plan.ok) {
       this.error(plan.reason);
-      return;
     }
 
     if (!flags['output-json'] && !flags.porcelain) {
@@ -105,11 +99,11 @@ export default class StackProfile extends BaseCommand {
       port: plan.port,
       durationMs,
       outPath,
+      alreadyOpen: plan.alreadyOpen,
     });
 
     if (!result.ok) {
       this.error(`${service}: ${result.reason}`);
-      return;
     }
 
     // A profile of pnpm/tsup has plenty of nodes but none from the service's own
@@ -131,7 +125,7 @@ export default class StackProfile extends BaseCommand {
     this.log(
       hasFrames
         ? '  contains frames from the service\'s own code.'
-        : `  WARNING: no frames from ${service}'s own dist — it may have been idle. Drive traffic while profiling.`,
+        : `  WARNING: no frames from ${service}'s own code — it may have been idle. Drive traffic while profiling.`,
     );
     this.log('  open in Chrome DevTools (Performance → Load profile) or VS Code.');
   }
@@ -148,11 +142,15 @@ export default class StackProfile extends BaseCommand {
     const proc = listenerPid === null ? null : await io.procInfo(listenerPid);
     const port = inspectorPort(service, slot);
     const busy = port === null ? false : await inspectorPortBusy(port);
+    // Who holds the inspector port decides refuse-vs-reattach, so resolve it
+    // rather than treating any held port as a conflict.
+    const inspectorPortPid = busy && port !== null ? await io.pidOnPort(port) : null;
     return planProfile(service, slot, {
       listenerPid,
       proc,
       ownedPgids: io.ownedPgids(stateDir),
       inspectorPortBusy: busy,
+      inspectorPortPid,
     });
   }
 }

--- a/packages/node/saga-stack-cli/src/commands/stack/profile.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/profile.ts
@@ -56,7 +56,7 @@ export default class StackProfile extends BaseCommand {
     }),
   };
 
-  /** Profiling targets ONE slot's service — the slot picks the inspector port. */
+  /** The slot picks WHICH service to profile; the inspector port is fixed (core/inspector.ts). */
   protected slotAware(): boolean {
     return true;
   }
@@ -77,11 +77,7 @@ export default class StackProfile extends BaseCommand {
     assertInspectorPortFree();
 
     const io: ForeignIo = makeRealForeignIo();
-    // Slot-excluded services keep their literal port at every slot, so the offset
-    // override would point at a port they never bind.
-    const servicePort = profile.excludedServices.includes(service)
-      ? manifest.services[service].port
-      : (profile.portOverrides[service] ?? manifest.services[service].port);
+    const servicePort = profile.portOverrides[service] ?? manifest.services[service].port;
     const plan = await this.buildPlan(service, servicePort, stateDir, io);
 
     if (!plan.ok) {
@@ -110,10 +106,8 @@ export default class StackProfile extends BaseCommand {
       this.error(`${service}: ${result.reason}`);
     }
 
-    // A profile of pnpm/tsup has plenty of nodes but none from the service's own
-    // dist — exactly how the earlier --cpu-prof attempt looked fine while being
-    // useless. Warn rather than fail: a genuinely idle service can sample no app
-    // frames, and the artifact is still valid.
+    // Warn, don't fail: an idle service legitimately samples no app frames, and the
+    // artifact is still valid. See `profileHasServiceFrames` for what the check means.
     const hasFrames = profileHasServiceFrames(result.profile, service);
     const samples = result.profile.samples?.length ?? 0;
 

--- a/packages/node/saga-stack-cli/src/commands/stack/profile.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/profile.ts
@@ -1,0 +1,163 @@
+/**
+ * `ss stack profile <service>` — capture a CPU profile from a RUNNING service.
+ *
+ * ATTACH MODE, and why it has to be. The app process is never a direct child of
+ * `pnpm dev`: 14 backends nest it inside tsup's quoted `--onSuccess` string and 2
+ * inside a `tsx watch` supervisor fork, so the real `node dist/main.js` sits 4
+ * levels below the pid `ss` records. Nothing injected at launch reaches it —
+ * `--inspect` as argv is rejected outright by tsup's cac, and via NODE_OPTIONS the
+ * pnpm wrapper binds the port first. So this command touches the launch path not at
+ * all: it finds the process that is actually LISTENING, opens its inspector with
+ * SIGUSR1, and pulls the profile over CDP while the process runs.
+ *
+ * `stack up` presets each backend's inspector PORT (`--inspect-port`, which leaves
+ * the inspector closed) so the attach is unambiguous and slot-isolated — see
+ * `core/inspector.ts`.
+ */
+
+import { Args, Flags } from '@oclif/core';
+import { BaseCommand } from '../../base-command.js';
+import { deriveInstance } from '../../core/derive-instance.js';
+import { inspectorPort } from '../../core/inspector.js';
+import { manifest } from '../../core/manifest/index.js';
+import type { ServiceId } from '../../core/manifest/index.js';
+import {
+  defaultArtifactPath,
+  parseDuration,
+  planProfile,
+  profileHasServiceFrames,
+} from '../../core/profile-plan.js';
+import { makeRealForeignIo, type ForeignIo } from '../../runtime/foreign-procs.js';
+import { captureCpuProfile, inspectorPortBusy } from '../../runtime/profiler.js';
+
+const DEFAULT_DURATION = '15s';
+
+export default class StackProfile extends BaseCommand {
+  static description =
+    'Capture a CPU profile from a running service by attaching to it (SIGUSR1 + Chrome DevTools Protocol). ' +
+    'Writes a .cpuprofile openable in Chrome DevTools or VS Code. Does not restart or modify the service.';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> iam-api',
+    '<%= config.bin %> <%= command.id %> sessions-api --duration 30s',
+    '<%= config.bin %> <%= command.id %> coach-api --out /tmp/coach.cpuprofile',
+    '<%= config.bin %> <%= command.id %> iam-api --slot 2 --output-json',
+  ];
+
+  static args = {
+    service: Args.string({
+      description: 'service to profile (a backend; frontends run a Vite dev server and are not profilable)',
+      required: true,
+      options: (Object.keys(manifest.services) as ServiceId[]).filter(
+        (id) => !manifest.services[id].isFrontend,
+      ),
+    }),
+  };
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    duration: Flags.string({
+      description: `how long to sample for (e.g. 500ms, 30s, 2m); default ${DEFAULT_DURATION}`,
+      default: DEFAULT_DURATION,
+    }),
+    out: Flags.string({
+      description: 'artifact path; defaults to <state-dir>/<service>-<timestamp>.cpuprofile',
+    }),
+  };
+
+  /** Profiling targets ONE slot's service — the slot picks the inspector port. */
+  protected slotAware(): boolean {
+    return true;
+  }
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(StackProfile);
+    const service = args.service as ServiceId;
+    const profile = deriveInstance({ slot: flags.slot });
+    const stateDir = flags['state-dir'] ?? profile.stateDir;
+
+    const durationMs = parseDuration(flags.duration);
+    if (durationMs === null) {
+      this.error(`--duration ${flags.duration} is not a duration (try 500ms, 30s, 2m)`);
+    }
+
+    const io: ForeignIo = makeRealForeignIo();
+    const servicePort = profile.portOverrides[service] ?? manifest.services[service].port;
+    const plan = await this.buildPlan(service, profile.slot, servicePort, stateDir, io);
+
+    if (!plan.ok) {
+      this.error(plan.reason);
+      return;
+    }
+
+    if (!flags['output-json'] && !flags.porcelain) {
+      this.log(`profiling ${service} (pid ${plan.pid}) for ${flags.duration} via inspector :${plan.port}`);
+      if (!plan.adopted) {
+        // Profilable, but not launched by this slot — say so rather than implying
+        // ownership (the same provenance gap `down` warns about for foreign procs).
+        this.log(`  note: pid ${plan.pid} was not launched by this slot — ${plan.command}`);
+      }
+    }
+
+    const outPath = flags.out ?? defaultArtifactPath(stateDir, service, stamp());
+    const result = await captureCpuProfile({
+      pid: plan.pid,
+      port: plan.port,
+      durationMs,
+      outPath,
+    });
+
+    if (!result.ok) {
+      this.error(`${service}: ${result.reason}`);
+      return;
+    }
+
+    // A profile of pnpm/tsup has plenty of nodes but none from the service's own
+    // dist — exactly how the earlier --cpu-prof attempt looked fine while being
+    // useless. Warn rather than fail: a genuinely idle service can sample no app
+    // frames, and the artifact is still valid.
+    const hasFrames = profileHasServiceFrames(result.profile, service);
+    const samples = result.profile.samples?.length ?? 0;
+
+    if (flags['output-json']) {
+      this.logJson({ service, pid: plan.pid, port: plan.port, outPath, samples, hasServiceFrames: hasFrames });
+      return;
+    }
+    if (flags.porcelain) {
+      this.log([service, plan.pid, plan.port, samples, hasFrames ? 'app-frames' : 'no-app-frames', outPath].join('\t'));
+      return;
+    }
+    this.log(`captured ${samples} samples → ${outPath}`);
+    this.log(
+      hasFrames
+        ? '  contains frames from the service\'s own code.'
+        : `  WARNING: no frames from ${service}'s own dist — it may have been idle. Drive traffic while profiling.`,
+    );
+    this.log('  open in Chrome DevTools (Performance → Load profile) or VS Code.');
+  }
+
+  /** Gather the live facts the pure planner needs, then let it decide. */
+  private async buildPlan(
+    service: ServiceId,
+    slot: number,
+    servicePort: number,
+    stateDir: string,
+    io: ForeignIo,
+  ) {
+    const listenerPid = await io.pidOnPort(servicePort);
+    const proc = listenerPid === null ? null : await io.procInfo(listenerPid);
+    const port = inspectorPort(service, slot);
+    const busy = port === null ? false : await inspectorPortBusy(port);
+    return planProfile(service, slot, {
+      listenerPid,
+      proc,
+      ownedPgids: io.ownedPgids(stateDir),
+      inspectorPortBusy: busy,
+    });
+  }
+}
+
+/** Filesystem-safe timestamp for the default artifact name. */
+function stamp(): string {
+  return new Date().toISOString().replace(/[:.]/g, '-');
+}

--- a/packages/node/saga-stack-cli/src/commands/stack/profile.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/profile.ts
@@ -1,11 +1,9 @@
 /**
  * `ss stack profile <service>` — capture a CPU profile from a RUNNING service.
  *
- * ATTACH MODE. The app is never a direct child of `pnpm dev` (backends nest it
- * inside tsup's quoted `--onSuccess` or a `tsx watch` fork), so nothing injected
- * at launch reaches it. This command leaves the launch path alone: find the
- * LISTENING process, open its inspector with SIGUSR1, pull the profile over CDP.
- * Port selection and its constraints: `core/inspector.ts`.
+ * ATTACH MODE: find the LISTENING process, open its inspector with SIGUSR1, pull
+ * the profile over CDP. The launch path is left untouched — nothing injected there
+ * reaches the app. Why: docs/instrumentation.md. Port constraints: `core/inspector.ts`.
  */
 
 import { Args, Flags } from '@oclif/core';

--- a/packages/node/saga-stack-cli/src/commands/stack/profile.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/profile.ts
@@ -11,7 +11,7 @@
 import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command.js';
 import { deriveInstance } from '../../core/derive-instance.js';
-import { assertInspectorBandFree, inspectorPort, profilableServices } from '../../core/inspector.js';
+import { assertInspectorPortFree, INSPECTOR_PORT, profilableServices } from '../../core/inspector.js';
 import { manifest } from '../../core/manifest/index.js';
 import type { ServiceId } from '../../core/manifest/index.js';
 import {
@@ -72,13 +72,17 @@ export default class StackProfile extends BaseCommand {
       this.error(`--duration ${flags.duration} is not a duration (try 500ms, 30s, 2m)`);
     }
 
-    // Fail loudly if a service has since been banded onto an inspector port —
+    // Fail loudly if a service has since been banded onto the inspector port —
     // otherwise the collision surfaces only as a profile of the wrong service.
-    assertInspectorBandFree();
+    assertInspectorPortFree();
 
     const io: ForeignIo = makeRealForeignIo();
-    const servicePort = profile.portOverrides[service] ?? manifest.services[service].port;
-    const plan = await this.buildPlan(service, profile.slot, servicePort, stateDir, io);
+    // Slot-excluded services keep their literal port at every slot, so the offset
+    // override would point at a port they never bind.
+    const servicePort = profile.excludedServices.includes(service)
+      ? manifest.services[service].port
+      : (profile.portOverrides[service] ?? manifest.services[service].port);
+    const plan = await this.buildPlan(service, servicePort, stateDir, io);
 
     if (!plan.ok) {
       this.error(plan.reason);
@@ -131,21 +135,14 @@ export default class StackProfile extends BaseCommand {
   }
 
   /** Gather the live facts the pure planner needs, then let it decide. */
-  private async buildPlan(
-    service: ServiceId,
-    slot: number,
-    servicePort: number,
-    stateDir: string,
-    io: ForeignIo,
-  ) {
+  private async buildPlan(service: ServiceId, servicePort: number, stateDir: string, io: ForeignIo) {
     const listenerPid = await io.pidOnPort(servicePort);
     const proc = listenerPid === null ? null : await io.procInfo(listenerPid);
-    const port = inspectorPort(service, slot);
-    const busy = port === null ? false : await inspectorPortBusy(port);
+    const busy = await inspectorPortBusy(INSPECTOR_PORT);
     // Who holds the inspector port decides refuse-vs-reattach, so resolve it
     // rather than treating any held port as a conflict.
-    const inspectorPortPid = busy && port !== null ? await io.pidOnPort(port) : null;
-    return planProfile(service, slot, {
+    const inspectorPortPid = busy ? await io.pidOnPort(INSPECTOR_PORT) : null;
+    return planProfile(service, {
       listenerPid,
       proc,
       ownedPgids: io.ownedPgids(stateDir),

--- a/packages/node/saga-stack-cli/src/core/__tests__/derive-instance.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/derive-instance.unit.test.ts
@@ -70,9 +70,23 @@ describe('deriveInstance(N) for N ∈ {1,2,3}', () => {
       SAGA_MESH_CONNECT_MONGO_CONTAINER: `soa-s${slot}-connect-mongo-1`,
     });
 
-    // every service port offset by exactly N*1000.
+    // every service port offset by exactly N*1000, EXCEPT the slot-excluded trio,
+    // which keeps its literal port at every slot.
+    const excluded = new Set(p.excludedServices);
     for (const id of Object.keys(manifest.services) as ServiceId[]) {
-      expect(p.portOverrides[id]).toBe(manifest.services[id].port + offset);
+      const expected = manifest.services[id].port + (excluded.has(id) ? 0 : offset);
+      expect(p.portOverrides[id]).toBe(expected);
+    }
+  });
+
+  it('never maps a slot-excluded service to a port it does not bind', () => {
+    // Every value here must be a port the service actually listens on — callers
+    // read this map directly rather than re-deriving the exclusion rule.
+    for (const slot of [0, 1, 5, 9]) {
+      const p = deriveInstance({ slot });
+      for (const id of p.excludedServices) {
+        expect(p.portOverrides[id]).toBe(manifest.services[id].port);
+      }
     }
   });
 });
@@ -83,9 +97,11 @@ describe('no-collision property — union of ALL resolved ports is duplicate-fre
     for (let slot = 0; slot <= 8; slot += 1) {
       const p = deriveInstance({ slot });
       const offset = slot * SLOT_PORT_STRIDE;
-      // service ports
+      // service ports. The slot-excluded trio keeps ONE literal port across every
+      // slot by design, so it is the one thing this disjointness cannot cover.
+      const excluded = new Set(p.excludedServices);
       for (const id of Object.keys(p.portOverrides) as ServiceId[]) {
-        all.push(p.portOverrides[id] as number);
+        if (!excluded.has(id)) all.push(p.portOverrides[id] as number);
       }
       // mesh ports (postgres/redis/rabbitmq/rabbitmq-mgmt/connect-mongo)
       const rabbit = getMesh('rabbitmq');
@@ -140,8 +156,13 @@ describe('two-slot (1 vs 2) — the full resolved port set is disjoint', () => {
       const p = deriveInstance({ slot });
       const offset = slot * SLOT_PORT_STRIDE;
       const rabbit = getMesh('rabbitmq');
+      // The excluded trio is SHARED across slots on purpose — disjointness is a
+      // claim about the slotted services only.
+      const excluded = new Set(p.excludedServices);
       return [
-        ...(Object.keys(p.portOverrides) as ServiceId[]).map((id) => p.portOverrides[id] as number),
+        ...(Object.keys(p.portOverrides) as ServiceId[])
+          .filter((id) => !excluded.has(id))
+          .map((id) => p.portOverrides[id] as number),
         getMesh('postgres').port + offset,
         getMesh('redis').port + offset,
         rabbit.port + offset,

--- a/packages/node/saga-stack-cli/src/core/__tests__/inspector.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/inspector.unit.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Inspector-port derivation (attach-mode profiling). PURE — no IO, no seams.
+ *
+ * The port is Node's SIGUSR1 default plus the slot offset — nothing is injected at
+ * launch (see the module docblock for why a per-service preset was removed). What
+ * matters operationally: the prediction is stable, slots are isolated, frontends
+ * are excluded, and the band never overlaps a real service/mesh port.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { SLOT_PORT_STRIDE } from '../derive-instance.js';
+import {
+  INSPECTOR_BASE_PORT,
+  assertInspectorBandFree,
+  inspectorPort,
+  profilableServices,
+} from '../inspector.js';
+import { manifest } from '../manifest/index.js';
+import type { ServiceId } from '../manifest/index.js';
+
+describe('profilableServices', () => {
+  it('includes backends and excludes every frontend', () => {
+    const ids = profilableServices();
+    expect(ids).toContain('iam-api');
+    expect(ids).toContain('coach-api');
+    for (const id of ids) expect(manifest.services[id].isFrontend).toBe(false);
+    for (const id of ['saga-dash', 'coach-web', 'connect-web', 'staff-admin-console'] as ServiceId[]) {
+      expect(ids).not.toContain(id);
+    }
+  });
+});
+
+describe('inspectorPort', () => {
+  it('is null for a frontend (profiling a vite dev server is not the ask)', () => {
+    expect(inspectorPort('coach-web', 0)).toBeNull();
+    expect(inspectorPort('saga-dash', 0)).toBeNull();
+  });
+
+  it("is Node's SIGUSR1 default at slot 0 (the port cannot be chosen)", () => {
+    const [first] = profilableServices();
+    expect(first).toBeDefined();
+    expect(inspectorPort(first!, 0)).toBe(INSPECTOR_BASE_PORT);
+    expect(inspectorPort('iam-api', 0)).toBe(INSPECTOR_BASE_PORT);
+  });
+
+  it('offsets by exactly slot * SLOT_PORT_STRIDE so slots stay isolated', () => {
+    const base = inspectorPort('iam-api', 0)!;
+    expect(inspectorPort('iam-api', 1)).toBe(base + SLOT_PORT_STRIDE);
+    expect(inspectorPort('iam-api', 7)).toBe(base + 7 * SLOT_PORT_STRIDE);
+  });
+
+  it('is SHARED across services in a slot — hence one-at-a-time profiling', () => {
+    // Not a defect: SIGUSR1 cannot be told a port, so every service in a slot
+    // lands on the same one. `planProfile` refuses when it is already held.
+    expect(inspectorPort('iam-api', 2)).toBe(inspectorPort('coach-api', 2));
+  });
+});
+
+describe('assertInspectorBandFree', () => {
+  it('passes against the real manifest for slots 0-9', () => {
+    expect(() => assertInspectorBandFree()).not.toThrow();
+  });
+
+  it('throws when a service is banded onto an inspector port', () => {
+    // A synthetic manifest whose service port sits exactly on slot 0's first
+    // inspector port — the regression this guard exists to catch.
+    const colliding = {
+      ...manifest,
+      services: {
+        ...manifest.services,
+        'iam-api': { ...manifest.services['iam-api'], port: INSPECTOR_BASE_PORT },
+      },
+    };
+    expect(() => assertInspectorBandFree(colliding, 0)).toThrow(/collides with/);
+  });
+});
+

--- a/packages/node/saga-stack-cli/src/core/__tests__/inspector.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/inspector.unit.test.ts
@@ -1,20 +1,15 @@
 /**
  * Inspector-port derivation (attach-mode profiling). PURE — no IO, no seams.
  *
- * The port is Node's SIGUSR1 default plus the slot offset — nothing is injected at
- * launch (see the module docblock for why a per-service preset was removed). What
- * matters operationally: the prediction is stable, slots are isolated, frontends
- * are excluded, and the band never overlaps a real service/mesh port.
+ * The port is Node's SIGUSR1 default, with NO slot offset: nothing is injected at
+ * launch, so SIGUSR1 always opens 9229 whatever the slot. What matters
+ * operationally: the prediction is stable, frontends are excluded, and the port
+ * never overlaps a real service/mesh port at any slot.
  */
 
 import { describe, expect, it } from 'vitest';
 import { SLOT_PORT_STRIDE } from '../derive-instance.js';
-import {
-  INSPECTOR_BASE_PORT,
-  assertInspectorBandFree,
-  inspectorPort,
-  profilableServices,
-} from '../inspector.js';
+import { INSPECTOR_PORT, assertInspectorPortFree, profilableServices } from '../inspector.js';
 import { manifest } from '../manifest/index.js';
 import type { ServiceId } from '../manifest/index.js';
 
@@ -30,48 +25,46 @@ describe('profilableServices', () => {
   });
 });
 
-describe('inspectorPort', () => {
-  it('is null for a frontend (profiling a vite dev server is not the ask)', () => {
-    expect(inspectorPort('coach-web', 0)).toBeNull();
-    expect(inspectorPort('saga-dash', 0)).toBeNull();
+describe('INSPECTOR_PORT', () => {
+  it("is Node's SIGUSR1 default, which cannot be chosen", () => {
+    expect(INSPECTOR_PORT).toBe(9229);
   });
 
-  it("is Node's SIGUSR1 default at slot 0 (the port cannot be chosen)", () => {
-    const [first] = profilableServices();
-    expect(first).toBeDefined();
-    expect(inspectorPort(first!, 0)).toBe(INSPECTOR_BASE_PORT);
-    expect(inspectorPort('iam-api', 0)).toBe(INSPECTOR_BASE_PORT);
-  });
-
-  it('offsets by exactly slot * SLOT_PORT_STRIDE so slots stay isolated', () => {
-    const base = inspectorPort('iam-api', 0)!;
-    expect(inspectorPort('iam-api', 1)).toBe(base + SLOT_PORT_STRIDE);
-    expect(inspectorPort('iam-api', 7)).toBe(base + 7 * SLOT_PORT_STRIDE);
-  });
-
-  it('is SHARED across services in a slot — hence one-at-a-time profiling', () => {
-    // Not a defect: SIGUSR1 cannot be told a port, so every service in a slot
-    // lands on the same one. `planProfile` refuses when it is already held.
-    expect(inspectorPort('iam-api', 2)).toBe(inspectorPort('coach-api', 2));
+  it('sits below the slot band, so no offset arithmetic can be mistaken for it', () => {
+    // Nothing injects --inspect-port (launch-plan.unit.test.ts pins NODE_OPTIONS
+    // undefined on every service), so SIGUSR1 opens 9229 in every slot. The port
+    // that planProfile reports is pinned in profile-plan.unit.test.ts.
+    expect(INSPECTOR_PORT).toBeLessThan(SLOT_PORT_STRIDE * 10);
   });
 });
 
-describe('assertInspectorBandFree', () => {
+describe('assertInspectorPortFree', () => {
   it('passes against the real manifest for slots 0-9', () => {
-    expect(() => assertInspectorBandFree()).not.toThrow();
+    expect(() => assertInspectorPortFree()).not.toThrow();
   });
 
-  it('throws when a service is banded onto an inspector port', () => {
-    // A synthetic manifest whose service port sits exactly on slot 0's first
-    // inspector port — the regression this guard exists to catch.
+  it('throws when a service is banded onto the inspector port', () => {
     const colliding = {
       ...manifest,
       services: {
         ...manifest.services,
-        'iam-api': { ...manifest.services['iam-api'], port: INSPECTOR_BASE_PORT },
+        'iam-api': { ...manifest.services['iam-api'], port: INSPECTOR_PORT },
       },
     };
-    expect(() => assertInspectorBandFree(colliding, 0)).toThrow(/collides with/);
+    expect(() => assertInspectorPortFree(colliding, 0)).toThrow(/collides with/);
+  });
+
+  it('catches a service that only reaches the inspector port at a HIGHER slot', () => {
+    // The offset applies to services, not the inspector — so a service whose base
+    // port is below 9229 can still land on it once slotted.
+    const colliding = {
+      ...manifest,
+      services: {
+        ...manifest.services,
+        'iam-api': { ...manifest.services['iam-api'], port: INSPECTOR_PORT - 2 * SLOT_PORT_STRIDE },
+      },
+    };
+    expect(() => assertInspectorPortFree(colliding, 0)).not.toThrow();
+    expect(() => assertInspectorPortFree(colliding, 2)).toThrow(/collides with service iam-api/);
   });
 });
-

--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
@@ -48,12 +48,10 @@ const env = (id: ServiceId) => {
 };
 
 describe('attach-mode profiling leaves the launch env UNTOUCHED', () => {
-  // `ss stack profile` attaches to a running process (SIGUSR1 + CDP) and injects
-  // nothing at launch. An earlier attempt DID preset `NODE_OPTIONS=--inspect-port`
-  // here and it failed in a way worth pinning: NODE_OPTIONS is inherited by the
-  // whole `pnpm dev → tsup → node dist/main.js` tree, so pnpm and tsup each
-  // reserved the port and the real service could not bind it. If NODE_OPTIONS ever
-  // reappears on a launch line, that regression is back.
+  // `ss stack profile` attaches to a running process (SIGUSR1 + CDP) and must
+  // inject nothing at launch: NODE_OPTIONS reaches the whole `pnpm dev → tsup →
+  // node dist/main.js` tree, so a wrapper reserves the port and the service
+  // cannot bind it. Rationale: docs/instrumentation.md.
   it('injects no NODE_OPTIONS on any service', () => {
     for (const id of Object.keys(manifest.services) as ServiceId[]) {
       expect(rawEnv(id).NODE_OPTIONS).toBeUndefined();

--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
@@ -47,6 +47,20 @@ const env = (id: ServiceId) => {
   return e;
 };
 
+describe('attach-mode profiling leaves the launch env UNTOUCHED', () => {
+  // `ss stack profile` attaches to a running process (SIGUSR1 + CDP) and injects
+  // nothing at launch. An earlier attempt DID preset `NODE_OPTIONS=--inspect-port`
+  // here and it failed in a way worth pinning: NODE_OPTIONS is inherited by the
+  // whole `pnpm dev → tsup → node dist/main.js` tree, so pnpm and tsup each
+  // reserved the port and the real service could not bind it. If NODE_OPTIONS ever
+  // reappears on a launch line, that regression is back.
+  it('injects no NODE_OPTIONS on any service', () => {
+    for (const id of Object.keys(manifest.services) as ServiceId[]) {
+      expect(rawEnv(id).NODE_OPTIONS).toBeUndefined();
+    }
+  });
+});
+
 describe('global PINO logger env (up.sh services_up export ~1384-1385)', () => {
   // soa-logger/soa-config validate these at startup with NO defaults, so every
   // node service crashes on boot without them — required on EVERY launched child.

--- a/packages/node/saga-stack-cli/src/core/__tests__/profile-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/profile-plan.unit.test.ts
@@ -8,9 +8,10 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { inspectorPort } from '../inspector.js';
+import { INSPECTOR_PORT } from '../inspector.js';
 import {
   defaultArtifactPath,
+  looksLikeNode,
   parseDuration,
   planProfile,
   profileHasServiceFrames,
@@ -30,31 +31,35 @@ function target(over: Partial<ProfileTarget> = {}): ProfileTarget {
 
 describe('planProfile', () => {
   it('plans a profile against the LISTENING pid, not a pidfile pid', () => {
-    const plan = planProfile('iam-api', 0, target());
+    const plan = planProfile('iam-api', target());
     expect(plan).toMatchObject({ ok: true, pid: 4242, adopted: true });
-    if (plan.ok) expect(plan.port).toBe(inspectorPort('iam-api', 0));
+    if (plan.ok) expect(plan.port).toBe(INSPECTOR_PORT);
   });
 
-  it('uses the slot-offset inspector port', () => {
-    const plan = planProfile('iam-api', 4, target());
-    if (!plan.ok) throw new Error('expected ok');
-    expect(plan.port).toBe(inspectorPort('iam-api', 4));
+  it('reports the un-offset inspector port for every service', () => {
+    // SIGUSR1 takes no port argument, so the port must never carry a slot offset:
+    // an offset port is one nothing ever binds.
+    for (const id of ['iam-api', 'coach-api', 'sessions-api'] as const) {
+      const plan = planProfile(id, target());
+      if (!plan.ok) throw new Error(`expected ok for ${id}`);
+      expect(plan.port).toBe(INSPECTOR_PORT);
+    }
   });
 
   it('refuses a frontend (that would profile the Vite dev server)', () => {
-    const plan = planProfile('coach-web', 0, target());
+    const plan = planProfile('coach-web', target());
     expect(plan).toMatchObject({ ok: false });
     if (!plan.ok) expect(plan.reason).toMatch(/frontend/i);
   });
 
   it('refuses when nothing is listening', () => {
-    const plan = planProfile('iam-api', 0, target({ listenerPid: null }));
+    const plan = planProfile('iam-api', target({ listenerPid: null }));
     expect(plan).toMatchObject({ ok: false });
     if (!plan.ok) expect(plan.reason).toMatch(/not listening/i);
   });
 
   it('refuses when the listener vanished before it could be inspected', () => {
-    const plan = planProfile('iam-api', 0, target({ proc: null }));
+    const plan = planProfile('iam-api', target({ proc: null }));
     expect(plan).toMatchObject({ ok: false });
     if (!plan.ok) expect(plan.reason).toMatch(/no longer inspectable/i);
   });
@@ -62,24 +67,23 @@ describe('planProfile', () => {
   it('HARD-refuses when SOMEONE ELSE holds the inspector port', () => {
     // SIGUSR1 cannot pick a port, so the service could not open its own inspector
     // and we would attach to the squatter.
-    const plan = planProfile(
-      'iam-api',
-      0,
-      target({ inspectorPortBusy: true, inspectorPortPid: 777 }),
-    );
+    const plan = planProfile('iam-api', target({ inspectorPortBusy: true, inspectorPortPid: 777 }));
     expect(plan).toMatchObject({ ok: false });
     if (!plan.ok) expect(plan.reason).toMatch(/held by pid 777/i);
   });
 
+  it('does not offer another slot as an escape from a held port', () => {
+    // The inspector port takes no slot offset, so "try another slot" is unachievable
+    // advice — the refusal must not imply the collision is slot-scoped.
+    const plan = planProfile('iam-api', target({ inspectorPortBusy: true, inspectorPortPid: 777 }));
+    if (plan.ok) throw new Error('expected refusal');
+    expect(plan.reason).not.toMatch(/profile in another slot/i);
+  });
+
   it('RE-ATTACHES when the target itself holds the port', () => {
     // Node leaves the inspector open after the CDP client disconnects, so a second
-    // profile of the same service must not be refused — that made the command
-    // single-use per service lifetime.
-    const plan = planProfile(
-      'iam-api',
-      0,
-      target({ inspectorPortBusy: true, inspectorPortPid: 4242 }),
-    );
+    // profile of the same service must not be refused.
+    const plan = planProfile('iam-api', target({ inspectorPortBusy: true, inspectorPortPid: 4242 }));
     expect(plan).toMatchObject({ ok: true, pid: 4242, alreadyOpen: true });
   });
 
@@ -87,24 +91,43 @@ describe('planProfile', () => {
     // SIGUSR1 has no handler there, so the default disposition TERMINATES it.
     const plan = planProfile(
       'iam-api',
-      0,
       target({ proc: { pgid: 4200, command: '/usr/bin/python3 -m http.server 3010' } }),
     );
     expect(plan).toMatchObject({ ok: false });
     if (!plan.ok) expect(plan.reason).toMatch(/not a node process/i);
   });
 
-  it('accepts the usual node command shapes', () => {
-    for (const command of ['node dist/main.js', '/usr/local/bin/node dist/main.js']) {
-      expect(planProfile('iam-api', 0, target({ proc: { pgid: 4200, command } }))).toMatchObject({
-        ok: true,
-      });
-    }
+  it('allows an unowned listener but reports it as not adopted', () => {
+    const plan = planProfile('iam-api', target({ ownedPgids: [999] }));
+    expect(plan).toMatchObject({ ok: true, adopted: false });
+  });
+});
+
+describe('looksLikeNode', () => {
+  // Both directions matter: a false POSITIVE gets a live non-node process killed by
+  // SIGUSR1's default disposition, and a false NEGATIVE refuses a real service.
+  it.each([
+    'node dist/main.js',
+    '/usr/bin/node dist/main.js',
+    '/usr/bin/env node dist/main.js',
+    '/usr/bin/env NODE_ENV=dev node dist/main.js',
+    '/home/u/.nvm/versions/node/v24.13.0/bin/node dist/main.js',
+    'nodejs server.js',
+    '/opt/node-22/bin/node app.js',
+  ])('accepts %s', (command) => {
+    expect(looksLikeNode(command)).toBe(true);
   });
 
-  it('allows an unowned listener but reports it as not adopted', () => {
-    const plan = planProfile('iam-api', 0, target({ ownedPgids: [999] }));
-    expect(plan).toMatchObject({ ok: true, adopted: false });
+  it.each([
+    'java -cp /opt/node/lib App',
+    'python /srv/node/app.py',
+    'ruby /srv/node/app.rb',
+    'nginx -c /etc/node/nginx.conf',
+    '/usr/bin/python3 -m http.server 3010',
+    '/usr/bin/env python3 /srv/node/x.py',
+    'node_modules/.bin/tsx watch src/main.ts',
+  ])('refuses %s', (command) => {
+    expect(looksLikeNode(command)).toBe(false);
   });
 });
 

--- a/packages/node/saga-stack-cli/src/core/__tests__/profile-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/profile-plan.unit.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Attach-mode profiling decisions. PURE — the IO is faked by the caller shape.
+ *
+ * These assert the REFUSALS more than the happy path, because every failure mode
+ * here is one where profiling would otherwise appear to succeed against the wrong
+ * process: a wrapper pid, a Vite dev server, or an inspector port already owned by
+ * someone else.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { inspectorPort } from '../inspector.js';
+import {
+  defaultArtifactPath,
+  parseDuration,
+  planProfile,
+  profileHasServiceFrames,
+  type ProfileTarget,
+} from '../profile-plan.js';
+
+/** A healthy target: listening, inspectable, owned by this slot, port free. */
+function target(over: Partial<ProfileTarget> = {}): ProfileTarget {
+  return {
+    listenerPid: 4242,
+    proc: { pgid: 4200, command: 'node dist/main.js' },
+    ownedPgids: [4200],
+    inspectorPortBusy: false,
+    ...over,
+  };
+}
+
+describe('planProfile', () => {
+  it('plans a profile against the LISTENING pid, not a pidfile pid', () => {
+    const plan = planProfile('iam-api', 0, target());
+    expect(plan).toMatchObject({ ok: true, pid: 4242, adopted: true });
+    if (plan.ok) expect(plan.port).toBe(inspectorPort('iam-api', 0));
+  });
+
+  it('uses the slot-offset inspector port', () => {
+    const plan = planProfile('iam-api', 4, target());
+    if (!plan.ok) throw new Error('expected ok');
+    expect(plan.port).toBe(inspectorPort('iam-api', 4));
+  });
+
+  it('refuses a frontend (that would profile the Vite dev server)', () => {
+    const plan = planProfile('coach-web', 0, target());
+    expect(plan).toMatchObject({ ok: false });
+    if (!plan.ok) expect(plan.reason).toMatch(/frontend/i);
+  });
+
+  it('refuses when nothing is listening', () => {
+    const plan = planProfile('iam-api', 0, target({ listenerPid: null }));
+    expect(plan).toMatchObject({ ok: false });
+    if (!plan.ok) expect(plan.reason).toMatch(/not listening/i);
+  });
+
+  it('refuses when the listener vanished before it could be inspected', () => {
+    const plan = planProfile('iam-api', 0, target({ proc: null }));
+    expect(plan).toMatchObject({ ok: false });
+    if (!plan.ok) expect(plan.reason).toMatch(/no longer inspectable/i);
+  });
+
+  it('HARD-refuses when the inspector port is already held', () => {
+    // The sharpest footgun: SIGUSR1 cannot pick a port, so the service would fail
+    // to open its inspector silently and we would attach to the squatter.
+    const plan = planProfile('iam-api', 0, target({ inspectorPortBusy: true }));
+    expect(plan).toMatchObject({ ok: false });
+    if (!plan.ok) expect(plan.reason).toMatch(/already in use/i);
+  });
+
+  it('allows an unowned listener but reports it as not adopted', () => {
+    const plan = planProfile('iam-api', 0, target({ ownedPgids: [999] }));
+    expect(plan).toMatchObject({ ok: true, adopted: false });
+  });
+});
+
+describe('parseDuration', () => {
+  it('parses ms / s / m and bare seconds', () => {
+    expect(parseDuration('500ms')).toBe(500);
+    expect(parseDuration('30s')).toBe(30_000);
+    expect(parseDuration('2m')).toBe(120_000);
+    expect(parseDuration('15')).toBe(15_000);
+  });
+
+  it('rejects junk and non-positive values', () => {
+    for (const bad of ['', 'soon', '-5s', '0', '10h']) expect(parseDuration(bad)).toBeNull();
+  });
+});
+
+describe('defaultArtifactPath', () => {
+  it('is slot-scoped and does not double a trailing slash', () => {
+    expect(defaultArtifactPath('/tmp/sds-synthetic', 'iam-api', 'T1')).toBe(
+      '/tmp/sds-synthetic/iam-api-T1.cpuprofile',
+    );
+    expect(defaultArtifactPath('/tmp/sds-synthetic-s2/', 'coach-api', 'T2')).toBe(
+      '/tmp/sds-synthetic-s2/coach-api-T2.cpuprofile',
+    );
+  });
+});
+
+describe('profileHasServiceFrames', () => {
+  it('detects the service\'s own frames', () => {
+    const profile = {
+      nodes: [{ hitCount: 3, callFrame: { url: 'file:///r/apps/node/iam-api/dist/main.js' } }],
+    };
+    expect(profileHasServiceFrames(profile, 'iam-api')).toBe(true);
+  });
+
+  it('rejects a wrapper-only profile (the --cpu-prof failure mode)', () => {
+    // pnpm + tsup frames only: plenty of nodes, none from the service.
+    const profile = {
+      nodes: [
+        { hitCount: 9, callFrame: { url: 'file:///g/pnpm/dist/pnpm.cjs' } },
+        { hitCount: 4, callFrame: { url: 'file:///r/node_modules/tsup/dist/cli-default.js' } },
+      ],
+    };
+    expect(profileHasServiceFrames(profile, 'iam-api')).toBe(false);
+  });
+
+  it('handles an empty profile', () => {
+    expect(profileHasServiceFrames({}, 'iam-api')).toBe(false);
+    expect(profileHasServiceFrames({ nodes: [] }, 'iam-api')).toBe(false);
+  });
+});

--- a/packages/node/saga-stack-cli/src/core/__tests__/profile-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/profile-plan.unit.test.ts
@@ -59,12 +59,47 @@ describe('planProfile', () => {
     if (!plan.ok) expect(plan.reason).toMatch(/no longer inspectable/i);
   });
 
-  it('HARD-refuses when the inspector port is already held', () => {
-    // The sharpest footgun: SIGUSR1 cannot pick a port, so the service would fail
-    // to open its inspector silently and we would attach to the squatter.
-    const plan = planProfile('iam-api', 0, target({ inspectorPortBusy: true }));
+  it('HARD-refuses when SOMEONE ELSE holds the inspector port', () => {
+    // SIGUSR1 cannot pick a port, so the service could not open its own inspector
+    // and we would attach to the squatter.
+    const plan = planProfile(
+      'iam-api',
+      0,
+      target({ inspectorPortBusy: true, inspectorPortPid: 777 }),
+    );
     expect(plan).toMatchObject({ ok: false });
-    if (!plan.ok) expect(plan.reason).toMatch(/already in use/i);
+    if (!plan.ok) expect(plan.reason).toMatch(/held by pid 777/i);
+  });
+
+  it('RE-ATTACHES when the target itself holds the port', () => {
+    // Node leaves the inspector open after the CDP client disconnects, so a second
+    // profile of the same service must not be refused — that made the command
+    // single-use per service lifetime.
+    const plan = planProfile(
+      'iam-api',
+      0,
+      target({ inspectorPortBusy: true, inspectorPortPid: 4242 }),
+    );
+    expect(plan).toMatchObject({ ok: true, pid: 4242, alreadyOpen: true });
+  });
+
+  it('refuses to signal a listener that is not a node process', () => {
+    // SIGUSR1 has no handler there, so the default disposition TERMINATES it.
+    const plan = planProfile(
+      'iam-api',
+      0,
+      target({ proc: { pgid: 4200, command: '/usr/bin/python3 -m http.server 3010' } }),
+    );
+    expect(plan).toMatchObject({ ok: false });
+    if (!plan.ok) expect(plan.reason).toMatch(/not a node process/i);
+  });
+
+  it('accepts the usual node command shapes', () => {
+    for (const command of ['node dist/main.js', '/usr/local/bin/node dist/main.js']) {
+      expect(planProfile('iam-api', 0, target({ proc: { pgid: 4200, command } }))).toMatchObject({
+        ok: true,
+      });
+    }
   });
 
   it('allows an unowned listener but reports it as not adopted', () => {
@@ -119,5 +154,30 @@ describe('profileHasServiceFrames', () => {
   it('handles an empty profile', () => {
     expect(profileHasServiceFrames({}, 'iam-api')).toBe(false);
     expect(profileHasServiceFrames({ nodes: [] }, 'iam-api')).toBe(false);
+  });
+
+  it('rejects frames that were never SAMPLED (hitCount 0)', () => {
+    // A profile's `nodes` is the whole call tree: parent and parse-time nodes
+    // exist with hitCount 0 even when the service never ran, so an idle service
+    // with a loaded module graph must not read as "has app frames".
+    const idle = {
+      nodes: [{ hitCount: 0, callFrame: { url: 'file:///r/apps/node/iam-api/dist/main.js' } }],
+    };
+    expect(profileHasServiceFrames(idle, 'iam-api')).toBe(false);
+  });
+
+  it('matches a tsx-watch service that runs from src/, not dist/', () => {
+    // staff-admin-bff is a profilable backend whose dev script is
+    // `tsx watch src/local.ts` — pinning `/dist` reported every valid capture
+    // of it as empty.
+    const profile = {
+      nodes: [
+        {
+          hitCount: 5,
+          callFrame: { url: 'file:///w/apps/web/staff-admin-console/backend/src/local.ts' },
+        },
+      ],
+    };
+    expect(profileHasServiceFrames(profile, 'staff-admin-bff')).toBe(true);
   });
 });

--- a/packages/node/saga-stack-cli/src/core/derive-instance.ts
+++ b/packages/node/saga-stack-cli/src/core/derive-instance.ts
@@ -251,9 +251,14 @@ export function deriveInstance(
   // Generic port-override map: every manifest service, offset applied. At slot 0
   // (offset 0) this is the base-port map, so `defaultLaunchContext` resolves the
   // same ports it would with no overrides — the byte-identical guard.
+  //
+  // Slot-excluded services are exempt: they keep their literal port at every slot,
+  // so an offset entry would name a port they never bind. Every value in this map
+  // is a port the service actually listens on.
+  const excluded = new Set(slotExcludedServices(slot));
   const portOverrides: Partial<Record<ServiceId, number>> = {};
   for (const id of Object.keys(m.services) as ServiceId[]) {
-    portOverrides[id] = m.services[id].port + offset;
+    portOverrides[id] = excluded.has(id) ? m.services[id].port : m.services[id].port + offset;
   }
 
   assertPortsDisjoint(slot, offset, m);

--- a/packages/node/saga-stack-cli/src/core/inspector.ts
+++ b/packages/node/saga-stack-cli/src/core/inspector.ts
@@ -12,9 +12,10 @@
  * A regression test in launch-plan.unit.test.ts pins this.
  *
  * Two consequences the callers depend on:
- *  - ONE SERVICE AT A TIME PER SLOT (every service in a slot shares the port).
- *    `planProfile` hard-refuses a held port rather than sampling whoever owns it.
- *    Slots stay isolated via the slot offset.
+ *  - ONE SERVICE AT A TIME, MACHINE-WIDE — not per slot. The port is Node's
+ *    default and takes no offset, so slot 2's inspector lands on 9229 exactly
+ *    like slot 0's. `planProfile` hard-refuses a held port rather than sampling
+ *    whoever owns it, and `captureCpuProfile` re-checks the holder after SIGUSR1.
  *  - SIGNAL THE POSITIVE, `lsof`-RESOLVED LISTENER PID, NEVER THE GROUP. Services
  *    launch `detached: true`, so the `pnpm dev` wrapper leads the process group;
  *    a group-delivered SIGUSR1 lets a wrapper win the port instead.
@@ -26,10 +27,10 @@ import type { Manifest, ServiceId } from './manifest/index.js';
 
 /**
  * Node's own default inspector port. SIGUSR1 opens here and cannot be redirected,
- * so this is a FACT about Node, not a choice — slot N adds `N * SLOT_PORT_STRIDE`
- * because slot N's services are separate processes on an offset port band.
+ * so this is a FACT about Node, not a choice — and it takes no slot offset: a
+ * second concurrent profile, in any slot, collides here.
  */
-export const INSPECTOR_BASE_PORT = 9229;
+export const INSPECTOR_PORT = 9229;
 
 /** Backends only — a frontend's `pnpm dev` is a Vite dev server, not the app. */
 export function profilableServices(m: Manifest = defaultManifest): ServiceId[] {
@@ -37,44 +38,30 @@ export function profilableServices(m: Manifest = defaultManifest): ServiceId[] {
 }
 
 /**
- * Where `service`'s inspector will appear once signalled at `slot`, or null when
- * the service is a frontend (not profilable).
- */
-export function inspectorPort(
-  service: ServiceId,
-  slot: number,
-  m: Manifest = defaultManifest,
-): number | null {
-  if (m.services[service]?.isFrontend !== false) return null;
-  return INSPECTOR_BASE_PORT + slot * SLOT_PORT_STRIDE;
-}
-
-/**
- * Throw when the inspector band overlaps a service or mesh port at any slot 0-9.
+ * Throw when the inspector port collides with a service or mesh port at any slot 0-9.
  * `deriveInstance` asserts service/mesh disjointness the same way; this extends
  * that guarantee to the inspector so a future service banded near 9229 fails
  * LOUDLY instead of silently stealing the port a profiler is about to attach to.
  */
-export function assertInspectorBandFree(m: Manifest = defaultManifest, maxSlot = 9): void {
-  const claimed = new Map<number, string>();
+export function assertInspectorPortFree(m: Manifest = defaultManifest, maxSlot = 9): void {
   for (let slot = 0; slot <= maxSlot; slot += 1) {
     const offset = slot * SLOT_PORT_STRIDE;
     for (const id of Object.keys(m.services) as ServiceId[]) {
-      claimed.set(getService(id, m).port + offset, `service ${id}`);
+      if (getService(id, m).port + offset === INSPECTOR_PORT) {
+        throw new Error(
+          `inspector: port ${INSPECTOR_PORT} collides with service ${id} at slot ${slot}. ` +
+            `Re-band INSPECTOR_PORT above the claimed range.`,
+        );
+      }
     }
     for (const unit of Object.values(m.mesh)) {
-      claimed.set(unit.port + offset, `mesh ${unit.id}`);
-      if (unit.mgmtPort !== undefined) claimed.set(unit.mgmtPort + offset, `mesh ${unit.id} mgmt`);
-    }
-  }
-  for (let slot = 0; slot <= maxSlot; slot += 1) {
-    const port = INSPECTOR_BASE_PORT + slot * SLOT_PORT_STRIDE;
-    const owner = claimed.get(port);
-    if (owner !== undefined) {
-      throw new Error(
-        `inspector: port ${port} (slot ${slot}) collides with ${owner}. ` +
-          `Re-band INSPECTOR_BASE_PORT above the claimed range.`,
-      );
+      const mesh = [unit.port, unit.mgmtPort].filter((p): p is number => p !== undefined);
+      if (mesh.some((p) => p + offset === INSPECTOR_PORT)) {
+        throw new Error(
+          `inspector: port ${INSPECTOR_PORT} collides with mesh ${unit.id} at slot ${slot}. ` +
+            `Re-band INSPECTOR_PORT above the claimed range.`,
+        );
+      }
     }
   }
 }

--- a/packages/node/saga-stack-cli/src/core/inspector.ts
+++ b/packages/node/saga-stack-cli/src/core/inspector.ts
@@ -5,11 +5,9 @@
  * SIGUSR1 opens the inspector on Node's DEFAULT port and cannot be told another,
  * so this module PREDICTS where the inspector will appear rather than choosing it.
  *
- * Don't inject `--inspect-port` into a service's launch env to get per-service
- * ports: NODE_OPTIONS is inherited by the whole `pnpm dev → tsup → node
- * dist/main.js` tree, so the wrappers reserve the port and the service fails to
- * bind it — visible only as `address already in use` in the service's own log.
- * A regression test in launch-plan.unit.test.ts pins this.
+ * Per-service inspector ports are not available: injecting `--inspect-port` via
+ * NODE_OPTIONS reserves the port in a wrapper instead of the service. Pinned by
+ * launch-plan.unit.test.ts; rationale in docs/instrumentation.md.
  *
  * Two consequences the callers depend on:
  *  - ONE SERVICE AT A TIME, MACHINE-WIDE — not per slot. The port is Node's

--- a/packages/node/saga-stack-cli/src/core/inspector.ts
+++ b/packages/node/saga-stack-cli/src/core/inspector.ts
@@ -1,0 +1,99 @@
+/**
+ * Inspector-port derivation for attach-mode profiling (`ss stack profile`).
+ *
+ * This module is PURE: port arithmetic only, zero IO.
+ *
+ * NOTHING IS INJECTED AT LAUNCH. A service's V8 inspector is opened on demand by
+ * SIGUSR1, which always uses Node's DEFAULT port (9229) and offers no way to pick
+ * one at signal time. So this module does not choose the port so much as PREDICT
+ * it — the profiler needs to know where the inspector will appear.
+ *
+ * WHY NOT PRESET THE PORT. An earlier revision set
+ * `NODE_OPTIONS=--inspect-port=<n>` on each service's launch env to get a distinct
+ * per-service port. It does not work, and the failure is instructive: NODE_OPTIONS
+ * is inherited by the ENTIRE launch tree, so `pnpm` and `tsup` each reserved the
+ * same port and the real `node dist/main.js` — 4 levels down — then failed to bind
+ * it, logging `Starting inspector on 127.0.0.1:9229 failed: address already in use`
+ * into its own log while `ss` saw nothing. (The deployed `docker-entrypoint.sh`
+ * avoids exactly this with a `[ "$1" = "node" ]` gate, but that works only because
+ * the entrypoint IS the exec wrapper; the `ss` launch path has no such hop.)
+ *
+ * CONSEQUENCE — ONE SERVICE AT A TIME PER SLOT. Without a preset, every service in
+ * a slot would open its inspector on the same port, so only one can be profiled at
+ * a time. That is enforced, not hoped for: `planProfile` hard-refuses when the port
+ * is already held (`ProfileTarget.inspectorPortBusy`) rather than silently
+ * attaching to whoever owns it. Slots stay isolated because the port carries the
+ * slot offset.
+ *
+ * SIGNAL THE SERVICE PID, NEVER THE GROUP. `ss` launches each service
+ * `detached: true`, so the `pnpm dev` wrapper is the PROCESS-GROUP LEADER and the
+ * real `node dist/main.js` shares its pgid. `launcher.ts` stops services by
+ * signalling the NEGATIVE pid (the whole group) — profiling must not copy that.
+ * A group-delivered SIGUSR1 would reach pnpm and tsup too, and whichever node in
+ * the tree binds the default port first wins, leaving the service unprofilable.
+ * Hence the positive, `lsof`-resolved listener pid only.
+ *
+ * A HELD PORT MAY NOT SPEAK HTTP. Whatever already owns the port need not be a
+ * working inspector — it can accept TCP and never answer `/json/version` (any
+ * stray listener does this). An HTTP probe HANGS against such a holder, so
+ * `inspectorPortBusy` uses a bounded raw TCP connect instead.
+ */
+
+import { SLOT_PORT_STRIDE } from './derive-instance.js';
+import { getService, manifest as defaultManifest } from './manifest/index.js';
+import type { Manifest, ServiceId } from './manifest/index.js';
+
+/**
+ * Node's own default inspector port. SIGUSR1 opens here and cannot be redirected,
+ * so this is a FACT about Node, not a choice — slot N adds `N * SLOT_PORT_STRIDE`
+ * because slot N's services are separate processes on an offset port band.
+ */
+export const INSPECTOR_BASE_PORT = 9229;
+
+/** Backends only — a frontend's `pnpm dev` is a Vite dev server, not the app. */
+export function profilableServices(m: Manifest = defaultManifest): ServiceId[] {
+  return (Object.keys(m.services) as ServiceId[]).filter((id) => !m.services[id].isFrontend);
+}
+
+/**
+ * Where `service`'s inspector will appear once signalled at `slot`, or null when
+ * the service is a frontend (not profilable).
+ */
+export function inspectorPort(
+  service: ServiceId,
+  slot: number,
+  m: Manifest = defaultManifest,
+): number | null {
+  if (m.services[service]?.isFrontend !== false) return null;
+  return INSPECTOR_BASE_PORT + slot * SLOT_PORT_STRIDE;
+}
+
+/**
+ * Throw when the inspector band overlaps a service or mesh port at any slot 0-9.
+ * `deriveInstance` asserts service/mesh disjointness the same way; this extends
+ * that guarantee to the inspector so a future service banded near 9229 fails
+ * LOUDLY instead of silently stealing the port a profiler is about to attach to.
+ */
+export function assertInspectorBandFree(m: Manifest = defaultManifest, maxSlot = 9): void {
+  const claimed = new Map<number, string>();
+  for (let slot = 0; slot <= maxSlot; slot += 1) {
+    const offset = slot * SLOT_PORT_STRIDE;
+    for (const id of Object.keys(m.services) as ServiceId[]) {
+      claimed.set(getService(id, m).port + offset, `service ${id}`);
+    }
+    for (const unit of Object.values(m.mesh)) {
+      claimed.set(unit.port + offset, `mesh ${unit.id}`);
+      if (unit.mgmtPort !== undefined) claimed.set(unit.mgmtPort + offset, `mesh ${unit.id} mgmt`);
+    }
+  }
+  for (let slot = 0; slot <= maxSlot; slot += 1) {
+    const port = INSPECTOR_BASE_PORT + slot * SLOT_PORT_STRIDE;
+    const owner = claimed.get(port);
+    if (owner !== undefined) {
+      throw new Error(
+        `inspector: port ${port} (slot ${slot}) collides with ${owner}. ` +
+          `Re-band INSPECTOR_BASE_PORT above the claimed range.`,
+      );
+    }
+  }
+}

--- a/packages/node/saga-stack-cli/src/core/inspector.ts
+++ b/packages/node/saga-stack-cli/src/core/inspector.ts
@@ -1,42 +1,23 @@
 /**
  * Inspector-port derivation for attach-mode profiling (`ss stack profile`).
+ * PURE: port arithmetic only, zero IO.
  *
- * This module is PURE: port arithmetic only, zero IO.
+ * SIGUSR1 opens the inspector on Node's DEFAULT port and cannot be told another,
+ * so this module PREDICTS where the inspector will appear rather than choosing it.
  *
- * NOTHING IS INJECTED AT LAUNCH. A service's V8 inspector is opened on demand by
- * SIGUSR1, which always uses Node's DEFAULT port (9229) and offers no way to pick
- * one at signal time. So this module does not choose the port so much as PREDICT
- * it — the profiler needs to know where the inspector will appear.
+ * Don't inject `--inspect-port` into a service's launch env to get per-service
+ * ports: NODE_OPTIONS is inherited by the whole `pnpm dev → tsup → node
+ * dist/main.js` tree, so the wrappers reserve the port and the service fails to
+ * bind it — visible only as `address already in use` in the service's own log.
+ * A regression test in launch-plan.unit.test.ts pins this.
  *
- * WHY NOT PRESET THE PORT. An earlier revision set
- * `NODE_OPTIONS=--inspect-port=<n>` on each service's launch env to get a distinct
- * per-service port. It does not work, and the failure is instructive: NODE_OPTIONS
- * is inherited by the ENTIRE launch tree, so `pnpm` and `tsup` each reserved the
- * same port and the real `node dist/main.js` — 4 levels down — then failed to bind
- * it, logging `Starting inspector on 127.0.0.1:9229 failed: address already in use`
- * into its own log while `ss` saw nothing. (The deployed `docker-entrypoint.sh`
- * avoids exactly this with a `[ "$1" = "node" ]` gate, but that works only because
- * the entrypoint IS the exec wrapper; the `ss` launch path has no such hop.)
- *
- * CONSEQUENCE — ONE SERVICE AT A TIME PER SLOT. Without a preset, every service in
- * a slot would open its inspector on the same port, so only one can be profiled at
- * a time. That is enforced, not hoped for: `planProfile` hard-refuses when the port
- * is already held (`ProfileTarget.inspectorPortBusy`) rather than silently
- * attaching to whoever owns it. Slots stay isolated because the port carries the
- * slot offset.
- *
- * SIGNAL THE SERVICE PID, NEVER THE GROUP. `ss` launches each service
- * `detached: true`, so the `pnpm dev` wrapper is the PROCESS-GROUP LEADER and the
- * real `node dist/main.js` shares its pgid. `launcher.ts` stops services by
- * signalling the NEGATIVE pid (the whole group) — profiling must not copy that.
- * A group-delivered SIGUSR1 would reach pnpm and tsup too, and whichever node in
- * the tree binds the default port first wins, leaving the service unprofilable.
- * Hence the positive, `lsof`-resolved listener pid only.
- *
- * A HELD PORT MAY NOT SPEAK HTTP. Whatever already owns the port need not be a
- * working inspector — it can accept TCP and never answer `/json/version` (any
- * stray listener does this). An HTTP probe HANGS against such a holder, so
- * `inspectorPortBusy` uses a bounded raw TCP connect instead.
+ * Two consequences the callers depend on:
+ *  - ONE SERVICE AT A TIME PER SLOT (every service in a slot shares the port).
+ *    `planProfile` hard-refuses a held port rather than sampling whoever owns it.
+ *    Slots stay isolated via the slot offset.
+ *  - SIGNAL THE POSITIVE, `lsof`-RESOLVED LISTENER PID, NEVER THE GROUP. Services
+ *    launch `detached: true`, so the `pnpm dev` wrapper leads the process group;
+ *    a group-delivered SIGUSR1 lets a wrapper win the port instead.
  */
 
 import { SLOT_PORT_STRIDE } from './derive-instance.js';

--- a/packages/node/saga-stack-cli/src/core/launch-plan.ts
+++ b/packages/node/saga-stack-cli/src/core/launch-plan.ts
@@ -521,6 +521,16 @@ export function resolveLaunchEnv(
     env[portEnvVar] = String(ctx.ports[service]);
   }
 
+  // NOTE (attach-mode profiling): do NOT inject `--inspect-port` here. NODE_OPTIONS
+  // is inherited by the WHOLE launch tree, so pnpm and tsup would each reserve the
+  // same port and the real `node dist/main.js` then fails to bind it
+  // ("Starting inspector on 127.0.0.1:9229 failed: address already in use" — the
+  // service's own log is the only trace). Verified empirically. The deployed
+  // entrypoint dodges this with a `[ "$1" = "node" ]` gate, but that only works
+  // because the entrypoint IS the exec wrapper; there is no such hop here.
+  // `ss stack profile` therefore presets nothing and lets SIGUSR1 open the
+  // inspector on its default port — see core/inspector.ts.
+
   // Lane overrides win (env last-wins, matching up.sh's trailing splat).
   return { ...env, ...laneOverlay(service, lane, ctx) };
 }

--- a/packages/node/saga-stack-cli/src/core/launch-plan.ts
+++ b/packages/node/saga-stack-cli/src/core/launch-plan.ts
@@ -521,15 +521,9 @@ export function resolveLaunchEnv(
     env[portEnvVar] = String(ctx.ports[service]);
   }
 
-  // NOTE (attach-mode profiling): do NOT inject `--inspect-port` here. NODE_OPTIONS
-  // is inherited by the WHOLE launch tree, so pnpm and tsup would each reserve the
-  // same port and the real `node dist/main.js` then fails to bind it
-  // ("Starting inspector on 127.0.0.1:9229 failed: address already in use" — the
-  // service's own log is the only trace). Verified empirically. The deployed
-  // entrypoint dodges this with a `[ "$1" = "node" ]` gate, but that only works
-  // because the entrypoint IS the exec wrapper; there is no such hop here.
-  // `ss stack profile` therefore presets nothing and lets SIGUSR1 open the
-  // inspector on its default port — see core/inspector.ts.
+  // Do NOT inject `--inspect-port` here: NODE_OPTIONS reaches the whole
+  // pnpm→tsup→node tree, so a wrapper reserves the port and the service fails to
+  // bind it. See core/inspector.ts and docs/instrumentation.md.
 
   // Lane overrides win (env last-wins, matching up.sh's trailing splat).
   return { ...env, ...laneOverlay(service, lane, ctx) };

--- a/packages/node/saga-stack-cli/src/core/profile-plan.ts
+++ b/packages/node/saga-stack-cli/src/core/profile-plan.ts
@@ -29,7 +29,7 @@ export interface ProfileTarget {
    * the CDP client disconnects, so the target's own inspector is a re-attach, not a
    * conflict.
    */
-  inspectorPortPid?: number | null;
+  inspectorPortPid: number | null;
 }
 
 /**

--- a/packages/node/saga-stack-cli/src/core/profile-plan.ts
+++ b/packages/node/saga-stack-cli/src/core/profile-plan.ts
@@ -1,0 +1,146 @@
+/**
+ * Attach-mode profiling: the PURE decision layer.
+ *
+ * Everything here is arithmetic + validation over already-gathered facts; the IO
+ * (resolving the listening pid, signalling, speaking CDP, writing the artifact)
+ * lives in `runtime/profiler.ts`. Splitting it this way keeps the parts that can
+ * silently do the WRONG thing — attaching to a wrapper, profiling a stale port —
+ * unit-testable without spawning anything.
+ *
+ * The failure this module exists to prevent: a profile that succeeds against the
+ * wrong process. `ss` records the `pnpm dev` WRAPPER pid in `<stateDir>/<id>.pid`,
+ * while the real service is a `node dist/main.js` grandchild 4 levels deeper
+ * (tsup re-spawns it on every rebuild, so its pid also churns). Profiling the
+ * recorded pid would silently sample the package manager. Ownership is therefore
+ * proven the way `classifyForeign` does it — resolve the pid LISTENING on the
+ * service's port, then require its pgid to match a pidfile-recorded pid.
+ */
+
+import { inspectorPort } from './inspector.js';
+import { getService, manifest as defaultManifest } from './manifest/index.js';
+import type { Manifest, ServiceId } from './manifest/index.js';
+
+/** What the runtime must gather before a profile can be planned. */
+export interface ProfileTarget {
+  /** The pid LISTENING on the service's port (`ForeignIo.pidOnPort`), or null. */
+  listenerPid: number | null;
+  /** That pid's process group + argv (`ForeignIo.procInfo`), or null. */
+  proc: { pgid: number; command: string } | null;
+  /** Pids recorded in this slot's pidfiles (`ForeignIo.ownedPgids`). */
+  ownedPgids: number[];
+  /** True when something already holds the inspector port (a stale/other session). */
+  inspectorPortBusy: boolean;
+}
+
+export type ProfilePlan =
+  | { ok: true; pid: number; port: number; command: string; adopted: boolean }
+  | { ok: false; reason: string };
+
+/** Human-facing hint appended to every "service isn't up" refusal. */
+const UP_HINT = 'Bring it up first: `ss stack up --only <service>`.';
+
+/**
+ * Decide whether `service` can be profiled, and on which pid/port.
+ *
+ * Refuses (rather than guessing) when:
+ *  - the service is a frontend — `pnpm dev` there is a Vite dev server, so a
+ *    profile would measure the bundler, not the app;
+ *  - nothing is listening on its port — it isn't up;
+ *  - the listening process can't be inspected (`procInfo` failed);
+ *  - the inspector port is already held — SIGUSR1 would fail SILENTLY (the only
+ *    trace is `address already in use` in the SERVICE's log) and the profiler
+ *    would then attach to whatever already owns that port. This is the feature's
+ *    sharpest footgun, so it is a hard error, never a warning.
+ *
+ * An unowned listener (pgid matches no pidfile) is allowed but reported via
+ * `adopted: false` so the caller can say whose process it is profiling — a
+ * foreign process is still profilable, it just wasn't launched by this slot.
+ */
+export function planProfile(
+  service: ServiceId,
+  slot: number,
+  target: ProfileTarget,
+  m: Manifest = defaultManifest,
+): ProfilePlan {
+  const def = getService(service, m);
+  if (def.isFrontend) {
+    return {
+      ok: false,
+      reason: `${service} is a frontend — \`pnpm dev\` runs a Vite dev server, so a CPU profile would measure the bundler, not the app.`,
+    };
+  }
+
+  const port = inspectorPort(service, slot, m);
+  if (port === null) {
+    return { ok: false, reason: `${service} has no inspector port (not profilable).` };
+  }
+
+  if (target.listenerPid === null) {
+    return { ok: false, reason: `${service} is not listening — nothing to profile. ${UP_HINT}` };
+  }
+
+  if (target.proc === null) {
+    return {
+      ok: false,
+      reason: `${service}: pid ${target.listenerPid} holds the port but is no longer inspectable (it exited mid-check). Re-run.`,
+    };
+  }
+
+  if (target.inspectorPortBusy) {
+    return {
+      ok: false,
+      reason:
+        `${service}: inspector port ${port} is already in use. SIGUSR1 cannot choose a port, so the ` +
+        `service would fail to open its inspector SILENTLY and this profile would attach to the ` +
+        `wrong process. Close the existing inspector (or profile a different service) and re-run.`,
+    };
+  }
+
+  return {
+    ok: true,
+    pid: target.listenerPid,
+    port,
+    command: target.proc.command,
+    adopted: target.ownedPgids.includes(target.proc.pgid),
+  };
+}
+
+/** Parse a `--duration` like `30s` / `500ms` / `2m` / a bare seconds count. */
+export function parseDuration(input: string): number | null {
+  const m = /^(\d+(?:\.\d+)?)(ms|s|m)?$/.exec(input.trim());
+  if (!m) return null;
+  const value = Number.parseFloat(m[1]!);
+  if (!Number.isFinite(value) || value <= 0) return null;
+  const unit = m[2] ?? 's';
+  const ms = unit === 'ms' ? value : unit === 'm' ? value * 60_000 : value * 1000;
+  return Math.round(ms);
+}
+
+/**
+ * Default artifact path: slot-scoped state dir, service + a caller-supplied
+ * timestamp so repeat runs don't overwrite each other. The timestamp is passed in
+ * (not read from a clock) to keep this pure.
+ */
+export function defaultArtifactPath(stateDir: string, service: ServiceId, stamp: string): string {
+  return `${stateDir.replace(/\/+$/, '')}/${service}-${stamp}.cpuprofile`;
+}
+
+/**
+ * Does a captured profile actually contain the SERVICE's own frames?
+ *
+ * The positive signal that separates a real capture from a wrapper profile: at
+ * least one sampled frame whose script URL sits under the service's own directory.
+ * A profile of pnpm/tsup has plenty of nodes but none from `<subpath>/dist`, which
+ * is exactly how the earlier `--cpu-prof` attempt looked "successful" while being
+ * useless.
+ */
+export function profileHasServiceFrames(
+  profile: { nodes?: Array<{ hitCount?: number; callFrame?: { url?: string } }> },
+  service: ServiceId,
+  m: Manifest = defaultManifest,
+): boolean {
+  const needle = `${getService(service, m).subpath}/dist`;
+  return (profile.nodes ?? []).some(
+    (n) => (n.hitCount ?? 0) >= 0 && (n.callFrame?.url ?? '').includes(needle),
+  );
+}

--- a/packages/node/saga-stack-cli/src/core/profile-plan.ts
+++ b/packages/node/saga-stack-cli/src/core/profile-plan.ts
@@ -9,7 +9,7 @@
  * the pidfiles for ownership (the `classifyForeign` approach). See `inspector.ts`.
  */
 
-import { inspectorPort } from './inspector.js';
+import { INSPECTOR_PORT } from './inspector.js';
 import { getService, manifest as defaultManifest } from './manifest/index.js';
 import type { Manifest, ServiceId } from './manifest/index.js';
 
@@ -32,9 +32,19 @@ export interface ProfileTarget {
   inspectorPortPid?: number | null;
 }
 
-/** SIGUSR1's default disposition is TERMINATE, so only signal a real node process. */
-function looksLikeNode(command: string): boolean {
-  return /(^|\/|\s)node(\s|$)|\bnode$/.test(command.split(/\s+/)[0] ?? '') || /(^|\/)node\b/.test(command);
+/**
+ * SIGUSR1's default disposition is TERMINATE, so only signal a real node process.
+ * Match argv[0]'s BASENAME only: a `/node/` path segment anywhere else in the
+ * command line belongs to some other runtime's arguments, and signalling it kills it.
+ */
+export function looksLikeNode(command: string): boolean {
+  const argv = command.trim().split(/\s+/);
+  let exe = argv[0] ?? '';
+  // `env` execs its first non-assignment argument, so unwrap to the real binary.
+  if (/(^|\/)env$/.test(exe)) {
+    exe = argv.slice(1).find((a) => !/^[A-Za-z_][A-Za-z0-9_]*=/.test(a)) ?? '';
+  }
+  return /^node(js)?(-[\d.]+)?$/.test(exe.split('/').pop() ?? '');
 }
 
 export type ProfilePlan =
@@ -63,7 +73,6 @@ const UP_HINT = 'Bring it up first: `ss stack up --only <service>`.';
  */
 export function planProfile(
   service: ServiceId,
-  slot: number,
   target: ProfileTarget,
   m: Manifest = defaultManifest,
 ): ProfilePlan {
@@ -73,11 +82,6 @@ export function planProfile(
       ok: false,
       reason: `${service} is a frontend — \`pnpm dev\` runs a Vite dev server, so a CPU profile would measure the bundler, not the app.`,
     };
-  }
-
-  const port = inspectorPort(service, slot, m);
-  if (port === null) {
-    return { ok: false, reason: `${service} has no inspector port (not profilable).` };
   }
 
   if (target.listenerPid === null) {
@@ -111,16 +115,17 @@ export function planProfile(
     return {
       ok: false,
       reason:
-        `${service}: inspector port ${port} is held by ${who}, not by the service. SIGUSR1 cannot ` +
-        `choose a port, so the service could not open its own inspector and this profile would ` +
-        `attach to the wrong process. Free the port (or profile in another slot) and re-run.`,
+        `${service}: inspector port ${INSPECTOR_PORT} is held by ${who}, not by the service. SIGUSR1 ` +
+        `cannot choose a port, so the service could not open its own inspector and this profile ` +
+        `would attach to the wrong process. The port takes no slot offset, so another slot is not ` +
+        `an escape — free it and re-run.`,
     };
   }
 
   return {
     ok: true,
     pid: target.listenerPid,
-    port,
+    port: INSPECTOR_PORT,
     command: target.proc.command,
     adopted: target.ownedPgids.includes(target.proc.pgid),
     // Already listening ⇒ SIGUSR1 is unnecessary (and would be a no-op on an open

--- a/packages/node/saga-stack-cli/src/core/profile-plan.ts
+++ b/packages/node/saga-stack-cli/src/core/profile-plan.ts
@@ -1,19 +1,12 @@
 /**
- * Attach-mode profiling: the PURE decision layer.
- *
- * Everything here is arithmetic + validation over already-gathered facts; the IO
- * (resolving the listening pid, signalling, speaking CDP, writing the artifact)
- * lives in `runtime/profiler.ts`. Splitting it this way keeps the parts that can
- * silently do the WRONG thing — attaching to a wrapper, profiling a stale port —
+ * Attach-mode profiling: the PURE decision layer. IO lives in
+ * `runtime/profiler.ts`, so the parts that can silently do the WRONG thing stay
  * unit-testable without spawning anything.
  *
- * The failure this module exists to prevent: a profile that succeeds against the
- * wrong process. `ss` records the `pnpm dev` WRAPPER pid in `<stateDir>/<id>.pid`,
- * while the real service is a `node dist/main.js` grandchild 4 levels deeper
- * (tsup re-spawns it on every rebuild, so its pid also churns). Profiling the
- * recorded pid would silently sample the package manager. Ownership is therefore
- * proven the way `classifyForeign` does it — resolve the pid LISTENING on the
- * service's port, then require its pgid to match a pidfile-recorded pid.
+ * The failure guarded against: a profile that succeeds against the wrong process.
+ * `<stateDir>/<id>.pid` holds the `pnpm dev` WRAPPER pid, not the service — so the
+ * target is the pid LISTENING on the service's port, with its pgid matched against
+ * the pidfiles for ownership (the `classifyForeign` approach). See `inspector.ts`.
  */
 
 import { inspectorPort } from './inspector.js';
@@ -30,10 +23,22 @@ export interface ProfileTarget {
   ownedPgids: number[];
   /** True when something already holds the inspector port (a stale/other session). */
   inspectorPortBusy: boolean;
+  /**
+   * The pid holding the inspector port, when it could be resolved. A held port is
+   * only an obstacle if someone ELSE holds it: Node keeps the inspector open after
+   * the CDP client disconnects, so the target's own inspector is a re-attach, not a
+   * conflict.
+   */
+  inspectorPortPid?: number | null;
+}
+
+/** SIGUSR1's default disposition is TERMINATE, so only signal a real node process. */
+function looksLikeNode(command: string): boolean {
+  return /(^|\/|\s)node(\s|$)|\bnode$/.test(command.split(/\s+/)[0] ?? '') || /(^|\/)node\b/.test(command);
 }
 
 export type ProfilePlan =
-  | { ok: true; pid: number; port: number; command: string; adopted: boolean }
+  | { ok: true; pid: number; port: number; command: string; adopted: boolean; alreadyOpen: boolean }
   | { ok: false; reason: string };
 
 /** Human-facing hint appended to every "service isn't up" refusal. */
@@ -86,13 +91,29 @@ export function planProfile(
     };
   }
 
-  if (target.inspectorPortBusy) {
+  // SIGUSR1 to a non-node process TERMINATES it (no handler ⇒ default disposition),
+  // so never signal a listener we can't identify as node.
+  if (!looksLikeNode(target.proc.command)) {
     return {
       ok: false,
       reason:
-        `${service}: inspector port ${port} is already in use. SIGUSR1 cannot choose a port, so the ` +
-        `service would fail to open its inspector SILENTLY and this profile would attach to the ` +
-        `wrong process. Close the existing inspector (or profile a different service) and re-run.`,
+        `${service}: pid ${target.listenerPid} holds port but is not a node process ` +
+        `(${target.proc.command}). Refusing — SIGUSR1 would kill it rather than open an inspector.`,
+    };
+  }
+
+  // A held inspector port blocks us only when someone ELSE holds it. Node leaves the
+  // inspector open after the CDP client disconnects, so the target's own inspector is
+  // a re-attach; refusing there would make the command single-use per service.
+  if (target.inspectorPortBusy && target.inspectorPortPid !== target.listenerPid) {
+    const who =
+      target.inspectorPortPid == null ? 'another process' : `pid ${target.inspectorPortPid}`;
+    return {
+      ok: false,
+      reason:
+        `${service}: inspector port ${port} is held by ${who}, not by the service. SIGUSR1 cannot ` +
+        `choose a port, so the service could not open its own inspector and this profile would ` +
+        `attach to the wrong process. Free the port (or profile in another slot) and re-run.`,
     };
   }
 
@@ -102,6 +123,9 @@ export function planProfile(
     port,
     command: target.proc.command,
     adopted: target.ownedPgids.includes(target.proc.pgid),
+    // Already listening ⇒ SIGUSR1 is unnecessary (and would be a no-op on an open
+    // inspector); the runtime skips the signal and attaches directly.
+    alreadyOpen: target.inspectorPortBusy && target.inspectorPortPid === target.listenerPid,
   };
 }
 
@@ -139,8 +163,13 @@ export function profileHasServiceFrames(
   service: ServiceId,
   m: Manifest = defaultManifest,
 ): boolean {
-  const needle = `${getService(service, m).subpath}/dist`;
+  // Match the service's DIRECTORY, not a build subdir: tsup services run from
+  // `<subpath>/dist` but tsx-watch ones (staff-admin-bff) run straight from
+  // `<subpath>/src`, and pinning `/dist` reports every valid tsx capture as empty.
+  const needle = `${getService(service, m).subpath}/`;
+  // hitCount > 0 — a profile's `nodes` is the whole call tree, so parent and
+  // parse-time nodes with hitCount 0 exist even when the service never ran.
   return (profile.nodes ?? []).some(
-    (n) => (n.hitCount ?? 0) >= 0 && (n.callFrame?.url ?? '').includes(needle),
+    (n) => (n.hitCount ?? 0) > 0 && (n.callFrame?.url ?? '').includes(needle),
   );
 }

--- a/packages/node/saga-stack-cli/src/core/profile-plan.ts
+++ b/packages/node/saga-stack-cli/src/core/profile-plan.ts
@@ -128,8 +128,8 @@ export function planProfile(
     port: INSPECTOR_PORT,
     command: target.proc.command,
     adopted: target.ownedPgids.includes(target.proc.pgid),
-    // Already listening ⇒ SIGUSR1 is unnecessary (and would be a no-op on an open
-    // inspector); the runtime skips the signal and attaches directly.
+    // Our own inspector already open ⇒ SIGUSR1 is a no-op; attach directly. Keep
+    // both conjuncts: this must not depend on the refusal above staying in place.
     alreadyOpen: target.inspectorPortBusy && target.inspectorPortPid === target.listenerPid,
   };
 }
@@ -159,9 +159,8 @@ export function defaultArtifactPath(stateDir: string, service: ServiceId, stamp:
  *
  * The positive signal that separates a real capture from a wrapper profile: at
  * least one sampled frame whose script URL sits under the service's own directory.
- * A profile of pnpm/tsup has plenty of nodes but none from `<subpath>/dist`, which
- * is exactly how the earlier `--cpu-prof` attempt looked "successful" while being
- * useless.
+ * A profile of pnpm/tsup has plenty of nodes but none from the service's subpath,
+ * so node count alone cannot tell the two apart.
  */
 export function profileHasServiceFrames(
   profile: { nodes?: Array<{ hitCount?: number; callFrame?: { url?: string } }> },

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/profiler.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/profiler.unit.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Capture-path identity guard. Every seam is injected, so no service is signalled.
+ *
+ * The port answering is not proof the TARGET answered: `inspector.open()` on a
+ * taken port logs `address already in use` and returns, leaving the loser running
+ * with no inspector while the first service's inspector keeps serving /json/list.
+ * /json/list carries no pid, so these pin the port-owner check that stands between
+ * a concurrent profile and a successful capture of the wrong process.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { captureCpuProfile, type CdpSession, type ProfilerDeps } from '../profiler.js';
+
+const PROFILE = { nodes: [{ id: 1 }], samples: [1], timeDeltas: [0] };
+
+/** A CDP session that yields a minimal valid profile. */
+function fakeSession(): CdpSession {
+  return {
+    send: async (method: string) => (method === 'Profiler.stop' ? { profile: PROFILE } : {}),
+    close: () => {},
+  };
+}
+
+/** Deps whose every seam is faked; `over` supplies the case under test. */
+function deps(over: Partial<ProfilerDeps> = {}): ProfilerDeps {
+  return {
+    signal: () => {},
+    fetchJson: async () => [{ webSocketDebuggerUrl: 'ws://127.0.0.1:9229/x', type: 'node' }],
+    connect: async () => fakeSession(),
+    sleep: async () => {},
+    writeFile: () => {},
+    portOwner: async () => 4242,
+    ...over,
+  };
+}
+
+const request = { pid: 4242, port: 9229, durationMs: 1, outPath: '/tmp/x.cpuprofile' };
+
+describe('captureCpuProfile — inspector port identity', () => {
+  it('captures when the port owner IS the signalled pid', async () => {
+    const result = await captureCpuProfile(request, deps());
+    expect(result).toMatchObject({ ok: true, outPath: '/tmp/x.cpuprofile' });
+  });
+
+  it('REFUSES when the port is owned by a different pid', async () => {
+    // The concurrent-profile case: another service's inspector is still open here,
+    // and /json/list would answer for it under our pid's name.
+    const result = await captureCpuProfile(request, deps({ portOwner: async () => 9999 }));
+    expect(result).toMatchObject({ ok: false });
+    if (result.ok) throw new Error('expected refusal');
+    expect(result.reason).toMatch(/held by pid 9999, not 4242/);
+  });
+
+  it('REFUSES when the owner cannot be resolved — unknown is not permission', async () => {
+    const result = await captureCpuProfile(request, deps({ portOwner: async () => null }));
+    expect(result).toMatchObject({ ok: false });
+    if (result.ok) throw new Error('expected refusal');
+    expect(result.reason).toMatch(/unidentifiable process/);
+  });
+
+  it('still checks identity on the re-attach path, which skips SIGUSR1', async () => {
+    let signalled = false;
+    const over = { signal: () => { signalled = true; } };
+    const ok = await captureCpuProfile({ ...request, alreadyOpen: true }, deps(over));
+    expect(ok).toMatchObject({ ok: true });
+    expect(signalled).toBe(false);
+
+    const stolen = await captureCpuProfile(
+      { ...request, alreadyOpen: true },
+      deps({ ...over, portOwner: async () => 9999 }),
+    );
+    expect(stolen).toMatchObject({ ok: false });
+  });
+
+  it('reports the inspector-never-answered case rather than capturing nothing', async () => {
+    const result = await captureCpuProfile(
+      request,
+      deps({ fetchJson: async () => [], attempts: 2 }),
+    );
+    expect(result).toMatchObject({ ok: false });
+    if (result.ok) throw new Error('expected refusal');
+    expect(result.reason).toMatch(/never came up/);
+  });
+
+  it('surfaces a write failure without claiming the profiling failed', async () => {
+    const result = await captureCpuProfile(
+      request,
+      deps({
+        writeFile: () => {
+          throw new Error('ENOENT');
+        },
+      }),
+    );
+    expect(result).toMatchObject({ ok: false });
+    if (result.ok) throw new Error('expected refusal');
+    expect(result.reason).toMatch(/captured OK but could not write/);
+  });
+});

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/profiler.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/profiler.unit.test.ts
@@ -82,6 +82,27 @@ describe('captureCpuProfile — inspector port identity', () => {
     expect(result.reason).toMatch(/never came up/);
   });
 
+  it('stops polling on the wall-clock budget, not just the attempt count', async () => {
+    // A holder that accepts TCP but never answers burns the full per-attempt
+    // timeout, so 30 attempts alone would block far longer than the budget.
+    let clock = 0;
+    let calls = 0;
+    const result = await captureCpuProfile(
+      request,
+      deps({
+        now: () => clock,
+        pollBudgetMs: 500,
+        fetchJson: async () => {
+          calls += 1;
+          clock += 2000;
+          return [];
+        },
+      }),
+    );
+    expect(result).toMatchObject({ ok: false });
+    expect(calls).toBe(1);
+  });
+
   it('surfaces a write failure without claiming the profiling failed', async () => {
     const result = await captureCpuProfile(
       request,

--- a/packages/node/saga-stack-cli/src/runtime/profiler.ts
+++ b/packages/node/saga-stack-cli/src/runtime/profiler.ts
@@ -17,8 +17,11 @@
  * Uses Node's global `WebSocket` — the `ws` package is not resolvable here.
  */
 
-import { writeFileSync } from 'node:fs';
+import { execFile } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
 import { Socket } from 'node:net';
+import { dirname } from 'node:path';
+import { promisify } from 'node:util';
 
 /** A V8 CPU profile as returned by `Profiler.stop`. */
 export interface CpuProfile {
@@ -38,12 +41,16 @@ export interface ProfilerDeps {
   connect?: (wsUrl: string) => Promise<CdpSession>;
   /** Sleep. Default a real timer. */
   sleep?: (ms: number) => Promise<void>;
-  /** Write the artifact. Default `fs.writeFileSync`. */
+  /** Write the artifact, creating parent dirs. Default `fs.writeFileSync` + `mkdirSync`. */
   writeFile?: (path: string, body: string) => void;
+  /** Resolve the pid listening on a port, for the post-signal identity check. */
+  portOwner?: (port: number) => Promise<number | null>;
   /** Attempts to wait for the inspector to answer after SIGUSR1. Default 30. */
   attempts?: number;
   /** Delay between those attempts, ms. Default 100. */
   intervalMs?: number;
+  /** Per-attempt HTTP timeout, ms — the dominant term in the poll's worst case. Default 2000. */
+  fetchTimeoutMs?: number;
 }
 
 /** The minimal CDP surface the capture needs. */
@@ -160,16 +167,24 @@ export async function captureCpuProfile(
   deps: ProfilerDeps = {},
 ): Promise<CaptureResult> {
   const signal = deps.signal ?? ((pid, sig) => process.kill(pid, sig));
+  const attempts = deps.attempts ?? 30;
+  const intervalMs = deps.intervalMs ?? 100;
+  const fetchTimeoutMs = deps.fetchTimeoutMs ?? 2000;
   // AbortSignal is mandatory here: a holder that accepts TCP but never answers HTTP
   // makes a bare fetch() hang forever, defeating the poll loop's own attempt bound.
   const fetchJson =
     deps.fetchJson ??
-    (async (url: string) => (await fetch(url, { signal: AbortSignal.timeout(2000) })).json());
+    (async (url: string) =>
+      (await fetch(url, { signal: AbortSignal.timeout(fetchTimeoutMs) })).json());
   const connect = deps.connect ?? defaultConnect;
   const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
-  const writeFile = deps.writeFile ?? ((p: string, b: string) => writeFileSync(p, b));
-  const attempts = deps.attempts ?? 30;
-  const intervalMs = deps.intervalMs ?? 100;
+  const writeFile =
+    deps.writeFile ??
+    ((p: string, b: string) => {
+      mkdirSync(dirname(p), { recursive: true });
+      writeFileSync(p, b);
+    });
+  const portOwner = deps.portOwner ?? defaultPortOwner;
 
   if (!req.alreadyOpen) {
     try {
@@ -209,6 +224,22 @@ export async function captureCpuProfile(
       reason:
         `inspector never came up on port ${req.port} after SIGUSR1. The service may have failed to ` +
         `bind it — check its log for "address already in use".`,
+    };
+  }
+
+  // The port answering is NOT proof it is OUR target answering. `inspector.open()`
+  // on a taken port logs "address already in use" and returns normally, leaving the
+  // loser running with no inspector — so a concurrent profile finds the FIRST
+  // service's still-open inspector here and would capture it under our pid's name.
+  // /json/list carries no pid, so identity comes from the port's actual owner.
+  const owner = await portOwner(req.port);
+  if (owner !== null && owner !== req.pid) {
+    return {
+      ok: false,
+      reason:
+        `inspector port ${req.port} is held by pid ${owner}, not ${req.pid}. Profiling is ` +
+        `machine-wide (Node's inspector port takes no slot offset) — wait for the other ` +
+        `profile to finish, then retry.`,
     };
   }
 
@@ -263,6 +294,20 @@ export async function inspectorPortBusy(
 ): Promise<boolean> {
   const probe = deps.probeTcp ?? tcpListening;
   return probe(port, 1000);
+}
+
+/**
+ * The pid listening on `port`, or null when it can't be resolved. Null is
+ * inconclusive, never "free" — callers must not read it as permission to proceed.
+ */
+async function defaultPortOwner(port: number): Promise<number | null> {
+  try {
+    const { stdout } = await promisify(execFile)('lsof', ['-ti', `:${port}`, '-sTCP:LISTEN']);
+    const pid = Number.parseInt(stdout.trim().split('\n')[0] ?? '', 10);
+    return Number.isFinite(pid) ? pid : null;
+  } catch {
+    return null;
+  }
 }
 
 /** Resolve true when a TCP connect to 127.0.0.1:port succeeds within `timeoutMs`. */

--- a/packages/node/saga-stack-cli/src/runtime/profiler.ts
+++ b/packages/node/saga-stack-cli/src/runtime/profiler.ts
@@ -231,13 +231,15 @@ export async function captureCpuProfile(
   // on a taken port logs "address already in use" and returns normally, leaving the
   // loser running with no inspector — so a concurrent profile finds the FIRST
   // service's still-open inspector here and would capture it under our pid's name.
-  // /json/list carries no pid, so identity comes from the port's actual owner.
+  // /json/list carries no pid, so identity comes from the port's actual owner, and
+  // an UNRESOLVABLE owner refuses too: unknown is not permission to sample.
   const owner = await portOwner(req.port);
-  if (owner !== null && owner !== req.pid) {
+  if (owner !== req.pid) {
+    const who = owner === null ? 'an unidentifiable process' : `pid ${owner}`;
     return {
       ok: false,
       reason:
-        `inspector port ${req.port} is held by pid ${owner}, not ${req.pid}. Profiling is ` +
+        `inspector port ${req.port} is held by ${who}, not ${req.pid}. Profiling is ` +
         `machine-wide (Node's inspector port takes no slot offset) — wait for the other ` +
         `profile to finish, then retry.`,
     };
@@ -298,7 +300,10 @@ export async function inspectorPortBusy(
 
 /**
  * The pid listening on `port`, or null when it can't be resolved. Null is
- * inconclusive, never "free" — callers must not read it as permission to proceed.
+ * inconclusive, never "free" — the caller refuses on it.
+ *
+ * Duplicates `ForeignIo.pidOnPort`; fold the two together so plan-time and
+ * post-signal can never disagree about who owns the port.
  */
 async function defaultPortOwner(port: number): Promise<number | null> {
   try {

--- a/packages/node/saga-stack-cli/src/runtime/profiler.ts
+++ b/packages/node/saga-stack-cli/src/runtime/profiler.ts
@@ -307,16 +307,7 @@ export async function captureCpuProfile(
  * are missing, which is right for a preflight warning and wrong here, where the
  * answer gates a hard refusal.
  */
-export async function inspectorPortBusy(
-  port: number,
-  deps: { probeTcp?: (port: number, timeoutMs: number) => Promise<boolean> } = {},
-): Promise<boolean> {
-  const probe = deps.probeTcp ?? tcpListening;
-  return probe(port, 1000);
-}
-
-/** Resolve true when a TCP connect to 127.0.0.1:port succeeds within `timeoutMs`. */
-function tcpListening(port: number, timeoutMs: number): Promise<boolean> {
+export function inspectorPortBusy(port: number, timeoutMs = 1000): Promise<boolean> {
   return new Promise((resolve) => {
     const socket = new Socket();
     const done = (held: boolean) => {

--- a/packages/node/saga-stack-cli/src/runtime/profiler.ts
+++ b/packages/node/saga-stack-cli/src/runtime/profiler.ts
@@ -5,21 +5,16 @@
  * decision logic is pure in `core/profile-plan.ts`. Every seam is injectable so
  * the command's wiring is testable without a real service.
  *
- * The capture sequence, and why each step is needed:
- *   1. SIGUSR1 the LISTENING pid — Node opens the V8 inspector on demand. No
- *      launch-time flag is involved, which is the whole point: the app process is
- *      a `node dist/main.js` grandchild nested inside tsup's quoted `--onSuccess`,
- *      so nothing injected at `pnpm dev` time ever reaches it.
- *   2. Poll `GET /json/list` until the inspector answers — SIGUSR1 is asynchronous.
- *   3. Speak CDP over the returned websocket: `Profiler.enable` → `.start` →
- *      wait → `.stop`, which RETURNS the profile inline.
+ * The capture sequence:
+ *   1. SIGUSR1 the LISTENING pid — Node opens the V8 inspector on demand, so no
+ *      launch-time flag is needed (see `core/inspector.ts` for why that matters).
+ *   2. Poll `GET /json/list` until it answers — SIGUSR1 is asynchronous.
+ *   3. `Profiler.enable` → `.start` → wait → `.stop`, which returns the profile.
  *
- * Because the artifact arrives over the wire while the process is alive, it does
- * NOT depend on a clean exit — unlike `--cpu-prof`, which writes only on graceful
- * shutdown and therefore produced nothing under `ss stack down`'s group-SIGKILL.
+ * The artifact arrives over the wire while the process is alive, so it survives
+ * the group-SIGKILL that `ss stack down` performs.
  *
- * No new dependency: Node 24 ships a global `WebSocket` (and `ws` is not resolvable
- * from this package anyway).
+ * Uses Node's global `WebSocket` — the `ws` package is not resolvable here.
  */
 
 import { writeFileSync } from 'node:fs';
@@ -62,8 +57,8 @@ export interface CaptureRequest {
   port: number;
   durationMs: number;
   outPath: string;
-  /** Invoked once the profiler is running, so the caller can drive load. */
-  onProfiling?: () => Promise<void> | void;
+  /** Skip SIGUSR1 — the target's inspector is already open (a re-attach). */
+  alreadyOpen?: boolean;
 }
 
 export type CaptureResult =
@@ -73,25 +68,52 @@ export type CaptureResult =
 /** Open a CDP session using Node's built-in global WebSocket (no `ws` dependency). */
 async function defaultConnect(wsUrl: string): Promise<CdpSession> {
   const socket = new WebSocket(wsUrl);
-  const pending = new Map<number, (result: Record<string, unknown>) => void>();
+  type Waiter = { resolve: (r: Record<string, unknown>) => void; reject: (e: Error) => void };
+  const pending = new Map<number, Waiter>();
   let nextId = 0;
 
-  // Bounded: an unreachable/half-open inspector must surface as an error, not a hang.
+  // Bounded, and the socket is closed on EVERY reject path — the caller's
+  // `finally { session.close() }` cannot run for a connect that never returned.
   await new Promise<void>((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error(`inspector websocket timed out: ${wsUrl}`)), 10_000);
+    const fail = (err: Error) => {
+      socket.close();
+      reject(err);
+    };
+    const timer = setTimeout(() => fail(new Error(`inspector websocket timed out: ${wsUrl}`)), 10_000);
     socket.onopen = () => {
       clearTimeout(timer);
       resolve();
     };
     socket.onerror = () => {
       clearTimeout(timer);
-      reject(new Error(`inspector websocket failed: ${wsUrl}`));
+      fail(new Error(`inspector websocket failed: ${wsUrl}`));
     };
   });
 
   socket.onmessage = (event: MessageEvent) => {
-    const msg = JSON.parse(String(event.data)) as { id?: number; result?: Record<string, unknown> };
-    if (typeof msg.id === 'number') pending.get(msg.id)?.(msg.result ?? {});
+    const msg = JSON.parse(String(event.data)) as {
+      id?: number;
+      result?: Record<string, unknown>;
+      error?: { message?: string; code?: number };
+    };
+    if (typeof msg.id !== 'number') return;
+    const waiter = pending.get(msg.id);
+    if (!waiter) return;
+    pending.delete(msg.id);
+    // A CDP `error` reply must REJECT — resolving it as {} let a failed
+    // Profiler.enable/start pass silently and produced a capture against a
+    // profiler that was never started.
+    if (msg.error) waiter.reject(new Error(`CDP error: ${msg.error.message ?? 'unknown'}`));
+    else waiter.resolve(msg.result ?? {});
+  };
+
+  // A mid-capture disconnect should surface immediately, not stall every
+  // outstanding request for the full send timeout.
+  socket.onclose = () => {
+    for (const [id, waiter] of pending) {
+      pending.delete(id);
+      waiter.reject(new Error('inspector connection closed mid-capture'));
+    }
   };
 
   // A socket that opens and THEN errors (or a command the target never answers)
@@ -107,9 +129,15 @@ async function defaultConnect(wsUrl: string): Promise<CdpSession> {
           pending.delete(id);
           reject(new Error(`${method} timed out after ${SEND_TIMEOUT_MS}ms`));
         }, SEND_TIMEOUT_MS);
-        pending.set(id, (result) => {
-          clearTimeout(timer);
-          resolve(result);
+        pending.set(id, {
+          resolve: (result) => {
+            clearTimeout(timer);
+            resolve(result);
+          },
+          reject: (err) => {
+            clearTimeout(timer);
+            reject(err);
+          },
         });
         socket.send(JSON.stringify({ id, method, params }));
       });
@@ -132,17 +160,23 @@ export async function captureCpuProfile(
   deps: ProfilerDeps = {},
 ): Promise<CaptureResult> {
   const signal = deps.signal ?? ((pid, sig) => process.kill(pid, sig));
-  const fetchJson = deps.fetchJson ?? (async (url: string) => (await fetch(url)).json());
+  // AbortSignal is mandatory here: a holder that accepts TCP but never answers HTTP
+  // makes a bare fetch() hang forever, defeating the poll loop's own attempt bound.
+  const fetchJson =
+    deps.fetchJson ??
+    (async (url: string) => (await fetch(url, { signal: AbortSignal.timeout(2000) })).json());
   const connect = deps.connect ?? defaultConnect;
   const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
   const writeFile = deps.writeFile ?? ((p: string, b: string) => writeFileSync(p, b));
   const attempts = deps.attempts ?? 30;
   const intervalMs = deps.intervalMs ?? 100;
 
-  try {
-    signal(req.pid, 'SIGUSR1');
-  } catch (err) {
-    return { ok: false, reason: `could not signal pid ${req.pid}: ${(err as Error).message}` };
+  if (!req.alreadyOpen) {
+    try {
+      signal(req.pid, 'SIGUSR1');
+    } catch (err) {
+      return { ok: false, reason: `could not signal pid ${req.pid}: ${(err as Error).message}` };
+    }
   }
 
   // SIGUSR1 is async — poll until the inspector's HTTP endpoint answers.
@@ -151,8 +185,18 @@ export async function captureCpuProfile(
     try {
       const list = (await fetchJson(`http://127.0.0.1:${req.port}/json/list`)) as Array<{
         webSocketDebuggerUrl?: string;
+        type?: string;
+        title?: string;
       }>;
-      wsUrl = list?.[0]?.webSocketDebuggerUrl;
+      // Prefer the MAIN thread: a service using worker_threads publishes a target
+      // per worker, and taking list[0] blindly can profile a worker while
+      // reporting success for the service.
+      const targets = (list ?? []).filter((t) => t.webSocketDebuggerUrl !== undefined);
+      const main =
+        targets.find((t) => t.type === 'node' && !/worker/i.test(t.title ?? '')) ??
+        targets.find((t) => t.type === 'node') ??
+        targets[0];
+      wsUrl = main?.webSocketDebuggerUrl;
       if (wsUrl !== undefined) break;
     } catch {
       // not up yet
@@ -175,23 +219,31 @@ export async function captureCpuProfile(
     return { ok: false, reason: `could not attach to inspector: ${(err as Error).message}` };
   }
 
+  let profile: CpuProfile;
   try {
     await session.send('Profiler.enable');
     await session.send('Profiler.start');
-    if (req.onProfiling) await req.onProfiling();
     await sleep(req.durationMs);
     const stopped = (await session.send('Profiler.stop')) as { profile?: CpuProfile };
-    const profile = stopped.profile;
-    if (!profile || !Array.isArray(profile.nodes)) {
+    if (!stopped.profile || !Array.isArray(stopped.profile.nodes)) {
       return { ok: false, reason: 'Profiler.stop returned no profile' };
     }
-    writeFile(req.outPath, JSON.stringify(profile));
-    return { ok: true, outPath: req.outPath, profile };
+    profile = stopped.profile;
   } catch (err) {
     return { ok: false, reason: `profiling failed: ${(err as Error).message}` };
   } finally {
     session.close();
   }
+
+  // Written OUTSIDE the capture try: a bad --out path must not be reported as a
+  // profiling failure, and must not discard a profile that cost a full sampling
+  // window against a live service.
+  try {
+    writeFile(req.outPath, JSON.stringify(profile));
+  } catch (err) {
+    return { ok: false, reason: `captured OK but could not write ${req.outPath}: ${(err as Error).message}` };
+  }
+  return { ok: true, outPath: req.outPath, profile };
 }
 
 /**

--- a/packages/node/saga-stack-cli/src/runtime/profiler.ts
+++ b/packages/node/saga-stack-cli/src/runtime/profiler.ts
@@ -17,11 +17,10 @@
  * Uses Node's global `WebSocket` — the `ws` package is not resolvable here.
  */
 
-import { execFile } from 'node:child_process';
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { Socket } from 'node:net';
 import { dirname } from 'node:path';
-import { promisify } from 'node:util';
+import { makeRealForeignIo } from './foreign-procs.js';
 
 /** A V8 CPU profile as returned by `Profiler.stop`. */
 export interface CpuProfile {
@@ -49,8 +48,16 @@ export interface ProfilerDeps {
   attempts?: number;
   /** Delay between those attempts, ms. Default 100. */
   intervalMs?: number;
-  /** Per-attempt HTTP timeout, ms — the dominant term in the poll's worst case. Default 2000. */
+  /** Per-attempt HTTP timeout, ms. Default 2000. */
   fetchTimeoutMs?: number;
+  /**
+   * Wall-clock ceiling on the whole poll, ms. Default 8000. A holder that accepts
+   * TCP but never answers HTTP burns the full per-attempt timeout every time, so
+   * `attempts * (fetchTimeoutMs + intervalMs)` alone would block for ~63s.
+   */
+  pollBudgetMs?: number;
+  /** Monotonic clock for the poll deadline. Default `Date.now`. */
+  now?: () => number;
 }
 
 /** The minimal CDP surface the capture needs. */
@@ -107,9 +114,8 @@ async function defaultConnect(wsUrl: string): Promise<CdpSession> {
     const waiter = pending.get(msg.id);
     if (!waiter) return;
     pending.delete(msg.id);
-    // A CDP `error` reply must REJECT — resolving it as {} let a failed
-    // Profiler.enable/start pass silently and produced a capture against a
-    // profiler that was never started.
+    // A CDP `error` reply must REJECT: resolving it as {} would hide a failed
+    // Profiler.enable/start and capture against a profiler that never started.
     if (msg.error) waiter.reject(new Error(`CDP error: ${msg.error.message ?? 'unknown'}`));
     else waiter.resolve(msg.result ?? {});
   };
@@ -170,6 +176,8 @@ export async function captureCpuProfile(
   const attempts = deps.attempts ?? 30;
   const intervalMs = deps.intervalMs ?? 100;
   const fetchTimeoutMs = deps.fetchTimeoutMs ?? 2000;
+  const pollBudgetMs = deps.pollBudgetMs ?? 8000;
+  const now = deps.now ?? Date.now;
   // AbortSignal is mandatory here: a holder that accepts TCP but never answers HTTP
   // makes a bare fetch() hang forever, defeating the poll loop's own attempt bound.
   const fetchJson =
@@ -184,7 +192,9 @@ export async function captureCpuProfile(
       mkdirSync(dirname(p), { recursive: true });
       writeFileSync(p, b);
     });
-  const portOwner = deps.portOwner ?? defaultPortOwner;
+  // The SAME resolver the plan used, so plan-time and post-signal can never
+  // disagree about who owns the port.
+  const portOwner = deps.portOwner ?? makeRealForeignIo().pidOnPort;
 
   if (!req.alreadyOpen) {
     try {
@@ -194,9 +204,12 @@ export async function captureCpuProfile(
     }
   }
 
-  // SIGUSR1 is async — poll until the inspector's HTTP endpoint answers.
+  // SIGUSR1 is async — poll until the inspector's HTTP endpoint answers. Bounded by
+  // BOTH attempts and wall clock: a holder that accepts TCP but never answers burns
+  // the full per-attempt timeout each pass, so attempts alone is not a time bound.
   let wsUrl: string | undefined;
-  for (let i = 0; i < attempts; i += 1) {
+  const deadline = now() + pollBudgetMs;
+  for (let i = 0; i < attempts && now() < deadline; i += 1) {
     try {
       const list = (await fetchJson(`http://127.0.0.1:${req.port}/json/list`)) as Array<{
         webSocketDebuggerUrl?: string;
@@ -289,6 +302,10 @@ export async function captureCpuProfile(
  * of its own. An HTTP probe HANGS against that (verified: `curl` connects, then
  * waits forever), which would both defeat the guard and stall the CLI. A connect
  * that succeeds is enough to know the real service cannot bind.
+ *
+ * Not `PortProbe.listening` (preflight.ts): that one degrades OPEN when `ss`/`lsof`
+ * are missing, which is right for a preflight warning and wrong here, where the
+ * answer gates a hard refusal.
  */
 export async function inspectorPortBusy(
   port: number,
@@ -296,23 +313,6 @@ export async function inspectorPortBusy(
 ): Promise<boolean> {
   const probe = deps.probeTcp ?? tcpListening;
   return probe(port, 1000);
-}
-
-/**
- * The pid listening on `port`, or null when it can't be resolved. Null is
- * inconclusive, never "free" — the caller refuses on it.
- *
- * Duplicates `ForeignIo.pidOnPort`; fold the two together so plan-time and
- * post-signal can never disagree about who owns the port.
- */
-async function defaultPortOwner(port: number): Promise<number | null> {
-  try {
-    const { stdout } = await promisify(execFile)('lsof', ['-ti', `:${port}`, '-sTCP:LISTEN']);
-    const pid = Number.parseInt(stdout.trim().split('\n')[0] ?? '', 10);
-    return Number.isFinite(pid) ? pid : null;
-  } catch {
-    return null;
-  }
 }
 
 /** Resolve true when a TCP connect to 127.0.0.1:port succeeds within `timeoutMs`. */

--- a/packages/node/saga-stack-cli/src/runtime/profiler.ts
+++ b/packages/node/saga-stack-cli/src/runtime/profiler.ts
@@ -1,0 +1,230 @@
+/**
+ * Attach-mode profiling: the IO half (signal + Chrome DevTools Protocol).
+ *
+ * INVARIANT (matches `launcher.ts`): signalling and sockets live ONLY here; the
+ * decision logic is pure in `core/profile-plan.ts`. Every seam is injectable so
+ * the command's wiring is testable without a real service.
+ *
+ * The capture sequence, and why each step is needed:
+ *   1. SIGUSR1 the LISTENING pid — Node opens the V8 inspector on demand. No
+ *      launch-time flag is involved, which is the whole point: the app process is
+ *      a `node dist/main.js` grandchild nested inside tsup's quoted `--onSuccess`,
+ *      so nothing injected at `pnpm dev` time ever reaches it.
+ *   2. Poll `GET /json/list` until the inspector answers — SIGUSR1 is asynchronous.
+ *   3. Speak CDP over the returned websocket: `Profiler.enable` → `.start` →
+ *      wait → `.stop`, which RETURNS the profile inline.
+ *
+ * Because the artifact arrives over the wire while the process is alive, it does
+ * NOT depend on a clean exit — unlike `--cpu-prof`, which writes only on graceful
+ * shutdown and therefore produced nothing under `ss stack down`'s group-SIGKILL.
+ *
+ * No new dependency: Node 24 ships a global `WebSocket` (and `ws` is not resolvable
+ * from this package anyway).
+ */
+
+import { writeFileSync } from 'node:fs';
+import { Socket } from 'node:net';
+
+/** A V8 CPU profile as returned by `Profiler.stop`. */
+export interface CpuProfile {
+  nodes: Array<{ id: number; hitCount?: number; callFrame?: { functionName?: string; url?: string } }>;
+  samples?: number[];
+  timeDeltas?: number[];
+  startTime?: number;
+  endTime?: number;
+}
+
+export interface ProfilerDeps {
+  /** Send a signal to a pid. Default `process.kill`. */
+  signal?: (pid: number, sig: NodeJS.Signals) => void;
+  /** Fetch JSON from the inspector's HTTP endpoint. Default global `fetch`. */
+  fetchJson?: (url: string) => Promise<unknown>;
+  /** Open a CDP session over a websocket url. Default a global-`WebSocket` client. */
+  connect?: (wsUrl: string) => Promise<CdpSession>;
+  /** Sleep. Default a real timer. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Write the artifact. Default `fs.writeFileSync`. */
+  writeFile?: (path: string, body: string) => void;
+  /** Attempts to wait for the inspector to answer after SIGUSR1. Default 30. */
+  attempts?: number;
+  /** Delay between those attempts, ms. Default 100. */
+  intervalMs?: number;
+}
+
+/** The minimal CDP surface the capture needs. */
+export interface CdpSession {
+  send(method: string, params?: Record<string, unknown>): Promise<Record<string, unknown>>;
+  close(): void;
+}
+
+export interface CaptureRequest {
+  pid: number;
+  port: number;
+  durationMs: number;
+  outPath: string;
+  /** Invoked once the profiler is running, so the caller can drive load. */
+  onProfiling?: () => Promise<void> | void;
+}
+
+export type CaptureResult =
+  | { ok: true; outPath: string; profile: CpuProfile }
+  | { ok: false; reason: string };
+
+/** Open a CDP session using Node's built-in global WebSocket (no `ws` dependency). */
+async function defaultConnect(wsUrl: string): Promise<CdpSession> {
+  const socket = new WebSocket(wsUrl);
+  const pending = new Map<number, (result: Record<string, unknown>) => void>();
+  let nextId = 0;
+
+  // Bounded: an unreachable/half-open inspector must surface as an error, not a hang.
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`inspector websocket timed out: ${wsUrl}`)), 10_000);
+    socket.onopen = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    socket.onerror = () => {
+      clearTimeout(timer);
+      reject(new Error(`inspector websocket failed: ${wsUrl}`));
+    };
+  });
+
+  socket.onmessage = (event: MessageEvent) => {
+    const msg = JSON.parse(String(event.data)) as { id?: number; result?: Record<string, unknown> };
+    if (typeof msg.id === 'number') pending.get(msg.id)?.(msg.result ?? {});
+  };
+
+  // A socket that opens and THEN errors (or a command the target never answers)
+  // would otherwise leave `send` pending forever and hang the CLI with no output.
+  // Every request is therefore bounded and rejects with the method name.
+  const SEND_TIMEOUT_MS = 30_000;
+
+  return {
+    send(method, params = {}) {
+      const id = (nextId += 1);
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+          pending.delete(id);
+          reject(new Error(`${method} timed out after ${SEND_TIMEOUT_MS}ms`));
+        }, SEND_TIMEOUT_MS);
+        pending.set(id, (result) => {
+          clearTimeout(timer);
+          resolve(result);
+        });
+        socket.send(JSON.stringify({ id, method, params }));
+      });
+    },
+    close: () => socket.close(),
+  };
+}
+
+/**
+ * SIGUSR1 `pid`, wait for its inspector to answer on `port`, capture a CPU profile
+ * for `durationMs`, and write it to `outPath`.
+ *
+ * Failure is always explicit. In particular, if the inspector never answers we say
+ * so rather than reporting a success with an empty artifact — the silent-bind
+ * failure (`address already in use`, visible only in the service's own log) is the
+ * exact trap this command is built to avoid.
+ */
+export async function captureCpuProfile(
+  req: CaptureRequest,
+  deps: ProfilerDeps = {},
+): Promise<CaptureResult> {
+  const signal = deps.signal ?? ((pid, sig) => process.kill(pid, sig));
+  const fetchJson = deps.fetchJson ?? (async (url: string) => (await fetch(url)).json());
+  const connect = deps.connect ?? defaultConnect;
+  const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const writeFile = deps.writeFile ?? ((p: string, b: string) => writeFileSync(p, b));
+  const attempts = deps.attempts ?? 30;
+  const intervalMs = deps.intervalMs ?? 100;
+
+  try {
+    signal(req.pid, 'SIGUSR1');
+  } catch (err) {
+    return { ok: false, reason: `could not signal pid ${req.pid}: ${(err as Error).message}` };
+  }
+
+  // SIGUSR1 is async — poll until the inspector's HTTP endpoint answers.
+  let wsUrl: string | undefined;
+  for (let i = 0; i < attempts; i += 1) {
+    try {
+      const list = (await fetchJson(`http://127.0.0.1:${req.port}/json/list`)) as Array<{
+        webSocketDebuggerUrl?: string;
+      }>;
+      wsUrl = list?.[0]?.webSocketDebuggerUrl;
+      if (wsUrl !== undefined) break;
+    } catch {
+      // not up yet
+    }
+    await sleep(intervalMs);
+  }
+  if (wsUrl === undefined) {
+    return {
+      ok: false,
+      reason:
+        `inspector never came up on port ${req.port} after SIGUSR1. The service may have failed to ` +
+        `bind it — check its log for "address already in use".`,
+    };
+  }
+
+  let session: CdpSession;
+  try {
+    session = await connect(wsUrl);
+  } catch (err) {
+    return { ok: false, reason: `could not attach to inspector: ${(err as Error).message}` };
+  }
+
+  try {
+    await session.send('Profiler.enable');
+    await session.send('Profiler.start');
+    if (req.onProfiling) await req.onProfiling();
+    await sleep(req.durationMs);
+    const stopped = (await session.send('Profiler.stop')) as { profile?: CpuProfile };
+    const profile = stopped.profile;
+    if (!profile || !Array.isArray(profile.nodes)) {
+      return { ok: false, reason: 'Profiler.stop returned no profile' };
+    }
+    writeFile(req.outPath, JSON.stringify(profile));
+    return { ok: true, outPath: req.outPath, profile };
+  } catch (err) {
+    return { ok: false, reason: `profiling failed: ${(err as Error).message}` };
+  } finally {
+    session.close();
+  }
+}
+
+/**
+ * True when ANYTHING already holds the inspector port.
+ *
+ * Deliberately a raw TCP connect, not an HTTP probe. The port is frequently held
+ * by a process that ACCEPTS the connection but never answers `/json/version` —
+ * notably the `pnpm dev` wrapper, which is the launch tree's process-group leader
+ * and so receives any group-delivered SIGUSR1 and opens a half-working inspector
+ * of its own. An HTTP probe HANGS against that (verified: `curl` connects, then
+ * waits forever), which would both defeat the guard and stall the CLI. A connect
+ * that succeeds is enough to know the real service cannot bind.
+ */
+export async function inspectorPortBusy(
+  port: number,
+  deps: { probeTcp?: (port: number, timeoutMs: number) => Promise<boolean> } = {},
+): Promise<boolean> {
+  const probe = deps.probeTcp ?? tcpListening;
+  return probe(port, 1000);
+}
+
+/** Resolve true when a TCP connect to 127.0.0.1:port succeeds within `timeoutMs`. */
+function tcpListening(port: number, timeoutMs: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = new Socket();
+    const done = (held: boolean) => {
+      socket.destroy();
+      resolve(held);
+    };
+    socket.setTimeout(timeoutMs);
+    socket.once('connect', () => done(true));
+    socket.once('timeout', () => done(false));
+    socket.once('error', () => done(false));
+    socket.connect(port, '127.0.0.1');
+  });
+}


### PR DESCRIPTION
Adds `ss stack profile <service>` — captures a V8 `.cpuprofile` from an **already-running**
service, without restarting it or altering how the stack launches.

```bash
ss stack profile iam-api --duration 30s
ss stack profile sessions-api --duration 2m --out /tmp/sessions.cpuprofile
```

Resolves the listening pid via `lsof`, sends SIGUSR1 to open the V8 inspector, then pulls the
profile over CDP and writes it to the slot's artifact dir. Load the result in Chrome DevTools →
Performance → Load profile.

## Why attach mode, not launch-time flags

The app is never a direct child of `pnpm dev`: 14 backends nest it inside tsup's quoted
`--onSuccess`, and 2 more in a `tsx watch` fork, so the real `node dist/main.js` sits ~4 levels
below the pid `ss` records. All three launch-time approaches were tried against a live iam-api
and fail:

| Approach | Result |
|---|---|
| `NODE_OPTIONS=--cpu-prof` | 53 profiles written (23 prisma, 17 pnpm, 5 tsup) — **zero** for the service |
| `pnpm dev --inspect` | crashes the service (tsup's cac parser: `Unknown option --inspect`) |
| `NODE_OPTIONS=--inspect-port` | inherited tree-wide; pnpm/tsup reserve the port first |

The launch path is therefore **byte-identical** to a stack without profiling. A regression test
in `launch-plan.unit.test.ts` asserts no service carries `NODE_OPTIONS`, so this stays true.

## Constraints worth knowing at review time

- **SIGUSR1 can't choose a port.** One service at a time holds `9229 + slot*1000` per slot. The
  same service re-attaches cleanly (Node keeps the inspector open); a *different* one is refused
  rather than silently profiling the wrong process.
- **SIGUSR1's default disposition is TERMINATE.** `planProfile` refuses any listener that isn't a
  node process — verified against a `python3 -m http.server` holding the port, which survives.
- **A port holder can accept TCP and never answer HTTP.** `inspectorPortBusy` uses a raw TCP
  connect, and the readiness poll's fetch carries an `AbortSignal` or it hangs indefinitely.
- Profiles that contain no frames from the service's own `dist` **warn rather than fail** — a
  genuinely idle service samples no app frames and the artifact is still valid. This is also the
  guard against the failure mode where the earlier `--cpu-prof` attempt looked fine but profiled
  pnpm.

## Testing

- 1683 tests pass (134 files), including new `profile-plan`, `inspector`, and `launch-plan`
  regression coverage
- `tsc --noEmit` clean; lint 0 errors
- Exercised end-to-end against a live iam-api in a running slot

Docs: new `docs/instrumentation.md`, plus cheatsheet and README entries.

Closes #416
