### PR TITLE
Add can_view_district_programs to the staff control plane

### DIFF
--- a/packages/core/saga-authz-model/model.fga
+++ b/packages/core/saga-authz-model/model.fga
@@ -286,6 +286,10 @@ type saga_platform
     define can_create_org: org_admin
     define can_admin_personas: org_admin
     define can_manage_staff: super_admin
+    # Breadth over every district's program list. Staff hold no roster
+    # membership, so without this iam-api returns them no program permissions
+    # and program lists render empty.
+    define can_view_district_programs: org_admin
 
 # An organization staff create/administer. Maps 1:1 to an iam-api group
 # (kind=district): object id is the rostering group id. DISTINCT from the

--- a/packages/core/saga-authz-model/package.json
+++ b/packages/core/saga-authz-model/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/saga-authz-model",
-    "version": "0.1.0-dev.3",
+    "version": "0.1.0-dev.4",
     "private": false,
     "type": "module",
     "description": "Saga's OpenFGA authorization model (.fga DSL) and tuple-key helpers. Source of truth for ReBAC types and relations.",

--- a/packages/core/saga-authz-model/src/__tests__/model-fga.unit.test.ts
+++ b/packages/core/saga-authz-model/src/__tests__/model-fga.unit.test.ts
@@ -226,8 +226,14 @@ describe('staff control-plane namespace (SEC-CRIT-2)', () => {
                 'can_create_org',
                 'can_admin_personas',
                 'can_manage_staff',
+                'can_view_district_programs',
             ]),
         );
+    });
+
+    it('can_view_district_programs resolves from org_admin, not super_admin alone', () => {
+        const rel = byType.saga_platform.relations?.can_view_district_programs;
+        expect(rel?.computedUserset?.relation).toBe('org_admin');
     });
 
     it('staff_org uses staff_admin and NEVER admin (SEC-CRIT-2)', () => {

--- a/packages/core/saga-authz-model/src/types.ts
+++ b/packages/core/saga-authz-model/src/types.ts
@@ -85,7 +85,8 @@ export interface FgaRelationsByType {
         | 'can_impersonate'
         | 'can_create_org'
         | 'can_admin_personas'
-        | 'can_manage_staff';
+        | 'can_manage_staff'
+        | 'can_view_district_programs';
     staff_org:
         | 'platform'
         | 'staff_admin'
@@ -151,6 +152,7 @@ export const FGA_RELATIONS = {
         'can_create_org',
         'can_admin_personas',
         'can_manage_staff',
+        'can_view_district_programs',
     ],
     staff_org: [
         'platform',


### PR DESCRIPTION
Adds `can_view_district_programs` to `saga_platform`, resolving from `org_admin`.

## Why

The staff-admin console's programs page has **never** shown programs. Root cause, traced end-to-end in source:

- iam-api `getAuthorizationContext` (`persona.data.ts:1433`) reads **only** `group_memberships` rows and their resolved personas — zero janus/staff/FGA references. Staff roles are janus_session claims, not DB rows; `jitProvisionStaffUser` writes no membership rows.
- So a JumpCloud operator resolves to the synthesized `DEFAULT_USER_BUNDLE` entry (`persona.data.ts:1470-1476`) carrying only `coach:access_coach_app`.
- programs-api roster-scopes its list to `[]` unless the context carries `programs:view_district_programs` (`programs.service.ts:282-294`), returning an **empty HTTP 200 with no error** — indistinguishable from "this district has no programs".

## Why a capability, and why FGA

The model's own contract (this file, `:283-284`) is explicit: *"Computed capabilities — app code (fgaCheck) evaluates these, never the role nouns above."* So iam-api checking `org_admin` directly was out; it needs a capability to check.

The alternative — threading the janus claim into the data layer — was rejected in design review: authz-api's `authz.capabilities` is pinned **wire-compatible** with `personas.getMyPermissions` (`authz.router.ts:177`) but resolves an *arbitrary* `userId` from a service token (`authz.router.ts:63`), so it has no request identity. A request-scoped derivation would return different answers per service and silently revoke program visibility at the authz-api cutover.

FGA tuples are the durable, caller-independent source: authz-sync already writes `user:<id> <role> saga_platform:root` on `IamStaffRoleAssignedV1` and — importantly — already handles revocation via `IamStaffRoleRevokedV1` (`fga-sync.ts:61-67`).

## Scope

Resolves from `org_admin`, matching `can_create_org` and `can_admin_personas`. A read-only breadth grant doesn't warrant `super_admin`.

Deliberately **not** wiring `ADMIN_BUNDLE` (~40 perms incl. `permViewUserPii`, `permForceOnerosterIngest`) to a JumpCloud claim on the consumer side — iam-api will map this to a new bundle carrying only `permViewDistrictPrograms`.

## Verification

`model.fga`, `FgaRelationsByType`, and `FGA_RELATIONS` kept in lockstep as the CI drift test requires. Validated against `@openfga/syntax-transformer`:

```
DSL parsed OK. type count: 16
saga_platform relations: super_admin, support, org_admin, can_impersonate,
  can_create_org, can_admin_personas, can_manage_staff, can_view_district_programs
can_view_district_programs present: true
  resolves from: {"relation":"org_admin"}
DRIFT missing-from-types: []  extra-in-types: []
```

Added a unit test pinning that it resolves from `org_admin`.

## Sequencing

This is step 1 of a chain. Nothing consumes the new relation yet, so merging is inert on its own:

1. **this PR** — add the capability
2. publish `@saga-ed/saga-authz-model`
3. deploy fga-bootstrap (dev → prod)
4. iam-api — DI `FgaClientService` into `PersonaDataService`; emit a staff entry from the `resolvedPersonaIds.size === 0` branch, fail-closed (omit, never throw)
5. programs-api — harden the unfiltered `.some()` (`programs.service.ts:345`)

⚠️ **Tracked follow-up:** the same derivation must be replicated in authz-api `capabilities.service.ts:163` before the authz-api cutover, or this fix regresses there — the very defect that disqualified the request-scoped approach.
