### PR TITLE
Log the real fate of a nacked poison message

### DIFF
--- a/packages/node/event-consumer/src/consumer.ts
+++ b/packages/node/event-consumer/src/consumer.ts
@@ -401,7 +401,9 @@ export class EventConsumer {
                 err instanceof MalformedEnvelopeError ||
                 err instanceof ConsumerVersionMismatchError;
             const requeue = poison ? false : !this.opts.dlq;
-            const fate = poison ? 'drop' : this.opts.dlq ? 'DLQ' : 'requeue';
+            // A nack with requeue=false lands in the DLQ whenever one is
+            // configured — poison included. Only an unrouteable nack drops.
+            const fate = this.opts.dlq ? 'DLQ' : poison ? 'drop' : 'requeue';
             this.opts.logger.error(
                 `[EventConsumer:${this.opts.consumerName}] handler error → ${fate}`,
                 err instanceof Error ? err : undefined,


### PR DESCRIPTION
## The defect

`EventConsumer.dispatch` nacks poison messages (malformed envelope, consumer version mismatch) with `requeue=false`. When a DLQ is configured, the broker routes that to the DLX — the message goes to the **DLQ**. The log line claimed `drop` for every poison error regardless:

```ts
const fate = poison ? 'drop' : this.opts.dlq ? 'DLQ' : 'requeue';
```

So an operator investigating a version-mismatched message was told it was gone, when it was sitting in the DLQ waiting to be inspected.

## The fix

Order the ternary on the DLQ configuration, which is what actually governs the broker's behavior:

```ts
const fate = this.opts.dlq ? 'DLQ' : poison ? 'drop' : 'requeue';
```

`drop` now applies only to the genuinely unrouteable case where no DLQ exists — which remains correct for poison-without-DLQ.

## Scope

Log-string only. No behavior change: `requeue` is untouched, so message routing is identical before and after. This will not be visible in downstream repos until `@saga-ed/soa-event-consumer` republishes and they pick it up.

Found while auditing event-consumer guardrails for the rostering program-authorization consolidation. The related ask there — a metric distinguishing version-mismatch from handler failure — is deliberately **not** in this PR: it's a new metric surface in a fleet-shared library and deserves its own decision.

## Verification

`pnpm check-types` clean; 26/26 tests pass. No test asserted the old label.

https://claude.ai/code/session_012jEPRkR3gAjWmChGwSEoYC