### PR TITLE
express-server: ALB-safe keep-alive timeouts + getServer() accessor (hipponot/iac#700)

### DIFF
--- a/packages/node/api-core/src/__tests__/express-server.int.test.ts
+++ b/packages/node/api-core/src/__tests__/express-server.int.test.ts
@@ -523,6 +523,102 @@ describe('ExpressServer (integration)', () => {
     }
   });
 
+  describe('keep-alive timeouts (hipponot/iac#700)', () => {
+    /** Builds an ExpressServer with the given extra config, runs fn, then stops it. */
+    async function withStartedServer(
+      extraConfig: Record<string, unknown>,
+      fn: (server: ExpressServer) => Promise<void> | void,
+    ) {
+      const container = new Container();
+      const mockLogger: ILogger = {
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      };
+
+      const config = {
+        configType: 'EXPRESS_SERVER' as const,
+        port: getRandomPort(),
+        logLevel: 'info' as const,
+        name: 'Keep-Alive Test',
+        ...extraConfig,
+      };
+
+      container.bind('ExpressServerConfig').toConstantValue(config);
+      container.bind('ILogger').toConstantValue(mockLogger);
+      container.bind(ExpressServer).toSelf();
+
+      const server = container.get(ExpressServer);
+      await server.init(container, [SimpleTestController]);
+      server.start();
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      try {
+        await fn(server);
+      } finally {
+        server.stop();
+        await new Promise(resolve => setTimeout(resolve, 100));
+      }
+    }
+
+    it('defaults exceed the ALB 60s idle timeout after start()', async () => {
+      await withStartedServer({}, server => {
+        const httpServer = server.getServer();
+        expect(httpServer).toBeDefined();
+        expect(httpServer!.keepAliveTimeout).toBe(65_000);
+        expect(httpServer!.headersTimeout).toBe(66_000);
+      });
+    });
+
+    it('honors keepAliveTimeoutMs / headersTimeoutMs overrides', async () => {
+      await withStartedServer(
+        { keepAliveTimeoutMs: 120_000, headersTimeoutMs: 121_000 },
+        server => {
+          const httpServer = server.getServer();
+          expect(httpServer!.keepAliveTimeout).toBe(120_000);
+          expect(httpServer!.headersTimeout).toBe(121_000);
+        },
+      );
+    });
+
+    it('getServer() is undefined before start() and returns the http.Server after', async () => {
+      const container = new Container();
+      const mockLogger: ILogger = {
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      };
+
+      const config = {
+        configType: 'EXPRESS_SERVER' as const,
+        port: getRandomPort(),
+        logLevel: 'info' as const,
+        name: 'Accessor Test',
+      };
+
+      container.bind('ExpressServerConfig').toConstantValue(config);
+      container.bind('ILogger').toConstantValue(mockLogger);
+      container.bind(ExpressServer).toSelf();
+
+      const server = container.get(ExpressServer);
+      await server.init(container, [SimpleTestController]);
+      expect(server.getServer()).toBeUndefined();
+
+      server.start();
+      await new Promise(resolve => setTimeout(resolve, 100));
+      try {
+        const httpServer = server.getServer();
+        expect(httpServer).toBeDefined();
+        expect(httpServer!.listening).toBe(true);
+      } finally {
+        server.stop();
+        await new Promise(resolve => setTimeout(resolve, 100));
+      }
+    });
+  });
+
   it('advertises the configured limit on an oversized JSON body (413)', async () => {
     const container = new Container();
     const mockLogger: ILogger = {

--- a/packages/node/api-core/src/express-server-schema.ts
+++ b/packages/node/api-core/src/express-server-schema.ts
@@ -32,6 +32,13 @@ export const ExpressServerSchema = z.object({
   // string, e.g. '5mb'). Consumers that mount their own parser first are
   // unaffected. Defaults to '5mb' (see ExpressServer) when omitted.
   jsonBodyLimit: z.string().optional(),
+  // HTTP keep-alive timeout in ms for the underlying http.Server. Must exceed
+  // the fronting load balancer's idle timeout (the shared ALB's is 60s) —
+  // see ExpressServer for the 502 mechanism. Defaults to 65_000 when omitted.
+  keepAliveTimeoutMs: z.number().int().positive().optional(),
+  // HTTP headers timeout in ms for the underlying http.Server. Node requires
+  // it to exceed keepAliveTimeout. Defaults to 66_000 when omitted.
+  headersTimeoutMs: z.number().int().positive().optional(),
 });
 
 // Use the INPUT type, not `z.infer` (the output): this config is bound directly

--- a/packages/node/api-core/src/express-server.ts
+++ b/packages/node/api-core/src/express-server.ts
@@ -24,6 +24,17 @@ const DEFAULT_ALLOWED_HEADERS: string[] = ['Content-Type', 'Authorization', ...D
 // 100kb). Consumers override via the `jsonBodyLimit` config field.
 const DEFAULT_JSON_BODY_LIMIT = '5mb';
 
+// Default HTTP keep-alive / headers timeouts. Node's default keepAliveTimeout
+// (5s) is below the shared ALB's 60s idle timeout, so the ALB can reuse an
+// idle connection just as Node closes it — surfacing as sporadic
+// ALB-generated 502s (`target_status="-"`) that browsers report as CORS
+// errors. The keep-alive timeout must exceed the ALB idle timeout, and Node
+// requires headersTimeout to exceed keepAliveTimeout. Consumers with unusual
+// fronting override via the `keepAliveTimeoutMs` / `headersTimeoutMs` config
+// fields. See hipponot/iac#700.
+const DEFAULT_KEEP_ALIVE_TIMEOUT_MS = 65_000;
+const DEFAULT_HEADERS_TIMEOUT_MS = 66_000;
+
 @injectable()
 export class ExpressServer {
   private readonly app: Application;
@@ -155,6 +166,12 @@ export class ExpressServer {
         `Express server '${this.config.name}' started on port ${this.config.port}${basePathInfo}`
       );
     });
+    // Keep-alive tuning — see DEFAULT_KEEP_ALIVE_TIMEOUT_MS above for the
+    // ALB 502 mechanism this prevents (hipponot/iac#700).
+    this.serverInstance.keepAliveTimeout =
+      this.config.keepAliveTimeoutMs ?? DEFAULT_KEEP_ALIVE_TIMEOUT_MS;
+    this.serverInstance.headersTimeout =
+      this.config.headersTimeoutMs ?? DEFAULT_HEADERS_TIMEOUT_MS;
   }
 
   public stop(): void {
@@ -167,6 +184,15 @@ export class ExpressServer {
 
   public getApp(): Application {
     return this.app;
+  }
+
+  /**
+   * The underlying http.Server created by start(), or undefined before
+   * start() is called. Exposed so consumers can inspect or tune the server
+   * (e.g. socket timeouts) without reaching into private state.
+   */
+  public getServer(): ReturnType<Application['listen']> | undefined {
+    return this.serverInstance;
   }
 
   private static applyParamInheritancePatch(): void {


### PR DESCRIPTION
## What / why

Node's default `server.keepAliveTimeout` (5s) sits below the shared prod ALB's 60s idle timeout, so the ALB reuses idle connections Node is simultaneously closing — producing sporadic ALB-generated 502s (`target_status="-"`) that browsers surface as CORS errors ([hipponot/iac#700](https://github.com/hipponot/iac/issues/700)). This puts the durable fix in `@saga-ed/soa-api-core` so every ExpressServer adopter gets it for free.

## Changes

- `ExpressServer.start()` now sets on the created `http.Server`:
  - `keepAliveTimeout = 65_000` (exceeds the ALB's 60s idle timeout)
  - `headersTimeout = 66_000` (Node requires it to exceed keepAliveTimeout)
- Overridable via new optional `ExpressServerConfig` fields `keepAliveTimeoutMs` / `headersTimeoutMs` for services with unusual fronting.
- New public `getServer()` accessor returns the underlying `http.Server` (undefined before `start()`), so consumers no longer need to reach into the private `serverInstance` field.
- Integration tests: defaults applied after `start()`, overrides honored, accessor behavior before/after `start()`.

## Downstream

Once this ships, the stopgap reach-ins can be dropped: saga-ed/coach#476 (private-field reach-in) and saga-ed/program-hub#697 (`applyAlbKeepAliveTimeouts()` in program-hub-service-kit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6J4qTRYYyxTVNNtgrJnzv