### PR TITLE
Point each synthetic slot's dash at its own authz-api instead of the CORS-blocked deployed host

### DIFF
--- a/packages/node/saga-stack-cli/src/runtime/__tests__/dash-defaults.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/runtime/__tests__/dash-defaults.unit.test.ts
@@ -84,10 +84,11 @@ describe('syncDashLocalDefaults', () => {
       type: 'url',
       url: 'https://ads-adm.abc.vms.wootdev.com',
     });
-    // transcripts-api/ledger-api are NOT forwarded by the tunnel, so they must
-    // stay out of the tunnel map (a label would point at a dead host).
+    // transcripts-api/ledger-api/authz-api are NOT forwarded by the tunnel, so they
+    // must stay out of the tunnel map (a label would point at a dead host).
     expect(parsed.localDefaults['transcripts-api']).toBeUndefined();
     expect(parsed.localDefaults['ledger-api']).toBeUndefined();
+    expect(parsed.localDefaults['authz-api']).toBeUndefined();
     // every label key present, trailing newline preserved.
     expect(Object.keys(parsed.localDefaults).sort()).toEqual(Object.keys(DASH_TUNNEL_LABELS).sort());
     expect(written[0].contents.endsWith('\n')).toBe(true);
@@ -125,6 +126,7 @@ describe('syncDashLocalDefaults — M7 stack-lane slot config', () => {
     'connect-api': 6106 + offset,
     'ads-adm-api': 5005 + offset,
     'transcripts-api': 6302 + offset,
+    'authz-api': 3200 + offset,
   });
 
   it('slot 0 still REMOVES config.local.json (byte-identical) even with stackPorts present', () => {
@@ -162,7 +164,14 @@ describe('syncDashLocalDefaults — M7 stack-lane slot config', () => {
       type: 'url',
       url: 'http://localhost:7302',
     });
-    // same key set as the tunnel writer.
+    // authz-api must be routed LOCALLY (3200 + 1000). Absent from this map the dash
+    // gets no local answer at all and falls through to the switchboard's deployed
+    // https://authz-api.wootdev.com — a CORS block on every affordances call.
+    expect(parsed.localDefaults['authz-api']).toEqual({
+      type: 'url',
+      url: 'http://localhost:4200',
+    });
+    // every key of its own map present — a SUPERSET of the tunnel writer's keys.
     expect(Object.keys(parsed.localDefaults).sort()).toEqual(Object.keys(DASH_LOCAL_SERVICES).sort());
     expect(written[0].contents.endsWith('\n')).toBe(true);
   });
@@ -171,6 +180,20 @@ describe('syncDashLocalDefaults — M7 stack-lane slot config', () => {
     const parsed = JSON.parse(stackSlotConfigContents({ 'iam-api': 4010 }));
     expect(parsed.localDefaults.iam).toEqual({ type: 'url', url: 'http://localhost:4010' });
     expect(parsed.localDefaults.connect).toBeUndefined(); // connect-api port absent → dropped
+  });
+
+  it("the dash's authz-api key resolves to the slot's OWN authz-api offset port", () => {
+    // Ties the map entry to the manifest rather than a literal: authz-api is
+    // slottable (not in SLOT_EXCLUDED_SERVICES), so base + slot*1000 is a port THIS
+    // slot listens on — measured on slot 5, where 8200 answers /health 200.
+    const port = getService('authz-api').port + 5 * 1000;
+    expect(port).toBe(8200);
+    expect(DASH_LOCAL_SERVICES['authz-api']).toBe('authz-api');
+    const parsed = JSON.parse(stackSlotConfigContents({ 'authz-api': port }));
+    expect(parsed.localDefaults['authz-api']).toEqual({
+      type: 'url',
+      url: 'http://localhost:8200',
+    });
   });
 });
 

--- a/packages/node/saga-stack-cli/src/runtime/dash-defaults.ts
+++ b/packages/node/saga-stack-cli/src/runtime/dash-defaults.ts
@@ -39,9 +39,10 @@ import type { ServiceId } from '../core/manifest/index.js';
  * (`ads-adm:5005` in tools/synthetic-dev/tunnel.sh) and the dash's Overview page
  * dials it for real (`adm.getOverviewSummary`) — without this entry the dash
  * falls back to `config.json`'s `ads-adm: localhost:5005`, a mixed-content block
- * from the HTTPS tunnel page. `transcripts-api`/`ledger-api` are intentionally
- * absent: the tunnel does not forward them, so a label here would point at a
- * dead host.
+ * from the HTTPS tunnel page. `transcripts-api`/`ledger-api`/`authz-api` are
+ * intentionally absent: the tunnel does not forward them (its `SERVICES` table
+ * has no authz entry — the manifest's `tunnelSlug: 'authz'` only shapes the lane
+ * URL, it forwards nothing), so a label here would point at a dead host.
  */
 export const DASH_TUNNEL_LABELS: Readonly<Record<string, string>> = {
   iam: 'iam',
@@ -57,10 +58,12 @@ export const DASH_TUNNEL_LABELS: Readonly<Record<string, string>> = {
 
 /**
  * The dash service-key → manifest `ServiceId` whose localhost port backs it (M7
- * stack-lane slot config). Same key set as `DASH_TUNNEL_LABELS`; `program-hub` and
- * `enrollment-api` both resolve to programs-api, `connect` to connect-api. Used to
- * WRITE a slot's `config.local.json` pointing each dash service at its offset
- * localhost port (else the dash's built-in defaults hit slot 0's base ports).
+ * stack-lane slot config). A SUPERSET of `DASH_TUNNEL_LABELS`'s keys —
+ * `transcripts-api` and `authz-api` are local-only, having no tunnel host to name;
+ * `program-hub` and `enrollment-api` both resolve to programs-api, `connect` to
+ * connect-api. Used to WRITE a slot's `config.local.json` pointing each dash service
+ * at its offset localhost port (else the dash's built-in defaults hit slot 0's base
+ * ports, or — for a key absent here entirely — the switchboard's DEPLOYED host).
  */
 export const DASH_LOCAL_SERVICES: Readonly<Record<string, ServiceId>> = {
   iam: 'iam-api',
@@ -82,6 +85,17 @@ export const DASH_LOCAL_SERVICES: Readonly<Record<string, ServiceId>> = {
   // refused) instead of writing cross-slot — the corruption gate.
   'ads-adm': 'ads-adm-api',
   'transcripts-api': 'transcripts-api',
+  // Missed when soa#402 added authz-api: the dash resolves its authz endpoint via
+  // `topologyStore.getEndpoint('authz-api')` and dials `authz.affordances` on every
+  // page load. With NO entry here that key never gets a local answer at all — it
+  // falls through to the switchboard's DEPLOYED host (https://authz-api.wootdev.com),
+  // which the browser CORS-blocks, so every slot quietly evaluates affordances
+  // through the iam getMyPermissions fallback while its own authz-api sits healthy on
+  // the offset port. Unlike the two above there is no cross-slot hazard to weigh:
+  // authz-api is slottable (tokenized `PORT: ${AUTHZ_PORT}`, absent from
+  // SLOT_EXCLUDED_SERVICES), so the offset port (8200 at slot 5) is the slot's OWN
+  // authz-api, and the affordances call is a read either way.
+  'authz-api': 'authz-api',
 };
 
 /** Inputs to the dash-defaults prelaunch hook. */


### PR DESCRIPTION
Every synthetic slot's dash was evaluating affordances through the IAM fallback instead of its own local authz-api, because `DASH_LOCAL_SERVICES` — the map that generates each slot's dash `config.local.json` — had no `authz-api` entry.

## Observed (2026-08-20, slot 5, real browser)

The dash resolves its authz endpoint via `topologyStore.getEndpoint('authz-api')` (saga-dash `apps/web/dash/src/routes/+layout.ts`, ~285-295 and ~513-524). With no local override the key never gets a local answer at all — it falls through to the switchboard's **deployed** host, which the browser then blocks:

```
Access to fetch at 'https://authz-api.wootdev.com/trpc/authz.affordances?batch=1&input=...'
from origin 'http://localhost:13900' has been blocked by CORS policy
[dash] authz affordances unavailable; falling back to permission-derived affordances
authz capabilities unavailable; falling back to iam getMyPermissions
```

Several times per page load, on every slot. Not fatal — the dash degrades to permission-derived affordances — but it means no slot ever exercises the local authz-api, which is up and healthy the whole time (slot 5: `http://localhost:8200/health` → 200). That masks authz-shaped bugs, shows affordances that differ from a deployed environment, and buries real console errors in noise.

## The fix

One entry in `DASH_LOCAL_SERVICES` (`packages/node/saga-stack-cli/src/runtime/dash-defaults.ts`):

```ts
'authz-api': 'authz-api',
```

so each slot's generated `config.local.json` (and the `DASH_CONFIG_LOCAL_JSON` launch env that shadows it, soa#328) points the dash at that slot's own authz-api on its offset port. The manifest `ServiceId` is `authz-api` (`core/manifest/types.ts:18`, `core/manifest/services.ts:210`), base port 3200 → 8200 at slot 5, matching the healthy port measured above.

Two stale doc-comment claims fixed alongside it: `DASH_LOCAL_SERVICES` is not the "same key set as `DASH_TUNNEL_LABELS`" (it is a superset — `transcripts-api` was already local-only), and the tunnel map's intentionally-absent list now names `authz-api` too.

## Judgement call 1 — `DASH_TUNNEL_LABELS`: NO, authz stays out

The tunnel does **not** forward authz, so a label here would point at a dead host — exactly the reason `transcripts-api`/`ledger-api` are already excluded.

Evidence: the `SERVICES` forward table in `tools/synthetic-dev/tunnel.sh` (~line 53-66) lists `iam`, `sis`, `programs`, `scheduling`, `sessions`, `content`, `ads-adm`, `dash`, `connect`, `connect-api`, `rtsm`, `coach`, `coach-api` — no authz. Same in the vendored copy `packages/node/saga-stack-cli/vendor/tunnel.sh` that `ss` actually ships (the two are kept in lockstep by `vendor-tunnel-drift.unit.test.ts`).

Worth flagging because it looks like a near miss: the manifest **does** carry `tunnelSlug: 'authz'` on authz-api. That slug only renders the `lane.tunnel` URL template (`lanes()`, services.ts:35); it does not cause frpc to forward anything. The existing test now pins `localDefaults['authz-api']` as undefined in tunnel mode so this can't drift.

## Judgement call 2 — slot-0 vs slot-N: no analogous corruption risk

The `ads-adm`/`transcripts-api` comment block guards a real hazard: a slot > 0 dash keeping base `config.json` ports (5005/6302 = **slot 0's** services) and writing across slots. Adding authz cannot reproduce it:

- **authz-api is slottable.** It is not in `SLOT_EXCLUDED_SERVICES` (`core/derive-instance.ts:114`), and its launch env is fully tokenized (`PORT: '${AUTHZ_PORT}'`, services.ts:225), so at slot N it genuinely listens on base + N*1000. Confirmed empirically: slot 5's authz-api answers on 8200, not 3200.
- **`portOverrides` covers every manifest service** unconditionally (`deriveInstance`, derive-instance.ts:~252), so `stackPorts['authz-api']` always resolves at slot > 0 — no risk of the key being silently dropped by `stackSlotConfigContents`.
- The direction of the bug is the opposite of the ads-adm one anyway: without the entry the dash reached a **deployed** host, not slot 0's. There is no local port it could have leaked onto.
- The call is a read (`authz.affordances` / capabilities), so even a hypothetical cross-slot reach would not corrupt state the way a stage-7 attendance write does.

Also verified: authz-api is a hard `dependsOn` of sessions-api (services.ts:339, soa#402) and the closure is transitive, so any dash closure that pulls sessions-api already brings authz-api up — the entry will not point at a dead port in practice. (`saga-dash`'s own `dependsOn` does not list authz-api directly; left alone, since adding a manifest edge would reshape closures well beyond this fix.)

## Tests

`src/runtime/__tests__/dash-defaults.unit.test.ts` is the only file that pins these maps — the other `transcripts-api` mentions (`stack-api.unit.test.ts`, `slot-guard.unit.test.ts`, `env-verify.int.test.ts`) are about slot exclusion and deployed hosts, not the dash maps, and needed no change. Updated:

- `slotPorts` helper gains `'authz-api': 3200 + offset` (needed — the whole-key-set assertion drops a key with no resolved port).
- slot > 0 write test asserts `localDefaults['authz-api'] === http://localhost:4200` (3200 + slot 1).
- tunnel test asserts `localDefaults['authz-api']` is undefined, alongside transcripts/ledger.
- New test tying the entry to the manifest rather than a literal: `getService('authz-api').port + 5 * 1000` → 8200, the port measured healthy on slot 5.

Results, run in the worktree:

- `pnpm test` (`vitest run`) — **135 files, 1734 passed, 14 todo, 0 failed**
- `pnpm check-types` (`tsc --noEmit`) — clean
- `pnpm lint` (`eslint src/`) — 0 errors (132 pre-existing `turbo/no-undeclared-env-vars` warnings, none in the touched files)

## Unblocking a slot that is already up

`config.local.json` is gitignored and regenerated on the next `ss stack up`, so a live slot does not need a restart to test this: add the entry by hand to that slot's `apps/web/dash/static/config.local.json` and reload —

```json
"authz-api": { "type": "url", "url": "http://localhost:8200" }
```

(8200 = slot 5; base 3200 + slot × 1000). The next `ss stack up` regenerates the file from this map anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4RkzkNSJ6rbpu8QihRjew
