### PR TITLE
Give authz-api the slot's dash CORS origin so slot > 0 affordances stop falling back

### DIFF
--- a/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.slot.unit.test.ts
+++ b/packages/node/saga-stack-cli/src/core/__tests__/launch-plan.slot.unit.test.ts
@@ -284,3 +284,50 @@ describe('coach-web x programs-api slottability (coach#329) — the browser dial
     );
   });
 });
+
+describe('authz-api CORS x slot — the dash origin the browser actually presents', () => {
+  const slotCtx = (slot: number) => {
+    const p = deriveInstance({ slot });
+    return defaultLaunchContext({
+      ...baseInputs,
+      portOverrides: p.portOverrides,
+      meshOffset: p.meshOffset,
+    });
+  };
+
+  it('slot 0: the dash origin authz-api already trusted via its hardcoded devOrigins', () => {
+    // rostering's origin-allowlist.ts hardcodes devOrigins ['http://localhost:8900',
+    // 'http://localhost:3010'] — slot 0's dash + the iam demo page. At slot 0 the
+    // stamped value is the same origin, so this is byte-identity, not new trust.
+    expect(resolveLaunchEnv('authz-api', 'stack', slotCtx(0)).CORS_ORIGIN).toBe(
+      'http://localhost:8900',
+    );
+  });
+
+  it('slot 5: admits the SLOT dash (:13900) — the origin devOrigins can never cover', () => {
+    // The measured break: with soa#432 pointing the slot-5 dash at its own
+    // authz-api (:8200 = 3200 + 5000), the preflight came back with no
+    // Access-Control-Allow-Origin because devOrigins only ever names slot 0.
+    // ${DASH_URL} offsets in lockstep with saga-dash's own listen port.
+    const env = resolveLaunchEnv('authz-api', 'stack', slotCtx(5));
+    expect(env.PORT).toBe(String(manifest.services['authz-api'].port + 5000)); // 8200
+    expect(env.CORS_ORIGIN).toBe('http://localhost:13900'); // dash 8900 + 5000
+    expect(env.CORS_ORIGIN).not.toBe('http://localhost:8900'); // never slot 0's
+  });
+
+  it('is dash-ONLY: no connect-web/coach-web origin rides along', () => {
+    // connect-web's authz client is gated on VITE_AUTHZ_API_URL (never set by
+    // this manifest or any deploy vehicle) and coach-web has none at all, so
+    // neither origin is earned. Guards against a future "just in case" widening.
+    const env = resolveLaunchEnv('authz-api', 'stack', slotCtx(2));
+    expect(env.CORS_ORIGIN).toBe('http://localhost:10900');
+    expect(env.CORS_ORIGIN).not.toContain(','); // exactly one origin
+  });
+
+  it('CORS_ORIGIN is adoption-guarded, so a pre-fix authz-api is refused not adopted', () => {
+    // Without this the manifest fix is inert on every slot that already had
+    // authz-api up: the launcher adopts the still-200-ing process, which was
+    // stamped with no allowlist at all (soa#305 pattern).
+    expect(manifest.services['authz-api'].adoptEnv).toContain('CORS_ORIGIN');
+  });
+});

--- a/packages/node/saga-stack-cli/src/core/manifest/services.ts
+++ b/packages/node/saga-stack-cli/src/core/manifest/services.ts
@@ -233,6 +233,20 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
         IAM_AUTH_USERJWKSURL: '${IAM_URL}/.well-known/jwks.json',
         IAM_AUTH_SERVICETOKENISSUER: '${IAM_ISSUER}',
         IAM_AUTH_USERTOKENISSUER: '${IAM_ISSUER}',
+        // The dash's browser calls `authz.affordances` DIRECT on every page load
+        // (soa#432 pointed each slot at its OWN authz-api), so authz-api must
+        // allow the slot's dash origin like every other browser-facing service
+        // here. Without this key authz-api's allowlist is just its hardcoded
+        // devOrigins — `http://localhost:8900` (SLOT 0's dash) + the iam demo
+        // page — so every slot > 0 is CORS-blocked by construction and the dash
+        // silently degrades to permission-derived affordances. Invisible until
+        // soa#432, because before it the dash never dialled local authz at all.
+        // Dash-only ON PURPOSE: connect-web's authz client is gated on
+        // VITE_AUTHZ_API_URL, which this manifest never sets (and no deploy
+        // vehicle does either — qboard infra/connectv3-web/dependencies.yaml
+        // calls it "code-complete, dormant"), and coach-web has no authz client
+        // at all. Neither origin belongs here until one actually dials it.
+        CORS_ORIGIN: '${DASH_URL}',
       },
     },
     seed: ['authz-projection-backfill'],
@@ -240,6 +254,14 @@ export const SERVICES: Readonly<Record<ServiceId, ServiceDef>> = {
     tunnelSlug: 'authz',
     isFrontend: false,
     optional: false,
+    // Adoption guard (soa#305 pattern, the ads-adm-api precedent below): an
+    // authz-api launched before CORS_ORIGIN existed carries no allowlist entry,
+    // and the launcher would happily adopt that still-200-ing process — so the
+    // fix above would land in the manifest and change nothing on any slot that
+    // already had authz-api up, presenting as "the CORS fix didn't work".
+    // Fingerprinting the key refuses the stale process instead. One-time
+    // "stop and re-run" cost, same as iam-api/saga-dash/ads-adm-api paid.
+    adoptEnv: ['CORS_ORIGIN'],
   },
   'programs-api': {
     id: 'programs-api',


### PR DESCRIPTION
Follow-up to #432 (merged as `f83394d`). That PR pointed each slot's dash at its own `authz-api`; it worked, and it immediately exposed the next gap in the same path.

## The bug

Measured today on **slot 5**, in a real browser, with the dash now correctly dialling the LOCAL authz-api:

```
Access to fetch at 'http://localhost:8200/trpc/authz.affordances?batch=1&input=...'
from origin 'http://localhost:13900' has been blocked by CORS policy:
Response to preflight request doesn't pass access control check:
No 'Access-Control-Allow-Origin' header is present on the requested resource.
[dash] authz affordances unavailable; falling back to permission-derived affordances
```

Measured process env on slot 5 — the sibling service the dash reaches fine, next to the one it doesn't:

| service | dash reaches it? | relevant env |
| --- | --- | --- |
| `ads-adm-api` | yes | `CORS_ORIGIN=http://localhost:13900` |
| `authz-api` | **blocked** | **no `CORS_ORIGIN` at all** — its only relevant var is `PORT=8200` |

## Root cause

1. `authz-api`'s manifest entry in `packages/node/saga-stack-cli/src/core/manifest/services.ts` has a `launch.env` with `NODE_ENV`, `PORT`, `AUTHZ_DATABASE_URL`, `RABBITMQ_URL` and four `IAM_AUTH_*` vars — but **no `CORS_ORIGIN`**. Every other browser-facing service in that file declares `CORS_ORIGIN: '${DASH_URL}'` (iam-api, sis-api, programs-api, scheduling-api, sessions-api, content-api, ads-adm-api).
2. authz-api DOES read the variable: `rostering apps/node/authz-api/src/main.ts:133` does `app.use(cors({ origin: buildOriginAllowlist(), credentials: true }))`, and `src/origin-allowlist.ts` delegates to `buildSagaOriginAllowlist` from `@saga-ed/soa-api-util`.
3. `buildSagaOriginAllowlist` (`packages/node/api-util/src/utils/cors.ts:66`) builds its list from **`env.CORS_ORIGIN`** (comma-split) + `devOrigins` when not production + a wootdev/saga wildcard.
4. authz-api's hardcoded `devOrigins` are `['http://localhost:8900', 'http://localhost:3010']` — **slot 0's dash port** and the iam demo page. So authz-api's CORS has only ever worked with the dash on slot 0; every slot > 0 is broken by construction. It stayed invisible because before #432 the dash never dialled the local authz-api at all — it fell through to the deployed host and failed the same way, silently.

The rostering side already supports this fully; the variable was simply never given a value. **Fix is soa-side only.**

## The judgement call: `${DASH_URL}` alone

Chosen value:

```ts
CORS_ORIGIN: '${DASH_URL}',
```

I checked which browser SPAs actually dial authz-api directly rather than padding the list with `${CONNECT_WEB_URL}` / `${COACH_WEB_URL}` the way iam-api does.

**saga-dash — YES, include.** `apps/web/dash/src/routes/+layout.ts:292` resolves `topologyStore.getEndpoint('authz-api')` and `:518` calls `authz.affordances` on every page load. This is the call in the console error above.

**connect-web — NO.** It *has* a code-complete authz client (`qboard apps/web/connectv3/src/auth/iam-client.ts:91` fetches `${base}/trpc/authz.capabilities`), but it is gated on `VITE_AUTHZ_API_URL`, and that var is **never set**: it is absent from connect-web's `launch.env` in this manifest, absent from its `.env`/`.env.development`, and qboard's own infra doc is explicit about the deployed side —

> `VITE_AUTHZ_API_URL` Fleet authz-api cutover for permission reads (iam-client.ts fetchAuthzCapabilities) — code-complete, dormant.
> — `qboard infra/connectv3-web/dependencies.yaml:191`

> Code-complete […] but `VITE_AUTHZ_API_URL` is NEVER injected by any real deploy vehicle — grepped `scripts/deploy-connectv3-web.sh`, the composite action, and every connectv3-web workflow: zero hits outside `iam-client.test.ts` and the type declaration. Every live deployment (dev, prod, training, every PR preview) stays on the legacy iam-api path.
> — same file, `s2s.calls[authz-api]`

With the var unset, every connect-web permission read stays on iam-api. Nothing to allow.

**coach-web — NO.** `grep -rn authz coach/apps/web/coach-web` returns **zero hits**. It has no authz client at all.

So exactly one origin is earned. Over-broad CORS is a real smell and this file reasons about it deliberately (see the coach-web note above `programs-api`'s `CORS_ORIGIN`), so I did not pad it. A test pins the single-origin shape so a future "just in case" widening has to argue with a red build.

## Also changed: `adoptEnv: ['CORS_ORIGIN']`

The prompt for this fix asked whether `adoptEnv` is relevant here the way it is for iam-api. The **tunnel** rationale that drives iam-api/coach-web/connect-web/programs-api does **not** apply — `tunnelOverlay()` has no `authz-api` case, and the tunnel doesn't forward authz-api at all (`dash-defaults.ts` calls this out: its `SERVICES` table has no authz entry), so plain-vs-tunnel fingerprints would be identical and the guard would be inert for mode drift.

But the **`ads-adm-api` precedent applies exactly**, and that comment could be describing this change:

> Adoption guard (soa#305 pattern): a process launched before this flag existed carries no gate, and the launcher would happily adopt it […] Fingerprinting the key refuses the stale process instead. One-time "stop and re-run" cost for pre-existing processes, same as iam-api/saga-dash paid.

Without the guard, `launcher.ts`'s `alreadyUp` short-circuit adopts the still-200-ing authz-api on every slot that already had one running — which is most of them, since authz-api is a dependency of sessions-api. The manifest would carry the fix and **nothing would change on any slot**, presenting as "the CORS fix didn't work." With it, the launcher refuses loudly and relaunches with the stamp. Note this does mean a one-time refusal on each slot's next `ss stack up`, which is the intended and visible cost.

Adding it does not disturb the `adoptEnv ⊇ tunnelOverlay() rewrite set` invariant test — that test iterates an explicit service list which authz-api is correctly not part of (its rewrite set is empty).

## Tests

Added a fourth `describe` block to `launch-plan.slot.unit.test.ts` in the file's existing per-service slot style:

- slot 0 → `http://localhost:8900` (byte-identity with the origin `devOrigins` already covered — this adds no new trust at slot 0)
- slot 5 → `PORT` is `8200` and `CORS_ORIGIN` is `http://localhost:13900`, and explicitly not slot 0's — the exact pair measured in the browser above
- dash-only: the resolved value contains no comma, so no second origin can quietly ride along
- `CORS_ORIGIN` is in authz-api's `adoptEnv`

Ran the package's real scripts (from `package.json`, in a clean worktree off `origin/main`):

| command | result |
| --- | --- |
| `pnpm test` (`vitest run`) | **135 files, 1738 passed**, 14 todo, 0 failed |
| `pnpm check-types` (`tsc --noEmit`) | **clean**, exit 0 |
| `pnpm lint` (`eslint src/`) | **0 errors**, 132 warnings — all pre-existing `turbo/no-undeclared-env-vars`, unchanged in kind from `main` |

No existing test pinned authz-api's launch env or the manifest env key set, so nothing needed updating — only the new coverage above.

## After merge

`ss` must be **rebuilt** before any slot picks this up. And because of the new adoption guard, the first `ss stack up` per slot will refuse to adopt the running pre-fix authz-api and ask for it to be stopped — that refusal is the fix landing, not a regression.

No running slot was touched by this PR (slot 5 is mid-verification), and the rostering repo is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4RkzkNSJ6rbpu8QihRjew
