### PR TITLE
Add can_view_user_pii capability to saga_platform (rostering#1126)

### DIFF
--- a/packages/core/saga-authz-model/model.fga
+++ b/packages/core/saga-authz-model/model.fga
@@ -283,15 +283,13 @@ type saga_platform
     # Computed capabilities — app code (fgaCheck) evaluates these, never the
     # role nouns above.
     define can_impersonate: support
+    define can_set_temporary_password: support
     define can_create_org: org_admin
     define can_admin_personas: org_admin
     define can_manage_staff: super_admin
-    # District-scoped user PII (email, name, phone, DOB) on iam-api user reads.
-    # Staff hold no district membership, so the persona permission
-    # `iam:view_user_pii` never resolves for them; iam-api's resolveIncludePii
-    # falls back to THIS. Narrowest role on purpose (rostering#1126,
-    # saga-dash#1152) — and the scope group's subtree check still bounds WHOSE
-    # PII is released.
+    # District-scoped user PII on iam-api user reads, for a STAFF session (no
+    # district persona can grant `iam:view_user_pii` to an operator who holds no
+    # district membership). super_admin only (rostering#1126).
     define can_view_user_pii: super_admin
     # Breadth over every district's program list. Staff hold no roster
     # membership, so without this iam-api returns them no program permissions
@@ -313,3 +311,5 @@ type staff_org
     # forceSync gate checks THIS, replacing the placeholder district-admin
     # `sis:force_clever_sync` persona permission.
     define can_force_clever_sync: staff_admin
+    define can_configure_district: staff_admin
+    define can_force_oneroster_ingest: staff_admin

--- a/packages/core/saga-authz-model/model.fga
+++ b/packages/core/saga-authz-model/model.fga
@@ -286,6 +286,13 @@ type saga_platform
     define can_create_org: org_admin
     define can_admin_personas: org_admin
     define can_manage_staff: super_admin
+    # District-scoped user PII (email, name, phone, DOB) on iam-api user reads.
+    # Staff hold no district membership, so the persona permission
+    # `iam:view_user_pii` never resolves for them; iam-api's resolveIncludePii
+    # falls back to THIS. Narrowest role on purpose (rostering#1126,
+    # saga-dash#1152) — and the scope group's subtree check still bounds WHOSE
+    # PII is released.
+    define can_view_user_pii: super_admin
     # Breadth over every district's program list. Staff hold no roster
     # membership, so without this iam-api returns them no program permissions
     # and program lists render empty.

--- a/packages/core/saga-authz-model/package.json
+++ b/packages/core/saga-authz-model/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@saga-ed/saga-authz-model",
-    "version": "0.1.0-dev.4",
+    "version": "0.1.0-dev.5",
     "private": false,
     "type": "module",
     "description": "Saga's OpenFGA authorization model (.fga DSL) and tuple-key helpers. Source of truth for ReBAC types and relations.",

--- a/packages/core/saga-authz-model/src/__tests__/model-fga.unit.test.ts
+++ b/packages/core/saga-authz-model/src/__tests__/model-fga.unit.test.ts
@@ -227,8 +227,14 @@ describe('staff control-plane namespace (SEC-CRIT-2)', () => {
                 'can_admin_personas',
                 'can_manage_staff',
                 'can_view_district_programs',
+                'can_view_user_pii',
             ]),
         );
+    });
+
+    it('can_view_user_pii resolves from super_admin only (rostering#1126)', () => {
+        const rel = byType.saga_platform.relations?.can_view_user_pii;
+        expect(rel?.computedUserset?.relation).toBe('super_admin');
     });
 
     it('can_view_district_programs resolves from org_admin, not super_admin alone', () => {

--- a/packages/core/saga-authz-model/src/types.ts
+++ b/packages/core/saga-authz-model/src/types.ts
@@ -83,6 +83,7 @@ export interface FgaRelationsByType {
         | 'support'
         | 'org_admin'
         | 'can_impersonate'
+        | 'can_set_temporary_password'
         | 'can_create_org'
         | 'can_admin_personas'
         | 'can_manage_staff'
@@ -94,6 +95,8 @@ export interface FgaRelationsByType {
         | 'can_view'
         | 'can_edit'
         | 'can_delete'
+        | 'can_configure_district'
+        | 'can_force_oneroster_ingest'
         | 'can_force_clever_sync';
 }
 
@@ -150,6 +153,7 @@ export const FGA_RELATIONS = {
         'support',
         'org_admin',
         'can_impersonate',
+        'can_set_temporary_password',
         'can_create_org',
         'can_admin_personas',
         'can_manage_staff',
@@ -163,6 +167,8 @@ export const FGA_RELATIONS = {
         'can_edit',
         'can_delete',
         'can_force_clever_sync',
+        'can_configure_district',
+        'can_force_oneroster_ingest',
     ],
 } as const satisfies {
     [T in FgaType]: readonly FgaRelationsByType[T][];

--- a/packages/core/saga-authz-model/src/types.ts
+++ b/packages/core/saga-authz-model/src/types.ts
@@ -86,7 +86,8 @@ export interface FgaRelationsByType {
         | 'can_create_org'
         | 'can_admin_personas'
         | 'can_manage_staff'
-        | 'can_view_district_programs';
+        | 'can_view_district_programs'
+        | 'can_view_user_pii';
     staff_org:
         | 'platform'
         | 'staff_admin'
@@ -153,6 +154,7 @@ export const FGA_RELATIONS = {
         'can_admin_personas',
         'can_manage_staff',
         'can_view_district_programs',
+        'can_view_user_pii',
     ],
     staff_org: [
         'platform',


### PR DESCRIPTION
Source-of-truth model change for saga-ed/rostering#1126 (PR saga-ed/rostering#1129), which backs saga-ed/saga-dash#1152.

Adds the computed capability `can_view_user_pii: super_admin` to `saga_platform` and mirrors it in `FGA_RELATIONS`/`types.ts`. Bumps the package to `0.1.0-dev.5` — publish skips an existing version, so the bump has to ride the PR (same as `can_view_district_programs`, bb93907b).

iam-api consults the new relation as the PII fallback for staff sessions (which hold no district persona). The model that actually deploys is rostering's vendored `scripts/fga/model.fga`, updated in saga-ed/rostering#1129; this keeps the package in step with it.

### ⚠️ Entangled scope — pre-existing drift fixed here

**Three of the four relations this PR adds are not `can_view_user_pii`.** The review found the package — labelled "source of truth", and what rostering's README says it will consume once published — was missing relations the **deployed** model already had, so they are ported in the same commit:

| relation | type | already in the deployed model |
|---|---|---|
| `can_set_temporary_password: support` | `saga_platform` | yes — gates `authAdmin.setTemporaryPassword` |
| `can_configure_district: staff_admin` | `staff_org` | yes — sis-api district config |
| `can_force_oneroster_ingest: staff_admin` | `staff_org` | yes — sis-api OneRoster ingest |

Why they ride along rather than a follow-up: `bootstrap.mjs` uses the vendored file only when `--model` is passed. CI does; the local/sandbox recipes in `scripts/fga/README.md` do **not** — they resolve this published package. Without the reconciliation a local stack silently denies temp-password issuance and both sis-api district gates while prod allows them, i.e. a false local signal on a permission surface.

All four definitions were diffed against rostering's vendored model and resolve identically. Nothing is removed. Remaining drift runs the other way (this package carries a persona/pgrant spine the vendored model lacks) and is **not** touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
