### PR TITLE
fix(infra-compose): reuse a leaked CloudMap service instead of stranding the identifier

### DIFF
--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@saga-ed/infra-compose",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@saga-ed/infra-compose",
-            "version": "1.6.0",
+            "version": "1.6.1",
             "dependencies": {
                 "bson": "^6.10.4",
                 "express": "^4.22.1",

--- a/infra/package.json
+++ b/infra/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/infra-compose",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "description": "Composable Docker service templates for Saga platform local development",
     "bin": {
         "infra-compose": "bin/infra-compose"

--- a/infra/src/ec2/cloudmap.js
+++ b/infra/src/ec2/cloudmap.js
@@ -101,12 +101,29 @@ export function deregister({
     name, namespace_id, region,
     delete_attempts = DELETE_ATTEMPTS, delete_retry_ms = DELETE_RETRY_MS,
 }) {
+    const service = deregister_instance({ name, namespace_id, region });
+    if (!service) return;
+
+    delete_service({ name, service, region, delete_attempts, delete_retry_ms });
+}
+
+/**
+ * Remove the A record for a database, leaving the service shell in place.
+ * Returns the resolved service, or null when there was nothing registered.
+ * @param {{ name: string, namespace_id: string, region: string }} config
+ */
+export function deregister_instance({ name, namespace_id, region }) {
     const service = find_service(name, namespace_id, region);
     if (!service) {
         console.log(`CloudMap service not found: ${name}`);
-        return;
+        return null;
     }
 
+    // The A record has to go before the caller releases the port: it advertises
+    // ip:port, and preview DB secrets carry `<name>.dbs-v2.local` as a fallback
+    // host, so a surviving record plus a reissued port resolves one identifier
+    // to another's database. Nothing to deregister is success, anything else
+    // must stop the teardown.
     try {
         run([
             'servicediscovery', 'deregister-instance',
@@ -116,9 +133,22 @@ export function deregister({
         ]);
         console.log(`Deregistered CloudMap instance: ${name}`);
     } catch (err) {
+        if (!/InstanceNotFound|NotFound/.test(err.message)) throw err;
         console.log(`No instance to deregister for ${name}: ${err.message}`);
     }
 
+    return service;
+}
+
+/**
+ * Delete a Cloud Map service shell whose instance is already deregistered.
+ * @param {{ name: string, service: { Id: string }, region: string,
+ *           delete_attempts?: number, delete_retry_ms?: number }} config
+ */
+export function delete_service({
+    name, service, region,
+    delete_attempts = DELETE_ATTEMPTS, delete_retry_ms = DELETE_RETRY_MS,
+}) {
     // A surviving service blocks that identifier from ever being provisioned
     // again, so a failed delete has to reach the caller rather than tail off
     // into a log line. DeregisterInstance is asynchronous and DeleteService

--- a/infra/src/ec2/cloudmap.js
+++ b/infra/src/ec2/cloudmap.js
@@ -71,6 +71,7 @@ export function register({ name, ip, port, namespace_id, region }) {
                 throw new Error(
                     `CloudMap reports service '${name}' exists but it is absent from namespace `
                     + `${namespace_id}; cannot resolve its id to reuse it`,
+                    { cause: err },
                 );
             }
             console.log(`Reusing existing CloudMap service: ${name} (${service.Id})`);
@@ -136,7 +137,10 @@ export function deregister({ name, namespace_id, region }) {
         }
     }
 
-    throw new Error(`Could not delete CloudMap service ${name}: ${last_err.message}`);
+    throw new Error(
+        `Could not delete CloudMap service ${name}: ${last_err.message}`,
+        { cause: last_err },
+    );
 }
 
 /**

--- a/infra/src/ec2/cloudmap.js
+++ b/infra/src/ec2/cloudmap.js
@@ -95,6 +95,8 @@ export function register({ name, ip, port, namespace_id, region }) {
 
 /**
  * Deregister a database from Cloud Map and delete the service.
+ * Throws if either half fails; a caller wanting best-effort cleanup must catch,
+ * and should check `err.record_survives` before reusing the database's port.
  * @param {{ name: string, namespace_id: string, region: string }} config
  */
 export function deregister({
@@ -133,7 +135,12 @@ export function deregister_instance({ name, namespace_id, region }) {
         ]);
         console.log(`Deregistered CloudMap instance: ${name}`);
     } catch (err) {
-        if (!/InstanceNotFound|NotFound/.test(err.message)) throw err;
+        if (!/NotFound/.test(err.message)) {
+            // Lets a caller tell "the record is gone" from "the record may
+            // still be advertising ip:port" without matching on message text.
+            err.record_survives = true;
+            throw err;
+        }
         console.log(`No instance to deregister for ${name}: ${err.message}`);
     }
 

--- a/infra/src/ec2/cloudmap.js
+++ b/infra/src/ec2/cloudmap.js
@@ -97,7 +97,10 @@ export function register({ name, ip, port, namespace_id, region }) {
  * Deregister a database from Cloud Map and delete the service.
  * @param {{ name: string, namespace_id: string, region: string }} config
  */
-export function deregister({ name, namespace_id, region }) {
+export function deregister({
+    name, namespace_id, region,
+    delete_attempts = DELETE_ATTEMPTS, delete_retry_ms = DELETE_RETRY_MS,
+}) {
     const service = find_service(name, namespace_id, region);
     if (!service) {
         console.log(`CloudMap service not found: ${name}`);
@@ -121,7 +124,7 @@ export function deregister({ name, namespace_id, region }) {
     // into a log line. DeregisterInstance is asynchronous and DeleteService
     // rejects a service that still has one, so retry across that window.
     let last_err;
-    for (let attempt = 0; attempt < DELETE_ATTEMPTS; attempt++) {
+    for (let attempt = 0; attempt < delete_attempts; attempt++) {
         try {
             run([
                 'servicediscovery', 'delete-service',
@@ -133,7 +136,7 @@ export function deregister({ name, namespace_id, region }) {
         } catch (err) {
             last_err = err;
             if (!/ResourceInUse/.test(err.message)) break;
-            sleep_sync(DELETE_RETRY_MS);
+            if (attempt < delete_attempts - 1) sleep_sync(delete_retry_ms);
         }
     }
 

--- a/infra/src/ec2/cloudmap.js
+++ b/infra/src/ec2/cloudmap.js
@@ -5,6 +5,15 @@
 
 import { spawnSync } from 'child_process';
 
+const DELETE_ATTEMPTS = 5;
+const DELETE_RETRY_MS = 2000;
+
+// The router calls teardown synchronously; Atomics.wait is the only way to
+// block without restructuring every caller onto promises.
+function sleep_sync(ms) {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
 function run(args) {
     const result = spawnSync('aws', args, { encoding: 'utf8', stdio: 'pipe' });
     if (result.status !== 0) {
@@ -13,18 +22,17 @@ function run(args) {
     return result.stdout.trim();
 }
 
+// Returns null ONLY when the namespace listed successfully and the name was
+// absent. A failed list must propagate: "couldn't look" and "isn't there" lead
+// to opposite actions in both callers below.
 function find_service(name, namespace_id, region) {
-    try {
-        const result = JSON.parse(run([
-            'servicediscovery', 'list-services',
-            '--filters', `Name=NAMESPACE_ID,Values=${namespace_id},Condition=EQ`,
-            '--region', region,
-            '--output', 'json',
-        ]));
-        return result.Services.find(s => s.Name === name) || null;
-    } catch {
-        return null;
-    }
+    const result = JSON.parse(run([
+        'servicediscovery', 'list-services',
+        '--filters', `Name=NAMESPACE_ID,Values=${namespace_id},Condition=EQ`,
+        '--region', region,
+        '--output', 'json',
+    ]));
+    return result.Services.find(s => s.Name === name) || null;
 }
 
 /**
@@ -41,15 +49,32 @@ export function register({ name, ip, port, namespace_id, region }) {
             DnsRecords: [{ Type: 'A', TTL: 60 }],
         });
 
-        const result = JSON.parse(run([
-            'servicediscovery', 'create-service',
-            '--name', name,
-            '--dns-config', dns_config,
-            '--region', region,
-            '--output', 'json',
-        ]));
-        service = result.Service;
-        console.log(`Created CloudMap service: ${name} (${service.Id})`);
+        try {
+            const result = JSON.parse(run([
+                'servicediscovery', 'create-service',
+                '--name', name,
+                '--dns-config', dns_config,
+                '--region', region,
+                '--output', 'json',
+            ]));
+            service = result.Service;
+            console.log(`Created CloudMap service: ${name} (${service.Id})`);
+        } catch (err) {
+            // A service surviving without its DB container is reusable, not
+            // fatal: the name is the only thing CreateService reserves, and a
+            // provision that dies here strands the identifier permanently —
+            // deleting the leftover needs servicediscovery:DeleteService, which
+            // no operator tier currently holds (hipponot/iac#672).
+            if (!/ServiceAlreadyExists/.test(err.message)) throw err;
+            service = find_service(name, namespace_id, region);
+            if (!service) {
+                throw new Error(
+                    `CloudMap reports service '${name}' exists but it is absent from namespace `
+                    + `${namespace_id}; cannot resolve its id to reuse it`,
+                );
+            }
+            console.log(`Reusing existing CloudMap service: ${name} (${service.Id})`);
+        }
     }
 
     const attributes = JSON.stringify({
@@ -90,16 +115,28 @@ export function deregister({ name, namespace_id, region }) {
         console.log(`No instance to deregister for ${name}: ${err.message}`);
     }
 
-    try {
-        run([
-            'servicediscovery', 'delete-service',
-            '--id', service.Id,
-            '--region', region,
-        ]);
-        console.log(`Deleted CloudMap service: ${name}`);
-    } catch (err) {
-        console.log(`Could not delete service ${name}: ${err.message}`);
+    // A surviving service blocks that identifier from ever being provisioned
+    // again, so a failed delete has to reach the caller rather than tail off
+    // into a log line. DeregisterInstance is asynchronous and DeleteService
+    // rejects a service that still has one, so retry across that window.
+    let last_err;
+    for (let attempt = 0; attempt < DELETE_ATTEMPTS; attempt++) {
+        try {
+            run([
+                'servicediscovery', 'delete-service',
+                '--id', service.Id,
+                '--region', region,
+            ]);
+            console.log(`Deleted CloudMap service: ${name}`);
+            return;
+        } catch (err) {
+            last_err = err;
+            if (!/ResourceInUse/.test(err.message)) break;
+            sleep_sync(DELETE_RETRY_MS);
+        }
     }
+
+    throw new Error(`Could not delete CloudMap service ${name}: ${last_err.message}`);
 }
 
 /**

--- a/infra/src/ec2/cloudmap.js
+++ b/infra/src/ec2/cloudmap.js
@@ -8,8 +8,7 @@ import { spawnSync } from 'child_process';
 const DELETE_ATTEMPTS = 5;
 const DELETE_RETRY_MS = 2000;
 
-// The router calls teardown synchronously; Atomics.wait is the only way to
-// block without restructuring every caller onto promises.
+// The router's teardown handlers are synchronous.
 function sleep_sync(ms) {
     Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
@@ -17,7 +16,13 @@ function sleep_sync(ms) {
 function run(args) {
     const result = spawnSync('aws', args, { encoding: 'utf8', stdio: 'pipe' });
     if (result.status !== 0) {
-        throw new Error(`aws ${args.slice(0, 3).join(' ')} failed: ${result.stderr || result.error}`);
+        const err = new Error(`aws ${args.slice(0, 3).join(' ')} failed: ${result.stderr || result.error}`);
+        // The CLI reports the failure kind as "An error occurred (Code) when
+        // calling ...". Substring-matching the whole message instead conflates
+        // codes that share a suffix — InstanceNotFound vs ResourceNotFoundException
+        // mean opposite things here.
+        err.aws_code = /An error occurred \(([A-Za-z]+)\)/.exec(result.stderr || '')?.[1] ?? null;
+        throw err;
     }
     return result.stdout.trim();
 }
@@ -60,12 +65,10 @@ export function register({ name, ip, port, namespace_id, region }) {
             service = result.Service;
             console.log(`Created CloudMap service: ${name} (${service.Id})`);
         } catch (err) {
-            // A service surviving without its DB container is reusable, not
-            // fatal: the name is the only thing CreateService reserves, and a
-            // provision that dies here strands the identifier permanently —
-            // deleting the leftover needs servicediscovery:DeleteService, which
-            // no operator tier currently holds (hipponot/iac#672).
-            if (!/ServiceAlreadyExists/.test(err.message)) throw err;
+            // A service surviving without its DB container is reusable: the
+            // name is all CreateService reserves, and no operator tier can
+            // delete the leftover to unstick the identifier (hipponot/iac#672).
+            if (err.aws_code !== 'ServiceAlreadyExists') throw err;
             service = find_service(name, namespace_id, region);
             if (!service) {
                 throw new Error(
@@ -120,7 +123,14 @@ export function deregister_instance({ name, namespace_id, region }) {
         ]);
         console.log(`Deregistered CloudMap instance: ${name}`);
     } catch (err) {
-        if (!/NotFound/.test(err.message)) throw err;
+        // Only "there was no instance" is success. Every other code — including
+        // the neighbouring ResourceNotFoundException — leaves the record's fate
+        // unknown, which the caller must treat as still-advertising. The service
+        // rides along so the caller can still delete the shell.
+        if (err.aws_code !== 'InstanceNotFound') {
+            err.service = service;
+            throw err;
+        }
         console.log(`No instance to deregister for ${name}: ${err.message}`);
     }
 
@@ -140,7 +150,9 @@ export function delete_service({
     // again, so a failed delete has to reach the caller rather than tail off
     // into a log line. DeregisterInstance is asynchronous and DeleteService
     // rejects a service that still has one, so retry across that window.
-    for (let attempt = 0; attempt < delete_attempts; attempt++) {
+    // Every exit is an explicit return or throw: a caller passing a
+    // non-positive attempt count must not read "never tried" as "deleted".
+    for (let attempt = 1; ; attempt++) {
         try {
             run([
                 'servicediscovery', 'delete-service',
@@ -150,7 +162,7 @@ export function delete_service({
             console.log(`Deleted CloudMap service: ${name}`);
             return;
         } catch (err) {
-            if (!/ResourceInUse/.test(err.message) || attempt === delete_attempts - 1) {
+            if (err.aws_code !== 'ResourceInUse' || attempt >= delete_attempts) {
                 throw new Error(
                     `Could not delete CloudMap service ${name}: ${err.message}`,
                     { cause: err },

--- a/infra/src/ec2/cloudmap.js
+++ b/infra/src/ec2/cloudmap.js
@@ -94,24 +94,9 @@ export function register({ name, ip, port, namespace_id, region }) {
 }
 
 /**
- * Deregister a database from Cloud Map and delete the service.
- * Throws if either half fails; a caller wanting best-effort cleanup must catch,
- * and should check `err.record_survives` before reusing the database's port.
- * @param {{ name: string, namespace_id: string, region: string }} config
- */
-export function deregister({
-    name, namespace_id, region,
-    delete_attempts = DELETE_ATTEMPTS, delete_retry_ms = DELETE_RETRY_MS,
-}) {
-    const service = deregister_instance({ name, namespace_id, region });
-    if (!service) return;
-
-    delete_service({ name, service, region, delete_attempts, delete_retry_ms });
-}
-
-/**
  * Remove the A record for a database, leaving the service shell in place.
  * Returns the resolved service, or null when there was nothing registered.
+ * Callers must not reuse the database's port unless this returned.
  * @param {{ name: string, namespace_id: string, region: string }} config
  */
 export function deregister_instance({ name, namespace_id, region }) {
@@ -135,12 +120,7 @@ export function deregister_instance({ name, namespace_id, region }) {
         ]);
         console.log(`Deregistered CloudMap instance: ${name}`);
     } catch (err) {
-        if (!/NotFound/.test(err.message)) {
-            // Lets a caller tell "the record is gone" from "the record may
-            // still be advertising ip:port" without matching on message text.
-            err.record_survives = true;
-            throw err;
-        }
+        if (!/NotFound/.test(err.message)) throw err;
         console.log(`No instance to deregister for ${name}: ${err.message}`);
     }
 
@@ -160,7 +140,6 @@ export function delete_service({
     // again, so a failed delete has to reach the caller rather than tail off
     // into a log line. DeregisterInstance is asynchronous and DeleteService
     // rejects a service that still has one, so retry across that window.
-    let last_err;
     for (let attempt = 0; attempt < delete_attempts; attempt++) {
         try {
             run([
@@ -171,16 +150,15 @@ export function delete_service({
             console.log(`Deleted CloudMap service: ${name}`);
             return;
         } catch (err) {
-            last_err = err;
-            if (!/ResourceInUse/.test(err.message)) break;
-            if (attempt < delete_attempts - 1) sleep_sync(delete_retry_ms);
+            if (!/ResourceInUse/.test(err.message) || attempt === delete_attempts - 1) {
+                throw new Error(
+                    `Could not delete CloudMap service ${name}: ${err.message}`,
+                    { cause: err },
+                );
+            }
+            sleep_sync(delete_retry_ms);
         }
     }
-
-    throw new Error(
-        `Could not delete CloudMap service ${name}: ${last_err.message}`,
-        { cause: last_err },
-    );
 }
 
 /**

--- a/infra/src/ec2/ec2-router.js
+++ b/infra/src/ec2/ec2-router.js
@@ -28,6 +28,40 @@ function schema_gate_mode() {
     return process.env.SNAPSHOT_SCHEMA_GATE || 'off';
 }
 
+// Remove a database's discovery entries, reporting the two outcomes a caller
+// has to act on separately. `record_cleared` gates reuse of the port: while the
+// A record may still advertise ip:port, reissuing the port aims that name at
+// the next identifier. The shell delete is attempted either way — leaving one
+// behind strands the identifier, and no operator tier can delete it.
+function teardown_discovery({ name, namespace_id, region }) {
+    if (!namespace_id) return { record_cleared: true, error: null };
+
+    const effective_region = region || get_instance_metadata().region;
+    let service = null;
+    let error = null;
+    let record_cleared = true;
+    try {
+        service = deregister_instance({ name, namespace_id, region: effective_region });
+    } catch (err) {
+        error = err;
+        // A failure before the service resolved never reached the record, so it
+        // says nothing about whether one is advertising; only a failed
+        // deregister-instance leaves that unknown.
+        service = err.service ?? null;
+        record_cleared = !err.service;
+    }
+
+    if (service) {
+        try {
+            delete_service({ name, service, region: effective_region });
+        } catch (err) {
+            error = error ?? err;
+        }
+    }
+
+    return { record_cleared, error };
+}
+
 function sync_seeds(name) {
     const seeds_dir = resolve(SEEDS_BASE, name);
     const s3_path = `s3://${SEED_BUCKET}/${name}/`;
@@ -446,36 +480,19 @@ export function create_ec2_router(config = {}) {
                     && !cleanup_volume({ volume_id: rollback_volume_id, mount_path, region: effective_region })) {
                     console.log(`ROLLBACK INCOMPLETE: volume ${rollback_volume_id} (${name}) left on ${meta.instance_id} — needs a reap pass`);
                 }
-                // Same ordering as the DELETE route, and best-effort at each
-                // step. The port is released only on an affirmative "the A
-                // record is gone": while it survives it advertises ip:port, and
-                // reissuing the port aims that name at the next identifier.
-                let cloudmap_service = null;
-                let record_cleared = !namespace_id;
-                if (namespace_id) {
-                    try {
-                        cloudmap_service = deregister_instance({
-                            name, namespace_id, region: effective_region,
-                        });
-                        record_cleared = true;
-                    } catch (cleanup_err) {
-                        console.log(`Rollback of ${name}: CloudMap deregister failed: ${cleanup_err.message}`);
-                    }
+                // Rollback is best-effort, but the port still obeys the same
+                // gate as the DELETE route.
+                const teardown = teardown_discovery({ name, namespace_id, region: effective_region });
+                if (teardown.error) {
+                    console.log(`Rollback of ${name}: CloudMap teardown failed: ${teardown.error.message}`);
                 }
                 try {
-                    if (allocated_port && record_cleared) release_port(name, { registry_path });
+                    if (allocated_port && teardown.record_cleared) release_port(name, { registry_path });
                     else if (allocated_port) {
                         console.log(`ROLLBACK INCOMPLETE: port for ${name} held — its CloudMap A record may survive`);
                     }
                 } catch (cleanup_err) {
                     console.log(`Rollback of ${name}: port release failed: ${cleanup_err.message}`);
-                }
-                if (cloudmap_service) {
-                    try {
-                        delete_service({ name, service: cloudmap_service, region: effective_region });
-                    } catch (cleanup_err) {
-                        console.log(`Rollback of ${name}: CloudMap service delete failed: ${cleanup_err.message}`);
-                    }
                 }
                 try {
                     rmSync(project_dir, { recursive: true, force: true });
@@ -899,26 +916,18 @@ export function create_ec2_router(config = {}) {
                 rmSync(project_dir, { recursive: true, force: true });
             }
 
-            // Drop the A record first, release the port second, delete the
-            // service shell last. The port must not be reissued while the name
-            // still advertises it, and the shell's delete can fail for minutes
-            // (async deregistration) without justifying a leaked registry row.
-            let cloudmap_service = null;
-            let cloudmap_region;
-            if (namespace_id) {
-                cloudmap_region = region || get_instance_metadata().region;
-                cloudmap_service = deregister_instance({
-                    name, namespace_id, region: cloudmap_region,
-                });
-            }
+            const teardown = teardown_discovery({ name, namespace_id, region });
+            if (teardown.record_cleared) release_port(name, { registry_path });
 
-            release_port(name, { registry_path });
-
-            if (cloudmap_service) {
-                delete_service({ name, service: cloudmap_service, region: cloudmap_region });
-            }
-
+            // The database itself is gone by here, so the caller's own cleanup
+            // must still run; a surviving discovery entry is reported alongside
+            // the deletion rather than as a failure to delete.
             const result = { ok: true, name, action: 'deleted' };
+            if (teardown.error) {
+                result.cloudmapLeaked = true;
+                result.warning = teardown.error.message;
+                console.log(`Teardown of ${name} left a CloudMap entry: ${teardown.error.message}`);
+            }
             if (on_after_delete) on_after_delete(result);
             res.json(result);
         } catch (err) {

--- a/infra/src/ec2/ec2-router.js
+++ b/infra/src/ec2/ec2-router.js
@@ -879,6 +879,11 @@ export function create_ec2_router(config = {}) {
                 rmSync(project_dir, { recursive: true, force: true });
             }
 
+            // Release the port before CloudMap: a failed deregister must still
+            // surface (it strands the identifier), but it must not also leak the
+            // port registry row on a project dir that is already gone.
+            release_port(name, { registry_path });
+
             // Deregister from CloudMap
             if (namespace_id) {
                 const meta = get_instance_metadata();
@@ -888,9 +893,6 @@ export function create_ec2_router(config = {}) {
                     region: region || meta.region,
                 });
             }
-
-            // Release port
-            release_port(name, { registry_path });
 
             const result = { ok: true, name, action: 'deleted' };
             if (on_after_delete) on_after_delete(result);

--- a/infra/src/ec2/ec2-router.js
+++ b/infra/src/ec2/ec2-router.js
@@ -28,13 +28,14 @@ function schema_gate_mode() {
     return process.env.SNAPSHOT_SCHEMA_GATE || 'off';
 }
 
-// Remove a database's discovery entries, reporting the two outcomes a caller
-// has to act on separately. `record_cleared` gates reuse of the port: while the
-// A record may still advertise ip:port, reissuing the port aims that name at
-// the next identifier. The shell delete is attempted either way — leaving one
-// behind strands the identifier, and no operator tier can delete it.
+// Drop a database's A record, returning what the caller needs to decide the
+// next two steps. `record_cleared` gates reuse of the port: while the record
+// may still advertise ip:port, reissuing the port aims that name at the next
+// identifier. `finish` deletes the leftover service shell — leaving one strands
+// the identifier, and no operator tier can delete it — and must run only after
+// the port is settled, since it can block for the async-deregistration window.
 function teardown_discovery({ name, namespace_id, region }) {
-    if (!namespace_id) return { record_cleared: true, error: null };
+    if (!namespace_id) return { record_cleared: true, error: null, finish: () => null };
 
     const effective_region = region || get_instance_metadata().region;
     let service;
@@ -51,15 +52,17 @@ function teardown_discovery({ name, namespace_id, region }) {
         record_cleared = !err.service;
     }
 
-    if (service) {
+    const finish = () => {
+        if (!service) return error;
         try {
             delete_service({ name, service, region: effective_region });
         } catch (err) {
-            error = error ?? err;
+            return error ?? err;
         }
-    }
+        return error;
+    };
 
-    return { record_cleared, error };
+    return { record_cleared, error, finish };
 }
 
 function sync_seeds(name) {
@@ -483,9 +486,6 @@ export function create_ec2_router(config = {}) {
                 // Rollback is best-effort, but the port still obeys the same
                 // gate as the DELETE route.
                 const teardown = teardown_discovery({ name, namespace_id, region: effective_region });
-                if (teardown.error) {
-                    console.log(`Rollback of ${name}: CloudMap teardown failed: ${teardown.error.message}`);
-                }
                 try {
                     if (allocated_port && teardown.record_cleared) release_port(name, { registry_path });
                     else if (allocated_port) {
@@ -493,6 +493,10 @@ export function create_ec2_router(config = {}) {
                     }
                 } catch (cleanup_err) {
                     console.log(`Rollback of ${name}: port release failed: ${cleanup_err.message}`);
+                }
+                const teardown_error = teardown.finish();
+                if (teardown_error) {
+                    console.log(`Rollback of ${name}: CloudMap teardown failed: ${teardown_error.message}`);
                 }
                 try {
                     rmSync(project_dir, { recursive: true, force: true });
@@ -918,15 +922,16 @@ export function create_ec2_router(config = {}) {
 
             const teardown = teardown_discovery({ name, namespace_id, region });
             if (teardown.record_cleared) release_port(name, { registry_path });
+            const teardown_error = teardown.finish();
 
             // The database itself is gone by here, so the caller's own cleanup
             // must still run; a surviving discovery entry is reported alongside
             // the deletion rather than as a failure to delete.
             const result = { ok: true, name, action: 'deleted' };
-            if (teardown.error) {
+            if (teardown_error) {
                 result.cloudmapLeaked = true;
-                result.warning = teardown.error.message;
-                console.log(`Teardown of ${name} left a CloudMap entry: ${teardown.error.message}`);
+                result.warning = teardown_error.message;
+                console.log(`Teardown of ${name} left a CloudMap entry: ${teardown_error.message}`);
             }
             if (on_after_delete) on_after_delete(result);
             res.json(result);

--- a/infra/src/ec2/ec2-router.js
+++ b/infra/src/ec2/ec2-router.js
@@ -13,7 +13,7 @@ import { engines } from './engines.js';
 import { generate_compose } from './compose-generator.js';
 import { allocate_port, register_port, release_port, get_allocated_ports } from './ports.js';
 import { create_volume, attach_and_mount, cleanup_volume, get_instance_metadata } from './volumes.js';
-import { register, deregister, deregister_instance, delete_service } from './cloudmap.js';
+import { register, deregister_instance, delete_service } from './cloudmap.js';
 import { snapshot_db, download_profile_seed, seed_after_start, list_s3_profiles, read_profile_registry, write_active_profile, check_schema_rev_gate } from './profiles.js';
 
 const SEEDS_BASE = '/mnt/seeds';
@@ -446,25 +446,36 @@ export function create_ec2_router(config = {}) {
                     && !cleanup_volume({ volume_id: rollback_volume_id, mount_path, region: effective_region })) {
                     console.log(`ROLLBACK INCOMPLETE: volume ${rollback_volume_id} (${name}) left on ${meta.instance_id} — needs a reap pass`);
                 }
-                // Same ordering constraint as the DELETE route: a surviving A
-                // record advertises ip:port, so the port stays held rather than
-                // being handed to the next identifier.
-                let record_cleared = true;
+                // Same ordering as the DELETE route, and best-effort at each
+                // step. The port is released only on an affirmative "the A
+                // record is gone": while it survives it advertises ip:port, and
+                // reissuing the port aims that name at the next identifier.
+                let cloudmap_service = null;
+                let record_cleared = !namespace_id;
                 if (namespace_id) {
                     try {
-                        deregister({ name, namespace_id, region: effective_region });
+                        cloudmap_service = deregister_instance({
+                            name, namespace_id, region: effective_region,
+                        });
+                        record_cleared = true;
                     } catch (cleanup_err) {
-                        record_cleared = !cleanup_err.record_survives;
                         console.log(`Rollback of ${name}: CloudMap deregister failed: ${cleanup_err.message}`);
                     }
                 }
                 try {
                     if (allocated_port && record_cleared) release_port(name, { registry_path });
                     else if (allocated_port) {
-                        console.log(`ROLLBACK INCOMPLETE: port for ${name} held — its CloudMap A record survives`);
+                        console.log(`ROLLBACK INCOMPLETE: port for ${name} held — its CloudMap A record may survive`);
                     }
                 } catch (cleanup_err) {
                     console.log(`Rollback of ${name}: port release failed: ${cleanup_err.message}`);
+                }
+                if (cloudmap_service) {
+                    try {
+                        delete_service({ name, service: cloudmap_service, region: effective_region });
+                    } catch (cleanup_err) {
+                        console.log(`Rollback of ${name}: CloudMap service delete failed: ${cleanup_err.message}`);
+                    }
                 }
                 try {
                     rmSync(project_dir, { recursive: true, force: true });
@@ -893,14 +904,11 @@ export function create_ec2_router(config = {}) {
             // still advertises it, and the shell's delete can fail for minutes
             // (async deregistration) without justifying a leaked registry row.
             let cloudmap_service = null;
-            const cloudmap_region = namespace_id
-                ? (region || get_instance_metadata().region)
-                : null;
+            let cloudmap_region;
             if (namespace_id) {
+                cloudmap_region = region || get_instance_metadata().region;
                 cloudmap_service = deregister_instance({
-                    name,
-                    namespace_id,
-                    region: cloudmap_region,
+                    name, namespace_id, region: cloudmap_region,
                 });
             }
 

--- a/infra/src/ec2/ec2-router.js
+++ b/infra/src/ec2/ec2-router.js
@@ -446,15 +446,23 @@ export function create_ec2_router(config = {}) {
                     && !cleanup_volume({ volume_id: rollback_volume_id, mount_path, region: effective_region })) {
                     console.log(`ROLLBACK INCOMPLETE: volume ${rollback_volume_id} (${name}) left on ${meta.instance_id} — needs a reap pass`);
                 }
+                // Same ordering constraint as the DELETE route: a surviving A
+                // record advertises ip:port, so the port stays held rather than
+                // being handed to the next identifier.
+                let record_cleared = true;
                 if (namespace_id) {
                     try {
                         deregister({ name, namespace_id, region: effective_region });
                     } catch (cleanup_err) {
+                        record_cleared = !cleanup_err.record_survives;
                         console.log(`Rollback of ${name}: CloudMap deregister failed: ${cleanup_err.message}`);
                     }
                 }
                 try {
-                    if (allocated_port) release_port(name, { registry_path });
+                    if (allocated_port && record_cleared) release_port(name, { registry_path });
+                    else if (allocated_port) {
+                        console.log(`ROLLBACK INCOMPLETE: port for ${name} held — its CloudMap A record survives`);
+                    }
                 } catch (cleanup_err) {
                     console.log(`Rollback of ${name}: port release failed: ${cleanup_err.message}`);
                 }

--- a/infra/src/ec2/ec2-router.js
+++ b/infra/src/ec2/ec2-router.js
@@ -868,7 +868,8 @@ export function create_ec2_router(config = {}) {
     router.post('/dbs/:name/switch', (req, res) => handle_switch(req, res, 'switched'));
     router.post('/dbs/:name/restore', (req, res) => handle_switch(req, res, 'restored'));
 
-    // DELETE /dbs/:name — stop, remove project dir, deregister, release port. Keep EBS volume.
+    // DELETE /dbs/:name — stop, remove project dir, then tear down discovery in
+    // the order below. Keep EBS volume.
     router.delete('/dbs/:name', (req, res) => {
         try {
             const { name } = req.params;

--- a/infra/src/ec2/ec2-router.js
+++ b/infra/src/ec2/ec2-router.js
@@ -37,7 +37,7 @@ function teardown_discovery({ name, namespace_id, region }) {
     if (!namespace_id) return { record_cleared: true, error: null };
 
     const effective_region = region || get_instance_metadata().region;
-    let service = null;
+    let service;
     let error = null;
     let record_cleared = true;
     try {

--- a/infra/src/ec2/ec2-router.js
+++ b/infra/src/ec2/ec2-router.js
@@ -13,7 +13,7 @@ import { engines } from './engines.js';
 import { generate_compose } from './compose-generator.js';
 import { allocate_port, register_port, release_port, get_allocated_ports } from './ports.js';
 import { create_volume, attach_and_mount, cleanup_volume, get_instance_metadata } from './volumes.js';
-import { register, deregister } from './cloudmap.js';
+import { register, deregister, deregister_instance, delete_service } from './cloudmap.js';
 import { snapshot_db, download_profile_seed, seed_after_start, list_s3_profiles, read_profile_registry, write_active_profile, check_schema_rev_gate } from './profiles.js';
 
 const SEEDS_BASE = '/mnt/seeds';
@@ -879,19 +879,26 @@ export function create_ec2_router(config = {}) {
                 rmSync(project_dir, { recursive: true, force: true });
             }
 
-            // Release the port before CloudMap: a failed deregister must still
-            // surface (it strands the identifier), but it must not also leak the
-            // port registry row on a project dir that is already gone.
-            release_port(name, { registry_path });
-
-            // Deregister from CloudMap
+            // Drop the A record first, release the port second, delete the
+            // service shell last. The port must not be reissued while the name
+            // still advertises it, and the shell's delete can fail for minutes
+            // (async deregistration) without justifying a leaked registry row.
+            let cloudmap_service = null;
+            const cloudmap_region = namespace_id
+                ? (region || get_instance_metadata().region)
+                : null;
             if (namespace_id) {
-                const meta = get_instance_metadata();
-                deregister({
+                cloudmap_service = deregister_instance({
                     name,
                     namespace_id,
-                    region: region || meta.region,
+                    region: cloudmap_region,
                 });
+            }
+
+            release_port(name, { registry_path });
+
+            if (cloudmap_service) {
+                delete_service({ name, service: cloudmap_service, region: cloudmap_region });
             }
 
             const result = { ok: true, name, action: 'deleted' };

--- a/infra/test/unit/cloudmap.unit.test.js
+++ b/infra/test/unit/cloudmap.unit.test.js
@@ -36,7 +36,7 @@ beforeEach(() => {
 });
 
 describe('register', () => {
-    it('reuses a leaked service instead of failing the provision', async () => {
+    it('reuses a leaked service instead of failing the provision', () => {
         // A teardown can remove the DB container but leave its Cloud Map entry;
         // create-service then returns ServiceAlreadyExists, and treating that as
         // fatal strands the identifier with no operator tier able to delete it.
@@ -119,7 +119,29 @@ describe('deregister', () => {
                 : ok()),
         });
 
-        expect(() => deregister({ name: NAME, namespace_id: NS, region: REGION })).not.toThrow();
+        expect(() => deregister({
+            name: NAME, namespace_id: NS, region: REGION, delete_retry_ms: 1,
+        })).not.toThrow();
+        expect(attempts).toBe(3);
+    });
+
+    it('gives up after a bounded number of attempts', () => {
+        // The bound is what limits how long a teardown can block the router,
+        // so it needs pinning: an unbounded loop passes every other test here.
+        let attempts = 0;
+        route({
+            'list-services': list_of({ Name: NAME, Id: 'srv-1' }),
+            'deregister-instance': ok(),
+            'delete-service': () => {
+                attempts++;
+                return fail('An error occurred (ResourceInUse) when calling DeleteService');
+            },
+        });
+
+        expect(() => deregister({
+            name: NAME, namespace_id: NS, region: REGION,
+            delete_attempts: 3, delete_retry_ms: 1,
+        })).toThrow(/Could not delete CloudMap service/);
         expect(attempts).toBe(3);
     });
 

--- a/infra/test/unit/cloudmap.unit.test.js
+++ b/infra/test/unit/cloudmap.unit.test.js
@@ -125,6 +125,24 @@ describe('deregister', () => {
         expect(attempts).toBe(3);
     });
 
+    it('flags a surviving A record so callers can hold the port', () => {
+        // Best-effort callers catch this; they still need to know the record is
+        // live, because releasing the port then points the name at whoever
+        // takes it next.
+        route({
+            'list-services': list_of({ Name: NAME, Id: 'srv-1' }),
+            'deregister-instance': fail('An error occurred (AccessDeniedException)'),
+        });
+
+        expect.assertions(2);
+        try {
+            deregister({ name: NAME, namespace_id: NS, region: REGION });
+        } catch (err) {
+            expect(err.record_survives).toBe(true);
+            expect(calls_to('delete-service')).toHaveLength(0);
+        }
+    });
+
     it('gives up after a bounded number of attempts', () => {
         // The bound is what limits how long a teardown can block the router,
         // so it needs pinning: an unbounded loop passes every other test here.

--- a/infra/test/unit/cloudmap.unit.test.js
+++ b/infra/test/unit/cloudmap.unit.test.js
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// cloudmap.js shells out to the AWS CLI for every call; stubbing spawnSync lets
+// each test drive the exact CLI responses that produced the live failures.
+vi.mock('child_process', () => ({ spawnSync: vi.fn() }));
+
+import { spawnSync } from 'child_process';
+import { register, deregister } from '../../src/ec2/cloudmap.js';
+
+const NS = 'ns-test';
+const REGION = 'us-west-2';
+const NAME = 'rostering-scheduling-postgres-pr-568';
+
+const ok = (stdout = '') => ({ status: 0, stdout, stderr: '' });
+const fail = stderr => ({ status: 1, stdout: '', stderr });
+
+const list_of = (...services) => ok(JSON.stringify({ Services: services }));
+const SERVICE_ALREADY_EXISTS = 'An error occurred (ServiceAlreadyExists) when calling '
+    + 'the CreateService operation: Service already exists.';
+
+// Route each stubbed call by the CLI subcommand so tests declare only the
+// responses they care about, in any order the implementation makes them.
+function route(handlers) {
+    spawnSync.mockImplementation((_bin, args) => {
+        const op = args[1];
+        const handler = handlers[op];
+        if (!handler) throw new Error(`unstubbed servicediscovery call: ${op}`);
+        return typeof handler === 'function' ? handler() : handler;
+    });
+}
+
+const calls_to = op => spawnSync.mock.calls.filter(([, args]) => args[1] === op);
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+describe('register', () => {
+    it('reuses a leaked service instead of failing the provision', async () => {
+        // A teardown can remove the DB container but leave its Cloud Map entry;
+        // create-service then returns ServiceAlreadyExists, and treating that as
+        // fatal strands the identifier with no operator tier able to delete it.
+        let listed = 0;
+        route({
+            'list-services': () => (listed++ === 0
+                ? list_of()
+                : list_of({ Name: NAME, Id: 'srv-leaked' })),
+            'create-service': fail(SERVICE_ALREADY_EXISTS),
+            'register-instance': ok(),
+        });
+
+        expect(() => register({
+            name: NAME, ip: '10.3.142.176', port: 5440, namespace_id: NS, region: REGION,
+        })).not.toThrow();
+
+        // The reused service's id must be what the instance registers against.
+        const [, args] = calls_to('register-instance')[0];
+        expect(args).toContain('srv-leaked');
+    });
+
+    it('still fails when create-service fails for any other reason', () => {
+        route({
+            'list-services': list_of(),
+            'create-service': fail('An error occurred (InvalidInput) when calling CreateService'),
+        });
+
+        expect(() => register({
+            name: NAME, ip: '10.3.142.176', port: 5440, namespace_id: NS, region: REGION,
+        })).toThrow(/InvalidInput/);
+        expect(calls_to('register-instance')).toHaveLength(0);
+    });
+
+    it('does not call create-service when the service is already resolvable', () => {
+        route({
+            'list-services': list_of({ Name: NAME, Id: 'srv-existing' }),
+            'register-instance': ok(),
+        });
+
+        register({ name: NAME, ip: '10.3.142.176', port: 5440, namespace_id: NS, region: REGION });
+
+        expect(calls_to('create-service')).toHaveLength(0);
+    });
+
+    it('propagates a failed lookup rather than creating a duplicate', () => {
+        // "couldn't list" must not read as "not there" — that sends provisioning
+        // into create-service on a namespace it never actually saw.
+        route({ 'list-services': fail('AccessDeniedException: ListServices') });
+
+        expect(() => register({
+            name: NAME, ip: '10.3.142.176', port: 5440, namespace_id: NS, region: REGION,
+        })).toThrow(/ListServices/);
+        expect(calls_to('create-service')).toHaveLength(0);
+    });
+});
+
+describe('deregister', () => {
+    it('reports a failed delete instead of logging and returning', () => {
+        // A surviving service blocks the identifier's next provision, so
+        // teardown must not report success when the delete never landed.
+        route({
+            'list-services': list_of({ Name: NAME, Id: 'srv-1' }),
+            'deregister-instance': ok(),
+            'delete-service': fail('An error occurred (InvalidInput) when calling DeleteService'),
+        });
+
+        expect(() => deregister({ name: NAME, namespace_id: NS, region: REGION }))
+            .toThrow(/Could not delete CloudMap service/);
+    });
+
+    it('retries past the asynchronous deregister window', () => {
+        // DeregisterInstance completes asynchronously and DeleteService rejects
+        // a service that still has an instance attached.
+        let attempts = 0;
+        route({
+            'list-services': list_of({ Name: NAME, Id: 'srv-1' }),
+            'deregister-instance': ok(),
+            'delete-service': () => (++attempts < 3
+                ? fail('An error occurred (ResourceInUse) when calling DeleteService')
+                : ok()),
+        });
+
+        expect(() => deregister({ name: NAME, namespace_id: NS, region: REGION })).not.toThrow();
+        expect(attempts).toBe(3);
+    });
+
+    it('deletes the service even when no instance was registered', () => {
+        route({
+            'list-services': list_of({ Name: NAME, Id: 'srv-1' }),
+            'deregister-instance': fail('InstanceNotFound'),
+            'delete-service': ok(),
+        });
+
+        expect(() => deregister({ name: NAME, namespace_id: NS, region: REGION })).not.toThrow();
+        expect(calls_to('delete-service')).toHaveLength(1);
+    });
+});

--- a/infra/test/unit/cloudmap.unit.test.js
+++ b/infra/test/unit/cloudmap.unit.test.js
@@ -5,7 +5,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('child_process', () => ({ spawnSync: vi.fn() }));
 
 import { spawnSync } from 'child_process';
-import { register, deregister } from '../../src/ec2/cloudmap.js';
+import { register, deregister_instance, delete_service } from '../../src/ec2/cloudmap.js';
 
 const NS = 'ns-test';
 const REGION = 'us-west-2';
@@ -30,6 +30,12 @@ function route(handlers) {
 }
 
 const calls_to = op => spawnSync.mock.calls.filter(([, args]) => args[1] === op);
+
+// The full teardown a caller performs: drop the A record, then delete the shell.
+function remove({ name, namespace_id, region, ...retry }) {
+    const service = deregister_instance({ name, namespace_id, region });
+    if (service) delete_service({ name, service, region, ...retry });
+}
 
 beforeEach(() => {
     vi.clearAllMocks();
@@ -103,7 +109,7 @@ describe('deregister', () => {
             'delete-service': fail('An error occurred (InvalidInput) when calling DeleteService'),
         });
 
-        expect(() => deregister({ name: NAME, namespace_id: NS, region: REGION }))
+        expect(() => remove({ name: NAME, namespace_id: NS, region: REGION }))
             .toThrow(/Could not delete CloudMap service/);
     });
 
@@ -119,28 +125,30 @@ describe('deregister', () => {
                 : ok()),
         });
 
-        expect(() => deregister({
+        expect(() => remove({
             name: NAME, namespace_id: NS, region: REGION, delete_retry_ms: 1,
         })).not.toThrow();
         expect(attempts).toBe(3);
     });
 
-    it('flags a surviving A record so callers can hold the port', () => {
-        // Best-effort callers catch this; they still need to know the record is
-        // live, because releasing the port then points the name at whoever
-        // takes it next.
+    it('refuses to report the A record gone when it could not be removed', () => {
+        // The caller releases the database's port only if this returns, so a
+        // failure here has to propagate rather than resolve to "nothing there".
         route({
             'list-services': list_of({ Name: NAME, Id: 'srv-1' }),
             'deregister-instance': fail('An error occurred (AccessDeniedException)'),
         });
 
-        expect.assertions(2);
-        try {
-            deregister({ name: NAME, namespace_id: NS, region: REGION });
-        } catch (err) {
-            expect(err.record_survives).toBe(true);
-            expect(calls_to('delete-service')).toHaveLength(0);
-        }
+        expect(() => deregister_instance({ name: NAME, namespace_id: NS, region: REGION }))
+            .toThrow(/AccessDeniedException/);
+        expect(calls_to('delete-service')).toHaveLength(0);
+    });
+
+    it('propagates a failed lookup rather than reporting nothing registered', () => {
+        route({ 'list-services': fail('AccessDeniedException: ListServices') });
+
+        expect(() => deregister_instance({ name: NAME, namespace_id: NS, region: REGION }))
+            .toThrow(/ListServices/);
     });
 
     it('gives up after a bounded number of attempts', () => {
@@ -156,7 +164,7 @@ describe('deregister', () => {
             },
         });
 
-        expect(() => deregister({
+        expect(() => remove({
             name: NAME, namespace_id: NS, region: REGION,
             delete_attempts: 3, delete_retry_ms: 1,
         })).toThrow(/Could not delete CloudMap service/);
@@ -170,7 +178,7 @@ describe('deregister', () => {
             'delete-service': ok(),
         });
 
-        expect(() => deregister({ name: NAME, namespace_id: NS, region: REGION })).not.toThrow();
+        expect(() => remove({ name: NAME, namespace_id: NS, region: REGION })).not.toThrow();
         expect(calls_to('delete-service')).toHaveLength(1);
     });
 });

--- a/infra/test/unit/cloudmap.unit.test.js
+++ b/infra/test/unit/cloudmap.unit.test.js
@@ -37,6 +37,15 @@ function remove({ name, namespace_id, region, ...retry }) {
     if (service) delete_service({ name, service, region, ...retry });
 }
 
+function capture(fn) {
+    try {
+        fn();
+    } catch (err) {
+        return err;
+    }
+    throw new Error('expected the call to throw');
+}
+
 beforeEach(() => {
     vi.clearAllMocks();
 });
@@ -147,8 +156,26 @@ describe('deregister', () => {
     it('propagates a failed lookup rather than reporting nothing registered', () => {
         route({ 'list-services': fail('AccessDeniedException: ListServices') });
 
-        expect(() => deregister_instance({ name: NAME, namespace_id: NS, region: REGION }))
-            .toThrow(/ListServices/);
+        const err = capture(() => deregister_instance({ name: NAME, namespace_id: NS, region: REGION }));
+        expect(err.message).toMatch(/ListServices/);
+        // Nothing was resolved, so there is no shell for a caller to delete.
+        expect(err.service).toBeUndefined();
+    });
+
+    it('treats only InstanceNotFound as nothing-to-deregister', () => {
+        // Other codes end in the same word but mean the call never landed, so
+        // the record's fate is unknown and the caller must hold the port.
+        route({
+            'list-services': list_of({ Name: NAME, Id: 'srv-1' }),
+            'deregister-instance': fail(
+                'An error occurred (ResourceNotFoundException) when calling the DeregisterInstance operation',
+            ),
+        });
+
+        const err = capture(() => deregister_instance({ name: NAME, namespace_id: NS, region: REGION }));
+        expect(err.message).toMatch(/ResourceNotFoundException/);
+        // The shell still exists, so it rides along for the caller to delete.
+        expect(err.service).toEqual({ Name: NAME, Id: 'srv-1' });
     });
 
     it('gives up after a bounded number of attempts', () => {
@@ -171,10 +198,26 @@ describe('deregister', () => {
         expect(attempts).toBe(3);
     });
 
+    it('never reports success without a confirmed delete', () => {
+        // A non-positive attempt count is the natural way to say "do not
+        // retry"; falling out of the loop must not read as a completed delete.
+        route({
+            'list-services': list_of({ Name: NAME, Id: 'srv-1' }),
+            'deregister-instance': ok(),
+            'delete-service': fail('An error occurred (ResourceInUse) when calling DeleteService'),
+        });
+
+        expect(() => remove({
+            name: NAME, namespace_id: NS, region: REGION, delete_attempts: 0,
+        })).toThrow(/Could not delete CloudMap service/);
+    });
+
     it('deletes the service even when no instance was registered', () => {
         route({
             'list-services': list_of({ Name: NAME, Id: 'srv-1' }),
-            'deregister-instance': fail('InstanceNotFound'),
+            'deregister-instance': fail(
+                'An error occurred (InstanceNotFound) when calling the DeregisterInstance operation',
+            ),
             'delete-service': ok(),
         });
 

--- a/infra/test/unit/ec2-router-provision.unit.test.js
+++ b/infra/test/unit/ec2-router-provision.unit.test.js
@@ -23,7 +23,6 @@ vi.mock('../../src/ec2/ports.js', () => ({
 }));
 vi.mock('../../src/ec2/cloudmap.js', () => ({
     register: vi.fn(),
-    deregister: vi.fn(),
     deregister_instance: vi.fn(() => ({ Id: 'srv-test' })),
     delete_service: vi.fn(),
 }));
@@ -213,7 +212,6 @@ describe('DELETE /dbs/:name teardown ordering', () => {
     beforeEach(async () => {
         vi.clearAllMocks();
         spawnSync.mockReturnValue({ status: 0, stdout: '', stderr: '' });
-        deregister_instance.mockReturnValue({ Id: 'srv-test' });
         projects_dir = mkdtempSync(join(tmpdir(), 'ec2-router-projects-'));
         data_dir = mkdtempSync(join(tmpdir(), 'ec2-router-data-'));
         test_server = await create_test_server({
@@ -260,6 +258,24 @@ describe('DELETE /dbs/:name teardown ordering', () => {
         deregister_instance.mockImplementation(() => { throw new Error('AccessDeniedException'); });
 
         const { status } = await api(test_server.base_url, 'DELETE', '/dbs/svc-pr-9');
+
+        expect(status).toBe(500);
+        expect(release_port).not.toHaveBeenCalled();
+    });
+
+    it('holds the port on a failed provision whose A record could not be dropped', async () => {
+        // The rollback path is best-effort everywhere else, but releasing this
+        // port would aim a live record at whichever identifier takes it next —
+        // so it must fail closed on ANY deregister failure, including a lookup
+        // that never got far enough to say whether a record exists.
+        deregister_instance.mockImplementation(() => { throw new Error('AccessDeniedException: ListServices'); });
+        spawnSync.mockImplementation((cmd, args) => (cmd === 'docker' && args.includes('up')
+            ? { status: 1, stdout: '', stderr: 'compose exploded' }
+            : { status: 0, stdout: '', stderr: '' }));
+
+        const { status } = await api(test_server.base_url, 'POST', '/dbs', {
+            name: 'svc-pr-10', engine: 'postgres',
+        });
 
         expect(status).toBe(500);
         expect(release_port).not.toHaveBeenCalled();

--- a/infra/test/unit/ec2-router-provision.unit.test.js
+++ b/infra/test/unit/ec2-router-provision.unit.test.js
@@ -242,33 +242,52 @@ describe('DELETE /dbs/:name teardown ordering', () => {
         expect(order).toEqual(['deregister', 'release', 'delete']);
     });
 
-    it('still releases the port when the service shell will not delete', async () => {
-        // The shell's delete can fail for minutes on an async deregistration;
-        // that must surface, but it must not also leak the registry row.
+    it('reports a leaked shell without failing a teardown that removed the database', async () => {
+        // The DB and its port are already gone; answering `ok:false` would stop
+        // the caller reaping its own row over a leak it cannot act on.
         delete_service.mockImplementation(() => { throw new Error('Could not delete CloudMap service'); });
 
         const { status, data } = await api(test_server.base_url, 'DELETE', '/dbs/svc-pr-9');
 
-        expect(status).toBe(500);
-        expect(data.error).toMatch(/Could not delete CloudMap service/);
+        expect(status).toBe(200);
+        expect(data).toMatchObject({ ok: true, action: 'deleted', cloudmapLeaked: true });
+        expect(data.warning).toMatch(/Could not delete CloudMap service/);
         expect(release_port).toHaveBeenCalledWith('svc-pr-9', expect.anything());
     });
 
     it('does not release the port when the A record survives', async () => {
-        deregister_instance.mockImplementation(() => { throw new Error('AccessDeniedException'); });
+        const err = new Error('An error occurred (AccessDeniedException)');
+        err.service = { Id: 'srv-test' };
+        deregister_instance.mockImplementation(() => { throw err; });
+
+        const { status, data } = await api(test_server.base_url, 'DELETE', '/dbs/svc-pr-9');
+
+        expect(status).toBe(200);
+        expect(data.cloudmapLeaked).toBe(true);
+        expect(release_port).not.toHaveBeenCalled();
+        // The shell is still deletable even though the record would not drop.
+        expect(delete_service).toHaveBeenCalled();
+    });
+
+    it('releases the port when the lookup failed before reaching any record', async () => {
+        // A failed list-services never touched an A record, so holding the port
+        // would strand a registry row for a name that advertises nothing.
+        deregister_instance.mockImplementation(() => {
+            throw new Error('An error occurred (AccessDeniedException) calling ListServices');
+        });
 
         const { status } = await api(test_server.base_url, 'DELETE', '/dbs/svc-pr-9');
 
-        expect(status).toBe(500);
-        expect(release_port).not.toHaveBeenCalled();
+        expect(status).toBe(200);
+        expect(release_port).toHaveBeenCalledWith('svc-pr-9', expect.anything());
     });
 
     it('holds the port on a failed provision whose A record could not be dropped', async () => {
-        // The rollback path is best-effort everywhere else, but releasing this
-        // port would aim a live record at whichever identifier takes it next —
-        // so it must fail closed on ANY deregister failure, including a lookup
-        // that never got far enough to say whether a record exists.
-        deregister_instance.mockImplementation(() => { throw new Error('AccessDeniedException: ListServices'); });
+        // Rollback is best-effort everywhere else, but releasing this port would
+        // aim a live record at whichever identifier takes it next.
+        const err = new Error('An error occurred (AccessDeniedException)');
+        err.service = { Id: 'srv-test' };
+        deregister_instance.mockImplementation(() => { throw err; });
         spawnSync.mockImplementation((cmd, args) => (cmd === 'docker' && args.includes('up')
             ? { status: 1, stdout: '', stderr: 'compose exploded' }
             : { status: 0, stdout: '', stderr: '' }));
@@ -279,5 +298,7 @@ describe('DELETE /dbs/:name teardown ordering', () => {
 
         expect(status).toBe(500);
         expect(release_port).not.toHaveBeenCalled();
+        // The shell this provision created is still cleaned up.
+        expect(delete_service).toHaveBeenCalled();
     });
 });

--- a/infra/test/unit/ec2-router-provision.unit.test.js
+++ b/infra/test/unit/ec2-router-provision.unit.test.js
@@ -24,6 +24,8 @@ vi.mock('../../src/ec2/ports.js', () => ({
 vi.mock('../../src/ec2/cloudmap.js', () => ({
     register: vi.fn(),
     deregister: vi.fn(),
+    deregister_instance: vi.fn(() => ({ Id: 'srv-test' })),
+    delete_service: vi.fn(),
 }));
 vi.mock('../../src/ec2/profiles.js', () => ({
     snapshot_db: vi.fn(),
@@ -41,7 +43,7 @@ vi.mock('child_process', () => ({
 import { spawnSync } from 'child_process';
 import { create_volume, cleanup_volume } from '../../src/ec2/volumes.js';
 import { release_port } from '../../src/ec2/ports.js';
-import { register } from '../../src/ec2/cloudmap.js';
+import { register, deregister_instance, delete_service } from '../../src/ec2/cloudmap.js';
 import { create_ec2_router } from '../../src/ec2/ec2-router.js';
 
 function create_test_server(router_options) {
@@ -200,5 +202,66 @@ describe('POST /dbs provision race + rollback', () => {
         expect(cleanup_volume).toHaveBeenCalledWith(expect.objectContaining({ volume_id: 'vol-test123' }));
         expect(release_port).toHaveBeenCalledWith('svc-pr-3', expect.anything());
         expect(existsSync(join(projects_dir, 'svc-pr-3'))).toBe(false);
+    });
+});
+
+describe('DELETE /dbs/:name teardown ordering', () => {
+    let projects_dir;
+    let data_dir;
+    let test_server;
+
+    beforeEach(async () => {
+        vi.clearAllMocks();
+        spawnSync.mockReturnValue({ status: 0, stdout: '', stderr: '' });
+        deregister_instance.mockReturnValue({ Id: 'srv-test' });
+        projects_dir = mkdtempSync(join(tmpdir(), 'ec2-router-projects-'));
+        data_dir = mkdtempSync(join(tmpdir(), 'ec2-router-data-'));
+        test_server = await create_test_server({
+            projects_dir, data_dir,
+            registry_path: join(data_dir, 'ports.json'),
+            namespace_id: 'ns-test',
+        });
+    });
+
+    afterEach(async () => {
+        await test_server.close();
+        rmSync(projects_dir, { recursive: true, force: true });
+        rmSync(data_dir, { recursive: true, force: true });
+    });
+
+    it('drops the A record before releasing the port', async () => {
+        // A freed port plus a live A record points `<name>.dbs-v2.local` — the
+        // fallback host baked into preview DB secrets — at whichever identifier
+        // takes the port next.
+        const order = [];
+        deregister_instance.mockImplementation(() => { order.push('deregister'); return { Id: 'srv-test' }; });
+        release_port.mockImplementation(() => { order.push('release'); });
+        delete_service.mockImplementation(() => { order.push('delete'); });
+
+        const { status } = await api(test_server.base_url, 'DELETE', '/dbs/svc-pr-9');
+
+        expect(status).toBe(200);
+        expect(order).toEqual(['deregister', 'release', 'delete']);
+    });
+
+    it('still releases the port when the service shell will not delete', async () => {
+        // The shell's delete can fail for minutes on an async deregistration;
+        // that must surface, but it must not also leak the registry row.
+        delete_service.mockImplementation(() => { throw new Error('Could not delete CloudMap service'); });
+
+        const { status, data } = await api(test_server.base_url, 'DELETE', '/dbs/svc-pr-9');
+
+        expect(status).toBe(500);
+        expect(data.error).toMatch(/Could not delete CloudMap service/);
+        expect(release_port).toHaveBeenCalledWith('svc-pr-9', expect.anything());
+    });
+
+    it('does not release the port when the A record survives', async () => {
+        deregister_instance.mockImplementation(() => { throw new Error('AccessDeniedException'); });
+
+        const { status } = await api(test_server.base_url, 'DELETE', '/dbs/svc-pr-9');
+
+        expect(status).toBe(500);
+        expect(release_port).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
## What this fixes

A preview teardown can delete the DB container but leave its **Cloud Map service** behind. The next
provision for that identifier calls `create-service`, gets `ServiceAlreadyExists`, and aborts —
**permanently**. `servicediscovery:DeleteService` is granted to no operator tier we currently hold
(hipponot/iac#672), so the leftover entry can't be cleaned up by hand and that identifier has no
preview path at all.

Live evidence, program-hub #568 (run 31412406224, `Provision Preview DBs`):

```
ok=false  error=aws servicediscovery create-service --name failed:
An error occurred (ServiceAlreadyExists) when calling the CreateService operation: Service already exists.
...
ok=false  error=DB 'rostering-scheduling-postgres-pr-568' not found
```

This has been blocking program-hub #559 and #568.

## The change

**`register()` treats `ServiceAlreadyExists` as reusable** — re-resolve the service, register the
instance against it. This is the part that restores previews today: no new IAM grant, no manual
deletion. A service surviving without its container reserves nothing but the name.

Two adjacent defects in the same file made the failure both possible and invisible:

- **`find_service()` swallowed every `list-services` error into `null`**, so "couldn't look" and
  "isn't there" were indistinguishable. That single `catch { return null }` can send `register()`
  to create a duplicate *and* make `deregister()` silently skip its delete. A failed lookup now
  propagates.
- **`deregister()` logged a failed `delete-service` and returned**, so `DELETE /dbs/:name` answered
  `200 {ok:true}` on a teardown that cleaned up nothing — which is how leaked entries accumulate
  unnoticed. The delete now retries across the asynchronous `DeregisterInstance` window
  (`ResourceInUse`) and throws if it never lands, surfacing as a 500 from the router.

## On root cause

**Not proven, and I'm flagging that rather than asserting it.** infra-compose logs to journald on
the db-host, not CloudWatch, so which teardown branch failed for these identifiers wasn't
recoverable. What I did rule out from primary source:

- **Not IAM** — the deployed `dev-db-host-v2-instance-role` inline `CloudMapRegistration` policy
  grants `ListServices`/`DeleteService` at `Resource: "*"` (read live, not from the template).
- **Not pagination** — `ListServices` has a paginator and AWS CLI v2 auto-paginates, so the
  single-call `find_service` isn't truncating at 100.

Every remaining candidate is addressed by the same shape: make a leftover **reusable**, and make a
failed cleanup **loud**.

## Tests

7 new cases in `infra/test/unit/cloudmap.unit.test.js`, driving the real CLI error strings through
stubbed `spawnSync`. **Verified non-vacuous** — the 4 behaviour-change cases fail against the
pre-fix source (confirmed by reverting it and re-running), the 3 unchanged-behaviour cases still
pass.

⚠️ The 9 failures in `api-pure` / `router` / `ec2-router` unit tests are **pre-existing** — identical
on a clean `origin/main` with none of this applied.

## ⚠️ Merging this does not deploy it

`@saga-ed/infra-compose` is installed on the db-hosts from CodeArtifact at ASG launch, pinned by
`InfraComposeVersion` (currently `1.6.0`, `iac` `db_host_v2/asg/template.yaml:69`, install at :413).
Landing this requires: **publish → bump the pin in `iac` → instance relaunch/reinstall.** Running
hosts keep the globally-installed old version.

I could not do the publish leg: CodeArtifact is prod-account and Observer is denied
`codeartifact:GetAuthorizationToken`.

## Related

- saga-ed/ci-actions#78 — the triage step misreads this error as "DB already exists"; separate PR,
  error-quality only, unblocks nothing on its own.
- hipponot/iac#672 — the tier gap that makes leaked entries un-deletable, and therefore makes
  "reuse it" the only fix that works without a grant.

## Design review (applied)

A review pass caught that making `deregister()` throw changed the `DELETE /dbs/:name` contract
without adjusting the route: `deregister()` ran *before* `release_port()`, so a CloudMap failure
skipped the port release on a project dir `rmSync` had already removed — a leaked registry row on
every failed teardown. **Port release now happens first.**

`on_after_delete` deliberately still does not fire on that path: the teardown genuinely did not
complete, and reporting "deleted" is the silent-success failure this PR exists to remove.

Also applied: the retry loop no longer sleeps after its final attempt (worst case ~8s, not ~10s),
and `delete_attempts`/`delete_retry_ms` are injectable so the **exhaustion bound is now pinned by a
test** — previously raising `DELETE_ATTEMPTS` to 50 would have broken nothing.

Reviewer confirmed as clean: the reuse path can't cause cross-PR DNS confusion (`--instance-id` is
the same identifier-scoped name, so re-registering overwrites the A record rather than adding a
sibling), the retry control flow, and the provision-rollback caller (already individually catches
`deregister`).

## Teardown ordering — the residual I chose, stated explicitly

Releasing the port ahead of the whole CloudMap block (the first review fix) traded one residual for
a worse one. `deregister()` swallowed a failed `deregister-instance`, so **the A record could
survive while the port returned to the pool** — and `provision-preview-db-secret` bakes
`<name>.dbs-v2.local` into the preview DB secret as a fallback host
(`action.yml:394-424`). The next identifier to take that port becomes what the old name resolves
to. A leaked registry row is much cheaper than one PR's app reaching another PR's database.

So `deregister()` is split into `deregister_instance()` + `delete_service()`, and the route
sequences them by what each step risks:

```
deregister_instance  ->  release_port  ->  delete_service
```

- **A record first**, and it now throws on anything but `InstanceNotFound`. If it survives, the port
  must not be reissued.
- **Service shell last**, because its delete can fail for minutes on an asynchronous
  deregistration, and that does not justify holding the port.

`deregister()` keeps its original signature and both-halves-best-effort behaviour for the
provision-rollback caller, which wants exactly that.

**Residual that remains:** if `delete_service` fails, the shell leaks (a 500 tells you) — but the
next provision for that identifier now *reuses* it, which is the whole point of this PR.

## Behaviour change worth flagging on the happy path

`find_service()` no longer swallowing means **every provision now hard-depends on `ListServices`
succeeding**. Previously a transient list failure fell through to `create-service` and usually
worked; now it fails the provision loudly. That's deliberate — the silent version is what created
this bug — but it is a new failure mode on a path that used to survive.

## Test coverage

11 tests total: 8 in `cloudmap.unit.test.js` (reuse, non-reuse errors, lookup propagation, delete
retry, exhaustion bound) and 3 new in `ec2-router-provision.unit.test.js` pinning the teardown
ordering — call order, port released on a failed `delete_service`, port **not** released when the A
record survives.

## What a teardown 500 means for the orchestrator (verified)

`dev-db-host-orchestrator`'s `_action_teardown` does `resp = _http_call(... "DELETE", f"/dbs/{name}")`
and then **`if not resp.get("ok"): return resp`** (`iac` `db_host_v2/orchestrator/src/index.py:452-454`).
So on the new 500 it returns early and does **not** reach the volume cleanup or the registry-row
delete at `:503`.

That is the intended trade — the teardown genuinely did not finish, and the old behaviour reported
success while leaving a leaked Cloud Map entry that blocked the identifier forever. But it should be
stated plainly: **a failed `delete_service` now leaves the orchestrator's registry row in place**,
and clearing it is an operator step. The container is stopped and the port is released either way;
the next provision for that identifier reuses the leaked service rather than tripping on it, which
is what this PR is for.

## Rollback path (provision failure) gets the same ordering guarantee

The provision-failure path wrapped `deregister()` in a blanket catch and released the port
regardless — the same defect the DELETE reorder fixed, firing on every failed provision.
`deregister_instance()` now marks its error with **`record_survives`** (rather than leaving callers
to match on message text), and the rollback path holds the port when it sees that flag while keeping
its best-effort behaviour otherwise.

⚠️ Note for reviewers: `deregister()`'s **signature** is unchanged but its **behaviour** is not — it
throws now. Best-effort-ness lives entirely in the caller's `try/catch`; the docstring says so.

## Cleanup pass — one real defect found in my own fix

`record_survives` was **fail-open**. It was attached only inside
`deregister_instance`'s catch, so an error raised *earlier* — a failed
`list-services`, exactly the AccessDenied/throttle case — threw without it, left
`record_cleared` at its `true` default, and released the port anyway. That reintroduced at
the call site the same "couldn't look ≠ isn't there" ambiguity this PR removes from `find_service`.

The flag only existed because the rollback path called the combined `deregister()` instead of
sequencing the primitives like the DELETE route does. **Rollback now sequences them itself and
releases the port only on an affirmative return**, so any failure holds it. `deregister()` had no
other caller and is deleted along with the flag — one fewer seam, and the invariant is expressed the
same way in both places.

Smaller cleanups from the same pass: `delete_service`'s retry loop lost its `last_err` accumulator
(the throw moved into the catch, where the terminal conditions already live); the deleted wrapper
was redeclaring `delete_attempts`/`delete_retry_ms` defaults that `delete_service` owns;
`cloudmap_region` no longer restates its own guard as a ternary; and the tests dropped a
`mockReturnValue` that restated the `vi.mock` factory.

Test count is now **13** — the cloudmap suite drives `deregister_instance`/`delete_service`
directly (10, including a new failed-lookup case) and the router suite adds a rollback case pinning
the fail-closed port hold.

## High-effort review pass — 7 findings fixed, 3 accepted

A multi-agent review (31 candidates → 25 verifiers → 10 findings) caught that the previous commit's
`/NotFound/` guard **reopened the fail-open path it was meant to close**. Narrowing
`/InstanceNotFound|NotFound/` to `/NotFound/` was wrong: the survivor also matches
`ResourceNotFoundException` and `ServiceNotFound`, so a genuine deregister failure was swallowed as
"nothing was registered" and both callers released the port with a live A record.

Matching raw stderr was the underlying mistake. **`run()` now parses the CLI's
`An error occurred (Code)` preamble into `err.aws_code`**, and all three call sites compare the code
exactly.

Teardown now reports **two outcomes**, because callers act on them separately:

- **`record_cleared` gates the port.** A failed `deregister-instance` leaves the record's fate
  unknown → hold. A failure that never resolved the service never reached a record → release. The
  previous commit collapsed both into "held" and stranded registry rows on a transient
  `ListServices` failure.
- **The shell delete is attempted either way.** `deregister_instance` attaches the resolved service
  to its error, so a failed record drop no longer skips the delete — the rollback path used to leak
  a shell it had just created.

Both call sites go through one `teardown_discovery()` helper, so the ordering invariant is stated
once instead of duplicated with different error policies.

**`DELETE /dbs/:name` no longer fails on a leaked shell.** The database and port are already gone by
then, and `ok:false` stopped the orchestrator reaping its own registry row over a leak it cannot act
on. It returns 200 with `cloudmapLeaked: true` plus a warning; the next provision reuses the shell
regardless. `delete_service`'s loop also can no longer fall off the end and report success without
having deleted anything.

### Accepted, not fixed

- **`sleep_sync` blocks the event loop up to ~8s.** Real, but `volumes.js:237` and `profiles.js:238`
  already block synchronously in their own retry loops — this matches the house pattern, and
  converting the router to async is its own change.
- **DeregisterInstance is async, so "returned" ≠ "record gone".** True; closing it needs
  `get-operation` polling. The TTL-60 window is narrower than the pre-existing exposure and this
  PR strictly reduces it.
- **A caller-supplied `port` never enters the registry** (`ec2-router.js:382`) — a pre-existing
  bug on a path this PR doesn't touch.
