### PR TITLE
feat(saga-fga): listUsersDiagnostic — debug-tier reverse query (who holds R on O)

### DIFF
--- a/packages/core/saga-fga/README.md
+++ b/packages/core/saga-fga/README.md
@@ -4,13 +4,14 @@ Tier-2 (per-resource) OpenFGA authorization gate for Saga services — a thin
 `check` client over [`@openfga/sdk`](https://www.npmjs.com/package/@openfga/sdk)
 plus an enforcement flag and a framework-agnostic helper.
 
-Two query shapes, and the choice matters:
+Three query shapes, and the choice matters:
 
-| Need | Use |
-|---|---|
-| Enforce on one object | `check` / `enforceFgaRelation` |
-| Attribute *which* rule allowed it | `checkDetailed` |
-| Return only the items a user may see | [`batchCheck`](#filtered-lists-batchcheck-not-listobjects) |
+| Need                                 | Use                                                                                                 |
+| ------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| Enforce on one object                | `check` / `enforceFgaRelation`                                                                      |
+| Attribute _which_ rule allowed it    | `checkDetailed`                                                                                     |
+| Return only the items a user may see | [`batchCheck`](#filtered-lists-batchcheck-not-listobjects)                                          |
+| Debug _who_ holds a relation         | [`listUsersDiagnostic`](#the-reverse-question-listusersdiagnostic-debug-tier) — **debug tier only** |
 
 Enumeration (`ListObjects`) is intentionally **absent** — see
 [why](#filtered-lists-batchcheck-not-listobjects).
@@ -32,13 +33,13 @@ await enforceFgaRelation(
   `user:${userId}`,
   'host',
   `session:${sessionId}`,
-  () => new TRPCError({ code: 'FORBIDDEN', message: 'Only the session host may do this' }),
+  () => new TRPCError({ code: 'FORBIDDEN', message: 'Only the session host may do this' })
 );
 ```
 
 ## Attribution: `checkDetailed`
 
-Some gates must report not just *whether* access was allowed but *which* rule
+Some gates must report not just _whether_ access was allowed but _which_ rule
 allowed it — program-hub's sessions gate derives its D19 actor (`HOST` vs
 `ADMIN`) from exactly that.
 
@@ -53,7 +54,7 @@ winners. No `Expand` call is involved.
 const d = await fga.checkDetailed(
   `user:${callerId}`,
   ['host', 'edit_grant'], // attribution-priority order
-  `session:${sessionId}`,
+  `session:${sessionId}`
 );
 // d.allowed → boolean
 // d.via     → 'host' | 'edit_grant' | undefined  (first branch that held)
@@ -82,10 +83,14 @@ records from your own datastore, then ask about them**:
 ```ts
 const districts = await db.districts.findMany({ where: { status: 'ACTIVE' } });
 const verdicts = await fga.batchCheck(
-  districts.map((d) => ({ user: `user:${actorId}`, relation: 'can_view', object: `staff_org:${d.id}` })),
+  districts.map(d => ({
+    user: `user:${actorId}`,
+    relation: 'can_view',
+    object: `staff_org:${d.id}`,
+  }))
 );
-const visible = districts.filter(
-  (d) => verdicts.get(fgaBatchKey(`user:${actorId}`, 'can_view', `staff_org:${d.id}`)),
+const visible = districts.filter(d =>
+  verdicts.get(fgaBatchKey(`user:${actorId}`, 'can_view', `staff_org:${d.id}`))
 );
 ```
 
@@ -101,7 +106,7 @@ measured reasons:
    — no continuation token, no truncation flag. The operation is bounded
    server-side by a max-results cap and a deadline, so a **capped** list and a
    **complete** list are the same response. Silently under-reporting a list is an
-   authorization *correctness* bug (items the user may see never render, with no
+   authorization _correctness_ bug (items the user may see never render, with no
    error), not a performance nit.
 2. **Result count is not the cost driver.** Measured on rostering's prototype
    (`scripts/fga/prototype/latency.md`): p50 **28ms for ~421 objects** vs **73ms
@@ -110,7 +115,7 @@ measured reasons:
    `check` goes ~23ms → ~1.4ms warm; every sub-check in a `batchCheck` is
    check-cache-eligible.
 
-If a caller genuinely needs the id set *before* touching its own datastore, that
+If a caller genuinely needs the id set _before_ touching its own datastore, that
 belongs behind the PDP's own API with an explicit `truncated` contract — not
 here, where the shape invites silent under-reporting.
 
@@ -125,11 +130,47 @@ layer — filter-after-fetch yields nondeterministic page sizes and no reliable
 total. If you need stable pagination, counts, or sort, the decision has to live
 in your datastore (a projection join), not in a post-filter.
 
+## The reverse question: `listUsersDiagnostic` (debug tier)
+
+`(user, action)` and `(user, object)` are covered above; `listUsersDiagnostic`
+completes the two-of-three triple — _"who holds `relation` on `object`?"_ —
+for **debugging and audit tooling only**, and the name is the guardrail:
+
+```ts
+const who = await fga.listUsersDiagnostic('can_view', `qtf_review:${id}`);
+// who.users         → ['user:ingrid']            direct subjects
+// who.usersets      → ['group:demo-north#member'] references, NOT enumerations
+// who.wildcardTypes → ['user']                    a public-wildcard tuple exists
+```
+
+OpenFGA's `ListUsers` has the same defect that keeps `ListObjects` out of this
+package: the response carries **no truncation flag** while the server bounds
+the search with a max-results cap and a deadline, so a capped listing and a
+complete listing are indistinguishable. That disqualifies it from every
+load-bearing job — never an enforcement input, never a notification/fan-out
+source, never the audit of record (the PDP's decision log is that). It answers
+"show me who the graph currently reaches" at a debugger's prompt, nothing else.
+
+Reading the result honestly:
+
+- A **userset** (`group:g#member`) is a reference — its members are not listed;
+  a complete "who" requires expanding it separately.
+- A **wildcard** entry means a `user:*` tuple holds **this** relation. On a
+  marker relation (a `released` flip) that is the expected shape; it does _not_
+  mean "everyone can" on any computed relation, where the model's intersections
+  bind the wildcard.
+- Ask for usersets explicitly with filter syntax:
+  `listUsersDiagnostic('can_view', obj, ['user', 'group#member'])`.
+
+Failures throw `FgaUnavailableError` like everything else here — a diagnostic
+that returned `[]` during an outage would send the debugger chasing a phantom
+missing-tuple bug.
+
 ## Contextual tuples
 
 Ephemeral objects are never materialized as stored tuples. A session id decodes
-to `(date, periodId, slotId, podId)`; the *durable* facts (pod tutorship,
-program scope edges) live in the graph, while the *derived* facts — effective
+to `(date, periodId, slotId, podId)`; the _durable_ facts (pod tutorship,
+program scope edges) live in the graph, while the _derived_ facts — effective
 pod after SWAP/ABSENT at NOW, the per-occurrence override host after its
 live-membership gate — are resolved by the caller and ride in on the request:
 
@@ -172,23 +213,23 @@ checks stay authoritative until the flag flips on.
 
 ## Env
 
-| Var | Meaning | Default |
-|---|---|---|
-| `AUTHZ_FGA_ENFORCE` | master switch (`"true"` to enable) | off |
-| `OPENFGA_API_URL` | OpenFGA HTTP API | `http://localhost:8080` |
-| `OPENFGA_STORE_ID` | store id (required once enforcing) | — |
-| `OPENFGA_MODEL_ID` | authorization model id | store's latest |
-| `OPENFGA_API_TOKEN` | preshared key, sent as `Authorization: Bearer` | — (no credentials) |
+| Var                 | Meaning                                        | Default                 |
+| ------------------- | ---------------------------------------------- | ----------------------- |
+| `AUTHZ_FGA_ENFORCE` | master switch (`"true"` to enable)             | off                     |
+| `OPENFGA_API_URL`   | OpenFGA HTTP API                               | `http://localhost:8080` |
+| `OPENFGA_STORE_ID`  | store id (required once enforcing)             | —                       |
+| `OPENFGA_MODEL_ID`  | authorization model id                         | store's latest          |
+| `OPENFGA_API_TOKEN` | preshared key, sent as `Authorization: Bearer` | — (no credentials)      |
 
 > **The shared dev and prod OpenFGA servers run `authn=preshared`** — the
 > `openfga-shared-<env>` task definition sets `OPENFGA_AUTHN_METHOD=preshared`.
 > Against those, `OPENFGA_API_TOKEN` is **required**: without it every call is a
 > 401, which the gate surfaces as `FgaUnavailableError`. That's the right
-> failure *direction* (never a silent deny), but the gate answers nothing. Leave
+> failure _direction_ (never a silent deny), but the gate answers nothing. Leave
 > it unset only for a local/CI OpenFGA started with no authn.
 
 > 🪤 **Supply ONE key.** The server-side var is `OPENFGA_AUTHN_PRESHARED_KEYS`
-> (*plural* — OpenFGA accepts a comma-separated list). If `OPENFGA_API_TOKEN` is
+> (_plural_ — OpenFGA accepts a comma-separated list). If `OPENFGA_API_TOKEN` is
 > pointed at a secret holding `key1,key2` or a JSON blob, the client sends
 > `Bearer key1,key2` and gets a 401 → `FgaUnavailableError` — a symptom
 > **identical to having no token at all**, and easily misread as "the token

--- a/packages/core/saga-fga/README.md
+++ b/packages/core/saga-fga/README.md
@@ -137,7 +137,10 @@ completes the two-of-three triple — _"who holds `relation` on `object`?"_ —
 for **debugging and audit tooling only**, and the name is the guardrail:
 
 ```ts
-const who = await fga.listUsersDiagnostic('can_view', `qtf_review:${id}`);
+const who = await fga.listUsersDiagnostic('can_view', `qtf_review:${id}`, [
+  'user', // direct subjects
+  'group#member', // usersets of that shape
+]);
 // who.users         → ['user:ingrid']            direct subjects
 // who.usersets      → ['group:demo-north#member'] references, NOT enumerations
 // who.wildcardTypes → ['user']                    a public-wildcard tuple exists
@@ -153,18 +156,25 @@ source, never the audit of record (the PDP's decision log is that). It answers
 
 Reading the result honestly:
 
+- **The listing contains only the subject shapes you asked for.** The
+  `userTypes` entries map to server-side filters, which is why the parameter is
+  required: a shape you don't name is _absent from the search_, not
+  empty-because-nobody-holds-it. Forget `'group#member'` and every group grant
+  reads as a missing tuple.
 - A **userset** (`group:g#member`) is a reference — its members are not listed;
   a complete "who" requires expanding it separately.
 - A **wildcard** entry means a `user:*` tuple holds **this** relation. On a
   marker relation (a `released` flip) that is the expected shape; it does _not_
   mean "everyone can" on any computed relation, where the model's intersections
   bind the wildcard.
-- Ask for usersets explicitly with filter syntax:
-  `listUsersDiagnostic('can_view', obj, ['user', 'group#member'])`.
 
-Failures throw `FgaUnavailableError` like everything else here — a diagnostic
-that returned `[]` during an outage would send the debugger chasing a phantom
-missing-tuple bug.
+A malformed argument — an object without its `type:` prefix, a filter that is
+not `type` or `type#relation`, an empty filter list — throws `TypeError`: a
+caller bug, detected locally, deliberately distinct from `FgaUnavailableError`
+so it can never read as a PDP outage. Failures to reach a verdict throw
+`FgaUnavailableError` like everything else here — a diagnostic that returned
+`[]` during an outage would send the debugger chasing a phantom missing-tuple
+bug.
 
 ## Contextual tuples
 

--- a/packages/core/saga-fga/README.md
+++ b/packages/core/saga-fga/README.md
@@ -160,7 +160,8 @@ Reading the result honestly:
   `userTypes` entries map to server-side filters, which is why the parameter is
   required: a shape you don't name is _absent from the search_, not
   empty-because-nobody-holds-it. Forget `'group#member'` and every group grant
-  reads as a missing tuple.
+  reads as a missing tuple. The wire accepts exactly one filter per `ListUsers`
+  call, so each entry is its own round trip with its own results cap.
 - A **userset** (`group:g#member`) is a reference — its members are not listed;
   a complete "who" requires expanding it separately.
 - A **wildcard** entry means a `user:*` tuple holds **this** relation. On a

--- a/packages/core/saga-fga/README.md
+++ b/packages/core/saga-fga/README.md
@@ -160,14 +160,21 @@ Reading the result honestly:
   `userTypes` entries map to server-side filters, which is why the parameter is
   required: a shape you don't name is _absent from the search_, not
   empty-because-nobody-holds-it. Forget `'group#member'` and every group grant
-  reads as a missing tuple. The wire accepts exactly one filter per `ListUsers`
-  call, so each entry is its own round trip with its own results cap.
+  reads as a missing tuple. Each entry is its own round trip with its own
+  results cap.
+- **Contextual-tuple-derived holders are invisible** unless you ride the same
+  tuples in via the optional `contextualTuples` parameter — the server can only
+  search stored tuples, and the ephemeral-session pattern above stores nothing.
+  Same rule as `check`.
 - A **userset** (`group:g#member`) is a reference — its members are not listed;
   a complete "who" requires expanding it separately.
 - A **wildcard** entry means a `user:*` tuple holds **this** relation. On a
   marker relation (a `released` flip) that is the expected shape; it does _not_
   mean "everyone can" on any computed relation, where the model's intersections
   bind the wildcard.
+
+Lookups request `HIGHER_CONSISTENCY` (unlike the check path's latency-first
+default) so a just-written tuple shows up when an operator verifies a write.
 
 A malformed argument — an object without its `type:` prefix, a filter that is
 not `type` or `type#relation`, an empty filter list — throws `TypeError`: a

--- a/packages/core/saga-fga/package.json
+++ b/packages/core/saga-fga/package.json
@@ -1,43 +1,51 @@
 {
-    "name": "@saga-ed/saga-fga",
-    "version": "0.1.0-dev.5",
-    "private": false,
-    "type": "module",
-    "description": "Saga OpenFGA Tier-2 authorization gate — check, batchCheck (authorization-filtered lists) + framework-agnostic enforcement helper over @openfga/sdk. Services check; they never write tuples (ADR 0005).",
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "default": "./dist/index.js"
-        }
-    },
-    "files": ["dist"],
-    "scripts": {
-        "build": "tsup",
-        "check-types": "tsc --noEmit",
-        "test": "vitest run --passWithNoTests",
-        "lint": "eslint src/",
-        "clean": "rm -rf dist"
-    },
-    "dependencies": {
-        "@openfga/sdk": "^0.9.0"
-    },
-    "devDependencies": {
-        "@saga-ed/soa-typescript-config": "workspace:*",
-        "@types/node": "^24.0.3",
-        "tsup": "^8.5.0",
-        "typescript": "5.8.2",
-        "vitest": "^1.6.1"
-    },
-    "publishConfig": {
-        "registry": "https://saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/",
-        "access": "public"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/saga-ed/soa.git",
-        "directory": "packages/core/saga-fga"
-    },
-    "keywords": ["saga-soa", "openfga", "authorization", "rebac", "tier-2"]
+  "name": "@saga-ed/saga-fga",
+  "version": "0.1.0-dev.5",
+  "private": false,
+  "type": "module",
+  "description": "Saga OpenFGA Tier-2 authorization gate — check, batchCheck (authorization-filtered lists), listUsersDiagnostic (debug-tier reverse lookup) + framework-agnostic enforcement helper over @openfga/sdk. Services check; they never write tuples (ADR 0005).",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "check-types": "tsc --noEmit",
+    "test": "vitest run --passWithNoTests",
+    "lint": "eslint src/",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@openfga/sdk": "^0.9.0"
+  },
+  "devDependencies": {
+    "@saga-ed/soa-typescript-config": "workspace:*",
+    "@types/node": "^24.0.3",
+    "tsup": "^8.5.0",
+    "typescript": "5.8.2",
+    "vitest": "^1.6.1"
+  },
+  "publishConfig": {
+    "registry": "https://saga-531314149529.d.codeartifact.us-west-2.amazonaws.com/npm/saga_js/",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/saga-ed/soa.git",
+    "directory": "packages/core/saga-fga"
+  },
+  "keywords": [
+    "saga-soa",
+    "openfga",
+    "authorization",
+    "rebac",
+    "tier-2"
+  ]
 }

--- a/packages/core/saga-fga/package.json
+++ b/packages/core/saga-fga/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/saga-fga",
-    "version": "0.1.0-dev.4",
+    "version": "0.1.0-dev.5",
     "private": false,
     "type": "module",
     "description": "Saga OpenFGA Tier-2 authorization gate — check, batchCheck (authorization-filtered lists) + framework-agnostic enforcement helper over @openfga/sdk. Services check; they never write tuples (ADR 0005).",

--- a/packages/core/saga-fga/src/__tests__/gate.unit.test.ts
+++ b/packages/core/saga-fga/src/__tests__/gate.unit.test.ts
@@ -340,7 +340,7 @@ describe('batchCheck — a per-item failure is NOT a deny', () => {
 });
 
 describe('listUsersDiagnostic — the reverse (debug-tier) question', () => {
-  it('partitions direct users, usersets, and wildcards, asking for user subjects by default', async () => {
+  it('partitions direct users, usersets, and wildcards by the requested subject shapes', async () => {
     listUsersMock.mockReset().mockResolvedValue({
       users: [
         { object: { type: 'user', id: 'ingrid' } },
@@ -348,7 +348,10 @@ describe('listUsersDiagnostic — the reverse (debug-tier) question', () => {
         { wildcard: { type: 'user' } },
       ],
     });
-    const listing = await gateWithStore().listUsersDiagnostic('can_view', 'qtf_review:r1');
+    const listing = await gateWithStore().listUsersDiagnostic('can_view', 'qtf_review:r1', [
+      'user',
+      'group#member',
+    ]);
 
     expect(listing).toEqual({
       users: ['user:ingrid'],
@@ -358,45 +361,64 @@ describe('listUsersDiagnostic — the reverse (debug-tier) question', () => {
     expect(listUsersMock.mock.calls[0]?.[0]).toEqual({
       object: { type: 'qtf_review', id: 'r1' },
       relation: 'can_view',
-      user_filters: [{ type: 'user' }],
-    });
-  });
-
-  it("maps 'group#member' filter syntax to a typed userset filter", async () => {
-    listUsersMock.mockReset().mockResolvedValue({ users: [] });
-    await gateWithStore().listUsersDiagnostic('can_view', 'session:s1', ['user', 'group#member']);
-    expect(listUsersMock.mock.calls[0]?.[0]).toMatchObject({
       user_filters: [{ type: 'user' }, { type: 'group', relation: 'member' }],
     });
   });
 
   it('splits the object on the FIRST colon only — instance ids contain separators', async () => {
     listUsersMock.mockReset().mockResolvedValue({ users: [] });
-    await gateWithStore().listUsersDiagnostic('host', 'session_instance:S|2026-08-05');
+    await gateWithStore().listUsersDiagnostic('host', 'session_instance:S|2026-08-05', ['user']);
     expect(listUsersMock.mock.calls[0]?.[0]).toMatchObject({
       object: { type: 'session_instance', id: 'S|2026-08-05' },
     });
   });
 
-  it('rejects an un-typed object id rather than sending a malformed filter', async () => {
+  it('rejects an un-typed object id as a caller bug (TypeError), never as unavailability', async () => {
     listUsersMock.mockReset();
-    await expect(gateWithStore().listUsersDiagnostic('host', 'no-type-separator')).rejects.toThrow(
-      FgaUnavailableError
-    );
+    await expect(
+      gateWithStore().listUsersDiagnostic('host', 'no-type-separator', ['user'])
+    ).rejects.toThrow(TypeError);
+    expect(listUsersMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed subject-type filters as caller bugs (TypeError)', async () => {
+    listUsersMock.mockReset();
+    const gate = gateWithStore();
+    for (const bad of ['#member', 'group#', 'group:member', '', 'group#member#extra']) {
+      await expect(gate.listUsersDiagnostic('can_view', 'session:s1', [bad])).rejects.toThrow(
+        TypeError
+      );
+    }
+    // An empty filter list means "no shapes", not "all shapes" — reject it too.
+    await expect(gate.listUsersDiagnostic('can_view', 'session:s1', [])).rejects.toThrow(TypeError);
     expect(listUsersMock).not.toHaveBeenCalled();
   });
 
   it('surfaces a transport failure as FgaUnavailableError — an outage must never read as an empty listing', async () => {
     listUsersMock.mockReset().mockRejectedValue(new Error('ECONNREFUSED'));
-    await expect(gateWithStore().listUsersDiagnostic('host', 'session:s1')).rejects.toThrow(
-      FgaUnavailableError
-    );
+    await expect(
+      gateWithStore().listUsersDiagnostic('host', 'session:s1', ['user'])
+    ).rejects.toThrow(FgaUnavailableError);
+  });
+
+  it('surfaces a 2xx body with no users array as FgaUnavailableError, not an empty listing', async () => {
+    listUsersMock.mockReset().mockResolvedValue({});
+    await expect(
+      gateWithStore().listUsersDiagnostic('host', 'session:s1', ['user'])
+    ).rejects.toThrow(FgaUnavailableError);
+  });
+
+  it('throws on an unrecognized subject entry rather than silently dropping it', async () => {
+    listUsersMock.mockReset().mockResolvedValue({ users: [{}] });
+    await expect(
+      gateWithStore().listUsersDiagnostic('host', 'session:s1', ['user'])
+    ).rejects.toThrow(FgaUnavailableError);
   });
 
   it('surfaces a missing store id without reaching the client', async () => {
     listUsersMock.mockReset();
     const gate = createFgaGate({ enforce: true, apiUrl: 'http://fga.test' });
-    await expect(gate.listUsersDiagnostic('host', 'session:s1')).rejects.toThrow(
+    await expect(gate.listUsersDiagnostic('host', 'session:s1', ['user'])).rejects.toThrow(
       FgaUnavailableError
     );
     expect(listUsersMock).not.toHaveBeenCalled();

--- a/packages/core/saga-fga/src/__tests__/gate.unit.test.ts
+++ b/packages/core/saga-fga/src/__tests__/gate.unit.test.ts
@@ -340,14 +340,22 @@ describe('batchCheck — a per-item failure is NOT a deny', () => {
 });
 
 describe('listUsersDiagnostic — the reverse (debug-tier) question', () => {
-  it('partitions direct users, usersets, and wildcards by the requested subject shapes', async () => {
-    listUsersMock.mockReset().mockResolvedValue({
-      users: [
-        { object: { type: 'user', id: 'ingrid' } },
-        { userset: { type: 'group', id: 'demo-north', relation: 'member' } },
-        { wildcard: { type: 'user' } },
-      ],
-    });
+  // The wire accepts exactly ONE user_filter per ListUsers call, so the mock
+  // answers per filter — a multi-filter request would be a real-server 400.
+  const respondPerFilter = () =>
+    listUsersMock
+      .mockReset()
+      .mockImplementation((req: { user_filters: { type: string; relation?: string }[] }) => {
+        expect(req.user_filters).toHaveLength(1);
+        return Promise.resolve({
+          users: req.user_filters[0]?.relation
+            ? [{ userset: { type: 'group', id: 'demo-north', relation: 'member' } }]
+            : [{ object: { type: 'user', id: 'ingrid' } }, { wildcard: { type: 'user' } }],
+        });
+      });
+
+  it('fans out one wire call per subject shape and merges the partitions', async () => {
+    respondPerFilter();
     const listing = await gateWithStore().listUsersDiagnostic('can_view', 'qtf_review:r1', [
       'user',
       'group#member',
@@ -358,11 +366,25 @@ describe('listUsersDiagnostic — the reverse (debug-tier) question', () => {
       usersets: ['group:demo-north#member'],
       wildcardTypes: ['user'],
     });
+    expect(listUsersMock).toHaveBeenCalledTimes(2);
     expect(listUsersMock.mock.calls[0]?.[0]).toEqual({
       object: { type: 'qtf_review', id: 'r1' },
       relation: 'can_view',
-      user_filters: [{ type: 'user' }, { type: 'group', relation: 'member' }],
+      user_filters: [{ type: 'user' }],
     });
+    expect(listUsersMock.mock.calls[1]?.[0]).toMatchObject({
+      user_filters: [{ type: 'group', relation: 'member' }],
+    });
+  });
+
+  it('collapses duplicate filters to one wire call — no double-counted subjects', async () => {
+    respondPerFilter();
+    const listing = await gateWithStore().listUsersDiagnostic('can_view', 'qtf_review:r1', [
+      'user',
+      'user',
+    ]);
+    expect(listUsersMock).toHaveBeenCalledTimes(1);
+    expect(listing.users).toEqual(['user:ingrid']);
   });
 
   it('splits the object on the FIRST colon only — instance ids contain separators', async () => {
@@ -373,11 +395,24 @@ describe('listUsersDiagnostic — the reverse (debug-tier) question', () => {
     });
   });
 
-  it('rejects an un-typed object id as a caller bug (TypeError), never as unavailability', async () => {
+  it('rejects an un-typed or id-less object as a caller bug (TypeError), never as unavailability', async () => {
     listUsersMock.mockReset();
-    await expect(
-      gateWithStore().listUsersDiagnostic('host', 'no-type-separator', ['user'])
-    ).rejects.toThrow(TypeError);
+    const gate = gateWithStore();
+    // 'session:' is the empty-interpolation bug (`session:${id}` with id '').
+    for (const bad of ['no-type-separator', 'session:', ':s1']) {
+      await expect(gate.listUsersDiagnostic('host', bad, ['user'])).rejects.toThrow(TypeError);
+    }
+    expect(listUsersMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed relation as a caller bug (TypeError)', async () => {
+    listUsersMock.mockReset();
+    const gate = gateWithStore();
+    for (const bad of ['', 'can view', 'session:can_view', 'can_view#x']) {
+      await expect(gate.listUsersDiagnostic(bad, 'session:s1', ['user'])).rejects.toThrow(
+        TypeError
+      );
+    }
     expect(listUsersMock).not.toHaveBeenCalled();
   });
 
@@ -408,11 +443,21 @@ describe('listUsersDiagnostic — the reverse (debug-tier) question', () => {
     ).rejects.toThrow(FgaUnavailableError);
   });
 
-  it('throws on an unrecognized subject entry rather than silently dropping it', async () => {
-    listUsersMock.mockReset().mockResolvedValue({ users: [{}] });
-    await expect(
-      gateWithStore().listUsersDiagnostic('host', 'session:s1', ['user'])
-    ).rejects.toThrow(FgaUnavailableError);
+  it('throws on an unrecognized or partial subject entry rather than misreporting it', async () => {
+    const gate = gateWithStore();
+    // A partial entry would otherwise stringify as a phantom subject like
+    // 'user:undefined' that matches no real tuple.
+    for (const entry of [
+      {},
+      { object: {} },
+      { object: { type: 'user' } },
+      { userset: { type: 'group', id: 'g' } },
+    ]) {
+      listUsersMock.mockReset().mockResolvedValue({ users: [entry] });
+      await expect(gate.listUsersDiagnostic('host', 'session:s1', ['user'])).rejects.toThrow(
+        FgaUnavailableError
+      );
+    }
   });
 
   it('surfaces a missing store id without reaching the client', async () => {

--- a/packages/core/saga-fga/src/__tests__/gate.unit.test.ts
+++ b/packages/core/saga-fga/src/__tests__/gate.unit.test.ts
@@ -20,6 +20,11 @@ vi.mock('@openfga/sdk', () => ({
     ApiToken: 'api_token',
     ClientCredentials: 'client_credentials',
   },
+  ConsistencyPreference: {
+    Unspecified: 'UNSPECIFIED',
+    MinimizeLatency: 'MINIMIZE_LATENCY',
+    HigherConsistency: 'HIGHER_CONSISTENCY',
+  },
   OpenFgaClient: class {
     check = checkMock;
     batchCheck = batchCheckMock;
@@ -340,8 +345,8 @@ describe('batchCheck — a per-item failure is NOT a deny', () => {
 });
 
 describe('listUsersDiagnostic — the reverse (debug-tier) question', () => {
-  // The wire accepts exactly ONE user_filter per ListUsers call, so the mock
-  // answers per filter — a multi-filter request would be a real-server 400.
+  // Mock answers per single filter, asserting the arity the real server
+  // enforces (see the implementation's fan-out comment).
   const respondPerFilter = () =>
     listUsersMock
       .mockReset()
@@ -377,6 +382,30 @@ describe('listUsersDiagnostic — the reverse (debug-tier) question', () => {
     });
   });
 
+  it('requests HIGHER_CONSISTENCY — a stale read misreads as a missing tuple', async () => {
+    respondPerFilter();
+    await gateWithStore().listUsersDiagnostic('can_view', 'qtf_review:r1', ['user']);
+    expect(listUsersMock.mock.calls[0]?.[1]).toEqual({ consistency: 'HIGHER_CONSISTENCY' });
+  });
+
+  it('forwards contextual tuples to every fanned-out call, omitting the key when absent', async () => {
+    respondPerFilter();
+    const tuples = [{ user: 'pod:p1', relation: 'pod', object: 'session:s1' }];
+    await gateWithStore().listUsersDiagnostic(
+      'host',
+      'session:s1',
+      ['user', 'group#member'],
+      tuples
+    );
+    for (const call of listUsersMock.mock.calls) {
+      expect(call[0]).toMatchObject({ contextualTuples: tuples });
+    }
+
+    respondPerFilter();
+    await gateWithStore().listUsersDiagnostic('host', 'session:s1', ['user'], []);
+    expect(listUsersMock.mock.calls[0]?.[0]).not.toHaveProperty('contextualTuples');
+  });
+
   it('collapses duplicate filters to one wire call — no double-counted subjects', async () => {
     respondPerFilter();
     const listing = await gateWithStore().listUsersDiagnostic('can_view', 'qtf_review:r1', [
@@ -399,7 +428,7 @@ describe('listUsersDiagnostic — the reverse (debug-tier) question', () => {
     listUsersMock.mockReset();
     const gate = gateWithStore();
     // 'session:' is the empty-interpolation bug (`session:${id}` with id '').
-    for (const bad of ['no-type-separator', 'session:', ':s1']) {
+    for (const bad of ['no-type-separator', 'session:', ':s1', 'qtf review:r1', 'session#occ:s1']) {
       await expect(gate.listUsersDiagnostic('host', bad, ['user'])).rejects.toThrow(TypeError);
     }
     expect(listUsersMock).not.toHaveBeenCalled();

--- a/packages/core/saga-fga/src/__tests__/gate.unit.test.ts
+++ b/packages/core/saga-fga/src/__tests__/gate.unit.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 import {
   loadFgaGateConfig,
   enforceFgaRelation,
@@ -359,6 +359,10 @@ describe('listUsersDiagnostic — the reverse (debug-tier) question', () => {
         });
       });
 
+  beforeEach(() => {
+    listUsersMock.mockReset();
+  });
+
   it('fans out one wire call per subject shape and merges the partitions', async () => {
     respondPerFilter();
     const listing = await gateWithStore().listUsersDiagnostic('can_view', 'qtf_review:r1', [
@@ -388,7 +392,7 @@ describe('listUsersDiagnostic — the reverse (debug-tier) question', () => {
     expect(listUsersMock.mock.calls[0]?.[1]).toEqual({ consistency: 'HIGHER_CONSISTENCY' });
   });
 
-  it('forwards contextual tuples to every fanned-out call, omitting the key when absent', async () => {
+  it('forwards contextual tuples to every fanned-out call', async () => {
     respondPerFilter();
     const tuples = [{ user: 'pod:p1', relation: 'pod', object: 'session:s1' }];
     await gateWithStore().listUsersDiagnostic(
@@ -400,7 +404,9 @@ describe('listUsersDiagnostic — the reverse (debug-tier) question', () => {
     for (const call of listUsersMock.mock.calls) {
       expect(call[0]).toMatchObject({ contextualTuples: tuples });
     }
+  });
 
+  it('omits the contextualTuples key when none are supplied', async () => {
     respondPerFilter();
     await gateWithStore().listUsersDiagnostic('host', 'session:s1', ['user'], []);
     expect(listUsersMock.mock.calls[0]?.[0]).not.toHaveProperty('contextualTuples');
@@ -417,80 +423,83 @@ describe('listUsersDiagnostic — the reverse (debug-tier) question', () => {
   });
 
   it('splits the object on the FIRST colon only — instance ids contain separators', async () => {
-    listUsersMock.mockReset().mockResolvedValue({ users: [] });
+    listUsersMock.mockResolvedValue({ users: [] });
     await gateWithStore().listUsersDiagnostic('host', 'session_instance:S|2026-08-05', ['user']);
     expect(listUsersMock.mock.calls[0]?.[0]).toMatchObject({
       object: { type: 'session_instance', id: 'S|2026-08-05' },
     });
   });
 
-  it('rejects an un-typed or id-less object as a caller bug (TypeError), never as unavailability', async () => {
-    listUsersMock.mockReset();
-    const gate = gateWithStore();
-    // 'session:' is the empty-interpolation bug (`session:${id}` with id '').
-    for (const bad of ['no-type-separator', 'session:', ':s1', 'qtf review:r1', 'session#occ:s1']) {
-      await expect(gate.listUsersDiagnostic('host', bad, ['user'])).rejects.toThrow(TypeError);
-    }
-    expect(listUsersMock).not.toHaveBeenCalled();
-  });
-
-  it('rejects a malformed relation as a caller bug (TypeError)', async () => {
-    listUsersMock.mockReset();
-    const gate = gateWithStore();
-    for (const bad of ['', 'can view', 'session:can_view', 'can_view#x']) {
-      await expect(gate.listUsersDiagnostic(bad, 'session:s1', ['user'])).rejects.toThrow(
+  // 'session:' is the empty-interpolation bug (`session:${id}` with id '').
+  it.each(['no-type-separator', 'session:', ':s1', 'qtf review:r1', 'session#occ:s1'])(
+    'rejects object "%s" as a caller bug (TypeError), never as unavailability',
+    async bad => {
+      await expect(gateWithStore().listUsersDiagnostic('host', bad, ['user'])).rejects.toThrow(
         TypeError
       );
+      expect(listUsersMock).not.toHaveBeenCalled();
     }
-    expect(listUsersMock).not.toHaveBeenCalled();
-  });
+  );
 
-  it('rejects malformed subject-type filters as caller bugs (TypeError)', async () => {
-    listUsersMock.mockReset();
-    const gate = gateWithStore();
-    for (const bad of ['#member', 'group#', 'group:member', '', 'group#member#extra']) {
-      await expect(gate.listUsersDiagnostic('can_view', 'session:s1', [bad])).rejects.toThrow(
-        TypeError
-      );
+  it.each(['', 'can view', 'session:can_view', 'can_view#x'])(
+    'rejects relation "%s" as a caller bug (TypeError)',
+    async bad => {
+      await expect(
+        gateWithStore().listUsersDiagnostic(bad, 'session:s1', ['user'])
+      ).rejects.toThrow(TypeError);
+      expect(listUsersMock).not.toHaveBeenCalled();
     }
-    // An empty filter list means "no shapes", not "all shapes" — reject it too.
-    await expect(gate.listUsersDiagnostic('can_view', 'session:s1', [])).rejects.toThrow(TypeError);
+  );
+
+  it.each(['#member', 'group#', 'group:member', '', 'group#member#extra'])(
+    'rejects subject-type filter "%s" as a caller bug (TypeError)',
+    async bad => {
+      await expect(
+        gateWithStore().listUsersDiagnostic('can_view', 'session:s1', [bad])
+      ).rejects.toThrow(TypeError);
+      expect(listUsersMock).not.toHaveBeenCalled();
+    }
+  );
+
+  it('rejects an empty filter list — "no shapes", not "all shapes"', async () => {
+    await expect(gateWithStore().listUsersDiagnostic('can_view', 'session:s1', [])).rejects.toThrow(
+      TypeError
+    );
     expect(listUsersMock).not.toHaveBeenCalled();
   });
 
   it('surfaces a transport failure as FgaUnavailableError — an outage must never read as an empty listing', async () => {
-    listUsersMock.mockReset().mockRejectedValue(new Error('ECONNREFUSED'));
+    listUsersMock.mockRejectedValue(new Error('ECONNREFUSED'));
     await expect(
       gateWithStore().listUsersDiagnostic('host', 'session:s1', ['user'])
     ).rejects.toThrow(FgaUnavailableError);
   });
 
   it('surfaces a 2xx body with no users array as FgaUnavailableError, not an empty listing', async () => {
-    listUsersMock.mockReset().mockResolvedValue({});
+    listUsersMock.mockResolvedValue({});
     await expect(
       gateWithStore().listUsersDiagnostic('host', 'session:s1', ['user'])
     ).rejects.toThrow(FgaUnavailableError);
   });
 
-  it('throws on an unrecognized or partial subject entry rather than misreporting it', async () => {
-    const gate = gateWithStore();
-    // A partial entry would otherwise stringify as a phantom subject like
-    // 'user:undefined' that matches no real tuple.
-    for (const entry of [
-      {},
-      { object: {} },
-      { object: { type: 'user' } },
-      { userset: { type: 'group', id: 'g' } },
-    ]) {
-      listUsersMock.mockReset().mockResolvedValue({ users: [entry] });
-      await expect(gate.listUsersDiagnostic('host', 'session:s1', ['user'])).rejects.toThrow(
-        FgaUnavailableError
-      );
+  // A partial entry would otherwise stringify as a phantom subject like
+  // 'user:undefined' that matches no real tuple.
+  it.each([
+    {},
+    { object: {} },
+    { object: { type: 'user' } },
+    { userset: { type: 'group', id: 'g' } },
+  ])(
+    'throws on unrecognized or partial subject entry %j rather than misreporting it',
+    async entry => {
+      listUsersMock.mockResolvedValue({ users: [entry] });
+      await expect(
+        gateWithStore().listUsersDiagnostic('host', 'session:s1', ['user'])
+      ).rejects.toThrow(FgaUnavailableError);
     }
-  });
+  );
 
   it('surfaces a missing store id without reaching the client', async () => {
-    listUsersMock.mockReset();
     const gate = createFgaGate({ enforce: true, apiUrl: 'http://fga.test' });
     await expect(gate.listUsersDiagnostic('host', 'session:s1', ['user'])).rejects.toThrow(
       FgaUnavailableError

--- a/packages/core/saga-fga/src/__tests__/gate.unit.test.ts
+++ b/packages/core/saga-fga/src/__tests__/gate.unit.test.ts
@@ -10,14 +10,20 @@ import {
 
 const checkMock = vi.hoisted(() => vi.fn());
 const batchCheckMock = vi.hoisted(() => vi.fn());
+const listUsersMock = vi.hoisted(() => vi.fn());
 // Capture constructor args so we can assert on the CLIENT CONFIG, not just on
 // calls — a token that never reaches the constructor never reaches the wire.
 const clientConfigs = vi.hoisted(() => [] as Record<string, unknown>[]);
 vi.mock('@openfga/sdk', () => ({
-  CredentialsMethod: { None: 'none', ApiToken: 'api_token', ClientCredentials: 'client_credentials' },
+  CredentialsMethod: {
+    None: 'none',
+    ApiToken: 'api_token',
+    ClientCredentials: 'client_credentials',
+  },
   OpenFgaClient: class {
     check = checkMock;
     batchCheck = batchCheckMock;
+    listUsers = listUsersMock;
     constructor(config: Record<string, unknown>) {
       clientConfigs.push(config);
     }
@@ -26,16 +32,20 @@ vi.mock('@openfga/sdk', () => ({
 
 /** Echo back an `allowed` verdict per requested item, in request order. */
 const respondAllowing = (allow: (item: { object: string; relation: string }) => boolean) =>
-  batchCheckMock.mockReset().mockImplementation(
-    (body: { checks: { user: string; relation: string; object: string; correlationId: string }[] }) =>
-      Promise.resolve({
-        result: body.checks.map((c) => ({
-          allowed: allow(c),
-          request: c,
-          correlationId: c.correlationId,
-        })),
-      }),
-  );
+  batchCheckMock
+    .mockReset()
+    .mockImplementation(
+      (body: {
+        checks: { user: string; relation: string; object: string; correlationId: string }[];
+      }) =>
+        Promise.resolve({
+          result: body.checks.map(c => ({
+            allowed: allow(c),
+            request: c,
+            correlationId: c.correlationId,
+          })),
+        })
+    );
 
 const gateWithStore = () =>
   createFgaGate({ enforce: true, apiUrl: 'http://fga.test', storeId: 's1' });
@@ -103,16 +113,30 @@ describe('enforceFgaRelation', () => {
     let called = false;
     const gate: Pick<FgaGate, 'enforce' | 'check'> = {
       enforce: false,
-      async check() { called = true; return false; },
+      async check() {
+        called = true;
+        return false;
+      },
     };
-    await enforceFgaRelation(gate, 'user:a', 'host', 'session:s', () => new Error('should not throw'));
+    await enforceFgaRelation(
+      gate,
+      'user:a',
+      'host',
+      'session:s',
+      () => new Error('should not throw')
+    );
     expect(called).toBe(false);
   });
 
   it('throws makeForbidden() when the relation does not hold', async () => {
-    const gate: Pick<FgaGate, 'enforce' | 'check'> = { enforce: true, async check() { return false; } };
+    const gate: Pick<FgaGate, 'enforce' | 'check'> = {
+      enforce: true,
+      async check() {
+        return false;
+      },
+    };
     await expect(
-      enforceFgaRelation(gate, 'user:a', 'host', 'session:s', () => new Error('forbidden')),
+      enforceFgaRelation(gate, 'user:a', 'host', 'session:s', () => new Error('forbidden'))
     ).rejects.toThrow('forbidden');
   });
 
@@ -120,10 +144,13 @@ describe('enforceFgaRelation', () => {
     let asked: [string, string, string] | undefined;
     const gate: Pick<FgaGate, 'enforce' | 'check'> = {
       enforce: true,
-      async check(u, r, o) { asked = [u, r, o]; return true; },
+      async check(u, r, o) {
+        asked = [u, r, o];
+        return true;
+      },
     };
     await expect(
-      enforceFgaRelation(gate, 'user:a', 'host', 'session:s', () => new Error('forbidden')),
+      enforceFgaRelation(gate, 'user:a', 'host', 'session:s', () => new Error('forbidden'))
     ).resolves.toBeUndefined();
     expect(asked).toEqual(['user:a', 'host', 'session:s']);
   });
@@ -149,9 +176,11 @@ describe('contextual tuples', () => {
 
 describe('checkDetailed attribution', () => {
   const allowOnly = (relation: string) =>
-    checkMock.mockReset().mockImplementation(
-      (req: { relation: string }) => Promise.resolve({ allowed: req.relation === relation }),
-    );
+    checkMock
+      .mockReset()
+      .mockImplementation((req: { relation: string }) =>
+        Promise.resolve({ allowed: req.relation === relation })
+      );
 
   it('reports which branch fired', async () => {
     allowOnly('edit_grant');
@@ -186,10 +215,10 @@ describe('checkDetailed attribution', () => {
 describe('batchCheck — the authorization-filtered-list primitive', () => {
   const districts = ['staff_org:d1', 'staff_org:d2', 'staff_org:d3'];
   const asChecks = (objects: string[]) =>
-    objects.map((object) => ({ user: 'user:a', relation: 'can_view', object }));
+    objects.map(object => ({ user: 'user:a', relation: 'can_view', object }));
 
   it('returns one verdict per item, keyed by fgaBatchKey', async () => {
-    respondAllowing((c) => c.object !== 'staff_org:d2');
+    respondAllowing(c => c.object !== 'staff_org:d2');
     const verdicts = await gateWithStore().batchCheck(asChecks(districts));
 
     expect(verdicts.size).toBe(3);
@@ -223,18 +252,18 @@ describe('batchCheck — the authorization-filtered-list primitive', () => {
 
   it('correlates by correlationId, not response order', async () => {
     // A server that answers out of order must not shuffle the verdicts.
-    batchCheckMock.mockReset().mockImplementation(
-      (body: { checks: { relation: string; object: string; correlationId: string }[] }) =>
-        Promise.resolve({
-          result: [...body.checks]
-            .reverse()
-            .map((c) => ({
+    batchCheckMock
+      .mockReset()
+      .mockImplementation(
+        (body: { checks: { relation: string; object: string; correlationId: string }[] }) =>
+          Promise.resolve({
+            result: [...body.checks].reverse().map(c => ({
               allowed: c.object === 'staff_org:d1',
               request: c,
               correlationId: c.correlationId,
             })),
-        }),
-    );
+          })
+      );
     const verdicts = await gateWithStore().batchCheck(asChecks(districts));
 
     expect(verdicts.get(fgaBatchKey('user:a', 'can_view', 'staff_org:d1'))).toBe(true);
@@ -310,11 +339,75 @@ describe('batchCheck — a per-item failure is NOT a deny', () => {
   });
 });
 
+describe('listUsersDiagnostic — the reverse (debug-tier) question', () => {
+  it('partitions direct users, usersets, and wildcards, asking for user subjects by default', async () => {
+    listUsersMock.mockReset().mockResolvedValue({
+      users: [
+        { object: { type: 'user', id: 'ingrid' } },
+        { userset: { type: 'group', id: 'demo-north', relation: 'member' } },
+        { wildcard: { type: 'user' } },
+      ],
+    });
+    const listing = await gateWithStore().listUsersDiagnostic('can_view', 'qtf_review:r1');
+
+    expect(listing).toEqual({
+      users: ['user:ingrid'],
+      usersets: ['group:demo-north#member'],
+      wildcardTypes: ['user'],
+    });
+    expect(listUsersMock.mock.calls[0]?.[0]).toEqual({
+      object: { type: 'qtf_review', id: 'r1' },
+      relation: 'can_view',
+      user_filters: [{ type: 'user' }],
+    });
+  });
+
+  it("maps 'group#member' filter syntax to a typed userset filter", async () => {
+    listUsersMock.mockReset().mockResolvedValue({ users: [] });
+    await gateWithStore().listUsersDiagnostic('can_view', 'session:s1', ['user', 'group#member']);
+    expect(listUsersMock.mock.calls[0]?.[0]).toMatchObject({
+      user_filters: [{ type: 'user' }, { type: 'group', relation: 'member' }],
+    });
+  });
+
+  it('splits the object on the FIRST colon only — instance ids contain separators', async () => {
+    listUsersMock.mockReset().mockResolvedValue({ users: [] });
+    await gateWithStore().listUsersDiagnostic('host', 'session_instance:S|2026-08-05');
+    expect(listUsersMock.mock.calls[0]?.[0]).toMatchObject({
+      object: { type: 'session_instance', id: 'S|2026-08-05' },
+    });
+  });
+
+  it('rejects an un-typed object id rather than sending a malformed filter', async () => {
+    listUsersMock.mockReset();
+    await expect(gateWithStore().listUsersDiagnostic('host', 'no-type-separator')).rejects.toThrow(
+      FgaUnavailableError
+    );
+    expect(listUsersMock).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a transport failure as FgaUnavailableError — an outage must never read as an empty listing', async () => {
+    listUsersMock.mockReset().mockRejectedValue(new Error('ECONNREFUSED'));
+    await expect(gateWithStore().listUsersDiagnostic('host', 'session:s1')).rejects.toThrow(
+      FgaUnavailableError
+    );
+  });
+
+  it('surfaces a missing store id without reaching the client', async () => {
+    listUsersMock.mockReset();
+    const gate = createFgaGate({ enforce: true, apiUrl: 'http://fga.test' });
+    await expect(gate.listUsersDiagnostic('host', 'session:s1')).rejects.toThrow(
+      FgaUnavailableError
+    );
+    expect(listUsersMock).not.toHaveBeenCalled();
+  });
+});
+
 describe('an unreachable verdict is NOT a deny', () => {
   it('surfaces a transport failure as FgaUnavailableError', async () => {
     checkMock.mockReset().mockRejectedValue(new Error('ECONNREFUSED'));
     await expect(gateWithStore().check('user:a', 'host', 'session:s')).rejects.toThrow(
-      FgaUnavailableError,
+      FgaUnavailableError
     );
   });
 
@@ -328,16 +421,20 @@ describe('an unreachable verdict is NOT a deny', () => {
   it('propagates out of checkDetailed rather than degrading to a denial', async () => {
     checkMock.mockReset().mockRejectedValue(new Error('boom'));
     await expect(
-      gateWithStore().checkDetailed('user:a', ['host', 'edit_grant'], 'session:s'),
+      gateWithStore().checkDetailed('user:a', ['host', 'edit_grant'], 'session:s')
     ).rejects.toThrow(FgaUnavailableError);
   });
 
   it('propagates through enforceFgaRelation instead of throwing makeForbidden()', async () => {
     checkMock.mockReset().mockRejectedValue(new Error('boom'));
     await expect(
-      enforceFgaRelation(gateWithStore(), 'user:a', 'host', 'session:s', () =>
-        new Error('MASKED-AS-DENY'),
-      ),
+      enforceFgaRelation(
+        gateWithStore(),
+        'user:a',
+        'host',
+        'session:s',
+        () => new Error('MASKED-AS-DENY')
+      )
     ).rejects.toThrow(FgaUnavailableError);
   });
 });

--- a/packages/core/saga-fga/src/index.ts
+++ b/packages/core/saga-fga/src/index.ts
@@ -56,8 +56,10 @@ export interface FgaGateConfig {
 }
 
 export function loadFgaGateConfig(
-  // core-tier package: `process` may not exist in the importing runtime.
-  env: Record<string, string | undefined> = typeof process === 'undefined' ? {} : process.env
+  // core-tier package: `process` may be absent, or a bundler shim without `env`.
+  env: Record<string, string | undefined> = typeof process === 'undefined'
+    ? {}
+    : (process.env ?? {})
 ): FgaGateConfig {
   return {
     enforce: env.AUTHZ_FGA_ENFORCE === 'true',
@@ -254,7 +256,9 @@ export interface FgaDiagnostics {
    * ONLY what it names: entries map to server-side filters, so the parameter is
    * required — an implicit default would silently hide the shapes it omits
    * (e.g. group grants). `'group#member'` asks for usersets of that shape; bare
-   * `'user'` asks for direct subjects.
+   * `'user'` asks for direct subjects. The wire accepts one filter per
+   * `ListUsers` call, so each entry costs its own (independently capped) round
+   * trip; results are merged.
    *
    * Throws `TypeError` on a malformed argument — a caller bug, detected
    * locally, deliberately NOT {@link FgaUnavailableError} so it can never read
@@ -384,60 +388,84 @@ export function createFgaGate(
     object: string,
     userTypes: readonly string[]
   ): Promise<FgaUserListing> => {
-    // Malformed arguments are caller bugs → TypeError, never FgaUnavailableError:
-    // a deterministic local rejection must not read as a PDP outage.
-    // 'type:id' → the wire's structured object. Split on the FIRST colon only —
-    // instance ids may themselves contain separators (session_instance:S|date).
+    // Malformed arguments are caller bugs → TypeError, never FgaUnavailableError.
+    // 'type:id' with a NON-EMPTY id, split on the FIRST colon only — instance
+    // ids may themselves contain separators (session_instance:S|date).
     const sep = object.indexOf(':');
-    if (sep <= 0) {
+    if (sep <= 0 || sep === object.length - 1) {
       throw new TypeError(
-        `FGA listUsers requires an object of the form "type:id", got "${object}"`
+        `FGA listUsersDiagnostic requires an object of the form "type:id", got "${object}"`
+      );
+    }
+    if (!/^[^\s#:]+$/.test(relation)) {
+      throw new TypeError(
+        `FGA listUsersDiagnostic requires a bare relation name, got "${relation}"`
       );
     }
     if (userTypes.length === 0) {
-      throw new TypeError('FGA listUsers requires at least one subject-type filter');
+      throw new TypeError('FGA listUsersDiagnostic requires at least one subject-type filter');
     }
-    // 'group#member' asks for usersets of that shape; bare 'user' asks for
-    // direct subjects.
-    const userFilters = userTypes.map(t => {
-      if (!/^[^\s#:]+(?:#[^\s#:]+)?$/.test(t)) {
-        throw new TypeError(`FGA listUsers filter must be "type" or "type#relation", got "${t}"`);
-      }
-      const hash = t.indexOf('#');
-      return hash > 0 ? { type: t.slice(0, hash), relation: t.slice(hash + 1) } : { type: t };
-    });
-    let res;
-    try {
-      res = await clientFor().listUsers({
-        object: { type: object.slice(0, sep), id: object.slice(sep + 1) },
-        relation,
-        user_filters: userFilters,
-      });
-    } catch (cause) {
-      // An outage must never present as an empty listing — the debugger would
-      // chase a phantom missing-tuple bug. Same contract as check/batchCheck.
-      throw new FgaUnavailableError(`FGA listUsers failed for ${relation} on ${object}`, { cause });
-    }
-    // A 2xx whose body carries no `users` array reached no verdict — it must
-    // not read as an empty listing.
-    if (!Array.isArray(res.users)) {
-      throw new FgaUnavailableError(
-        `FGA listUsers returned a malformed response for ${relation} on ${object}`
-      );
-    }
-    const listing: FgaUserListing = { users: [], usersets: [], wildcardTypes: [] };
-    for (const u of res.users) {
-      if (u.object) listing.users.push(`${u.object.type}:${u.object.id}`);
-      else if (u.userset)
-        listing.usersets.push(`${u.userset.type}:${u.userset.id}#${u.userset.relation}`);
-      else if (u.wildcard) listing.wildcardTypes.push(u.wildcard.type);
-      else {
-        // An entry of an unrecognized kind cannot be partitioned; skipping it
-        // would silently under-report the listing.
-        throw new FgaUnavailableError(
-          `FGA listUsers returned an unrecognized subject entry for ${relation} on ${object}`
+    // Duplicate filters would double-count subjects in the merged listing.
+    const userFilters = [...new Set(userTypes)].map(t => {
+      const m = /^([^\s#:]+)(?:#([^\s#:]+))?$/.exec(t);
+      if (!m?.[1]) {
+        throw new TypeError(
+          `FGA listUsersDiagnostic filter must be "type" or "type#relation", got "${t}"`
         );
       }
+      return m[2] ? { type: m[1], relation: m[2] } : { type: m[1] };
+    });
+    const wireObject = { type: object.slice(0, sep), id: object.slice(sep + 1) };
+    // The wire accepts exactly ONE user_filter per ListUsers call
+    // (ListUsersRequest.user_filters: "Only accepts exactly one value"), so a
+    // multi-shape query fans out one call per filter and merges.
+    const partials = await Promise.all(
+      userFilters.map(async filter => {
+        let res;
+        try {
+          res = await clientFor().listUsers({
+            object: wireObject,
+            relation,
+            user_filters: [filter],
+          });
+        } catch (cause) {
+          // Same contract as check/batchCheck: failure to reach a verdict is
+          // unavailability, never an empty listing.
+          throw new FgaUnavailableError(
+            `FGA listUsersDiagnostic failed for ${relation} on ${object}`,
+            { cause }
+          );
+        }
+        // A 2xx whose body carries no `users` array reached no verdict.
+        if (!Array.isArray(res.users)) {
+          throw new FgaUnavailableError(
+            `FGA listUsersDiagnostic got a malformed response for ${relation} on ${object}`
+          );
+        }
+        const partial: FgaUserListing = { users: [], usersets: [], wildcardTypes: [] };
+        for (const u of res.users) {
+          if (u.object?.type && u.object.id) {
+            partial.users.push(`${u.object.type}:${u.object.id}`);
+          } else if (u.userset?.type && u.userset.id && u.userset.relation) {
+            partial.usersets.push(`${u.userset.type}:${u.userset.id}#${u.userset.relation}`);
+          } else if (u.wildcard?.type) {
+            partial.wildcardTypes.push(u.wildcard.type);
+          } else {
+            // A partial or unrecognized entry cannot be partitioned; skipping
+            // or stringifying it would misreport the listing.
+            throw new FgaUnavailableError(
+              `FGA listUsersDiagnostic got an unrecognized subject entry for ${relation} on ${object}`
+            );
+          }
+        }
+        return partial;
+      })
+    );
+    const listing: FgaUserListing = { users: [], usersets: [], wildcardTypes: [] };
+    for (const p of partials) {
+      listing.users.push(...p.users);
+      listing.usersets.push(...p.usersets);
+      listing.wildcardTypes.push(...p.wildcardTypes);
     }
     return listing;
   };

--- a/packages/core/saga-fga/src/index.ts
+++ b/packages/core/saga-fga/src/index.ts
@@ -1,4 +1,4 @@
-import { CredentialsMethod, OpenFgaClient } from '@openfga/sdk';
+import { ConsistencyPreference, CredentialsMethod, OpenFgaClient } from '@openfga/sdk';
 
 /**
  * @saga-ed/saga-fga — Tier-2 (per-resource) OpenFGA authorization gate.
@@ -245,32 +245,28 @@ export interface FgaGate {
  */
 export interface FgaDiagnostics {
   /**
-   * The reverse question — "WHO holds `relation` on `object`?" — completing the
-   * two-of-three (user, relation, object) debugging triple. **Diagnostic tier
-   * ONLY**, and the name is the guardrail: `ListUsers` cannot report truncation
-   * (the same defect that keeps `ListObjects` out of this package), so it is
-   * never an enforcement input, a notification/fan-out source, or an
-   * audit-of-record. Rationale → README "The reverse question".
+   * The reverse question — "WHO holds `relation` on `object`?" — for debugging
+   * and audit tooling ONLY; the name is the guardrail (`ListUsers` cannot
+   * report truncation). Full rationale + honest-reading guide → README
+   * "The reverse question".
    *
-   * `userTypes` names the subject shapes to search, and the listing contains
-   * ONLY what it names: entries map to server-side filters, so the parameter is
-   * required — an implicit default would silently hide the shapes it omits
-   * (e.g. group grants). `'group#member'` asks for usersets of that shape; bare
-   * `'user'` asks for direct subjects. The wire accepts one filter per
-   * `ListUsers` call, so each entry costs its own (independently capped) round
-   * trip; results are merged.
+   * `userTypes` is required and the listing contains ONLY the shapes it names
+   * (`'user'` direct subjects, `'group#member'` usersets of that shape); each
+   * entry costs its own (independently capped) round trip. Holders derived
+   * through contextual tuples are invisible unless the same tuples ride in via
+   * `contextualTuples`, exactly as on `check`. Reads request
+   * HIGHER_CONSISTENCY: this surface answers "who does the graph reach NOW",
+   * often right after a tuple write.
    *
-   * Throws `TypeError` on a malformed argument — a caller bug, detected
-   * locally, deliberately NOT {@link FgaUnavailableError} so it can never read
-   * as a PDP outage. Throws {@link FgaUnavailableError} when no verdict could
-   * be reached, like every other method here — a diagnostic that silently
-   * returns `[]` on an outage would send the debugger chasing a phantom
-   * missing-tuple bug.
+   * Throws `TypeError` on a malformed argument (a caller bug, detected
+   * locally — never read as a PDP outage); {@link FgaUnavailableError} when no
+   * verdict could be reached — never an empty listing on an outage.
    */
   listUsersDiagnostic(
     relation: string,
     object: string,
-    userTypes: readonly string[]
+    userTypes: readonly string[],
+    contextualTuples?: readonly FgaContextualTuple[]
   ): Promise<FgaUserListing>;
 }
 
@@ -386,13 +382,14 @@ export function createFgaGate(
   const listUsersDiagnostic = async (
     relation: string,
     object: string,
-    userTypes: readonly string[]
+    userTypes: readonly string[],
+    contextualTuples?: readonly FgaContextualTuple[]
   ): Promise<FgaUserListing> => {
     // Malformed arguments are caller bugs → TypeError, never FgaUnavailableError.
-    // 'type:id' with a NON-EMPTY id, split on the FIRST colon only — instance
-    // ids may themselves contain separators (session_instance:S|date).
+    // 'type:id' with a well-formed type and NON-EMPTY id, split on the FIRST
+    // colon only — instance ids may contain separators (session_instance:S|date).
     const sep = object.indexOf(':');
-    if (sep <= 0 || sep === object.length - 1) {
+    if (sep <= 0 || sep === object.length - 1 || !/^[^\s#]+$/.test(object.slice(0, sep))) {
       throw new TypeError(
         `FGA listUsersDiagnostic requires an object of the form "type:id", got "${object}"`
       );
@@ -423,11 +420,17 @@ export function createFgaGate(
       userFilters.map(async filter => {
         let res;
         try {
-          res = await clientFor().listUsers({
-            object: wireObject,
-            relation,
-            user_filters: [filter],
-          });
+          res = await clientFor().listUsers(
+            {
+              object: wireObject,
+              relation,
+              user_filters: [filter],
+              ...(contextualTuples?.length ? { contextualTuples: [...contextualTuples] } : {}),
+            },
+            // A stale read here misreads as a missing tuple (the very thing a
+            // debugger comes to verify), so trade latency for consistency.
+            { consistency: ConsistencyPreference.HigherConsistency }
+          );
         } catch (cause) {
           // Same contract as check/batchCheck: failure to reach a verdict is
           // unavailability, never an empty listing.
@@ -461,13 +464,11 @@ export function createFgaGate(
         return partial;
       })
     );
-    const listing: FgaUserListing = { users: [], usersets: [], wildcardTypes: [] };
-    for (const p of partials) {
-      listing.users.push(...p.users);
-      listing.usersets.push(...p.usersets);
-      listing.wildcardTypes.push(...p.wildcardTypes);
-    }
-    return listing;
+    return {
+      users: partials.flatMap(p => p.users),
+      usersets: partials.flatMap(p => p.usersets),
+      wildcardTypes: partials.flatMap(p => p.wildcardTypes),
+    };
   };
 
   return {

--- a/packages/core/saga-fga/src/index.ts
+++ b/packages/core/saga-fga/src/index.ts
@@ -14,8 +14,8 @@ import { CredentialsMethod, OpenFgaClient } from '@openfga/sdk';
  *     candidates, then ask about them. Deliberately NOT `ListObjects`, which
  *     cannot report truncation (see `batchCheck`'s doc comment).
  *   - `listUsersDiagnostic` — the reverse question ("WHO holds R on O"), for
- *     debugging and audit tooling ONLY. Same truncation dishonesty as
- *     ListObjects, hence the name (see its doc comment).
+ *     debugging and audit tooling ONLY ({@link FgaDiagnostics}; rationale →
+ *     README "The reverse question").
  *
  * Enumeration (`ListObjects`) is intentionally absent. If a caller ever truly
  * needs the id set before touching its own datastore, that belongs behind the
@@ -56,7 +56,8 @@ export interface FgaGateConfig {
 }
 
 export function loadFgaGateConfig(
-  env: Record<string, string | undefined> = process.env
+  // core-tier package: `process` may not exist in the importing runtime.
+  env: Record<string, string | undefined> = typeof process === 'undefined' ? {} : process.env
 ): FgaGateConfig {
   return {
     enforce: env.AUTHZ_FGA_ENFORCE === 'true',
@@ -139,18 +140,17 @@ export function fgaBatchKey(user: string, relation: string, object: string): str
 }
 
 /**
- * The subjects holding a relation, from {@link FgaGate.listUsersDiagnostic},
- * partitioned by subject kind because they mean different things:
+ * The subjects holding a relation, from
+ * {@link FgaDiagnostics.listUsersDiagnostic}, partitioned by subject kind:
  *
- *   - `users` — direct subjects (`user:<id>`). What a debugger usually wants.
- *   - `usersets` — indirect subjects (`group:<id>#member`). A userset is a
- *     REFERENCE, not an enumeration: its members are not listed here, so a
- *     complete "who" requires expanding each userset yourself.
+ *   - `users` — direct subjects (`user:<id>`).
+ *   - `usersets` — indirect subjects (`group:<id>#member`); references, not
+ *     enumerations — their members are not listed here.
  *   - `wildcardTypes` — object types with a public-wildcard tuple on this
- *     relation (`user:*` → `['user']`). Meaningful for MARKER relations
- *     (e.g. a `released` flip); on a computed relation the model's
- *     intersections have already bound the wildcard, so one appearing here
- *     does NOT mean "everyone".
+ *     relation (`user:*` → `['user']`).
+ *
+ * Reading these honestly (userset expansion, wildcard-on-marker semantics) →
+ * README "The reverse question".
  */
 export interface FgaUserListing {
   users: string[];
@@ -234,31 +234,39 @@ export interface FgaGate {
    * map keyed by {@link fgaBatchKey}; duplicate questions collapse to one entry.
    */
   batchCheck(checks: readonly FgaBatchCheckItem[]): Promise<FgaBatchCheckResult>;
+}
+
+/**
+ * Debug-tier query surface, deliberately separate from {@link FgaGate}:
+ * enforcement call sites (and their hand-rolled `FgaGate` test fakes) never
+ * carry a diagnostic member. {@link createFgaGate} returns both.
+ */
+export interface FgaDiagnostics {
   /**
    * The reverse question — "WHO holds `relation` on `object`?" — completing the
    * two-of-three (user, relation, object) debugging triple. **Diagnostic tier
-   * ONLY**, and the name is the guardrail:
+   * ONLY**, and the name is the guardrail: `ListUsers` cannot report truncation
+   * (the same defect that keeps `ListObjects` out of this package), so it is
+   * never an enforcement input, a notification/fan-out source, or an
+   * audit-of-record. Rationale → README "The reverse question".
    *
-   * OpenFGA's `ListUsers` response is `{ users: [...] }` — no continuation
-   * token, no truncation flag — while the server bounds the search with a
-   * max-results cap and a deadline. A CAPPED listing and a COMPLETE listing are
-   * therefore the same response, which disqualifies it from every load-bearing
-   * job: never an enforcement input, never a notification/fan-out source, never
-   * an audit-of-record (the PDP's decision log is that). It answers "show me
-   * who the graph currently reaches" during debugging, and nothing else.
+   * `userTypes` names the subject shapes to search, and the listing contains
+   * ONLY what it names: entries map to server-side filters, so the parameter is
+   * required — an implicit default would silently hide the shapes it omits
+   * (e.g. group grants). `'group#member'` asks for usersets of that shape; bare
+   * `'user'` asks for direct subjects.
    *
-   * `userTypes` selects the subject kinds to search (default `['user']`).
-   * `'group#member'` syntax asks for usersets of that shape. Each entry maps to
-   * one server-side filter.
-   *
-   * Throws {@link FgaUnavailableError} when no verdict could be reached, like
-   * every other method here — a diagnostic that silently returns `[]` on an
-   * outage would send the debugger chasing a phantom missing-tuple bug.
+   * Throws `TypeError` on a malformed argument — a caller bug, detected
+   * locally, deliberately NOT {@link FgaUnavailableError} so it can never read
+   * as a PDP outage. Throws {@link FgaUnavailableError} when no verdict could
+   * be reached, like every other method here — a diagnostic that silently
+   * returns `[]` on an outage would send the debugger chasing a phantom
+   * missing-tuple bug.
    */
   listUsersDiagnostic(
     relation: string,
     object: string,
-    userTypes?: readonly string[]
+    userTypes: readonly string[]
   ): Promise<FgaUserListing>;
 }
 
@@ -267,7 +275,9 @@ export interface FgaGate {
  * `check`, so a disabled gate (enforce=false, no storeId) never constructs a
  * client and never reaches the network.
  */
-export function createFgaGate(config: FgaGateConfig = loadFgaGateConfig()): FgaGate {
+export function createFgaGate(
+  config: FgaGateConfig = loadFgaGateConfig()
+): FgaGate & FgaDiagnostics {
   let client: OpenFgaClient | undefined;
   const clientFor = (): OpenFgaClient => {
     if (!config.storeId) {
@@ -372,32 +382,48 @@ export function createFgaGate(config: FgaGateConfig = loadFgaGateConfig()): FgaG
   const listUsersDiagnostic = async (
     relation: string,
     object: string,
-    userTypes: readonly string[] = ['user']
+    userTypes: readonly string[]
   ): Promise<FgaUserListing> => {
+    // Malformed arguments are caller bugs → TypeError, never FgaUnavailableError:
+    // a deterministic local rejection must not read as a PDP outage.
     // 'type:id' → the wire's structured object. Split on the FIRST colon only —
     // instance ids may themselves contain separators (session_instance:S|date).
     const sep = object.indexOf(':');
     if (sep <= 0) {
-      throw new FgaUnavailableError(
+      throw new TypeError(
         `FGA listUsers requires an object of the form "type:id", got "${object}"`
       );
     }
+    if (userTypes.length === 0) {
+      throw new TypeError('FGA listUsers requires at least one subject-type filter');
+    }
+    // 'group#member' asks for usersets of that shape; bare 'user' asks for
+    // direct subjects.
+    const userFilters = userTypes.map(t => {
+      if (!/^[^\s#:]+(?:#[^\s#:]+)?$/.test(t)) {
+        throw new TypeError(`FGA listUsers filter must be "type" or "type#relation", got "${t}"`);
+      }
+      const hash = t.indexOf('#');
+      return hash > 0 ? { type: t.slice(0, hash), relation: t.slice(hash + 1) } : { type: t };
+    });
     let res;
     try {
       res = await clientFor().listUsers({
         object: { type: object.slice(0, sep), id: object.slice(sep + 1) },
         relation,
-        // 'group#member' asks for usersets of that shape; bare 'user' asks for
-        // direct subjects.
-        user_filters: userTypes.map(t => {
-          const hash = t.indexOf('#');
-          return hash > 0 ? { type: t.slice(0, hash), relation: t.slice(hash + 1) } : { type: t };
-        }),
+        user_filters: userFilters,
       });
     } catch (cause) {
       // An outage must never present as an empty listing — the debugger would
       // chase a phantom missing-tuple bug. Same contract as check/batchCheck.
       throw new FgaUnavailableError(`FGA listUsers failed for ${relation} on ${object}`, { cause });
+    }
+    // A 2xx whose body carries no `users` array reached no verdict — it must
+    // not read as an empty listing.
+    if (!Array.isArray(res.users)) {
+      throw new FgaUnavailableError(
+        `FGA listUsers returned a malformed response for ${relation} on ${object}`
+      );
     }
     const listing: FgaUserListing = { users: [], usersets: [], wildcardTypes: [] };
     for (const u of res.users) {
@@ -405,6 +431,13 @@ export function createFgaGate(config: FgaGateConfig = loadFgaGateConfig()): FgaG
       else if (u.userset)
         listing.usersets.push(`${u.userset.type}:${u.userset.id}#${u.userset.relation}`);
       else if (u.wildcard) listing.wildcardTypes.push(u.wildcard.type);
+      else {
+        // An entry of an unrecognized kind cannot be partitioned; skipping it
+        // would silently under-report the listing.
+        throw new FgaUnavailableError(
+          `FGA listUsers returned an unrecognized subject entry for ${relation} on ${object}`
+        );
+      }
     }
     return listing;
   };

--- a/packages/core/saga-fga/src/index.ts
+++ b/packages/core/saga-fga/src/index.ts
@@ -8,11 +8,14 @@ import { CredentialsMethod, OpenFgaClient } from '@openfga/sdk';
  * "can user X do action A on object R?" — they NEVER write tuples (ADR 0005);
  * writes flow through the sync worker.
  *
- * Two query shapes, and the choice matters:
+ * Three query shapes, and the choice matters:
  *   - `check`/`checkDetailed` — one object. Enforcement.
  *   - `batchCheck` — many objects. **Authorization-filtered lists**: fetch the
  *     candidates, then ask about them. Deliberately NOT `ListObjects`, which
  *     cannot report truncation (see `batchCheck`'s doc comment).
+ *   - `listUsersDiagnostic` — the reverse question ("WHO holds R on O"), for
+ *     debugging and audit tooling ONLY. Same truncation dishonesty as
+ *     ListObjects, hence the name (see its doc comment).
  *
  * Enumeration (`ListObjects`) is intentionally absent. If a caller ever truly
  * needs the id set before touching its own datastore, that belongs behind the
@@ -53,7 +56,7 @@ export interface FgaGateConfig {
 }
 
 export function loadFgaGateConfig(
-  env: Record<string, string | undefined> = process.env,
+  env: Record<string, string | undefined> = process.env
 ): FgaGateConfig {
   return {
     enforce: env.AUTHZ_FGA_ENFORCE === 'true',
@@ -136,6 +139,26 @@ export function fgaBatchKey(user: string, relation: string, object: string): str
 }
 
 /**
+ * The subjects holding a relation, from {@link FgaGate.listUsersDiagnostic},
+ * partitioned by subject kind because they mean different things:
+ *
+ *   - `users` — direct subjects (`user:<id>`). What a debugger usually wants.
+ *   - `usersets` — indirect subjects (`group:<id>#member`). A userset is a
+ *     REFERENCE, not an enumeration: its members are not listed here, so a
+ *     complete "who" requires expanding each userset yourself.
+ *   - `wildcardTypes` — object types with a public-wildcard tuple on this
+ *     relation (`user:*` → `['user']`). Meaningful for MARKER relations
+ *     (e.g. a `released` flip); on a computed relation the model's
+ *     intersections have already bound the wildcard, so one appearing here
+ *     does NOT mean "everyone".
+ */
+export interface FgaUserListing {
+  users: string[];
+  usersets: string[];
+  wildcardTypes: string[];
+}
+
+/**
  * The outcome of a `checkDetailed` call: whether access is allowed, and — when
  * it is — which relation branch produced it.
  */
@@ -163,7 +186,7 @@ export interface FgaGate {
     user: string,
     relation: string,
     object: string,
-    contextualTuples?: readonly FgaContextualTuple[],
+    contextualTuples?: readonly FgaContextualTuple[]
   ): Promise<boolean>;
   /**
    * Evaluate several relation branches on the same object and report which
@@ -183,7 +206,7 @@ export interface FgaGate {
     user: string,
     relations: readonly string[],
     object: string,
-    contextualTuples?: readonly FgaContextualTuple[],
+    contextualTuples?: readonly FgaContextualTuple[]
   ): Promise<FgaDetailedDecision>;
   /**
    * Evaluate many independent (user, relation, object) questions in one call.
@@ -211,6 +234,32 @@ export interface FgaGate {
    * map keyed by {@link fgaBatchKey}; duplicate questions collapse to one entry.
    */
   batchCheck(checks: readonly FgaBatchCheckItem[]): Promise<FgaBatchCheckResult>;
+  /**
+   * The reverse question — "WHO holds `relation` on `object`?" — completing the
+   * two-of-three (user, relation, object) debugging triple. **Diagnostic tier
+   * ONLY**, and the name is the guardrail:
+   *
+   * OpenFGA's `ListUsers` response is `{ users: [...] }` — no continuation
+   * token, no truncation flag — while the server bounds the search with a
+   * max-results cap and a deadline. A CAPPED listing and a COMPLETE listing are
+   * therefore the same response, which disqualifies it from every load-bearing
+   * job: never an enforcement input, never a notification/fan-out source, never
+   * an audit-of-record (the PDP's decision log is that). It answers "show me
+   * who the graph currently reaches" during debugging, and nothing else.
+   *
+   * `userTypes` selects the subject kinds to search (default `['user']`).
+   * `'group#member'` syntax asks for usersets of that shape. Each entry maps to
+   * one server-side filter.
+   *
+   * Throws {@link FgaUnavailableError} when no verdict could be reached, like
+   * every other method here — a diagnostic that silently returns `[]` on an
+   * outage would send the debugger chasing a phantom missing-tuple bug.
+   */
+  listUsersDiagnostic(
+    relation: string,
+    object: string,
+    userTypes?: readonly string[]
+  ): Promise<FgaUserListing>;
 }
 
 /**
@@ -247,7 +296,7 @@ export function createFgaGate(config: FgaGateConfig = loadFgaGateConfig()): FgaG
     user: string,
     relation: string,
     object: string,
-    contextualTuples?: readonly FgaContextualTuple[],
+    contextualTuples?: readonly FgaContextualTuple[]
   ): Promise<boolean> => {
     let res;
     try {
@@ -260,17 +309,12 @@ export function createFgaGate(config: FgaGateConfig = loadFgaGateConfig()): FgaG
     } catch (cause) {
       // Any failure to REACH a verdict — unconfigured store, transport error,
       // non-2xx — is unavailability, not denial. Never collapse it to `false`.
-      throw new FgaUnavailableError(
-        `FGA check failed for ${relation} on ${object}`,
-        { cause },
-      );
+      throw new FgaUnavailableError(`FGA check failed for ${relation} on ${object}`, { cause });
     }
     return res.allowed === true;
   };
 
-  const batchCheck = async (
-    checks: readonly FgaBatchCheckItem[],
-  ): Promise<FgaBatchCheckResult> => {
+  const batchCheck = async (checks: readonly FgaBatchCheckItem[]): Promise<FgaBatchCheckResult> => {
     const verdicts = new Map<string, boolean>();
     if (checks.length === 0) return verdicts;
 
@@ -288,10 +332,9 @@ export function createFgaGate(config: FgaGateConfig = loadFgaGateConfig()): FgaG
     try {
       res = await clientFor().batchCheck({ checks: items });
     } catch (cause) {
-      throw new FgaUnavailableError(
-        `FGA batchCheck failed for ${checks.length} item(s)`,
-        { cause },
-      );
+      throw new FgaUnavailableError(`FGA batchCheck failed for ${checks.length} item(s)`, {
+        cause,
+      });
     }
 
     for (const single of res.result) {
@@ -301,7 +344,7 @@ export function createFgaGate(config: FgaGateConfig = loadFgaGateConfig()): FgaG
       if (single.error) {
         throw new FgaUnavailableError(
           `FGA batchCheck item failed for ${single.request.relation} on ${single.request.object}`,
-          { cause: single.error },
+          { cause: single.error }
         );
       }
       const key = keyByCorrelationId.get(single.correlationId);
@@ -309,7 +352,7 @@ export function createFgaGate(config: FgaGateConfig = loadFgaGateConfig()): FgaG
       // a question we asked; treating it as anything would be a guess.
       if (key === undefined) {
         throw new FgaUnavailableError(
-          `FGA batchCheck returned an unrecognized correlationId: ${single.correlationId}`,
+          `FGA batchCheck returned an unrecognized correlationId: ${single.correlationId}`
         );
       }
       verdicts.set(key, single.allowed === true);
@@ -320,19 +363,60 @@ export function createFgaGate(config: FgaGateConfig = loadFgaGateConfig()): FgaG
     const expected = new Set(keyByCorrelationId.values());
     if (verdicts.size !== expected.size) {
       throw new FgaUnavailableError(
-        `FGA batchCheck returned ${verdicts.size} verdict(s) for ${expected.size} distinct item(s)`,
+        `FGA batchCheck returned ${verdicts.size} verdict(s) for ${expected.size} distinct item(s)`
       );
     }
     return verdicts;
+  };
+
+  const listUsersDiagnostic = async (
+    relation: string,
+    object: string,
+    userTypes: readonly string[] = ['user']
+  ): Promise<FgaUserListing> => {
+    // 'type:id' → the wire's structured object. Split on the FIRST colon only —
+    // instance ids may themselves contain separators (session_instance:S|date).
+    const sep = object.indexOf(':');
+    if (sep <= 0) {
+      throw new FgaUnavailableError(
+        `FGA listUsers requires an object of the form "type:id", got "${object}"`
+      );
+    }
+    let res;
+    try {
+      res = await clientFor().listUsers({
+        object: { type: object.slice(0, sep), id: object.slice(sep + 1) },
+        relation,
+        // 'group#member' asks for usersets of that shape; bare 'user' asks for
+        // direct subjects.
+        user_filters: userTypes.map(t => {
+          const hash = t.indexOf('#');
+          return hash > 0 ? { type: t.slice(0, hash), relation: t.slice(hash + 1) } : { type: t };
+        }),
+      });
+    } catch (cause) {
+      // An outage must never present as an empty listing — the debugger would
+      // chase a phantom missing-tuple bug. Same contract as check/batchCheck.
+      throw new FgaUnavailableError(`FGA listUsers failed for ${relation} on ${object}`, { cause });
+    }
+    const listing: FgaUserListing = { users: [], usersets: [], wildcardTypes: [] };
+    for (const u of res.users) {
+      if (u.object) listing.users.push(`${u.object.type}:${u.object.id}`);
+      else if (u.userset)
+        listing.usersets.push(`${u.userset.type}:${u.userset.id}#${u.userset.relation}`);
+      else if (u.wildcard) listing.wildcardTypes.push(u.wildcard.type);
+    }
+    return listing;
   };
 
   return {
     enforce: config.enforce,
     check: checkOne,
     batchCheck,
+    listUsersDiagnostic,
     async checkDetailed(user, relations, object, contextualTuples) {
       const held = await Promise.all(
-        relations.map((relation) => checkOne(user, relation, object, contextualTuples)),
+        relations.map(relation => checkOne(user, relation, object, contextualTuples))
       );
       const branches = relations.filter((_, i) => held[i]);
       return {
@@ -363,7 +447,7 @@ export async function enforceFgaRelation(
   user: string,
   relation: string,
   object: string,
-  makeForbidden: () => Error,
+  makeForbidden: () => Error
 ): Promise<void> {
   if (!gate.enforce) return;
   const allowed = await gate.check(user, relation, object);

--- a/packages/core/saga-fga/src/index.ts
+++ b/packages/core/saga-fga/src/index.ts
@@ -104,6 +104,11 @@ export class FgaUnavailableError extends Error {
   }
 }
 
+/** Every no-verdict path throws through here — one site owns the invariant. */
+function unavailable(message: string, cause?: unknown): never {
+  throw new FgaUnavailableError(message, cause === undefined ? undefined : { cause });
+}
+
 /**
  * One (user, relation, object) question in a {@link FgaGate.batchCheck} call.
  *
@@ -270,6 +275,27 @@ export interface FgaDiagnostics {
   ): Promise<FgaUserListing>;
 }
 
+/** Bare type/relation names: no whitespace, '#', or ':'. */
+const BARE_NAME = /^[^\s#:]+$/;
+const USER_FILTER = /^([^\s#:]+)(?:#([^\s#:]+))?$/;
+
+/**
+ * 'type:id' with a well-formed type and NON-EMPTY id, split on the FIRST colon
+ * only — instance ids may contain separators (session_instance:S|date).
+ * `undefined` = malformed.
+ */
+function parseFgaObject(object: string): { type: string; id: string } | undefined {
+  const sep = object.indexOf(':');
+  if (sep <= 0 || sep === object.length - 1 || !BARE_NAME.test(object.slice(0, sep))) {
+    return undefined;
+  }
+  return { type: object.slice(0, sep), id: object.slice(sep + 1) };
+}
+
+/** Wire field for request-supplied tuples: key OMITTED when none, readonly caller array copied. */
+const contextualTuplesField = (tuples?: readonly FgaContextualTuple[]) =>
+  tuples?.length ? { contextualTuples: [...tuples] } : {};
+
 /**
  * Build a gate from config. The OpenFGA client is created lazily on first
  * `check`, so a disabled gate (enforce=false, no storeId) never constructs a
@@ -314,12 +340,12 @@ export function createFgaGate(
         user,
         relation,
         object,
-        ...(contextualTuples?.length ? { contextualTuples: [...contextualTuples] } : {}),
+        ...contextualTuplesField(contextualTuples),
       });
     } catch (cause) {
       // Any failure to REACH a verdict — unconfigured store, transport error,
       // non-2xx — is unavailability, not denial. Never collapse it to `false`.
-      throw new FgaUnavailableError(`FGA check failed for ${relation} on ${object}`, { cause });
+      unavailable(`FGA check failed for ${relation} on ${object}`, cause);
     }
     return res.allowed === true;
   };
@@ -342,9 +368,7 @@ export function createFgaGate(
     try {
       res = await clientFor().batchCheck({ checks: items });
     } catch (cause) {
-      throw new FgaUnavailableError(`FGA batchCheck failed for ${checks.length} item(s)`, {
-        cause,
-      });
+      unavailable(`FGA batchCheck failed for ${checks.length} item(s)`, cause);
     }
 
     for (const single of res.result) {
@@ -352,16 +376,16 @@ export function createFgaGate(
       // as `allowed: false` would be a silent deny — the exact failure mode
       // `check`'s contract exists to prevent.
       if (single.error) {
-        throw new FgaUnavailableError(
+        unavailable(
           `FGA batchCheck item failed for ${single.request.relation} on ${single.request.object}`,
-          { cause: single.error }
+          single.error
         );
       }
       const key = keyByCorrelationId.get(single.correlationId);
       // An unrecognized correlation id means we cannot attribute this verdict to
       // a question we asked; treating it as anything would be a guess.
       if (key === undefined) {
-        throw new FgaUnavailableError(
+        unavailable(
           `FGA batchCheck returned an unrecognized correlationId: ${single.correlationId}`
         );
       }
@@ -372,7 +396,7 @@ export function createFgaGate(
     // not a set of denials.
     const expected = new Set(keyByCorrelationId.values());
     if (verdicts.size !== expected.size) {
-      throw new FgaUnavailableError(
+      unavailable(
         `FGA batchCheck returned ${verdicts.size} verdict(s) for ${expected.size} distinct item(s)`
       );
     }
@@ -386,15 +410,13 @@ export function createFgaGate(
     contextualTuples?: readonly FgaContextualTuple[]
   ): Promise<FgaUserListing> => {
     // Malformed arguments are caller bugs → TypeError, never FgaUnavailableError.
-    // 'type:id' with a well-formed type and NON-EMPTY id, split on the FIRST
-    // colon only — instance ids may contain separators (session_instance:S|date).
-    const sep = object.indexOf(':');
-    if (sep <= 0 || sep === object.length - 1 || !/^[^\s#]+$/.test(object.slice(0, sep))) {
+    const wireObject = parseFgaObject(object);
+    if (!wireObject) {
       throw new TypeError(
         `FGA listUsersDiagnostic requires an object of the form "type:id", got "${object}"`
       );
     }
-    if (!/^[^\s#:]+$/.test(relation)) {
+    if (!BARE_NAME.test(relation)) {
       throw new TypeError(
         `FGA listUsersDiagnostic requires a bare relation name, got "${relation}"`
       );
@@ -404,7 +426,7 @@ export function createFgaGate(
     }
     // Duplicate filters would double-count subjects in the merged listing.
     const userFilters = [...new Set(userTypes)].map(t => {
-      const m = /^([^\s#:]+)(?:#([^\s#:]+))?$/.exec(t);
+      const m = USER_FILTER.exec(t);
       if (!m?.[1]) {
         throw new TypeError(
           `FGA listUsersDiagnostic filter must be "type" or "type#relation", got "${t}"`
@@ -412,7 +434,7 @@ export function createFgaGate(
       }
       return m[2] ? { type: m[1], relation: m[2] } : { type: m[1] };
     });
-    const wireObject = { type: object.slice(0, sep), id: object.slice(sep + 1) };
+    const contextualField = contextualTuplesField(contextualTuples);
     // The wire accepts exactly ONE user_filter per ListUsers call
     // (ListUsersRequest.user_filters: "Only accepts exactly one value"), so a
     // multi-shape query fans out one call per filter and merges.
@@ -421,12 +443,7 @@ export function createFgaGate(
         let res;
         try {
           res = await clientFor().listUsers(
-            {
-              object: wireObject,
-              relation,
-              user_filters: [filter],
-              ...(contextualTuples?.length ? { contextualTuples: [...contextualTuples] } : {}),
-            },
+            { object: wireObject, relation, user_filters: [filter], ...contextualField },
             // A stale read here misreads as a missing tuple (the very thing a
             // debugger comes to verify), so trade latency for consistency.
             { consistency: ConsistencyPreference.HigherConsistency }
@@ -434,41 +451,35 @@ export function createFgaGate(
         } catch (cause) {
           // Same contract as check/batchCheck: failure to reach a verdict is
           // unavailability, never an empty listing.
-          throw new FgaUnavailableError(
-            `FGA listUsersDiagnostic failed for ${relation} on ${object}`,
-            { cause }
-          );
+          unavailable(`FGA listUsersDiagnostic failed for ${relation} on ${object}`, cause);
         }
         // A 2xx whose body carries no `users` array reached no verdict.
         if (!Array.isArray(res.users)) {
-          throw new FgaUnavailableError(
+          unavailable(
             `FGA listUsersDiagnostic got a malformed response for ${relation} on ${object}`
           );
         }
-        const partial: FgaUserListing = { users: [], usersets: [], wildcardTypes: [] };
-        for (const u of res.users) {
-          if (u.object?.type && u.object.id) {
-            partial.users.push(`${u.object.type}:${u.object.id}`);
-          } else if (u.userset?.type && u.userset.id && u.userset.relation) {
-            partial.usersets.push(`${u.userset.type}:${u.userset.id}#${u.userset.relation}`);
-          } else if (u.wildcard?.type) {
-            partial.wildcardTypes.push(u.wildcard.type);
-          } else {
-            // A partial or unrecognized entry cannot be partitioned; skipping
-            // or stringifying it would misreport the listing.
-            throw new FgaUnavailableError(
-              `FGA listUsersDiagnostic got an unrecognized subject entry for ${relation} on ${object}`
-            );
-          }
-        }
-        return partial;
+        return res.users;
       })
     );
-    return {
-      users: partials.flatMap(p => p.users),
-      usersets: partials.flatMap(p => p.usersets),
-      wildcardTypes: partials.flatMap(p => p.wildcardTypes),
-    };
+    // Partials arrive in filter order (Promise.all), so the listing does too.
+    const listing: FgaUserListing = { users: [], usersets: [], wildcardTypes: [] };
+    for (const u of partials.flat()) {
+      if (u.object?.type && u.object.id) {
+        listing.users.push(`${u.object.type}:${u.object.id}`);
+      } else if (u.userset?.type && u.userset.id && u.userset.relation) {
+        listing.usersets.push(`${u.userset.type}:${u.userset.id}#${u.userset.relation}`);
+      } else if (u.wildcard?.type) {
+        listing.wildcardTypes.push(u.wildcard.type);
+      } else {
+        // A partial or unrecognized entry cannot be partitioned; skipping or
+        // stringifying it would misreport the listing.
+        unavailable(
+          `FGA listUsersDiagnostic got an unrecognized subject entry for ${relation} on ${object}`
+        );
+      }
+    }
+    return listing;
   };
 
   return {


### PR DESCRIPTION
Closes #421

Completes the two-of-three `(user, relation, object)` debugging triple committed to in the staffed-tutoring authz reference model:

| Ask | Answered by |
|---|---|
| (user, object) → actions | `checkDetailed` (existing) |
| (user, relation) → objects | candidate set + `batchCheck` (existing) |
| **(relation, object) → who** | **`listUsersDiagnostic` (this PR)** |

## What it is

A thin wrapper over OpenFGA `ListUsers` (SDK 0.9.x), exposed under a name that carries its tier. The response partitions subjects by kind, because they mean different things to a debugger:

- `users` — direct subjects (`user:ingrid`)
- `usersets` — references, NOT enumerations (`group:demo-north#member`)
- `wildcardTypes` — a public-wildcard tuple holds this relation (meaningful on marker relations like a `released` flip; on computed relations the model's intersections bind the wildcard, so it does not mean "everyone")

`'group#member'` filter syntax maps to typed userset filters. Object ids split on the FIRST colon only — `session_instance:S|2026-08-05` ids contain separators.

## Why debug-tier is load-bearing, not a disclaimer

`ListUsers` has the exact defect that keeps `ListObjects` out of this package: no truncation flag in the response while the server bounds the search with a max-results cap and a deadline — a capped listing and a complete listing are indistinguishable. That disqualifies it from every load-bearing job: never an enforcement input, never a notification/fan-out source, never the audit-of-record (the PDP decision log is that). The README section spells out the honest-reading rules.

## Failure contract

Same as every other method here: any failure to reach a verdict throws `FgaUnavailableError`. A diagnostic that returned `[]` during an outage would send the debugger chasing a phantom missing-tuple bug.

## Verification

- 35/35 vitest (29 existing + 6 new: partitioning + default filter, userset filter syntax, first-colon splitting, malformed-object rejection before the wire, transport failure → `FgaUnavailableError`, missing store id without touching the client)
- `tsc --noEmit` clean; prettier applied; eslint clean from repo root
- Version bumped 0.1.0-dev.4 → 0.1.0-dev.5 (publish via CI `single_package` dispatch after merge)