### PR TITLE
feat(ss): run coach-api's iam event consumer locally (prereq for coach#413)

### DIFF
--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/up-native.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/up-native.int.test.ts
@@ -286,7 +286,12 @@ describe('stack up --only — native partial-stack', () => {
 
     // the seed plan dropped coach-pg — NOTHING ran against the coach-db dir (which
     // would have spawn-crashed on the missing checkout with a real runner).
-    expect(runs.some((r) => r.cwd.includes('/coach'))).toBe(false);
+    // Anchored at the FIXTURE's coach checkout, not a bare '/coach' substring:
+    // the loose form also matched any path merely containing "coach" (a worktree
+    // named `coach-api-events`, say), which made this assertion fail for reasons
+    // having nothing to do with the coach repo.
+    const coachRepo = resolve(DEV_ROOT, 'coach');
+    expect(runs.some((r) => r.cwd === coachRepo || r.cwd.startsWith(`${coachRepo}/`))).toBe(false);
     expect(runs.some((r) => r.command === 'pnpm' && r.args.includes('db:seed') && r.cwd.includes('coach-db'))).toBe(
       false,
     );

--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.unit.test.ts
@@ -304,7 +304,7 @@ describe('resolveLaunchEnv — faithful to up.sh services_up (stack lane)', () =
       IAM_API_TARGET: 'http://localhost:3010',
       AUTH_JWKSURL: 'http://localhost:3010/.well-known/jwks.json',
       AUTH_ISSUER: 'https://iam.wootdev.com',
-      RABBITMQ_ENABLED: 'false',
+      RABBITMQ_ENABLED: 'true',
       RABBITMQ_URL: 'amqp://rabbitmq_admin:password123@localhost:5672',
       EXPRESS_SERVER_CORSALLOWEDDOMAINS: 'localhost',
       SAGA_API_TARGET: 'https://staging.wootmath.com',

--- a/packages/node/saga-stack-cli/src/core/manifest/services.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/services.ts
@@ -693,8 +693,15 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
     // curriculum read path is Postgres now (PostgresContentReadStore over
     // content_release), coach-api carries no mongo dependency and reads no MONGO_*
     // env, so the mesh mongo is NOT gated on and those vars are not injected.
-    // RABBITMQ_ENABLED=false, so rabbitmq is intentionally NOT gated on either.
-    mesh: [],
+    // Rabbitmq IS gated on: coach-api consumes iam.persona_assignment.{added,
+    // removed} + iam.persona_definition.upserted off the shared iam.events
+    // exchange and projects them into persona_assignment / persona_definition —
+    // the table coachReport's roster joins against. With the consumer off (the
+    // pre-2026-08-06 default) `consumed_events` stayed empty on every slot and
+    // that projection was only ever written by concierge's direct-SQL mirror, so
+    // the event path that production depends on was NEVER exercised locally.
+    // coach#413 is that same path being cold in prod. Mongo stays retired.
+    mesh: ['rabbitmq'],
     launch: {
       cmd: 'pnpm dev',
       env: {
@@ -705,7 +712,7 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
         IAM_API_TARGET: '${IAM_URL}',
         AUTH_JWKSURL: '${IAM_URL}/.well-known/jwks.json',
         AUTH_ISSUER: '${IAM_ISSUER}',
-        RABBITMQ_ENABLED: 'false',
+        RABBITMQ_ENABLED: 'true',
         RABBITMQ_URL: '${MESH_MQ}',
         EXPRESS_SERVER_CORSALLOWEDDOMAINS: '${COACH_WEB_HOST}',
         SAGA_API_TARGET: '${SAGA_API_TARGET_COACH}',


### PR DESCRIPTION
Prerequisite for testing the [coach#413](https://github.com/saga-ed/coach/issues/413) fix locally.

## The gap

coach-api consumes `iam.persona_assignment.{added,removed}` and `iam.persona_definition.upserted` off the shared `iam.events` exchange and projects them into `persona_assignment` / `persona_definition` — **the table `coachReport`'s roster joins against**.

The slot manifest set `RABBITMQ_ENABLED: 'false'` with `mesh: []`, so on every local slot that consumer never connected and never bound its queue. Measured on slot 0 just now:

```
consumed_events       0 rows      ← the consumer has never processed a message
persona_assignment   61 rows      ← all written by coach-concierge's direct-SQL mirror
```

So local reporting works, but **only via a shortcut**. The event path production actually depends on has never run locally — and coach#413 is that same path being cold in prod, where `persona_assignment` is empty and every `coachReport` therefore returns an empty roster over 65 real content instances.

## The change

`RABBITMQ_ENABLED: 'true'`, and `rabbitmq` joins coach-api's `mesh` so the broker is genuinely gated on rather than assumed. The container already runs in every slot; only coach-api was declining to talk to it.

That makes the local stack able to prove the prod fix: iam-api's `backfill-outbox-reemit` re-drives the real pipeline (`writeOutbox` + `OutboxRelay`), and with the consumer running a slot can show `persona_assignment` repopulating **from events alone**, with `consumed_events` going non-zero — no concierge involvement.

## Also: an over-broad test assertion

`up-native.int.test.ts` asserted `runs.some(r => r.cwd.includes('/coach')) === false`, meaning "nothing ran in the coach checkout". The bare substring also matches any path merely *containing* "coach" — a worktree named `coach-api-events`, for instance — so it failed for reasons unrelated to the coach repo. Now anchored at the fixture's actual coach checkout (`resolve(DEV_ROOT, 'coach')`).

Worth knowing why it surfaced: adding rabbitmq to the mesh means `--only coach-web` now brings the mesh up even when the coach repo is absent and coach-api is skipped. That is a real (small) behaviour change — a broker starts for a service that will not launch. Harmless, but called out rather than buried.

## Verification

- **1649 tests pass.** One failure, `env-aws > probeLocalPort`, is a **pre-existing flake**: it fails identically on untouched `main` under full-suite concurrency (a port-binding race) and passes in isolation on both branches. Not introduced here.

## Scope

Local dev only — this is the synthetic-stack manifest. Deployed environments already set `RABBITMQ_ENABLED=true` and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NA3hmaQwFyvMsGotCsyRZb
