### PR TITLE
fix(infra-compose): survive a Cloud Map namespace larger than spawnSync's default buffer

### DIFF
--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@saga-ed/infra-compose",
-    "version": "1.6.1",
+    "version": "1.6.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@saga-ed/infra-compose",
-            "version": "1.6.1",
+            "version": "1.6.2",
             "dependencies": {
                 "bson": "^6.10.4",
                 "express": "^4.22.1",

--- a/infra/package.json
+++ b/infra/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/infra-compose",
-    "version": "1.6.1",
+    "version": "1.6.2",
     "description": "Composable Docker service templates for Saga platform local development",
     "bin": {
         "infra-compose": "bin/infra-compose"

--- a/infra/src/ec2/cloudmap.js
+++ b/infra/src/ec2/cloudmap.js
@@ -13,8 +13,21 @@ function sleep_sync(ms) {
     Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 
+// list-services returns every service in the namespace (the CLI auto-paginates),
+// so the response scales with accumulated leaked entries, not with what we asked
+// for: dev measured 1.7k services / ~1.1MB, just past spawnSync's 1MB default.
+const MAX_BUFFER = 64 * 1024 * 1024;
+
 function run(args) {
-    const result = spawnSync('aws', args, { encoding: 'utf8', stdio: 'pipe' });
+    const result = spawnSync('aws', args, { encoding: 'utf8', stdio: 'pipe', maxBuffer: MAX_BUFFER });
+    // A spawn-level failure (ENOBUFS, ENOENT) leaves status null and stderr
+    // empty; without this branch it falls through as an AWS error whose code
+    // can't be parsed, and the caller's triage misreads it.
+    if (result.error) {
+        const err = new Error(`aws ${args.slice(0, 3).join(' ')} failed: ${result.error.message}`);
+        err.spawn_code = result.error.code ?? null;
+        throw err;
+    }
     if (result.status !== 0) {
         const err = new Error(`aws ${args.slice(0, 3).join(' ')} failed: ${result.stderr || result.error}`);
         // The CLI reports the failure kind as "An error occurred (Code) when

--- a/infra/test/unit/cloudmap.unit.test.js
+++ b/infra/test/unit/cloudmap.unit.test.js
@@ -225,3 +225,41 @@ describe('deregister', () => {
         expect(calls_to('delete-service')).toHaveLength(1);
     });
 });
+
+describe('AWS CLI spawn failures', () => {
+    // list-services returns the whole namespace, so its size tracks accumulated
+    // leaked entries: dev hit 1.7k services / ~1.1MB and overflowed spawnSync's
+    // 1MB default, which surfaces as status null + empty stderr, not a CLI error.
+    const enobufs = () => ({
+        status: null,
+        stdout: '',
+        stderr: '',
+        error: Object.assign(new Error('spawnSync aws ENOBUFS'), { code: 'ENOBUFS' }),
+    });
+
+    it('raises a spawn failure instead of parsing it as an AWS error', () => {
+        route({ 'list-services': enobufs });
+
+        const err = capture(() => register({
+            name: NAME, namespace_id: NS, region: REGION, ip: '10.0.0.1', port: 5432,
+        }));
+
+        expect(err.spawn_code).toBe('ENOBUFS');
+        // aws_code stays null: nothing came back from the CLI to classify, and
+        // reporting one would send the caller's triage down the wrong branch.
+        expect(err.aws_code).toBeUndefined();
+    });
+
+    it('asks for a buffer far above the response that broke the default', () => {
+        route({
+            'list-services': list_of(),
+            'create-service': ok(JSON.stringify({ Service: { Id: 'srv-1' } })),
+            'register-instance': ok(),
+        });
+
+        register({ name: NAME, namespace_id: NS, region: REGION, ip: '10.0.0.1', port: 5432 });
+
+        const [[, , options]] = calls_to('list-services');
+        expect(options.maxBuffer).toBeGreaterThan(2 * 1024 * 1024);
+    });
+});


### PR DESCRIPTION
Follow-up to #423. Bumps to **1.6.2**.

## What happened

With 1.6.1 live on all 6 dev db-hosts, the `ServiceAlreadyExists` failure is **gone** — `register()` reached the reuse path. The preview deploy now fails one step earlier:

```
aws servicediscovery list-services --filters failed: Error: spawnSync aws ENOBUFS
```

## Why

`list-services` returns **every** service in the namespace and the CLI auto-paginates, so the response size tracks accumulated leaked entries rather than the query. Measured live in dev:

| | |
|---|---|
| services in `ns-nvwzrsxfhyqvv7fx` | **1,701** |
| response size | **1,120,936 bytes** |
| `spawnSync` default `maxBuffer` | 1,048,576 bytes |

It cleared the default by ~72KB. This is a **latent bug 1.6.1 exposed, not caused** — before #423, `find_service()` swallowed lookup failures, so the overflow was invisible.

## Two defects fixed

1. **`maxBuffer` unset** → now 64MB, sized against the measured 1.1MB rather than a round guess.
2. **A spawn-level failure leaves `status === null` and stderr empty** (verified by local repro), so it fell through the `status !== 0` guard and produced an error with `aws_code: null`. The triage step in ci-actions#79 cannot classify that. Now `result.error` is reported separately and carries `spawn_code`.

Both call sites share `run()`, so one change covers them.

## ⚠️ This is a floor, not a cure

**~1,302 of the 1,701 services (77%) are leaked per-PR preview entries.** Raising the buffer stops today's failure, but the namespace keeps growing and `find_service()` still linearly scans it on every provision. The Cloud Map half of the cleanup sweep is still unowned — and `servicediscovery:DeleteService` is held by no operator tier (hipponot/iac#672), so reclaiming them needs that gap closed first.

## Rollout cost

Landing this needs another **publish → 6-host in-place SSM update** (the recipe from 1.6.1 is known-good). Draft until that's agreed.