### PR TITLE
feat(ss): stack up --no-seed — bring services back without destroying data

### DIFF
--- a/packages/node/saga-stack-cli/oclif.manifest.json
+++ b/packages/node/saga-stack-cli/oclif.manifest.json
@@ -5761,6 +5761,16 @@
           "name": "no-auto-pull",
           "type": "boolean"
         },
+        "no-seed": {
+          "allowNo": false,
+          "description": "launch WITHOUT seeding. The only way to bring services back up over data you want kept: an absent --seed still seeds the roster baseline, which is destructive to non-fixture data (it drops a hydrated or synced org). Required after `stack hydrate`, whose database swap leaves the running services on dead connections — `stack restart` is slot-0 only, so on slots 1..9 this is the bounce.",
+          "exclusive": [
+            "seed",
+            "reset"
+          ],
+          "name": "no-seed",
+          "type": "boolean"
+        },
         "only": {
           "description": "services to bring up. With --dry-run, a comma-list whose dependency closure is printed. On a real run a comma-list boots the closure NATIVELY (never up.sh); combine freely with --sandbox/--tunnel/--record (all native Phase-2 overlays).",
           "hasDynamicHelp": false,

--- a/packages/node/saga-stack-cli/src/commands/stack/__tests__/up-native.int.test.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/__tests__/up-native.int.test.ts
@@ -209,6 +209,30 @@ describe('stack up --only — native partial-stack', () => {
     expect(runs.some((r) => r.command.endsWith('up.sh'))).toBe(false);
   });
 
+  it('--no-seed launches the closure but runs NO seed step', async () => {
+    // The seed is destructive to non-fixture data (the iam seed drops an org it
+    // did not write), and it is the ONLY thing standing between `stack up` and
+    // being usable as a post-hydrate bounce: `stack restart` refuses slots 1..9,
+    // and an absent --seed still seeds the roster baseline. Measured on a live
+    // slot: an ordinary `up` over a freshly hydrated slot took iam_local from
+    // 6935 users to 314 and removed the org entirely.
+    await StackUp.run(['--only', 'scheduling-api,sessions-api', '--no-seed', ...WS], config);
+
+    // the closure still launches — this is a bounce, not a no-op.
+    expect(launches.map((s) => s.id)).toEqual([
+      'iam-api',
+      'authz-api',
+      'programs-api',
+      'scheduling-api',
+      'sessions-api',
+    ]);
+    // …and NOTHING from the seed lane ran.
+    const seedRuns = runs.filter((r) => r.command !== 'make');
+    expect(seedRuns.some((r) => r.args.some((a) => a.includes('seed-dev-user')))).toBe(false);
+    expect(seedRuns.some((r) => r.args.includes('db:seed'))).toBe(false);
+    expect(seedRuns.some((r) => r.args.some((a) => a.includes('seed-registry')))).toBe(false);
+  });
+
   it('runs the dash prelaunch hook when saga-dash is in the closure', async () => {
     await StackUp.run(['--only', 'saga-dash', ...WS], config);
     expect(launches.some((s) => s.id === 'saga-dash')).toBe(true);

--- a/packages/node/saga-stack-cli/src/commands/stack/up.ts
+++ b/packages/node/saga-stack-cli/src/commands/stack/up.ts
@@ -61,7 +61,7 @@ import { parseWorkspace } from '../../core/workspace.js';
 import type { WorkspaceSelection } from '../../core/workspace.js';
 import { resolveVendorScript } from '../../runtime/index.js';
 import { makeStackApi } from '../../stack-api.js';
-import type { Runtime, StackApi } from '../../stack-api.js';
+import type { Runtime, SeedResult, StackApi } from '../../stack-api.js';
 
 /** `--sandbox <name>` shape gate (up.sh ~2154; the composition API's IDENTIFIER shape). */
 const SANDBOX_NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9-]{0,39}$/;
@@ -101,6 +101,12 @@ export default class StackUp extends BaseCommand {
       description:
         'seed the named profile after launch (native). An absent --seed still seeds the `roster` baseline (the up.sh bare-default).',
       options: ['roster', 'full'],
+    }),
+    'no-seed': Flags.boolean({
+      default: false,
+      exclusive: ['seed', 'reset'],
+      description:
+        'launch WITHOUT seeding. The only way to bring services back up over data you want kept: an absent --seed still seeds the roster baseline, which is destructive to non-fixture data (it drops a hydrated or synced org). Required after `stack hydrate`, whose database swap leaves the running services on dead connections — `stack restart` is slot-0 only, so on slots 1..9 this is the bounce.',
     }),
     pull: Flags.boolean({
       description:
@@ -589,12 +595,26 @@ export default class StackUp extends BaseCommand {
     // pass a fully-restored set later.)
     const skippedIds = new Set(up.skipped.map((s) => s.id));
     const active = new Set(services.filter((id) => !skippedIds.has(id)));
-    const plan: SeedPlan = composeSeedPlan(
-      this.seedSelection(flags),
-      active,
-      new Set<ServiceId>(),
-    );
-    const seeded = await api.seed(plan);
+    // --no-seed: launch only. The seed is DESTRUCTIVE to non-fixture data — the
+    // iam seed drops an org it did not write — so bringing services back up over
+    // a hydrated or synced slot needs a way to skip it. There is no other:
+    // `stack restart` refuses slots 1..9, and an absent --seed still seeds the
+    // roster baseline. Measured 2026-08-07: `up` over a freshly hydrated slot 1
+    // took iam_local from 6935 users to 314 and removed the org entirely.
+    let seeded: SeedResult;
+    if (flags['no-seed']) {
+      // `ok: true` because nothing FAILED — the phase was deliberately not run.
+      // Downstream (`--tunnel`, `--login`) reads seeded.ok as "the stack is in a
+      // good state", and skipping the seed does not make it otherwise.
+      seeded = { ok: true, ran: { offline: [], online: [] }, skipped: [] };
+    } else {
+      const plan: SeedPlan = composeSeedPlan(
+        this.seedSelection(flags),
+        active,
+        new Set<ServiceId>(),
+      );
+      seeded = await api.seed(plan);
+    }
 
     // Phase 2 --tunnel: after a successful native (tunnel-aware) launch, start the
     // reverse tunnels via the VENDORED tunnel.sh (up.sh drives the frpc tunnels the
@@ -847,6 +867,7 @@ type NativeFlags = DryRunFlags & {
   'state-dir'?: string;
   slot: number;
   reset: boolean;
+  'no-seed': boolean;
   login: boolean;
   'skip-prep': boolean;
   pull: boolean;


### PR DESCRIPTION
Unblocks the mirror-based local workflow: without this, `stack hydrate` (#418) cannot be used on a running slot.

## The gap

`stack hydrate` swaps a slot's databases underneath the running services — the rename-swap terminates their connections — so they must be bounced afterwards. There was no way to do that without destroying the hydration:

- **`stack restart` refuses slots 1..9** (slot-0 only, by design), and **`hydrate` refuses slot 0** (also by design). The two never meet.
- **`stack up` always seeds.** `--seed` only chooses `roster|full`; an absent flag still seeds the roster baseline. The iam seed is destructive to data it did not write.

Measured on a live slot 1: an ordinary `up` over a freshly hydrated slot took `iam_local` from **6935 users to 314** and removed the org entirely — undoing a 2.5-minute hydrate. Before that, `iam-api` was simply **down** after the swap and `devLogin` failed, with no supported way to bring it back.

## The change

`--no-seed` launches the closure and skips the seed lane.

- **Exclusive with `--seed` and `--reset`** — asking to seed and not-seed is a contradiction, not a precedence question, so it errors rather than silently picking one.
- The skipped phase reports `ok: true` because nothing *failed*; `--tunnel` and `--login` read `seeded.ok` as "the stack is in a good state", and deliberately not running the seed does not make it otherwise.

## Verified

Live, on slot 1:

```
ss stack hydrate --slot 1 --db coach_api,iam_db --profile dev_admin --execute --yes
ss stack up --slot 1 --no-seed
  → seed offline: (none)   seed online: (none)
  → iam_local users=6935, org present, iam-api 200, devLogin works
```

Then `concierge project` + a login rendered `/reports` with **62 tutors enrolled** — the whole mirror flow, no prod credentials anywhere.

`tsc` clean; **1730 tests pass**. The new test asserts the closure still launches (this is a bounce, not a no-op) *and* that nothing from the seed lane ran — and it **fails when the flag is neutered**, checked by mutation rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NA3hmaQwFyvMsGotCsyRZb
