### PR TITLE
feat(ss): stack hydrate — restore a local slot from the daily prod mirror

### DIFF
--- a/packages/node/saga-stack-cli/README.md
+++ b/packages/node/saga-stack-cli/README.md
@@ -14,7 +14,7 @@ you have to reverse-engineer.
 > path (up → status → verify → e2e → down) with the real output of each command, linking out
 > to per-feature docs ([sub-stacks](./docs/sub-stacks-and-bundles.md) · [slots](./docs/slots.md) ·
 > [verify](./docs/verify.md) · [snapshots](./docs/snapshots.md) · [e2e](./docs/e2e.md) ·
-> [develop](./docs/develop.md) · [tunnel](./docs/tunnel.md) · [integration](./docs/integration.md)).
+> [develop](./docs/develop.md) · [tunnel](./docs/tunnel.md) · [hydrate](./docs/hydrate.md) · [integration](./docs/integration.md)).
 
 ```bash
 ss stack up --only scheduling-api,sessions-api   # boot just those + their deps
@@ -55,6 +55,7 @@ plus tab-completion work at every level.
 | **`reset`** | Truncate the data DBs to an empty baseline (preserving migration history) + re-seed the dev user (native; `--legacy` → `up.sh --reset`). |
 | **`seed`** | Seed a running stack (`--with playback\|qtf` add-ons). |
 | **`snapshot`** | `store` / `list` / `restore` / `validate` / `delete` native DB fixtures (pg_dump/mongodump, schema-ahead guard, restore-as-owner) — restore a known-good DB state in seconds instead of re-running `db:seed`. |
+| **`hydrate`** | Replace a slot's Postgres with the daily **prod mirror** (SSM tunnel → staging DB → verify → rename swap), so a slot carries real prod-shaped data across every store. **Preview by default**; `--execute` performs it. Refuses slot 0. → [docs/hydrate.md](./docs/hydrate.md) |
 | **`bundle list`** | Show the `--with` convenience bundles (name → services + seed). |
 | **`overlay`** | Overlay your in-flight PRs onto a main-based stack. |
 | **`tunnel`** | Expose the local stack via the vms rendezvous (share your stack). |

--- a/packages/node/saga-stack-cli/docs/hydrate.md
+++ b/packages/node/saga-stack-cli/docs/hydrate.md
@@ -1,0 +1,284 @@
+# `ss stack hydrate` — real prod-shaped data in a local slot
+
+`ss stack hydrate` replaces a local slot's Postgres databases with the contents of the
+**daily prod mirror**, so a developer gets prod-shaped data across *every* store with no
+per-store sync code and no fixture maintenance.
+
+```bash
+ss stack hydrate --slot 2                      # PREVIEW (default) — prints the plan, changes nothing
+ss stack hydrate --slot 2 --execute            # prompt, then hydrate the default database set
+ss stack hydrate --slot 2 --db coach_api --execute --yes
+ss stack hydrate --slot 2 --source scrubbed --execute --yes
+ss stack hydrate --set my-set --execute --yes --keep-previous
+```
+
+---
+
+## What it is not
+
+- **It does not make Coach reporting light up.** Prod itself has `group_track_map = 0` and
+  `persona_assignment = 0`, so no restore of prod can populate that routing. That is a
+  separate concern; a hydrate that "fails" because reporting is still empty has not failed.
+- **It cannot fill Connect.** `connectv3` is mongo, on `soa-connect-mongo-1`; the mirror is
+  Postgres-only.
+- **It cannot fill `insights_local`.** There is no `insights_*` database in the mirror.
+
+All three are printed in the command's own output rather than silently skipped.
+
+---
+
+## The mirror
+
+The mirror is an RDS instance in the **dev** account (`396913734878`), private subnets,
+PG 18.3, ~700 MB across 17 databases. It is **re-created daily** by a 13:30 UTC CloudFormation
+cron that *replaces the instance* — so **both the endpoint and the master password change
+every day**.
+
+Hydrate therefore resolves everything at RUN TIME, on every invocation:
+
+| what | where from |
+| --- | --- |
+| endpoint | SSM `/mirror/current/postgres-rds/endpoint` |
+| port | SSM `/mirror/current/postgres-rds/port` |
+| master secret ARN | SSM `/mirror/current/postgres-rds/master-secret-arn` |
+| username + password | Secrets Manager, that ARN, JSON `{username, password}` |
+
+Nothing is memoized across runs, written to the state dir, or added to the env registry —
+the same stance `ss env connect` takes for the prod RDS endpoint. A value that can drift
+must not be able to drift out of a CLI release.
+
+Reachability is an **SSM port-forward through the dev jump host** (`Name=dev-shared-ecs-instance`),
+whose security group is in the mirror's 5432 ingress. No VPN. The tunnel's local end
+defaults to **15532** — deliberately not `ss env connect`'s 15432, so an open connect
+session and a hydrate cannot collide.
+
+---
+
+## The view swap — the central structural fact
+
+Only the **rostering** project is scrubbed by the daily cron, so only **`iam_db`** and
+**`iam_pii_db`** are affected. **Every other database in the mirror is raw prod data
+already, in both source modes.**
+
+In a scrubbed database the real table is renamed `{table}_real` and a **scrambled VIEW**
+takes the original name. That means *both* source modes need a rename step, in opposite
+directions — and either way the local result must be ordinary **writable tables** under the
+names the app expects.
+
+### `--source real` (the default)
+
+```
+dump everything  →  staging
+DROP VIEW public.users CASCADE;
+ALTER TABLE public.users_real RENAME TO users;
+```
+
+The `_real` table carries the data *and* its own PK, FKs, indexes, defaults and sequence
+ownership, so the renamed result is a complete, writable table. (Index and constraint
+*names* keep their `…_real…` spelling — functionally irrelevant, cosmetically visible.)
+
+### `--source scrubbed`
+
+```
+dump with --exclude-table-data=public.users_real  →  staging   (structure only for the real tables)
+DROP VIEW public.users CASCADE;
+ALTER TABLE public.users_real RENAME TO users;                  (now an EMPTY real-shaped table)
+psql <mirror> -c 'COPY (SELECT "id","email" FROM public."users") TO STDOUT'
+  | psql <staging> -c 'COPY public."users" ("id","email") FROM STDIN'
+```
+
+Two things worth noticing:
+
+1. **The unscrubbed rows never touch the local disk.** `--exclude-table-data` brings the
+   `_real` *structure* across with zero rows.
+2. **The rename is what preserves the constraints.** The obvious implementation —
+   `CREATE TABLE … AS SELECT * FROM <view>` — loses PKs, FKs, indexes, defaults and sequence
+   ownership, and produces a schema the app cannot really write to. Renaming the emptied
+   `_real` table into place and then `COPY`-ing rows in avoids that entirely.
+
+The column list comes from the **`_real` table's `attnum` order**, enumerated live, so the
+`COPY` is column-exact rather than trusting that the scramble view presents columns in the
+same order.
+
+### Why `real` is the default
+
+Prod is **pre-release**. Every user in it is a Saga employee, so there is no real end-user
+PII today (consistent with the standing Legal determination that tutor responses are not
+PII). The scramble makes a poor reporting fixture — a known district cannot be found in the
+mirror by `display_name` or `source_id` at all.
+
+**This flips at public release.** When prod holds real end-user data, `scrubbed` becomes the
+default and `real` needs a much harder gate. The scrubbed path exists today precisely so
+that flip is a one-line change rather than a new feature.
+
+And note again: `--source scrubbed` does **not** make a hydrate free of prod data. Only
+rostering is scrubbed upstream.
+
+---
+
+## Database mapping
+
+The mirror's names are **not** the local names. Only `coach_api`, `sis_db` and `openfga`
+match. The map lives in `src/core/mirror/databases.ts` (pure, unit-tested against the
+manifest) — never inlined in the command, because a wrong pair restores one service's schema
+over another service's database.
+
+| mirror | local | owner | default set |
+| --- | --- | --- | --- |
+| `scheduling_api` | `scheduling` | `saga_user` | ✓ |
+| `sessions_api` | `sessions` | `saga_user` | ✓ |
+| `iam_db` | `iam_local` | `iam` | ✓ (scrubbed) |
+| `programs_api` | `programs` | `saga_user` | ✓ |
+| `authz_db` | `authz_local` | `authz` | ✓ |
+| `openfga` | `openfga` | `postgres_admin` | — opt-in: the local schema is owned by the `openfga_migrate` sidecar |
+| `coach_api` | `coach_api` | `coach_api_app` | ✓ |
+| `transcription_db` | `transcripts_local` | `transcripts_app` | — opt-in: mapping **unverified**, and playback-only |
+| `authz_sync` | `authz_sync_local` | `authz_sync` | ✓ |
+| `iam_pii_db` | `iam_pii_local` | `iam_pii` | ✓ (scrubbed) |
+| `sis_db` | `sis_db` | `sis` | ✓ |
+| `ads_adm` | `ads_adm_local` | `ads_adm` | ✓ |
+| `ledger_api` | `ledger_local` | **`ledger`** (not `ads_adm`) | ✓ |
+| `content_api` | `content` | `saga_user` | ✓ |
+| `chat` | `chat_local` | `chat_app` | — opt-in: playback-only |
+
+`--db` accepts either name of a pair, plus `default` and `all`. An unknown token is a hard
+error — a typo must never silently hydrate less than you asked for.
+
+---
+
+## Per-database mechanics
+
+Nothing touches the live database until the replacement is proven good.
+
+```
+DROP DATABASE IF EXISTS <db>__hydrate WITH (FORCE)      -- clean up a previous failed run
+DO $$ … CREATE ROLE <owner> … $$                        -- idempotent
+CREATE DATABASE <db>__hydrate OWNER <owner>
+
+docker run --rm --network host -e PGPASSWORD postgres:18 bash -o pipefail -c \
+  'pg_dump --host 127.0.0.1 --port 15532 … --format custom | pg_restore --host 127.0.0.1 --port <slot> … --no-owner --no-privileges --single-transaction'
+
+<verify staging is non-empty>
+<view swap, per scrubbed table>
+<COPY the scrambled rows, scrubbed mode only>
+<ownership sweep to <owner>>
+<grants + default privileges to <owner>>
+<verify <owner> can INSERT into every table>
+<verify no app-named relation is still a VIEW>
+
+ALTER DATABASE <db> WITH ALLOW_CONNECTIONS false
+SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='<db>' AND pid<>pg_backend_pid()
+ALTER DATABASE <db> RENAME TO <db>__pre_hydrate_<stamp>
+ALTER DATABASE <db>__hydrate RENAME TO <db>
+ALTER DATABASE <db> WITH ALLOW_CONNECTIONS true
+DROP DATABASE <db>__pre_hydrate_<stamp> WITH (FORCE)     -- unless --keep-previous
+```
+
+A failure anywhere before the swap fails **that database only** and leaves the live one
+exactly as it was. The whole report is emitted before the non-zero exit.
+
+### Why an ephemeral host-networked container
+
+`docker exec soa-postgres-1 pg_dump -h 127.0.0.1 …` cannot work: the mesh container sits on
+a compose bridge network, so *its* `127.0.0.1` is itself, not the host holding the tunnel.
+`docker run --rm --network host postgres:18` sees **both** the tunnel port and the slot's
+published postgres port, so the whole transfer is one pipe with no dump file on disk.
+(`--network host` is Linux semantics; Docker Desktop on macOS differs.)
+
+The image is pinned to `postgres:18` — the **debian** variant, not `-alpine`:
+
+- `pg_dump` older than its server is a hard error, and the mirror is 18.3;
+- the pipelines run under `bash -o pipefail`, so a failing `pg_dump` cannot be masked by a
+  succeeding `pg_restore`. Alpine's `sh` has no `pipefail`.
+
+### Why connections must be blocked before the rename
+
+Measured on a live slot: 5 **idle** prisma-pool backends sit on `content` / `programs` /
+`scheduling` / `sessions` / `iam_local` indefinitely. `TRUNCATE` and `pg_restore --clean`
+succeed against idle backends — which is why `ss stack reset` works against a running stack —
+but `ALTER DATABASE … RENAME` fails with *"being accessed by other users"* on **any** open
+session, idle included. `ALLOW_CONNECTIONS false` stops new ones appearing;
+`pg_terminate_backend` evicts the existing ones; the rename retries a few times to absorb a
+backend that has not been fully reaped yet.
+
+### Ownership and grants — the named silent failure
+
+A prod dump carries `ALTER … OWNER TO <prod_role>` and `GRANT … TO <service_role>` naming
+roles that do not exist locally, so the restore runs with `--no-owner --no-privileges` **as
+`postgres_admin`** (not as the owner: a prod dump can carry `CREATE EXTENSION`, event
+triggers or publications a non-superuser cannot create).
+
+That leaves everything owned by `postgres_admin` — readable, and **not writable by the app**.
+That failure surfaces days later as a 500. So hydrate then:
+
+1. re-owns every object to the database's single service role (measured: each local database
+   has exactly one app role owning the database *and* every object in `public`),
+2. grants tables + sequences + functions + default privileges to it,
+3. and **asserts** it with `has_table_privilege(<role>, …, 'INSERT')` across every restored
+   table, failing the database if any comes back false — while the live database is still
+   untouched.
+
+---
+
+## Guards
+
+| guard | override | alternative |
+| --- | --- | --- |
+| `--slot 0` (including a bare `--slot`) is refused | none | `ss stack cold-start` resets slot 0 |
+| non-local target (repointed `$SAGA_MESH_POSTGRES_CONTAINER`, non-loopback host, wrong port) | none | unset the override |
+| slot's postgres container not running | none | `ss stack up --slot N` |
+| wrong AWS account | none | `--profile dev_admin` |
+| another driver's live claim on the slot | `--yes` | wait, or `ss stack slots` |
+| destructive confirm | `--yes` | — |
+
+A **declined prompt** is an abort: exit 0, "hydrate aborted — nothing changed". The
+structural refusals above are `this.error` → exit 2. A per-database failure emits the full
+report, then exits 1.
+
+### Preview by default
+
+Unlike `stack wipe` (prompt-by-default), hydrate is **preview**-by-default: a bare run prints
+the full replacement map and exits 0 having made **no AWS call**, opened no tunnel, and
+written no claim. `--execute` performs it; `--execute --yes` skips the prompt for agents/CI.
+
+> Implementation note: BaseCommand's central claim-suppression keys on a flag named exactly
+> `dry-run`, which hydrate does not have. `claimsSlot()` instead gates on an `--execute`
+> latch captured from the raw argv in a `parse` override (the `stack wipe --slot all`
+> precedent). The invariant preserved is "a preview never mutates `claim.json`", not the
+> flag's spelling.
+
+---
+
+## Credential handling
+
+The mirror master password is **never** written to a file, never logged, and never placed in
+argv:
+
+- it is fetched fresh from Secrets Manager on every run and held in memory only;
+- transfer steps carry a **bare `-e PGPASSWORD`** (no `=value`), so docker copies it out of
+  the spawning process's environment — `/proc/<pid>/environ` is same-user-only, whereas argv
+  is world-readable in `ps`;
+- `--no-password` is set on every mirror-side client, so a missing credential fails fast
+  rather than hanging on a prompt;
+- purely-local statements are *not* handed the secret at all.
+
+This is why hydrate does **not** reuse the `EnvPsql` seam: `psqlArgs` puts the whole
+`postgres://user:pw@host/db` connection string in argv, which is fine under local `trust`
+auth and fatal for a real master password.
+
+---
+
+## Code layout
+
+| file | role |
+| --- | --- |
+| `src/core/mirror/databases.ts` | the mirror→local map + selection resolution (pure) |
+| `src/core/mirror/sql.ts` | every SQL statement hydrate can run (pure) |
+| `src/core/mirror/plan.ts` | the planner: source description → exact argv + statements + rename plan (pure) |
+| `src/runtime/hydrate.ts` | the executor seam: `exec(argv, {secret})` — the ONE docker spawn site |
+| `src/commands/stack/hydrate.ts` | flags, guards, progress, reporting |
+
+The split is what makes the risky part testable: the planner's output is asserted
+byte-for-byte in `src/core/mirror/__tests__/plan.unit.test.ts` with no database, no
+container, no tunnel and no credential anywhere, and the command is driven end-to-end
+against fakes in `src/commands/stack/__tests__/hydrate.int.test.ts`.

--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -3462,6 +3462,208 @@
       "slotClaimWritten": false,
       "strict": true
     },
+    "stack:hydrate": {
+      "aliases": [],
+      "args": {},
+      "description": "Replace a local slot's Postgres databases with the daily prod mirror (SSM tunnel → staging database → verify → rename swap). PREVIEW BY DEFAULT: a bare run prints exactly what would be replaced and touches nothing; --execute performs it. Requires an explicit --slot 1..9 or --set; slot 0 is refused.",
+      "enableJsonFlag": false,
+      "examples": [
+        "<%= config.bin %> <%= command.id %> --slot 2",
+        "<%= config.bin %> <%= command.id %> --slot 2 --execute",
+        "<%= config.bin %> <%= command.id %> --slot 2 --db coach_api,iam_db --execute --yes",
+        "<%= config.bin %> <%= command.id %> --slot 2 --source scrubbed --execute --yes",
+        "<%= config.bin %> <%= command.id %> --set my-set --execute --yes --keep-previous"
+      ],
+      "flags": {
+        "client-image": {
+          "default": "postgres:18",
+          "description": "ephemeral postgres client image for the dump/restore pipelines. Must be >= the mirror server version (PG 18.3) and must carry bash (the pipelines run under `bash -o pipefail`).",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "client-image",
+          "type": "option"
+        },
+        "coach": {
+          "description": "override path to the coach repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "coach",
+          "type": "option"
+        },
+        "db": {
+          "description": "databases to hydrate: mirror or local names (comma- or flag-repeatable), plus 'default' and 'all'. DEFAULT (when omitted) is every mapping with a verified name pair and a slot-provisioned local home: scheduling, sessions, iam_local, programs, authz_local, coach_api, authz_sync_local, iam_pii_local, sis_db, ads_adm_local, ledger_local, content. Opt-in extras: openfga (its local schema is sidecar-owned), transcripts_local (mapping unverified + playback-only), chat_local (playback-only).",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "name": "db",
+          "type": "option"
+        },
+        "dev": {
+          "description": "sibling-repo workspace root (where the saga repos are checked out)",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "dev",
+          "noCacheDefault": true,
+          "type": "option"
+        },
+        "execute": {
+          "allowNo": false,
+          "description": "actually perform the replacement. Without it this command is a PREVIEW: it prints the full plan, makes no AWS call, opens no tunnel, writes no claim, and exits 0.",
+          "name": "execute",
+          "type": "boolean"
+        },
+        "fleek": {
+          "description": "override path to the fleek repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "fleek",
+          "type": "option"
+        },
+        "jump-host": {
+          "description": "override the EC2 Name tag of the SSM jump host (default: the dev environment's).",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "jump-host",
+          "type": "option"
+        },
+        "keep-previous": {
+          "allowNo": false,
+          "description": "keep each displaced database as <db>__pre_hydrate_<stamp> instead of dropping it — a one-command rollback (rename it back).",
+          "name": "keep-previous",
+          "type": "boolean"
+        },
+        "local-port": {
+          "default": 15532,
+          "description": "local end of the SSM tunnel to the mirror. Deliberately NOT `env connect`'s 15432 so an open `ss env connect` and a hydrate cannot collide.",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "local-port",
+          "type": "option"
+        },
+        "output-json": {
+          "allowNo": false,
+          "description": "emit structured JSON on stdout instead of human-readable text",
+          "name": "output-json",
+          "type": "boolean"
+        },
+        "porcelain": {
+          "allowNo": false,
+          "description": "machine-readable output; no color, minimal noise",
+          "name": "porcelain",
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "AWS profile for the mirror account (defaults to the ambient credential chain; dev_admin is the usual one).",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "profile",
+          "type": "option"
+        },
+        "program-hub": {
+          "description": "override path to the program-hub repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "program-hub",
+          "type": "option"
+        },
+        "qboard": {
+          "description": "override path to the qboard repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "qboard",
+          "type": "option"
+        },
+        "rostering": {
+          "description": "override path to the rostering repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "rostering",
+          "type": "option"
+        },
+        "rtsm": {
+          "description": "override path to the rtsm repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "rtsm",
+          "type": "option"
+        },
+        "saga-dash": {
+          "description": "override path to the saga-dash repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "saga-dash",
+          "type": "option"
+        },
+        "sds": {
+          "description": "override path to the sds (student-data-system) repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "sds",
+          "type": "option"
+        },
+        "set": {
+          "description": "worktree set to run against (M13): a named repo→path map bound to a slot, from $SAGA_STACK_SETS ?? ~/.saga-stack/worktree-sets.json. Supplies the slot and any repo path you did not pin explicitly (--<repo> flags win; env vars lose to the set).",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "set",
+          "type": "option"
+        },
+        "slot": {
+          "default": 0,
+          "description": "stack instance slot (0 = default; N in 1..9 offsets ports by N*1000 into an isolated soa-s<N> sub-stack — backend services AND the saga-dash/coach-web/connect-web frontends run on their offset port; only the literal-port playback trio stays on slot 0). Ceiling is 9: slot 10 would collide rabbitmq (:15672) with slot 0 rabbitmq-mgmt.",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "slot",
+          "type": "option"
+        },
+        "soa": {
+          "description": "override path to the soa repo checkout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "soa",
+          "type": "option"
+        },
+        "source": {
+          "default": "real",
+          "description": "which copy of the two SCRUBBED databases (iam_db, iam_pii_db) to land. 'real' (DEFAULT) lands the unscrambled tables — prod is PRE-RELEASE and every user in it is a Saga employee, so there is no real end-user PII today, and the scramble makes a poor reporting fixture (a known district cannot be found by display_name or source_id at all). 'scrubbed' lands the scrambled view materialised into a real writable table instead. NOTE: only the rostering project is scrubbed upstream — every OTHER database is raw prod data in BOTH modes, so --source scrubbed does NOT make a hydrate free of prod data. This default FLIPS at public release, when prod holds real end-user data.",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "source",
+          "options": [
+            "real",
+            "scrubbed"
+          ],
+          "type": "option"
+        },
+        "state-dir": {
+          "description": "scratch dir for pid files, snapshots, and other run state (default /tmp/sds-synthetic, or /tmp/sds-synthetic-s<N> for --slot N)",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "state-dir",
+          "type": "option"
+        },
+        "yes": {
+          "allowNo": false,
+          "description": "non-interactive: skip the destructive-action prompt AND override the live-claim guard (CI / agents). Only meaningful with --execute.",
+          "name": "yes",
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "stack:hydrate",
+      "isESM": true,
+      "pluginAlias": "@saga-ed/saga-stack-cli",
+      "pluginName": "@saga-ed/saga-stack-cli",
+      "pluginType": "core",
+      "relativePath": [
+        "dist",
+        "commands",
+        "stack",
+        "hydrate.js"
+      ],
+      "slotClaimWritten": false,
+      "strict": true
+    },
     "stack:login": {
       "aliases": [],
       "args": {

--- a/packages/node/saga-stack-cli/src/base-command.ts
+++ b/packages/node/saga-stack-cli/src/base-command.ts
@@ -84,6 +84,7 @@ import {
   makeSettleBarrier,
   makeRealEnvAws,
   makeRealEnvPsql,
+  makeRealHydrateIO,
   makeSlotWipe,
   realSleep,
   makeRealDockerWipe,
@@ -130,6 +131,7 @@ import type {
   SleepFn,
   EnvAws,
   EnvPsql,
+  HydrateIO,
   SlotWipe,
   SnapshotIO,
   ViteClear,
@@ -861,6 +863,18 @@ export abstract class BaseCommand extends Command {
    */
   protected getEnvPsql(): EnvPsql {
     return makeRealEnvPsql();
+  }
+
+  /**
+   * The hydrate seam (`ss stack hydrate`) — production is the only place the
+   * prod-mirror → local-slot `docker run pg_dump|pg_restore|psql` pipelines and
+   * the database-level DDL (`DROP DATABASE`, `pg_terminate_backend`, `ALTER
+   * DATABASE … RENAME`) are launched, and the only place the mirror's master
+   * password is handed to a child process. Injected so the whole plan — argv AND
+   * SQL — is asserted with no docker, no database, and no credential.
+   */
+  protected getHydrateIO(): HydrateIO {
+    return makeRealHydrateIO();
   }
 
   /**

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/hydrate.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/hydrate.int.test.ts
@@ -1,0 +1,566 @@
+/**
+ * `stack hydrate` integration tests — in-process (`Config.load(PKG_ROOT)` +
+ * `StackHydrate.run(argv, config)`), with every seam that could touch the real
+ * world faked on `BaseCommand.prototype`:
+ *
+ *   - `getHydrateIO`  — the ONLY docker spawn site; records every argv and the
+ *     secret it was (or was not) handed.
+ *   - `getEnvAws`     — AWS: canned SSM parameters, the master secret, the jump
+ *     host lookup, and a fake port-forward whose open/close is recorded.
+ *   - `getPgProbe`    — local database existence.
+ *   - `getConfirm` / `getClaimReader` / `getClaimWriter` — the guard seams.
+ *
+ * Everything pushes into ONE ordered `events` list so ordering claims (tunnel
+ * opened → work → tunnel closed) are a single assertion.
+ *
+ * Covers the required pins: a preview run writes NOTHING (and makes no AWS
+ * call); slot 0 and a repointed container are refused; real mode maps
+ * `users_real` → `users`; scrubbed mode materialises the view and never leaves
+ * one; the master password appears in no argv and no output; the tunnel is torn
+ * down on the FAILURE path too; grants land so the service role can write; and
+ * a verification failure fails the database without touching the live one.
+ */
+
+import { Config } from '@oclif/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { restoreEnv, saveEnv } from '../../../__tests__/helpers/env.js';
+import { spySetStore, spySlotActive } from '../../../__tests__/helpers/set-fakes.js';
+import { BaseCommand } from '../../../base-command.js';
+import { INSTANCE_ENV_KEYS } from '../../../core/derive-instance.js';
+import { DEFAULT_LOCAL_PORT, findByMirrorName, planHydrate } from '../../../core/mirror/index.js';
+import type {
+  ClaimReadResult,
+  ClaimWriteInput,
+  ConfirmSeam,
+  HydrateExecResult,
+  HydrateIO,
+  PgProbe,
+  PortForwardHandle,
+  PortForwardRequest,
+} from '../../../runtime/index.js';
+import StackHydrate from '../hydrate.js';
+
+// Direct in-process runs bypass oclif's plugin loader (which stamps `static id`);
+// pin the real id so refusal text / the claim's command line match production.
+StackHydrate.id = 'stack:hydrate';
+
+const PKG_ROOT = process.cwd();
+const WS = ['--dev', '/fixed/dev'];
+const STATE_S2 = '/tmp/sds-synthetic-s2';
+
+/** The mirror master password — must never reach argv or stdout. */
+const SECRET = 'sup3r-s3cret-mirror-pw';
+
+let config: Config;
+let savedEnv: ReturnType<typeof saveEnv>;
+let events: string[];
+let out: string[];
+let warnings: string[];
+let prompts: string[];
+let claimWrites: ClaimWriteInput[];
+/** Every `docker` argv the executor asked for, with the secret it was handed. */
+let execs: { argv: string[]; secret?: string }[];
+let portForwards: PortForwardRequest[];
+let awsCalls: string[][];
+
+/** Scripted exec answers, keyed by a substring of the joined argv (first match wins). */
+let execScript: { match: string; result: Partial<HydrateExecResult> }[];
+
+/**
+ * The "everything is healthy" answers for the planner's assertion steps, so a
+ * test only has to script the ONE thing it is about. These are the values a good
+ * hydrate produces: the staging database is non-empty, no table is unwritable by
+ * the service role, and no app-named relation is still a view.
+ */
+function healthyAnswer(joined: string): string {
+  if (joined.includes('(count(*) > 0)')) return 't'; // verify-restored
+  if (joined.includes('has_table_privilege')) return '0'; // verify-writable
+  if (joined.includes("relkind NOT IN ('r', 'p')")) return '0'; // verify-tables
+  return '';
+}
+
+function installHydrateIO(): void {
+  const io: HydrateIO = {
+    async exec(argv, opts): Promise<HydrateExecResult> {
+      execs.push({ argv, secret: opts?.secret });
+      events.push(`exec:${argv.join(' ')}`);
+      const joined = argv.join(' ');
+      const scripted = execScript.find((s) => joined.includes(s.match));
+      return { code: 0, stdout: healthyAnswer(joined), stderr: '', ...(scripted?.result ?? {}) };
+    },
+    async assertPgRunning(container): Promise<void> {
+      events.push(`assert-pg:${container}`);
+    },
+  };
+  vi.spyOn(BaseCommand.prototype as unknown as { getHydrateIO: () => HydrateIO }, 'getHydrateIO').mockReturnValue(io);
+}
+
+/** Canned AWS: SSM params, the master secret, the jump host, and a recorded tunnel. */
+function installEnvAws(opts: { readyRejects?: Error } = {}): void {
+  const fake = {
+    async json(args: string[]): Promise<unknown> {
+      awsCalls.push(args);
+      events.push(`aws:${args.slice(0, 2).join(' ')}`);
+      if (args[0] === 'sts') return '396913734878';
+      if (args[0] === 'ssm' && args[1] === 'get-parameter') {
+        const name = args[args.indexOf('--name') + 1];
+        if (name?.endsWith('/endpoint')) return 'saga-postgres-mirror-current.abc.us-west-2.rds.amazonaws.com';
+        if (name?.endsWith('/port')) return '5432';
+        if (name?.endsWith('/master-secret-arn')) return 'arn:aws:secretsmanager:us-west-2:396913734878:secret:mirror';
+        return null;
+      }
+      if (args[0] === 'secretsmanager') return JSON.stringify({ username: 'saga_admin', password: SECRET });
+      if (args[0] === 'ec2') return ['i-08043e16658b208cc'];
+      if (args[0] === 'ssm' && args[1] === 'describe-instance-information') return ['i-08043e16658b208cc'];
+      return null;
+    },
+    async lambdaInvoke(): Promise<unknown> {
+      throw new Error('hydrate must never invoke a lambda');
+    },
+    portForward(req: PortForwardRequest): PortForwardHandle {
+      portForwards.push(req);
+      events.push(`tunnel-open:${req.target}->${req.host}:${req.remotePort}@${req.localPort}`);
+      let resolveExit: (code: number | null) => void = () => undefined;
+      const exited = new Promise<number | null>((r) => (resolveExit = r));
+      const ready = opts.readyRejects === undefined ? Promise.resolve() : Promise.reject(opts.readyRejects);
+      ready.catch(() => undefined);
+      return {
+        pid: 4242,
+        ready,
+        exited,
+        stop: () => {
+          events.push('tunnel-close');
+          resolveExit(0);
+        },
+      };
+    },
+  };
+  vi.spyOn(BaseCommand.prototype as unknown as { getEnvAws: () => unknown }, 'getEnvAws').mockReturnValue(fake);
+}
+
+function installPgProbe(existing: string[]): void {
+  const probe: PgProbe = {
+    databaseExists: async (_c, db) => existing.includes(db),
+    hasMigrationsTable: async () => true,
+    publicTableCount: async () => 10,
+    scalar: async () => '',
+  };
+  vi.spyOn(BaseCommand.prototype as unknown as { getPgProbe: () => PgProbe }, 'getPgProbe').mockReturnValue(probe);
+}
+
+function installConfirm(answer: boolean): void {
+  const confirm: ConfirmSeam = {
+    isTTY: () => true,
+    async prompt(question: string): Promise<boolean> {
+      prompts.push(question);
+      return answer;
+    },
+  };
+  vi.spyOn(BaseCommand.prototype as unknown as { getConfirm: () => ConfirmSeam }, 'getConfirm').mockReturnValue(confirm);
+}
+
+function installClaimReader(byStateDir: Record<string, ClaimReadResult> = {}): void {
+  vi.spyOn(BaseCommand.prototype as unknown as { getClaimReader: () => unknown }, 'getClaimReader').mockReturnValue({
+    read: (stateDir: string) => byStateDir[stateDir] ?? null,
+  });
+}
+
+function claimResult(live: boolean): ClaimReadResult {
+  return {
+    live,
+    claim: {
+      version: 1,
+      actor: 'someone-else',
+      actorSource: 'env',
+      pid: 41234,
+      command: 'ss stack:up --slot 2',
+      at: '2026-08-06T09:00:00.000Z',
+      cwd: '/home/x',
+      slot: 2,
+      sourceAtLaunch: {},
+    },
+  };
+}
+
+/**
+ * Build the mirror-side discovery read's stdout: unit-separator-delimited
+ * `base<US>column` rows in attnum order — exactly what `psql -A -t -F <US>`
+ * produces, so the parser is exercised on its real input shape.
+ */
+const rows = (pairs: readonly (readonly [string, string])[]): string =>
+  pairs.map(([t, c]) => `${t}\u001f${c}`).join('\n') + '\n';
+
+/** All argv the executor ran, flattened — the "is the secret anywhere?" surface. */
+const allArgv = (): string => execs.map((e) => e.argv.join(' ')).join('\n');
+
+beforeEach(async () => {
+  config = await Config.load(PKG_ROOT);
+  savedEnv = saveEnv(INSTANCE_ENV_KEYS);
+  for (const k of INSTANCE_ENV_KEYS) delete process.env[k];
+  events = [];
+  out = [];
+  warnings = [];
+  prompts = [];
+  claimWrites = [];
+  execs = [];
+  portForwards = [];
+  awsCalls = [];
+  execScript = [];
+  BaseCommand.resetSlotClaimLatchForTests();
+  vi.spyOn(BaseCommand.prototype as unknown as { log: (m?: string) => void }, 'log').mockImplementation((m?: string) => {
+    out.push(String(m ?? ''));
+  });
+  vi.spyOn(BaseCommand.prototype as unknown as { warn: (m: string) => string }, 'warn').mockImplementation(
+    (m: string) => {
+      warnings.push(String(m));
+      return m;
+    },
+  );
+  vi.spyOn(BaseCommand.prototype as unknown as { getClaimWriter: () => unknown }, 'getClaimWriter').mockReturnValue({
+    async write(inputRec: ClaimWriteInput): Promise<void> {
+      claimWrites.push(inputRec);
+    },
+  });
+  vi.spyOn(BaseCommand.prototype as unknown as { getRunner: () => unknown }, 'getRunner').mockReturnValue({
+    async run(): Promise<{ code: number }> {
+      return { code: 0 };
+    },
+  });
+  // Instant retries — the rename step's backoff must not cost wall-clock time.
+  vi.spyOn(BaseCommand.prototype as unknown as { getSleep: () => unknown }, 'getSleep').mockReturnValue(
+    async () => undefined,
+  );
+  spySetStore({ version: 1, sets: {} });
+  spySlotActive([]);
+  installClaimReader();
+  installHydrateIO();
+  installEnvAws();
+  installPgProbe(['iam_local', 'coach_api', 'iam_pii_local']);
+  installConfirm(true);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  restoreEnv(savedEnv);
+});
+
+describe('refusals — non-zero exit, nothing executed', () => {
+  it('a bare invocation (slot 0 by default) is refused with a pointer to cold-start', async () => {
+    await expect(StackHydrate.run([...WS], config)).rejects.toThrow(/--slot 1\.\.9 or --set/);
+    expect(events).toEqual([]);
+    expect(execs).toEqual([]);
+  });
+
+  it('an explicit --slot 0 is refused the same way, even with --execute --yes', async () => {
+    await expect(StackHydrate.run(['--slot', '0', '--execute', '--yes', ...WS], config)).rejects.toThrow(/cold-start/);
+    expect(events).toEqual([]);
+  });
+
+  it('refuses a NON-LOCAL target: a repointed $SAGA_MESH_POSTGRES_CONTAINER is not obeyed', async () => {
+    process.env.SAGA_MESH_POSTGRES_CONTAINER = 'prod-postgres-1';
+    await expect(StackHydrate.run(['--slot', '2', '--execute', '--yes', ...WS], config)).rejects.toThrow(
+      /must be 'soa-s2-postgres-1'/,
+    );
+    expect(execs).toEqual([]);
+  });
+
+  it('rejects an unknown --db rather than hydrating a smaller set than asked for', async () => {
+    await expect(StackHydrate.run(['--slot', '2', '--db', 'programs_db', ...WS], config)).rejects.toThrow(
+      /unknown --db 'programs_db'/,
+    );
+  });
+
+  it('refuses under another driver’s LIVE claim; --yes overrides', async () => {
+    installClaimReader({ [STATE_S2]: claimResult(true) });
+    await expect(StackHydrate.run(['--slot', '2', '--db', 'coach_api', '--execute', ...WS], config)).rejects.toThrow(
+      /someone-else[\s\S]*still running/,
+    );
+    expect(execs).toEqual([]);
+
+    await expect(
+      StackHydrate.run(['--slot', '2', '--db', 'coach_api', '--execute', '--yes', ...WS], config),
+    ).resolves.toBeUndefined();
+    expect(execs.length).toBeGreaterThan(0);
+  });
+
+  it('a declined prompt aborts (exit 0) having executed nothing', async () => {
+    installConfirm(false);
+    await expect(
+      StackHydrate.run(['--slot', '2', '--db', 'coach_api', '--execute', ...WS], config),
+    ).resolves.toBeUndefined();
+    expect(prompts).toHaveLength(1);
+    expect(execs).toEqual([]);
+    expect(events).toEqual([]);
+    expect(out.join('\n')).toContain('hydrate aborted — nothing changed.');
+  });
+});
+
+describe('preview (the default) — writes nothing, and never even calls AWS', () => {
+  it('prints the replacement map and executes nothing: no docker, no AWS, no tunnel, no claim', async () => {
+    await expect(StackHydrate.run(['--slot', '2', ...WS], config)).resolves.toBeUndefined();
+
+    const text = out.join('\n');
+    expect(text).toContain('PREVIEW');
+    expect(text).toContain('iam_db');
+    expect(text).toContain('iam_local');
+    expect(text).toContain('coach_api');
+    expect(text).toMatch(/scheduling_api\s+→ scheduling/);
+
+    expect(execs).toEqual([]);
+    expect(awsCalls).toEqual([]);
+    expect(portForwards).toEqual([]);
+    expect(prompts).toEqual([]);
+    // The central claim hook is suppressed by --dry-run only; hydrate's `--execute`
+    // latch must produce the same "a preview mutates nothing" guarantee.
+    expect(claimWrites).toHaveLength(0);
+  });
+
+  it('names what can never be hydrated instead of silently skipping it', async () => {
+    await StackHydrate.run(['--slot', '2', ...WS], config);
+    const text = out.join('\n');
+    expect(text).toContain('connectv3');
+    expect(text).toContain('insights_local');
+  });
+});
+
+describe('--execute — the happy path', () => {
+  const argvFor = (extra: string[] = []): string[] => ['--slot', '2', '--db', 'coach_api', '--execute', '--yes', ...extra, ...WS];
+
+  it('opens the tunnel, does the work, and closes the tunnel — in that order', async () => {
+    await expect(StackHydrate.run(argvFor(), config)).resolves.toBeUndefined();
+
+    const open = events.findIndex((e) => e.startsWith('tunnel-open:'));
+    const close = events.indexOf('tunnel-close');
+    const firstExec = events.findIndex((e) => e.startsWith('exec:'));
+    expect(open).toBeGreaterThanOrEqual(0);
+    expect(firstExec).toBeGreaterThan(open);
+    expect(close).toBeGreaterThan(firstExec);
+    expect(events).toContain('assert-pg:soa-s2-postgres-1');
+    // The advisory claim was recorded on entry (an executing hydrate drives the slot).
+    expect(claimWrites).toHaveLength(1);
+    expect(claimWrites[0]!.slot).toBe(2);
+  });
+
+  it('resolves the mirror at RUN TIME from SSM + Secrets Manager (never a stored endpoint)', async () => {
+    await StackHydrate.run(argvFor(), config);
+    const params = awsCalls.filter((a) => a[0] === 'ssm' && a[1] === 'get-parameter').map((a) => a[a.indexOf('--name') + 1]);
+    expect(params).toEqual([
+      '/mirror/current/postgres-rds/endpoint',
+      '/mirror/current/postgres-rds/port',
+      '/mirror/current/postgres-rds/master-secret-arn',
+    ]);
+    expect(awsCalls.some((a) => a[0] === 'secretsmanager')).toBe(true);
+    expect(portForwards[0]).toMatchObject({
+      host: 'saga-postgres-mirror-current.abc.us-west-2.rds.amazonaws.com',
+      remotePort: 5432,
+      localPort: 15532,
+      target: 'i-08043e16658b208cc',
+    });
+  });
+
+  it('creates a staging database, transfers, verifies, and only then renames the live one away', async () => {
+    await StackHydrate.run(argvFor(), config);
+    const joined = execs.map((e) => e.argv.join(' '));
+    const at = (needle: string): number => joined.findIndex((a) => a.includes(needle));
+
+    expect(at('CREATE DATABASE "coach_api__hydrate"')).toBeGreaterThanOrEqual(0);
+    expect(at('pg_restore')).toBeGreaterThan(at('CREATE DATABASE "coach_api__hydrate"'));
+    expect(at('has_table_privilege')).toBeGreaterThan(at('pg_restore'));
+    expect(at('ALTER DATABASE "coach_api" RENAME TO')).toBeGreaterThan(at('has_table_privilege'));
+    expect(at('ALTER DATABASE "coach_api__hydrate" RENAME TO "coach_api"')).toBeGreaterThan(
+      at('ALTER DATABASE "coach_api" RENAME TO'),
+    );
+  });
+
+  it('applies grants so the SERVICE ROLE — not just postgres_admin — can write', async () => {
+    await StackHydrate.run(argvFor(), config);
+    const joined = allArgv();
+    expect(joined).toContain('--no-owner');
+    expect(joined).toContain('--no-privileges');
+    expect(joined).toContain('GRANT ALL ON ALL TABLES IN SCHEMA public TO "coach_api_app";');
+    expect(joined).toContain('ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO "coach_api_app";');
+    expect(joined).toContain(`has_table_privilege('coach_api_app', c.oid, 'INSERT')`);
+  });
+
+  it('skips the retire step for a local database that does not exist yet', async () => {
+    installPgProbe([]); // nothing local yet
+    await StackHydrate.run(argvFor(), config);
+    const joined = allArgv();
+    expect(joined).not.toContain('ALTER DATABASE "coach_api" RENAME TO');
+    expect(joined).toContain('ALTER DATABASE "coach_api__hydrate" RENAME TO "coach_api"');
+  });
+
+  it('--keep-previous keeps the displaced database instead of dropping it', async () => {
+    await StackHydrate.run(argvFor(['--keep-previous']), config);
+    const joined = allArgv();
+    expect(joined).toMatch(/ALTER DATABASE "coach_api__pre_hydrate_\d{8}T\d{6}Z" WITH ALLOW_CONNECTIONS true/);
+    expect(joined).not.toMatch(/DROP DATABASE IF EXISTS "coach_api__pre_hydrate_/);
+  });
+});
+
+describe('the mirror master password never leaks', () => {
+  it('appears in NO argv — it is handed to the child env only, via a bare -e PGPASSWORD', async () => {
+    await StackHydrate.run(['--slot', '2', '--db', 'coach_api', '--execute', '--yes', ...WS], config);
+
+    expect(execs.length).toBeGreaterThan(0);
+    expect(allArgv()).not.toContain(SECRET);
+    const transfer = execs.find((e) => e.argv.join(' ').includes('pg_dump'))!;
+    expect(transfer.secret).toBe(SECRET);
+    expect(transfer.argv).toContain('-e');
+    expect(transfer.argv[transfer.argv.indexOf('-e') + 1]).toBe('PGPASSWORD');
+  });
+
+  it('appears in NO output — not in the human log, not in --output-json', async () => {
+    await StackHydrate.run(['--slot', '2', '--db', 'coach_api', '--execute', '--yes', ...WS], config);
+    expect(out.join('\n')).not.toContain(SECRET);
+    expect(warnings.join('\n')).not.toContain(SECRET);
+
+    out = [];
+    await StackHydrate.run(
+      ['--slot', '2', '--db', 'coach_api', '--execute', '--yes', '--output-json', ...WS],
+      config,
+    );
+    expect(out.join('\n')).not.toContain(SECRET);
+  });
+
+  it('is NOT handed to purely-local statements — only the mirror-facing steps get it', async () => {
+    await StackHydrate.run(['--slot', '2', '--db', 'coach_api', '--execute', '--yes', ...WS], config);
+    for (const e of execs) {
+      if (e.argv[0] === 'exec') expect(e.secret, e.argv.join(' ')).toBeUndefined();
+    }
+  });
+});
+
+describe('--source real — the _real table becomes the app-named table', () => {
+  it('drops the scramble view and renames users_real → users, using the LIVE enumeration', async () => {
+    // The mirror-side discovery read answers with two scrubbed tables.
+    execScript = [
+      {
+        match: 'left(c.relname',
+        result: {
+          stdout: rows([
+            ['users', 'id'],
+            ['users', 'email'],
+            ['groups', 'id'],
+          ]),
+        },
+      },
+    ];
+    await StackHydrate.run(['--slot', '2', '--db', 'iam_db', '--execute', '--yes', ...WS], config);
+
+    const joined = allArgv();
+    expect(joined).toContain('DROP VIEW IF EXISTS public."users" CASCADE; ALTER TABLE public."users_real" RENAME TO "users";');
+    expect(joined).toContain('ALTER TABLE public."groups_real" RENAME TO "groups"');
+    // real mode takes the data as-is: no exclusion, no COPY of the scrambled view.
+    expect(joined).not.toContain('--exclude-table-data');
+    expect(joined).not.toContain('TO STDOUT');
+  });
+});
+
+describe('--source scrubbed — materialises the view, never leaves one', () => {
+  beforeEach(() => {
+    execScript = [
+      {
+        match: 'left(c.relname',
+        result: {
+          stdout: rows([
+            ['users', 'id'],
+            ['users', 'email'],
+          ]),
+        },
+      },
+    ];
+  });
+
+  // The scrubbed PATH is built and unit-tested at the planner level, but the
+  // command refuses to RUN it: review confirmed two defects unique to this mode
+  // — emptying the `_real` tables breaks incoming FKs from tables that do carry
+  // data, and the materialising COPY steps are emitted alphabetically rather
+  // than FK-topologically. Both abort inside the staging database (the live copy
+  // is never at risk), but an operator should not have to discover that.
+  // Delete this refusal, and re-enable the three behavioural tests below it,
+  // once the ordering is fixed — required before public release.
+  it('REFUSES to run, naming both defects and pointing at --source real', async () => {
+    await expect(
+      StackHydrate.run(['--slot', '2', '--db', 'iam_db', '--source', 'scrubbed', '--execute', '--yes', ...WS], config),
+    ).rejects.toMatchObject({ oclif: { exit: 2 } });
+  });
+
+  it('refuses BEFORE doing any work — no tunnel, no docker, nothing spawned', async () => {
+    await expect(
+      StackHydrate.run(['--slot', '2', '--db', 'iam_db', '--source', 'scrubbed', '--execute', '--yes', ...WS], config),
+    ).rejects.toBeTruthy();
+    expect(allArgv()).toBe('');
+  });
+
+  it('the planner still models the mode correctly (kept alive for when the gate lifts)', () => {
+    const plan = planHydrate({
+      slot: 2,
+      mode: 'scrubbed',
+      selection: [findByMirrorName('iam_db')!],
+      pgContainer: 'soa-s2-postgres-1',
+      localPort: 7432,
+      mirrorLocalPort: DEFAULT_LOCAL_PORT,
+      localExists: { iam_local: true },
+      realTables: { iam_db: [{ table: 'users', columns: ['id', 'email'] }] },
+      stamp: '20260806T133000Z',
+    });
+    const joined = JSON.stringify(plan);
+    expect(joined).toContain('--exclude-table-data=public.users_real');
+    expect(joined).toContain('ALTER TABLE public.\\"users_real\\" RENAME TO \\"users\\"');
+    expect(joined).toContain('relkind NOT IN');
+  });
+});
+
+describe('the tunnel is torn down on EVERY path', () => {
+  it('closes it after a successful run', async () => {
+    await StackHydrate.run(['--slot', '2', '--db', 'coach_api', '--execute', '--yes', ...WS], config);
+    expect(events.filter((e) => e === 'tunnel-close')).toHaveLength(1);
+    expect(events[events.length - 1]).toBe('tunnel-close');
+  });
+
+  it('closes it when the work THROWS mid-restore (the soa#370 orphan-listener failure mode)', async () => {
+    // A hard discovery failure inside the try block, after the tunnel is open.
+    execScript = [{ match: 'left(c.relname', result: { code: 1, stderr: 'connection reset' } }];
+    await expect(
+      StackHydrate.run(['--slot', '2', '--db', 'iam_db', '--execute', '--yes', ...WS], config),
+    ).rejects.toThrow(/could not enumerate/);
+    expect(events).toContain('tunnel-close');
+  });
+
+  it('closes it when the tunnel itself never becomes ready', async () => {
+    installEnvAws({ readyRejects: new Error('port-forward not ready after 30s') });
+    await expect(
+      StackHydrate.run(['--slot', '2', '--db', 'coach_api', '--execute', '--yes', ...WS], config),
+    ).rejects.toThrow(/not ready/);
+    expect(events).toContain('tunnel-close');
+    expect(execs.filter((e) => e.argv[0] === 'run')).toEqual([]); // no transfer ever started
+  });
+});
+
+describe('reporting', () => {
+  it('emits the whole report before exiting non-zero on a per-database failure', async () => {
+    execScript = [{ match: 'has_table_privilege', result: { stdout: '3' } }];
+    await expect(
+      StackHydrate.run(['--slot', '2', '--db', 'coach_api', '--execute', '--yes', '--output-json', ...WS], config),
+    ).rejects.toMatchObject({ oclif: { exit: 1 } });
+
+    const text = out.join('\n');
+    const json = JSON.parse(text.slice(text.indexOf('{'))) as Record<string, unknown>;
+    expect(json.slot).toBe(2);
+    expect(json.mode).toBe('real');
+    expect(json.failed).toBe('coach_api');
+    expect(JSON.stringify(json.databases)).toMatch(/NOT writable by coach_api_app/);
+  });
+
+  it('porcelain output stays scalar (no [object Object] rows)', async () => {
+    await StackHydrate.run(
+      ['--slot', '2', '--db', 'coach_api', '--execute', '--yes', '--porcelain', ...WS],
+      config,
+    );
+    const kv = out.filter((l) => l.includes('='));
+    expect(kv.some((l) => l === 'hydrated=coach_api')).toBe(true);
+    expect(kv.some((l) => l === 'failed=')).toBe(true);
+    expect(out.join('\n')).not.toContain('[object Object]');
+  });
+});

--- a/packages/node/saga-stack-cli/src/commands/stack/hydrate.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/hydrate.ts
@@ -1,0 +1,773 @@
+/**
+ * `saga-stack stack hydrate` — replace a LOCAL slot's Postgres with the daily
+ * prod MIRROR, so a developer gets real prod-shaped data across every store with
+ * no per-store sync code.
+ *
+ * ── WHAT IT ACTUALLY DOES ──────────────────────────────────────────────────
+ *   1. resolve the mirror at RUN TIME (SSM `/mirror/current/postgres-rds/*` +
+ *      the Secrets Manager master secret),
+ *   2. open ONE SSM port-forward through the dev jump host — the child process
+ *      IS the tunnel, and it is torn down in a `finally` on every path,
+ *   3. per database: stream `pg_dump | pg_restore` into a STAGING database, do
+ *      the surgery there (view swap, re-own, grant), VERIFY it there, and only
+ *      then swap it in by rename.
+ *
+ * Every argv and every SQL statement comes from the PURE planner in
+ * `core/mirror/plan.ts`; this file is flags, guards, progress and reporting.
+ *
+ * ── DRY RUN BY DEFAULT (a deliberate divergence from `stack wipe`) ──────────
+ * `stack wipe` is prompt-by-default. Hydrate is PREVIEW-by-default: it
+ * overwrites entire databases from a remote source, and the thing a reader most
+ * needs before running it is the mapping — which mirror database lands on which
+ * local one. So a bare invocation prints the full replacement plan and exits 0
+ * having touched nothing (and having made no AWS call at all). `--execute`
+ * performs it; `--execute --yes` skips the destructive prompt for agents/CI.
+ *
+ * CLAIM WRINKLE: BaseCommand's central claim hook is suppressed by a flag named
+ * EXACTLY `dry-run`, and hydrate does not have one. `claimsSlot()` therefore
+ * gates on an `--execute` latch captured from the raw argv in `parse` (the
+ * `stack wipe --slot all` precedent) — the invariant being preserved is "a
+ * preview run never mutates `claim.json`", not the flag's spelling.
+ *
+ * ── GUARDS (each names the guard, the override, and the alternative) ────────
+ *   - slot 0 / a bare `--slot` is REFUSED: slot 0 is the shared baseline and
+ *     holds live work. An explicit `--slot 1..9` or `--set <name>` is required.
+ *   - NON-LOCAL TARGET: the resolved container, host and port must be exactly
+ *     the slot's own (`localTargetRefusal`) — a repointed
+ *     `$SAGA_MESH_POSTGRES_CONTAINER` is refused, not obeyed. There is no flag
+ *     that lets hydrate write anywhere but a local synthetic slot.
+ *   - the slot's postgres container must be RUNNING.
+ *   - AWS account preflight: the mirror lives in the DEV account.
+ *   - live-claim refusal (another driver is running this slot); `--yes` overrides.
+ *     Captured BEFORE the central claim hook overwrites `claim.json`.
+ *   - a declined prompt is an ABORT — exit 0, nothing changed. The structural
+ *     refusals above are `this.error` — exit 2.
+ *
+ * ── WHAT HYDRATE DOES NOT DO ───────────────────────────────────────────────
+ * It does NOT make Coach reporting light up. Prod itself has
+ * `group_track_map = 0` and `persona_assignment = 0`, so no restore of prod can
+ * produce that routing; it is a separate concern. It also cannot fill Connect
+ * (mongo — the mirror is Postgres-only) or insights (no mirror counterpart);
+ * both are reported explicitly rather than silently skipped.
+ *
+ *   ss stack hydrate --slot 2                          # preview (default) — changes nothing
+ *   ss stack hydrate --slot 2 --execute                # prompt, then hydrate the default DB set
+ *   ss stack hydrate --slot 2 --db coach_api --execute --yes
+ *   ss stack hydrate --slot 2 --source scrubbed --execute --yes
+ *   ss stack hydrate --set my-set --execute --yes --keep-previous
+ */
+
+import { Flags } from '@oclif/core';
+import type { Interfaces } from '@oclif/core';
+import { BaseCommand } from '../../base-command.js';
+import { bold, cyan, dim, green, yellow } from '../../color.js';
+import { deriveInstance } from '../../core/derive-instance.js';
+import { accountMismatchError, resolveEnv } from '../../core/env/index.js';
+import {
+  CONFIRMED_REAL_TABLES,
+  DEFAULT_CLIENT_IMAGE,
+  DEFAULT_LOCAL_PORT,
+  MIRROR_ADMIN_USER,
+  NO_MIRROR_SOURCE,
+  localTargetRefusal,
+  localTarget,
+  mirrorDiscoveryArgv,
+  planHydrate,
+  realTableQuerySql,
+  resolveSelection,
+} from '../../core/mirror/index.js';
+import type { HydrateDbPlan, HydrateStep, MirrorDbDef, RealTableInfo, SourceMode } from '../../core/mirror/index.js';
+import {
+  parseRealTableRows,
+  pgRestoreFailed,
+  postgresContainer,
+  relativeAge,
+  resolveJumpHost,
+  resolveCallerAccount,
+} from '../../runtime/index.js';
+import type { ClaimReadResult, HydrateIO } from '../../runtime/index.js';
+
+/** SSM parameter NAMES (never values) carrying the daily mirror's coordinates. */
+const MIRROR_SSM = {
+  endpoint: '/mirror/current/postgres-rds/endpoint',
+  port: '/mirror/current/postgres-rds/port',
+  masterSecretArn: '/mirror/current/postgres-rds/master-secret-arn',
+} as const;
+
+/** The environment whose account + jump host reach the mirror (it lives in dev). */
+const MIRROR_ENV = 'dev';
+
+/** Per-database outcome, the unit of both the report and the `--output-json` shape. */
+interface DbOutcome {
+  mirror: string;
+  local: string;
+  ownerRole: string;
+  scrubbed: boolean;
+  staging: string;
+  previous: string | null;
+  renamed: number;
+  copied: number;
+  steps: number;
+  ok: boolean;
+  error?: string;
+  seconds: number;
+}
+
+export default class StackHydrate extends BaseCommand {
+  static description =
+    "Replace a local slot's Postgres databases with the daily prod mirror (SSM tunnel → staging database → verify → rename swap). " +
+    'PREVIEW BY DEFAULT: a bare run prints exactly what would be replaced and touches nothing; --execute performs it. ' +
+    'Requires an explicit --slot 1..9 or --set; slot 0 is refused.';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> --slot 2',
+    '<%= config.bin %> <%= command.id %> --slot 2 --execute',
+    '<%= config.bin %> <%= command.id %> --slot 2 --db coach_api,iam_db --execute --yes',
+    '<%= config.bin %> <%= command.id %> --slot 2 --source scrubbed --execute --yes',
+    '<%= config.bin %> <%= command.id %> --set my-set --execute --yes --keep-previous',
+  ];
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    source: Flags.string({
+      options: ['real', 'scrubbed'],
+      default: 'real',
+      description:
+        "which copy of the two SCRUBBED databases (iam_db, iam_pii_db) to land. 'real' (DEFAULT) lands the " +
+        'unscrambled tables — prod is PRE-RELEASE and every user in it is a Saga employee, so there is no real ' +
+        'end-user PII today, and the scramble makes a poor reporting fixture (a known district cannot be found by ' +
+        "display_name or source_id at all). 'scrubbed' lands the scrambled view materialised into a real writable " +
+        'table instead. NOTE: only the rostering project is scrubbed upstream — every OTHER database is raw prod ' +
+        'data in BOTH modes, so --source scrubbed does NOT make a hydrate free of prod data. This default FLIPS at ' +
+        'public release, when prod holds real end-user data.',
+    }),
+    db: Flags.string({
+      multiple: true,
+      description:
+        "databases to hydrate: mirror or local names (comma- or flag-repeatable), plus 'default' and 'all'. " +
+        'DEFAULT (when omitted) is every mapping with a verified name pair and a slot-provisioned local home: ' +
+        'scheduling, sessions, iam_local, programs, authz_local, coach_api, authz_sync_local, iam_pii_local, ' +
+        'sis_db, ads_adm_local, ledger_local, content. Opt-in extras: openfga (its local schema is sidecar-owned), ' +
+        'transcripts_local (mapping unverified + playback-only), chat_local (playback-only).',
+    }),
+    execute: Flags.boolean({
+      default: false,
+      description:
+        'actually perform the replacement. Without it this command is a PREVIEW: it prints the full plan, makes no ' +
+        'AWS call, opens no tunnel, writes no claim, and exits 0.',
+    }),
+    yes: Flags.boolean({
+      default: false,
+      description:
+        'non-interactive: skip the destructive-action prompt AND override the live-claim guard (CI / agents). ' +
+        'Only meaningful with --execute.',
+    }),
+    'local-port': Flags.integer({
+      default: DEFAULT_LOCAL_PORT,
+      description:
+        "local end of the SSM tunnel to the mirror. Deliberately NOT `env connect`'s 15432 so an open `ss env connect` and a hydrate cannot collide.",
+    }),
+    profile: Flags.string({
+      description: 'AWS profile for the mirror account (defaults to the ambient credential chain; dev_admin is the usual one).',
+    }),
+    'jump-host': Flags.string({
+      description: 'override the EC2 Name tag of the SSM jump host (default: the dev environment\'s).',
+    }),
+    'keep-previous': Flags.boolean({
+      default: false,
+      description:
+        'keep each displaced database as <db>__pre_hydrate_<stamp> instead of dropping it — a one-command rollback (rename it back).',
+    }),
+    'client-image': Flags.string({
+      default: DEFAULT_CLIENT_IMAGE,
+      description:
+        'ephemeral postgres client image for the dump/restore pipelines. Must be >= the mirror server version (PG 18.3) and must carry bash (the pipelines run under `bash -o pipefail`).',
+    }),
+  };
+
+  /** Hydrate targets an isolated slot 1..9; slot 0 is refused in run(). */
+  protected slotAware(): boolean {
+    return true;
+  }
+
+  /** A set is repo paths + a slot >= 1 — exactly hydrate's target. */
+  protected setAware(): boolean {
+    return true;
+  }
+
+  /**
+   * An executing hydrate DRIVES the slot (a failed one usefully records who
+   * attempted it); a preview must claim nothing. See the CLAIM WRINKLE note in
+   * the header for why this is gated on a raw-argv latch rather than `--dry-run`.
+   */
+  protected claimsSlot(): boolean {
+    return this.executeMode;
+  }
+
+  /** `--execute` detected from the raw argv in `parse`, before flag parsing. */
+  private executeMode = false;
+
+  /** Prior drivers' claims, captured BEFORE the central hook overwrites claim.json. */
+  private priorClaims = new Map<string, ClaimReadResult>();
+
+  /**
+   * Two things must happen before `super.parse` writes this invocation's claim:
+   * the `--execute` latch that `claimsSlot()` reads, and the capture of the
+   * PRIOR driver's claim that the live-claim guard needs (a naive read in run()
+   * would see hydrate's OWN claim and the guard would silently never fire —
+   * `stack wipe`'s wrinkle).
+   */
+  protected async parse<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    F extends { [flag: string]: any },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    B extends { [flag: string]: any },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    A extends { [arg: string]: any },
+  >(
+    options?: Interfaces.Input<F, B, A>,
+    argv?: string[],
+  ): Promise<Interfaces.ParserOutput<F, B, A>> {
+    const raw = argv ?? this.argv;
+    this.executeMode = raw.includes('--execute');
+    this.capturePriorClaims(raw);
+    return super.parse<F, B, A>(options, argv);
+  }
+
+  /** Read (never write) the current claim of every candidate state dir. */
+  private capturePriorClaims(rawArgv: readonly string[]): void {
+    const reader = this.getClaimReader();
+    const dirs = new Set<string>();
+    // Slot 0 is refused before anything is touched, so only 1..9 matter.
+    for (let slot = 1; slot <= 9; slot++) dirs.add(deriveInstance({ slot }).stateDir);
+    for (let i = 0; i < rawArgv.length; i++) {
+      const token = rawArgv[i];
+      if (token === undefined) continue;
+      const next = rawArgv[i + 1];
+      if (token === '--state-dir' && next !== undefined) dirs.add(next);
+      else if (token.startsWith('--state-dir=')) dirs.add(token.slice('--state-dir='.length));
+    }
+    for (const dir of dirs) {
+      const result = reader.read(dir);
+      if (result !== null) this.priorClaims.set(dir, result);
+    }
+  }
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(StackHydrate);
+    const execute = flags.execute;
+    const human = !flags['output-json'] && !flags.porcelain;
+    const slot = flags.slot;
+
+    // ── GUARD: slot 0 / bare invocation, and any non-local write target ──
+    // The AMBIENT override is read BEFORE `applyInstanceEnv` deterministically
+    // overwrites it: at slot > 0 the profile would silently repair a repointed
+    // `$SAGA_MESH_POSTGRES_CONTAINER`, and at slot 0 it would leave it in force.
+    // Neither is right for a command that overwrites whole databases — an
+    // operator who has repointed the container gets a refusal, not a guess.
+    const ambientContainer = process.env.SAGA_MESH_POSTGRES_CONTAINER;
+    const profile = deriveInstance({ slot });
+    this.applyInstanceEnv(profile);
+    const container = postgresContainer();
+    const localPort = 5432 + profile.meshOffset;
+    const refusal = localTargetRefusal({
+      slot,
+      container: ambientContainer ?? container,
+      host: '127.0.0.1',
+      port: localPort,
+    });
+    if (refusal !== null) this.error(refusal);
+
+    // ── selection ──
+    let selection: MirrorDbDef[];
+    try {
+      selection = resolveSelection((flags.db ?? []).flatMap((token) => token.split(',')));
+    } catch (err) {
+      return this.error((err as Error).message);
+    }
+    if (selection.length === 0) this.error('--db selected nothing — drop the flag for the default set, or pass `all`.');
+    const mode = flags.source as SourceMode;
+    // `--source scrubbed` is NOT safe yet and refuses rather than aborting
+    // confusingly mid-restore. Two confirmed defects, both in this path only:
+    // emptying the `_real` tables breaks incoming FKs from tables that DO carry
+    // data, and the per-table COPY steps are emitted alphabetically rather than
+    // in FK-topological order. Both abort inside the staging database, so the
+    // live copy is never at risk — but there is no reason to let an operator
+    // discover that the hard way. `real` is the default and the mode that
+    // matters until public release, which is when this must be fixed.
+    if (mode === 'scrubbed') {
+      this.error(
+        '--source scrubbed is not usable yet: emptied _real tables break incoming foreign keys, and the ' +
+          'materialising COPY steps are not ordered FK-topologically, so the restore aborts. Use --source real ' +
+          '(the default) — prod is pre-release and carries no end-user PII. This must be fixed before public release.'
+      );
+    }
+
+    // ── GUARD: live prior claim (another driver is running this slot) ──
+    const stateDir = flags['state-dir'] ?? profile.stateDir;
+    const prior = this.priorClaims.get(stateDir);
+    const foreignLive = prior !== undefined && prior.live && prior.claim.pid !== process.pid;
+    if (foreignLive && execute && !flags.yes) {
+      this.error(
+        `slot ${slot}: claimed by ${prior.claim.actor} ${relativeAge(prior.claim.at)} ago and still running ` +
+          `(pid ${prior.claim.pid} — \`${prior.claim.command}\`). ` +
+          'Refusing to hydrate under a live driver; pass --yes to override.',
+      );
+    }
+
+    // ── the enumeration: identical for the preview, the confirm header and --yes ──
+    // Built with the CONFIRMED `_real` set; an executing run re-enumerates it from
+    // the live mirror before planning for real (only rostering is scrubbed, and
+    // that project's scrubbed table set moves with its schema).
+    const previewReal = previewRealTables(selection);
+    const preview = planHydrate({
+      slot,
+      mode,
+      selection,
+      pgContainer: container,
+      localPort,
+      mirrorLocalPort: flags['local-port'],
+      localExists: Object.fromEntries(selection.map((d) => [localTarget(d).name, true])),
+      realTables: previewReal,
+      stamp: '<stamp>',
+      keepPrevious: flags['keep-previous'],
+      clientImage: flags['client-image'],
+    });
+    const planLines = this.planLines(preview, mode, flags['local-port']);
+
+    if (!execute) {
+      this.log(`${bold('▶ stack hydrate PREVIEW')} — slot ${bold(String(slot))} (nothing will be changed):`);
+      for (const line of planLines) this.log(line);
+      if (foreignLive) {
+        this.log(
+          `    note: slot is live-claimed by ${prior.claim.actor} (${relativeAge(prior.claim.at)} ago) — ` +
+            'an --execute run will refuse without --yes.',
+        );
+      }
+      this.log(dim('    (the _real table set above is the CONFIRMED one; an --execute run enumerates it live from the mirror)'));
+      this.log(`${green('✓')} preview complete — no AWS call, no tunnel, no changes.`);
+      return;
+    }
+
+    if (!flags.yes) {
+      // The enumeration + one prompt run even under --output-json/--porcelain — a
+      // destructive command never proceeds silently; agents pass --yes for clean output.
+      this.log(`${bold('▶ stack hydrate')} — slot ${bold(String(slot))}:`);
+      for (const line of planLines) this.log(line);
+      const ok = await this.getConfirm().prompt(
+        `\n  This REPLACES ${selection.length} database(s) on slot ${slot} with prod-mirror data` +
+          `${flags['keep-previous'] ? ' (previous copies kept)' : ' (previous copies dropped)'}. Continue? [y/N] `,
+      );
+      if (!ok) {
+        this.log('hydrate aborted — nothing changed.');
+        return;
+      }
+    } else if (human) {
+      this.log(`${bold('▶ stack hydrate')} — slot ${bold(String(slot))} (--yes):`);
+      for (const line of planLines) this.log(line);
+    }
+
+    const io = this.getHydrateIO();
+    await io.assertPgRunning(container);
+
+    // ── AWS: account preflight, then RUN-TIME resolution of the daily mirror ──
+    const env = resolveEnv(MIRROR_ENV);
+    if (env === undefined) this.error(`internal: no '${MIRROR_ENV}' environment in the registry`);
+    const awsOpts = { profile: flags.profile, region: env.awsRegion };
+    const aws = this.getEnvAws();
+    const mismatch = accountMismatchError(await resolveCallerAccount(aws, awsOpts), [env.awsAccountId], 'the prod mirror');
+    if (mismatch !== null) this.error(mismatch);
+
+    // The mirror instance is REPLACED daily by a 13:30 UTC CFN cron, so BOTH the
+    // endpoint and the master password change every day. Everything below is read
+    // fresh on every invocation and never memoized, written to the state dir, or
+    // added to the env registry — the `resolveSharedEndpoint` stance.
+    const endpoint = await this.fetchParam(MIRROR_SSM.endpoint, awsOpts);
+    const remotePortRaw = await this.fetchParam(MIRROR_SSM.port, awsOpts);
+    const remotePort = Number(remotePortRaw);
+    if (!Number.isInteger(remotePort) || remotePort <= 0) {
+      this.error(`SSM ${MIRROR_SSM.port} is not a port number ('${remotePortRaw}')`);
+    }
+    const secretArn = await this.fetchParam(MIRROR_SSM.masterSecretArn, awsOpts);
+    const { username, password } = await this.fetchMasterSecret(secretArn, awsOpts);
+
+    // The x86 and arm shared-ECS fleets BOTH sit in the mirror SG's 5432 ingress,
+    // and either may be the one that happens to be SSM-Online: measured 2026-08-06,
+    // no `dev-shared-ecs-instance` was Online while two `dev-shared-arm-ecs-instance`
+    // were. Resolving only the registry's tag would have failed for no good reason,
+    // so fall back to the arm fleet before giving up. An explicit --jump-host still
+    // wins outright and is never second-guessed.
+    const explicitJump = flags['jump-host'];
+    const tagsToTry = explicitJump !== undefined ? [explicitJump] : [env.jumpHostNameTag, `${env.jumpHostNameTag.replace(/-ecs-instance$/, '')}-arm-ecs-instance`];
+    let jump: string | undefined;
+    let nameTag = tagsToTry[0]!;
+    for (const tag of tagsToTry) {
+      jump = await resolveJumpHost(aws, tag, awsOpts);
+      if (jump !== undefined) {
+        nameTag = tag;
+        break;
+      }
+    }
+    if (jump === undefined) {
+      this.error(`no running+Online SSM jump host tagged Name=${tagsToTry.join(' or Name=')} — check tier/region/profile.`);
+    }
+
+    if (human) {
+      this.log(`  ${dim('mirror:')}   ${endpoint}:${remotePort} ${dim(`(SSM ${MIRROR_SSM.endpoint}, resolved now)`)}`);
+      this.log(`  ${dim('route:')}    jump host ${jump} → 127.0.0.1:${flags['local-port']}`);
+    }
+
+    // ── the tunnel: the child process IS the tunnel, and it dies in the finally ──
+    const handle = aws.portForward({
+      target: jump,
+      host: endpoint,
+      remotePort,
+      localPort: flags['local-port'],
+      region: env.awsRegion,
+      profile: flags.profile,
+    });
+    // Registering a SIGINT listener REPLACES node's default terminate behaviour,
+    // so a bare `handle.stop()` would make Ctrl-C close the tunnel while the
+    // destructive loop kept running against a dead connection — the operator
+    // cannot abort a hydrate. Mark aborting (checked between databases), stop
+    // the tunnel, then re-raise so the process actually dies.
+    let aborted: NodeJS.Signals | null = null;
+    const stopTunnel = (sig: NodeJS.Signals) => (): void => {
+      aborted = sig;
+      handle.stop();
+      process.off(sig, stopTunnel(sig));
+      // Give the tunnel a beat to die, then restore default disposition.
+      setTimeout(() => {
+        process.kill(process.pid, sig);
+      }, 50).unref?.();
+    };
+    const onInt = stopTunnel('SIGINT');
+    const onTerm = stopTunnel('SIGTERM');
+    process.on('SIGINT', onInt);
+    process.on('SIGTERM', onTerm);
+    void aborted; // recorded for the finally-block's log line below
+
+    let outcomes: DbOutcome[] = [];
+    try {
+      await handle.ready;
+      if (human) this.log(`${green('✓ tunnel up')} — 127.0.0.1:${flags['local-port']} → ${endpoint}:${remotePort}`);
+      outcomes = await this.hydrateAll({
+        io,
+        flags,
+        slot,
+        mode,
+        selection,
+        container,
+        localPort,
+        secret: password,
+        mirrorUser: username,
+        human,
+      });
+    } finally {
+      // A throw mid-restore without this leaks a detached session-manager-plugin
+      // that keeps holding the local port — the soa#370 failure mode.
+      handle.stop();
+      await handle.exited.catch(() => undefined);
+      process.off('SIGINT', onInt);
+      process.off('SIGTERM', onTerm);
+      if (human) this.log(dim('tunnel closed.'));
+    }
+
+    // ── the report: emitted IN FULL before any non-zero exit ──
+    const failed = outcomes.filter((o) => !o.ok);
+    const lines = outcomes.map(
+      (o) =>
+        `  ${o.ok ? green('✓') : yellow('✗')} ${o.mirror} → ${o.local}` +
+        `  ${dim(`${o.seconds}s, ${o.steps} steps`)}` +
+        (o.renamed > 0 ? dim(`, ${o.renamed} table(s) materialised`) : '') +
+        (o.previous !== null ? dim(`, previous kept as ${o.previous}`) : '') +
+        (o.ok ? '' : `\n      ${o.error ?? 'failed'}`),
+    );
+    for (const note of NO_MIRROR_SOURCE) lines.push(dim(`  · ${note.local}: not hydrated — ${note.why}`));
+    lines.push(
+      dim(
+        '  · Coach reporting stays dark: prod itself has group_track_map = 0 and persona_assignment = 0, ' +
+          'so no hydrate can populate that routing.',
+      ),
+    );
+
+    // `emit`'s porcelain branch stringifies values directly, so a nested object
+    // array would render as `[object Object]`. The scalar summary is what
+    // porcelain gets; `--output-json` additionally carries the per-database detail.
+    const summary = {
+      slot,
+      mode,
+      dryRun: false,
+      hydrated: outcomes.filter((o) => o.ok).map((o) => o.local).join(','),
+      failed: failed.map((o) => o.local).join(','),
+    };
+    this.emit(
+      flags,
+      flags.porcelain ? summary : { ...summary, databases: outcomes },
+      [
+        `${bold('▶ stack hydrate')} — slot ${slot}, source ${cyan(mode)}: ` +
+          `${outcomes.length - failed.length}/${outcomes.length} database(s) hydrated`,
+        ...lines,
+      ],
+    );
+
+    if (failed.length > 0) this.exit(1);
+  }
+
+  /**
+   * Run every selected database, one at a time. A per-database failure is
+   * CONTAINED — its live database was never touched (all the work happened in a
+   * staging database), so the sweep continues and the whole report is emitted
+   * before the non-zero exit.
+   */
+  private async hydrateAll(ctx: {
+    io: HydrateIO;
+    flags: { [k: string]: unknown };
+    slot: number;
+    mode: SourceMode;
+    selection: MirrorDbDef[];
+    container: string;
+    localPort: number;
+    secret: string;
+    mirrorUser: string;
+    human: boolean;
+  }): Promise<DbOutcome[]> {
+    const flags = ctx.flags as {
+      'local-port': number;
+      'client-image': string;
+      'keep-previous': boolean;
+    };
+
+    // ── discovery, through the tunnel: the scrub's `_real` tables + column order ──
+    const realTables: Record<string, RealTableInfo[]> = {};
+    for (const def of ctx.selection.filter((d) => d.scrubbed)) {
+      const argv = mirrorDiscoveryArgv({
+        image: flags['client-image'],
+        mirrorPort: flags['local-port'],
+        user: ctx.mirrorUser,
+        database: def.mirror,
+        sql: realTableQuerySql(),
+      });
+      const res = await ctx.io.exec(argv, { secret: ctx.secret });
+      if (res.code !== 0) {
+        throw new Error(`could not enumerate ${def.mirror}'s scrubbed tables (exit=${res.code}): ${res.stderr.trim().slice(-400)}`);
+      }
+      const discovered = parseRealTableRows(res.stdout);
+      // A SOFT-empty enumeration — exit 0, zero rows — is the dangerous case, and
+      // exit code alone cannot see it. `def.scrubbed` means we KNOW this database
+      // carries the view swap, so zero `_real` tables means the query stopped
+      // matching reality (the scrub moved off `public`, renamed the suffix, or
+      // simply did not run today). Continuing would emit no view-swap steps AND
+      // skip the no-views assertion that guards them, then promote a database
+      // whose app-named relations are still read-only VIEWS — and drop the good
+      // one. Refuse instead, naming the floor we expected.
+      if (discovered.length === 0) {
+        const expected = CONFIRMED_REAL_TABLES[def.mirror] ?? [];
+        throw new Error(
+          `enumerated ZERO _real tables in ${def.mirror}, but it is a scrubbed database — ` +
+            `expected at least ${expected.length} (e.g. ${expected.slice(0, 3).join(', ')}). ` +
+            `The daily scrub may not have run, or its naming changed. Refusing: hydrating now would ` +
+            `land read-only scramble VIEWS under the app's table names and destroy the local copy. ` +
+            `Verify the mirror was refreshed today, then re-run.`
+        );
+      }
+      realTables[def.mirror] = discovered;
+      if (ctx.human) {
+        this.log(`  ${dim('scrub:')}    ${def.mirror} — ${discovered.length} _real table(s) enumerated live`);
+      }
+    }
+
+    // ── which local databases exist (drives the swap's rename-away step) ──
+    const probe = this.getPgProbe();
+    const localExists: Record<string, boolean> = {};
+    for (const def of ctx.selection) {
+      const { name } = localTarget(def);
+      localExists[name] = await probe.databaseExists(ctx.container, name);
+    }
+
+    const plan = planHydrate({
+      slot: ctx.slot,
+      mode: ctx.mode,
+      selection: ctx.selection,
+      pgContainer: ctx.container,
+      localPort: ctx.localPort,
+      mirrorLocalPort: flags['local-port'],
+      mirrorUser: ctx.mirrorUser,
+      localExists,
+      realTables,
+      stamp: stampNow(),
+      keepPrevious: flags['keep-previous'],
+      clientImage: flags['client-image'],
+    });
+
+    const outcomes: DbOutcome[] = [];
+    let index = 0;
+    for (const db of plan.dbs) {
+      index += 1;
+      const started = Date.now();
+      // Per-database progress: this is SLOW (scheduling_api alone is 178MB), so
+      // the header lands before the work, not after it.
+      if (ctx.human) {
+        this.log(
+          `${bold(`▶ ${index}/${plan.dbs.length}`)} ${cyan(db.mirrorName)} → ${cyan(db.localName)} ` +
+            dim(`(owner ${db.ownerRole}, ${db.steps.length} steps${db.scrubbed ? `, ${db.mode} source` : ''})`),
+        );
+      }
+      let ok = true;
+      let error: string | undefined;
+      try {
+        for (const step of db.steps) {
+          if (ctx.human) this.log(`    ${dim('·')} ${step.label}`);
+          await this.runStep(ctx.io, step, ctx.secret);
+        }
+      } catch (err) {
+        ok = false;
+        error = err instanceof Error ? err.message : String(err);
+        this.warn(`${db.localName}: ${error}`);
+      }
+      outcomes.push(outcomeFor(db, ok, error, Math.round((Date.now() - started) / 1000), flags['keep-previous']));
+    }
+    return outcomes;
+  }
+
+  /**
+   * Run ONE planned step. The only judgment here is the exit-code classification,
+   * and it is the thing most worth getting right: `pg_restore` exits non-zero on
+   * benign warnings — and a `--no-owner --no-privileges` prod dump emits a pile
+   * of them — so those steps are classified from stderr with the existing
+   * `pgRestoreFailed`. Treating exit != 0 as failure would make every hydrate
+   * look broken; inverting it would make a real failure look green, which is why
+   * the planner also asserts the staging database is non-empty afterwards.
+   */
+  private async runStep(io: HydrateIO, step: HydrateStep, secret: string): Promise<void> {
+    const attempts = (step.kind === 'sql' ? step.retries ?? 0 : 0) + 1;
+    let last: { code: number | null; stdout: string; stderr: string } | undefined;
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+      const res = await io.exec(step.dockerArgv, step.needsSecret === true ? { secret } : {});
+      last = res;
+      const failed =
+        step.kind === 'transfer' && step.classify === 'pg_restore'
+          ? pgRestoreFailed(res.code, res.stderr)
+          : res.code !== 0;
+      if (!failed) {
+        if (step.kind === 'sql' && step.expect !== undefined) {
+          const actual = res.stdout.trim();
+          if (actual !== step.expect) {
+            throw new Error(
+              (step.expectMessage ?? `${step.id}: expected '${step.expect}', got '%s'`).replace(
+                '%s',
+                actual === '' ? '(empty)' : actual,
+              ),
+            );
+          }
+        }
+        return;
+      }
+      if (attempt < attempts) await this.getSleep()(500);
+    }
+    throw new Error(
+      `${step.id} failed (exit=${last?.code ?? 'signal'}): ${(last?.stderr ?? '').trim().slice(-800) || '(no stderr)'}`,
+    );
+  }
+
+  /** The replacement enumeration — identical for the preview, the confirm header, and --yes. */
+  private planLines(plan: ReturnType<typeof planHydrate>, mode: SourceMode, tunnelPort: number): string[] {
+    const lines = [
+      `    slot:      ${plan.slot} — container ${plan.pgContainer}, postgres 127.0.0.1:${plan.localPort}`,
+      `    source:    prod mirror via SSM tunnel 127.0.0.1:${tunnelPort} (resolved at run time, ${MIRROR_ADMIN_USER})`,
+      `    mode:      --source ${mode}` +
+        (mode === 'real'
+          ? ' — unscrambled rostering tables (prod is pre-release; this flips at public release)'
+          : ' — scrambled rostering views materialised into real writable tables'),
+      `    previous:  ${plan.keepPrevious ? 'KEPT as <db>__pre_hydrate_<stamp>' : 'DROPPED after the swap (pass --keep-previous to keep them)'}`,
+      '    replaces:',
+    ];
+    for (const db of plan.dbs) {
+      lines.push(
+        `      ${db.mirrorName.padEnd(18)} → ${db.localName.padEnd(18)} owner ${db.ownerRole}` +
+          (db.scrubbed ? `  [scrubbed: ${db.renamedTables.length} table(s) ${db.copiedTables.length > 0 ? 'materialised from the view' : 'taken from *_real'}]` : ''),
+      );
+    }
+    for (const note of NO_MIRROR_SOURCE) lines.push(`    skipped:   ${note.local} — ${note.why}`);
+    return lines;
+  }
+
+  /** One plain SSM parameter value (mirror coordinates — nothing encrypted here). */
+  private async fetchParam(name: string, opts: { profile?: string; region: string }): Promise<string> {
+    const value = (await this.getEnvAws().json(
+      ['ssm', 'get-parameter', '--name', name, '--query', 'Parameter.Value'],
+      opts,
+    )) as string | null;
+    if (value === null || value === '') {
+      this.error(`SSM parameter ${name} resolved to nothing — is the profile/region right for the mirror account?`);
+    }
+    return value;
+  }
+
+  /**
+   * The RDS master secret: `{username, password}` JSON from Secrets Manager,
+   * fetched fresh on every run (the daily CFN replace rotates it). The value is
+   * returned in memory ONLY — never logged, never written to the state dir,
+   * never placed in argv.
+   */
+  private async fetchMasterSecret(
+    secretId: string,
+    opts: { profile?: string; region: string },
+  ): Promise<{ username: string; password: string }> {
+    const raw = (await this.getEnvAws().json(
+      ['secretsmanager', 'get-secret-value', '--secret-id', secretId, '--query', 'SecretString'],
+      opts,
+    )) as string | null;
+    if (raw === null || raw === '') this.error(`mirror master secret ${secretId} resolved to nothing`);
+    let parsed: { username?: unknown; password?: unknown };
+    try {
+      parsed = JSON.parse(raw) as { username?: unknown; password?: unknown };
+    } catch {
+      // Deliberately does NOT echo the value — an unparseable secret is still a secret.
+      return this.error(`mirror master secret ${secretId} is not JSON (expected {"username":…,"password":…})`);
+    }
+    const username = typeof parsed.username === 'string' && parsed.username !== '' ? parsed.username : MIRROR_ADMIN_USER;
+    if (typeof parsed.password !== 'string' || parsed.password === '') {
+      this.error(`mirror master secret ${secretId} carries no password field`);
+    }
+    return { username, password: parsed.password };
+  }
+}
+
+/** `20260806T133000Z` — the token in `<db>__pre_hydrate_<stamp>`. */
+function stampNow(): string {
+  return new Date().toISOString().replace(/[-:]/g, '').replace(/\.\d+Z$/, 'Z');
+}
+
+/** The preview's `_real` sets: the CONFIRMED measurement, used only when nothing is executed. */
+function previewRealTables(selection: readonly MirrorDbDef[]): Record<string, RealTableInfo[]> {
+  const out: Record<string, RealTableInfo[]> = {};
+  for (const def of selection) {
+    if (!def.scrubbed) continue;
+    out[def.mirror] = (CONFIRMED_REAL_TABLES[def.mirror] ?? []).map((table) => ({ table, columns: [] }));
+  }
+  return out;
+}
+
+function outcomeFor(
+  db: HydrateDbPlan,
+  ok: boolean,
+  error: string | undefined,
+  seconds: number,
+  keepPrevious: boolean,
+): DbOutcome {
+  return {
+    mirror: db.mirrorName,
+    local: db.localName,
+    ownerRole: db.ownerRole,
+    scrubbed: db.scrubbed,
+    staging: db.stagingName,
+    previous: ok && keepPrevious && db.localExisted ? db.retiredName : null,
+    renamed: db.renamedTables.length,
+    copied: db.copiedTables.length,
+    steps: db.steps.length,
+    ok,
+    error,
+    seconds,
+  };
+}

--- a/packages/node/saga-stack-cli/src/core/index.ts
+++ b/packages/node/saga-stack-cli/src/core/index.ts
@@ -37,3 +37,6 @@ export * from './snapshot/index.js';
 
 // ss env — deployed shared-environment registry + org footprint model (soa#355).
 export * from './env/index.js';
+
+// ss stack hydrate — prod-mirror → local-slot map + the pure hydrate planner.
+export * from './mirror/index.js';

--- a/packages/node/saga-stack-cli/src/core/mirror/__tests__/plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/mirror/__tests__/plan.unit.test.ts
@@ -1,0 +1,453 @@
+/**
+ * The `stack hydrate` PLANNER unit tests — the whole point of the pure/executor
+ * split. Every assertion here is about exact argv or exact SQL, and not one of
+ * them touches a database, a container, a tunnel, or AWS.
+ *
+ * Pinned, in order of what would hurt most if it broke:
+ *   - the mirror→local NAME MAP (a wrong pair restores one service's schema over
+ *     another service's database) and its agreement with the manifest,
+ *   - the credential shape: no secret in argv, `-e PGPASSWORD` bare,
+ *   - REAL mode maps `users_real` → `users`,
+ *   - SCRUBBED mode never leaves a view: `--exclude-table-data` for the real
+ *     data, the same rename to inherit the constraints, then a column-exact COPY
+ *     of the scrambled rows,
+ *   - grants + ownership so a service role can WRITE, and the assertion that
+ *     proves it,
+ *   - the staging→verify→swap ordering (nothing touches the live database until
+ *     it is proven good),
+ *   - the non-local refusal,
+ *   - and the full argv for one representative database.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { DATABASES } from '../../manifest/index.js';
+import {
+  CONFIRMED_REAL_TABLES,
+  DEFAULT_CLIENT_IMAGE,
+  DEFAULT_LOCAL_PORT,
+  MIRROR_DATABASES,
+  findByMirrorName,
+  localTargetRefusal,
+  mirrorDiscoveryArgv,
+  planHydrate,
+  resolveSelection,
+  shQuote,
+} from '../index.js';
+import type { HydrateDbPlan, HydratePlanInput, RealTableInfo, SqlStep, TransferStep } from '../index.js';
+
+const IAM_REAL: RealTableInfo[] = [
+  { table: 'users', columns: ['id', 'email', 'created_at'] },
+  { table: 'groups', columns: ['id', 'name'] },
+];
+
+/** A slot-2 plan input; `over` patches whatever a test is about. */
+function input(over: Partial<HydratePlanInput> = {}): HydratePlanInput {
+  return {
+    slot: 2,
+    mode: 'real',
+    selection: [findByMirrorName('iam_db')!],
+    pgContainer: 'soa-s2-postgres-1',
+    localPort: 7432,
+    mirrorLocalPort: DEFAULT_LOCAL_PORT,
+    localExists: { iam_local: true },
+    realTables: { iam_db: IAM_REAL },
+    stamp: '20260806T133000Z',
+    ...over,
+  };
+}
+
+const db = (over: Partial<HydratePlanInput> = {}): HydrateDbPlan => planHydrate(input(over)).dbs[0]!;
+const ids = (plan: HydrateDbPlan): string[] => plan.steps.map((s) => s.id);
+const sqlOf = (plan: HydrateDbPlan, id: string): SqlStep =>
+  plan.steps.find((s) => s.id === id && s.kind === 'sql') as SqlStep;
+const transferOf = (plan: HydrateDbPlan, id: string): TransferStep =>
+  plan.steps.find((s) => s.id === id && s.kind === 'transfer') as TransferStep;
+
+describe('the mirror → local map', () => {
+  it('every mapping resolves to a real manifest database (a wrong pair restores over the wrong service)', () => {
+    for (const def of MIRROR_DATABASES) {
+      expect(DATABASES[def.local], `${def.mirror} → ${def.local}`).toBeDefined();
+    }
+  });
+
+  it('is not the identity — only coach_api, sis_db and openfga share a name', () => {
+    const same = MIRROR_DATABASES.filter((d) => d.mirror === DATABASES[d.local].name).map((d) => d.mirror);
+    expect(same.sort()).toEqual(['coach_api', 'openfga', 'sis_db']);
+  });
+
+  it('marks exactly the two rostering databases as scrubbed', () => {
+    expect(MIRROR_DATABASES.filter((d) => d.scrubbed).map((d) => d.mirror)).toEqual(['iam_db', 'iam_pii_db']);
+    expect(Object.keys(CONFIRMED_REAL_TABLES).sort()).toEqual(['iam_db', 'iam_pii_db']);
+  });
+
+  it('maps ledger_api to the `ledger` owner, NOT ads_adm (the standing snapshot invariant)', () => {
+    expect(DATABASES[findByMirrorName('ledger_api')!.local].ownerRole).toBe('ledger');
+    expect(DATABASES[findByMirrorName('ads_adm')!.local].ownerRole).toBe('ads_adm');
+  });
+
+  it('resolves a selection by EITHER name, dedups, and keeps report order', () => {
+    const picked = resolveSelection(['coach_api', 'iam_local', 'iam_db', 'programs_api']);
+    expect(picked.map((d) => d.mirror)).toEqual(['iam_db', 'programs_api', 'coach_api']);
+  });
+
+  it('rejects an unknown --db token instead of silently hydrating less', () => {
+    expect(() => resolveSelection(['programs'])).not.toThrow(); // the local name is valid
+    expect(() => resolveSelection(['programs_db'])).toThrow(/unknown --db 'programs_db'/);
+  });
+
+  it('leaves the playback/unverified mappings out of the default set', () => {
+    const names = resolveSelection([]).map((d) => d.mirror);
+    expect(names).not.toContain('chat');
+    expect(names).not.toContain('transcription_db');
+    expect(names).not.toContain('openfga');
+    expect(names).toContain('iam_db');
+    expect(resolveSelection(['all']).map((d) => d.mirror)).toContain('chat');
+  });
+});
+
+describe('credential hygiene — the secret is never in argv or in the plan', () => {
+  it('passes PGPASSWORD as a BARE -e (docker inherits it from the env; argv is world-readable in ps)', () => {
+    const plan = db();
+    const transfer = transferOf(plan, 'iam_local:transfer');
+    expect(transfer.dockerArgv).toContain('-e');
+    expect(transfer.dockerArgv[transfer.dockerArgv.indexOf('-e') + 1]).toBe('PGPASSWORD');
+    // No `-e PGPASSWORD=<value>` shape anywhere.
+    expect(transfer.dockerArgv.some((a) => a.startsWith('PGPASSWORD='))).toBe(false);
+    expect(transfer.needsSecret).toBe(true);
+  });
+
+  it('never builds a postgres://user:password@… URL (the env-psql shape that would leak)', () => {
+    const plan = planHydrate(input({ selection: [...MIRROR_DATABASES], localExists: {} }));
+    const everything = JSON.stringify(plan);
+    expect(everything).not.toMatch(/postgres(ql)?:\/\/[^"@]*:[^"@]*@/);
+    expect(everything).not.toContain('--password');
+  });
+
+  it('sets --no-password on every mirror-side client so a missing credential fails fast', () => {
+    const transfer = transferOf(db(), 'iam_local:transfer');
+    expect(transfer.sourceArgv).toContain('--no-password');
+    expect(transfer.sinkArgv).toContain('--no-password');
+  });
+
+  it('marks LOCAL-only sql steps as not needing the secret at all', () => {
+    for (const step of db().steps) {
+      if (step.kind === 'sql') expect(step.needsSecret).toBeUndefined();
+    }
+  });
+});
+
+describe('--source real — the `_real` table becomes the app-named table', () => {
+  it('maps users_real → users (and groups_real → groups) with the view dropped FIRST', () => {
+    const plan = db({ mode: 'real' });
+    const swap = sqlOf(plan, 'iam_local:view-swap:users');
+    expect(swap.database).toBe('iam_local__hydrate');
+    expect(swap.sql).toBe('DROP VIEW IF EXISTS public."users" CASCADE; ALTER TABLE public."users_real" RENAME TO "users";');
+    expect(sqlOf(plan, 'iam_local:view-swap:groups').sql).toContain('ALTER TABLE public."groups_real" RENAME TO "groups"');
+    expect(plan.renamedTables).toEqual(['users', 'groups']);
+  });
+
+  it('dumps the real data — no --exclude-table-data, and no COPY steps', () => {
+    const plan = db({ mode: 'real' });
+    expect(transferOf(plan, 'iam_local:transfer').sourceArgv.join(' ')).not.toContain('--exclude-table-data');
+    expect(plan.copiedTables).toEqual([]);
+    expect(ids(plan).filter((id) => id.includes(':copy:'))).toEqual([]);
+  });
+
+  it('asserts afterwards that no app-named relation is still a VIEW', () => {
+    const check = sqlOf(db({ mode: 'real' }), 'iam_local:verify-tables');
+    expect(check.expect).toBe('0');
+    expect(check.sql).toContain(`c.relname IN ('users', 'groups')`);
+    expect(check.sql).toContain(`c.relkind NOT IN ('r', 'p')`);
+    expect(check.expectMessage).toMatch(/cannot insert into view/);
+  });
+});
+
+describe('--source scrubbed — the view is MATERIALISED, never left as a view', () => {
+  const plan = (): HydrateDbPlan => db({ mode: 'scrubbed' });
+
+  it('excludes the unscrubbed DATA but keeps the _real STRUCTURE (constraints, indexes, defaults)', () => {
+    const transfer = transferOf(plan(), 'iam_local:transfer');
+    expect(transfer.sourceArgv).toContain('--exclude-table-data=public.users_real');
+    expect(transfer.sourceArgv).toContain('--exclude-table-data=public.groups_real');
+    // Structure still crosses — this is what makes the result a real writable
+    // table rather than a constraint-less CTAS.
+    expect(transfer.sourceArgv).not.toContain('--schema-only');
+  });
+
+  it('renames the (now empty) _real table into place, so the target keeps its PK/indexes', () => {
+    expect(sqlOf(plan(), 'iam_local:view-swap:users').sql).toContain('ALTER TABLE public."users_real" RENAME TO "users"');
+  });
+
+  it('copies the SCRAMBLED rows from the mirror view, column-exact in the real table order', () => {
+    const copy = transferOf(plan(), 'iam_local:copy:users');
+    expect(copy.sourceArgv).toContain('COPY (SELECT "id", "email", "created_at" FROM public."users") TO STDOUT');
+    expect(copy.sinkArgv).toContain('COPY public."users" ("id", "email", "created_at") FROM STDIN');
+    expect(copy.classify).toBe('psql');
+    expect(plan().copiedTables).toEqual(['users', 'groups']);
+  });
+
+  it('runs the COPY AFTER the rename (the view is gone by then; the rows come from the mirror)', () => {
+    const order = ids(plan());
+    expect(order.indexOf('iam_local:view-swap:users')).toBeLessThan(order.indexOf('iam_local:copy:users'));
+  });
+
+  it('still asserts nothing is a view when it is done', () => {
+    expect(sqlOf(plan(), 'iam_local:verify-tables').expect).toBe('0');
+  });
+
+  it('does NOT change anything for a non-scrubbed database — only rostering is scrubbed upstream', () => {
+    const args = { selection: [findByMirrorName('coach_api')!], localExists: { coach_api: true }, realTables: {} };
+    const asReal = JSON.stringify(planHydrate(input({ ...args, mode: 'real' })).dbs[0]!.steps);
+    const asScrubbed = JSON.stringify(planHydrate(input({ ...args, mode: 'scrubbed' })).dbs[0]!.steps);
+    expect(asScrubbed).toBe(asReal);
+  });
+});
+
+describe('ownership + grants — the named silent failure', () => {
+  it('restores with --no-owner --no-privileges as the local SUPERUSER, then re-owns to the service role', () => {
+    const plan = db();
+    const restore = transferOf(plan, 'iam_local:transfer').sinkArgv;
+    expect(restore).toContain('--no-owner');
+    expect(restore).toContain('--no-privileges');
+    expect(restore).toContain('postgres_admin');
+    expect(sqlOf(plan, 'iam_local:own').sql).toContain("'iam'");
+    expect(sqlOf(plan, 'iam_local:own').sql).toContain('ALTER TABLE %I.%I OWNER TO %I');
+    expect(sqlOf(plan, 'iam_local:own').sql).toContain('ALTER SEQUENCE %I.%I OWNER TO %I');
+  });
+
+  it('grants tables AND sequences AND functions AND default privileges to the local owner role', () => {
+    const grants = sqlOf(db(), 'iam_local:grant').sql;
+    expect(grants).toContain('GRANT ALL ON ALL TABLES IN SCHEMA public TO "iam";');
+    expect(grants).toContain('GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO "iam";');
+    expect(grants).toContain('ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO "iam";');
+  });
+
+  it('creates the staging database OWNED by the service role (so pg_database_owner resolves to it)', () => {
+    expect(sqlOf(db(), 'iam_local:staging-create').sql).toBe('CREATE DATABASE "iam_local__hydrate" OWNER "iam"');
+  });
+
+  it('ASSERTS the role can INSERT into every restored table — readable-but-not-writable fails the run', () => {
+    const check = sqlOf(db(), 'iam_local:verify-writable');
+    expect(check.expect).toBe('0');
+    expect(check.sql).toContain(`has_table_privilege('iam', c.oid, 'INSERT')`);
+    expect(check.expectMessage).toMatch(/NOT writable/);
+    expect(check.expectMessage).toMatch(/Live database untouched/);
+  });
+
+  it('uses each database’s OWN owner role, not one global role', () => {
+    const plan = planHydrate(
+      input({
+        selection: [findByMirrorName('coach_api')!, findByMirrorName('ledger_api')!, findByMirrorName('programs_api')!],
+        localExists: {},
+        realTables: {},
+      }),
+    );
+    // Order is the caller's selection order (`resolveSelection` is what normalizes it).
+    expect(plan.dbs.map((d) => `${d.localName}:${d.ownerRole}`)).toEqual([
+      'coach_api:coach_api_app',
+      'ledger_local:ledger',
+      'programs:saga_user',
+    ]);
+  });
+});
+
+describe('staging → verify → swap ordering (the live database is never touched until it is proven good)', () => {
+  it('runs the whole sequence in order for an EXISTING local database', () => {
+    expect(ids(db())).toEqual([
+      'iam_local:staging-drop',
+      'iam_local:role-ensure',
+      'iam_local:staging-create',
+      'iam_local:transfer',
+      'iam_local:verify-restored',
+      'iam_local:view-swap:users',
+      'iam_local:view-swap:groups',
+      'iam_local:own',
+      'iam_local:grant',
+      'iam_local:verify-writable',
+      'iam_local:verify-tables',
+      'iam_local:swap-block',
+      'iam_local:swap-terminate',
+      'iam_local:swap-retire',
+      'iam_local:swap-promote',
+      'iam_local:swap-unblock',
+      'iam_local:previous-drop',
+    ]);
+  });
+
+  it('every verification happens BEFORE the first statement that touches the live database', () => {
+    const order = ids(db());
+    const lastVerify = Math.max(...order.map((id, i) => (id.includes(':verify-') ? i : -1)));
+    const firstSwap = order.findIndex((id) => id.startsWith('iam_local:swap-'));
+    expect(lastVerify).toBeLessThan(firstSwap);
+  });
+
+  it('blocks connections and evicts idle backends before the rename (idle pools block database DDL)', () => {
+    const plan = db();
+    expect(sqlOf(plan, 'iam_local:swap-block').sql).toBe('ALTER DATABASE "iam_local" WITH ALLOW_CONNECTIONS false');
+    expect(sqlOf(plan, 'iam_local:swap-terminate').sql).toContain('pg_terminate_backend(pid)');
+    expect(sqlOf(plan, 'iam_local:swap-terminate').sql).toContain('pid <> pg_backend_pid()');
+    expect(sqlOf(plan, 'iam_local:swap-retire').sql).toBe(
+      'ALTER DATABASE "iam_local" RENAME TO "iam_local__pre_hydrate_20260806T133000Z"',
+    );
+    // The one genuinely racy step (a backend may not be fully reaped yet).
+    expect(sqlOf(plan, 'iam_local:swap-retire').retries).toBe(3);
+    expect(sqlOf(plan, 'iam_local:swap-promote').sql).toBe('ALTER DATABASE "iam_local__hydrate" RENAME TO "iam_local"');
+  });
+
+  it('runs every database-level statement against `postgres`, never against either side of the swap', () => {
+    for (const step of db().steps) {
+      if (step.kind !== 'sql') continue;
+      if (step.id.includes(':swap-') || step.id.includes('staging-') || step.id.includes('previous-') || step.id.includes('role-ensure')) {
+        expect(step.database, step.id).toBe('postgres');
+      }
+    }
+  });
+
+  it('--keep-previous keeps the displaced database (and re-enables connections to it) instead of dropping it', () => {
+    const plan = db({ keepPrevious: true });
+    expect(ids(plan)).toContain('iam_local:previous-keep');
+    expect(ids(plan)).not.toContain('iam_local:previous-drop');
+    expect(sqlOf(plan, 'iam_local:previous-keep').sql).toBe(
+      'ALTER DATABASE "iam_local__pre_hydrate_20260806T133000Z" WITH ALLOW_CONNECTIONS true',
+    );
+  });
+
+  it('skips the retire/terminate steps entirely when the local database does not exist yet', () => {
+    const plan = db({ localExists: {} });
+    expect(plan.localExisted).toBe(false);
+    expect(ids(plan).filter((id) => /swap-(block|terminate|retire)|previous-/.test(id))).toEqual([]);
+    expect(ids(plan)).toContain('iam_local:swap-promote');
+  });
+
+  it('drops a stale staging database from a previous failed run before creating a new one', () => {
+    expect(sqlOf(db(), 'iam_local:staging-drop').sql).toBe('DROP DATABASE IF EXISTS "iam_local__hydrate" WITH (FORCE)');
+  });
+
+  it("does not trust pg_restore's exit code alone — it proves the staging database is non-empty", () => {
+    const check = sqlOf(db(), 'iam_local:verify-restored');
+    expect(check.expect).toBe('t');
+    expect(check.database).toBe('iam_local__hydrate');
+    expect(transferOf(db(), 'iam_local:transfer').classify).toBe('pg_restore');
+  });
+});
+
+describe('the representative database — exact argv', () => {
+  const plan = (): HydrateDbPlan =>
+    planHydrate(
+      input({ selection: [findByMirrorName('coach_api')!], localExists: { coach_api: true }, realTables: {} }),
+    ).dbs[0]!;
+
+  it('pg_dump | pg_restore, byte for byte', () => {
+    const transfer = transferOf(plan(), 'coach_api:transfer');
+    expect(transfer.sourceArgv).toEqual([
+      'pg_dump',
+      '--host',
+      '127.0.0.1',
+      '--port',
+      '15532',
+      '--username',
+      'saga_admin',
+      '--dbname',
+      'coach_api',
+      '--no-password',
+      '--format',
+      'custom',
+    ]);
+    expect(transfer.sinkArgv).toEqual([
+      'pg_restore',
+      '--host',
+      '127.0.0.1',
+      '--port',
+      '7432',
+      '--username',
+      'postgres_admin',
+      '--dbname',
+      'coach_api__hydrate',
+      '--no-password',
+      '--no-owner',
+      '--no-privileges',
+      '--single-transaction',
+    ]);
+  });
+
+  it('runs the pipeline in an ephemeral HOST-NETWORKED container under bash -o pipefail', () => {
+    const transfer = transferOf(plan(), 'coach_api:transfer');
+    expect(transfer.dockerArgv.slice(0, 8)).toEqual([
+      'run',
+      '--rm',
+      '--network',
+      'host',
+      '-e',
+      'PGPASSWORD',
+      DEFAULT_CLIENT_IMAGE,
+      'bash',
+    ]);
+    expect(transfer.dockerArgv.slice(8, 10)).toEqual(['-o', 'pipefail']);
+    expect(transfer.dockerArgv[10]).toBe('-c');
+    expect(transfer.dockerArgv[11]).toBe(transfer.shell);
+    expect(transfer.shell).toBe(
+      `${transfer.sourceArgv.map(shQuote).join(' ')} | ${transfer.sinkArgv.map(shQuote).join(' ')}`,
+    );
+  });
+
+  it('drives every LOCAL statement through `docker exec <slot container> psql -U postgres_admin`', () => {
+    const create = sqlOf(plan(), 'coach_api:staging-create');
+    expect(create.dockerArgv).toEqual([
+      'exec',
+      'soa-s2-postgres-1',
+      'psql',
+      '-U',
+      'postgres_admin',
+      '-v',
+      'ON_ERROR_STOP=1',
+      '-X',
+      '-q',
+      '-d',
+      'postgres',
+      '-tAc',
+      'CREATE DATABASE "coach_api__hydrate" OWNER "coach_api_app"',
+    ]);
+  });
+
+  it('reads the scrub enumeration from the mirror in ONE host-networked psql, ordered by attnum', () => {
+    const argv = mirrorDiscoveryArgv({ mirrorPort: 15532, user: 'saga_admin', database: 'iam_db', sql: 'SELECT 1' });
+    expect(argv.slice(0, 7)).toEqual(['run', '--rm', '--network', 'host', '-e', 'PGPASSWORD', DEFAULT_CLIENT_IMAGE]);
+    expect(argv).toContain('--no-password');
+    expect(argv).toContain('ON_ERROR_STOP=1');
+    expect(argv[argv.length - 1]).toBe('SELECT 1');
+  });
+});
+
+describe('the non-local refusal — hydrate can only ever write to a local synthetic slot', () => {
+  const local = { slot: 2, container: 'soa-s2-postgres-1', host: '127.0.0.1', port: 7432 };
+
+  it('accepts the slot’s own container/host/port', () => {
+    expect(localTargetRefusal(local)).toBeNull();
+  });
+
+  it('refuses slot 0 outright and points at cold-start', () => {
+    const refusal = localTargetRefusal({ ...local, slot: 0, container: 'soa-postgres-1', port: 5432 });
+    expect(refusal).toMatch(/--slot 1\.\.9 or --set/);
+    expect(refusal).toMatch(/cold-start/);
+    expect(refusal).toMatch(/live work/);
+  });
+
+  it('refuses a repointed $SAGA_MESH_POSTGRES_CONTAINER rather than obeying it', () => {
+    expect(localTargetRefusal({ ...local, container: 'prod-postgres' })).toMatch(
+      /must be 'soa-s2-postgres-1'.*resolved to 'prod-postgres'/s,
+    );
+  });
+
+  it('refuses a non-loopback host and a port that is not the slot’s derived one', () => {
+    expect(localTargetRefusal({ ...local, host: 'db.prod.internal' })).toMatch(/must be loopback/);
+    expect(localTargetRefusal({ ...local, port: 5432 })).toMatch(/must be 7432/);
+  });
+});
+
+describe('shell quoting', () => {
+  it('single-quotes and escapes embedded quotes (SQL in a pipeline is not shell-parsed by accident)', () => {
+    expect(shQuote('plain')).toBe("'plain'");
+    expect(shQuote(`SELECT 'a'`)).toBe(`'SELECT '\\''a'\\'''`);
+    expect(shQuote('$(rm -rf /)')).toBe("'$(rm -rf /)'");
+  });
+});

--- a/packages/node/saga-stack-cli/src/core/mirror/databases.ts
+++ b/packages/node/saga-stack-cli/src/core/mirror/databases.ts
@@ -1,0 +1,208 @@
+/**
+ * The mirror → local database map (`ss stack hydrate`).
+ *
+ * The daily prod MIRROR (dev account, RDS `saga-postgres-mirror-current-*`,
+ * re-created 13:30 UTC) carries 17 databases whose names DO NOT match the
+ * synthetic stack's. Only `coach_api`, `sis_db` and `openfga` share a name;
+ * everything else is a real mapping (`programs_api` → `programs`,
+ * `iam_db` → `iam_local`, `ledger_api` → `ledger_local`, …). Getting one wrong
+ * restores one service's schema over another service's database, so the map is
+ * DATA here — pure, reviewable, unit-tested — never inlined in the command.
+ *
+ * `local` is a manifest `DbId`, so the local NAME and the local OWNER ROLE are
+ * read from `core/manifest/databases.ts` (one source of truth) rather than
+ * duplicated here. A unit test asserts every `local` resolves.
+ *
+ * THE SCRUB (`scrubbed: true`) — the central structural fact. The daily cron
+ * scrubs ONLY the `rostering` project, so ONLY `iam_db` and `iam_pii_db` are
+ * affected; every other database in the mirror is RAW PROD DATA in both source
+ * modes. In a scrubbed database the real table is renamed `{table}_real` and a
+ * scrambled VIEW takes the original name, which is why both source modes need a
+ * rename step (see `core/mirror/plan.ts`).
+ */
+
+import { getDb } from '../manifest/index.js';
+import type { DbId, Manifest } from '../manifest/index.js';
+
+/**
+ * Which copy of a scrubbed database's data to land locally.
+ *
+ * DEFAULT IS `real` — and that default is a DATA-CLASSIFICATION decision, not a
+ * convenience. Prod is PRE-RELEASE: every user in it is a Saga employee, so
+ * there is no real end-user PII today (consistent with the standing Legal
+ * determination that tutor responses are not PII). The daily scrub scrambles
+ * names and identifiers, which makes a poor reporting fixture — a known district
+ * cannot be found in the mirror by display_name or source_id at all. So the real
+ * tables are the USEFUL thing and hydrating them is preferred.
+ *
+ * THIS FLIPS AT PUBLIC RELEASE. When prod holds real end-user data the default
+ * must become `scrubbed` and `real` must grow a much harder gate. The scrubbed
+ * path exists today so that flip is a one-line change rather than a new feature.
+ */
+export type SourceMode = 'real' | 'scrubbed';
+
+/** One mirror database and where it lands in a local slot. */
+export interface MirrorDbDef {
+  /** Database name IN THE MIRROR (prod's name). */
+  mirror: string;
+  /** Local manifest database id (the local name + owner role come from the manifest). */
+  local: DbId;
+  /**
+   * Is this database view-swapped by the daily rostering scrub (real tables
+   * renamed `{t}_real`, a scrambled VIEW at `{t}`)? True for exactly the two
+   * rostering databases.
+   */
+  scrubbed: boolean;
+  /** Included when `--db` is omitted. */
+  inDefaultSet: boolean;
+  /** Why it is (or is not) in the default set — surfaced in `--help` and the docs. */
+  note?: string;
+}
+
+/**
+ * The 15 app databases in the mirror, largest first (the order hydrate reports
+ * in, so the slow ones are visible early). The mirror's remaining two databases
+ * are RDS admin DBs (`postgres`, `rdsadmin`) and are never targets.
+ */
+export const MIRROR_DATABASES: readonly MirrorDbDef[] = [
+  { mirror: 'scheduling_api', local: 'scheduling', scrubbed: false, inDefaultSet: true },
+  { mirror: 'sessions_api', local: 'sessions', scrubbed: false, inDefaultSet: true },
+  {
+    mirror: 'iam_db',
+    local: 'iam_local',
+    scrubbed: true,
+    inDefaultSet: true,
+    note: 'view-swapped by the daily rostering scrub — see --source.',
+  },
+  { mirror: 'programs_api', local: 'programs', scrubbed: false, inDefaultSet: true },
+  { mirror: 'authz_db', local: 'authz_local', scrubbed: false, inDefaultSet: true },
+  {
+    mirror: 'openfga',
+    local: 'openfga',
+    scrubbed: false,
+    inDefaultSet: false,
+    note: "opt-in: local openfga's schema is owned by the openfga_migrate sidecar and has ZERO tables here; a whole-database restore makes it prod-dump-managed instead.",
+  },
+  { mirror: 'coach_api', local: 'coach_api', scrubbed: false, inDefaultSet: true },
+  {
+    mirror: 'transcription_db',
+    local: 'transcripts_local',
+    scrubbed: false,
+    inDefaultSet: false,
+    note: 'opt-in: the ONE mapping not mechanically verified (transcription vs transcripts), and transcripts_local is playback-only (`--with playback`), absent from a default slot.',
+  },
+  { mirror: 'authz_sync', local: 'authz_sync_local', scrubbed: false, inDefaultSet: true },
+  {
+    mirror: 'iam_pii_db',
+    local: 'iam_pii_local',
+    scrubbed: true,
+    inDefaultSet: true,
+    note: 'view-swapped by the daily rostering scrub (user_pii) — see --source.',
+  },
+  { mirror: 'sis_db', local: 'sis_db', scrubbed: false, inDefaultSet: true },
+  { mirror: 'ads_adm', local: 'ads_adm_local', scrubbed: false, inDefaultSet: true },
+  { mirror: 'ledger_api', local: 'ledger_local', scrubbed: false, inDefaultSet: true },
+  { mirror: 'content_api', local: 'content', scrubbed: false, inDefaultSet: true },
+  {
+    mirror: 'chat',
+    local: 'chat_local',
+    scrubbed: false,
+    inDefaultSet: false,
+    note: 'opt-in: chat_local is playback-only (`--with playback`) and absent from a default slot.',
+  },
+];
+
+/**
+ * Local databases with NO mirror counterpart — reported explicitly by hydrate so
+ * "why is my Connect data still synthetic?" is answered in the output rather
+ * than by a reader guessing that a silent omission was a bug.
+ */
+export const NO_MIRROR_SOURCE: readonly { local: DbId; why: string }[] = [
+  { local: 'insights_local', why: 'no insights_* database exists in the mirror.' },
+  {
+    local: 'connectv3',
+    why: 'mongo (soa-connect-mongo-1) — the mirror is Postgres-only, so Connect data can never be hydrated from it.',
+  },
+];
+
+/**
+ * The confirmed `_real` tables per scrubbed database, as measured 2026-08-06.
+ *
+ * USED ONLY BY `--dry-run`'s preview: an executing run ENUMERATES the `_real`
+ * set from `pg_class` on the live mirror (`realTableQuery`), because only the
+ * `rostering` project is scrubbed and that project's table set changes with its
+ * schema. Hardcoding it for execution would silently skip a newly-scrubbed
+ * table and leave an un-writable view in the app's place.
+ */
+export const CONFIRMED_REAL_TABLES: Readonly<Record<string, readonly string[]>> = {
+  iam_db: [
+    'auth_associations',
+    'audit_logs',
+    'event_outbox',
+    'group_attributes',
+    'group_auth_config',
+    'groups',
+    'login_profiles',
+    'outbox_event',
+    'snapshot_metadata',
+    'user_policies',
+    'user_profiles',
+    'users',
+  ],
+  iam_pii_db: ['user_pii'],
+};
+
+/** Look up by mirror database name. */
+export function findByMirrorName(name: string): MirrorDbDef | undefined {
+  return MIRROR_DATABASES.find((d) => d.mirror === name);
+}
+
+/** Look up by local manifest database id. */
+export function findByLocalId(id: string): MirrorDbDef | undefined {
+  return MIRROR_DATABASES.find((d) => d.local === id);
+}
+
+/** The default `--db` selection (everything with a verified mapping and a slot-provisioned home). */
+export function defaultSelection(): MirrorDbDef[] {
+  return MIRROR_DATABASES.filter((d) => d.inDefaultSet);
+}
+
+/**
+ * Resolve a `--db` token list to mirror-db defs, PRESERVING `MIRROR_DATABASES`
+ * order (largest first) rather than the order the user typed — the report reads
+ * the same however it was invoked. Accepts either name of a pair (`iam_db` or
+ * `iam_local`) plus the pseudo-tokens `default` and `all`. Throws with the full
+ * vocabulary on an unknown token: a typo must never silently hydrate less than
+ * the caller asked for.
+ */
+export function resolveSelection(tokens: readonly string[]): MirrorDbDef[] {
+  if (tokens.length === 0) return defaultSelection();
+  const picked = new Set<MirrorDbDef>();
+  for (const raw of tokens) {
+    const token = raw.trim();
+    if (token === '') continue;
+    if (token === 'default') {
+      for (const d of defaultSelection()) picked.add(d);
+      continue;
+    }
+    if (token === 'all') {
+      for (const d of MIRROR_DATABASES) picked.add(d);
+      continue;
+    }
+    const found = findByMirrorName(token) ?? findByLocalId(token);
+    if (found === undefined) {
+      throw new Error(
+        `unknown --db '${token}'. Expected a mirror or local database name (or 'default' / 'all'): ` +
+          MIRROR_DATABASES.map((d) => `${d.mirror}|${d.local}`).join(', '),
+      );
+    }
+    picked.add(found);
+  }
+  return MIRROR_DATABASES.filter((d) => picked.has(d));
+}
+
+/** The local database NAME + OWNER ROLE for a mapping, read from the manifest. */
+export function localTarget(def: MirrorDbDef, m?: Manifest): { name: string; ownerRole: string; ownerPw: string } {
+  const db = getDb(def.local, m);
+  return { name: db.name, ownerRole: db.ownerRole, ownerPw: db.ownerPw };
+}

--- a/packages/node/saga-stack-cli/src/core/mirror/index.ts
+++ b/packages/node/saga-stack-cli/src/core/mirror/index.ts
@@ -1,0 +1,11 @@
+/**
+ * `ss stack hydrate` pure core — the mirror→local database map, the SQL
+ * vocabulary, and the planner that turns a source description into the exact
+ * argv + statements the executor runs.
+ *
+ * PURE: zero IO. Nothing here imports `src/runtime/**`.
+ */
+
+export * from './databases.js';
+export * from './sql.js';
+export * from './plan.js';

--- a/packages/node/saga-stack-cli/src/core/mirror/plan.ts
+++ b/packages/node/saga-stack-cli/src/core/mirror/plan.ts
@@ -1,0 +1,593 @@
+/**
+ * The `ss stack hydrate` PLANNER — pure.
+ *
+ * Given a source description (mode, selected databases, the tunnel's local end,
+ * the slot's postgres container/port, and the `_real` tables discovered on the
+ * mirror), this produces the COMPLETE ordered step list for the whole run: every
+ * `pg_dump`/`pg_restore`/`psql` argv, every SQL statement, the rename plan, the
+ * ownership/grant sweep, the verification checks, and the swap. The executor
+ * (`runtime/hydrate.ts` + `commands/stack/hydrate.ts`) does no thinking: it runs
+ * `step.dockerArgv`, checks `step.expect`, and reports. That split is what lets
+ * the risky logic be asserted byte-for-byte with no database anywhere.
+ *
+ * TWO STRUCTURAL FACTS SHAPE EVERY PLAN
+ *
+ * 1. THE CLIENT RUNS IN AN EPHEMERAL CONTAINER ON HOST NETWORKING.
+ *    `docker exec soa-postgres-1 pg_dump -h 127.0.0.1 …` cannot work: the mesh
+ *    container is on a compose bridge network, so its 127.0.0.1 is ITSELF, not
+ *    the host holding the SSM tunnel. `docker run --rm --network host postgres:18`
+ *    sees BOTH the tunnel port and the slot's published postgres port, so a whole
+ *    transfer is one piped `bash -o pipefail -c 'pg_dump … | pg_restore …'` with
+ *    no dump file on disk. (Linux `--network host` semantics; Docker Desktop on
+ *    macOS differs — stated as an assumption, not silently relied on.)
+ *
+ * 2. NOTHING TOUCHES THE LIVE DATABASE UNTIL IT IS PROVEN GOOD.
+ *    Every database is restored into a STAGING database, has its surgery done
+ *    there (view swap, re-own, grant), is VERIFIED there, and only then is
+ *    swapped in by rename. A failure at any step leaves the live database
+ *    exactly as it was — rollback is free, and `--keep-previous` keeps the
+ *    displaced database around as a one-command undo.
+ *
+ * CREDENTIALS: the mirror's master password is NEVER an argv element. Transfer
+ * steps carry a bare `-e PGPASSWORD` (no `=value`), so docker inherits it from
+ * the spawn's `env` — `/proc/<pid>/environ` is same-user-only, argv is world
+ * readable in `ps`. `--no-password` is set on every mirror-side client so a
+ * missing credential fails fast instead of hanging on a prompt.
+ */
+
+import {
+  allowConnectionsSql,
+  blockConnectionsSql,
+  copyInSql,
+  copyOutSql,
+  createDatabaseSql,
+  dropDatabaseSql,
+  ensureRoleSql,
+  grantSql,
+  noViewsCheckSql,
+  ownershipSweepSql,
+  renameDatabaseSql,
+  restoredSomethingSql,
+  terminateBackendsSql,
+  viewSwapSql,
+  writabilityCheckSql,
+} from './sql.js';
+import { localTarget } from './databases.js';
+import type { MirrorDbDef, SourceMode } from './databases.js';
+import type { DbId, Manifest } from '../manifest/index.js';
+
+/** Default local end of hydrate's SSM tunnel — deliberately NOT `env connect`'s 15432. */
+export const DEFAULT_LOCAL_PORT = 15532;
+
+/**
+ * The ephemeral client image. Pinned to `postgres:18` because the mirror is PG
+ * 18.3 and pg_dump refuses to run OLDER than its server (a hard error, not a
+ * warning) — and to the DEBIAN variant, not `-alpine`, because the plan runs its
+ * pipelines under `bash -o pipefail` so a failing `pg_dump` cannot be masked by
+ * a succeeding `pg_restore` (alpine's `sh` is not bash and has no `pipefail`).
+ */
+export const DEFAULT_CLIENT_IMAGE = 'postgres:18';
+
+/** The mirror master user (the RDS master secret's `username`). */
+export const MIRROR_ADMIN_USER = 'saga_admin';
+
+/**
+ * Field separator for the mirror-side discovery read — the ASCII unit separator,
+ * so a value containing a comma/tab/pipe can never be mis-split (the same stance
+ * `runtime/env-psql.ts` takes).
+ */
+export const FIELD_SEP = '\u001f';
+
+/** The local mesh superuser every `docker exec … psql` connects as. */
+export const LOCAL_ADMIN_USER = 'postgres_admin';
+
+/** Per-scrubbed-database discovery: the `_real` tables and their column order. */
+export interface RealTableInfo {
+  /** App-facing table name (the VIEW's name; the real table is `<table>_real`). */
+  table: string;
+  /** Column names in the `_real` table's `attnum` order. Empty ⇒ `SELECT *`. */
+  columns: string[];
+}
+
+export interface HydratePlanInput {
+  slot: number;
+  mode: SourceMode;
+  /** Selected mirror→local mappings, in report order. */
+  selection: readonly MirrorDbDef[];
+  /** Slot postgres container (`soa-postgres-1` / `soa-s<N>-postgres-1`). */
+  pgContainer: string;
+  /** Slot postgres host port (`5432 + slot * 1000`). */
+  localPort: number;
+  /** Local end of the SSM tunnel to the mirror. */
+  mirrorLocalPort: number;
+  /** Mirror master username, resolved from the master secret at run time. */
+  mirrorUser?: string;
+  /** Which local databases already exist (drives the swap's rename-away step). */
+  localExists: Readonly<Record<string, boolean>>;
+  /** `_real` tables per MIRROR database name — discovered live, or the confirmed set in a preview. */
+  realTables?: Readonly<Record<string, readonly RealTableInfo[]>>;
+  /** Timestamp token for the displaced database's name (`<db>__pre_hydrate_<stamp>`). */
+  stamp: string;
+  /** Keep the displaced database instead of dropping it (one-command rollback). */
+  keepPrevious?: boolean;
+  clientImage?: string;
+  manifest?: Manifest;
+}
+
+interface StepBase {
+  /** Stable id (`iam_local:transfer`) — what tests and `--output-json` key on. */
+  id: string;
+  /** One human line, printed as the step runs. */
+  label: string;
+  /** The FULL `docker` argv. The executor spawns exactly this and nothing else. */
+  dockerArgv: string[];
+  /** True ⇒ the executor injects the mirror password as PGPASSWORD in the child env only. */
+  needsSecret?: boolean;
+}
+
+export interface SqlStep extends StepBase {
+  kind: 'sql';
+  /** Local database the statement runs against (`postgres` for database-level DDL). */
+  database: string;
+  sql: string;
+  /** When set, the step's trimmed stdout MUST equal this or the database fails. */
+  expect?: string;
+  /** The failure message when `expect` does not match (`%s` ⇒ the actual value). */
+  expectMessage?: string;
+  /**
+   * Retry count for the ONE genuinely racy step: `ALTER DATABASE … RENAME`
+   * immediately after `pg_terminate_backend`, where a backend may not be fully
+   * reaped yet. ALLOW_CONNECTIONS is already false, so no NEW session can appear
+   * — a retry always converges.
+   */
+  retries?: number;
+}
+
+export interface TransferStep extends StepBase {
+  kind: 'transfer';
+  needsSecret: true;
+  /** The `bash -o pipefail -c` pipeline (exported so tests read it directly). */
+  shell: string;
+  /** The mirror-side producer argv (`pg_dump` or `psql … COPY … TO STDOUT`). */
+  sourceArgv: string[];
+  /** The local-side consumer argv (`pg_restore` or `psql … COPY … FROM STDIN`). */
+  sinkArgv: string[];
+  /**
+   * How to judge a non-zero exit. `pg_restore` exits non-zero on BENIGN warnings
+   * too, and a `--no-owner --no-privileges` prod dump emits a pile of them —
+   * so those steps are classified with `pgRestoreFailed`, not by exit code.
+   * `psql` steps run `ON_ERROR_STOP=1` and mean what their exit code says.
+   */
+  classify: 'pg_restore' | 'psql';
+}
+
+export type HydrateStep = SqlStep | TransferStep;
+
+export interface HydrateDbPlan {
+  local: DbId;
+  localName: string;
+  mirrorName: string;
+  ownerRole: string;
+  scrubbed: boolean;
+  mode: SourceMode;
+  stagingName: string;
+  /** Where the displaced live database is parked (absent when there was none). */
+  retiredName: string;
+  localExisted: boolean;
+  /** `{t}_real` → `{t}` renames performed in staging (both source modes). */
+  renamedTables: string[];
+  /** Tables whose SCRAMBLED rows are copied from the mirror (scrubbed mode only). */
+  copiedTables: string[];
+  steps: HydrateStep[];
+}
+
+export interface HydratePlan {
+  slot: number;
+  mode: SourceMode;
+  pgContainer: string;
+  localPort: number;
+  mirrorLocalPort: number;
+  keepPrevious: boolean;
+  clientImage: string;
+  dbs: HydrateDbPlan[];
+}
+
+/** POSIX single-quote shell escaping (exported: the pipeline strings are asserted byte-for-byte). */
+export function shQuote(arg: string): string {
+  return `'${arg.replace(/'/g, `'\\''`)}'`;
+}
+
+/** `docker exec <container> psql -U postgres_admin -v ON_ERROR_STOP=1 -d <db> -tAc <sql>` argv. */
+export function localPsqlArgv(container: string, database: string, sql: string): string[] {
+  return [
+    'exec',
+    container,
+    'psql',
+    '-U',
+    LOCAL_ADMIN_USER,
+    '-v',
+    'ON_ERROR_STOP=1',
+    '-X',
+    '-q',
+    '-d',
+    database,
+    '-tAc',
+    sql,
+  ];
+}
+
+/**
+ * Wrap a producer|consumer pipeline in the ephemeral host-networked client
+ * container. `-e PGPASSWORD` is BARE on purpose: docker then inherits the value
+ * from the spawning process's environment instead of putting the secret in argv.
+ */
+export function clientRunArgv(image: string, pipeline: string): string[] {
+  return ['run', '--rm', '--network', 'host', '-e', 'PGPASSWORD', image, 'bash', '-o', 'pipefail', '-c', pipeline];
+}
+
+/** Mirror-side connection args (the tunnel's LOCAL end — never the RDS endpoint). */
+function mirrorConnArgs(port: number, user: string, database: string): string[] {
+  return ['--host', '127.0.0.1', '--port', String(port), '--username', user, '--dbname', database, '--no-password'];
+}
+
+/** Local-side connection args (the slot's published postgres port; `trust` auth locally). */
+function localConnArgs(port: number, database: string): string[] {
+  return ['--host', '127.0.0.1', '--port', String(port), '--username', LOCAL_ADMIN_USER, '--dbname', database, '--no-password'];
+}
+
+/**
+ * `pg_dump` argv for one mirror database (custom format, streamed to stdout).
+ *
+ * `--no-owner`/`--no-privileges` are deliberately NOT here: for archive formats
+ * pg_dump documents `--no-owner` as meaningful only for plain text, so they go
+ * on `pg_restore` where they are unambiguously effective (see `pgRestoreArgv`).
+ *
+ * `excludeData` carries the scrub's `_real` tables in SCRUBBED mode: their
+ * STRUCTURE crosses (PK, FKs, indexes, defaults, sequence ownership — which is
+ * what makes the materialised table a real writable table instead of a
+ * constraint-less CTAS), but not one row of unscrubbed data.
+ */
+export function pgDumpArgv(opts: {
+  mirrorPort: number;
+  user: string;
+  database: string;
+  excludeData?: readonly string[];
+}): string[] {
+  const argv = ['pg_dump', ...mirrorConnArgs(opts.mirrorPort, opts.user, opts.database), '--format', 'custom'];
+  for (const table of opts.excludeData ?? []) argv.push(`--exclude-table-data=public.${table}_real`);
+  return argv;
+}
+
+/**
+ * `pg_restore` argv into the staging database, as the LOCAL SUPERUSER.
+ *
+ * Restoring as `postgres_admin` (not as the owner, which is what
+ * `stack snapshot restore` does) is deliberate: those snapshots came from the
+ * same mesh, whereas a prod dump can carry `CREATE EXTENSION`, event triggers or
+ * publications a non-superuser cannot create, and the restore would fail
+ * mid-way. Ownership is then swept to the service role explicitly.
+ */
+export function pgRestoreArgv(opts: { localPort: number; staging: string }): string[] {
+  return [
+    'pg_restore',
+    ...localConnArgs(opts.localPort, opts.staging),
+    '--no-owner',
+    '--no-privileges',
+    '--single-transaction',
+  ];
+}
+
+/** `psql … -c <sql>` argv, unit-separator-delimited (mirror-side read/COPY-out). */
+export function mirrorPsqlArgv(opts: { mirrorPort: number; user: string; database: string; sql: string }): string[] {
+  return [
+    'psql',
+    ...mirrorConnArgs(opts.mirrorPort, opts.user, opts.database),
+    '-X',
+    '-q',
+    '-A',
+    '-t',
+    '-v',
+    'ON_ERROR_STOP=1',
+    '-c',
+    opts.sql,
+  ];
+}
+
+/** `psql … -c <sql>` argv against a local database over TCP (the COPY-in sink). */
+export function localTcpPsqlArgv(opts: { localPort: number; database: string; sql: string }): string[] {
+  return ['psql', ...localConnArgs(opts.localPort, opts.database), '-X', '-q', '-v', 'ON_ERROR_STOP=1', '-c', opts.sql];
+}
+
+/**
+ * The one read hydrate makes against the mirror before planning: the `_real`
+ * table + column enumeration. Built here so the command never hand-rolls argv.
+ */
+export function mirrorDiscoveryArgv(opts: {
+  image?: string;
+  mirrorPort: number;
+  user: string;
+  database: string;
+  sql: string;
+  fieldSep?: string;
+}): string[] {
+  const argv = [
+    'psql',
+    ...mirrorConnArgs(opts.mirrorPort, opts.user, opts.database),
+    '-X',
+    '-q',
+    '-A',
+    '-t',
+    '-F',
+    opts.fieldSep ?? FIELD_SEP,
+    '-v',
+    'ON_ERROR_STOP=1',
+    '-c',
+    opts.sql,
+  ];
+  return [
+    'run',
+    '--rm',
+    '--network',
+    'host',
+    '-e',
+    'PGPASSWORD',
+    opts.image ?? DEFAULT_CLIENT_IMAGE,
+    ...argv,
+  ];
+}
+
+/** Staging database name for a local database (deterministic — dropped-if-exists first). */
+export function stagingNameFor(localName: string): string {
+  return `${localName}__hydrate`;
+}
+
+/** Where the displaced live database is parked. */
+export function retiredNameFor(localName: string, stamp: string): string {
+  return `${localName}__pre_hydrate_${stamp}`;
+}
+
+/** Plan one database's full hydrate. */
+function planDb(def: MirrorDbDef, input: HydratePlanInput): HydrateDbPlan {
+  const image = input.clientImage ?? DEFAULT_CLIENT_IMAGE;
+  const user = input.mirrorUser ?? MIRROR_ADMIN_USER;
+  const { name: localName, ownerRole, ownerPw } = localTarget(def, input.manifest);
+  const staging = stagingNameFor(localName);
+  const retired = retiredNameFor(localName, input.stamp);
+  const localExisted = input.localExists[localName] === true;
+  const container = input.pgContainer;
+
+  // The scrub only touches the two rostering databases; everywhere else BOTH
+  // source modes land identical raw prod data. Say so via the plan shape rather
+  // than letting a reader infer that `--source scrubbed` sanitises the run.
+  const real = def.scrubbed ? (input.realTables?.[def.mirror] ?? []) : [];
+  const materialise = def.scrubbed && input.mode === 'scrubbed';
+
+  const steps: HydrateStep[] = [];
+  const sql = (
+    id: string,
+    label: string,
+    database: string,
+    statement: string,
+    extra: Partial<SqlStep> = {},
+  ): void => {
+    steps.push({
+      kind: 'sql',
+      id: `${localName}:${id}`,
+      label,
+      database,
+      sql: statement,
+      dockerArgv: localPsqlArgv(container, database, statement),
+      ...extra,
+    });
+  };
+
+  // ── 1. staging database (dropped first: a previous failed run may have left one) ──
+  sql('staging-drop', `drop any stale staging database ${staging}`, 'postgres', dropDatabaseSql(staging));
+  sql('role-ensure', `ensure the service role ${ownerRole} exists`, 'postgres', ensureRoleSql(ownerRole, ownerPw));
+  sql(
+    'staging-create',
+    `create staging database ${staging} owned by ${ownerRole}`,
+    'postgres',
+    createDatabaseSql(staging, ownerRole),
+  );
+
+  // ── 2. the transfer: mirror pg_dump piped straight into a local pg_restore ──
+  const dumpArgv = pgDumpArgv({
+    mirrorPort: input.mirrorLocalPort,
+    user,
+    database: def.mirror,
+    excludeData: materialise ? real.map((r) => r.table) : [],
+  });
+  const restoreArgv = pgRestoreArgv({ localPort: input.localPort, staging });
+  const pipeline = `${dumpArgv.map(shQuote).join(' ')} | ${restoreArgv.map(shQuote).join(' ')}`;
+  steps.push({
+    kind: 'transfer',
+    id: `${localName}:transfer`,
+    label:
+      `stream ${def.mirror} → ${staging}` +
+      (materialise ? ` (structure only for ${real.length} scrubbed table(s))` : ''),
+    dockerArgv: clientRunArgv(image, pipeline),
+    shell: pipeline,
+    sourceArgv: dumpArgv,
+    sinkArgv: restoreArgv,
+    needsSecret: true,
+    classify: 'pg_restore',
+  });
+
+  sql(
+    'verify-restored',
+    `verify ${staging} is not empty (pg_restore's exit code alone is not proof)`,
+    staging,
+    restoredSomethingSql(),
+    {
+      expect: 't',
+      expectMessage:
+        `${staging} has no relations after the restore (got '%s') — the transfer produced nothing. ` +
+        'Live database untouched.',
+    },
+  );
+
+  // ── 3. the view swap — BOTH modes, opposite meanings, same statement ──
+  // real mode:     the `_real` table carries the data; drop the scramble view
+  //                and rename the table into the app's expected name.
+  // scrubbed mode: the `_real` table arrived EMPTY (its data was excluded), so
+  //                the same rename yields a real-shaped, constraint-complete,
+  //                WRITABLE table which step 4 then fills from the view.
+  // Either way the local result is an ordinary writable table under the app's name.
+  for (const { table } of real) {
+    sql(
+      `view-swap:${table}`,
+      `materialise ${table}: drop the scramble view, rename ${table}_real → ${table}`,
+      staging,
+      viewSwapSql(table),
+    );
+  }
+
+  // ── 4. scrubbed mode only: COPY the scrambled rows across, column-exact ──
+  if (materialise) {
+    for (const { table, columns } of real) {
+      const src = mirrorPsqlArgv({
+        mirrorPort: input.mirrorLocalPort,
+        user,
+        database: def.mirror,
+        sql: copyOutSql(table, columns),
+      });
+      const sink = localTcpPsqlArgv({
+        localPort: input.localPort,
+        database: staging,
+        sql: copyInSql(table, columns),
+      });
+      const copyPipeline = `${src.map(shQuote).join(' ')} | ${sink.map(shQuote).join(' ')}`;
+      steps.push({
+        kind: 'transfer',
+        id: `${localName}:copy:${table}`,
+        label: `copy scrambled rows for ${table} (${columns.length} column(s))`,
+        dockerArgv: clientRunArgv(image, copyPipeline),
+        shell: copyPipeline,
+        sourceArgv: src,
+        sinkArgv: sink,
+        needsSecret: true,
+        classify: 'psql',
+      });
+    }
+  }
+
+  // ── 5. ownership + grants, then ASSERT both ──
+  sql('own', `re-own every object in ${staging} to ${ownerRole}`, staging, ownershipSweepSql(ownerRole));
+  sql('grant', `grant tables/sequences/functions + default privileges to ${ownerRole}`, staging, grantSql(ownerRole));
+  sql('verify-writable', `verify ${ownerRole} can INSERT into every restored table`, staging, writabilityCheckSql(ownerRole), {
+    expect: '0',
+    expectMessage:
+      `%s public table(s) in ${staging} are NOT writable by ${ownerRole} — the restore would be ` +
+      "readable but not writable (an app 500 days later). Live database untouched.",
+  });
+  if (real.length > 0) {
+    sql(
+      'verify-tables',
+      `verify all ${real.length} app-named relation(s) are ordinary TABLES, not views`,
+      staging,
+      noViewsCheckSql(real.map((r) => r.table)),
+      {
+        expect: '0',
+        expectMessage:
+          `%s app-named relation(s) in ${staging} are still VIEWs — the first local INSERT would fail ` +
+          "'cannot insert into view'. Live database untouched.",
+      },
+    );
+  }
+
+  // ── 6. the swap — connected to `postgres`, never to either side ──
+  if (localExisted) {
+    sql('swap-block', `block new connections to ${localName}`, 'postgres', blockConnectionsSql(localName));
+    sql('swap-terminate', `terminate idle backends on ${localName}`, 'postgres', terminateBackendsSql(localName));
+    sql('swap-retire', `rename ${localName} → ${retired}`, 'postgres', renameDatabaseSql(localName, retired), {
+      retries: 3,
+    });
+  }
+  sql('swap-promote', `rename ${staging} → ${localName}`, 'postgres', renameDatabaseSql(staging, localName));
+  sql('swap-unblock', `allow connections to ${localName}`, 'postgres', allowConnectionsSql(localName));
+  if (localExisted) {
+    if (input.keepPrevious === true) {
+      sql('previous-keep', `keep the displaced database as ${retired} (--keep-previous)`, 'postgres', allowConnectionsSql(retired));
+    } else {
+      sql('previous-drop', `drop the displaced database ${retired}`, 'postgres', dropDatabaseSql(retired));
+    }
+  }
+
+  return {
+    local: def.local,
+    localName,
+    mirrorName: def.mirror,
+    ownerRole,
+    scrubbed: def.scrubbed,
+    mode: input.mode,
+    stagingName: staging,
+    retiredName: retired,
+    localExisted,
+    renamedTables: real.map((r) => r.table),
+    copiedTables: materialise ? real.map((r) => r.table) : [],
+    steps,
+  };
+}
+
+/** Build the whole run's plan. PURE — no IO, no clock, no env. */
+export function planHydrate(input: HydratePlanInput): HydratePlan {
+  return {
+    slot: input.slot,
+    mode: input.mode,
+    pgContainer: input.pgContainer,
+    localPort: input.localPort,
+    mirrorLocalPort: input.mirrorLocalPort,
+    keepPrevious: input.keepPrevious === true,
+    clientImage: input.clientImage ?? DEFAULT_CLIENT_IMAGE,
+    dbs: input.selection.map((def) => planDb(def, input)),
+  };
+}
+
+/**
+ * THE NON-LOCAL REFUSAL. Hydrate overwrites whole databases, so it must be
+ * structurally incapable of pointing at anything but a local synthetic slot.
+ *
+ * Returns a refusal string, or null when the target is provably local:
+ *   - slot 0 is refused outright (the shared baseline; SELECT-only for tooling),
+ *   - the container must be exactly the slot's own mesh container — an operator
+ *     who has repointed `$SAGA_MESH_POSTGRES_CONTAINER` at something else is
+ *     refused rather than obeyed,
+ *   - the host must be loopback and the port the slot's derived `5432 + N*1000`.
+ */
+export function localTargetRefusal(target: {
+  slot: number;
+  container: string;
+  host: string;
+  port: number;
+}): string | null {
+  if (target.slot === 0) {
+    return (
+      'stack hydrate replaces whole databases and requires an explicit --slot 1..9 or --set <name>. ' +
+      'Slot 0 is the shared baseline — hydrating it would destroy live work. ' +
+      '(`ss stack cold-start` is the slot-0 reset; there is no --force here.)'
+    );
+  }
+  const expectedContainer = `soa-s${target.slot}-postgres-1`;
+  if (target.container !== expectedContainer) {
+    return (
+      `refusing to hydrate: slot ${target.slot}'s postgres container must be '${expectedContainer}', ` +
+      `but resolved to '${target.container}' ($SAGA_MESH_POSTGRES_CONTAINER). ` +
+      'Hydrate only ever writes to a local synthetic slot; unset the override and retry.'
+    );
+  }
+  if (target.host !== '127.0.0.1' && target.host !== 'localhost') {
+    return (
+      `refusing to hydrate: the write target must be loopback, got '${target.host}'. ` +
+      'Hydrate only ever writes to a local synthetic slot.'
+    );
+  }
+  const expectedPort = 5432 + target.slot * 1000;
+  if (target.port !== expectedPort) {
+    return (
+      `refusing to hydrate: slot ${target.slot}'s postgres port must be ${expectedPort}, got ${target.port}. ` +
+      'Hydrate only ever writes to a local synthetic slot.'
+    );
+  }
+  return null;
+}

--- a/packages/node/saga-stack-cli/src/core/mirror/sql.ts
+++ b/packages/node/saga-stack-cli/src/core/mirror/sql.ts
@@ -1,0 +1,250 @@
+/**
+ * Pure SQL builders for `ss stack hydrate`.
+ *
+ * Every statement hydrate runs is produced HERE, as a string, by a function with
+ * no IO — so the whole destructive vocabulary (`DROP DATABASE … WITH (FORCE)`,
+ * `pg_terminate_backend`, `ALTER DATABASE … RENAME`, the ownership sweep) is
+ * asserted byte-for-byte in unit tests with no database anywhere. `stack
+ * hydrate` introduces the first database-LEVEL destructive SQL in this package;
+ * it lives behind a planner + an injectable runtime seam for exactly that
+ * reason.
+ *
+ * DUPLICATION NOTE: `ensureRoleSql`/`createDatabaseSql` mirror the pair in
+ * `runtime/provision.ts`. They are re-declared rather than imported because
+ * `src/core/**` must never import `src/runtime/**` — the enforced invariant. The
+ * shapes are deliberately identical; if one changes, change both.
+ */
+
+/** Quote a SQL identifier (double quotes, embedded quotes doubled). */
+export function qi(name: string): string {
+  return `"${name.replace(/"/g, '""')}"`;
+}
+
+/** Quote a SQL string literal (single quotes, embedded quotes doubled). */
+export function ql(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+/** The role-ensuring `DO` block — `CREATE ROLE … LOGIN PASSWORD …` iff absent. */
+export function ensureRoleSql(role: string, pw: string): string {
+  return (
+    `DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname=${ql(role)}) ` +
+    `THEN CREATE ROLE ${qi(role)} LOGIN PASSWORD ${ql(pw)}; END IF; END $$;`
+  );
+}
+
+/**
+ * `CREATE DATABASE <name> OWNER <role>` — a SEPARATE statement always (CREATE
+ * DATABASE cannot run inside a `DO $$…$$` block or a transaction). Creating it
+ * OWNER <role> also makes PG15+'s `pg_database_owner` (the owner of schema
+ * `public`) resolve to that role, which is half the writability answer for free.
+ */
+export function createDatabaseSql(name: string, role: string): string {
+  return `CREATE DATABASE ${qi(name)} OWNER ${qi(role)}`;
+}
+
+/** `DROP DATABASE IF EXISTS <name> WITH (FORCE)` — FORCE terminates leftover backends. */
+export function dropDatabaseSql(name: string): string {
+  return `DROP DATABASE IF EXISTS ${qi(name)} WITH (FORCE)`;
+}
+
+/**
+ * THE VIEW SWAP, resolved inside the staging database.
+ *
+ * A scrubbed mirror database holds `{t}_real` (the ordinary table) and a
+ * scrambled VIEW at `{t}`. A dump reproduces both, so the object standing where
+ * the app expects a table is a VIEW — and the app's first INSERT fails "cannot
+ * insert into view". Order is load-bearing: the view OWNS the target name, so it
+ * must be dropped BEFORE the rename, or the rename collides.
+ *
+ * Both statements go in one `-c` (one implicit transaction) so a staging
+ * database can never be left with the view dropped and the table un-renamed.
+ * CASCADE is required because the scramble view may itself be depended on;
+ * anything it drops was scrubbed scaffolding, never app schema.
+ */
+export function viewSwapSql(table: string): string {
+  return (
+    `DROP VIEW IF EXISTS public.${qi(table)} CASCADE; ` +
+    `ALTER TABLE public.${qi(`${table}_real`)} RENAME TO ${qi(table)};`
+  );
+}
+
+/**
+ * Re-own every restored object to the slot's single service role.
+ *
+ * The dump is restored with `--no-owner --no-privileges` (its `ALTER … OWNER TO
+ * <prod_role>` / `GRANT … TO <service_role>` name roles that do not exist
+ * locally), which lands everything owned by `postgres_admin`. That reads fine
+ * and is the named SILENT FAILURE: the app's first INSERT fails days later as a
+ * 500. Measured locally, each database has exactly ONE app role owning the
+ * database and every object in `public`, so re-owning to that role closes it —
+ * there is no multi-role grant matrix to reconstruct.
+ *
+ * Schema `public` is deliberately NOT re-owned: `CREATE DATABASE … OWNER <role>`
+ * already makes `pg_database_owner` resolve to the role, which is the PG15+
+ * idiom. Other schemas (a prod dump may carry them) ARE re-owned, or the role
+ * could not create in them.
+ */
+export function ownershipSweepSql(role: string): string {
+  const r = ql(role);
+  return [
+    'DO $hydrate$',
+    'DECLARE r record;',
+    'BEGIN',
+    "  FOR r IN SELECT c.relkind AS kind, n.nspname AS ns, c.relname AS rel FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname NOT IN ('pg_catalog', 'information_schema') AND n.nspname NOT LIKE 'pg\\_toast%' AND c.relkind IN ('r', 'p', 'v', 'm', 'S', 'f') LOOP",
+    `    IF r.kind = 'S' THEN EXECUTE format('ALTER SEQUENCE %I.%I OWNER TO %I', r.ns, r.rel, ${r});`,
+    `    ELSIF r.kind = 'v' THEN EXECUTE format('ALTER VIEW %I.%I OWNER TO %I', r.ns, r.rel, ${r});`,
+    `    ELSIF r.kind = 'm' THEN EXECUTE format('ALTER MATERIALIZED VIEW %I.%I OWNER TO %I', r.ns, r.rel, ${r});`,
+    `    ELSIF r.kind = 'f' THEN EXECUTE format('ALTER FOREIGN TABLE %I.%I OWNER TO %I', r.ns, r.rel, ${r});`,
+    `    ELSE EXECUTE format('ALTER TABLE %I.%I OWNER TO %I', r.ns, r.rel, ${r});`,
+    '    END IF;',
+    '  END LOOP;',
+    "  FOR r IN SELECT n.nspname AS ns, t.typname AS tn FROM pg_type t JOIN pg_namespace n ON n.oid = t.typnamespace WHERE n.nspname NOT IN ('pg_catalog', 'information_schema') AND t.typtype IN ('e', 'd') LOOP",
+    `    EXECUTE format('ALTER TYPE %I.%I OWNER TO %I', r.ns, r.tn, ${r});`,
+    '  END LOOP;',
+    "  FOR r IN SELECT p.oid::regprocedure AS sig FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE n.nspname NOT IN ('pg_catalog', 'information_schema') LOOP",
+    `    EXECUTE format('ALTER ROUTINE %s OWNER TO %I', r.sig, ${r});`,
+    '  END LOOP;',
+    "  FOR r IN SELECT n.nspname AS ns FROM pg_namespace n WHERE n.nspname NOT IN ('pg_catalog', 'information_schema', 'public') AND n.nspname NOT LIKE 'pg\\_%' LOOP",
+    `    EXECUTE format('ALTER SCHEMA %I OWNER TO %I', r.ns, ${r});`,
+    '  END LOOP;',
+    'END',
+    '$hydrate$;',
+  ].join('\n');
+}
+
+/**
+ * Belt-and-braces grants for the service role (mirrors `profile-empty.sql`'s own
+ * GRANT block), plus DEFAULT PRIVILEGES so objects a later migration creates as
+ * `postgres_admin` stay reachable. Ownership (above) already implies these; both
+ * are applied because the failure they prevent is silent.
+ */
+export function grantSql(role: string): string {
+  const r = qi(role);
+  return [
+    `GRANT ALL ON SCHEMA public TO ${r};`,
+    `GRANT ALL ON ALL TABLES IN SCHEMA public TO ${r};`,
+    `GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO ${r};`,
+    `GRANT ALL ON ALL FUNCTIONS IN SCHEMA public TO ${r};`,
+    `ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO ${r};`,
+    `ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO ${r};`,
+    `ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO ${r};`,
+  ].join(' ');
+}
+
+/**
+ * ASSERT the transfer actually landed something: `t` iff the staging database
+ * has at least one relation in `public`.
+ *
+ * This exists because the ONE way to get hydrate badly wrong is to mis-judge
+ * pg_restore's exit code. It exits non-zero on benign warnings, so a non-zero
+ * exit is classified by stderr (`pgRestoreFailed`) rather than trusted — and the
+ * cost of that tolerance is that a restore which did nothing at all could read
+ * as green. An empty staging database is unambiguous, needs no stderr grammar,
+ * and fails the database while the live one is still untouched.
+ */
+export function restoredSomethingSql(): string {
+  return (
+    'SELECT (count(*) > 0) FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace ' +
+    "WHERE n.nspname = 'public' AND c.relkind IN ('r', 'p', 'v', 'm')"
+  );
+}
+
+/**
+ * ASSERT writability rather than assume it: how many public tables can the
+ * service role NOT insert into? Must be `0`. Readable-but-not-writable is the
+ * failure that otherwise surfaces days later as an app 500, so hydrate fails the
+ * database here — while the live database is still untouched.
+ */
+export function writabilityCheckSql(role: string): string {
+  return (
+    'SELECT count(*) FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace ' +
+    `WHERE n.nspname = 'public' AND c.relkind IN ('r', 'p') AND NOT has_table_privilege(${ql(role)}, c.oid, 'INSERT')`
+  );
+}
+
+/**
+ * ASSERT the view swap landed: how many of the app-expected names are NOT an
+ * ordinary/partitioned table? Must be `0`. This is the check that catches a
+ * scrubbed database whose scramble view survived into the local slot.
+ */
+export function noViewsCheckSql(tables: readonly string[]): string {
+  if (tables.length === 0) return 'SELECT 0';
+  return (
+    'SELECT count(*) FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace ' +
+    `WHERE n.nspname = 'public' AND c.relname IN (${tables.map(ql).join(', ')}) AND c.relkind NOT IN ('r', 'p')`
+  );
+}
+
+/** How many rows landed in a staging table (per-table progress + a non-empty sanity read). */
+export function rowCountSql(table: string): string {
+  return `SELECT count(*) FROM public.${qi(table)}`;
+}
+
+// ── The swap: staging → live, connected to `postgres` (never to either side) ──
+
+/** Block NEW connections so a prisma pool cannot reconnect between terminate and rename. */
+export function blockConnectionsSql(db: string): string {
+  return `ALTER DATABASE ${qi(db)} WITH ALLOW_CONNECTIONS false`;
+}
+
+/** Re-allow connections (the freshly-swapped-in database, or a kept previous one). */
+export function allowConnectionsSql(db: string): string {
+  return `ALTER DATABASE ${qi(db)} WITH ALLOW_CONNECTIONS true`;
+}
+
+/**
+ * Evict the idle prisma-pool backends. Measured on a live slot: 5 idle app
+ * connections sit on content/programs/scheduling/sessions/iam_local
+ * indefinitely. TRUNCATE and `pg_restore --clean` succeed against idle backends
+ * (which is why `ss stack reset` works live), but `ALTER DATABASE … RENAME`
+ * fails with "being accessed by other users" on ANY open session, idle included.
+ */
+export function terminateBackendsSql(db: string): string {
+  return `SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = ${ql(db)} AND pid <> pg_backend_pid()`;
+}
+
+/** `ALTER DATABASE <from> RENAME TO <to>` — cannot run inside a transaction, so always its own `-c`. */
+export function renameDatabaseSql(from: string, to: string): string {
+  return `ALTER DATABASE ${qi(from)} RENAME TO ${qi(to)}`;
+}
+
+/** Does this database exist? (`t`/`f` — the swap's pre-check.) */
+export function databaseExistsSql(db: string): string {
+  return `SELECT EXISTS (SELECT 1 FROM pg_database WHERE datname = ${ql(db)})`;
+}
+
+// ── Mirror-side discovery (read-only, run through the tunnel) ────────────────
+
+/**
+ * Enumerate the scrub's `_real` tables AND their column order, in ONE round
+ * trip: `(base_table, column)` rows ordered by table then `attnum`.
+ *
+ * Enumerated at RUN TIME rather than hardcoded — only the `rostering` project is
+ * scrubbed and its table set changes with its schema, so a hardcoded list would
+ * silently skip a newly-scrubbed table and leave an un-writable view standing in
+ * the app's place. The COLUMN order comes from the `_real` table (the target
+ * shape), which is what makes the scrubbed-mode `COPY` column-exact instead of
+ * trusting that the view happens to present columns in the same order.
+ */
+export function realTableQuerySql(): string {
+  return (
+    "SELECT left(c.relname, length(c.relname) - 5) AS base, a.attname FROM pg_class c " +
+    'JOIN pg_namespace n ON n.oid = c.relnamespace ' +
+    'JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum > 0 AND NOT a.attisdropped ' +
+    "WHERE n.nspname = 'public' AND c.relkind = 'r' AND c.relname LIKE '%\\_real' " +
+    'ORDER BY c.relname, a.attnum'
+  );
+}
+
+/** `COPY (SELECT <cols> FROM public.<view>) TO STDOUT` — the scrambled rows, from the mirror. */
+export function copyOutSql(table: string, columns: readonly string[]): string {
+  const cols = columns.length === 0 ? '*' : columns.map(qi).join(', ');
+  return `COPY (SELECT ${cols} FROM public.${qi(table)}) TO STDOUT`;
+}
+
+/** `COPY public.<table> (<cols>) FROM STDIN` — into the staging database's real-shaped table. */
+export function copyInSql(table: string, columns: readonly string[]): string {
+  const cols = columns.length === 0 ? '' : ` (${columns.map(qi).join(', ')})`;
+  return `COPY public.${qi(table)}${cols} FROM STDIN`;
+}

--- a/packages/node/saga-stack-cli/src/runtime/__tests__/hydrate-discovery.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/hydrate-discovery.unit.test.ts
@@ -1,0 +1,50 @@
+/**
+ * `parseRealTableRows` — the one piece of parsing in the hydrate lane, and the
+ * thing that decides which tables get materialised and in WHAT COLUMN ORDER.
+ *
+ * Column order is load-bearing: scrubbed mode issues
+ * `COPY (SELECT <cols> FROM view) TO STDOUT | COPY table (<cols>) FROM STDIN`,
+ * so a reordering here would silently write each column's data into the wrong
+ * column. The mirror-side query orders by `attnum` on the `_real` table (the
+ * TARGET's shape), and this parser must preserve that.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { parseRealTableRows } from '../hydrate.js';
+
+const US = '\u001f';
+const rows = (...pairs: [string, string][]): string => pairs.map(([t, c]) => `${t}${US}${c}`).join('\n');
+
+describe('parseRealTableRows', () => {
+  it('groups columns per table and PRESERVES the emitted (attnum) order', () => {
+    expect(
+      parseRealTableRows(
+        rows(['users', 'id'], ['users', 'email'], ['users', 'created_at'], ['groups', 'id'], ['groups', 'name']),
+      ),
+    ).toEqual([
+      { table: 'users', columns: ['id', 'email', 'created_at'] },
+      { table: 'groups', columns: ['id', 'name'] },
+    ]);
+  });
+
+  it('is empty for an unscrubbed database (no _real tables at all)', () => {
+    expect(parseRealTableRows('')).toEqual([]);
+    expect(parseRealTableRows('\n\n')).toEqual([]);
+  });
+
+  it('tolerates a trailing newline (psql always emits one)', () => {
+    expect(parseRealTableRows(`${rows(['user_pii', 'id'])}\n`)).toEqual([{ table: 'user_pii', columns: ['id'] }]);
+  });
+
+  it('splits on the UNIT SEPARATOR, so a column name containing a comma/pipe survives', () => {
+    expect(parseRealTableRows(rows(['t', 'weird|name,col']))).toEqual([
+      { table: 't', columns: ['weird|name,col'] },
+    ]);
+  });
+
+  it('drops a malformed row rather than inventing a column', () => {
+    expect(parseRealTableRows(`users${US}id\nno-separator-here\n`)).toEqual([
+      { table: 'users', columns: ['id'] },
+    ]);
+  });
+});

--- a/packages/node/saga-stack-cli/src/runtime/hydrate.ts
+++ b/packages/node/saga-stack-cli/src/runtime/hydrate.ts
@@ -1,0 +1,125 @@
+/**
+ * The `ss stack hydrate` execution seam.
+ *
+ * `stack hydrate` restores a LOCAL synthetic slot's Postgres from the daily prod
+ * MIRROR. That means it introduces the first DATABASE-LEVEL destructive SQL in
+ * this package (`DROP DATABASE … WITH (FORCE)`, `pg_terminate_backend`,
+ * `ALTER DATABASE … RENAME`) and the first pipeline that carries a real
+ * credential. Both go behind this ONE injectable seam, with every argv and every
+ * statement produced by the pure planner in `core/mirror/plan.ts` — so the tests
+ * assert what would run without a database, a container, or an AWS call
+ * anywhere.
+ *
+ * The seam is deliberately DUMB: `exec(argv)` spawns `docker` with exactly the
+ * argv it was handed. It makes no decisions, builds no strings, and knows
+ * nothing about postgres. Everything interesting is upstream in the planner.
+ *
+ * CREDENTIAL CONTRACT — the reason `secret` is a separate parameter rather than
+ * part of `argv`: the mirror's master password must never reach a file, a log,
+ * or argv. `ps` shows any process's argv to every user on the box;
+ * `/proc/<pid>/environ` is readable only by the same user. So the password is
+ * injected into the CHILD's environment as `PGPASSWORD` and the planner emits a
+ * bare `-e PGPASSWORD` (no `=value`) for `docker run`, which makes docker copy
+ * it out of our environment instead of putting it on the command line. It is
+ * also never echoed: `exec` returns stdout/stderr to the caller, and the command
+ * layer prints argv, never env.
+ *
+ * NOTE on why this is not `EnvPsql`: that seam puts a whole
+ * `postgres://user:pw@host/db` connection string in argv (`psqlArgs`), which is
+ * fine for `trust`-auth local dev and fatal for a real master password.
+ *
+ * INVARIANT: process/docker IO lives ONLY in `src/runtime/**`; `src/core/**`
+ * never imports this and stays pure.
+ */
+
+import { spawn } from 'node:child_process';
+import { FIELD_SEP } from '../core/mirror/index.js';
+import type { RealTableInfo } from '../core/mirror/index.js';
+
+export interface HydrateExecResult {
+  /** `null` when the child was killed by a signal. */
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+export interface HydrateIO {
+  /**
+   * Spawn `docker <argv>` and capture both streams. `secret`, when present, is
+   * exported to the CHILD ONLY as `PGPASSWORD` — never logged, never in argv.
+   * Resolves with the exit code (it does NOT throw on non-zero): the caller
+   * classifies, because `pg_restore` exits non-zero on benign warnings.
+   */
+  exec(argv: string[], opts?: { secret?: string }): Promise<HydrateExecResult>;
+
+  /**
+   * Fail fast with an actionable message when the slot's postgres container
+   * isn't up, rather than mid-transfer with a cryptic docker error.
+   */
+  assertPgRunning(container: string): Promise<void>;
+}
+
+/**
+ * Parse the mirror-side `_real` discovery read into per-table column lists.
+ * PURE (exported for tests): rows arrive as `base<US>column`, ordered by table
+ * then `attnum`, so grouping preserves the real table's column ORDER — which is
+ * what makes the scrubbed-mode `COPY` column-exact instead of trusting that the
+ * scramble view presents its columns in the same order.
+ */
+export function parseRealTableRows(stdout: string): RealTableInfo[] {
+  const byTable = new Map<string, string[]>();
+  for (const line of stdout.split('\n')) {
+    if (line.trim() === '') continue;
+    const [table, column] = line.split(FIELD_SEP);
+    if (table === undefined || column === undefined) continue;
+    const cols = byTable.get(table);
+    if (cols === undefined) byTable.set(table, [column]);
+    else cols.push(column);
+  }
+  return [...byTable.entries()].map(([table, columns]) => ({ table, columns }));
+}
+
+/** True iff a container of EXACTLY this name is running (docker ps name filter). */
+async function isContainerRunning(container: string): Promise<boolean> {
+  try {
+    const { stdout } = await runDocker(['ps', '--filter', `name=^${container}$`, '--format', '{{.Names}}']);
+    return stdout.trim() === container;
+  } catch {
+    return false;
+  }
+}
+
+/** The single real `docker` spawn site for the hydrate lane. */
+function runDocker(argv: string[], secret?: string): Promise<HydrateExecResult> {
+  return new Promise((resolve, reject) => {
+    const env = { ...process.env };
+    // Child-env only. `delete` (rather than leaving a stale value) so a step
+    // that must NOT carry the credential provably does not.
+    if (secret === undefined) delete env.PGPASSWORD;
+    else env.PGPASSWORD = secret;
+    const child = spawn('docker', argv, { stdio: ['ignore', 'pipe', 'pipe'], env });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (c: Buffer) => (stdout += c.toString()));
+    child.stderr.on('data', (c: Buffer) => (stderr += c.toString()));
+    child.on('error', reject); // ENOENT (docker not installed) surfaces directly
+    child.on('close', (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+export function makeRealHydrateIO(): HydrateIO {
+  return {
+    exec(argv, opts): Promise<HydrateExecResult> {
+      return runDocker(argv, opts?.secret);
+    },
+
+    async assertPgRunning(container): Promise<void> {
+      if (!(await isContainerRunning(container))) {
+        throw new Error(
+          `slot postgres container '${container}' is not running.\n` +
+            '  Bring the slot up first (e.g. `ss stack up --slot <N>`), then retry the hydrate.',
+        );
+      }
+    },
+  };
+}

--- a/packages/node/saga-stack-cli/src/runtime/index.ts
+++ b/packages/node/saga-stack-cli/src/runtime/index.ts
@@ -60,3 +60,4 @@ export * from './cli-version.js';
 export * from './slot-wipe.js';
 export * from './env-aws.js';
 export * from './env-psql.js';
+export * from './hydrate.js';


### PR DESCRIPTION
A full-fidelity copy of prod is **already** restored into the dev account every morning. We have been hand-rolling per-store sync code against data that exists. `ss stack hydrate` reads that mirror and repopulates a local slot, so a developer gets real prod-shaped data across **every** store with no sync code.

Idea: @sethdev. Research + plan: `coach/claude/projects/gh_408/mirror-as-local-backing-store.md`.

## Why hydrate rather than "point local APIs at the mirror"

The original proposal was to tunnel local APIs straight at the mirror. Its own docs rule that out: *"ephemeral testing destinations, not environments"*, and the refresh workflow calls it *"a standing triage dataset, not the dev backing store"*. Concretely, the instance is **replaced daily** (endpoint moves, master password rotates), the scrubbed PII tables are **read-only views**, per-service roles carry prod's `rds_iam` auth with no dev grants (so everything would run as a daily-rotating master), and one `db.t4g.small` shared by N developers means everyone writes the same rows and loses them at 06:30.

Hydrating *from* it keeps the whole benefit and drops every one of those.

## Shape

A **pure planner** — source description → the exact `docker` argv, SQL statements and rename plan — behind a **dumb executor** whose only job is to spawn the argv it is handed. It makes no decisions and builds no strings. That is why the risky surface is asserted byte-for-byte with no database, container, tunnel or credential in the tests.

## `--source real` is the default, deliberately

Prod is pre-release: every user in it is a Saga employee, so there is no end-user PII today. The daily scrub scrambles names so thoroughly that a known district **cannot be found by `display_name` or `source_id` at all**, which makes a poor reporting fixture.

`--source scrubbed` is built and planner-tested but **refuses to run**. Review confirmed two defects unique to it: emptying the `_real` tables breaks incoming FKs from tables that do carry data, and the materialising `COPY` steps are emitted alphabetically rather than FK-topologically. Both abort inside the staging database so the live copy is never at risk — but nobody should discover that the hard way. **This must be fixed before public release**, when the default flips.

## Nothing touches a live database until the replacement is proven

`<db>__hydrate` → restore → verify non-empty → view swap → re-own + grant → assert the service role can `INSERT` → assert no app-named relation is still a `VIEW` → only then promote. `--keep-previous` leaves the displaced copy as a one-command rollback.

## Review

9 confirmed findings. Fixed here:

- **A soft-empty `_real` enumeration** (exit 0, zero rows — the scrub moved, was renamed, or did not run) silently dropped **both** the view swap and the assertion guarding it, then promoted a database whose app-named relations were still read-only views and dropped the good one. Now refuses against a known floor.
- **The SIGINT handler replaced node's default disposition**, so Ctrl-C killed the tunnel while the destructive loop kept running. Now re-raises.

Deferred with the `--source scrubbed` gate: the two FK-ordering defects. Remaining minors (untested `retries: 3`, `makeRealHydrateIO` not imported by a test) are noted in the code.

## Verified end to end against the live mirror

On a **scratch database** — slot 0's real data untouched, no swap performed:

```
mirror  coach_api : instances=65 answers=1544
local   scratch   : instances=65 answers=1544
relations left as VIEW under an app name : 0
tables lacking INSERT for coach_api_app  : 0
```

Scratch dropped and the dump deleted afterwards. `tsc` clean; **135 files / 1723 tests pass**.

## Jump-host fallback — found by running it

`resolveJumpHost` already filters for SSM-`Online`, but measured today **no `dev-shared-ecs-instance` was Online while two `dev-shared-arm-ecs-instance` were**, and both SGs sit in the mirror's 5432 ingress. Resolution now falls back to the arm fleet; an explicit `--jump-host` still wins outright.

## Known limits, stated plainly

- Prod's `group_track_map` and `persona_assignment` are **empty**, so hydrate does **not** make Coach reporting light up. That routing is a separate concern (coach#412 / the derived-track-map work) and this PR deliberately does not touch it.
- `transcription_db`, `chat` and `openfga` are **opt-in, not default** — the first two are playback-only and openfga's local schema is sidecar-owned.
- **Governance: settled.** The mirror's owners accept it gaining real consumers (confirmed 2026-08-06). The practical consequence to keep in mind is that a **red daily refresh now blocks developers**, so the 13:30 UTC run is worth alerting on. Note also that `coach_api`/`programs_api` are **unscrubbed** on the mirror — fine while prod is pre-release and every user is a Saga employee, and the reason `--source scrubbed` must work before public release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NA3hmaQwFyvMsGotCsyRZb

