### PR TITLE
fix(saga-stack-cli): unbreak `--with staff-admin` on slot 0 + seed content with a session

### DIFF
--- a/packages/node/saga-stack-cli/src/core/manifest/__tests__/staff-admin.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/__tests__/staff-admin.unit.test.ts
@@ -62,7 +62,27 @@ describe('staff-admin manifest entries', () => {
 
   it('brings the BFF up before the SPA that proxies to it', () => {
     expect(spa.dependsOn).toContain('staff-admin-bff');
-    expect(bff.dependsOn).toEqual(['iam-api', 'programs-api', 'sis-api']);
+    expect(bff.dependsOn).toEqual(['iam-api', 'programs-api', 'sis-api', 'content-api']);
+  });
+
+  it('TELLS the BFF its listen port instead of relying on offset injection', () => {
+    // 🪤 launch-plan injects `portEnvVar` ONLY when the resolved port differs
+    // from the manifest base ("so slot-0 env stays byte-identical"). At slot 0
+    // this BFF resolves to 3011 === its manifest 3011, so nothing is injected —
+    // and local.ts falls back to its OWN baked default of 3000. The health poll
+    // then watches :3011 forever and the launch fails as "never became healthy".
+    // Every other portEnvVar service bakes the same default as its manifest
+    // port; this one is the lone exception, so it must say so explicitly.
+    expect(bff.launch.env.PORT).toBe('${STAFF_ADMIN_BFF_PORT}');
+  });
+
+  it('points the BFF at content-api, whose baked default is another service', () => {
+    // 🪤 The BFF's built-in CONTENT_API_URL default is localhost:3010 — which in
+    // this manifest is iam-api, not content-api (:3009). Unset, the console's
+    // connect-content pages query iam-api and get plausible 200s off the wrong
+    // service, reading as "content is empty" rather than as a misconfiguration.
+    expect(bff.launch.env.CONTENT_API_URL).toBe('http://localhost:${CONTENT_PORT}');
+    expect(bff.depKinds['content-api']).toBe('url');
   });
 
   it('keeps the BFF off the contested :3000', () => {
@@ -95,11 +115,13 @@ describe('staff-admin closure admission', () => {
   it('resolves the pair + its upstream closure under withStaffAdmin', () => {
     const c = computeClosure(manifest, [...ids], { withStaffAdmin: true });
     // The whole point of the bundle: one flag, and the upstreams the console
-    // reads come along automatically.
+    // reads come along automatically — content-api included, since the
+    // connect-content pages (search + bulk ingest) are unusable without it.
     expect(c.services).toEqual([
       'iam-api',
       'sis-api',
       'programs-api',
+      'content-api',
       'staff-admin-bff',
       'staff-admin-console',
     ]);

--- a/packages/node/saga-stack-cli/src/core/manifest/services.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/services.ts
@@ -1003,15 +1003,23 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
     port: 3011,
     // `pnpm dev` = `JANUS_REQUIRED=false tsx watch src/local.ts`, so the janus
     // (JumpCloud) perimeter bypass rides along for free — a local operator has
-    // no janus_session to present. src/local.ts reads `PORT`, so the launcher
-    // injects 3011 (and the slot offset) rather than the app's baked default.
+    // no janus_session to present. src/local.ts reads `PORT`.
     portEnvVar: 'PORT',
     healthPath: '/health/ready',
     databases: [],
-    dependsOn: ['iam-api', 'programs-api', 'sis-api'],
+    dependsOn: ['iam-api', 'programs-api', 'sis-api', 'content-api'],
     // All plain URL reads — the BFF proxies the operator's forwarded cookie to
     // each. No S2S: access rides on the `iam_session` `ss stack login` mints.
-    depKinds: { 'iam-api': 'url', 'programs-api': 'url', 'sis-api': 'url' },
+    // content-api is what the console's `connect-content` pages read and bulk-
+    // ingest through (backend/src/content-client.ts); it was undeclared until
+    // this fix, which left `--with staff-admin` composing a closure with no
+    // content-api in it.
+    depKinds: {
+      'iam-api': 'url',
+      'programs-api': 'url',
+      'sis-api': 'url',
+      'content-api': 'url',
+    },
     mesh: [],
     launch: {
       cmd: 'pnpm dev',
@@ -1028,6 +1036,22 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
         // compose the origin from the port tokens and slot correctly.
         PROGRAMS_API_URL: 'http://localhost:${PROGRAMS_PORT}',
         SIS_API_URL: 'http://localhost:${SIS_PORT}',
+        // 🪤 The BFF's baked CONTENT_API_URL default is localhost:3010 — which
+        // in THIS stack is iam-api, not content-api (:3009). Left unset, the
+        // console's connect-content pages query iam-api and get plausible 200s
+        // off the wrong service, which reads as "content is empty" rather than
+        // as a misconfiguration. Always inject it.
+        CONTENT_API_URL: 'http://localhost:${CONTENT_PORT}',
+        // 🪤 PORT must be explicit, NOT left to launch-plan's offset injection.
+        // That injection is guarded on `ctx.ports[service] !== def.port`, so at
+        // slot 0 (resolved 3011 === manifest 3011) it does not fire — and
+        // local.ts then falls back to its OWN baked default of 3000. The health
+        // poll watches :3011, the BFF listens on :3000, and the launch fails as
+        // "never became healthy". Every other portEnvVar service bakes the same
+        // default as its manifest port, so this one is the lone exception. An
+        // explicit launch.env entry wins over the injection, and the token keeps
+        // slots 1..9 correct.
+        PORT: '${STAFF_ADMIN_BFF_PORT}',
         // Impersonation hands off to the local dash. Slot-correct via the token
         // rather than the BFF's own localhost:8900 default.
         IMPERSONATION_MOCK_DASH_ORIGIN: '${DASH_URL}',

--- a/packages/node/saga-stack-cli/src/core/seed/profiles.ts
+++ b/packages/node/saga-stack-cli/src/core/seed/profiles.ts
@@ -427,6 +427,18 @@ export function buildSeedRegistry(m: Manifest = manifest): Record<SeedStepId, Se
           // is VENDORED under the CLI's `vendor/` dir (Phase-2 DECOUPLING) — the `vendor`
           // sentinel cwd tells the runtime adapter (`stack-api` seedCwd) to run it from
           // there (resolved via the VENDOR_DIR launch token), NOT `tools/synthetic-dev`.
+          //
+          // AUTH: content-api gates REST writes on a verified iam_session
+          // (program-hub#570), so this step 401s unless `IAM_SESSION` is set. It is
+          // deliberately NOT in `vars` below — there is no token for a minted JWT, and
+          // exec spawns seed steps with `{...process.env, ...spec.env}`, so an exported
+          // IAM_SESSION reaches both this script and the legacy-poll migrate below:
+          //
+          //   IAM_SESSION=$(awk '/iam_session/{print $7}' /tmp/sds-synthetic/cookies.txt) \
+          //     ss stack seed full
+          //
+          // `failureMode: 'warn'` keeps a session-less `up` green — you lose the demo
+          // polls, not the stack. Teaching the CLI to mint its own jar is a follow-up.
           id: 'demo-polls',
           service: 'content-api',
           databases: ['content'],

--- a/packages/node/saga-stack-cli/vendor/seed-demo-polls.mjs
+++ b/packages/node/saga-stack-cli/vendor/seed-demo-polls.mjs
@@ -9,9 +9,43 @@
 // the migrate tool's idempotency: GET /items/:ref → 404 ⇒ POST, 200 ⇒ PUT,
 // then POST /publish. Safe to re-run (and to call from up.sh `seed_content`).
 //
-//   CONTENT_API=http://localhost:3009 node seed-demo-polls.mjs
+//   CONTENT_API=http://localhost:3009 IAM_SESSION=<jwt> node seed-demo-polls.mjs
+//
+// IAM_SESSION is REQUIRED against a content-api built after program-hub#570,
+// which gates every REST write on a verified `iam_session` (cookie or bearer)
+// and fails closed with no dev bypass. Same env var, same spelling, as
+// content-api's own `tools/legacy-poll-migrate/migrate.ts`. Mint one with
+// `ss stack login` and read it out of the cookie jar:
+//
+//   IAM_SESSION=$(awk '/iam_session/{print $7}' /tmp/sds-synthetic/cookies.txt)
 // ───────────────────────────────────────────────────────────────────────────
 const BASE = (process.env.CONTENT_API || 'http://localhost:3009').replace(/\/$/, '');
+const IAM_SESSION = process.env.IAM_SESSION ?? '';
+
+/** Headers for a WRITE leg. The read leg (GET) needs none — content-api's gate
+ *  lets safe methods through — but sending the cookie there too is harmless and
+ *  keeps one code path. Omitting the cookie entirely when unset preserves the
+ *  pre-gate behaviour against an older content-api. */
+function writeHeaders(hasBody = true) {
+  return {
+    ...(hasBody ? { 'content-type': 'application/json' } : {}),
+    ...(IAM_SESSION ? { cookie: `iam_session=${IAM_SESSION}` } : {}),
+  };
+}
+
+/** A 401 here is almost always "no session", not "bad payload" — say so, rather
+ *  than making the reader diff a poll body against the schema. Mirrors the hint
+ *  migrate.ts prints for the identical failure. */
+async function writeFailed(verb, ref, res) {
+  const body = await res.text();
+  const hint =
+    res.status === 401
+      ? ` — content-api requires a verified iam_session on writes; ${
+          IAM_SESSION ? 'the IAM_SESSION passed was rejected (expired?)' : 'set IAM_SESSION'
+        } (mint one with \`ss stack login\`)`
+      : '';
+  return new Error(`${verb} ${ref} → ${res.status}: ${body}${hint}`);
+}
 
 /** One question → one page: grid background + a textbox carrying the prompt.
  *  `TextBoxElement.content` is what the qboard synthesizer renders (HTML-stripped);
@@ -63,25 +97,28 @@ async function upsertAndPublish(p) {
   if (existing.status === 404) {
     const r = await fetch(`${BASE}/content/items`, {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
+      headers: writeHeaders(),
       body: JSON.stringify(payload),
     });
-    if (!r.ok) throw new Error(`POST ${p.ref} → ${r.status}: ${await r.text()}`);
+    if (!r.ok) throw await writeFailed('POST', p.ref, r);
     action = 'created';
   } else if (existing.status === 200) {
     const r = await fetch(`${BASE}/content/items/${p.ref}`, {
       method: 'PUT',
-      headers: { 'content-type': 'application/json' },
+      headers: writeHeaders(),
       body: JSON.stringify({ title: payload.title, body, metadata: payload.metadata }),
     });
-    if (!r.ok) throw new Error(`PUT ${p.ref} → ${r.status}: ${await r.text()}`);
+    if (!r.ok) throw await writeFailed('PUT', p.ref, r);
     action = 'updated';
   } else {
     throw new Error(`GET ${p.ref} → unexpected ${existing.status}`);
   }
 
-  const pub = await fetch(`${BASE}/content/items/${p.ref}/publish`, { method: 'POST' });
-  if (!pub.ok) throw new Error(`publish ${p.ref} → ${pub.status}: ${await pub.text()}`);
+  const pub = await fetch(`${BASE}/content/items/${p.ref}/publish`, {
+    method: 'POST',
+    headers: writeHeaders(false),
+  });
+  if (!pub.ok) throw await writeFailed('publish', p.ref, pub);
   return `${action} + published  ${p.ref}  (${body.pages.length} pages)`;
 }
 


### PR DESCRIPTION
Three cross-repo drifts in `saga-stack-cli`, each of which fails as a plausible-looking 200/404 or a silent misroute rather than a crash. Found while trying to reach the staff-admin console's bulk content upload on a slot-0 stack.

## 1. `--with staff-admin` never comes up on slot 0

`stack up --with staff-admin` fails with `service launch FAILED at staff-admin-bff — it never became healthy`, and :8910 404s.

`launch-plan.ts` injects `portEnvVar` **only when the resolved port differs from the manifest base**:

```js
if (portEnvVar != null && ctx.ports[service] !== def.port && !(portEnvVar in env)) {
```

with the rationale *"so slot-0 env stays byte-identical"*. At slot 0 this BFF resolves to 3011 — equal to its manifest 3011 — so `PORT` is never set, and `backend/src/local.ts` falls back to `Number(process.env.PORT ?? 3000)`. The health poll watches :3011 while the BFF listens on :3000. `staff-admin-console` `dependsOn` the BFF, so it never launches either.

That guard assumes a service's baked default equals its manifest port. True for programs/scheduling/sessions; **false for staff-admin-bff alone** (3000 vs 3011) — which is also why this only reproduces on slot 0, and why slots 1–9 were fine.

Fixed with an explicit `PORT: '${STAFF_ADMIN_BFF_PORT}'` in `launch.env` — the guard's `!(portEnvVar in env)` clause defers to an explicit entry, and the token keeps offset slots correct.

## 2. content-api was an undeclared dependency of the BFF

The console's `connect-content` pages (search + bulk ingest) go through `backend/src/content-client.ts` to content-api, but `staff-admin-bff` declared only `['iam-api', 'programs-api', 'sis-api']` — so `--with staff-admin` composed a closure with no content-api in it.

Worse than a missing service: the BFF's baked `CONTENT_API_URL` default is `localhost:3010`, which in this manifest is **iam-api**, not content-api (:3009). Unset, the pages query the wrong service and get plausible 200s — which reads as "content is empty" rather than as a misconfiguration.

Declared `content-api` as a `url` dep and inject the URL from `${CONTENT_PORT}`.

## 3. The demo-polls seeder sends no credential

content-api began gating REST writes on a verified `iam_session` in program-hub#570 — fails closed, no `x-user-id` fallback, no dev bypass. The vendored `seed-demo-polls.mjs` sends only `content-type`, so every write 401s and the demo polls silently stopped seeding on any stack pulled past that commit:

```
Error: POST demo-poll-arithmetic → 401: {"error":"Authentication required"}
```

It now honours `IAM_SESSION` — the same env var and spelling as content-api's own `tools/legacy-poll-migrate/migrate.ts`, which already supported it — and a 401 explains itself rather than looking like a bad payload.

```
IAM_SESSION=$(awk '/iam_session/{print $7}' /tmp/sds-synthetic/cookies.txt) ss stack seed full
```

`exec.ts` spawns seed steps with `{...process.env, ...spec.env}`, so an exported `IAM_SESSION` reaches both this script and the legacy-poll migrate step. Both steps stay `failureMode: 'warn'`, so a session-less `up` is still green — you lose the demo polls, not the stack.

## Verification

Against a live slot-0 stack:

- BFF comes up on :3011, `/health/ready` → 200
- console serves `/connect-content/bulk-add` → 200
- `GET :3011/api/content/search` with the `ss stack login` jar returns real content-api rows (proving the :3009 wiring, not :3010)
- the patched seeder creates + publishes all three demo polls with a session, and prints an actionable error without one

`pnpm build`, `pnpm check-types` and the full suite pass — **1733 tests / 135 files**. Two assertions in `staff-admin.unit.test.ts` encoded the old dependency list and were updated; two new regression tests cover the `PORT` and `CONTENT_API_URL` guarantees, in the same "fails as a plausible 200" idiom the file already documents.

`pnpm lint` couldn't run locally (eslint isn't in the filtered install); prettier flags only pre-existing violations in untouched regions of these files — no new ones added.

## Follow-up (not in this PR)

The CLI could mint its own session for the content seed steps instead of requiring an exported `IAM_SESSION` — it already has the login path that writes the cookie jar. Left out to keep this scoped to the breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
