### PR TITLE
docs(ss): document the scrub gap that makes hydrate refuse after a restore

### DIFF
--- a/packages/node/saga-stack-cli/docs/hydrate.md
+++ b/packages/node/saga-stack-cli/docs/hydrate.md
@@ -227,13 +227,45 @@ That failure surfaces days later as a 500. So hydrate then:
 | `--slot 0` (including a bare `--slot`) is refused | none | `ss stack cold-start` resets slot 0 |
 | non-local target (repointed `$SAGA_MESH_POSTGRES_CONTAINER`, non-loopback host, wrong port) | none | unset the override |
 | slot's postgres container not running | none | `ss stack up --slot N` |
-| wrong AWS account | none | `--profile dev_admin` |
+| wrong AWS account | none | a profile resolving to the dev account (`396913734878`) — `dev_admin` is an example name, not an issued profile |
+| a scrubbed database enumerates zero `_real` tables (the daily scrub has not landed yet) | none | wait ~30 min and re-run — see [The scrub gap](#the-scrub-gap) |
 | another driver's live claim on the slot | `--yes` | wait, or `ss stack slots` |
 | destructive confirm | `--yes` | — |
 
 A **declined prompt** is an abort: exit 0, "hydrate aborted — nothing changed". The
 structural refusals above are `this.error` → exit 2. A per-database failure emits the full
 report, then exits 1.
+
+### The scrub gap
+
+The mirror's endpoint is published to SSM **before** the daily scrub renames each app table to
+`{table}_real` and lays a scramble view over it. A hydrate started inside that window fails
+discovery:
+
+```
+enumerated ZERO _real tables in iam_db, but it is a scrubbed database — expected at
+least 12 (e.g. auth_associations, audit_logs, event_outbox).
+```
+
+That is a refusal, not a defect. Zero `_real` tables is ambiguous, and the two causes want
+opposite answers: the scrub may simply not have run (the database is raw prod, every app-named
+relation is already an ordinary writable table, and hydrating would be safe), or it may have run
+and moved off `public` / renamed its suffix (the app names are read-only VIEWs, and promoting
+those over a good local database is exactly the outcome the view-swap exists to prevent). A count
+alone cannot separate them, so hydrate declines both.
+
+Measured 2026-08-10: mirror RDS instance created 14:06 UTC,
+`/mirror/current/postgres-rds/endpoint` updated 14:16, hydrate still refused at 14:22, succeeded
+at 14:49. **Wait ~30 minutes and re-run.** To see where you are in the cycle:
+
+```bash
+aws ssm get-parameter --name /mirror/current/postgres-rds/endpoint \
+  --profile dev_admin --query Parameter.LastModifiedDate --output text
+```
+
+`pii-scrubber-api-dev` is **not** the job that performs this scrub — it has been idle since
+2026-04-28 and carries no EventBridge schedule. Its CloudWatch history is a dead end; do not
+spend time there.
 
 ### Preview by default
 


### PR DESCRIPTION
Docs only, `saga-stack-cli/docs/hydrate.md`.

## The gap

`hydrate.md` documents every structural refusal in its Guards table but says nothing about the failure you are most likely to actually hit, which is transient and self-resolving. Run `ss stack hydrate` too soon after the daily mirror restore and you get:

```
enumerated ZERO _real tables in iam_db, but it is a scrubbed database — expected at
least 12 (e.g. auth_associations, audit_logs, event_outbox). The daily scrub may not
have run, or its naming changed.
```

The message is accurate but gives no timing guidance, so it reads as a broken mirror. The endpoint in `/mirror/current/postgres-rds/endpoint` is already updated at that point, which makes it look like the mirror is ready when the scrub has not finished.

## What this adds

A **"The scrub gap"** section covering:

- **Why the refusal is correct.** Zero `_real` tables is genuinely ambiguous, and the two causes want opposite answers. The scrub may not have run — the database is raw prod, every app-named relation is already an ordinary writable table, and hydrating would be safe. Or the scrub ran and moved off `public` / renamed its suffix — the app names are read-only VIEWs, and promoting those over a good local database is exactly what the view swap exists to prevent. A count cannot separate them, so hydrate declines both.
- **Measured timings**, so people know how long to wait rather than guessing.
- **A command** to check where you are in the cycle (`LastModifiedDate` on the endpoint parameter).
- **An explicit dead end.** `pii-scrubber-api-dev` is not the job that performs this scrub — no invocations in 24h, last log stream 2026-04-28, no matching EventBridge rule, no relevant Step Function. I lost time in its CloudWatch history and would rather nobody repeats that.

Two Guards-table rows: the scrub gap, and a correction that `dev_admin` is an **example** profile name rather than one anyone is issued. The CLI validates the resolved account (`DEV_ACCOUNT_ID = 396913734878` in `core/env/registry.ts`), and `exampleProfile: 'dev_admin'` is literally labelled as an example in the same file — but the docs read as though it is a name you have. That was the first thing that blocked a real run.

## Measurements

All from a live hydrate of slot 1 on 2026-08-10:

- mirror RDS instance created **14:06 UTC**
- `/mirror/current/postgres-rds/endpoint` updated **14:16**
- hydrate refused **14:22** (probed the mirror directly: 22 relations in `public`, all `relkind='r'`, zero views, zero `_real`)
- hydrate succeeded **14:49**, 12 tables materialised

## Related

There is a real argument that the guard itself is over-broad — it could census views and allow the provably-safe case (0 `_real` **and** 0 views) instead of refusing both. I prototyped that and backed it out, because on the day it turned out waiting ~30 minutes was the correct answer and the tooling change was not needed. Documenting the wait is the cheap fix; tightening the guard is a separate call for whoever owns hydrate.

The coach-side walkthrough is corrected in saga-ed/coach#424.
